### PR TITLE
OBSDOCS-71: [POC] Observability operators upgrade resource

### DIFF
--- a/observability/index.adoc
+++ b/observability/index.adoc
@@ -23,10 +23,14 @@ ifndef::openshift-dedicated,openshift-rosa[]
 * {PM-shortname-c}
 endif::openshift-dedicated,openshift-rosa[]
 
-
 {ObservabilityLongName} connects open-source observability tools and technologies to create a unified {ObservabilityShortName} solution. The components of {ObservabilityLongName} work together to help you collect, store, deliver, analyze, and visualize data.
 
-[id="monitoring-overview-index"]
+[NOTE]
+====
+With the exception of monitoring, {ObservabilityLongName} components have distinct release cycles separate from the core {product-title} release cycles. See the Red{nbsp}Hat link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] page for their release compatibility.
+====
+
+[id="monitoring-overview-index_{context}"]
 == Monitoring
 Monitor the in-cluster health and performance of your applications running on {product-title} with metrics and customized alerts for CPU and memory usage, network connectivity, and other resource usage. Monitoring stack components are deployed and managed by the {cmo-full}.
 
@@ -34,32 +38,32 @@ Monitoring stack components are deployed by default in every {product-title} ins
 
 For more information, see xref:../observability/monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview] and xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring].
 
-[id="cluster-logging-index"]
+[id="cluster-logging-index_{context}"]
 == Logging
 Collect, visualize, forward, and store log data to troubleshoot issues, identify performance bottlenecks, and detect security threats. In logging 5.7 and later versions, users can configure the LokiStack deployment to produce customized alerts and recorded metrics.
 
 For more information, see xref:../observability/logging/cluster-logging.adoc#cluster-logging[About Logging].
 
 ifdef::openshift-enterprise,openshift-origin[]
-[id="distr-tracing-architecture-index"]
+[id="distr-tracing-architecture-index_{context}"]
 == Distributed tracing
 Store and visualize large volumes of requests passing through distributed systems, across the whole stack of microservices, and under heavy loads. Use it for monitoring distributed transactions, gathering insights into your instrumented services, network profiling, performance and latency optimization, root cause analysis, and troubleshooting the interaction between components in modern cloud-native microservices-based applications.
 
 For more information, see xref:distr_tracing/distr_tracing_arch/distr-tracing-architecture.adoc#distributed-tracing-architecture[Distributed tracing architecture].
 
-[id="otel-release-notes-index"]
+[id="otel-release-notes-index_{context}"]
 == {OTELName}
 Instrument, generate, collect, and export telemetry traces, metrics, and logs to analyze and understand your software's performance and behavior. Use open-source back ends like Tempo or Prometheus, or use commercial offerings. Learn a single set of APIs and conventions, and own the data that you generate.
 
 For more information, see xref:otel/otel-installing.adoc#install-otel[{OTELName}].
 
-[id="network-observability-overview-index"]
+[id="network-observability-overview-index_{context}"]
 == Network Observability
 Observe the network traffic for {product-title} clusters and create network flows with the Network Observability Operator. View and analyze the stored network flows information in the {product-title} console for further insight and troubleshooting.
 
 For more information, see xref:../observability/network_observability/network-observability-overview.adoc#network-observability-overview[Network Observability overview].
 
-[id="power-monitoring-overview-index"]
+[id="power-monitoring-overview-index_{context}"]
 == Power monitoring
 Monitor the power usage of workloads and identify the most power-consuming namespaces running in a cluster with key power consumption metrics, such as CPU or DRAM measured at the container level. Visualize energy-related system statistics with the {PM-operator}.
 


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-71](https://issues.redhat.com/browse/OBSDOCS-71)

Link to docs preview: https://80691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/index.html

QE review:
- [x] QE has approved this change.

**Additional information:**