### PR TITLE
OCPBUGS-38723: Add section for new roles for short lived credentials

### DIFF
--- a/modules/installation-gcp-service-account.adoc
+++ b/modules/installation-gcp-service-account.adoc
@@ -33,8 +33,6 @@ While making the service account an owner of the project is the easiest way to g
 . You can create the service account key in JSON format, or attach the service account to a GCP virtual machine.
 See link:https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys[Creating service account keys] and link:https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances[Creating and enabling service accounts for instances] in the GCP documentation.
 +
-You must have a service account key or a virtual machine with an attached service account to create the cluster.
-+
 [NOTE]
 ====
 If you use a virtual machine with an attached service account to create your cluster, you must set `credentialsMode: Manual` in the `install-config.yaml` file before installation.

--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -186,6 +186,12 @@ If your organization’s security policies require a more restrictive set of per
 * `iam.roles.get`
 ====
 
+.Required permissions when authenticating without a service account key
+[%collapsible]
+====
+* `iam.serviceAccounts.signBlob`
+====
+
 .Optional Images permissions for installation
 [%collapsible]
 ====

--- a/modules/minimum-required-permissions-upi-gcp.adoc
+++ b/modules/minimum-required-permissions-upi-gcp.adoc
@@ -187,6 +187,12 @@ If your organization’s security policies require a more restrictive set of per
 * `iam.roles.get`
 ====
 
+.Required permissions when authenticating without a service account key
+[%collapsible]
+====
+* `iam.serviceAccounts.signBlob`
+====
+
 .Required Images permissions for installation
 [%collapsible]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OCPBUGS-37821

Link to docs preview:
https://80701--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-permissions_installing-gcp-account

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

** GCP Short lived credentials does not fill out certain fields in the GCP structure. This causes failures when creating resources such as signed urls. In order to create these resources the user should add the role Service Account User which has the permission "iam.serviceAccounts.signBlob".

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
