### PR TITLE
OSDOCS-10060-15-update: Documented Support for migrating from SDN to OVN

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -7,22 +7,22 @@
 
 Migrating to the OVN-Kubernetes network plugin is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
 
-A migration to the OVN-Kubernetes network plugin is supported on the following platforms:
-
-* Bare metal hardware
-* Amazon Web Services (AWS)
-* Google Cloud Platform (GCP)
-* {ibm-cloud-name}
-* Microsoft Azure
-* {rh-openstack-first}
-* VMware vSphere
-
 [IMPORTANT]
 ====
 Migrating to or from the OVN-Kubernetes network plugin is not supported for managed OpenShift cloud services such as {product-dedicated}, Azure Red Hat OpenShift(ARO), and Red Hat OpenShift Service on AWS (ROSA).
 
 Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin is not supported on Nutanix.
 ====
+
+A migration to the OVN-Kubernetes network plugin is supported on the following platforms:
+
+* Bare metal hardware
+* {aws-first}
+* {gcp-first}
+* {ibm-cloud-name}
+* {azure-first}
+* {rh-openstack-first}
+* {vmw-first}
 
 include::snippets/sdn-deprecation-statement.adoc[]
 
@@ -45,6 +45,14 @@ While the OVN-Kubernetes network plugin implements many of the capabilities pres
 * OVN-Kubernetes, the default network provider in {product-title} 4.14 and later versions, uses the following IP address ranges internally: `100.64.0.0/16`, `169.254.169.0/29`, `100.88.0.0/16`, `fd98::/64`, `fd69::/125`, and `fd97::/64`. If your cluster uses OVN-Kubernetes, do not include any of these IP address ranges in any other CIDR definitions in your cluster or infrastructure.
 
 The following sections highlight the differences in configuration between the aforementioned capabilities in OVN-Kubernetes and OpenShift SDN network plugins.
+
+[discrete]
+[id="migrating-sdn-primary-interface_{context}"]
+=== Primary network interface
+
+The OpenShift SDN plugin allows application of the `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) to the primary interface on a node. The OVN-Kubernetes network plugin does not have this capability.
+
+If you have an NNCP applied to the primary interface, you must delete the NNCP before migrating to the OVN-Kubernetes network plugin. Deleting the NNCP does not remove the configuration from the primary interface, but the Kubernetes-NMState cannot manage this configuration. Instead, the `configure-ovs.sh` shell script manages the primary interface and the configuration attached to this interface.
 
 [discrete]
 [id="namespace-isolation_{context}"]

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -7,25 +7,23 @@
 [id="nw-ovn-kubernetes-migration_{context}"]
 = Migrating to the OVN-Kubernetes network plugin
 
-As a cluster administrator, you can change the network plugin for your cluster to OVN-Kubernetes.
-During the migration, you must reboot every node in your cluster.
+As a cluster administrator, you can change the network plugin for your cluster to OVN-Kubernetes. During the migration, you must reboot every node in your cluster.
 
 [IMPORTANT]
 ====
-While performing the migration, your cluster is unavailable and workloads might be interrupted.
-Perform the migration only when an interruption in service is acceptable.
+While performing the migration, your cluster is unavailable and workloads might be interrupted. Perform the migration only when an interruption in service is acceptable.
 ====
 
 .Prerequisites
 
-* A cluster configured with the OpenShift SDN CNI network plugin in the network policy isolation mode.
-* Install the OpenShift CLI (`oc`).
-* Access to the cluster as a user with the `cluster-admin` role.
-* A recent backup of the etcd database is available.
-* A reboot can be triggered manually for each node.
-* The cluster is in a known good state, without any errors.
-* Before migration to the OVN-Kubernetes plugin, a security group rule must be in place to allow UDP packets on port `6081` for all nodes on all cloud platforms.
-* Before migration to the OVN-Kubernetes plugin, you must either set all timeouts for webhooks to `3` seconds or remove the webhooks.
+* You have a cluster configured with the OpenShift SDN CNI network plugin in the network policy isolation mode.
+* You installed the {oc-first}.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have a recent backup of the etcd database.
+* You can manually reboot each node.
+* You checked that your cluster is in a known good state without any errors.
+* You created a security group rule that allows User Datagram Protocol (UDP) packets on port `6081` for all nodes on all cloud platforms.
+* You set all timeouts for webhooks to `3` seconds or removed the webhooks.
 
 .Procedure
 
@@ -67,6 +65,31 @@ EOT
 ----
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
 --patch '{"spec":{"migration":null}}'
+----
+
+. . Delete the `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) that defines the primary network interface for the OpenShift SDN network plugin by completing the following steps:
++
+.. Check that the existing NNCP CR bonded the primary interface to your cluster by entering the following command: 
++
+[source,terminal]
+----
+$ oc get nncp
+----
++
+.Example output
+[source,terminal]
+----
+NAME          STATUS      REASON
+bondmaster0   Available   SuccessfullyConfigured
+----
++
+Network Manager stores the connection profile for the bonded primary interface in the `/etc/NetworkManager/system-connections` system path.
++
+.. Remove the NNCP from your cluster:
++
+[source,terminal]
+----
+$ oc delete nncp <nncp_manifest_filename>
 ----
 
 . To prepare all the nodes for the migration, set the `migration` field on the CNO configuration object by running the following command:

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -10,9 +10,13 @@ As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin
 
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 
+// Migration to the OVN-Kubernetes network plugin
 include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
+
+// How the migration process works
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
 
+// Migrating to the OVN-Kubernetes network plugin
 include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
The update applies to 4.16 to 4.12. The 4.16 update was merged on [this PR](https://github.com/openshift/openshift-docs/pull/80277). Cherry-picking from enterprise branches is not recommended in the OCP Docs Manual, so I need to create individual PRs for 4.15 to 4.12. SME and QE approvals are on the 4.16 PR. Also, the doc structure for 4.16 is more complicated for the targeted sections as it documents two methods.

Version(s):
4.15

Issue:
[OSDOCS-10060](https://issues.redhat.com/browse/OSDOCS-10060)

Link to docs preview:
[Migrating from the OpenShift SDN network plugin](https://80707--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)
