### PR TITLE
OSDOCS:11739 add support for cron scaler in CMA

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-trigger-cron.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-cron.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-cma-autoscaling-custom-trigger-cron_{context}"]
+= Understanding the cron trigger
+
+You can scale pods based on a time range. 
+
+When the time range starts, the custom metrics autoscaler scales the pods associated with an object from the configured minimum number of pods to the specified number of desired pods. At the end of the time range, the pods are scaled back to the configured minimum. The time period must be configured in link:https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec[cron format]. 
+
+[NOTE]
+====
+The custom metrics autoscaler with cron trigger scales pods based only on the specified times and cannot scale pods on a daily, weekly, monthly, or yearly schedule.
+====
+
+The following example scales the pods associated with this scaled object from `0` to `100` from 6:00 AM to 6:30 PM India Standard Time.
+
+.Example scaled object with a cron trigger
+[source,yaml]
+----
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: cron-scaledobject
+  namespace: default
+spec:
+  scaleTargetRef:
+    name: my-deployment
+  minReplicaCount: 0 <1>
+  maxReplicaCount: 100 <2>
+  cooldownPeriod: 300
+  triggers:
+  - type: cron <3>
+    metadata: 
+      timezone: Asia/Kolkata <4>
+      start: "0 6 * * *" <5>
+      end: "30 18 * * *" <6>
+      desiredReplicas: "100" <7>
+----
+<1> Specifies the minimum number of pods to scale down to at the end of the time frame.
+<2> Specifies the maximum number of replicas when scaling up. This value should be the same as `desiredReplicas`. The default is `100`.
+<3> Specifies a cron trigger.
+<4> Specifies the timezone for the time frame. This value must be from the link:https://data.iana.org/time-zones/tzdb-2021a/zone1970.tab[IANA Time Zone Database].
+<5> Specifies the start of the time frame.
+<6> Specifies the end of the time frame.
+<7> Specifies the number of pods to scale to between the start and end of the time frame. This value should be the same as `maxReplicaCount`.

--- a/nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc
@@ -24,4 +24,5 @@ include::modules/nodes-cma-autoscaling-custom-prometheus-config.adoc[leveloffset
 include::modules/nodes-cma-autoscaling-custom-trigger-cpu.adoc[leveloffset=+1]
 include::modules/nodes-cma-autoscaling-custom-trigger-memory.adoc[leveloffset=+1]
 include::modules/nodes-cma-autoscaling-custom-trigger-kafka.adoc[leveloffset=+1]
+include::modules/nodes-cma-autoscaling-custom-trigger-cron.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-11739

Preview:
[Understanding the cron trigger](https://80708--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger.html#nodes-cma-autoscaling-custom-trigger-cron_nodes-cma-autoscaling-custom-trigger)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
