### PR TITLE
OSDOCS 11742 fix direct https includes with huge books

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -621,7 +621,12 @@ def scrub_file(info, book_src_dir, src_file, tag=None, cwd=None):
     # procedure loads the file recognizing that it starts with http
     # it then checks if it exists or not, and if it exists, returns the raw data
     # data that it finds.
-    if base_src_file.startswith("https://raw.githubusercontent.com/openshift/"):
+    # modified 20/Aug/2024 to process https links which are preceded
+    # by an added directory (happens with hugeBook)
+
+    https_pos = base_src_file.find("https://raw.githubusercontent.com/openshift/")
+    if https_pos >=0:
+        base_src_file = base_src_file[https_pos:]
         try:
             response = requests.get(base_src_file)
             if response:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
enterprise-4.12 only (will make another PR for others)

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
OSDPCS 11742

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This is a fix for the build_for_portal.py script. Doc content is not affected.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
