### PR TITLE
OSDOCS-11734: GCP Workload ID OLM stub and related updates

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -309,6 +309,9 @@ endif::openshift-origin[]
 //Microsoft Entra Workload ID (FKA Azure Active Directory Workload Identities)
 :entra-first: Microsoft Entra Workload ID
 :entra-short: Workload ID
+//Google Cloud Platform Workload Identity
+:gcp-wid-first: Google Cloud Platform Workload Identity
+:gcp-wid-short: GCP Workload Identity
 
 
 // Cluster API terminology

--- a/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
@@ -10,7 +10,7 @@ During installation, you can configure the Cloud Credential Operator (CCO) to op
 
 [NOTE]
 ====
-This credentials strategy is supported for Amazon Web Services (AWS), Google Cloud Platform (GCP), and global Microsoft Azure only. The strategy must be configured during installation of a new {product-title} cluster. You cannot configure an existing cluster that uses a different credentials strategy to use this feature.
+This credentials strategy is supported for {aws-first}, {gcp-first}, and global {azure-full} only. The strategy must be configured during installation of a new {product-title} cluster. You cannot configure an existing cluster that uses a different credentials strategy to use this feature.
 ====
 
 //todo: Should provide some more info about the benefits of this here as well. Note: Azure is not yet limited-priv, but still gets the benefit of not storing root creds on the cluster and some sort of time-based rotation
@@ -21,11 +21,11 @@ Cloud providers use different terms for their implementation of this authenticat
 |====
 |Cloud provider |Provider nomenclature
 
-|Amazon Web Services (AWS)
-|AWS Security Token Service (STS)
+|{aws-first}
+|{aws-short} {sts-first}
 
-|Google Cloud Platform (GCP)
-|GCP Workload Identity
+|{gcp-first}
+|{gcp-wid-short}
 
 |Global Microsoft Azure
 |{entra-first}
@@ -33,13 +33,13 @@ Cloud providers use different terms for their implementation of this authenticat
 |====
 
 [id="cco-short-term-creds-aws_{context}"]
-== AWS Security Token Service
+== {aws-short} {sts-full}
 
-In manual mode with STS, the individual {product-title} cluster components use the AWS Security Token Service (STS) to assign components IAM roles that provide short-term, limited-privilege security credentials. These credentials are associated with IAM roles that are specific to each component that makes AWS API calls.
+In manual mode with {sts-first}, the individual {product-title} cluster components use the {aws-short} {sts-short} to assign components IAM roles that provide short-term, limited-privilege security credentials. These credentials are associated with IAM roles that are specific to each component that makes {aws-short} API calls.
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-customizations[Configuring an AWS cluster to use short-term credentials]
+* xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-customizations[Configuring an {aws-short} cluster to use short-term credentials]
 
 //AWS Security Token Service authentication process
 include::modules/cco-short-term-creds-auth-flow-aws.adoc[leveloffset=+2]
@@ -55,16 +55,16 @@ include::modules/cco-short-term-creds-aws-olm.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../operators/operator_sdk/token_auth/osdk-cco-aws-sts.adoc#osdk-cco-aws-sts[CCO-based workflow for OLM-managed Operators with AWS STS]
+* xref:../../operators/operator_sdk/token_auth/osdk-cco-aws-sts.adoc#osdk-cco-aws-sts[CCO-based workflow for OLM-managed Operators with {aws-short} {sts-short}]
 
 [id="cco-short-term-creds-gcp_{context}"]
-== GCP Workload Identity
+== {gcp-wid-short}
 
-In manual mode with GCP Workload Identity, the individual {product-title} cluster components use the GCP workload identity provider to allow components to impersonate GCP service accounts using short-term, limited-privilege credentials.
+In manual mode with {gcp-wid-short}, the individual {product-title} cluster components use the {gcp-short} workload identity provider to allow components to impersonate {gcp-short} service accounts using short-term, limited-privilege credentials.
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a GCP cluster to use short-term credentials]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a {gcp-short} cluster to use short-term credentials]
 
 //GCP Workload Identity authentication process
 include::modules/cco-short-term-creds-auth-flow-gcp.adoc[leveloffset=+2]
@@ -75,6 +75,14 @@ include::modules/cco-short-term-creds-format-gcp.adoc[leveloffset=+2]
 //GCP component secret permissions requirements (placeholder)
 //include::modules/cco-short-term-creds-component-permissions-gcp.adoc[leveloffset=+2]
 
+//OLM-managed Operator support for authentication with GCP Workload Identity
+include::modules/cco-short-term-creds-gcp-olm.adoc[leveloffset=+2]
+
+// Placeholder/guess for OLM link
+// [role="_additional-resources"]
+// .Additional resources
+// * xr3f:../../operators/operator_sdk/token_auth/osdk-cco-gcp.adoc#osdk-cco-gcp[CCO-based workflow for OLM-managed Operators with {gcp-wid-first}]
+
 [id="cco-short-term-creds-azure_{context}"]
 == {entra-first}
 
@@ -82,7 +90,7 @@ In manual mode with {entra-first}, the individual {product-title} cluster compon
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_azure/ipi/installing-azure-customizations.adoc#installing-azure-with-short-term-creds_installing-azure-customizations[Configuring a global Microsoft Azure cluster to use short-term credentials]
+* xref:../../installing/installing_azure/ipi/installing-azure-customizations.adoc#installing-azure-with-short-term-creds_installing-azure-customizations[Configuring a global {azure-first} cluster to use short-term credentials]
 
 //Microsoft Entra Workload ID authentication process
 include::modules/cco-short-term-creds-auth-flow-azure.adoc[leveloffset=+2]
@@ -104,7 +112,7 @@ include::modules/cco-short-term-creds-azure-olm.adoc[leveloffset=+2]
 [id="additional-resources_{context}"]
 == Additional resources
 
-* xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-customizations[Configuring an AWS cluster to use short-term credentials]
-* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a GCP cluster to use short-term credentials]
-* xref:../../installing/installing_azure/ipi/installing-azure-customizations.adoc#installing-azure-with-short-term-creds_installing-azure-customizations[Configuring a global Microsoft Azure cluster to use short-term credentials]
+* xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-customizations[Configuring an {aws-short} cluster to use short-term credentials]
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a {gcp-short} cluster to use short-term credentials]
+* xref:../../installing/installing_azure/ipi/installing-azure-customizations.adoc#installing-azure-with-short-term-creds_installing-azure-customizations[Configuring a global {azure-first} cluster to use short-term credentials]
 * xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#preparing-manual-creds-update[Preparing to update a cluster with manually maintained credentials]

--- a/modules/cco-short-term-creds-aws-olm.adoc
+++ b/modules/cco-short-term-creds-aws-olm.adoc
@@ -4,6 +4,8 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="cco-short-term-creds-aws-olm_{context}"]
-= OLM-managed Operator support for authentication with AWS STS
+= OLM-managed Operator support for authentication with {aws-short} {sts-short}
 
-In addition to {product-title} cluster components, some Operators managed by the Operator Lifecycle Manager (OLM) on AWS clusters can use manual mode with STS. These Operators authenticate with limited-privilege, short-term credentials that are managed outside the cluster. To determine if an Operator supports authentication with AWS STS, see the Operator description in OperatorHub.
+Certain Operators managed by the Operator Lifecycle Manager (OLM) on {aws-short} clusters can use manual mode with {sts-short}. 
+These Operators authenticate with limited-privilege, short-term credentials that are managed outside the cluster. 
+To determine if an Operator supports authentication with {aws-short} {sts-short}, see the Operator description in OperatorHub.

--- a/modules/cco-short-term-creds-azure-olm.adoc
+++ b/modules/cco-short-term-creds-azure-olm.adoc
@@ -6,4 +6,6 @@
 [id="cco-short-term-creds-azure-olm_{context}"]
 = OLM-managed Operator support for authentication with {entra-first}
 
-In addition to {product-title} cluster components, some Operators managed by the Operator Lifecycle Manager (OLM) on Azure clusters can use manual mode with {entra-first}. These Operators authenticate with short-term credentials that are managed outside the cluster. To determine if an Operator supports authentication with {entra-short}, see the Operator description in OperatorHub.
+Certain Operators managed by the Operator Lifecycle Manager (OLM) on {azure-short} clusters can use manual mode with {entra-first}. 
+These Operators authenticate with short-term credentials that are managed outside the cluster. 
+To determine if an Operator supports authentication with {entra-short}, see the Operator description in OperatorHub.

--- a/modules/cco-short-term-creds-gcp-olm.adoc
+++ b/modules/cco-short-term-creds-gcp-olm.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cco-short-term-creds-gcp-olm_{context}"]
+= OLM-managed Operator support for authentication with {gcp-wid-short}
+
+Certain Operators managed by the Operator Lifecycle Manager (OLM) on {gcp-short} clusters can use manual mode with {gcp-wid-short}. 
+These Operators authenticate with limited-privilege, short-term credentials that are managed outside the cluster. 
+To determine if an Operator supports authentication with {gcp-wid-short}, see the Operator description in OperatorHub.


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-11734](https://issues.redhat.com//browse/OSDOCS-11734)

Link to docs preview:
* [OLM-managed Operator support for authentication with GCP Workload Identity](https://80721--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-short-term-creds.html#cco-short-term-creds-gcp-olm_cco-short-term-creds) (new section)
* [Manual mode with short-term credentials for components](https://80721--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-short-term-creds.html) (variable updates for all three platforms, should be no change in output)

QE review:
- [x] QE has approved this change.

Additional information:
Will need xref to OLM docs when avail