### PR TITLE
CNV-37050: OVN-K secondary network IP address management

### DIFF
--- a/modules/virt-creating-layer2-nad-cli.adoc
+++ b/modules/virt-creating-layer2-nad-cli.adoc
@@ -30,21 +30,22 @@ spec:
             "name": "my-namespace-l2-network", <2>
             "type": "ovn-k8s-cni-overlay", <3>
             "topology":"layer2", <4>
-            "mtu": 1300, <5>
-            "netAttachDefName": "my-namespace/l2-network" <6>
+            "subnets": "192.168.10.0/29", <5>
+            "mtu": 1300, <6>
+            "netAttachDefName": "my-namespace/l2-network", <7>
+            "excludeSubnets": "192.168.10.1/32, 192.168.10.2/32, 192.168.10.3/32, 192.168.10.4/32", <8>
+            "allowPersistentIPs": "true" <9>
     }
 ----
 <1> The CNI specification version. The required value is `0.3.1`.
 <2> The name of the network. This attribute is not namespaced. For example, you can have a network named `l2-network` referenced from two different `NetworkAttachmentDefinition` objects that exist in two different namespaces. This feature is useful to connect VMs in different namespaces.
 <3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
 <4> The topological configuration for the network. The required value is `layer2`.
-<5> Optional: The maximum transmission unit (MTU) value. The default value is automatically set by the kernel.
-<6> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
-+
-[NOTE]
-====
-The above example configures a cluster-wide overlay without a subnet defined. This means that the logical switch implementing the network only provides layer 2 communication. You must configure an IP address when you create the virtual machine by either setting a static IP address or by deploying a DHCP server on the network for a dynamic IP address.
-====
+<5> Optional: A comma-separated list of subnets. If you specify multiple subnets, IP addresses are assigned from each subnet. When the `subnets` field is omitted, the logical switch implementing the network only provides layer 2 communication. You must configure an IP address when you create the VM by either setting a static IP address or by deploying a DHCP server on the network for a dynamic IP address.
+<6> Optional: The maximum transmission unit (MTU) value. The default value is automatically set by the kernel.
+<7> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
+<8> Optional: A comma-separated list of CIDRs and IP addresses. IP addresses are removed from the assignable IP address pool and are not passed to the pods.
+<9> Optional: When set to `true`, the assigned IP addresses persist of a VM connected to this secondary network persist in an `IPClaims` object after live migration These IP addresses are reused by other pods, if requested. This works only if the `subnets` attribute is also defined.
 
 . Apply the manifest:
 +

--- a/modules/virt-creating-localnet-nad-cli.adoc
+++ b/modules/virt-creating-localnet-nad-cli.adoc
@@ -32,14 +32,20 @@ spec:
             "name": "localnet-network", <2>
             "type": "ovn-k8s-cni-overlay", <3>
             "topology": "localnet", <4>
-            "netAttachDefName": "default/localnet-network" <5>
+            "subnets": "192.168.10.0/29", <5>
+            "netAttachDefName": "default/localnet-network", <6>
+            "excludeSubnets": "192.168.10.1/32, 192.168.10.2/32, 192.168.10.3/32, 192.168.10.4/32", <7>
+            "allowPersistentIPs": "true" <8>
     }
 ----
 <1> The CNI specification version. The required value is `0.3.1`.
 <2> The name of the network. This attribute must match the value of the `spec.desiredState.ovn.bridge-mappings.localnet` field of the `NodeNetworkConfigurationPolicy` object that defines the OVS bridge mapping.
 <3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
 <4> The topological configuration for the network. The required value is `localnet`.
-<5> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
+<5> Optional: A comma-separated list of subnets. A VM connected to this secondary network interface is assigne an IP address from this pool. If you specify multiple subnets, IP addresses are assigned from each subnet.
+<6> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
+<7> Optional: A comma-separated list of CIDRs and IP addresses. IP addresses are removed from the assignable IP address pool and are not passed to the pods. 
+<8> Optional: When set to `true`, the assigned IP addresses persist of a VM connected to this secondary network persist in an `IPClaims` object after live migration. These IP addresses are reused by other pods, if requested. This works only if the `subnets` attribute is also defined.
 
 . Apply the manifest:
 +

--- a/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
@@ -35,12 +35,10 @@ endif::openshift-rosa,openshift-dedicated[]
 [id="creating-ovn-nad_{context}"]
 == Creating an OVN-Kubernetes NAD
 
-You can create an OVN-Kubernetes layer 2 or localnet network attachment definition (NAD) by using the {product-title} web console or the CLI.
+You can create an OVN-Kubernetes layer 2 or localnet network attachment definition (NAD) by using the {product-title} web console or the CLI. For both layer 2 and localnet topologies, you can configure IP address management (IPAM) in a NAD for virtual machines. Hot plugging and hot unplugging is not supported for interfaces that use IPAM.
 
-[NOTE]
-====
-Configuring IP address management (IPAM) in a network attachment definition for virtual machines is not supported.
-====
+:FeatureName: Configuring IPAM in a network attachment definition for VMs
+include::snippets/technology-preview.adoc[]
 
 include::modules/virt-creating-layer2-nad-cli.adoc[leveloffset=+2]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-37050](https://issues.redhat.com//browse/CNV-37050)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://80724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.html#creating-ovn-nad_virt-connecting-vm-to-ovn-secondary-network
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
