### PR TITLE
CMA 2.14.1 release notes

### DIFF
--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -10,6 +10,32 @@ The following release notes are for previous versions of the Custom Metrics Auto
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+[id="nodes-pods-autoscaling-custom-rn-2131_{context}"]
+== Custom Metrics Autoscaler Operator 2.13.1 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.13.1-421 provides a new feature and a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHBA-2024:4837[RHBA-2024:4837].
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2131-new_{context}"]
+=== New features and enhancements
+
+[id="nodes-pods-autoscaling-custom-rn-2131-new-ca_{context}"]
+==== Support for custom certificates with the Custom Metrics Autoscaler Operator 
+
+The Custom Metrics Autoscaler Operator can now use custom service CA certificates to connect securely to TLS-enabled metrics sources, such as an external Kafka cluster or an external Prometheus service. By default, the Operator uses automatically-generated service certificates to connect to on-cluster services only. There is a new field in the `KedaController` object that allows you to load custom server CA certificates for connecting to external services by using config maps. 
+
+For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom.adoc#nodes-cma-autoscaling-custom-ca_nodes-cma-autoscaling-custom[Custom CA certificates for the Custom Metrics Autoscaler].
+
+[id="nodes-pods-autoscaling-custom-rn-2.13.1-bugs_{context}"]
+=== Bug fixes
+
+* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. Scaled objects containing `cron` triggers are currently not supported for the custom metrics autoscaler. (link:https://issues.redhat.com/browse/OCPBUGS-34018[*OCPBUGS-34018*])
+
+
 [id="nodes-pods-autoscaling-custom-rn-2121-394_{context}"]
 == Custom Metrics Autoscaler Operator 2.12.1-394 release notes
 

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -26,49 +26,53 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |{product-title} version
 |General availability
 
-|2.13.1
+|2.14.1
 |4.16
 |General availability
 
-|2.13.1
+|2.14.1
 |4.15
 |General availability
 
-|2.13.1
+|2.14.1
 |4.14
 |General availability
 
-|2.13.1
+|2.14.1
 |4.13
 |General availability
 
-|2.13.1
+|2.14.1
 |4.12
 |General availability
 |===
 
-[id="nodes-pods-autoscaling-custom-rn-2131_{context}"]
-== Custom Metrics Autoscaler Operator 2.13.1 release notes
+[id="nodes-pods-autoscaling-custom-rn-2141_{context}"]
+== Custom Metrics Autoscaler Operator 2.14.1 release notes
 
-This release of the Custom Metrics Autoscaler Operator 2.13.1-421 provides a new feature and a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHBA-2024:4837[RHBA-2024:4837].
+This release of the Custom Metrics Autoscaler Operator 2.14.1-454 provides a CVE, a new feature, and bug fixes for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHBA-2024:5865[RHBA-2024:5865].
 
 [IMPORTANT]
 ====
 Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
 ====
 
-[id="nodes-pods-autoscaling-custom-rn-2131-new_{context}"]
+[id="nodes-pods-autoscaling-custom-rn-2141-new_{context}"]
 === New features and enhancements
 
-[id="nodes-pods-autoscaling-custom-rn-2131-new-ca_{context}"]
-==== Support for custom certificates with the Custom Metrics Autoscaler Operator 
+[id="nodes-pods-autoscaling-custom-rn-2141-new-ca_{context}"]
+==== Support for the cron trigger with the Custom Metrics Autoscaler Operator
 
-The Custom Metrics Autoscaler Operator can now use custom service CA certificates to connect securely to TLS-enabled metrics sources, such as an external Kafka cluster or an external Prometheus service. By default, the Operator uses automatically-generated service certificates to connect to on-cluster services only. There is a new field in the `KedaController` object that allows you to load custom server CA certificates for connecting to external services by using config maps. 
+The Custom Metrics Autoscaler Operator can now use the Cron trigger to scale pods based on an hourly schedule. When your specified time frame starts, the Custom Metrics Autoscaler Operator scales pods to your desired amount. When the time frame ends, the Operator scales back down to the previous level.
 
-For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom.adoc#nodes-cma-autoscaling-custom-ca_nodes-cma-autoscaling-custom[Custom CA certificates for the Custom Metrics Autoscaler].
+For more information, see link:https://keda.sh/docs/2.14/scalers/cron/[Cron] in the Keda documentation.
 
-[id="nodes-pods-autoscaling-custom-rn-2.13.1-bugs_{context}"]
+////
+If I can get this module reviewed on time for CMA 2.14.1 GA, add this link in place of the Keda docs link.
+For more information, see xref: nodes/cma/nodes-cma-autoscaling-custom-trigger.html#nodes-cma-autoscaling-custom-trigger-cron_nodes-cma-autoscaling-custom-trigger[Understanding the cron trigger].
+////
+
+[id="nodes-pods-autoscaling-custom-rn-2141-bugs_{context}"]
 === Bug fixes
 
-* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. Scaled objects containing `cron` triggers are currently not supported for the custom metrics autoscaler. (link:https://issues.redhat.com/browse/OCPBUGS-34018[*OCPBUGS-34018*])
-
+* Previously, if you made changes to audit configuration parameters in the `KedaController` custom resource, the `keda-metrics-server-audit-policy` config map would not get updated. As a consequence, you could not change the audit configuration parameters after the initial deployment of the Custom Metrics Autoscaler. With this fix, changes to the audit configuration now render properly in the config map, allowing you to change the audit configuration any time after installation. (link:https://issues.redhat.com/browse/OCPBUGS-32521[*OCPBUGS-32521*])


### PR DESCRIPTION
https://errata.devel.redhat.com/docs/show/137245

**PEER REVIEWER**
* The link to the errata (RHBA-TBD) in the first paragraph of the release notes is not available until the CMA 2.14.1 GAs.
* I have a [PR to add a module](https://github.com/openshift/openshift-docs/pull/80708) about the new feature (Cron trigger) in flight. The l[ink to that new doc is hidden](https://github.com/openshift/openshift-docs/pull/80725/files#diff-6af965f377aff4b3c4946a1ede31a0a6195a602e1551d7bbb922f80c780e6721R69-R72) in the meantime. Until I get the PR QE and Peer reviewed, I will leave the [link to the upstream docs](https://github.com/openshift/openshift-docs/pull/80725/files#diff-6af965f377aff4b3c4946a1ede31a0a6195a602e1551d7bbb922f80c780e6721R68) in place. 

Previews:
[Supported versions table](https://80725--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-rn) - Updated to 2.14.1.
[Custom Metrics Autoscaler Operator 2.14.1 release notes](https://80725--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2141_nodes-cma-autoscaling-custom-rn) -- Added new feature and a bug text.
[Custom Metrics Autoscaler Operator 2.13.1 release notes](https://80725--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past#nodes-pods-autoscaling-custom-rn-2131_nodes-cma-autoscaling-custom-rn-past) -- Moved without change to Past Releases. No need to review the text.  