### PR TITLE
OSDOCS-10969: adds TP image mode release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -36,16 +36,13 @@ This release adds improvements related to the following components and concepts.
 === Updating
 Updating two minor versions in a single step is supported in 4.17. Updates for both single-version minor releases and patch releases are still supported.
 
-//[id="microshift-4-17-updates-supported_{context}"]
-//==== Update two minor versions in a single step
-
 //TODO add new features and enhancements as needed, L4 [discrete] headings
 
-[id="microshift-4-17-installation"]
-=== Installation
+//[id="microshift-4-17-installation_{context}"]
+//=== Installation
 
-[id="microshift-4-17-configuring_{context}"]
-=== Configuring
+//[id="microshift-4-17-configuring_{context}"]
+//=== Configuring
 
 //[id="microshift-4-17-custom-cert-auths_{context}"]
 //==== Customizable certificate authorities for the API server are supported
@@ -83,54 +80,37 @@ With this release, the resource footprint of the LVM storage driver is significa
 You can now run a {microshift-short} cluster with low-latency response rates. Using a low-latency {microshift-short} configuration with operating system tuning results in reduced application response times and can include deterministic performance. Using workload partitioning is also recommended.
 //See (crossrefs here to ll and wp)
 
-[id="microshift-4-17-support_{context}"]
-=== Support
+//[id="microshift-4-17-support_{context}"]
+//=== Support
 
 //[id="microshift-4-17-support-updates_{context}"]
 //==== Getting a cluster ID
 
-[id="microshift-4-17-security_{context}"]
-=== Security and compliance
+//[id="microshift-4-17-security_{context}"]
+//=== Security and compliance
 
 //[id="microshift-4-17-ssl-medium-cipher-suites_{context}"]
 //==== SSL Medium Strength Cipher Suites now supported
 
-[id="microshift-4-17-doc-enhancements_{context}"]
-=== Documentation enhancements
+//[id="microshift-4-17-doc-enhancements_{context}"]
+//=== Documentation enhancements
 //Doc enhancements include additions for RFEs and other continuous improvement items that are substantial and are not tied to new features or bug fixes already listed here. These can also go under the relevant section as applicable.
 
 //[id="microshift-4-17-route-config_{context}"]
 //==== Route configuration now documented
 
-//TODO: determine the guidelines for how long to maintain this table when nothing has been deprecated or removed in x number of releases
-//[id="microshift-4-17-deprecated-and-removed"]
-//== Deprecated and removed features
 
-//Some features available in previous releases of {microshift-short} have been deprecated or removed.
+[id="microshift-4-17-tech-preview_{context}"]
+== Technology preview features
 
-//Deprecated functionality is still included in {microshift-short} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {microshift-short} {product-version}, see the following table.
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
 
-//In the following table, features are marked with the following statuses:
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
-//* _Deprecated_
-
-//* _Removed_
-
-//.{product-title} deprecated and removed features tracker
-//[cols="5,1,1,1",options="header"]
-//|====
-//|Feature |4.14 |4.15 |4.17
-
-//|Network configuration flags
-//|Removed
-//|-
-//|-
-
-//|CIDR notation
-//|Removed
-//|-
-//|-
-//|====
+[id="microshift-4-17-rhel-image-mode_{context}"]
+=== {op-system-base-full} image mode Technology Preview feature
+* You can now install {microshift-short} using a `bootc` container image. Image mode for {op-system} is a technology preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
+//TODO add crossref once main PR merges
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
 [id="microshift-4-17-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-10968](https://issues.redhat.com/browse/OSDOCS-10969)

Link to docs preview:
[Tech Preview - Image mode for RHEL release note](https://80730--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-tech-preview)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Feature work PR](https://github.com/openshift/openshift-docs/pull/80599)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
