### PR TITLE
OSDOCS#11238: Add relnote for etcd certificate automatic rotation

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -503,6 +503,17 @@ The Network Observability Operator releases updates independently from the {prod
 [id="ocp-4-17-etcd-certificates_{context}"]
 === Security
 
+[id="ocp-17-auto-rotate-etcd-ca_{context}"]
+==== Automatic rotation of signer certificates
+
+With this release, all `etcd` certificates originate from a new namespace: `openshift-etcd`. When a new signer certificate is close to its expiration date, the following actions occur:
+
+. An automatic rotation of the signer certificate activates.
+. The certificate bundle updates.
+. All certificates regenerate with the new signers.
+
+Manual rotation of signer certificates is still supported by deleting the specific secret and waiting for the status pod rollout to complete.
+
 [id="ocp-4-17-notable-technical-changes_{context}"]
 == Notable technical changes
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11238](https://issues.redhat.com/browse/OSDOCS-11238)

Link to docs preview:
[Security](https://80746--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes#ocp-4-17-etcd-certificates_release-notes) Updated: 08/29/2024

QE review:
- [x] QE has approved this change. 
