### PR TITLE
[enterprise-4.16]: Collapse and Expand Feature Incorrectly Listed Under Developer Perspective

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -221,6 +221,7 @@ This release introduces the following updates to the *Administrator* perspective
 * A new quick start, *Impersonating the system:admin user*, is available with information on impersonating the `system:admin` user.
 * A pod's last termination state is now available to view on the *Container list* and *Container details* pages.
 * An `Impersonate Group` action is now available from the *Groups* and *Group details* pages without having to search for the appropriate `RoleBinding`.
+* You can collapse and expand the *Getting started* section.
 
 [id="ocp-4-16-node-csr-handling"]
 ===== Node CSR handling in the {product-title} web console
@@ -237,7 +238,6 @@ With this release, you can select a storage class from the same provider when co
 This release introduces the following updates to the *Developer* perspective of the web console:
 
 * When searching, a new section was added to the list of *Resources* on the *Search* page to display the recently searched items in the order they were searched.
-* With this release, you can collapse and expand the *Getting started* section.
 
 [id="ocp-4-16-console-telemetry"]
 ===== Console Telemetry


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OCPBUGS-38761

Link to docs preview:
https://docs.openshift.com/container-platform/4.16/release_notes/ocp-4-16-release-notes.html#ocp-4-16-developer-perspective_release-notes

QE review:
- [ ] QE has approved this change.

Additional information:
The documentation currently states, "With this release, you can collapse and expand the Getting started section," under the Developer Perspective section. 

However, this feature should be documented under the Administrative Perspective instead, as it is actually present in that section. 

This misplacement may lead to confusion about where to find and utilize the feature.
