### PR TITLE
OSDOCS-11741: trouble shooting cleanup  data added to release notes

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -92,9 +92,13 @@ You can now run a {microshift-short} cluster with low-latency response rates. Us
 //[id="microshift-4-17-ssl-medium-cipher-suites_{context}"]
 //==== SSL Medium Strength Cipher Suites now supported
 
-//[id="microshift-4-17-doc-enhancements_{context}"]
-//=== Documentation enhancements
+[id="microshift-4-17-doc-enhancements_{context}"]
+=== Documentation enhancements
 //Doc enhancements include additions for RFEs and other continuous improvement items that are substantial and are not tied to new features or bug fixes already listed here. These can also go under the relevant section as applicable.
+
+[id="microshift-4-17-data-cleanup_{context}"]
+==== Data cleanup now documented
+With this release, the `microshift-cleanup-data` script is documented. For more information, see xref:../microshift_troubleshooting/microshift-cleanup-data.adoc#microshift-cleanup-data[Data cleanup].
 
 //[id="microshift-4-17-route-config_{context}"]
 //==== Route configuration now documented


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11741](https://issues.redhat.com/browse/OSDOCS-11741)

Link to docs preview:
[Data cleanup now documented](https://80750--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-doc-enhancements_release-notes)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
