### PR TITLE
[enterprise-4.14] Alertmanager change version

### DIFF
--- a/observability/monitoring/managing-alerts.adoc
+++ b/observability/monitoring/managing-alerts.adoc
@@ -112,7 +112,7 @@ endif::openshift-dedicated,openshift-rosa[]
 
 [NOTE]
 ====
-All features of a supported version of upstream Alertmanager are also supported in an OpenShift Alertmanager configuration. To check all the configuration options of a supported version of upstream Alertmanager, see link:https://prometheus.io/docs/alerting/0.26/configuration/[Alertmanager configuration].
+All features of a supported version of upstream Alertmanager are also supported in an OpenShift Alertmanager configuration. To check all the configuration options of a supported version of upstream Alertmanager, see link:https://prometheus.io/docs/alerting/0.25/configuration/[Alertmanager configuration].
 ====
 
 // Configuring notifications for default platform alerts


### PR DESCRIPTION
Manual change version from https://github.com/openshift/openshift-docs/pull/79966 to 4.14