### PR TITLE
Adds an extra step in the limited live migration docs to remove resou…

### DIFF
--- a/modules/nw-ovn-kubernetes-rollback-live.adoc
+++ b/modules/nw-ovn-kubernetes-rollback-live.adoc
@@ -71,9 +71,18 @@ The command prints the following information every second:
 * The conditions on the status of the `network.config.openshift.io/cluster` object, reporting the progress of the migration.
 * The status of different nodes with respect to the `machine-config-operator` resource, including whether they are upgrading or have been upgraded, as well as their current and desired configurations.
 
-. After the rollback procedure has completed, enter the following command to remove the `network.openshift.io/network-type-migration=` annotation from the `network.config` custom resource:
+. Complete the following steps only if the migration succeeds and your cluster is in a good state:
+
+.. Remove the `network.openshift.io/network-type-migration=` annotation from the `network.config` custom resource by entering the following command:
 +
 [source,terminal]
 ----
 $ oc annotate network.config cluster network.openshift.io/network-type-migration-
+----
+
+.. Remove the OVN-Kubernetes network provider namespace by entering the following command:
++
+[source,terminal]
+----
+$ oc delete namespace openshift-ovn-kubernetes
 ----


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OCPBUGS-37166

Link to docs preview:
https://80759--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.html#nw-ovn-kubernetes-rollback-live_rollback-to-openshift-sdn

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
