### PR TITLE
Fix type-o

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -3235,7 +3235,7 @@ The name of one or more failures domains.
 
 |platform:
   nutanix:
-    defaulatMachinePlatform:
+    defaultMachinePlatform:
       failureDomains:
 d|The failure domains that apply to both control plane and compute machines.
 


### PR DESCRIPTION
Fix type-o

Version(s):
4.15+

Link to docs preview:
Installation configuration parameters for Nutanix -> Additional Nutanix configuration parameters -> [ `platform:
  nutanix: defaultMachinePlatform: failureDomains:` table cell](https://80760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installation-config-parameters-nutanix#installation-configuration-parameters-additional-nutanix_installation-config-parameters-nutanix).

QE review:
- [x] QE has approved this change.
