### PR TITLE
HCIDOCS-316: Add information about Metal3 database to bare-metal IPI troubleshooting

### DIFF
--- a/modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc
+++ b/modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc
@@ -6,18 +6,18 @@
 
 = Troubleshooting latency when deleting a BareMetalHost resource
 
-When the Bare Metal Operator (BMO) deletes a `BareMetalHost` resource, Ironic deprovisions the bare-metal host. For example, this might happen when scaling down a machine set. Deprovisioning involves a process known as "cleaning," which performs multiple steps:
+When the Bare Metal Operator (BMO) deletes a `BareMetalHost` resource, Ironic deprovisions the bare-metal host. For example, this might happen when scaling down a machine set. Deprovisioning involves a process known as "cleaning", which performs the following steps:
 
 * Powering off the bare-metal host
-* Booting a service ramdisk on the bare-metal host
-* Removing partioning metadata from all disks
+* Booting a service RAM disk on the bare-metal host
+* Removing partitioning metadata from all disks
 * Powering off the bare-metal host again
 
-If cleaning doesn't succeed, the deletion of the `BareMetalHost` resource will take a long time and might not finish.
+If cleaning does not succeed, the deletion of the `BareMetalHost` resource will take a long time and might not finish.
 
 [IMPORTANT]
 ====
-Do not remove finalizers from `BareMetalHost` resources that take a long time to get deleted.
+Do not remove the finalizers to force deletion of a `BareMetalHost` resource. The provisioning back-end has its own database, which maintains a host record. Running actions will continue to run even if you try to force the deletion by removing the finalizers. You might face unexpected issues when attempting to add the bare-metal host later.
 ====
 
 .Procedure

--- a/modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc
+++ b/modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+// //installing/installing_bare_metal_ipi/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ipi-install-troubleshooothing-latency-when-deleting-a-baremetalhost-resource_{context}"]
+
+= Troubleshooting latency when deleting a BareMetalHost resource
+
+When the Bare Metal Operator (BMO) deletes a `BareMetalHost` resource, Ironic deprovisions the bare-metal host. For example, this might happen when scaling down a machine set. Deprovisioning involves a process known as "cleaning," which performs multiple steps:
+
+* Powering off the bare-metal host
+* Booting a service ramdisk on the bare-metal host
+* Removing partioning metadata from all disks
+* Powering off the bare-metal host again
+
+If cleaning doesn't succeed, the deletion of the `BareMetalHost` resource will take a long time and might not finish.
+
+[IMPORTANT]
+====
+Do not remove finalizers from `BareMetalHost` resources that take a long time to get deleted.
+====
+
+.Procedure
+
+. If the cleaning process can recover, wait for it to finish.
+
+. If cleaning cannot recover, disable the cleaning process by modifying the `BareMetalHost` resource and setting the `automatedCleaningMode` field to `disabled`.
+
+See "Editing a BareMetalHost resource" for additional details.

--- a/post_installation_configuration/post-install-bare-metal-configuration.adoc
+++ b/post_installation_configuration/post-install-bare-metal-configuration.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: post-install-bare-metal-configuration
 [id="post-install-bare-metal-configuration"]
-= Bare metal configuration
+= Bare-metal configuration
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-When deploying {product-title} on bare metal hosts, there are times when you need to make changes to the host either before or after provisioning. This can include inspecting the host's hardware, firmware, and firmware details. It can also include formatting disks or changing modifiable firmware settings.
+When deploying {product-title} on bare-metal hosts, there are times when you need to make changes to the host either before or after provisioning. This can include inspecting the host's hardware, firmware, and firmware details. It can also include formatting disks or changing modifiable firmware settings.
 
 // About the Bare Metal Operator
 include::modules/bmo-about-the-bare-metal-operator.adoc[leveloffset=+1]
@@ -25,6 +25,9 @@ include::modules/bmo-getting-the-baremetalhost-resource.adoc[leveloffset=+1]
 
 // Editing a BareMetalHost resource
 include::modules/bmo-editing-a-baremetalhost-resource.adoc[leveloffset=+1]
+
+// Troubleshooting latency when deleting a baremetalhost resource
+include::modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc[leveloffset=+1]
 
 // Attaching a non-bootable ISO to a bare-metal node
 include::modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc[leveloffset=+1]


### PR DESCRIPTION
Added a troubleshooting module for BMO.

Fixes: [HCIDOCS-316](https://issues.redhat.com//browse/HCIDOCS-316)

See https://issues.redhat.com/browse/HCIDOCS-316 for additional details.

Preview URL: https://80775--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/post-install-bare-metal-configuration.html#ipi-install-troubleshooothing-latency-when-deleting-a-baremetalhost-resource_post-install-bare-metal-configuration

For release(s): 4.16-4.17
QE Review: 

- [x] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
