### PR TITLE
OSDOCS12386: Add graceful reboot module to WMCO docs

### DIFF
--- a/modules/nodes-nodes-rebooting-gracefully.adoc
+++ b/modules/nodes-nodes-rebooting-gracefully.adoc
@@ -2,9 +2,20 @@
 //
 // * nodes/nodes-nodes-rebooting.adoc
 
+ifeval::["{context}" == "nodes-nodes-rebooting"]
+:nodes:
+endif::[]
+ifeval::["{context}" == "enabling-windows-container-workloads"]
+:windows:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
 [id="nodes-nodes-rebooting-gracefully_{context}"]
 = Rebooting a node gracefully
+
+ifdef::windows[]
+The Windows Machine Config Operator (WMCO) minimizes node reboots whenever possible. However, certain operations and updates require a reboot to ensure that changes are applied correctly and securely. To safely reboot your Windows nodes, use the graceful reboot process. For information on gracefully rebooting a standard {product-title} node, see "Rebooting a node gracefully" in the Nodes documentation.
+endif::windows[]
 
 Before rebooting a node, it is recommended to backup etcd data to avoid any data loss on the node.
 
@@ -48,6 +59,7 @@ In this case, run the drain command again, adding the `disable-eviction` flag, w
 $ oc adm drain <node1> --ignore-daemonsets --delete-emptydir-data --force --disable-eviction
 ----
 
+ifdef::nodes[]
 . Access the node in debug mode:
 +
 [source,terminal]
@@ -85,6 +97,44 @@ $ ssh core@<master-node>.<cluster_name>.<base_domain>
 $ sudo systemctl reboot
 ----
 ====
+endif::nodes[]
+ifdef::windows[]
+. SSH into the Windows node and enter PowerShell by running the following command:
++
+[source,terminal]
+----
+C:\> powershell
+----
+
+. Restart the node by running the following command:
++
+[source,terminal]
+----
+C:\>  Restart-Computer -Force
+----
+
+. Windows nodes on Amazon Web Services (AWS) do not return to `READY` state after a graceful reboot due to an inconsistency with the EC2 instance metadata routes and the Host Network Service (HNS) networks.
++
+After the reboot, SSH into any Windows node on AWS and add the route by running the following command in a shell prompt:
++
+[source,terminal]
+----
+C:\> route add 169.254.169.254 mask 255.255.255.0 <gateway_ip>
+----
++
+where:
++
+--
+`169.254.169.254`:: Specifies the address of the EC2 instance metadata endpoint.
+`255.255.255.255`:: Specifies the network mask of the EC2 instance metadata endpoint.
+`<gateway_ip>`:: Specifies the corresponding IP address of the gateway in the Windows instance, which you can find by running the following command:
++
+[source,terminal]
+---- 
+C:\> ipconfig | findstr /C:"Default Gateway"
+----
+--
+endif::windows[]
 
 . After the reboot is complete, mark the node as schedulable by running the following command:
 +
@@ -92,6 +142,7 @@ $ sudo systemctl reboot
 ----
 $ oc adm uncordon <node1>
 ----
+ifdef::nodes[]
 +
 [NOTE]
 ====
@@ -107,6 +158,7 @@ $ ssh core@<target_node>
 $ sudo oc adm uncordon <node> --kubeconfig /etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig
 ----
 ====
+endif::nodes[]
 
 . Verify that the node is ready:
 +

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -67,8 +67,15 @@ include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 
+include::modules/nodes-nodes-rebooting-gracefully.adoc[leveloffset=+1]
+
+.Additional references
+* xref:../nodes/nodes/nodes-nodes-rebooting.adoc#nodes-nodes-rebooting-gracefully_nodes-nodes-rebooting[Rebooting a {product-title} node gracefully]
+* xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd data]
+
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../installing/installing_azure/ipi/installing-azure-default.adoc#ssh-agent-using_installing-azure-default[Generating a key pair for cluster node SSH access]
-* xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster].
+* xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+


### PR DESCRIPTION
Adding text from the [WMCO internal docs](https://github.com/openshift/windows-machine-config-operator/compare/openshift:3304c85...openshift:afca0a5#diff-96160ca341eafe20466fcf7f74d2d720f3f05a614452c5ab41f32d8756a3fec0).

https://issues.redhat.com/browse/OSDOCS-12386

Previews:
Windows containers - [Rebooting a node gracefully](https://80780--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads#nodes-nodes-rebooting-gracefully_enabling-windows-container-workloads) - New location for the existing module, with ifdefs to delineate node/Windows differences.  Hiding SNO step, as not supported by WMCO.
Node -> [Rebooting a node gracefully](https://80780--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-rebooting.html#nodes-nodes-rebooting-gracefully_nodes-nodes-rebooting) - Existing location for this module, unaffected by ifdefs. [Current docs](https://docs.openshift.com/container-platform/4.16/nodes/nodes/nodes-nodes-rebooting.html#nodes-nodes-rebooting-gracefully_nodes-nodes-rebooting). 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
