### PR TITLE
[OSDOCS-11762]:Fix typo in Shared VPC docs (several locations, GCP)

### DIFF
--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -266,7 +266,7 @@ To install a cluster into a Shared VPC, you must use {product-title} version 4.1
 +
 [IMPORTANT]
 ====
-Once you complete the steps within the cluster configuration wizard and click *Create Cluster*, the cluster will go into the "Installation Waiting" state. At this point, you must contact the VPC owner of the host project, who must assign the dynamically-generated service account the following roles: *Computer Network Administrator*, *Compute Security Administrator*, and *DNS Administrator*.
+Once you complete the steps within the cluster configuration wizard and click *Create Cluster*, the cluster will go into the "Installation Waiting" state. At this point, you must contact the VPC owner of the host project, who must assign the dynamically-generated service account the following roles: *Compute Network Administrator*, *Compute Security Administrator*, and *DNS Administrator*.
 The VPC owner of the host project has 30 days to grant the listed permissions before the cluster creation fails.
 For information about Shared VPC permissions, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#migs-service-accounts[Provision Shared VPC].
 ====

--- a/modules/osd-create-cluster-gcp-account.adoc
+++ b/modules/osd-create-cluster-gcp-account.adoc
@@ -110,7 +110,7 @@ To install a cluster into a Shared VPC, you must use {product-title} version 4.1
 +
 [IMPORTANT]
 ====
-Once you complete the steps within the cluster configuration wizard and click *Create Cluster*, the cluster will go into the "Installation Waiting" state. At this point, you must contact the VPC owner of the host project, who must assign the dynamically-generated service account the following roles: *Computer Network Administrator*, *Compute Security Administrator*, and *DNS Administrator*.
+Once you complete the steps within the cluster configuration wizard and click *Create Cluster*, the cluster will go into the "Installation Waiting" state. At this point, you must contact the VPC owner of the host project, who must assign the dynamically-generated service account the following roles: *Compute Network Administrator*, *Compute Security Administrator*, and *DNS Administrator*.
 The VPC owner of the host project has 30 days to grant the listed permissions before the cluster creation fails.
 For information about Shared VPC permissions, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#migs-service-accounts[Provision Shared VPC].
 ====

--- a/modules/osd-create-cluster-rhm-gcp-account.adoc
+++ b/modules/osd-create-cluster-rhm-gcp-account.adoc
@@ -110,7 +110,7 @@ To install a cluster into a Shared VPC, you must use {product-title} version 4.1
 +
 [IMPORTANT]
 ====
-Once you complete the steps within the cluster configuration wizard and click *Create Cluster*, the cluster will go into the "Installation Waiting" state. At this point, you must contact the VPC owner of the host project, who must assign the dynamically-generated service account the following roles: *Computer Network Administrator*, *Compute Security Administrator*, and *DNS Administrator*.
+Once you complete the steps within the cluster configuration wizard and click *Create Cluster*, the cluster will go into the "Installation Waiting" state. At this point, you must contact the VPC owner of the host project, who must assign the dynamically-generated service account the following roles: *Compute Network Administrator*, *Compute Security Administrator*, and *DNS Administrator*.
 The VPC owner of the host project has 30 days to grant the listed permissions before the cluster creation fails.
 For information about Shared VPC permissions, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#migs-service-accounts[Provision Shared VPC].
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11762
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://80782--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp

https://80782--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-cluster-gcp-account_osd-creating-a-cluster-on-gcp

https://80782--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-cluster-rhm-gcp-account_osd-creating-a-cluster-on-gcp

QE review:
- [ ] QE has approved this change. **QE N/A as this is a typo.**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
