### PR TITLE
Ability to run CRO on infra/worker node

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -131,6 +131,8 @@ include::modules/infrastructure-moving-monitoring.adoc[leveloffset=+2]
 
 include::modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc[leveloffset=+2]
 
+include::modules/nodes-cluster-resource-override-move-infra.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../observability/monitoring/configuring-the-monitoring-stack.adoc#moving-monitoring-components-to-different-nodes_configuring-the-monitoring-stack[Moving monitoring components to different nodes]

--- a/modules/nodes-cluster-resource-configure.adoc
+++ b/modules/nodes-cluster-resource-configure.adoc
@@ -11,6 +11,10 @@
 The Cluster Resource Override Operator requires a `ClusterResourceOverride` custom resource (CR)
 and a label for each project where you want the Operator to control overcommit.
 
+ifndef::openshift-rosa,openshift-dedicated[]
+By default, the installation process creates two Cluster Resource Override pods on the control plane nodes in the `clusterresourceoverride-operator` namespace. You can move these pods to other nodes, such as infrastructure nodes, as needed. Infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see "Moving the Cluster Resource Override Operator pods".
+endif::openshift-rosa,openshift-dedicated[]
+
 .Prerequisites
 
 * The Cluster Resource Override Operator has no effect if limits have not
@@ -36,9 +40,9 @@ spec:
       limitCPUToMemoryPercent: 200 <3>
 # ...
 ----
-<1> Optional. Specify the percentage to override the container memory limit, if used, between 1-100. The default is 50.
-<2> Optional. Specify the percentage to override the container CPU limit, if used, between 1-100. The default is 25.
-<3> Optional. Specify the percentage to override the container memory limit, if used. Scaling 1Gi of RAM at 100 percent is equal to 1 CPU core. This is processed prior to overriding the CPU request, if configured. The default is 200.
+<1> Optional: Specify the percentage to override the container memory limit, if used, between 1-100. The default is `50`.
+<2> Optional: Specify the percentage to override the container CPU limit, if used, between 1-100. The default is `25`.
+<3> Optional: Specify the percentage to override the container memory limit, if used. Scaling 1Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request, if configured. The default is `200`.
 
 . Ensure the following label has been added to the Namespace object for each project where you want the Cluster Resource Override Operator to control overcommit:
 +

--- a/modules/nodes-cluster-resource-override-deploy-cli.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-cli.adoc
@@ -7,7 +7,11 @@
 [id="nodes-cluster-resource-override-deploy-cli_{context}"]
 = Installing the Cluster Resource Override Operator using the CLI
 
-You can use the {product-title} CLI to install the Cluster Resource Override Operator to help control overcommit in your cluster.
+You can use the {product-title} CLI to install the Cluster Resource Override Operator to help control overcommit in your cluster. 
+
+ifndef::openshift-rosa,openshift-dedicated[]
+By default, the installation process creates a Cluster Resource Override Operator pod on a worker node in the `clusterresourceoverride-operator` namespace. You can move this pod to another node, such as an infrastructure node, as needed. Infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see "Moving the Cluster Resource Override Operator pods".
+endif::openshift-rosa,openshift-dedicated[]
 
 .Prerequisites
 
@@ -130,9 +134,9 @@ spec:
       limitCPUToMemoryPercent: 200 <4>
 ----
 <1> The name must be `cluster`.
-<2> Optional. Specify the percentage to override the container memory limit, if used, between 1-100. The default is 50.
-<3> Optional. Specify the percentage to override the container CPU limit, if used, between 1-100. The default is 25.
-<4> Optional. Specify the percentage to override the container memory limit, if used. Scaling 1Gi of RAM at 100 percent is equal to 1 CPU core. This is processed prior to overriding the CPU request, if configured. The default is 200.
+<2> Optional: Specify the percentage to override the container memory limit, if used, between 1-100. The default is `50`.
+<3> Optional: Specify the percentage to override the container CPU limit, if used, between 1-100. The default is `25`.
+<4> Optional: Specify the percentage to override the container memory limit, if used. Scaling 1 Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request, if configured. The default is `200`.
 
 .. Create the `ClusterResourceOverride` object:
 +

--- a/modules/nodes-cluster-resource-override-deploy-console.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-console.adoc
@@ -6,7 +6,11 @@
 [id="nodes-cluster-resource-override-deploy-console_{context}"]
 = Installing the Cluster Resource Override Operator using the web console
 
-You can use the {product-title} web console to install the Cluster Resource Override Operator to help control overcommit in your cluster.
+You can use the {product-title} CLI to install the Cluster Resource Override Operator to help control overcommit in your cluster. 
+
+ifndef::openshift-rosa,openshift-dedicated[]
+By default, the installation process creates a Cluster Resource Override Operator pod on a worker node in the `clusterresourceoverride-operator` namespace. You can move this pod to another node, such as an infrastructure node, as needed. Infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see "Moving the Cluster Resource Override Operator pods".
+endif::openshift-rosa,openshift-dedicated[]
 
 .Prerequisites
 
@@ -55,12 +59,11 @@ spec:
       memoryRequestToLimitPercent: 50 <2>
       cpuRequestToLimitPercent: 25 <3>
       limitCPUToMemoryPercent: 200 <4>
-# ...
 ----
 <1> The name must be `cluster`.
-<2> Optional. Specify the percentage to override the container memory limit, if used, between 1-100. The default is 50.
-<3> Optional. Specify the percentage to override the container CPU limit, if used, between 1-100. The default is 25.
-<4> Optional. Specify the percentage to override the container memory limit, if used. Scaling 1Gi of RAM at 100 percent is equal to 1 CPU core. This is processed prior to overriding the CPU request, if configured. The default is 200.
+<2> Optional: Specify the percentage to override the container memory limit, if used, between 1-100. The default is `50`.
+<3> Optional: Specify the percentage to override the container CPU limit, if used, between 1-100. The default is `25`.
+<4> Optional: Specify the percentage to override the container memory limit, if used. Scaling 1 Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request, if configured. The default is `200`.
 
 .. Click *Create*.
 

--- a/modules/nodes-cluster-resource-override-move-infra.adoc
+++ b/modules/nodes-cluster-resource-override-move-infra.adoc
@@ -1,0 +1,188 @@
+// Module included in the following assemblies:
+//
+// * nodes/clusters/nodes-cluster-overcommit.adoc
+// * machine_management/creating-infrastructure-machinesets.adoc
+
+ifeval::["{context}" == "nodes-cluster-overcommit"]
+:cro:
+endif::[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-cluster-resource-override-move-infra_{context}"]
+= Moving the Cluster Resource Override Operator pods
+
+By default, the Cluster Resource Override Operator installation process creates an Operator pod and two Cluster Resource Override pods on nodes in the `clusterresourceoverride-operator` namespace. You can move these pods to other nodes, such as infrastructure nodes, as needed.
+
+ifdef::cro[]
+You can create and use infrastructure nodes to host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information about infrastructure nodes, see "Creating infrastructure machine sets".
+endif::cro[]
+
+The following examples shows the Cluster Resource Override pods are deployed to control plane nodes and the Cluster Resource Override Operator pod is deployed to a worker node.
+
+.Example Cluster Resource Override pods
+[source,terminal]
+----
+NAME                                                READY   STATUS    RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
+clusterresourceoverride-786b8c898c-9wrdq            1/1     Running   0          23s   10.128.2.32   ip-10-0-14-183.us-west-2.compute.internal   <none>           <none>
+clusterresourceoverride-786b8c898c-vn2lf            1/1     Running   0          26s   10.130.2.10   ip-10-0-20-140.us-west-2.compute.internal   <none>           <none>
+clusterresourceoverride-operator-6b8b8b656b-lvr62   1/1     Running   0          56m   10.131.0.33   ip-10-0-2-39.us-west-2.compute.internal     <none>           <none>
+----
+
+.Example node list
+[source,terminal]
+----
+NAME                                        STATUS   ROLES                  AGE   VERSION
+ip-10-0-14-183.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.30.4
+ip-10-0-2-39.us-west-2.compute.internal     Ready    worker                 58m   v1.30.4
+ip-10-0-20-140.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.30.4
+ip-10-0-23-244.us-west-2.compute.internal   Ready    infra                  55m   v1.30.4
+ip-10-0-77-153.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.30.4
+ip-10-0-99-108.us-west-2.compute.internal   Ready    worker                 24m   v1.30.4
+ip-10-0-24-233.us-west-2.compute.internal   Ready    infra                  55m   v1.30.4
+ip-10-0-88-109.us-west-2.compute.internal   Ready    worker                 24m   v1.30.4
+ip-10-0-67-453.us-west-2.compute.internal   Ready    infra                  55m   v1.30.4
+----
+
+.Procedure
+
+. Move the Cluster Resource Override Operator pod by adding a node selector to the `Subscription` custom resource (CR) for the Cluster Resource Override Operator.
+
+.. Edit the CR:
++
+[source,terminal]
+----
+$ oc edit -n clusterresourceoverride-operator subscriptions.operators.coreos.com clusterresourceoverride
+----
+
+.. Add a node selector to match the node role label on the node where you want to install the Cluster Resource Override Operator pod:
++
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: clusterresourceoverride
+  namespace: clusterresourceoverride-operator
+# ...
+spec:
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/infra: "" <1>
+# ...
+----
+<1> Specify the role of the node where you want to deploy the Cluster Resource Override Operator pod.
++
+[NOTE]
+====
+If the infra node uses taints, you need to add a toleration to the `Subscription` CR.
+
+For example:
+
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: clusterresourceoverride
+  namespace: clusterresourceoverride-operator
+# ...
+spec:
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations: <1>
+    - key: "node-role.kubernetes.io/infra"
+      operator: "Exists"
+      effect: "NoSchedule"
+----
+<1> Specifies a toleration for a taint on the infra node.
+====
+
+. Move the Cluster Resource Override pods by adding a node selector to the `ClusterResourceOverride` custom resource (CR):
+
+.. Edit the CR:
++
+[source,terminal]
+----
+$ oc edit ClusterResourceOverride cluster -n clusterresourceoverride-operator
+----
+
+.. Add a node selector to match the node role label on the infra node:
++
+[source,terminal]
+----
+apiVersion: operator.autoscaling.openshift.io/v1
+kind: ClusterResourceOverride
+metadata:
+  name: cluster
+  resourceVersion: "37952"
+spec:
+  podResourceOverride:
+    spec:
+      cpuRequestToLimitPercent: 25
+      limitCPUToMemoryPercent: 200
+      memoryRequestToLimitPercent: 50
+  deploymentOverrides:
+    replicas: 1 <1>
+    nodeSelector:
+      node-role.kubernetes.io/infra: "" <2>
+# ...
+----
+<1> Optional: Specify the number of Cluster Resource Override pods to deploy. The default is `2`. Only one pod is allowed per node.
+<2> Optional: Specify the role of the node where you want to deploy the Cluster Resource Override pods.
++
+[NOTE]
+====
+If the infra node uses taints, you need to add a toleration to the `ClusterResourceOverride` CR.
+
+For example:
+
+[source,terminal]
+----
+apiVersion: operator.autoscaling.openshift.io/v1
+kind: ClusterResourceOverride
+metadata:
+  name: cluster
+# ...
+spec:
+  podResourceOverride:
+    spec:
+      memoryRequestToLimitPercent: 50
+      cpuRequestToLimitPercent: 25
+      limitCPUToMemoryPercent: 200
+  deploymentOverrides:
+    replicas: 3
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
+    tolerations: <1>
+    - key: "key"
+      operator: "Equal"
+      value: "value"
+      effect: "NoSchedule"
+----
+<1> Specifies a toleration for a taint on the infra node.
+====
+
+.Verification
+
+* You can verify that the pods have moved by using the following command:
++
+[source,terminal]
+----
+$ oc get pods -n clusterresourceoverride-operator -o wide
+----
++
+The Cluster Resource Override pods are now deployed to the infra nodes.
++
+.Example output
+[source,terminal]
+----
+NAME                                                READY   STATUS    RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
+clusterresourceoverride-786b8c898c-9wrdq            1/1     Running   0          23s   10.127.2.25   ip-10-0-23-244.us-west-2.compute.internal   <none>           <none>
+clusterresourceoverride-786b8c898c-vn2lf            1/1     Running   0          26s   10.128.0.80   ip-10-0-24-233.us-west-2.compute.internal   <none>           <none>
+clusterresourceoverride-operator-6b8b8b656b-lvr62   1/1     Running   0          56m   10.129.0.71   ip-10-0-67-453.us-west-2.compute.internal   <none>           <none>
+----
+
+ifeval::["{context}" == "nodes-pods-vertical-autoscaler"]
+:!cro:
+endif::[]

--- a/nodes/clusters/nodes-cluster-overcommit.adoc
+++ b/nodes/clusters/nodes-cluster-overcommit.adoc
@@ -58,9 +58,31 @@ include::modules/nodes-cluster-resource-override.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-resource-override-deploy-console.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
+.Additional resources
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets[Moving the Cluster Resource Override Operator pods]
+endif::openshift-rosa,openshift-dedicated[]
+
 include::modules/nodes-cluster-resource-override-deploy-cli.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
+.Additional resources
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets[Moving the Cluster Resource Override Operator pods]
+endif::openshift-rosa,openshift-dedicated[]
+
 include::modules/nodes-cluster-resource-configure.adoc[leveloffset=+2]
+
+ifndef::openshift-rosa,openshift-dedicated[]
+.Additional resources
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets[Moving the Cluster Resource Override Operator pods]
+endif::openshift-rosa,openshift-dedicated[]
+
+ifndef::openshift-rosa,openshift-dedicated[]
+include::modules/nodes-cluster-resource-override-move-infra.adoc[leveloffset=+2]
+
+.Additional resources
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/nodes-cluster-node-overcommit.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-11069

Previews

* Machine management -> Creating infra machine sets -> [Moving the Cluster Resource Override Operator pods](https://80822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets) - New module.
* Nodes -> Clusters -> Overcommit -> [Moving the Cluster Resource Override Operator pods](https://80822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-resource-override-move-infra_nodes-cluster-overcommit) - Same module with second paragraph specific to this location.
* Nodes -> Clusters -> [Installing the Cluster Resource Override Operator using the web console](https://80822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-resource-override-deploy-console_nodes-cluster-overcommit) - New second paragraph in the intro. Paragraph is not in [OSD](https://80822--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-override-deploy-console_nodes-cluster-overcommit) or [ROSA](https://80822--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-override-deploy-console_nodes-cluster-overcommit).  Module-level additional references are not in OSD and ROSA.
* Nodes -> Clusters -> [Installing the Cluster Resource Override Operator using the CLI](https://80822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-resource-override-deploy-cli_nodes-cluster-overcommit) - New second paragraph in the intro. Paragraph is not in [OSD](https://80822--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-override-deploy-cli_nodes-cluster-overcommit) and [ROSA](https://80822--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-override-deploy-cli_nodes-cluster-overcommit). Module-level additional references are not in OSD and ROSA. 
* Nodes -> Clusters -> Configuring cluster-level overcommit - New second paragraph in the intro. Paragraph is not in [OSD](https://80822--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-configure_nodes-cluster-overcommit) and [ROSA](https://80822--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-configure_nodes-cluster-overcommit).

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
