### PR TITLE
OSDOCS-11169: making CSI optional for microshift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -121,6 +121,8 @@ Topics:
   File: microshift-greenboot-checking-status
 - Name: Configuring audit logging policies
   File: microshift-audit-logs-config
+- Name: Disabling LVMS CSI provider and CSI snapshot
+  File: microshift-disable-lvms-csi-provider-csi-snapshot
 - Name: Configuring low latency
   Dir: microshift_low_latency
   Topics:

--- a/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
+++ b/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-disable-lvms-csi-provider-csi-snapshot"]
+= Disabling LVMS CSI provider and CSI snapshot
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-disable-lvms-csi-provider-csi-snapshot
+
+toc::[]
+
+You can configure {microshift-short} to disable the built-in logical volume manager storage (LVMS) Container Storage Interface (CSI) provider or the CSI snapshot capabilities to reduce the use of runtime resources such as RAM, CPU, and storage.
+
+include::modules/microshift-disabling-lvms-csi-snapshot.adoc[leveloffset=+1]
+
+include::modules/microshift-disabling-lvms-csi-driver.adoc[leveloffset=+1]

--- a/microshift_storage/microshift-storage-plugin-overview.adoc
+++ b/microshift_storage/microshift-storage-plugin-overview.adoc
@@ -13,6 +13,16 @@ LVMS provisions new LVM logical volumes for container workloads with appropriate
 
 include::modules/microshift-lvms-system-requirements.adoc[leveloffset=+1]
 
+include::modules/microshift-disabling-uninstalling-lvms-csi-snapshot.adoc[leveloffset=+1]
+
+include::modules/microshift-disabling-lvms-csi-snapshot.adoc[leveloffset=+1]
+
+include::modules/microshift-disabling-lvms-csi-driver.adoc[leveloffset=+1]
+
+include::modules/microshift-uninstalling-lvms-csi-snapshot.adoc[leveloffset=+1]
+
+include::modules/microshift-uninstalling-lvms-csi-driver.adoc[leveloffset=+1]
+
 include::modules/microshift-lvms-deployment.adoc[leveloffset=+1]
 
 //OCP module with edits

--- a/modules/microshift-disabling-lvms-csi-driver.adoc
+++ b/modules/microshift-disabling-lvms-csi-driver.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/microshift-storage-plugin-overview.adoc
+// * microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-disabling-lvms-csi-driver_{context}"]
+= Disabling deployments that run the CSI driver implementations
+
+Use the following procedure to disable installation of the CSI implementation pods.
+
+[IMPORTANT]
+====
+This procedure is for users who are defining the configuration file before installing and running {microshift-short}. If {microshift-short} is already started then CSI driver implementation will be running. Users must manually remove it by following the uninstallation instructions.
+====
+
+[NOTE]
+====
+{microshift-short} will not delete CSI driver implementation pods. You must configure {microshift-short} to disable installation of the CSI driver implementation pods during the startup process.
+====
+
+.Procedure
+
+. Disable installation of the CSI driver by entering the `driver` value under the `storage` section of the {microshift-short} configuration file in `/etc/microshift/config.yaml`:
++
+[source,yaml]
+----
+# ...
+  storage
+   driver:
+   - "none" <1>
+# ...
+----
+<1> Valid values are `none` or `lvms`.
++
+[NOTE]
+====
+By default, the `driver` value is empty or null and LVMS is deployed.
+====
+
+. Start {microshift-short} after the `driver` field is specified with a supported value in the `/etc/microshift/config.yaml` file by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl enable --now microshift
+----
++
+[NOTE]
+====
+{microshift-short} does not redeploy the disabled components after a restart operation.
+====

--- a/modules/microshift-disabling-lvms-csi-snapshot.adoc
+++ b/modules/microshift-disabling-lvms-csi-snapshot.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/microshift-storage-plugin-overview.adoc
+// * microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-disabling-lvms-csi-snapshot_{context}"]
+= Disabling deployments that run CSI snapshot implementations
+
+Use the following procedure to disable installation of the CSI implementation pods.
+
+[IMPORTANT]
+====
+This procedure is for users who are defining the configuration file before installing and running {microshift-short}. If {microshift-short} is already started then CSI snapshot implementation will be running. Users must manually remove it by following the uninstallation instructions.
+====
+
+[NOTE]
+====
+{microshift-short} will not delete CSI snapshot implementation pods. You must configure {microshift-short} to disable installation of the CSI snapshot implementation pods during the startup process.
+====
+
+.Procedure
+
+. Disable installation of the CSI snapshot controller by entering the `optionalCsiComponents` value under the `storage` section of the {microshift-short} configuration file in `/etc/microshift/config.yaml`:
++
+[source,yaml]
+----
+# ...
+  storage: {} <1>
+# ...
+----
+<1> Accepted values are:
+* Not defining `optionalCsiComponents`.
+* Specifying `optionalCsiComponents` field with an empty value (`[]`) or a single empty string element (`[""]`).
+* Specifying `optionalCsiComponents` with one of the accepted values which are `snapshot-controller`, `snapshot-webhook`, or `none`. `none` is mutually exclusive with all other values.
++
+[NOTE]
+====
+If the `optionalCsiComponents` value is empty or null, {microshift-short} defaults to deploying snapshot-controller and snapshot-webhook.
+====
+
+. After the `optionalCsiComponents` field is specified with a supported value in the `config.yaml`, start {microshift-short} by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl start microshift
+----
++
+[NOTE]
+====
+{microshift-short} does not redeploy the disabled components after a restart.
+====

--- a/modules/microshift-disabling-uninstalling-lvms-csi-snapshot.adoc
+++ b/modules/microshift-disabling-uninstalling-lvms-csi-snapshot.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/microshift-storage-plugin-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-disabling-uninstalling-lvms-csi-snapshot_{context}"]
+= Disabling and uninstalling LVMS CSI provider and CSI snapshot deployments
+
+You can reduce the use of runtime resources such as RAM, CPU, and storage by removing or disabling the following storage components:
+
+* You can configure {microshift-short} to disable the built-in logical volume manager storage (LVMS) Container Storage Interface (CSI) provider.
+* You can configure {microshift-short} to disable the Container Storage Interface (CSI) snapshot capabilities.
+* You can uninstall the installed CSI implementations using `oc` commands.
+
+[IMPORTANT]
+====
+Automated uninstallation is not supported as this can cause orphaning of the provisioned volumes. Without the LVMS CSI driver, the cluster does not have knowledge of the underlying storage interface and cannot perform provisioning and deprovisioning or mounting and unmounting operations.
+====
+
+[NOTE]
+====
+You can configure {microshift-short} to disable CSI provider and CSI snapshot only before installing and running {microshift-short}.After {microshift-short} is installed and running, you must update the configuration file and uninstall the components.
+====

--- a/modules/microshift-uninstalling-lvms-csi-driver.adoc
+++ b/modules/microshift-uninstalling-lvms-csi-driver.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/microshift-storage-plugin-overview.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-uninstalling-lvms-csi-driver_{context}"]
+= Uninstalling the CSI driver implementation
+
+To uninstall the installed CSI driver implementation, use the following procedure.
+
+.Prerequisites
+
+* {microshift-short} is installed and running.
+* The CSI driver implementation is deployed on the MicroShift cluster.
+
+.Procedure
+
+. Delete the `lvmclusters` object by running the following command:
++
+[source,terminal]
+----
+$ oc delete -n openshift-storage lvmclusters.lvm.topolvm.io/lvms
+----
++
+.Example output
+[source,terminal]
+----
+lvmcluster.lvm.topolvm.io "lvms" deleted
+----
+. Delete the `lvms-operator` by running the following command:
++
+[source,terminal]
+----
+$ oc delete -n openshift-storage deployment.apps/lvms-operator
+----
++
+.Example output
+[source,terminal]
+----
+deployment.apps "lvms-operator" deleted
+----
+. Delete the `topolvm-provisioner` `StorageClass` by running the following command:
++
+[source,terminal]
+----
+$ oc delete storageclasses.storage.k8s.io/topolvm-provisioner
+----
++
+.Example output
+[source,terminal]
+----
+storageclass.storage.k8s.io "topolvm-provisioner" deleted
+----

--- a/modules/microshift-uninstalling-lvms-csi-snapshot.adoc
+++ b/modules/microshift-uninstalling-lvms-csi-snapshot.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/microshift-storage-plugin-overview.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-uninstalling-lvms-csi-snapshot_{context}"]
+= Uninstalling the CSI snapshot implementation
+
+To uninstall the installed CSI snapshot implementation, use the following procedure.
+
+.Prerequisites
+
+* {microshift-short} is installed and running.
+* The CSI snapshot implementation is deployed on the MicroShift cluster.
+
+.Procedure
+
+. Uninstall the CSI snapshot implementation by running the following command:
++
+[source,terminal]
+----
+$ oc delete -n kube-system deployment.apps/snapshot-controller deployment.apps/snapshot-webhook
+----
++
+.Example output
+[source,terminal]
+----
+deployment.apps "snapshot-controller" deleted
+deployment.apps "snapshot-webhook" deleted
+----


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-11169](https://issues.redhat.com/browse/OSDOCS-11169)

Link to docs preview:
[Disabling and uninstalling LVMS CSI provider and CSI snapshot deployments](https://80823--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/microshift-storage-plugin-overview.html#microshift-disabling-uninstalling-lvms-csi-snapshot_microshift-storage-plugin-overview)
[Disabling LVMS CSI provider and CSI snapshot](https://80823--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.html)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
