### PR TITLE
OSDOCS-10290: machine mgmt for Alicloud removal 4.17 RN updates

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -695,6 +695,26 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
+=== Machine management deprecated and removed features
+
+.Machine management deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.15 |4.16 |4.17
+
+|Managing machine with Machine API for {alibaba}
+|Technology Preview
+|Removed
+|Removed
+
+|Cloud controller manager for {alibaba}
+|Technology Preview
+|Removed
+|Removed
+
+|====
+
+[discrete]
 === Storage deprecated and removed features
 
 .Storage deprecated and removed tracker
@@ -1542,8 +1562,8 @@ In the following tables, features are marked with the following statuses:
 
 |Cloud controller manager for {alibaba}
 |Technology Preview
-|Technology Preview
-|Technology Preview
+|Removed
+|Removed
 
 |Cloud controller manager for {gcp-full}
 |General Availability


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-10290](https://issues.redhat.com//browse/OSDOCS-10290)

Link to docs preview:
* [Deprecated and removed features](https://80829--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-deprecated-removed-features_release-notes) (Machine management deprecated and removed features)
* [Technology Preview features status](https://80829--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-technology-preview-tables_release-notes) (Machine management Technology Preview features)

QE review:
- [x] QE has approved this change.

Additional information:
This actually should have applied to 4.16, will refresh accordingly
Content removal in #80824 
4.16 RN update in #80970