### PR TITLE
OCPBUGS-15814 Updated step 5 in the Running the installer section (4.12)

### DIFF
--- a/modules/sts-mode-installing-manual-run-installer.adoc
+++ b/modules/sts-mode-installing-manual-run-installer.adoc
@@ -51,7 +51,7 @@ $ openshift-install create manifests
 $ cp /<path_to_ccoctl_output_dir>/manifests/* ./manifests/
 ----
 
-. Copy the private key that the `ccoctl` generated in the `tls` directory to the installation directory:
+. Copy the `tls` directory containing the private key that the `ccoctl` generated to the installation directory:
 +
 [source,terminal,subs="+quotes"]
 ----


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-15814

Link to docs preview:
https://80830--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.html
https://80830--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
