### PR TITLE
OSDOCS#11757: Adding nodes to on-premise clusters

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2621,6 +2621,8 @@ Topics:
     File: nodes-nodes-working
   - Name: Managing nodes
     File: nodes-nodes-managing
+  - Name: Adding worker nodes to an on-premise cluster
+    File: nodes-nodes-adding-node-iso
 # Hiding this assembly per @rphillips: "We are trying to enable the feature, but there are cases we are running into where networking does not get enabled at boot."
 #  - Name: Managing graceful node shutdown
 #    File: nodes-nodes-graceful-shutdown

--- a/modules/adding-node-iso-configs.adoc
+++ b/modules/adding-node-iso-configs.adoc
@@ -1,0 +1,161 @@
+// Module included in the following assemblies:
+//
+// *nodes/nodes/nodes-nodes-adding-node-iso.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="adding-node-iso-configs_{context}"]
+= Cluster configuration reference
+
+When creating the ISO image, configurations are retrieved from the target cluster and are applied to the new nodes.
+Any configurations for your cluster are applied to the nodes unless you override the configurations in either the `nodes-config.yaml` file or any flags you add to the `oc adm node-image create` command.
+
+[id="adding-node-iso-yaml-config_{context}"]
+== YAML file parameters
+
+Configuration parameters that can be specified in the `nodes-config.yaml` file are described in the following table:
+
+.`nodes-config.yaml` parameters
+[cols=".^4l,.^3,.^2",options="header"]
+|====
+|Parameter|Description|Values
+
+|hosts:
+|Host configuration.
+|An array of host configuration objects.
+
+|hosts:
+  hostname:
+|Hostname.
+Overrides the hostname obtained from either the Dynamic Host Configuration Protocol (DHCP) or a reverse DNS lookup.
+Each host must have a unique hostname supplied by one of these methods, although configuring a hostname through this parameter is optional.
+|String.
+
+|hosts:
+  interfaces:
+|Provides a table of the name and MAC address mappings for the interfaces on the host.
+If a `NetworkConfig` section is provided in the `nodes-config.yaml` file, this table must be included and the values must match the mappings provided in the `NetworkConfig` section.
+|An array of host configuration objects.
+
+|hosts:
+  interfaces:
+    name:
+|The name of an interface on the host.
+|String.
+
+|hosts:
+  interfaces:
+    macAddress:
+|The MAC address of an interface on the host.
+|A MAC address such as the following example: `00-B0-D0-63-C2-26`.
+
+|hosts:
+  rootDeviceHints:
+|Enables provisioning of the {op-system-first} image to a particular device.
+The node-adding tool examines the devices in the order it discovers them, and compares the discovered values with the hint values.
+It uses the first discovered device that matches the hint value.
+|A dictionary of key-value pairs.
+For more information, see "Root device hints" in the "Setting up the environment for an OpenShift installation" page.
+
+|hosts:
+  rootDeviceHints:
+    deviceName:
+|The name of the device the {op-system} image is provisioned to.
+|String.
+
+|hosts:
+  networkConfig:
+|The host network definition.
+The configuration must match the Host Network Management API defined in the link:https://nmstate.io/[nmstate documentation].
+|A dictionary of host network configuration objects.
+
+|====
+
+
+[id="adding-node-iso-flags-config_{context}"]
+== Command flag options
+
+You can use command flags with the `oc adm node-image create` command to configure the nodes you are creating.
+
+The following table describes command flags that are not limited to the single-node use case:
+
+.General command flags
+[cols=".^4,.^3,.^2",options="header"]
+|====
+|Flag|Description|Values
+
+|`--certificate-authority`
+|The path to a certificate authority bundle to use when communicating with the managed container image registries.
+If the `--insecure` flag is used, this flag is ignored.
+|String
+
+|`--dir`
+|The path containing the configuration file, if provided.
+This path is also used to store the generated artifacts.
+|String
+
+|`--insecure`
+|Allows push and pull operations to registries to be made over HTTP.
+|Boolean
+
+|`-o`, `--output-name`
+|The name of the generated output image.
+|String
+
+|`-a`, `--registry-config`
+|The path to your registry credentials.
+Alternatively, you can specify the `REGISTRY_AUTH_FILE` environment variable.
+The default paths are `${XDG_RUNTIME_DIR}/containers/auth.json`, `/run/containers/${UID}/auth.json`, `${XDG_CONFIG_HOME}/containers/auth.json`, `${DOCKER_CONFIG}`, `~/.docker/config.json`, `~/.dockercfg.`
+The order can be changed through the deprecated `REGISTRY_AUTH_PREFERENCE` environment variable to a "docker" value, in order to prioritize Docker credentials over Podman.
+|String
+
+|`--skip-verification`
+|An option to skip verifying the integrity of the retrieved content.
+This is not recommended, but might be necessary when importing images from older image registries.
+Bypass verification only if the registry is known to be trustworthy.
+|Boolean
+
+|====
+
+The following table describes command flags that can be used only when creating a single node:
+
+.Single-node only command flags
+[cols=".^4,.^3,.^2",options="header"]
+|====
+|Flag|Description|Values
+
+|`-c`, `--cpu-architecture`
+|The CPU architecture to be used to install the node.
+This flag can be used to create only a single node, and the `--mac-address` flag must be defined.
+|String
+
+|`--hostname`
+|The hostname to be set for the node.
+This flag can be used to create only a single node, and the `--mac-address` flag must be defined.
+|String
+
+|`-m`, `--mac-address`
+|The MAC address used to identify the host to apply configurations to.
+This flag can be used to create only a single node, and the `--mac-address` flag must be defined.
+|String
+
+|`--network-config-path`
+|The path to a YAML file containing NMState configurations to be applied to the node.
+This flag can be used to create only a single node, and the `--mac-address` flag must be defined.
+|String
+
+|`--root-device-hint`
+|A hint for specifying the storage location for the image root filesystem. The accepted format is `<hint_name>:<value>`.
+This flag can be used to create only a single node, and the `--mac-address` flag must be defined.
+|String
+
+|`-k`, `--ssh-key-path`
+|The path to the SSH key used to access the node.
+This flag can be used to create only a single node, and the `--mac-address` flag must be defined.
+|String
+|====
+
+////
+Content to be added here. If the nodes-config.yaml has similar configuration options to the agent-config.yaml, is there a chance that we can duplicate or reuse some of the configuration reference we have for the Agent Installer?
+
+Here's the reference doc for agent-config.yaml: https://docs.openshift.com/container-platform/4.16/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html#agent-configuration-parameters_installation-config-parameters-agent
+////

--- a/modules/adding-node-iso-flags.adoc
+++ b/modules/adding-node-iso-flags.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// *nodes/nodes/nodes-nodes-adding-node-iso.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="adding-node-iso-flags_{context}"]
+= Adding a node with command flags
+
+You can add a single node to your cluster by using command flags to specify configurations for the new node.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`)
+* You have an active connection to your target cluster
+* You have a kubeconfig file available
+
+.Procedure
+
+. Generate the ISO image by running the following command. The MAC address must be specified using a command flag. See the "Cluster configuration reference" section for more flags that you can use with this command.
++
+[source,terminal]
+----
+$ oc adm node-image create --mac-address=<mac_address>
+----
++
+--
+where:
+
+`<mac_address>`:: Specifies the MAC address of the node that is being added.
+--
++
+[IMPORTANT]
+====
+In order for the `create` command to fetch a release image that matches the target cluster version, you must specify a valid pull secret.
+You can specify the pull secret either by using the `--registry-config` flag or by setting the `REGISTRY_AUTH_FILE` environment variable beforehand.
+====
++
+[TIP]
+====
+To see additional flags that can be used to configure your node, run the following `oc adm node-image create --help` command.
+====
+
+. Verify that a new `node.<arch>.iso` file is present in the asset directory.
+The asset directory is your current directory, unless you specified a different one when creating the ISO image.
+
+. Boot the node with the generated ISO image.
+
+. Track progress of the node creation by running the following command:
++
+[source,terminal]
+----
+$ oc adm node-image monitor <ip_address>
+----
++
+--
+where:
+
+`<ip_address>`:: Specifies a list of the IP addresses of the nodes that are being added.
+--
++
+[NOTE]
+====
+If reverse DNS entries are not available for your node, the `oc adm node-image monitor` command skips checks for pending certificate signing requests (CSRs).
+If these checks are skipped, you must manually check for CSRs by running the `oc get csr` command.
+====
+
+. Approve the pending CSRs by running the following command for each CSR:
++
+[source,terminal]
+----
+$ oc adm certificate approve <csr_name>
+----

--- a/modules/adding-node-iso-yaml.adoc
+++ b/modules/adding-node-iso-yaml.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+//
+// *nodes/nodes/nodes-nodes-adding-node-iso.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="adding-node-iso-yaml_{context}"]
+= Adding one or more nodes using a configuration file
+
+You can add one or more nodes to your cluster by using the `nodes-config.yaml` file to specify configurations for the new nodes.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`)
+* You have an active connection to your target cluster
+* You have a kubeconfig file available
+
+.Procedure
+
+. Create a new YAML file that contains configurations for the nodes you are adding and is named `nodes-config.yaml`. You must provide a MAC address for each new node.
++
+In the following example file, two new workers are described with an initial static network configuration:
++
+.Example `nodes-config.yaml` file
+[source,yaml]
+----
+hosts:
+- hostname: extra-worker-1
+  rootDeviceHints:
+   deviceName: /dev/sda
+  interfaces:
+   - macAddress: 00:00:00:00:00:00
+     name: eth0
+  networkConfig:
+   interfaces:
+     - name: eth0
+       type: ethernet
+       state: up
+       mac-address: 00:00:00:00:00:00
+       ipv4:
+         enabled: true
+         address:
+           - ip: 192.168.122.2
+             prefix-length: 23
+         dhcp: false
+- hostname: extra-worker-2
+  rootDeviceHints:
+   deviceName: /dev/sda
+  interfaces:
+   - macAddress: 00:00:00:00:00:02
+     name: eth0
+  networkConfig:
+   interfaces:
+     - name: eth0
+       type: ethernet
+       state: up
+       mac-address: 00:00:00:00:00:02
+       ipv4:
+         enabled: true
+         address:
+           - ip: 192.168.122.3
+             prefix-length: 23
+         dhcp: false
+----
+
+. Generate the ISO image by running the following command:
++
+[source,terminal]
+----
+$ oc adm node-image create nodes-config.yaml
+----
++
+[IMPORTANT]
+====
+In order for the `create` command to fetch a release image that matches the target cluster version, you must specify a valid pull secret.
+You can specify the pull secret either by using the `--registry-config` flag or by setting the `REGISTRY_AUTH_FILE` environment variable beforehand.
+====
++
+[NOTE]
+====
+If the directory of the `nodes-config.yaml` file is not specified by using the `--dir` flag, the tool looks for the file in the current directory.
+====
+
+. Verify that a new `node.<arch>.iso` file is present in the asset directory.
+The asset directory is your current directory, unless you specified a different one when creating the ISO image.
+
+. Boot the selected node with the generated ISO image.
+
+. Track progress of the node creation by running the following command:
++
+[source,terminal]
+----
+$ oc adm node-image monitor <ip_addresses>
+----
++
+where:
+
+`<ip_addresses>`:: Specifies a list of the IP addresses of the nodes that are being added.
++
+[NOTE]
+====
+If reverse DNS entries are not available for your node, the `oc adm node-image monitor` command skips checks for pending certificate signing requests (CSRs).
+If these checks are skipped, you must manually check for CSRs by running the `oc get csr` command.
+====
+
+. Approve the CSRs by running the following command for each CSR:
++
+[source,terminal]
+----
+$ oc adm certificate approve <csr_name>
+----

--- a/nodes/nodes/nodes-nodes-adding-node-iso.adoc
+++ b/nodes/nodes/nodes-nodes-adding-node-iso.adoc
@@ -1,0 +1,52 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="adding-node-iso"]
+= Adding worker nodes to an on-premise cluster
+include::_attributes/common-attributes.adoc[]
+:context: adding-node-iso
+
+toc::[]
+
+For on-premise clusters, you can add worker nodes by using the xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI (`oc`)] to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
+This process can be used regardless of how you installed your cluster.
+
+You can add one or more nodes at a time while customizing each node with more complex configurations, such as static network configuration, or you can specify only the MAC address of each node.
+Any required configurations that are not specified during ISO generation are retrieved from the target cluster and applied to the new nodes.
+
+Preflight validation checks are also performed when booting the ISO image to inform you of failure-causing issues before you attempt to boot each node.
+
+[id="supported-platforms_{context}"]
+== Supported platforms
+
+The following platforms are supported for this method of adding nodes:
+
+* `baremetal`
+* `vsphere`
+* `none`
+* `external`
+
+[id="adding-nodes-cluster_{context}"]
+== Adding nodes to your cluster
+You can add nodes with this method in the following two ways:
+
+* Adding one or more nodes using a configuration file.
++
+You can specify configurations for one or more nodes in the `nodes-config.yaml` file before running the the `oc adm node-image create` command.
+This is useful if you want to add more than one node at a time, or if you are specifying complex configurations.
+
+* Adding a single node using only command flags.
++
+You can add a node by running the `oc adm node-image create` command with flags to specify your configurations.
+This is useful if you want to add only a single node at a time, and have only simple configurations to specify for that node.
+
+// Adding one or more nodes using a configuration file
+include::modules/adding-node-iso-yaml.adoc[leveloffset=+2]
+
+// Adding a single node with command flags
+include::modules/adding-node-iso-flags.adoc[leveloffset=+2]
+
+// Cluster configuration reference
+include::modules/adding-node-iso-configs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#root-device-hints_ipi-install-installation-workflow[Root device hints]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -165,6 +165,19 @@ xref:../installing/installing_aws/ipi/installing-aws-network-customizations.adoc
 
 After you deploy your {product-title} cluster, you can add worker nodes to scale cluster resources. There are different ways you can add worker nodes depending on the installation method and the environment of your cluster.
 
+[id="adding-nodes-iso_{context}"]
+=== Adding worker nodes to an on-premise cluster
+
+For on-premise clusters, you can add worker nodes by using the {product-title} CLI (`oc`) to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
+This process can be used regardless of how you installed your cluster.
+
+You can add one or more nodes at a time while customizing each node with more complex configurations, such as static network configuration, or you can specify only the MAC address of each node.
+Any configurations that are not specified during ISO generation are retrieved from the target cluster and applied to the new nodes.
+
+Preflight validation checks are also performed when booting the ISO image to inform you of failure-causing issues before you attempt to boot each node.
+
+xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster]
+
 === Adding worker nodes to installer-provisioned infrastructure clusters
 
 For installer-provisioned infrastructure clusters, you can manually or automatically scale the `MachineSet` object to match the number of available bare-metal hosts.


### PR DESCRIPTION
[OSDOCS-11757](https://issues.redhat.com/browse/OSDOCS-11757)

Version(s): 4.17+

This PR documents a new, streamlined method for adding worker nodes to an on-premise cluster. This is intended to be framed as the simplest and most automated option for users.

Links to docs preview:

- [Adding worker nodes to an on-premise cluster](https://80845--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso)
- [Adding worker nodes](https://80845--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#adding-worker-nodes_post-install-cluster-tasks) (overview section in postinstall config with links to various methods)

QE review:
- [x] QE has approved this change.
