### PR TITLE
Jira OCPBUGS-38888: Align RDS SCTP module with documentation

### DIFF
--- a/snippets/telco-core_sctp_module_mc.yaml
+++ b/snippets/telco-core_sctp_module_mc.yaml
@@ -9,17 +9,16 @@ metadata:
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.2.0
     storage:
       files:
         - contents:
             source: data:,
-            verification: {}
-          filesystem: root
           mode: 420
+          overwrite: true
           path: /etc/modprobe.d/sctp-blacklist.conf
         - contents:
-            source: data:text/plain;charset=utf-8;base64,c2N0cA==
-          filesystem: root
+            source: data:,sctp
           mode: 420
+          overwrite: true
           path: /etc/modules-load.d/sctp-load.conf


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
Reported-at: https://github.com/openshift/openshift-docs/issues/80849

Link to docs preview:
https://80850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs#telco-core-sctp_module_mc-yaml

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

The fields are in slightly different order from the documentation snippet as I aligned them with the output that one would get from OpenShift (to make a diff with life documentation easier, this is the canonical format for the RDS files as far as I can tell):
```
# oc get mc load-sctp-module -o yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
(...)
  labels:
    machineconfiguration.openshift.io/role: worker
  name: load-sctp-module
(...)
spec:
  config:
    ignition:
      version: 3.2.0
    storage:
      files:
      - contents:
          source: data:,
        mode: 420
        overwrite: true
        path: /etc/modprobe.d/sctp-blacklist.conf
      - contents:
          source: data:,sctp
        mode: 420
        overwrite: true
        path: /etc/modules-load.d/sctp-load.conf
```
