### PR TITLE
Fixed the command to download the roxctl binary on Linux and Mac OS

### DIFF
--- a/modules/install-roxctl-cli-linux.adoc
+++ b/modules/install-roxctl-cli-linux.adoc
@@ -26,7 +26,7 @@ $ arch="$(uname -m | sed "s/x86_64//")"; arch="${arch:+-$arch}"
 +
 [source,terminal,subs=attributes+]
 ----
-$ curl -f -o roxctl "https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Linux/roxctl${arch}"
+$ curl -L -f -o roxctl "https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Linux/roxctl${arch}"
 ----
 
 . Make the `roxctl` binary executable:

--- a/modules/install-roxctl-cli-macos.adoc
+++ b/modules/install-roxctl-cli-macos.adoc
@@ -26,7 +26,7 @@ $ arch="$(uname -m | sed "s/x86_64//")"; arch="${arch:+-$arch}"
 +
 [source,terminal,subs=attributes+]
 ----
-$ curl -f -O "https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Darwin/roxctl${arch}"
+$ curl -L -f -o roxctl "https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Darwin/roxctl${arch}"
 ----
 
 . Remove all extended attributes from the binary:


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-25402

Fixed the command for Linux and Mac OS


Cherrypick:
- `rhacs-docs-4.4`
- `rhacs-docs-4.5`
- `rhacs-docs-4.6`