### PR TITLE
OCPBUGS-33530 - Adding docs for subscribing to PTP gnss-sync-status events

### DIFF
--- a/modules/ptp-subscribing-consumer-app-to-events.adoc
+++ b/modules/ptp-subscribing-consumer-app-to-events.adoc
@@ -79,3 +79,27 @@ To create a subscription for PTP `ptp-clock-class-change` events, send a `POST` 
 "resource": "/cluster/node/<node_name>/sync/ptp-status/ptp-clock-class-change",
 }
 ----
+
+[id="ptp-sub-ptp-gnss-sync-status_{context}"]
+== Subscribing to PTP gnss-sync-status events
+
+To create a subscription for PTP `gnss-sync-status` events, send a `POST` action to the cloud event API at `+http://localhost:8081/api/ocloudNotifications/v1/subscriptions+` with the following payload:
+
+[source,json]
+----
+{
+"endpointUri": "http://localhost:8989/event",
+"resource": "/cluster/node/<node_name>/sync/gnss-status/gnss-sync-status",
+}
+----
+
+.Example response
+[source,json]
+----
+{
+"id": "bbc1ebf0-401e-4622-a87b-da09cc5e7fae",
+"endpointUri": "http://localhost:8989/event",
+"uriLocation": "http://localhost:8089/api/ocloudNotifications/v1/subscriptions/bbc1ebf0-401e-4622-a87b-da09cc5e7fae",
+"resource": "/cluster/node/<node_name>/sync/gnss-status/gnss-sync-status",
+}
+----


### PR DESCRIPTION
Adding docs for subscribing to PTP gnss-sync-status events which were previously missing.

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-33530

Link to docs preview:
https://80856--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/ptp-cloud-events-consumer-dev-reference.html#ptp-sub-ptp-gnss-sync-status_ptp-consumer

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->