### PR TITLE
OSDOCS-11765: Documented the 4.16.9 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3327,6 +3327,34 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.9
+[id="ocp-4-16-9_{context}"]
+=== RHBA-2024:5757 - {product-title} {product-version}.9 bug fix update
+
+Issued: 29 August 2024
+
+{product-title} release {product-version}.9 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:5757[RHBA-2024:5757] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5760[RHBA-2024:5760] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.9 --pullspecs
+----
+
+[id="ocp-4-16-9-enhancements_{context}"]
+==== Enhancements
+
+* The Insights Operator (IO) can now collect data from the `haproxy_exporter_server_threshold` metric. 
+(link:https://issues.redhat.com/browse/OCPBUGS-38230[*OCPBUGS-38230*])
+
+[id="ocp-4-16-9-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.16.8
 [id="ocp-4-16-8_{context}"]
 === RHSA-2024:5422 - {product-title} {product-version}.8 bug fix and security update
@@ -3349,7 +3377,7 @@ $ oc adm release info 4.16.8 --pullspecs
 
 * Previously, when you clicked the {ols-official} link on the *Settings* page of your {product-title} cluster, the {ols} modal in Operator Hub did not open. With this update, the {ols} modal opens as expected. (link:https://issues.redhat.com/browse/OCPBUGS-38093[*OCPBUGS-38093*])
 
-* Previously, when you mirrored Operator catalogs with the `--rebuild-catalogs` argument, catalog cache was recreated on the local machine. This required extraction and use of the `opm` binary from the catalog image, which caused failure of either the mirroring operation or the catalog source. These failures would happen because the supported operating system and the platform of the `opm` binary caused a mismatch with the operating system and platform of `oc-mirror`. With this release, the value of `true` is applied to the `--rebuild-catalogs` argument by default so that any catalog rebuilds do not re-create internal cache. Additionally, this release updates the image from `opm serve /configs --cache-dir=/tmp/cache` to `opm serve /configs` so that the creation of cache happens at pod startup. Cache at startup might increase pod startup time. (link:https://issues.redhat.com/browse/OCPBUGS-38035[*OCPBUGS-38035*])
+* Previously, when you mirrored Operator catalogs with the `--rebuild-catalogs` argument, catalog cache was recreated on the local machine. This required extraction and use of the `opm` binary from the catalog image, which caused failure of either the mirroring operation or the catalog source. These failures would happen because the supported operating system and the platform of the `opm` binary caused a mismatch with the operating system and platform of `oc-mirror`. With this release, the value of `true` is applied to the `--rebuild-catalogs` argument by default; any catalog rebuilds do not re-create internal cache. Additionally, this release updates the image from `opm serve /configs --cache-dir=/tmp/cache` to `opm serve /configs` so that the creation of cache happens at pod startup. Cache at startup might increase pod startup time. (link:https://issues.redhat.com/browse/OCPBUGS-38035[*OCPBUGS-38035*])
 
 * Previously, the `PrometheusRemoteWriteBehind` alert was only triggered after Prometheus sent data to the `remote-write` endpoint on at least one occasion. With this release, the alert now also triggers if a connection could never be established with the endpoint, such as when an error exists with the endpoint URL from the time you added it to the `remote-write` endpoint configuration.  (link:https://issues.redhat.com/browse/OCPBUGS-36918[*OCPBUGS-36918*])
 
@@ -3360,13 +3388,12 @@ $ oc adm release info 4.16.8 --pullspecs
 [id="ocp-4-16-8-known-issues_{context}"]
 ==== Known issues
 
-* An error might occur when deleting a pod that uses an SR-IOV network device. This error is caused by a change in {op-system-base} 9 where the previous name of a network interface is added to its alternative names list when it is renamed. As a consequence, when a pod attached to an SR-IOV virtual function (VF) is deleted, the VF returns to the pool with a new unexpected name, for example `dev69`, instead of its original name, for example `ensf0v2`. Although this error is non-fatal, Multus and SR-IOV logs might show the error while the system reboots. Deleting the pod might take a few extra seconds due to this error. (link:https://issues.redhat.com/browse/OCPBUGS-11281[*OCPBUGS-11281*],link:https://issues.redhat.com/browse/OCPBUGS-18822[*OCPBUGS-18822*], link:https://issues.redhat.com/browse/RHEL-5988[*RHEL-5988*])
+* An error might occur when deleting a pod that uses an SR-IOV network device. This error is caused by a change in {op-system-base} 9 where the previous name of a network interface is added to its alternative names list when it is renamed. As a consequence, when a pod attached to an SR-IOV virtual function (VF) is deleted, the VF returns to the pool with a new unexpected name, for example `dev69`, instead of its original name, for example `ensf0v2`. Although this error is non-fatal, Multus and SR-IOV logs might show the error while the system reboots. Deleting the pod might take a few extra seconds due to this error. (link:https://issues.redhat.com/browse/OCPBUGS-11281[*OCPBUGS-11281*], link:https://issues.redhat.com/browse/OCPBUGS-18822[*OCPBUGS-18822*], link:https://issues.redhat.com/browse/RHEL-5988[*RHEL-5988*])
 
 [id="ocp-4-16-8-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
-
 
 [id="ocp-4-16-7_{context}"]
 === RHSA-2024:5107 - {product-title} {product-version}.7 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16.9

Issue:
[OSDOCS-11765](https://issues.redhat.com/browse/OSDOCS-11765)

Link to docs preview:
* [4.16.9](https://80858--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-9_release-notes)

