### PR TITLE
OCPBUGS#31071: Changing catalog source name in disconnected workflow 

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -34,7 +34,7 @@ metadata:
   namespace: operator-namspace
 # ...
 spec:
-  source: redhat-operators-v2 <1>
+  source: redhat-operators-disconnected-v2 <1>
 # ...
 ----
 <1> Enter the name of the additional catalog source configuration that you defined in the `{policy-gen-cr}` resource.

--- a/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -29,11 +29,11 @@ ifeval::["{policy-gen-cr}" == "PolicyGenerator"]
 include::snippets/pg-cnf-topology-aware-lifecycle-manager-operator-update.adoc[]
 endif::[]
 
-.. This update generates one policy, `du-upgrade-operator-catsrc-policy`, to update the `redhat-operators` catalog source with the new index images that contain the desired Operators images.
+.. This update generates one policy, `du-upgrade-operator-catsrc-policy`, to update the `redhat-operators-disconnected` catalog source with the new index images that contain the desired Operators images.
 +
 [NOTE]
 ====
-If you want to use the image pre-caching for Operators and there are Operators from a different catalog source other than `redhat-operators`,  you must perform the following tasks:
+If you want to use the image pre-caching for Operators and there are Operators from a different catalog source other than `redhat-operators-disconnected`,  you must perform the following tasks:
 
 * Prepare a separate catalog source policy with the new index image or registry poll interval update for the different catalog source.
 * Prepare a separate subscription policy for the desired Operators that are from the different catalog source.

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -4,10 +4,10 @@ manifests:
 - path: source-crs/DefaultCatsrc.yaml
   patches:
     - metadata:
-        name: redhat-operators
+        name: redhat-operators-disconnected
       spec:
         displayName: Red Hat Operators Catalog
-        image: registry.example.com:5000/olm/redhat-operators:v{product-version}
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version}
         updateStrategy:
             registryPoll:
                 interval: 1h
@@ -17,10 +17,10 @@ manifests:
 - path: source-crs/DefaultCatsrc.yaml
   patches:
     - metadata:
-        name: redhat-operators-v2 <1>
+        name: redhat-operators-disconnected-v2 <1>
       spec:
         displayName: Red Hat Operators Catalog v2 <2>
-        image: registry.example.com:5000/olredhat-operators:<version> <3>
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version> <3>
         updateStrategy:
             registryPoll:
                 interval: 1h

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -32,10 +32,10 @@ policies:
         - path: source-crs/DefaultCatsrc.yaml
           patches:
             - metadata:
-                name: redhat-operators
+                name: redhat-operators-disconnected
               spec:
                 displayName: Red Hat Operators Catalog
-                image: registry.example.com:5000/olm/redhat-operators:v{product-version} <1>
+                image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version} <1>
                 updateStrategy: <2>
                     registryPoll:
                         interval: 1h

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -5,10 +5,10 @@
       remediationAction: inform
       policyName: "operator-catsrc-policy"
       metadata:
-        name: redhat-operators
+        name: redhat-operators-disconnected
       spec:
         displayName: Red Hat Operators Catalog
-        image: registry.example.com:5000/olm/redhat-operators:v{product-version}
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version}
         updateStrategy:
           registryPoll:
             interval: 1h
@@ -19,10 +19,10 @@
       remediationAction: inform
       policyName: "operator-catsrc-policy"
       metadata:
-        name: redhat-operators-v2 <1>
+        name: redhat-operators-disconnected-v2 <1>
       spec:
         displayName: Red Hat Operators Catalog v2 <2>
-        image: registry.example.com:5000/olredhat-operators:<version> <3>
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version> <3>
         updateStrategy:
           registryPoll:
             interval: 1h

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -16,10 +16,10 @@ spec:
       remediationAction: inform
       policyName: "operator-catsrc-policy"
       metadata:
-        name: redhat-operators
+        name: redhat-operators-disconnected
       spec:
         displayName: Red Hat Operators Catalog
-        image: registry.example.com:5000/olm/redhat-operators:v{product-version} <1>
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version} <1>
         updateStrategy: <2>
           registryPoll:
             interval: 1h


### PR DESCRIPTION
OCPBUGS-31071: Changing catalog source name in disconnected workflow as its a custom catalog and cannot be the same name as default catalog

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-31071

Link to docs preview:
- https://80859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.html
- https://80859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
