### PR TITLE
OSDOCS-11546: adds 4.15.29 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -431,3 +431,12 @@ The {product-title} release 4.15.28 is now available. The list of bug fixes that
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
+[id="microshift-4-15-29-dp_{context}"]
+=== RHBA-2024:5753 - {microshift-short} 4.15.29 bug fix and enhancement advisory
+
+Issued: 2024-08-28
+
+The {product-title} release 4.15.29 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5753[RHBA-2024:5753] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5751[RHBA-2024:5751] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-11546](https://issues.redhat.com/browse/OSDOCS-11546)

Link to docs preview:
[4-15-29 release note](https://80868--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-29-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
