### PR TITLE
OSDOCS-11551: adds 4.16.9 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -263,9 +263,17 @@ For the latest images included with {microshift-short}, view the contents of the
 
 [id="microshift-4-16-8-dp_{context}"]
 === RHBA-2024:5424 - {microshift-short} 4.16.8 bug fix and enhancement advisory
-
 Issued: 20 August 2024
 
 {product-title} release 4.16.8 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5424[RHBA-2024:5424] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5422[RHSA-2024:5422] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-16-9-dp_{context}"]
+=== RHBA-2024:5759 - {microshift-short} 4.16.9 bug fix and enhancement advisory
+
+Issued: 29 August 2024
+
+{product-title} release 4.16.9 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5759[RHBA-2024:5759] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5757[RHBA-2024:5757] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-11551](https://issues.redhat.com/browse/OSDOCS-11551)

Link to docs preview:
[4-16-9 release note](https://80870--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-9-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
