### PR TITLE
OSDOCS-10059 remove the table only

### DIFF
--- a/modules/sd-planning-cluster-maximums.adoc
+++ b/modules/sd-planning-cluster-maximums.adoc
@@ -10,22 +10,12 @@ Consider the following tested object maximums when you plan a {product-title}
 ifdef::openshift-rosa[]
 (ROSA)
 endif::[]
-cluster installation. The table specifies the maximum limits for each tested type in a
-ifdef::openshift-rosa[]
-(ROSA)
-endif::[]
-ifdef::openshift-dedicated[]
-{product-title}
-endif::[]
-cluster.
+cluster installation. 
 
-These guidelines are based on a cluster of 102 compute (also known as worker) nodes in a multiple availability zone configuration. For smaller clusters, the maximums are lower.
+These guidelines are based on a cluster of 180 compute (also known as worker) nodes in a multiple availability zone configuration. For smaller clusters, the maximums are lower.
 
-[NOTE]
-====
-The OpenShift Container Platform version used in all of the tests is OCP 4.8.0.
-====
 
+////
 .Tested cluster maximums
 [options="header",cols="50,50"]
 |===
@@ -70,3 +60,4 @@ The OpenShift Container Platform version used in all of the tests is OCP 4.8.0.
 --
 
 In OpenShift Container Platform 4.8, half of a CPU core (500 millicore) is reserved by the system compared to previous versions of OpenShift Container Platform.
+////


### PR DESCRIPTION
Removing the 4.8 testing table as it is inaccurate. 

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10059
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://80871--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-limits-scalability.html
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
