### PR TITLE
OCPBUGS#38762: Updated the Creating an IAM role for the AWS Load Bala…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1415,7 +1415,7 @@ Topics:
     File: understanding-aws-load-balancer-operator
   - Name: Installing the AWS Load Balancer Operator
     File: install-aws-load-balancer-operator
-  - Name: Preparing for the AWS Load Balancer Operator on a cluster using the AWS Security Token Service (STS)
+  - Name: Installing the AWS Load Balancer Operator on a cluster that uses AWS STS
     File: installing-albo-sts-cluster
   - Name: Creating an instance of the AWS Load Balancer Controller
     File: create-instance-aws-load-balancer-controller

--- a/modules/aws-installing-an-aws-load-balancer-operator.adoc
+++ b/modules/aws-installing-an-aws-load-balancer-operator.adoc
@@ -180,7 +180,7 @@ For more information about formatting credentials files, see link:https://access
 ----
 $ oc -n aws-load-balancer-operator create secret generic aws-load-balancer-operator --from-file=credentials=albo-operator-aws-credentials.cfg
 ----
-. Create the AWS IAM policy required for the AWS Load Balancer Controller (ALBC):
+. Create the AWS IAM policy required for the AWS Load Balancer Controller:
 +
 .. Generate a trust policy file for your identity provider. The following example uses OpenID Connect:
 +

--- a/modules/specifying-role-arn-albo-sts.adoc
+++ b/modules/specifying-role-arn-albo-sts.adoc
@@ -6,11 +6,11 @@
 [id="specifying-role-arn-albo-sts_{context}"]
 = Configuring the ARN role for the AWS Load Balancer Operator
 
-You can configure the Amazon Resource Name (ARN) role for the AWS Load Balancer Operator as an environment variable. You can configure the ARN role by using the CLI.
+You can configure the Amazon Resource Name (ARN) role for the {aws-short} Load Balancer Operator as an environment variable. You can configure the ARN role by using the CLI.
 
 .Prerequisites
 
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 
@@ -54,12 +54,12 @@ spec:
   config:
     env:
     - name: ROLEARN
-      value: "<role-arn>" <1>
+      value: "<albo_role_arn>" <1>
 EOF
 ----
-<1> Specifies the ARN role to be used in the `CredentialsRequest` to provision the AWS credentials for the AWS Load Balancer Operator.
+<1> Specifies the ARN role to be used in the `CredentialsRequest` to provision the {aws-short} credentials for the {aws-short} Load Balancer Operator. An example for `<albo_role_arn>` is `arn:aws:iam::<aws_account_number>:role/albo-operator`.
 +
 [NOTE]
 ====
-The AWS Load Balancer Operator waits until the secret is created before moving to the `Available` status.
+The {aws-short} Load Balancer Operator waits until the secret is created before moving to the `Available` status.
 ====

--- a/modules/using-aws-cli-create-iam-role-alb-controller.adoc
+++ b/modules/using-aws-cli-create-iam-role-alb-controller.adoc
@@ -6,11 +6,11 @@
 [id="using-aws-cli-create-iam-role-alb-controller_{context}"]
 = Creating an AWS IAM role for the controller by using the AWS CLI
 
-You can use the AWS command line interface to create an AWS IAM role for the AWS Load Balancer Controller. An AWS IAM role is used to interact with subnets and Virtual Private Clouds (VPCs).
+You can use the {aws-short} command line interface to create an {aws-short} IAM role for the {aws-short} Load Balancer Controller. An {aws-short} IAM role is used to interact with subnets and Virtual Private Clouds (VPCs).
 
 .Prerequisites
 
-* You must have access to the AWS command line interface (`aws`).
+* You must have access to the {aws-short} command line interface (`aws`).
 
 .Procedure
 
@@ -25,12 +25,12 @@ $ cat <<EOF > albo-controller-trust-policy.json
         {
             "Effect": "Allow",
             "Principal": {
-                "Federated": "arn:aws:iam::777777777777:oidc-provider/<oidc-provider-id>" <1>
+                "Federated": "<oidc_arn>" <1>
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "<oidc-provider-id>:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-cluster" <2>
+                    "<cluster_oidc_endpoint>:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-cluster" <2>
                 }
             }
         }
@@ -38,10 +38,10 @@ $ cat <<EOF > albo-controller-trust-policy.json
 }
 EOF
 ----
-<1> Specifies the Amazon Resource Name (ARN) of the identity provider.
-<2> Specifies the service account for the AWS Load Balancer Controller.
+<1> Specifies the Amazon Resource Name (ARN) of the OIDC identity provider, such as `arn:aws:iam::777777777777:oidc-provider/rh-oidc.s3.us-east-1.amazonaws.com/28292va7ad7mr9r4he1fb09b14t59t4f`.
+<2> Specifies the service account for the {aws-short} Load Balancer Controller. An example of `<cluster_oidc_endpoint>` is `rh-oidc.s3.us-east-1.amazonaws.com/28292va7ad7mr9r4he1fb09b14t59t4f`.
 
-. Create an AWS IAM role with the generated trust policy by running the following command:
+. Create an {aws-short} IAM role with the generated trust policy by running the following command:
 +
 [source,terminal]
 ----
@@ -51,22 +51,22 @@ $ aws iam create-role --role-name albo-controller --assume-role-policy-document 
 .Example output
 [source,terminal]
 ----
-ROLE	arn:aws:iam::777777777777:role/albo-controller	2023-08-02T12:13:22Z <1>
+ROLE	arn:aws:iam::<aws_account_number>:role/albo-controller	2023-08-02T12:13:22Z <1>
 ASSUMEROLEPOLICYDOCUMENT	2012-10-17
 STATEMENT	sts:AssumeRoleWithWebIdentity	Allow
 STRINGEQUALS	system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-cluster
-PRINCIPAL	arn:aws:iam:777777777777:oidc-provider/<oidc-provider-id>
+PRINCIPAL	arn:aws:iam:<aws_account_number>:oidc-provider/<cluster_oidc_endpoint>
 ----
-<1> Note the ARN of an AWS IAM role.
+<1> Note the ARN of an {aws-short} IAM role for the {aws-short} Load Balancer Controller, such as `arn:aws:iam::777777777777:role/albo-controller`.
 
-. Download the permission policy for the AWS Load Balancer Controller by running the following command:
+. Download the permission policy for the {aws-short} Load Balancer Controller by running the following command:
 +
 [source,terminal]
 ----
 $ curl -o albo-controller-permission-policy.json https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/assets/iam-policy.json
 ----
 
-. Attach the permission policy for the AWS Load Balancer Controller to an AWS IAM role by running the following command:
+. Attach the permission policy for the {aws-short} Load Balancer Controller to an {aws-short} IAM role by running the following command:
 +
 [source,terminal]
 ----
@@ -84,8 +84,8 @@ metadata:
   name: cluster <2>
 spec:
   credentialsRequestConfig:
-    stsIAMRoleARN: <role-arn> <3>
+    stsIAMRoleARN: <albc_role_arn> <3>
 ----
 <1> Defines the `AWSLoadBalancerController` object.
-<2> Defines the AWS Load Balancer Controller name. All related resources use this instance name as a suffix.
-<3> Specifies the ARN role. The `CredentialsRequest` object uses this ARN role to provision the AWS credentials.
+<2> Defines the {aws-short} Load Balancer Controller name. All related resources use this instance name as a suffix.
+<3> Specifies the ARN role for the {aws-short} Load Balancer Controller. The `CredentialsRequest` object uses this ARN role to provision the {aws-short} credentials. An example of `<albc_role_arn>` is `arn:aws:iam::777777777777:role/albo-controller`.

--- a/modules/using-aws-cli-create-iam-role-alb-operator.adoc
+++ b/modules/using-aws-cli-create-iam-role-alb-operator.adoc
@@ -6,11 +6,11 @@
 [id="using-aws-cli-create-iam-role-alb-operator_{context}"]
 = Creating an AWS IAM role by using the AWS CLI
 
-You can use the AWS Command Line Interface to create an IAM role for the AWS Load Balancer Operator. The IAM role is used to interact with subnets and Virtual Private Clouds (VPCs).
+You can use the {aws-short} Command Line Interface to create an IAM role for the {aws-short} Load Balancer Operator. The IAM role is used to interact with subnets and Virtual Private Clouds (VPCs).
 
 .Prerequisites
 
-* You must have access to the AWS Command Line Interface (`aws`).
+* You must have access to the {aws-short} Command Line Interface (`aws`).
 
 .Procedure
 
@@ -25,12 +25,12 @@ $ cat <<EOF > albo-operator-trust-policy.json
         {
             "Effect": "Allow",
             "Principal": {
-                "Federated": "arn:aws:iam::777777777777:oidc-provider/<oidc-provider-id>" <1>
+                "Federated": "<oidc_arn>" <1>
             },
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "<oidc-provider-id>:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-operator-controller-manager" <2>
+                    "<cluster_oidc_endpoint>:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-cluster" <2>
                 }
             }
         }
@@ -38,8 +38,8 @@ $ cat <<EOF > albo-operator-trust-policy.json
 }
 EOF
 ----
-<1> Specifies the Amazon Resource Name (ARN) of the identity provider.
-<2> Specifies the service account for the AWS Load Balancer Operator.
+<1> Specifies the Amazon Resource Name (ARN) of the OIDC identity provider, such as `arn:aws:iam::777777777777:oidc-provider/rh-oidc.s3.us-east-1.amazonaws.com/28292va7ad7mr9r4he1fb09b14t59t4f`.
+<2> Specifies the service account for the {aws-short} Load Balancer Controller. An example of `<cluster_oidc_endpoint>` is `rh-oidc.s3.us-east-1.amazonaws.com/28292va7ad7mr9r4he1fb09b14t59t4f`.
 
 . Create the IAM role with the generated trust policy by running the following command:
 +
@@ -51,22 +51,22 @@ $ aws iam create-role --role-name albo-operator --assume-role-policy-document fi
 .Example output
 [source,terminal]
 ----
-ROLE	arn:aws:iam::777777777777:role/albo-operator	2023-08-02T12:13:22Z <1>
+ROLE	arn:aws:iam::<aws_account_number>:role/albo-operator	2023-08-02T12:13:22Z <1>
 ASSUMEROLEPOLICYDOCUMENT	2012-10-17
 STATEMENT	sts:AssumeRoleWithWebIdentity	Allow
 STRINGEQUALS	system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-manager
-PRINCIPAL	arn:aws:iam:777777777777:oidc-provider/<oidc-provider-id>
+PRINCIPAL	arn:aws:iam:<aws_account_number>:oidc-provider/<cluster_oidc_endpoint>
 ----
-<1> Note the ARN of the created IAM role.
+<1> Note the ARN of the created {aws-short} IAM role that was created for the {aws-short} Load Balancer Operator, such as `arn:aws:iam::777777777777:role/albo-operator`.
 
-. Download the permission policy for the AWS Load Balancer Operator by running the following command:
+. Download the permission policy for the {aws-short} Load Balancer Operator by running the following command:
 +
 [source,terminal]
 ----
 $ curl -o albo-operator-permission-policy.json https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/hack/operator-permission-policy.json
 ----
 
-. Attach the permission policy for the AWS Load Balancer Controller to the IAM role by running the following command:
+. Attach the permission policy for the {aws-short} Load Balancer Controller to the IAM role by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/using-ccoctl-create-iam-role-alb-controller.adoc
+++ b/modules/using-ccoctl-create-iam-role-alb-controller.adoc
@@ -6,7 +6,7 @@
 [id="using-ccoctl-create-iam-role-alb-controller_{context}"]
 = Creating an AWS IAM role for the controller by using the Cloud Credential Operator utility
 
-You can use the Cloud Credential Operator utility (`ccoctl`) to create an AWS IAM role for the AWS Load Balancer Controller. An AWS IAM role is used to interact with subnets and Virtual Private Clouds (VPCs).
+You can use the Cloud Credential Operator utility (`ccoctl`) to create an {aws-short} IAM role for the {aws-short} Load Balancer Controller. An {aws-short} IAM role is used to interact with subnets and Virtual Private Clouds (VPCs).
 
 .Prerequisites
 
@@ -18,28 +18,28 @@ You can use the Cloud Credential Operator utility (`ccoctl`) to create an AWS IA
 +
 [source,terminal]
 ----
-$ curl --create-dirs -o <credrequests-dir>/controller.yaml https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/hack/controller/controller-credentials-request.yaml
+$ curl --create-dirs -o <credentials_requests_dir>/controller.yaml https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/hack/controller/controller-credentials-request.yaml
 ----
 
-. Use the `ccoctl` utility to create an AWS IAM role by running the following command:
+. Use the `ccoctl` utility to create an {aws-short} IAM role by running the following command:
 +
 [source,terminal]
 ----
 $ ccoctl aws create-iam-roles \
     --name <name> \
     --region=<aws_region> \
-    --credentials-requests-dir=<credrequests-dir> \
-    --identity-provider-arn <oidc-arn>
+    --credentials-requests-dir=<credentials_requests_dir> \
+    --identity-provider-arn <oidc_arn>
 ----
 +
 .Example output
 [source,terminal]
 ----
 2023/09/12 11:38:57 Role arn:aws:iam::777777777777:role/<name>-aws-load-balancer-operator-aws-load-balancer-controller created <1>
-2023/09/12 11:38:57 Saved credentials configuration to: /home/user/<credrequests-dir>/manifests/aws-load-balancer-operator-aws-load-balancer-controller-credentials.yaml
+2023/09/12 11:38:57 Saved credentials configuration to: /home/user/<credentials_requests_dir>/manifests/aws-load-balancer-operator-aws-load-balancer-controller-credentials.yaml
 2023/09/12 11:38:58 Updated Role policy for Role <name>-aws-load-balancer-operator-aws-load-balancer-controller created
 ----
-<1> Note the Amazon Resource Name (ARN) of an AWS IAM role.
+<1> Note the Amazon Resource Name (ARN) of an {aws-short} IAM role that was created for the {aws-short} Load Balancer Controller, such as `arn:aws:iam::777777777777:role/<name>-aws-load-balancer-operator-aws-load-balancer-controller`.
 +
 [NOTE]
 ====

--- a/modules/using-ccoctl-create-iam-role-alb-operator.adoc
+++ b/modules/using-ccoctl-create-iam-role-alb-operator.adoc
@@ -6,7 +6,7 @@
 [id="using-ccoctl-create-iam-role-alb-operator_{context}"]
 = Creating an AWS IAM role by using the Cloud Credential Operator utility
 
-You can use the Cloud Credential Operator utility (`ccoctl`) to create an AWS IAM role for the AWS Load Balancer Operator. An AWS IAM role is used to interact with subnets and Virtual Private Clouds (VPCs).
+You can use the Cloud Credential Operator utility (`ccoctl`) to create an {aws-short} IAM role for the {aws-short} Load Balancer Operator. An {aws-short} IAM role interacts with subnets and Virtual Private Clouds (VPCs).
 
 .Prerequisites
 
@@ -18,30 +18,30 @@ You can use the Cloud Credential Operator utility (`ccoctl`) to create an AWS IA
 +
 [source,terminal]
 ----
-$ curl --create-dirs -o <credrequests-dir>/operator.yaml https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/hack/operator-credentials-request.yaml
+$ curl --create-dirs -o <credentials_requests_dir>/operator.yaml https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/hack/operator-credentials-request.yaml
 ----
 
-. Use the `ccoctl` utility to create an AWS IAM role by running the following command:
+. Use the `ccoctl` utility to create an {aws-short} IAM role by running the following command:
 +
 [source,terminal]
 ----
 $ ccoctl aws create-iam-roles \
     --name <name> \
     --region=<aws_region> \
-    --credentials-requests-dir=<credrequests-dir> \
-    --identity-provider-arn <oidc-arn>
+    --credentials-requests-dir=<credentials_requests_dir> \
+    --identity-provider-arn <oidc_arn>
 ----
 +
 .Example output
 [source,terminal]
 ----
 2023/09/12 11:38:57 Role arn:aws:iam::777777777777:role/<name>-aws-load-balancer-operator-aws-load-balancer-operator created <1>
-2023/09/12 11:38:57 Saved credentials configuration to: /home/user/<credrequests-dir>/manifests/aws-load-balancer-operator-aws-load-balancer-operator-credentials.yaml
+2023/09/12 11:38:57 Saved credentials configuration to: /home/user/<credentials_requests_dir>/manifests/aws-load-balancer-operator-aws-load-balancer-operator-credentials.yaml
 2023/09/12 11:38:58 Updated Role policy for Role <name>-aws-load-balancer-operator-aws-load-balancer-operator created
 ----
-<1> Note the Amazon Resource Name (ARN) of an AWS IAM role.
+<1> Note the Amazon Resource Name (ARN) of an {aws-short} IAM role that was created for the {aws-short} Load Balancer Operator, such as `arn:aws:iam::777777777777:role/<name>-aws-load-balancer-operator-aws-load-balancer-operator`.
 +
 [NOTE]
 ====
-The length of an AWS IAM role name must be less than or equal to 12 characters.
+The length of an {aws-short} IAM role name must be less than or equal to 12 characters.
 ====

--- a/networking/aws_load_balancer_operator/installing-albo-sts-cluster.adoc
+++ b/networking/aws_load_balancer_operator/installing-albo-sts-cluster.adoc
@@ -1,45 +1,74 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="albo-sts-cluster"]
-= Preparing for the AWS Load Balancer Operator on a cluster using the AWS {sts-full}
+= Installing the AWS Load Balancer Operator on a cluster that uses AWS STS
 :context: albo-sts-cluster
 
 toc::[]
 
-You can install the AWS Load Balancer Operator on a cluster that uses STS. Follow these steps to prepare your cluster before installing the Operator.
+You can install the {aws-first} Load Balancer Operator on a cluster that uses the {sts-first}. Follow these steps to prepare your cluster before installing the Operator.
 
-The AWS Load Balancer Operator relies on the `CredentialsRequest` object to bootstrap the Operator and the AWS Load Balancer Controller. The AWS Load Balancer Operator waits until the required secrets are created and available.
+The {aws-short} Load Balancer Operator relies on the `CredentialsRequest` object to bootstrap the Operator and the {aws-short} Load Balancer Controller. The {aws-short} Load Balancer Operator waits until the required secrets are created and available.
+
+[id="{context}_prerequisites"]
+== Prerequisites
+
+* You installed the {oc-first}.
+
+* You know the infrastructure ID of your cluster. To show this ID, run the following command in your CLI:
++
+[source,terminal]
+----
+$ oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}" 
+----
+
+* You know the OpenID Connect (OIDC) DNS information for your cluster. To show this information, enter the following command in your CLI:
++
+[source,terminal]
+----
+$ oc get authentication.config cluster -o=jsonpath="{.spec.serviceAccountIssuer}" <1>
+----
+<1> An OIDC DNS example is `https://rh-oidc.s3.us-east-1.amazonaws.com/28292va7ad7mr9r4he1fb09b14t59t4f`.
+
+* You logged into the {aws-short} Web Console, navigated to *IAM* -> *Access management* -> *Identity providers*, and located the OIDC Amazon Resource Name (ARN) information. An OIDC ARN example is `arn:aws:iam::777777777777:oidc-provider/<oidc_dns_url>`.
 
 [id="creating-iam-role-albo-operator_{context}"]
 == Creating an IAM role for the AWS Load Balancer Operator
 
-An additional AWS Identity and Access Management (IAM) role is required to successfully install the AWS Load Balancer Operator on a cluster that uses STS. The IAM role is required to interact with subnets and Virtual Private Clouds (VPCs). The AWS Load Balancer Operator generates the `CredentialsRequest` object with the IAM role to bootstrap itself.
+An additional {aws-first} Identity and Access Management (IAM) role is required to successfully install the {aws-short} Load Balancer Operator on a cluster that uses {sts-short}. The IAM role is required to interact with subnets and Virtual Private Clouds (VPCs). The {aws-short} Load Balancer Operator generates the `CredentialsRequest` object with the IAM role to bootstrap itself.
 
 You can create the IAM role by using the following options:
 
 * Using xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#cco-ccoctl-configuring_installing-aws-customizations[the Cloud Credential Operator utility (`ccoctl`)] and a predefined `CredentialsRequest` object.
-* Using the AWS CLI and predefined AWS manifests.
+* Using the {aws-short} CLI and predefined {aws-short} manifests.
 
-Use the AWS CLI if your environment does not support the `ccoctl` command.
+Use the {aws-short} CLI if your environment does not support the `ccoctl` command.
 
+// Creating an AWS IAM role by using the Cloud Credential Operator utility
 include::modules/using-ccoctl-create-iam-role-alb-operator.adoc[leveloffset=+2]
+
+// Creating an AWS IAM role by using the AWS CLI
 include::modules/using-aws-cli-create-iam-role-alb-operator.adoc[leveloffset=+2]
 
+// Configuring the ARN role for the AWS Load Balancer Operator
 include::modules/specifying-role-arn-albo-sts.adoc[leveloffset=+1]
 
 [id="creating-iam-role-albo-controller_{context}"]
 == Creating an IAM role for the AWS Load Balancer Controller
 
-The `CredentialsRequest` object for the AWS Load Balancer Controller must be set with a manually provisioned IAM role.
+The `CredentialsRequest` object for the {aws-short} Load Balancer Controller must be set with a manually provisioned IAM role.
 
 You can create the IAM role by using the following options:
 
 * Using xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#cco-ccoctl-configuring_installing-aws-customizations[the Cloud Credential Operator utility (`ccoctl`)] and a predefined `CredentialsRequest` object.
-* Using the AWS CLI and predefined AWS manifests.
+* Using the {aws-short} CLI and predefined {aws-short} manifests.
 
-Use the AWS CLI if your environment does not support the `ccoctl` command.
+Use the {aws-short} CLI if your environment does not support the `ccoctl` command.
 
+// Creating an AWS IAM role for the controller by using the Cloud Credential Operator utility
 include::modules/using-ccoctl-create-iam-role-alb-controller.adoc[leveloffset=+2]
+
+// Creating an AWS IAM role for the controller by using the AWS CLI
 include::modules/using-aws-cli-create-iam-role-alb-controller.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-38762](https://issues.redhat.com/browse/OCPBUGS-38762)

Link to docs preview:
* [Preparing for the AWS Load Balancer Operator on a cluster using the AWS Security Token Service - Enterprise](https://80881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/installing-albo-sts-cluster.html)
* [Preparing for the AWS Load Balancer Operator on a cluster using the AWS Security Token Service - ROSA](https://80881--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/aws-load-balancer-operator.html#aws-installing-an-aws-load-balancer-operator_aws-load-balancer-operator)

- [x] SME has approved this change. (Andrey Lebedev)
- [x] QE has approved this change (Shudi Li)

