### PR TITLE
Update restore-replace-stopped-etcd-member.adoc

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -134,6 +134,13 @@ After you turn off the quorum guard, the cluster might be unreachable for a shor
 etcd cannot tolerate any additional member failure when running with two members. Restarting either remaining member breaks the quorum and causes downtime in your cluster. The quorum guard protects etcd from restarts due to configuration changes that could cause downtime, so it must be disabled to complete this procedure.
 ====
 
+. Delete the affected node by running the following command:
++
+[source,terminal]
+----
+$ oc delete node <node_name>
+----
+
 . Remove the old secrets for the unhealthy etcd member that was removed.
 
 .. List the secrets for the unhealthy etcd member that was removed.

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -138,7 +138,7 @@ etcd cannot tolerate any additional member failure when running with two members
 +
 [source,terminal]
 ----
-$ oc delete node <node_name>
+$ oc delete node ip-10-0-131-183.ec2.internal
 ----
 
 . Remove the old secrets for the unhealthy etcd member that was removed.


### PR DESCRIPTION
Add the missing step in the RHOCP 4.12 documentation

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Add the missing step for replacing unhealthy etcd members in the RHOCP4 documentation
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
In RHOCP 4.13+ documentation [1], there is a step mentioned to delete the affected node by running the following command: $ oc delete node <node_name>

However this step is missing in the RHOCP 4.12 documentation [2] and older version documentation.

This step to delete the affected node by running the following command: "$ oc delete node <node_name>"{{ is required to replace }}an unhealthy etcd member whose machine is not running or whose node is not ready.

[1] RHOCP 4.13 documentation : https://docs.openshift.com/container-platform/4.13/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member

[2] RHOCP 4.12 documentation : https://docs.openshift.com/container-platform/4.12/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
RHOCP 4.12 

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11775

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[1] RHOCP 4.13 documentation : https://docs.openshift.com/container-platform/4.13/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member

[2] RHOCP 4.12 documentation : https://docs.openshift.com/container-platform/4.12/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
