### PR TITLE
OSDOCS#11775: Add missing step in 4.12 for replacing an unhealthy etcd member

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -134,6 +134,13 @@ After you turn off the quorum guard, the cluster might be unreachable for a shor
 etcd cannot tolerate any additional member failure when running with two members. Restarting either remaining member breaks the quorum and causes downtime in your cluster. The quorum guard protects etcd from restarts due to configuration changes that could cause downtime, so it must be disabled to complete this procedure.
 ====
 
+. Delete the affected node by running the following command:
++
+[source,terminal]
+----
+$ oc delete node <node_name>
+----
+
 . Remove the old secrets for the unhealthy etcd member that was removed.
 
 .. List the secrets for the unhealthy etcd member that was removed.


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-11775](https://issues.redhat.com/browse/OSDOCS-11775)

Link to docs [preview](https://80746--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member) Updated 8/26/24

QE review:
- [x ] QE has approved this change.

Additional information:
This PR adds a new Step #3 in the procedure published in 4.13+, but not in 4.12.