### PR TITLE
CMA add link to new Cron trigger docs

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-trigger-cron.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-cron.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nodes-cma-autoscaling-custom-trigger-cron_{context}"]
-= Understanding the cron trigger
+= Understanding the Cron trigger
 
 You can scale pods based on a time range. 
 
@@ -12,12 +12,12 @@ When the time range starts, the custom metrics autoscaler scales the pods associ
 
 [NOTE]
 ====
-The custom metrics autoscaler with cron trigger scales pods based only on the specified times and cannot scale pods on a daily, weekly, monthly, or yearly schedule.
+The custom metrics autoscaler with Cron trigger scales pods based only on the specified times and cannot scale pods on a daily, weekly, monthly, or yearly schedule.
 ====
 
 The following example scales the pods associated with this scaled object from `0` to `100` from 6:00 AM to 6:30 PM India Standard Time.
 
-.Example scaled object with a cron trigger
+.Example scaled object with a Cron trigger
 [source,yaml]
 ----
 apiVersion: keda.sh/v1alpha1
@@ -41,7 +41,7 @@ spec:
 ----
 <1> Specifies the minimum number of pods to scale down to at the end of the time frame.
 <2> Specifies the maximum number of replicas when scaling up. This value should be the same as `desiredReplicas`. The default is `100`.
-<3> Specifies a cron trigger.
+<3> Specifies a Cron trigger.
 <4> Specifies the timezone for the time frame. This value must be from the link:https://data.iana.org/time-zones/tzdb-2021a/zone1970.tab[IANA Time Zone Database].
 <5> Specifies the start of the time frame.
 <6> Specifies the end of the time frame.

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -61,16 +61,11 @@ Before installing this version of the Custom Metrics Autoscaler Operator, remove
 === New features and enhancements
 
 [id="nodes-pods-autoscaling-custom-rn-2141-new-ca_{context}"]
-==== Support for the cron trigger with the Custom Metrics Autoscaler Operator
+==== Support for the Cron trigger with the Custom Metrics Autoscaler Operator
 
 The Custom Metrics Autoscaler Operator can now use the Cron trigger to scale pods based on an hourly schedule. When your specified time frame starts, the Custom Metrics Autoscaler Operator scales pods to your desired amount. When the time frame ends, the Operator scales back down to the previous level.
 
-For more information, see link:https://keda.sh/docs/2.14/scalers/cron/[Cron] in the Keda documentation.
-
-////
-If I can get this module reviewed on time for CMA 2.14.1 GA, add this link in place of the Keda docs link.
-For more information, see xref: nodes/cma/nodes-cma-autoscaling-custom-trigger.html#nodes-cma-autoscaling-custom-trigger-cron_nodes-cma-autoscaling-custom-trigger[Understanding the cron trigger].
-////
+For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc#nodes-cma-autoscaling-custom-trigger-cron_nodes-cma-autoscaling-custom-trigger[Understanding the Cron trigger].
 
 [id="nodes-pods-autoscaling-custom-rn-2141-bugs_{context}"]
 === Bug fixes


### PR DESCRIPTION
The [docs for the new cron trigger feature](https://github.com/openshift/openshift-docs/pull/80708) in CMA 2.14.1 were not ready when I merged the [CMA 2.14.1 release notes](https://github.com/openshift/openshift-docs/pull/80725). In the release notes, I had a link to the upstream cron trigger docs. This PR replaces that link with a link to the OCP cron trigger docs.  

Preview
[Support for the cron trigger with the Custom Metrics Autoscaler Operator](https://80903--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2141-new-ca_nodes-cma-autoscaling-custom-rn) -- Link in _For more information..._ sentence.

No QE

