### PR TITLE
Adds a small procedure to completely remove CSO by deleting the CRD

### DIFF
--- a/modules/removing-cso-operator.adoc
+++ b/modules/removing-cso-operator.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * security/pod-vulnerability-scan.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="uninstalling-container-security-operator_{context}"]
+= Uninstalling the {rhq-cso}
+
+To uninstall the Container Security Operator, you must uninstall the Operator and delete the `imagemanifestvulns.secscan.quay.redhat.com` custom resource definition (CRD).
+
+.Procedure
+
+. On the {product-title} web console, click *Operators* -> *Installed Operators*.
+
+. Click the menu {kebab} of the Container Security Operator.
+
+. Click *Uninstall Operator*. 
+
+. Confirm your decision by clicking *Uninstall* in the popup window.
+
+. Use the CLI to delete the `imagemanifestvulns.secscan.quay.redhat.com` CRD.
+
+.. Remove the `imagemanifestvulns.secscan.quay.redhat.com` custom resource definition by entering the following command:
++
+[source,terminal]
+----
+$ oc delete customresourcedefinition imagemanifestvulns.secscan.quay.redhat.com
+----
++
+.Example output
++
+[source,terminal]
+----
+customresourcedefinition.apiextensions.k8s.io "imagemanifestvulns.secscan.quay.redhat.com" deleted
+----

--- a/security/pod-vulnerability-scan.adoc
+++ b/security/pod-vulnerability-scan.adoc
@@ -27,3 +27,4 @@ include::modules/security-pod-scan-cso-using.adoc[leveloffset=+1]
 
 //
 include::modules/security-pod-scan-query-cli.adoc[leveloffset=+1]
+include::modules/removing-cso-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
Simply uninstalling the CSO does not remove its CRD. Consequently, the Overview page on the Web Console still reports Image Vulnerabilities. 

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-38948

Link to docs preview:
https://80905--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/pod-vulnerability-scan.html#uninstalling-container-security-operator_pod-vulnerability-scan

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
