### PR TITLE
OSDOCS-11764 OCP Release Notes 4.15.29

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2740,7 +2740,32 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
-// 4.15.28 
+[id="ocp-4-15-29_{context}"]
+=== RHSA-2024:5439 - {product-title} 4.15.29 bug fix and security update
+
+Issued: 28 August 2024
+
+{product-title} release 4.15.29, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHBA-2024:5751[RHBA-2024:5751] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5754[RHSA-2024:5754] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.29 --pullspecs
+----
+
+[id="ocp-4-15-29-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the ordering of Network Interface Controllers (NICs) in the cloud provider was non-deterministic, which could result in the node using the wrong NIC for communication with the cluster. With this update, the ordering is now consistent. This fix prevents the random ordering that was causing the node networking fail. (link:https://issues.redhat.com/browse/OCPBUGS-38577[*OCPBUGS-38577*])
+
+[id="ocp-4-15-29-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.15.28
 [id="ocp-4-15-28_{context}"]
 === RHSA-2024:5439 - {product-title} 4.15.28 bug fix and security update
 
@@ -2776,7 +2801,7 @@ To update an {product-title} 4.15 cluster to this latest release, see xref:../up
 [id="ocp-4-15-27_{context}"]
 === RHSA-2024:5160 - {product-title} 4.15.27 bug fix and security update
 
-Issued: 2024-08-15
+Issued: 15 August 2024
 
 {product-title} release 4.15.27, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:5160[RHSA-2024:5160] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5163[RHBA-2024:5163] advisory.
 
@@ -2797,7 +2822,7 @@ The following enhancement is included in this z-stream release:
 [id="ocp-4-15-27-collecting-ingress-dates_{context}"]
 ===== Collecting Ingress controller certificate information
 
-* The Insights Operator now collects `NotBefore` and `NotAfter` date information about all Ingress Controller certificates and aggregates the information into a JSON file in the `aggregated/ingress_controllers_certs.json` path. (link:https://issues.redhat.com/browse/OCPBUGS-37672[*OCPBUGS-37672*])  
+* The Insights Operator now collects `NotBefore` and `NotAfter` date information about all Ingress Controller certificates and aggregates the information into a JSON file in the `aggregated/ingress_controllers_certs.json` path. (link:https://issues.redhat.com/browse/OCPBUGS-37672[*OCPBUGS-37672*])
 
 [id="ocp-4-15-27-bug-fixes_{context}"]
 ==== Bug fixes
@@ -2820,7 +2845,7 @@ To update an {product-title} 4.15 cluster to this latest release, see xref:../up
 [id="ocp-4-15-25_{context}"]
 === RHSA-2024:4955 - {product-title} 4.15.25 bug fix and security update
 
-Issued: 2024-08-07
+Issued: 7 August 2024
 
 {product-title} release 4.15.25, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4955[RHSA-2024:4955] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4958[RHSA-2024:4958] advisory.
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11764](https://issues.redhat.com/browse/OSDOCS-11764)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview](https://80914--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-29_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links will not work until August 28.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
