### PR TITLE
OCPBUGS#22828: Fixup source block formatting

### DIFF
--- a/modules/osdk-java-create-api-controller.adoc
+++ b/modules/osdk-java-create-api-controller.adoc
@@ -15,9 +15,9 @@ Use the Operator SDK CLI to create a custom resource definition (CRD) API and co
 [source,terminal]
 ----
 $ operator-sdk create api \
-    --plugins=quarkus \ <1>
-    --group=cache \ <2>
-    --version=v1 \ <3>
+    --plugins=quarkus \// <1>
+    --group=cache \// <2>
+    --version=v1 \// <3>
     --kind=Memcached <4>
 ----
 <1> Set the plugin flag to `quarkus`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: OCPBUGS-22828
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://80925--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/java/osdk-java-tutorial.html#osdk-create-project_osdk-java-tutorial (step 3)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

~QE review:~
~- [ ] QE has approved this change.~
Fixes formatting. No QE required.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
