### PR TITLE
[rhacs-docs-4.4] Fixed the command to download the roxctl binary on Linux and Mac OS 

### DIFF
--- a/modules/install-roxctl-cli-linux.adoc
+++ b/modules/install-roxctl-cli-linux.adoc
@@ -26,7 +26,7 @@ $ arch="$(uname -m | sed "s/x86_64//")"; arch="${arch:+-$arch}"
 +
 [source,terminal,subs=attributes+]
 ----
-$ curl -f -o roxctl "https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Linux/roxctl${arch}"
+$ curl -L -f -o roxctl "https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Linux/roxctl${arch}"
 ----
 
 . Make the `roxctl` binary executable:

--- a/modules/install-roxctl-cli-macos.adoc
+++ b/modules/install-roxctl-cli-macos.adoc
@@ -19,7 +19,7 @@ You can install the `roxctl` CLI binary on macOS by using the following procedur
 +
 [source,terminal,subs=attributes+]
 ----
-$ curl -f -O https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Darwin/roxctl
+$ curl -L -f -o roxctl "https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Darwin/roxctl${arch}"
 ----
 
 . Remove all extended attributes from the binary:


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/80855