### PR TITLE
[SRVCOM-2455] Add a mention of disconnected support

### DIFF
--- a/install/preparing-serverless-install.adoc
+++ b/install/preparing-serverless-install.adoc
@@ -13,6 +13,8 @@ For {ocp-product-title}:
 
 * {ServerlessProductName} is supported for installation in a restricted network environment.
 
+* {ServerlessProductName} is supported for disconnected installation, except for {FunctionsProductName}.
+
 * {ServerlessProductName} currently cannot be used in a multi-tenant configuration on a single cluster.
 
 


### PR DESCRIPTION
Version(s):
serverless-docs-1.33+

Issue:
https://issues.redhat.com/browse/SRVCOM-2455

Link to docs preview:
https://80936--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/preparing-serverless-install.html

QE review:
- [x] QE has approved this change.
