### PR TITLE
OBSDOCS-1279: Missing include statement for a file

### DIFF
--- a/observability/otel/otel-installing.adoc
+++ b/observability/otel/otel-installing.adoc
@@ -21,6 +21,8 @@ include::modules/otel-install-cli.adoc[leveloffset=+1]
 
 To schedule the OpenTelemetry pods on dedicated nodes, see link:https://access.redhat.com/solutions/7040771[How to deploy the different OpenTelemetry components on infra nodes using nodeSelector and tolerations in OpenShift 4]
 
+include::modules/otel-creating-required-RBAC-resources-automatically.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_otel-installing_{context}"]
 == Additional resources


### PR DESCRIPTION
The include line must have been lost during some rebase or merge conflict.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16, 4.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1279

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://80954--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-installing.html#otel-creating-required-RBAC-resources-automatically_install-otel

QE review:
- N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
