### PR TITLE
OSDOCS-11798: Move AWS local zone docs to AWS installation section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -202,6 +202,9 @@ Topics:
     File: uninstalling-cluster-aws
   - Name: Installation configuration parameters
     File: installation-config-parameters-aws
+  - Name: AWS Local Zone or Wavelength Zone tasks
+    File: aws-compute-edge-zone-tasks
+    Distros: openshift-enterprise
 - Name: Installing on Azure
   Dir: installing_azure
   Distros: openshift-origin,openshift-enterprise
@@ -650,9 +653,6 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Configuring additional devices in an IBM Z or IBM LinuxONE environment
   File: ibmz-post-install
-- Name: AWS Local Zone or Wavelength Zone tasks
-  File: aws-compute-edge-zone-tasks
-  Distros: openshift-enterprise
 ---
 Name: Updating clusters
 Dir: updating

--- a/installing/installing_aws/aws-compute-edge-zone-tasks.adoc
+++ b/installing/installing_aws/aws-compute-edge-zone-tasks.adoc
@@ -62,8 +62,8 @@ include::modules/machineset-creating.adoc[leveloffset=+3]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../installing/installing_aws/ipi/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster on AWS with compute nodes on AWS Local Zones]
-* xref:../installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc#installing-aws-wavelength-zone[Installing a cluster on AWS with compute nodes on AWS Wavelength Zones]
+* xref:../../installing/installing_aws/ipi/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster on AWS with compute nodes on AWS Local Zones]
+* xref:../../installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc#installing-aws-wavelength-zone[Installing a cluster on AWS with compute nodes on AWS Wavelength Zones]
 
 // Creating user workloads in AWS Local Zones or Wavelength Zones
 include::modules/installation-extend-edge-nodes-aws-local-zones.adoc[leveloffset=+1]
@@ -71,11 +71,11 @@ include::modules/installation-extend-edge-nodes-aws-local-zones.adoc[leveloffset
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../installing/installing_aws/ipi/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster on AWS with compute nodes on AWS Local Zones]
-* xref:../installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc#installing-aws-wavelength-zone[Installing a cluster on AWS with compute nodes on AWS Wavelength Zones]
-* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
+* xref:../../installing/installing_aws/ipi/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster on AWS with compute nodes on AWS Local Zones]
+* xref:../../installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc#installing-aws-wavelength-zone[Installing a cluster on AWS with compute nodes on AWS Wavelength Zones]
+* xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
 
 [id="next-steps_aws-zone-tasks"]
 == Next steps
 
-* Optional: Use the AWS Load Balancer (ALB) Operator to expose a pod from a targeted edge compute node to services that run inside of a {zone-type} subnet from a public network. See xref:../networking/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc#nw-installing-aws-load-balancer-operator_aws-load-balancer-operator[Installing the AWS Load Balancer Operator].
+* Optional: Use the AWS Load Balancer (ALB) Operator to expose a pod from a targeted edge compute node to services that run inside of a {zone-type} subnet from a public network. See xref:../../networking/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc#nw-aws-load-balancer-operator[Installing the AWS Load Balancer Operator].

--- a/installing/installing_aws/ipi/installing-aws-localzone.adoc
+++ b/installing/installing_aws/ipi/installing-aws-localzone.adoc
@@ -214,6 +214,5 @@ include::modules/machine-edge-pool-review-nodes.adoc[leveloffset=+2]
 
 .Next steps
 
-//* xref:../../../post_installation_configuration/aws-compute-edge-zone-tasks#installation-extend-edge-nodes-aws-local-zones_aws-compute-edge-zone-tasks[Creating user workloads in AWS Local Zones or Wavelength Zones]
 * xref:../../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health].

--- a/modules/edge-machine-pools-aws-local-zones.adoc
+++ b/modules/edge-machine-pools-aws-local-zones.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // * installing/installing_aws/installing-aws-localzone.adoc (Installing a cluster on AWS with compute nodes on AWS Local Zones)
 // * installing/installing_aws/installing-aws-wavelength.adoc (Installing a cluster on AWS with compute nodes on AWS Wavelength Zones)
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 
 ifeval::["{context}" == "installing-aws-localzone"]
 :local-zone:

--- a/modules/installation-aws-add-zone-locations.adoc
+++ b/modules/installation-aws-add-zone-locations.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-aws-localzone.adoc (Installing a cluster on AWS with worker nodes on AWS Local Zones)
-// * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with worker nodes on AWS Wavelength Zones) 
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with worker nodes on AWS Wavelength Zones)
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 
 ifeval::["{context}" == "installing-aws-localzone"]
 :local-zone:
@@ -74,7 +74,7 @@ $ aws ec2 modify-availability-zone-group \
     --group-name "<value_of_GroupName>" \// <1>
     --opt-in-status opted-in
 ----
-<1> Replace `<value_of_GroupName>` with the name of the group of the {zone-type} where you want to create subnets. 
+<1> Replace `<value_of_GroupName>` with the name of the group of the {zone-type} where you want to create subnets.
 ifdef::local-zone[]
 For example, specify `us-east-1-nyc-1` to use the zone `us-east-1-nyc-1a` (US East New York).
 endif::local-zone[]

--- a/modules/installation-cloudformation-subnet-localzone.adoc
+++ b/modules/installation-cloudformation-subnet-localzone.adoc
@@ -2,7 +2,7 @@
 //
 // * installing/installing-aws-localzone.adoc (Installing a cluster on AWS with worker nodes on AWS Local Zones)
 // * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with compute nodes on AWS Wavelength Zones)
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc (AWS zone tasks)
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 // * installing/installing_aws/ipi/installing-aws-outposts.adoc
 
 ifeval::["{context}" == "installing-aws-outposts"]

--- a/modules/installation-cloudformation-vpc-carrier-gw.adoc
+++ b/modules/installation-cloudformation-vpc-carrier-gw.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with worker nodes on AWS Wavelength Zones) 
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc (AWS zone tasks) 
+// * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with worker nodes on AWS Wavelength Zones)
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
 
 ifeval::["{context}" == "installing-aws-wavelength-zone"]
 :wavelength-zone:

--- a/modules/installation-creating-aws-vpc-carrier-gw.adoc
+++ b/modules/installation-creating-aws-vpc-carrier-gw.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with compute nodes on AWS Wavelength Zones)
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc (AWS zone tasks) 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
 
 ifeval::["{context}" == "installing-aws-wavelength-zone"]
 :wavelength-zone:
@@ -29,7 +29,7 @@ To create edge nodes or internet-facing load balancers in Wavelength Zones locat
 
 Carrier gateways exist for VPCs that only contain subnets in a Wavelength Zone.
 
-The following list explains the functions of a carrier gateway in the context of an AWS Wavelength Zones location: 
+The following list explains the functions of a carrier gateway in the context of an AWS Wavelength Zones location:
 
 * Provides connectivity between your Wavelength Zone and the carrier network, which includes any available devices from the carrier network.
 * Performs Network Address Translation (NAT) functions, such as translating IP addresses that are public IP addresses stored in a network border group, from Wavelength Zones to carrier IP addresses. These translation functions apply to inbound and outbound traffic.

--- a/modules/installation-extend-edge-nodes-aws-local-zones.adoc
+++ b/modules/installation-extend-edge-nodes-aws-local-zones.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-extend-edge-nodes-aws-local-zones_{context}"]
@@ -15,7 +15,7 @@ The installation program creates the compute machine set manifests file with `no
 [NOTE]
 ====
 The examples in the procedure are for a Local Zones infrastructure. If you are working with a Wavelength Zones infrastructure, ensure you adapt the examples to what is supported in this infrastructure.
-==== 
+====
 
 .Prerequisites
 

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -12,7 +12,7 @@
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
 // * post_installation_configuration/cluster-tasks.adoc
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix.adoc
 
 ifeval::["{context}" == "creating-windows-machineset-aws"]

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -2,7 +2,7 @@
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :infra:
@@ -29,7 +29,7 @@ This sample YAML defines a compute machine set that runs in the `us-east-1-nyc-1
 [NOTE]
 ====
 If you want to reference the sample YAML file in the context of Wavelength Zones, ensure that you replace the AWS Region and zone information with supported Wavelength Zone values.
-==== 
+====
 endif::[]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and

--- a/modules/nw-cluster-mtu-change-about.adoc
+++ b/modules/nw-cluster-mtu-change-about.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/changing-cluster-network-mtu.adoc
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-cluster-mtu-change-about_{context}"]

--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/changing-cluster-network-mtu.adoc
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
 // * installing/installing_aws/ipi/installing-aws-outposts.adoc
 
 ifeval::["{context}" == "aws-compute-edge-tasks-local-zone"]

--- a/modules/post-install-edge-aws-extend-machineset.adoc
+++ b/modules/post-install-edge-aws-extend-machineset.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
 
 :_mod-docs-content-type: PROCEDURE
 [id="post-install-edge-aws-extend-machineset"]
@@ -50,7 +50,7 @@ $ aws ec2 describe-availability-zones --region <value_of_Region> \// <1>
     }
 ]
 ----
-+ 
++
 .Example output for Wavelength Zone `us-east-1-wl1`
 [source,terminal]
 ----

--- a/modules/post-install-extend-existing-to-zone-type.adoc
+++ b/modules/post-install-extend-existing-to-zone-type.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
 
 :_mod-docs-content-type: CONCEPT
 [id="post-install-existing-local-zone-subnet_{context}"]
@@ -17,7 +17,7 @@ Extending nodes to Local Zones requires that you create the following resources:
 Extending nodes to Wavelength Zones requires that you create the following resources:
 
 * 1 VPC Carrier Gateway associated to the provided VPC ID.
-* 1 VPC Route Table for Wavelength Zones with a default route entry to VPC Carrier Gateway. 
+* 1 VPC Route Table for Wavelength Zones with a default route entry to VPC Carrier Gateway.
 * 2 VPC Subnets: public and private. The public subnet associates to the public route table for an AWS Wavelength Zone. The private subnet associates to the provided route table ID.
 
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-11798

Link to docs preview:
- https://80955--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks.html

QE review:
- N/A moving existing content only, no content changes

FYI @bscott-rh 