### PR TITLE
OLS-970: corrected spelling of language specifiers

### DIFF
--- a/modules/cert-manager-configure-cpu-memory.adoc
+++ b/modules/cert-manager-configure-cpu-memory.adoc
@@ -124,7 +124,7 @@ spec:
 <12> Defines the amount of CPU and memory set by scheduler for the Webhook pod.
 +
 .Example output
-[source,termnal]
+[source,terminal]
 ----
 certmanager.operator.openshift.io/cluster patched
 ----

--- a/modules/connected-to-disconnected-verify.adoc
+++ b/modules/connected-to-disconnected-verify.adoc
@@ -20,7 +20,7 @@ $ oc get pods --all-namespaces
 ----
 +
 .Example output
-[source,terinal]
+[source,terminal]
 ----
 NAMESPACE                                          NAME                                                          READY   STATUS      RESTARTS   AGE
 kube-system                                        apiserver-watcher-ci-ln-47ltxtb-f76d1-mrffg-master-0          1/1     Running     0          39m

--- a/modules/describe-function-kn.adoc
+++ b/modules/describe-function-kn.adoc
@@ -8,7 +8,7 @@ The `kn func info` command prints information about a deployed function, such as
 
 * Describe a function:
 +
-[source,termnal]
+[source,terminal]
 ----
 $ kn func info [-f <format> -n <namespace> -p <path>]
 ----

--- a/modules/images-test-s2i.adoc
+++ b/modules/images-test-s2i.adoc
@@ -44,7 +44,7 @@ The S2I tooling comes with powerful generation tools to speed up the process of
 creating a new S2I image. The `s2i create` command produces all the necessary S2I
 scripts and testing tools along with the `Makefile`:
 
-[source,termnal]
+[source,terminal]
 ----
 $ s2i create _<image name>_ _<destination directory>_
 ----

--- a/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
+++ b/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
@@ -16,7 +16,7 @@ If the `provisioning` network is enabled and you want to expand the cluster usin
 
 . Edit the `provisioning` custom resource (CR) to enable deploying with Virtual Media on the `baremetal` network:
 +
-[source,terminmal]
+[source,terminal]
 ----
 oc edit provisioning
 ----

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -189,7 +189,7 @@ $ cat <path>/<file_name>.pub
 +
 For example, run the following to view the `~/.ssh/id_ed25519.pub` public key:
 +
-[source,termanal]
+[source,terminal]
 ----
 $ cat ~/.ssh/id_ed25519.pub
 ----

--- a/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
+++ b/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
@@ -30,7 +30,7 @@ When creating your plugin, follow these general guidelines:
 * Maintain a consistent look, feel, and behavior with other console pages.
 * Follow link:https://www.i18next.com/[react-i18next] localization guidelines when creating your plugin. You can use the `useTranslation` hook like the one in the following example:
 +
-[source,ymal]
+[source,typescript]
 ----
 conster Header: React.FC = () => {
   const { t } = useTranslation('plugin__console-demo-plugin');


### PR DESCRIPTION
Corrected spelling of language specifiers. This is needed in OpenShift Lightspeed for correct content rendering.

Version(s):
4.x

Issue:
https://issues.redhat.com/browse/OLS-970

Link to docs preview:
?

QE review:
- [ ] QE has approved this change.