### PR TITLE
OSDOCS-10290: machine mgmt for Alicloud removal 4.16 RN updates

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1622,6 +1622,26 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
+=== Machine management deprecated and removed features
+
+.Machine management deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.14 |4.15 |4.16
+
+|Managing machine with Machine API for {alibaba}
+|Technology Preview
+|Technology Preview
+|Removed
+
+|Cloud controller manager for {alibaba}
+|Technology Preview
+|Technology Preview
+|Removed
+
+|====
+
+[discrete]
 === Storage deprecated and removed features
 
 .Storage deprecated and removed tracker
@@ -1882,6 +1902,12 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 |`flowcontrol.apiserver.k8s.io/v1` or `flowcontrol.apiserver.k8s.io/v1beta3`
 |link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v129[Yes]
 |===
+
+[id="ocp-4-16-removed-features-alicloud-machine-management_{context}"]
+==== Managing machine with Machine API for {alibaba}
+
+{product-title} {product-version} removes support for managing machines with Machine API for {alibaba} clusters.
+This change includes removing support for the cloud controller manager for {alibaba}, which was previously a Technology Preview feature.
 
 //[id="ocp-4-16-future-deprecation"]
 //=== Notice of future deprecation
@@ -3140,7 +3166,7 @@ In the following tables, features are marked with the following statuses:
 |Cloud controller manager for {alibaba}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|Removed
 
 |Cloud controller manager for {gcp-full}
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10290](https://issues.redhat.com//browse/OSDOCS-10290)

Link to docs preview:
* [Deprecated and removed features](https://80970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-deprecated-removed-features_release-notes) (Machine management deprecated and removed features)
* [Managing machine with Machine API for Alibaba Cloud](https://80970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-removed-features-alicloud-machine-management_release-notes)
* [Technology Preview features status](https://80970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-technology-preview-tables_release-notes) (Machine management Technology Preview features)

QE review:
- [x] QE has approved this change.

Change management acks:
- [x] PX
- [x] QA engg
- [x] Dev engg
- [x] PM
- [x] Docs

Additional information:
Missed in 4.16, requires change mgmt
Content removal in #80824 
4.17 RN update in #80829