### PR TITLE
OSDOCS-11167: LVMS CSI and volume snapshot deployment is made optiona…

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -58,6 +58,10 @@ With this release, you can run {microshift-short} and your workloads with either
 ==== Resource footprint reduction for LVM storage driver now available
 With this release, the resource footprint of the LVM storage driver is significantly reduced, particularly in terms of memory consumption.
 
+[id="microshift-4-17-LVMS-volume-snapshot-deployment-optional_{context}"]
+==== Disabling and uninstalling LVM Storage CSI provider and CSI snapshot deployments now available
+With this release, {microshift-short} can now be configured to disable and uninstall the container storage interface (CSI) provider or the CSI snapshot capabilities which can reduce the use of runtime resources such as RAM, CPU, and storage. See xref:../microshift_storage/microshift-storage-plugin-overview.adoc#microshift-disabling-uninstalling-lvms-csi-snapshot_microshift-storage-plugin-overview[Disabling and uninstalling LVMS CSI provider and CSI snapshot deployments].
+
 [id="microshift-4-17-running-apps_{context}"]
 === Running applications
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11167](https://issues.redhat.com/browse/OSDOCS-11167)

Link to docs preview:
[LVMS CSI provider and CSI snapshot deployments are now configurable](https://80995--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-storage_release-notes)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Additional information:
related to PR https://github.com/openshift/openshift-docs/pull/80823
