### PR TITLE
TELCODOCS-1841: Configuring disk encryption with PCR protection

### DIFF
--- a/edge_computing/ztp-deploying-far-edge-sites.adoc
+++ b/edge_computing/ztp-deploying-far-edge-sites.adoc
@@ -55,6 +55,8 @@ include::modules/ztp-sno-siteconfig-config-reference.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-disk-encryption_sno-configure-for-vdu[About disk encryption with TPM and PCR protection].
+
 * xref:../edge_computing/ztp-advanced-install-ztp.adoc#ztp-customizing-the-install-extra-manifests_ztp-advanced-install-ztp[Customizing extra installation manifests in the {ztp} pipeline]
 
 * xref:../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster[Preparing the {ztp} site configuration repository]

--- a/edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
+++ b/edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
@@ -30,6 +30,15 @@ include::modules/ztp-enabling-workload-partitioning-sno.adoc[leveloffset=+1]
 
 * For the recommended {sno} workload partitioning configuration, see xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-enabling-workload-partitioning_sno-configure-for-vdu[Workload partitioning].
 
+include::modules/ztp-sno-du-disk-encryption.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../security/network_bound_disk_encryption/nbde-about-disk-encryption-technology.adoc#nbde-tpm-encryption_nbde-implementation[TPM encryption]
+
+* For information about enabling disk encryption, see xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-configuring-disk-encryption-with-pcr-protection_sno-configure-for-vdu[Enabling disk encryption with TPM and PCR protection].
+
 [id="ztp-sno-install-time-cluster-config"]
 == Recommended cluster install manifests
 
@@ -55,6 +64,13 @@ include::modules/ztp-sno-du-enabling-kdump.adoc[leveloffset=+2]
 include::modules/ztp-sno-du-disabling-crio-wipe.adoc[leveloffset=+2]
 
 include::modules/ztp-sno-du-configuring-crun-container-runtime.adoc[leveloffset=+2]
+
+include::modules/ztp-sno-du-configuring-disk-encryption-with-pcr-protection.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-disk-encryption_sno-configure-for-vdu[About disk encryption with TPM and PCR protection]
 
 [id="ztp-sno-post-install-time-cluster-config"]
 == Recommended postinstallation cluster configurations

--- a/modules/ztp-sno-du-configuring-disk-encryption-with-pcr-protection.adoc
+++ b/modules/ztp-sno-du-configuring-disk-encryption-with-pcr-protection.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ztp-sno-du-configuring-disk-encryption-with-pcr-protection_{context}"]
+= Enabling disk encryption with TPM and PCR protection
+
+You can use the `diskEncryption` field in the `SiteConfig` custom resource (CR) to configure disk encryption with Trusted Platform Module (TPM) and Platform Configuration Registers (PCRs) protection. 
+
+Configuring the `SiteConfig` CR enables disk encryption at the time of cluster installation.
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+* You have logged in as a user with `cluster-admin` privileges.
+* You read the "About disk encryption with TPM and PCR protection" section.
+
+.Procedure
+
+* Configure the `spec.clusters.diskEncryption` field in the `SiteConfig` CR:
++
+.Recommended `SiteConfig` CR configuration to enable disk encryption with PCR protection
+[source,yaml]
+----
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "encryption-tpm2"
+  namespace: "encryption-tpm2"
+spec:
+  clusters:
+  - clusterName: "encryption-tpm2"
+    clusterImageSetNameRef: "openshift-v4.13.0"
+    diskEncryption: 
+      type: "tpm2" <1>
+      tpm2:
+        pcrList: "1,7" <2>
+    nodes:
+      - hostName: "node1"
+        role: master
+----
+<1> Set the disk encryption type to `tpm2`.
+<2> Configure the list of PCRs to be used for disk encryption. You must use PCR registers 1 and 7.
+
+.Verification
+
+* Check that the disk encryption with TPM and PCR protection is enabled by running the following command:
++
+[source,terminal]
+----
+$ clevis luks list -d <disk_path> <1>
+----
+<1> Replace `<disk_path>` with the path to the disk. For example, `/dev/sda4`.
++
+.Example output
+[source,terminal]
+----
+1: tpm2 '{"hash":"sha256","key":"ecc","pcr_bank":"sha256","pcr_ids":"1,7"}'
+----

--- a/modules/ztp-sno-du-disk-encryption.adoc
+++ b/modules/ztp-sno-du-disk-encryption.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ztp-sno-du-disk-encryption_{context}"]
+= About disk encryption with TPM and PCR protection
+
+You can use the `diskEncryption` field in the `SiteConfig` custom resource (CR) to configure disk encryption with Trusted Platform Module (TPM) and Platform Configuration Registers (PCRs) protection. 
+
+TPM is a hardware component that stores cryptographic keys and evaluates the security state of your system. PCRs within the TPM store hash values that represent the current hardware and software configuration of your system. You can use the following PCR registers to protect the encryption keys for disk encryption:
+
+PCR 1:: Represents the Unified Extensible Firmware Interface (UEFI) state.
+PCR 7:: Represents the secure boot state. 
+
+The TPM safeguards encryption keys by linking them to the system's current state, as recorded in PCR 1 and PCR 7. The `dmcrypt` utility uses these keys to encrypt the disk. The binding between the encryption keys and the expected PCR registers is automatically updated after upgrades, if needed.
+
+During the system boot process, the `dmcrypt` utility uses the TPM PCR values to unlock the disk. If the current PCR values match with the previously linked values, the unlock succeeds. If the PCR values do not match, the encryption keys cannot be released, and the disk remains encrypted and inaccessible.
+
+:FeatureName: Configuring disk encryption by using the `diskEncryption` field in the `SiteConfig` CR
+include::snippets/technology-preview.adoc[]
+:!FeatureName:

--- a/modules/ztp-sno-siteconfig-config-reference.adoc
+++ b/modules/ztp-sno-siteconfig-config-reference.adoc
@@ -49,6 +49,22 @@ For example, `acmpolicygenerator/acm-common-ranGen.yaml` applies to all clusters
 |`spec.clusters.crTemplates.KlusterletAddonConfig`
 |Optional. Set `KlusterletAddonConfig` to `KlusterletAddonConfigOverride.yaml to override the default `KlusterletAddonConfig` that is created for the cluster.
 
+|`spec.clusters.diskEncryption`
+a|Configure this field to enable disk encryption with Trusted Platform Module (TPM) and Platform Configuration Registers (PCRs) protection. For more information, see "About disk encryption with TPM and PCR protection".
+[NOTE]
+====
+Configuring disk encryption by using the `diskEncryption` field in the `SiteConfig` CR is a Technology Preview feature in {product-title} 4.17.
+====
+
+|`spec.clusters.diskEncryption.type`
+|Set the disk encryption type to `tpm2`.
+
+|`spec.clusters.diskEncryption.tpm2`
+|Configure the Platform Configuration Registers (PCRs) protection for disk encryption.
+
+|`spec.clusters.diskEncryption.tpm2.pcrList`
+|Configure the list of Platform Configuration Registers (PCRs) to be used for disk encryption. You must use PCR registers 1 and 7.
+
 |`spec.clusters.nodes.hostName`
 |For single-node deployments, define a single host.
 For three-node deployments, define three hosts.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-1841](https://issues.redhat.com/browse/TELCODOCS-1841)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Single-node OpenShift SiteConfig CR installation reference](https://80996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-sites.html#ztp-sno-siteconfig-config-reference_ztp-deploying-far-edge-sites)
- [About disk encryption with PCR protection](https://80996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-disk-encryption_sno-configure-for-vdu)
- [Enabling disk encryption with PCR protection](https://80996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-configuring-disk-encryption-with-pcr-protection_sno-configure-for-vdu)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->