### PR TITLE
TELCODOCS#1996: Configuring IPsec encryption for multi-node OpenShift clusters

### DIFF
--- a/edge_computing/ztp-deploying-far-edge-sites.adoc
+++ b/edge_computing/ztp-deploying-far-edge-sites.adoc
@@ -44,11 +44,28 @@ include::modules/ztp-configuring-ipsec-using-ztp-and-siteconfig.adoc[leveloffset
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-verifying-ipsec_ztp-deploying-far-edge-sites[Verifying the IPsec encryption]
+
 * xref:../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
 
 * xref:../networking/network_security/configuring-ipsec-ovn.adoc#nw-ovn-ipsec-encryption_configuring-ipsec-ovn[Encryption protocol and IPsec mode]
 
 * xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-deploying-far-edge-sites[Installing managed clusters with {rh-rhacm} and SiteConfig resources]
+
+include::modules/ztp-configuring-ipsec-using-ztp-and-siteconfig-for-mno.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-verifying-ipsec_ztp-deploying-far-edge-sites[Verifying the IPsec encryption]
+
+* xref:../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
+
+* xref:../networking/network_security/configuring-ipsec-ovn.adoc#nw-ovn-ipsec-encryption_configuring-ipsec-ovn[Encryption protocol and IPsec mode]
+
+* xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-deploying-far-edge-sites[Installing managed clusters with {rh-rhacm} and SiteConfig resources]
+
+include::modules/ztp-verifying-ipsec.adoc[leveloffset=+2]
 
 include::modules/ztp-sno-siteconfig-config-reference.adoc[leveloffset=+2]
 

--- a/modules/ztp-configuring-ipsec-using-ztp-and-siteconfig-for-mno.adoc
+++ b/modules/ztp-configuring-ipsec-using-ztp-and-siteconfig-for-mno.adoc
@@ -2,17 +2,12 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc
 
-:_module-type: PROCEDURE
-[id="ztp-configuring-ipsec-using-ztp-and-siteconfig_{context}"]
-= Configuring IPsec encryption for {sno} clusters using {ztp} and SiteConfig resources
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-configuring-ipsec-using-ztp-and-siteconfig-for-mno_{context}"]
+= Configuring IPsec encryption for multi-node clusters using {ztp} and SiteConfig resources
 
-You can enable IPsec encryption in managed {sno} clusters that you install using {ztp} and {rh-rhacm-first}.
+You can enable IPsec encryption in managed multi-node clusters that you install using {ztp} and {rh-rhacm-first}.
 You can encrypt traffic between the managed cluster and IPsec endpoints external to the managed cluster. All network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec in Transport mode.
-
-[IMPORTANT]
-====
-You can also configure IPsec encryption for {sno} clusters with an additional worker node by following this procedure. It is recommended to use the `MachineConfig` custom resource (CR) to configure IPsec encryption for {sno} clusters and {sno} clusters with an additional worker node because of their low resource availability. 
-====
 
 .Prerequisites
 
@@ -29,29 +24,59 @@ The repository must be accessible from the hub cluster and be defined as a sourc
 
 * You have a PKCS#12 certificate for the IPsec endpoint and a CA cert in PEM format.
 
+* You have installed the NMState Operator.
+
 .Procedure
 
 . Extract the latest version of the `ztp-site-generate` container source and merge it with your repository where you manage your custom site configuration data.
 
-. Configure `optional-extra-manifest/ipsec/ipsec-endpoint-config.yaml` with the required values that configure IPsec in the cluster. For example:
+. Configure the `optional-extra-manifest/ipsec/ipsec-config-policy.yaml` file with the required values that configure IPsec in the cluster.
 +
+.`ConfigurationPolicy` object for creating an IPsec configuration
 [source,yaml]
 ----
-interfaces:
-- name: hosta_conn
-  type: ipsec
-  libreswan:
-    left: '%defaultroute'
-    leftid: '%fromcert'
-    leftmodecfgclient: false
-    leftcert: left_server <1>
-    leftrsasigkey: '%cert'
-    right: <external_host> <2>
-    rightid: '%fromcert'
-    rightrsasigkey: '%cert'
-    rightsubnet: <external_address> <3>
-    ikev2: insist <4>
-    type: tunnel
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-config
+spec:
+  namespaceSelector:
+    include: ["default"]
+    exclude: []
+    matchExpressions: []
+    matchLabels: {}
+  remediationAction: inform
+  severity: low
+  evaluationInterval:
+    compliant:
+    noncompliant:
+  object-templates-raw: |
+    {{- range (lookup "v1" "Node" "" "").items }}
+    - complianceType: musthave
+      objectDefinition:
+        kind: NodeNetworkConfigurationPolicy
+        apiVersion: nmstate.io/v1
+        metadata:
+          name: {{ .metadata.name }}-ipsec-policy
+        spec:
+          nodeSelector:
+            kubernetes.io/hostname: {{ .metadata.name }}
+          desiredState:
+            interfaces:
+            - name: hosta_conn
+              type: ipsec
+              libreswan:
+                left: '%defaultroute'
+                leftid: '%fromcert'
+                leftmodecfgclient: false
+                leftcert: left_server <1>
+                leftrsasigkey: '%cert'
+                right: <external_host> <2>
+                rightid: '%fromcert'
+                rightrsasigkey: '%cert'
+                rightsubnet: <external_address> <3>
+                ikev2: insist <4>
+                type: tunnel
 ----
 <1> The value of this field must match with the name of the certificate used on the remote system.
 <2> Replace `<external_host>` with the external host IP address or DNS hostname.
@@ -68,7 +93,7 @@ The certificate files are required for the Network Security Services (NSS) datab
 
 . Open a shell prompt at the `optional-extra-manifest/ipsec` folder of the Git repository where you maintain your custom site configuration data.
 
-. Run the `optional-extra-manifest/ipsec/build.sh` script to generate the required Butane and `MachineConfig` CRs files.
+. Run the `optional-extra-manifest/ipsec/import-certs.sh` script to generate the required Butane and `MachineConfig` CRs to import the external certs.
 +
 If the PKCS#12 certificate is protected with a password, set the `-W` argument.
 +
@@ -80,48 +105,48 @@ out
       └── example
            └── optional-extra-manifest
                 └── ipsec
-                     ├── 99-ipsec-master-endpoint-config.bu <1>
-                     ├── 99-ipsec-master-endpoint-config.yaml <1>
-                     ├── 99-ipsec-worker-endpoint-config.bu <1>
-                     ├── 99-ipsec-worker-endpoint-config.yaml <1>
-                     ├── build.sh
+                     ├── 99-ipsec-master-import-certs.bu <1> 
+                     ├── 99-ipsec-master-import-certs.yaml <1>
+                     ├── 99-ipsec-worker-import-certs.bu <1>
+                     ├── 99-ipsec-worker-import-certs.yaml <1>
+                     ├── import-certs.sh
                      ├── ca.pem <2>
                      ├── left_server.p12 <2>
                      ├── enable-ipsec.yaml
-                     ├── ipsec-endpoint-config.yml
+                     ├── ipsec-config-policy.yaml
                      └── README.md
 ----
-<1> The `ipsec/build.sh` script generates the Butane and endpoint configuration CRs.
-<2> You provide `ca.pem` and `left_server.p12` certificate files that are relevant to your network.
+<1> The `ipsec/import-certs.sh` script generates the Butane and endpoint configuration CRs.
+<2> Add the `ca.pem` and `left_server.p12` certificate files that are relevant to your network.
 
-. Create a `custom-manifest/` folder in the repository where you manage your custom site configuration data.
-Add the `enable-ipsec.yaml` and `99-ipsec-*` YAML files to the directory.
-For example:
+. Create a `custom-manifest/` folder in the repository where you manage your custom site configuration data and add the `enable-ipsec.yaml` and `99-ipsec-*` YAML files to the directory.
 +
+.Example `siteconfig` directory
 [source,terminal]
 ----
 siteconfig
-  ├── site1-sno-du.yaml
+  ├── site1-mno-du.yaml
   ├── extra-manifest/
   └── custom-manifest
         ├── enable-ipsec.yaml
-        ├── 99-ipsec-worker-endpoint-config.yaml
-        └── 99-ipsec-master-endpoint-config.yaml
+        ├── 99-ipsec-master-import-certs.yaml
+        └── 99-ipsec-worker-import-certs.yaml
 ----
 
-. In your `SiteConfig` CR, add the `custom-manifest/` directory to the `extraManifests.searchPaths` field.
-For example:
+. In your `SiteConfig` CR, add the `custom-manifest/` directory to the `extraManifests.searchPaths` field, as in the following example:
 +
 [source,yaml]
 ----
 clusters:
-- clusterName: "site1-sno-du"
+- clusterName: "site1-mno-du"
   networkType: "OVNKubernetes"
   extraManifests:
     searchPaths:
       - extra-manifest/
       - custom-manifest/
 ----
+
+. Include the `ipsec-config-policy.yaml` config policy file in the `source-crs` directory in GitOps and reference the file in one of the `PolicyGenerator` CRs.
 
 . Commit the `SiteConfig` CR changes and updated files in your Git repository and push the changes to provision the managed cluster and configure IPsec encryption.
 +

--- a/modules/ztp-verifying-ipsec.adoc
+++ b/modules/ztp-verifying-ipsec.adoc
@@ -1,0 +1,96 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-verifying-ipsec_{context}"]
+= Verifying the IPsec encryption
+
+You can verify that the IPsec encryption is successfully applied in a managed {product-title} cluster.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in to the hub cluster as a user with `cluster-admin` privileges.
+
+* You have configured the IPsec encryption.
+
+.Procedure
+
+. Start a debug pod for the managed cluster by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Check that the IPsec policy is applied in the cluster node by running the following command:
++
+[source,terminal]
+----
+sh-5.1# ip xfrm policy
+----
++
+.Example output
+[source,terminal]
+----
+src 172.16.123.0/24 dst 10.1.232.10/32
+  dir out priority 1757377 ptype main
+  tmpl src 10.1.28.190 dst 10.1.232.10
+    proto esp reqid 16393 mode tunnel
+src 10.1.232.10/32 dst 172.16.123.0/24
+  dir fwd priority 1757377 ptype main
+  tmpl src 10.1.232.10 dst 10.1.28.190
+    proto esp reqid 16393 mode tunnel
+src 10.1.232.10/32 dst 172.16.123.0/24
+  dir in priority 1757377 ptype main
+  tmpl src 10.1.232.10 dst 10.1.28.190
+    proto esp reqid 16393 mode tunnel
+----
+
+. Check that the IPsec tunnel is up and connected by running the following command:
++
+[source,terminal]
+----
+sh-5.1# ip xfrm state
+----
++
+.Example output
+[source,terminal]
+----
+src 10.1.232.10 dst 10.1.28.190
+  proto esp spi 0xa62a05aa reqid 16393 mode tunnel
+  replay-window 0 flag af-unspec esn
+  auth-trunc hmac(sha1) 0x8c59f680c8ea1e667b665d8424e2ab749cec12dc 96
+  enc cbc(aes) 0x2818a489fe84929c8ab72907e9ce2f0eac6f16f2258bd22240f4087e0326badb
+  anti-replay esn context:
+   seq-hi 0x0, seq 0x0, oseq-hi 0x0, oseq 0x0
+   replay_window 128, bitmap-length 4
+   00000000 00000000 00000000 00000000
+src 10.1.28.190 dst 10.1.232.10
+  proto esp spi 0x8e96e9f9 reqid 16393 mode tunnel
+  replay-window 0 flag af-unspec esn
+  auth-trunc hmac(sha1) 0xd960ddc0a6baaccb343396a51295e08cfd8aaddd 96
+  enc cbc(aes) 0x0273c02e05b4216d5e652de3fc9b3528fea94648bc2b88fa01139fdf0beb27ab
+  anti-replay esn context:
+   seq-hi 0x0, seq 0x0, oseq-hi 0x0, oseq 0x0
+   replay_window 128, bitmap-length 4
+   00000000 00000000 00000000 00000000
+----
+
+. Ping a known IP in the external host subnet by running the following command:
+For example, ping an IP address in the `rightsubnet` range that you set in the `ipsec/ipsec-endpoint-config.yaml` file:
++
+[source,terminal]
+----
+sh-5.1# ping 172.16.110.8
+----
++
+.Example output
+[source,terminal]
+----
+PING 172.16.110.8 (172.16.110.8) 56(84) bytes of data.
+64 bytes from 172.16.110.8: icmp_seq=1 ttl=64 time=153 ms
+64 bytes from 172.16.110.8: icmp_seq=2 ttl=64 time=155 ms
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-1996](https://issues.redhat.com/browse/TELCODOCS-1996)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Configuring IPsec encryption for multi-node OpenShift clusters using GitOps ZTP and SiteConfig resources](https://80997--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-sites.html#ztp-configuring-ipsec-using-ztp-and-siteconfig-for-mno_ztp-deploying-far-edge-sites)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->