### PR TITLE
OBSDOCS-1286 Release notes for COO 0.3.2

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -16,6 +16,26 @@ The {coo-short} complements the built-in monitoring capabilities of {product-tit
 
 These release notes track the development of the {coo-full} in {product-title}.
 
+[id="cluster-observability-operator-release-notes-0-3-2_{context}"]
+== {coo-full} 0.3.2
+
+The following advisory is available for {coo-full} 0.3.2:
+
+* link:https://access.redhat.com/errata/RHEA-2024:5985[RHEA-2024:5985 {coo-full} 0.3.2]
+
+
+[id="cluster-observability-operator-0-3-2-new-features-enhancements_{context}"]
+=== New features and enhancements
+
+* With this release, you can now use tolerations and node selectors with `MonitoringStack` components.
+
+
+[id="cluster-observability-operator-0-3-2-bug-fixes_{context}"]
+=== Bug fixes
+
+* Previously, the logging UIPlugin was not in the `Available` state and the logging pod was not created, when installed on a specific version of {product-title}.
+This release resolves the issue. (link:https://issues.redhat.com/browse/COO-260[*COO-260*])
+
 [id="cluster-observability-operator-release-notes-0-3-0"]
 == {coo-full} 0.3.0
 The following advisory is available for {coo-full} 0.3.0:


### PR DESCRIPTION
Version(s):
4.12+ 

Issue:
[OBSDOCS-1286](https://issues.redhat.com//browse/OBSDOCS-1286)

Link to docs preview:
https://81008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html


Additional information:

Approved by engineering and QE

The errata link has been updated.
