### PR TITLE
OSDOCS-11780: 4.12.64 RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4865,3 +4865,22 @@ $ oc adm release info 4.12.63 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-64"]
+=== RHSA-2024:5808 - {product-title} 4.12.64 bug fix and security update
+
+Issued: 29 August 2024
+
+{product-title} release 4.12.64, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:5808[RHSA-2024:5808] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5810[RHSA-2024:5810] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.64 --pullspecs
+----
+
+[id="ocp-4-12-64-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-11780

Link to docs preview:
https://81011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-64

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (08/29/2024)
