### PR TITLE
OSDOCS-11278: updates oc table and other fixes MicroShift

### DIFF
--- a/microshift_cli_ref/microshift-cli-tools-introduction.adoc
+++ b/microshift_cli_ref/microshift-cli-tools-introduction.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-cli-tools"]
-= {product-title} CLI tools introduction
+= {microshift-short} CLI tools introduction
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-cli-tools-introduction
 
 toc::[]
 
-You can use different command-line interface (CLI) tools to build, deploy, and manage {product-title} clusters and workloads. With CLI tools, you can complete various administration and development operations from the terminal to manage deployments and interact with each component of the system.
+You can use different command-line interface (CLI) tools to build, deploy, and manage a {microshift-short} cluster and workloads. With CLI tools, you can complete various administration and development operations from the terminal to manage deployments and interact with each component of the system.
 
-CLI tools available for use with {product-title} are the following:
+CLI tools available for use with {microshift-short} are the following:
 
 * Kubernetes CLI (`kubectl`)
 * The {oc-first} tool with an enabled subset of commands
@@ -23,7 +23,7 @@ Commands for multi-node deployments, projects, and developer tooling are not sup
 [id="additional-resources_microshift-cli-tools"]
 == Additional resources
 
-* xref:..//microshift_cli_ref/microshift-oc-cli-install.adoc#microshift-oc-cli-install[Installing the OpenShift CLI tool for MicroShift].
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.16/html/cli_tools/openshift-cli-oc[Detailed description of the OpenShift CLI (oc)].
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9[Red Hat Enterprise Linux (RHEL) documentation for specific use cases].
+* xref:..//microshift_cli_ref/microshift-oc-cli-install.adoc#microshift-oc-cli-install[Getting started with the OpenShift CLI]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/cli_tools/openshift-cli-oc#cli-about-cli_cli-developer-commands[About the OpenShift CLI] (OpenShift Container Platform documentation)
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9[Red Hat Enterprise Linux (RHEL) documentation for specific use cases]
 * xref:../microshift_configuring/microshift-cluster-access-kubeconfig.adoc#microshift-kubeconfig[Cluster access with kubeconfig]

--- a/microshift_cli_ref/microshift-cli-using-oc.adoc
+++ b/microshift_cli_ref/microshift-cli-using-oc.adoc
@@ -6,14 +6,14 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-The optional OpenShift CLI (`oc`) tool provides a subset of `oc` commands for {product-title} deployments. Using `oc` is convenient if you are familiar with {OCP} and Kubernetes.
+The optional {oc-first} tool provides a subset of `oc` commands for {microshift-short} deployments. Using `oc` is convenient if you are familiar with {OCP} and Kubernetes.
 
 include::modules/microshift-cli-oc-about.adoc[leveloffset=+1]
 
 [id="cli-using-cli_{context}"]
-== Using the OpenShift CLI in {product-title}
+== Using oc with a {microshift-short} cluster
 
-Review the following sections to learn how to complete common tasks in {product-title} using the `oc` CLI.
+Review the following sections to learn how to complete common tasks in {microshift-short} using the `oc` CLI.
 
 [id="viewing-pods_{context}"]
 === Viewing pods

--- a/microshift_cli_ref/microshift-oc-cli-commands-list.adoc
+++ b/microshift_cli_ref/microshift-oc-cli-commands-list.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Descriptions and example commands for OpenShift CLI (`oc`) commands are included in this reference document. You must have `cluster-admin` or equivalent permissions to use these commands. To list administrator commands and information about them, use the following commands:
+Descriptions and example commands for {oc-first} commands are included in this reference document. You must have `cluster-admin` or equivalent permissions to use these commands. To list administrator commands and information about them, use the following commands:
 
 * Enter the `oc adm -h` command to list all administrator commands:
 +

--- a/microshift_cli_ref/microshift-oc-cli-install.adoc
+++ b/microshift_cli_ref/microshift-oc-cli-install.adoc
@@ -6,18 +6,13 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-To use the OpenShift CLI (`oc`) tool, you must download and install it separately from your {microshift-short} installation.
-
-[id="installing-the-openshift-cli"]
-== Installing the OpenShift CLI
-
-You can install the OpenShift CLI (`oc`) either by downloading the binary or by using Homebrew.
+To use the {oc-first} tool, you must download and install it separately from your {microshift-short} installation. You can install `oc` by downloading the binary or by using Homebrew.
 
 // Installing the CLI by downloading the binary
-include::modules/cli-installing-cli.adoc[leveloffset=+2]
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 // Installing the CLI by using Homebrew
-include::modules/cli-installing-cli-brew.adoc[leveloffset=+2]
+include::modules/cli-installing-cli-brew.adoc[leveloffset=+1]
 
 // Installing the CLI using RPM
-include::modules/cli-installing-cli-rpm.adoc[leveloffset=+2]
+include::modules/cli-installing-cli-rpm.adoc[leveloffset=+1]

--- a/microshift_cli_ref/microshift-oc-config.adoc
+++ b/microshift_cli_ref/microshift-oc-config.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Configure `oc` based on your preferences for working with it.
+Configure {oc-first} based on your preferences for working with it.
 
 [id="cli-enabling-tab-completion"]
 == Enabling tab completion

--- a/microshift_cli_ref/microshift-usage-oc-kubectl.adoc
+++ b/microshift_cli_ref/microshift-usage-oc-kubectl.adoc
@@ -6,25 +6,25 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-The Kubernetes command-line interface (CLI), `kubectl`, can be used to run commands against a Kubernetes cluster. Because {product-title} is a certified Kubernetes distribution, you can use the supported `kubectl` CLI tool that ships with {product-title}, or you can gain extended functionality by using the `oc` CLI tool.
+The Kubernetes command-line interface (CLI), `kubectl`, can be used to run commands against a Kubernetes cluster. Because {microshift-short} is a certified Kubernetes distribution, you can use the supported `kubectl` CLI tool or you can gain extended functionality by using the {oc-first}.
 
 [id="microshift-kubectl-binary_{context}"]
 == The kubectl CLI tool
 
-You can use the `kubectl` CLI tool to interact with Kubernetes primitives on your {product-title} cluster. You can also use existing `kubectl` workflows and scripts for new {product-title} users coming from another Kubernetes environment, or for those who prefer to use the `kubectl` CLI.
+You can use the `kubectl` CLI tool to interact with Kubernetes primitives on your {microshift-short} cluster. You can also use existing `kubectl` workflows and scripts for users coming from another Kubernetes environment, or for those who prefer to use the `kubectl` CLI.
 
-The `kubectl` CLI tool is included in the archive if you download the `oc` CLI tool.
+* The `kubectl` CLI tool is included in the archive when you download `oc`.
 
-For more information, read the link:https://kubernetes.io/docs/reference/kubectl/overview/[Kubernetes CLI tool documentation].
+* For more information, see the link:https://kubernetes.io/docs/reference/kubectl/overview/[Kubernetes CLI tool documentation].
 
 [id="microshift-oc-binary_{context}"]
 == The oc CLI tool
 
-The `oc` CLI tool offers the same capabilities as the `kubectl` CLI tool, but it extends to natively support additional {product-title} features, including:
+The `oc` CLI tool offers the same capabilities as the `kubectl` CLI tool, but it extends to natively support additional {OCP} features, including:
 
 * **Route resource**
 +
-The `Route` resource object is specific to {product-title} distributions, and builds upon standard Kubernetes primitives.
+The `Route` resource object is specific to {OCP} distributions, and builds upon standard Kubernetes primitives.
 +
 * **Additional commands**
 +
@@ -32,10 +32,10 @@ The additional command `oc new-app`, for example, makes it easier to get new app
 
 [IMPORTANT]
 ====
-If you installed an earlier version of the `oc` CLI tool, you cannot use it to complete all of the commands in {product-title} {ocp-version}. If you want the latest features, you must download and install the latest version of the `oc` CLI tool corresponding to your {product-title} version.
+If you installed an earlier version of `oc`, you might not be able use it to complete all of the commands in {microshift-short} {product-version}. If you want the latest features, you must download and install the latest version of `oc` that corresponds with your {microshift-short} version.
 ====
 
-Non-security API changes will involve, at minimum, two minor releases (4.1 to 4.2 to 4.3, for example) to allow older `oc` binaries to update. Using new capabilities might require newer `oc` binaries. A 4.3 server might have additional capabilities that a 4.2 `oc` binary cannot use and a 4.3 `oc` binary might have additional capabilities that are unsupported by a 4.2 server.
+Using new capabilities often requires the latest `oc` binary. A 4.17 server might have additional capabilities that a 4.12 `oc` binary cannot use and a 4.17 `oc` binary might have additional capabilities that are unsupported by a 4.13 server.
 
 .Compatibility Matrix
 
@@ -47,16 +47,11 @@ Non-security API changes will involve, at minimum, two minor releases (4.1 to 4.
 |*X.Y+N* footnote:versionpolicyn[Where *N* is a number greater than or equal to 1.] (`oc` Client)
 
 |*X.Y* (Server)
-|image:redcircle-1.png[]
-|image:redcircle-3.png[]
+|Fully compatible.
+|The `oc` CLI tool might provide options and features that are not compatible with the accessed server.
 
 |*X.Y+N* footnote:versionpolicyn[] (Server)
-|image:redcircle-2.png[]
-|image:redcircle-1.png[]
+|The `oc` CLI tool might not be able to access server features.
+|Fully compatible.
 
 |===
-image:redcircle-1.png[] Fully compatible.
-
-image:redcircle-2.png[] `oc` client might not be able to access server features.
-
-image:redcircle-3.png[] `oc` client might provide options and features that might not be compatible with the accessed server.

--- a/modules/cli-installing-cli-brew.adoc
+++ b/modules/cli-installing-cli-brew.adoc
@@ -15,9 +15,18 @@ For macOS, you can install the OpenShift CLI (`oc`) by using the link:https://br
 
 .Procedure
 
-* Run the following command to install the link:https://formulae.brew.sh/formula/openshift-cli[openshift-cli] package:
+* Install the link:https://formulae.brew.sh/formula/openshift-cli[openshift-cli] package by running the following command:
 +
 [source,terminal]
 ----
 $ brew install openshift-cli
+----
+
+.Verification
+
+* Verify your installation by using an `oc` command:
+
+[source,terminal]
+----
+$ oc <command>
 ----

--- a/modules/cli-installing-cli-rpm.adoc
+++ b/modules/cli-installing-cli-rpm.adoc
@@ -13,9 +13,9 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 subscription on your Red Hat account.
 
-[NOTE]
+[IMPORTANT]
 ====
-It is not supported to install the OpenShift CLI (`oc`) as an RPM for {op-system-base-full} 9. You must install the OpenShift CLI for {op-system-base} 9 by downloading the binary.
+You must install `oc` for {op-system-base} 9 by downloading the binary. Installing `oc` by using an RPM package is not supported on {op-system-base-full} 9.
 ====
 
 .Prerequisites
@@ -79,7 +79,9 @@ endif::openshift-rosa[]
 # yum install openshift-clients
 ----
 
-After you install the CLI, it is available using the `oc` command:
+.Verification
+
+* Verify your installation by using an `oc` command:
 
 [source,terminal]
 ----

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -230,7 +230,7 @@ $ echo $PATH
 
 .Verification
 
-* After you install the OpenShift CLI, it is available using the `oc` command:
+* Verify your installation by using an `oc` command:
 +
 [source,terminal]
 ----

--- a/modules/microshift-oc-apis-errors.adoc
+++ b/modules/microshift-oc-apis-errors.adoc
@@ -6,7 +6,7 @@
 [id="microshift-oc-apis-errors_{context}"]
 = oc command errors in {product-title}
 
-Not all OpenShift CLI (oc) tool commands are relevant for {product-title} deployments. When you use `oc` to make a request call against an unsupported API, the `oc` binary usually generates an error message about a resource that cannot be found.
+Not all {oc-first} commands are relevant for {microshift-short} deployments. When you use `oc` to make a request call against an unsupported API, the `oc` binary usually generates an error message about a resource that cannot be found.
 
 .Example output
 


### PR DESCRIPTION
Version(s):
4.14, 4.15, 4.16, 4.17

Issue:
[OSDOCS-11278](https://issues.redhat.com/browse/OSDOCS-11278)

Link to docs preview:
https://81012--ocpdocs-pr.netlify.app/microshift/latest/microshift_cli_ref/microshift-cli-tools-introduction.html
https://81012--ocpdocs-pr.netlify.app/microshift/latest/microshift_cli_ref/microshift-cli-using-oc.html
https://81012--ocpdocs-pr.netlify.app/microshift/latest/microshift_cli_ref/microshift-oc-cli-commands-list.html
https://81012--ocpdocs-pr.netlify.app/microshift/latest/microshift_cli_ref/microshift-oc-cli-install.html
https://81012--ocpdocs-pr.netlify.app/microshift/latest/microshift_cli_ref/microshift-oc-config.html
https://81012--ocpdocs-pr.netlify.app/microshift/latest/microshift_cli_ref/microshift-usage-oc-kubectl.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is doc work which did not need an engineering SME. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
