### PR TITLE
update-feature-status-rn-doc-16: Listed more statuses for the TP+ tables

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1443,6 +1443,8 @@ Deprecated functionality is still included in {product-title} and continues to b
 
 In the following tables, features are marked with the following statuses:
 
+* _Not Available_
+* _Technology Preview_
 * _General Availability_
 * _Deprecated_
 * _Removed_
@@ -2575,10 +2577,11 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 In the following tables, features are marked with the following statuses:
 
+* _Not Available_
 * _Technology Preview_
 * _General Availability_
-* _Not Available_
 * _Deprecated_
+* _Removed_
 
 [discrete]
 === Networking Technology Preview features


### PR DESCRIPTION
Expand the statuses for the **Technology Preview features status** and **Deprecated and removed features** tables

Version(s):
4.16

Link to docs preview:
* [Deprecated and removed features](https://81015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-deprecated-removed-features_release-notes)
* [Technology Preview features status](https://81015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-technology-preview-tables_release-notes)