### PR TITLE
Add 'Additional release notes' page

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -52,8 +52,10 @@ Name: Release notes
 Dir: release_notes
 Distros: openshift-enterprise
 Topics:
-- Name: OpenShift Container Platform 4.18 release notes
-  File: ocp-4-18-release-notes
+- Name: OpenShift Container Platform release notes
+  File: ocp-release-notes
+- Name: Additional release notes
+  File: addtl-release-notes
 ---
 Name: Getting started
 Dir: getting_started

--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -9,7 +9,7 @@ toc::[]
 {product-title} {product-version} introduces architectural changes and enhancements. The procedures that you used to manage your {product-title} 3 cluster might not apply to {product-title} 4.
 
 ifndef::openshift-origin[]
-For information about configuring your {product-title} 4 cluster, review the appropriate sections of the {product-title} documentation. For information about new features and other notable technical changes, review the xref:../release_notes/ocp-4-18-release-notes.adoc#ocp-4-18-release-notes[{product-title} 4.18 release notes].
+For information about configuring your {product-title} 4 cluster, review the appropriate sections of the {product-title} documentation. For information about new features and other notable technical changes, review the xref:../release_notes/ocp-release-notes.adoc#ocp-4-release-notes[OpenShift Container Platform release notes].
 endif::[]
 
 It is not possible to upgrade your existing {product-title} 3 cluster to {product-title} 4. You must start with a new {product-title} 4 installation. Tools are available to assist in migrating your control plane settings and application workloads.

--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -1,0 +1,99 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="addtl-release-notes"]
+= Additional release notes
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-microshift.adoc[]
+include::_attributes/servicebinding-document-attributes.adoc[]
+:context: addtl-release-notes
+
+toc::[]
+
+Release notes for additional related components and products not included in the core xref:../release_notes/ocp-release-notes.adoc#ocp-release-notes[{product-title} {product-version} release notes] are available in the following documentation.
+
+[IMPORTANT]
+====
+The following release notes are for downstream Red Hat products only; upstream or community release notes for related products are not included.
+====
+
+[cols="1a,1a,1a",frame=none,grid=none]
+|===
+|A::
+xref:../networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc#aws-load-balancer-operator-release-notes[AWS Load Balancer Operator]
+
+|B::
+link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1/html/about_builds/ob-release-notes#ob-release-notes[{builds-v2title}]
+
+|C::
+xref:../security/cert_manager_operator/cert-manager-operator-release-notes.adoc#cert-manager-operator-release-notes[{cert-manager-operator}] +
+{nbsp} +
+xref:../observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc#cluster-observability-operator-release-notes[{coo-first}] +
+{nbsp} +
+xref:../security/compliance_operator/compliance-operator-release-notes.adoc#compliance-operator-release-notes[Compliance Operator] +
+{nbsp} +
+xref:../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator]
+
+|D::
+link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/#Release%20Notes[{rh-dev-hub} Operator]
+
+|E::
+xref:../networking/external_dns_operator/external-dns-operator-release-notes.adoc#external-dns-operator-release-notes[External DNS Operator]
+
+|F::
+xref:../security/file_integrity_operator/file-integrity-operator-release-notes.adoc#file-integrity-operator-release-notes-v0[File Integrity Operator]
+
+|K::
+xref:../nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc#nodes-descheduler-release-notes[{descheduler-operator}]
+
+|L::
+xref:../observability/logging/logging_release_notes/logging-5-9-release-notes.adoc#logging-5-9-release-notes[{logging-uc}]
+
+|M::
+xref:../migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc#mtc-release-notes[{mtc-full} ({mtc-short})]
+
+|N::
+xref:../observability/network_observability/network-observability-operator-release-notes.adoc#network-observability-operator-release-notes[Network Observability Operator] +
+{nbsp} +
+xref:../security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc#nbde-tang-server-operator-release-notes[Network-bound Disk Encryption (NBDE) Tang Server Operator]
+
+|O::
+xref:../backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc#oadp-1-4-release-notes[{oadp-first}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/#Release%20Notes[{openshift-dev-spaces-productname}] +
+{nbsp} +
+xref:../observability/distr_tracing/distr-tracing-rn.adoc#distr-tracing-rn[{DTProductName}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/#Get%20started[{gitops-title}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_local/#Release%20Notes[{openshift-local-productname}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/#Getting%20Started[{pipelines-title}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/#Release%20Notes[{osc}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.33/html/about_openshift_serverless/serverless-release-notes#serverless-release-notes[Red Hat {ServerlessProductName}] +
+{nbsp} +
+xref:../windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.adoc#windows-containers-release-notes-10-17-x[{productwinc}] +
+{nbsp} +
+xref:../virt/release_notes/virt-release-notes-placeholder.adoc#virt-release-notes-placeholder[Red Hat {VirtProductName}] +
+{nbsp} +
+xref:../observability/otel/otel-rn.adoc#otel-rn[{OTELName}]
+
+|P::
+xref:../observability/power_monitoring/power-monitoring-release-notes.adoc#power-monitoring-release-notes[{PM-title-c}]
+
+|R::
+xref:../nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc#run-once-duration-override-release-notes[{run-once-operator}]
+
+|S::
+xref:../nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc#nodes-secondary-scheduler-release-notes[{secondary-scheduler-operator-full}] +
+{nbsp} +
+xref:../security/security_profiles_operator/spo-release-notes.adoc#spo-release-notes[Security Profiles Operator] +
+{nbsp} +
+xref:../service_mesh/v2x/servicemesh-release-notes.adoc#service-mesh-release-notes[{SMProductName} 2.x] +
+{nbsp} +
+link:https://docs.openshift.com/service-mesh/3.0.0tp1/ossm-release-notes/ossm-release-notes-assembly.html[{SMProductName} 3.x]
+
+|
+|
+
+|===

--- a/release_notes/ocp-release-notes.adoc
+++ b/release_notes/ocp-release-notes.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ocp-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/common-attributes.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+Release note changes should be added/edited in their own PR.
+
+This file is here to allow builds to work.

--- a/rosa_architecture/index.adoc
+++ b/rosa_architecture/index.adoc
@@ -60,7 +60,7 @@ Start with xref:../architecture/architecture.adoc#architecture-overview-architec
 xref:../security/container_security/security-understanding.adoc#understanding-security[Security and compliance].
 ifdef::openshift-enterprise,openshift-webscale[]
 Next, view the
-xref:../release_notes/ocp-4-18-release-notes.adoc#ocp-4-18-release-notes[release notes].
+xref:../release_notes/ocp-release-notes.adoc#ocp-4-release-notes[release notes].
 endif::[]
 
 ifdef::openshift-online,openshift-aro[]


### PR DESCRIPTION
https://issues.redhat.com/browse/CONTENTX-194

Version: 4.17 and 4.18 for now, to test Portal builds. Will need a little more double-checking re: products/Operators/versions for backporting to 4.16 and earlier.

Continuation of (Closed) https://github.com/openshift/openshift-docs/pull/40736 per recent working group discussions about release notes for async Operators.

Arranged alphabetically in the style of https://docs.redhat.com/en/products (i.e., ignore the "Red Hat" or "Red Hat build of" prefix in the official product name, but respect the inclusion of "OpenShift").

Also cleaned-up the versioned file for the core OCP RN file as well, since this is the `main` branch (and adjusting the few related xrefs). Sync'd with Darragh.

Preview: https://81026--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/addtl-release-notes.html