### PR TITLE
OSDOCS-11735: Update GCP installation info

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2109,6 +2109,13 @@ Additional GCP configuration parameters are described in the following table:
 |The name of the custom {op-system} image that the installation program is to use to boot compute machines. If you use `compute.platform.gcp.osImage.project`, this field is required.
 |String. The name of the {op-system} image.
 
+|compute:
+  platform:
+    gcp:
+      serviceAccount:
+|Specifies the email address of a {gcp-short} service account to be used during installations. This service account will be used to provision compute machines.
+|String. The email address of the service account.
+
 |platform:
   gcp:
     network:
@@ -2384,6 +2391,17 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
       onHostMaintenance:
 |Specifies the behavior of control plane VMs during a host maintenance event, such as a software or hardware update. For Confidential VMs, this parameter must be set to `Terminate`. Confidential VMs do not support live VM migration.
 |`Terminate` or `Migrate`. The default value is `Migrate`.
+
+|controlPlane:
+  platform:
+    gcp:
+      serviceAccount:
+|Specifies the email address of a {gcp-short} service account to be used during installations. This service account will be used to provision control plane machines.
+[IMPORTANT]
+====
+In the case of shared VPC installations, when the service account is not provided, the installer service account must have the `resourcemanager.projects.getIamPolicy` and `resourcemanager.projects.setIamPolicy` permissions in the host project.
+====
+|String. The email address of the service account.
 
 |compute:
   platform:

--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -31,3 +31,12 @@ Ensure that the host project applies one of the following configurations to the 
 * `projects/<host-project>/roles/dns.networks.bindPrivateDNSZone`
 * `roles/compute.networkUser`
 ====
+
+If you do not supply a service account for control plane nodes in the `install-config.yaml` file, please grant the below permissions to the service account in the host project.
+
+[%collapsible]
+====
+* `resourcemanager.projects.getIamPolicy`
+* `resourcemanager.projects.setIamPolicy`
+====
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
/label branch/enterprise-4.17
/label branch/enterprise-4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-11735

Link to docs preview:
[Configuring a GCP account](https://81053--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#minimum-required-permissions-ipi-gcp-xpn)
[Installation configuration parameters](https://81053--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp
)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

** Add in notes for permissions when user does not provide service accounts for installs. 
** Add in service account field for the install parameters


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
