### PR TITLE
OSDOCS#11823: Add an example command with an actual value in step 3 of the procedure

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -140,6 +140,12 @@ etcd cannot tolerate any additional member failure when running with two members
 ----
 $ oc delete node <node_name>
 ---- 
++
+.Example command
+[source,terminal]
+----
+$ oc delete node ip-10-0-131-183.ec2.internal
+----
 
 . Remove the old secrets for the unhealthy etcd member that was removed.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-11823](https://issues.redhat.com/browse/OSDOCS-11823)

Link to docs preview:
[Step 3](https://81065--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member) 

QE review:
- [x] QE has approved this change.

Additional information:
This PR is a continuation of PR #[80902](https://github.com/openshift/openshift-docs/pull/80902) to add an example command that uses an actual value for the variable <node_name>. 


