### PR TITLE
Update cluster-logging-cpu-memory.adoc

### DIFF
--- a/modules/cluster-logging-cpu-memory.adoc
+++ b/modules/cluster-logging-cpu-memory.adoc
@@ -61,15 +61,13 @@ spec:
             memory: 100Mi
       replicas: 2
   collection:
-    logs:
-      type: "fluentd"
-      fluentd:
-        resources: <3>
-          limits:
-            memory: 736Mi
-          requests:
-            cpu: 200m
-            memory: 736Mi
+    resources: <3>
+      limits:
+        memory: 736Mi
+      requests:
+        cpu: 200m
+        memory: 736Mi
+    type: fluentd
 ----
 <1> Specify the CPU and memory limits and requests for the log store as needed. For Elasticsearch, you must adjust both the request value and the limit value.
 <2> Specify the CPU and memory limits and requests for the log visualizer as needed.


### PR DESCRIPTION
The configuration format mentioned in documentation was old and let to below error

    - lastTransitionTime: '2024-08-28T17:35:34Z'      message: spec.collection.logs.* is deprecated in favor of spec.collection.*      reason: DeprecatedCollectionLogsSpec      status: 'True'      type: Deprecated 

updated it as per new format

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->4.12,4.13,4.14,4.15,4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->https://issues.redhat.com/browse/OBSDOCS-1287

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->https://81066--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/config/cluster-logging-memory.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
