### PR TITLE
CNV-39881-undo: Reverting previous update as this development was dro…

### DIFF
--- a/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
@@ -15,7 +15,7 @@ You can connect a virtual machine (VM) to an Open Virtual Network (OVN)-Kubernet
 ifndef::openshift-rosa,openshift-dedicated[]
 [NOTE]
 ====
-An OVN-Kubernetes secondary network is compatible with the xref:../../networking/multiple_networks/configuring-additional-network.adoc#compatibility-with-multi-network-policy_configuring-additional-network[multi-network policy API] which provides the `MultiNetworkPolicy` custom resource definition (CRD) to control traffic flow to and from VMs.
+An OVN-Kubernetes secondary network is compatible with the xref:../../networking/multiple_networks/configuring-additional-network.adoc#compatibility-with-multi-network-policy_configuring-additional-network[multi-network policy API] which provides the `MultiNetworkPolicy` custom resource definition (CRD) to control traffic flow to and from VMs. You can use the `ipBlock` attribute to define network policy ingress and egress rules for specific CIDR blocks.
 ====
 endif::openshift-rosa,openshift-dedicated[]
 


### PR DESCRIPTION
Version(s):
Main, 4.17

Issue - no applicable issue

[Link to docs preview](https://81067--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR reverts the changes made in #80043. This development was dropped last week from 4.17 and the change needs to be undone.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
