### PR TITLE
[OSDOCS-11363]  Updating images-configuration-allowed to correct MCO…

### DIFF
--- a/modules/images-configuration-allowed.adoc
+++ b/modules/images-configuration-allowed.adoc
@@ -59,7 +59,7 @@ status:
 Either the `allowedRegistries` parameter or the `blockedRegistries` parameter can be set, but not both.
 ====
 +
-The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, the allowed registries list is used to update the image signature policy in the `/etc/containers/policy.json` file on each node.
+The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it triggers a rollout on nodes in machine config pool (MCP). The allowed registries list is used to update the image signature policy in the `/etc/containers/policy.json` file on each node. Changes to the `/etc/containers/policy.json` file do not require the node to drain.
 
 ifndef::openshift-rosa,openshift-dedicated[]
 .Verification


### PR DESCRIPTION
…workflow

Adding/removing registries under `spec.registrySources.allowedRegistries` in `image.config.openshift.io/cluster` updates `/etc/containers/policy.json file` on each node. Changes to the `/etc/containers/policy.json` do not require node drain.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[https://issues.redhat.com/browse/OSDOCS-11363](https://issues.redhat.com/browse/OSDOCS-11363
)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [Enterprise branch](https://81068--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html)
- [ROSA](https://81068--ocpdocs-pr.netlify.app/openshift-rosa/latest/openshift_images/image-configuration.html)
- [OSD](https://81068--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-configuration.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
