### PR TITLE
TELCODOCS-1947: EOL for bare metal relay operator - release note

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -853,7 +853,7 @@ In the following tables, features are marked with the following statuses:
 |Bare Metal Event Relay Operator
 |Deprecated
 |Deprecated
-|Deprecated
+|Removed
 
 |====
 
@@ -862,6 +862,11 @@ In the following tables, features are marked with the following statuses:
 
 [id="ocp-4-17-removed-features_{context}"]
 === Removed features
+
+[id="ocp-4-17-bare-metal-operator_{context}"]
+==== Bare Metal Event Relay Operator (BMER)
+
+BMER was deprecated in {product-title} version 4.15 and 4.16. With this release, BMER is no longer supported and the related BMER content is removed from the documentation.
 
 [id="ocp-4-17-future-deprecation"]
 === Notice of future deprecation


### PR DESCRIPTION
[TELCODOCS-1947](https://issues.redhat.com//browse/TELCODOCS-1947): EOL for bare metal relay operator - release note

Version(s):
4.17

Issue:
https://issues.redhat.com/browse/TELCODOCS-1947

Link to docs preview:
https://81069--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-bare-metal-operator_release-notes
https://81069--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-deprecated-removed-features_release-notes (BMER table at bottom of section)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
