### PR TITLE
update-cluster-logging-cpu-memory

### DIFF
--- a/modules/cluster-logging-cpu-memory.adoc
+++ b/modules/cluster-logging-cpu-memory.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * observability/logging/cluster-logging-collector.adoc
+// * observability/logging/log_visualization/logging-kibana.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-memory-limits_{context}"]
@@ -60,16 +61,14 @@ spec:
             cpu: 100m
             memory: 100Mi
       replicas: 2
-  collection:
-    logs:
-      type: "fluentd"
-      fluentd:
-        resources: <3>
-          limits:
-            memory: 736Mi
-          requests:
-            cpu: 200m
-            memory: 736Mi
+collection:
+    resources: <3>
+      limits:
+        memory: 736Mi
+      requests:
+        cpu: 200m
+        memory: 736Mi
+    type: fluentd
 ----
 <1> Specify the CPU and memory limits and requests for the log store as needed. For Elasticsearch, you must adjust both the request value and the limit value.
 <2> Specify the CPU and memory limits and requests for the log visualizer as needed.


### PR DESCRIPTION
Peer review done, and SME and QE approvals on [PR](https://github.com/openshift/openshift-docs/pull/81066#pullrequestreview-2269531027)

Version(s):
4.16 to 4.12

Issue:
N/A. Takes over [81066](https://github.com/openshift/openshift-docs/pull/81066)

Link to docs preview:
* [Configuring CPU and memory limits for logging components (core)](https://81066--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/config/cluster-logging-memory.html)
* [Configuring Kibana (core)](https://81066--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_visualization/logging-kibana.html#cluster-logging-memory-limits_logging-kibana)
* [Configuring CPU and memory limits for logging components (dedicated)](https://81066--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/config/cluster-logging-memory.html)
* [Configuring Kibana (dedicated)](https://81066--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/log_visualization/logging-kibana.html#logging-kibana-configuring)
* [Configuring CPU and memory limits for logging components (rosa)](https://81066--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/config/cluster-logging-memory.html)
* [Configuring Kibana (rosa)](https://81066--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/log_visualization/logging-kibana.html#logging-kibana-configuring) 


- [x] SME has approved this change: Jeff Cantrill, see [PR](https://github.com/openshift/openshift-docs/pull/81066#pullrequestreview-2269531027)
- [x] QE has approved this change: Anping LI, see [PR](https://github.com/openshift/openshift-docs/pull/81066).

