### PR TITLE
update toc::[] location in guidelines to render a TOC in github

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1,8 +1,9 @@
+:toc: macro
 [id="contributing-to-docs-doc-guidelines"]
 = Documentation guidelines
 include::_attributes/common-attributes.adoc
 
-:toc: macro
+toc::[]
 
 The documentation guidelines for OpenShift 4 build on top of the
 link:https://redhat-documentation.github.io/modular-docs/[_Red Hat modular docs reference guide_].
@@ -17,7 +18,6 @@ These _Documentation guidelines_ are primarily concerned with the modular struct
 When looking for style guidance, reference the _Red Hat supplementary style guide for product documentation_ first, because it overrides certain guidance from the _IBM Style_ guide.
 ====
 
-toc::[]
 
 == General file guidelines
 


### PR DESCRIPTION
Need to shuffle some stuff around to get github to render the TOC.

Preview: https://github.com/openshift/openshift-docs/blob/edee12ecf542dbefcc4f501e8df39763bc0308ff/contributing_to_docs/doc_guidelines.adoc