### PR TITLE
[enterprise-4.12] OCPBUGS-38432: Added step to networking Converting HTTP header case s…

### DIFF
--- a/modules/nw-ingress-converting-http-header-case.adoc
+++ b/modules/nw-ingress-converting-http-header-case.adoc
@@ -6,12 +6,14 @@
 [id="nw-ingress-converting-http-header-case_{context}"]
 = Converting HTTP header case
 
-HAProxy 2.2 lowercases HTTP header names by default, for example, changing `Host: xyz.com` to `host: xyz.com`. If legacy applications are sensitive to the capitalization of HTTP header names, use the Ingress Controller `spec.httpHeaders.headerNameCaseAdjustments` API field for a solution to accommodate legacy applications until they can be fixed.
+HAProxy lowercases HTTP header names by default; for example, changing `Host: xyz.com` to `host: xyz.com`. If legacy applications are sensitive to the capitalization of HTTP header names, use the Ingress Controller `spec.httpHeaders.headerNameCaseAdjustments` API field for a solution to accommodate legacy applications until they can be fixed.
 
 [IMPORTANT]
 ====
-Because {product-title} includes HAProxy 2.2, make sure to add the necessary configuration by using `spec.httpHeaders.headerNameCaseAdjustments` before upgrading.
+{product-title} includes HAProxy 2.2. If you want to update to this version of the web-based load balancer, ensure that you add the `spec.httpHeaders.headerNameCaseAdjustments` section to your cluster's configuration file.
 ====
+
+As a cluster administrator, you can convert the HTTP header case by entering the `oc patch` command or by setting the `HeaderNameCaseAdjustments` field in the Ingress Controller YAML file.
 
 .Prerequisites
 
@@ -20,41 +22,34 @@ Because {product-title} includes HAProxy 2.2, make sure to add the necessary con
 
 .Procedure
 
-As a cluster administrator, you can convert the HTTP header case by entering the `oc patch` command or by setting the `HeaderNameCaseAdjustments` field in the Ingress Controller YAML file.
+* Capitalize an HTTP header by using the `oc patch` command.
 
-* Specify an HTTP header to be capitalized by entering the `oc patch` command.
-
-. Enter the `oc patch` command to change the HTTP `host` header to `Host`:
+.. Change the HTTP header from `host` to `Host` by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator patch ingresscontrollers/default --type=merge --patch='{"spec":{"httpHeaders":{"headerNameCaseAdjustments":["Host"]}}}'
 ----
 +
-. Annotate the route of the application:
+.. Create a `Route` resource YAML file so that the annotation can be applied to the application.
 +
-[source,terminal]
+.Example of a route named `my-application`
+[source,yaml]
 ----
-$ oc annotate routes/my-application haproxy.router.openshift.io/h1-adjust-case=true
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    haproxy.router.openshift.io/h1-adjust-case: true <1>
+  name: <application_name>
+  namespace: <application_name>
+# ...
 ----
-+
-The Ingress Controller then adjusts the `host` request header as specified.
+<1> Set `haproxy.router.openshift.io/h1-adjust-case` so that the Ingress Controller can adjust the `host` request header as specified. 
 
-//Extra example if needed
-////
-* This example changes the HTTP `cache-control` header to `Cache-Control`:
-+
-[source,terminal]
-----
-$ oc -n openshift-ingress-operator patch ingresscontrollers/default --type=json --patch='[{"op":"add","path":"/spec/httpHeaders/headerNameCaseAdjustments/-","value":"Cache-Control"}]'
-----
-+
-The Ingress Controller adjusts the `cache-control` response header as specified.
-////
+* Specify adjustments by configuring the `HeaderNameCaseAdjustments` field in the Ingress Controller YAML configuration file.
 
-* Specify adjustments using the `HeaderNameCaseAdjustments` field by configuring the Ingress Controller YAML file.
-
-. The following example Ingress Controller YAML adjusts the `host` header to `Host` for HTTP/1 requests to appropriately annotated routes:
+.. The following example Ingress Controller YAML file adjusts the `host` header to `Host` for HTTP/1 requests to appropriately annotated routes:
 +
 .Example Ingress Controller YAML
 [source,yaml]
@@ -70,7 +65,7 @@ spec:
     - Host
 ----
 +
-. The following example route enables HTTP response header name case adjustments using the `haproxy.router.openshift.io/h1-adjust-case` annotation:
+.. The following example route enables HTTP response header name case adjustments by using the `haproxy.router.openshift.io/h1-adjust-case` annotation:
 +
 .Example route YAML
 [source,yaml]


### PR DESCRIPTION
Cherry pick from #80474 with commit ID 7c0439ab5b83bd7cb3b7a5159c7bbdee8eec5b7d

MERGE CONFLICT REASON: HAProxy version is 2.2 and not 2.8. See [link](https://docs.openshift.com/container-platform/4.13/networking/ingress-operator.html#nw-ingress-converting-http-header-case_configuring-ingress).

Version: 4.12

[Preview link](https://81079--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-converting-http-header-case_configuring-ingress)