### PR TITLE
OSDOCS#11002: Migrating installing the HCP CLI

### DIFF
--- a/hosted_control_planes/hcp-prepare/hcp-cli.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-cli.adoc
@@ -1,7 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="hcp-cli"]
 include::_attributes/common-attributes.adoc[]
-= Installing the {hcp} command line interface 
+= Installing the {hcp} command-line interface
 :context: hcp-cli
 
 toc::[]
+
+The {hcp} command-line interface, `hcp`, is a tool that you can use to get started with {hcp}. For Day 2 operations, such as management and configuration, use GitOps or your own automation tool.
+
+include::modules/hcp-cli-terminal.adoc[leveloffset=+1]
+include::modules/hcp-cli-console.adoc[leveloffset=+1]
+include::modules/hcp-cli-gateway.adoc[leveloffset=+1]

--- a/modules/hcp-cli-console.adoc
+++ b/modules/hcp-cli-console.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+// * hosted-control-planes/hcp-prepare/hcp-cli.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-cli-console_{context}"]
+= Installing the {hcp} command-line interface by using the web console
+
+You can install the {hcp} command-line interface (CLI), `hcp`, by using the {product-title} web console.
+
+.Procedure
+
+. From the {product-title} web console, click the *Help icon* -> *Command Line Tools*.
+
+. Click *Download hcp CLI* for your platform.
+
+. Unpack the downloaded archive by running the following command:
++
+[source,terminal]
+----
+$ tar xvzf hcp.tar.gz
+----
+
+. Run the following command to make the binary file executable:
++
+[source,terminal]
+----
+$ chmod +x hcp
+----
+
+. Run the following command to move the binary file to a directory in your path:
++
+[source,terminal]
+----
+$ sudo mv hcp /usr/local/bin/.
+----
+
+.Verification
+
+* Verify that you see the list of available parameters by running the following command:
++
+[source,terminal]
+----
+$ hcp create cluster <platform> --help <1>
+----
++
+<1> You can use the `hcp create cluster` command to create and manage hosted clusters. The supported platforms are `aws`, `agent`, and `kubevirt`.

--- a/modules/hcp-cli-gateway.adoc
+++ b/modules/hcp-cli-gateway.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+// * hosted-control-planes/hcp-prepare/hcp-cli.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-cli-gateway_{context}"]
+= Installing the {hcp} command-line interface by using the content gateway
+
+You can install the {hcp} command-line interface (CLI), `hcp`, by using the content gateway.
+
+.Procedure
+
+. Navigate to the link:https://developers.redhat.com/content-gateway/rest/browse/pub/mce/clients/hcp-cli/[content gateway] and download the `hcp` binary.
+
+. Unpack the downloaded archive by running the following command:
++
+[source,terminal]
+----
+$ tar xvzf hcp.tar.gz
+----
+
+. Make the `hcp` binary file executable by running the following command:
++
+[source,terminal]
+----
+$ chmod +x hcp
+----
+
+. Move the `hcp` binary file to a directory in your path by running the following command:
++
+[source,terminal]
+----
+$ sudo mv hcp /usr/local/bin/.
+----
+
+.Verification
+
+* Verify that you see the list of available parameters by running the following command:
++
+[source,terminal]
+----
+$ hcp create cluster <platform> --help <1>
+----
++
+<1> You can use the `hcp create cluster` command to create and manage hosted clusters. The supported platforms are `aws`, `agent`, and `kubevirt`.

--- a/modules/hcp-cli-terminal.adoc
+++ b/modules/hcp-cli-terminal.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+// * hosted-control-planes/hcp-prepare/hcp-cli.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-cli-terminal_{context}"]
+= Installing the {hcp} command-line interface by using the CLI
+
+You can install the {hcp} command-line interface (CLI), `hcp`, by using the CLI.
+
+.Procedure
+
+. Get the URL to download the `hcp` binary by running the following command:
++
+[source,terminal]
+----
+$ oc get ConsoleCLIDownload hcp-cli-download -o json | jq -r ".spec"
+----
+
+. Download the `hcp` binary by running the following command:
++
+[source,terminal]
+----
+$ wget <hcp_cli_download_url> <1>
+----
++
+<1> Replace `hcp_cli_download_url` with the URL that you obtained from the previous step.
+
+. Unpack the downloaded archive by running the following command:
++
+[source,terminal]
+----
+$ tar xvzf hcp.tar.gz
+----
+
+. Make the `hcp` binary file executable by running the following command:
++
+[source,terminal]
+----
+$ chmod +x hcp
+----
+
+. Move the `hcp` binary file to a directory in your path by running the following command:
++
+[source,terminal]
+----
+$ sudo mv hcp /usr/local/bin/.
+----
+
+.Verification
+
+* Verify that you see the list of available parameters by running the following command:
++
+[source,terminal]
+----
+$ hcp create cluster <platform> --help <1>
+----
++
+<1> You can use the `hcp create cluster` command to create and manage hosted clusters. The supported platforms are `aws`, `agent`, and `kubevirt`.


### PR DESCRIPTION

This PR is a part of HCP content migration and modularization. Installing HCP CLI has been removed from the RHACM docs and added to the OCP docs. The content has not been changed for this PR.

Version(s): 4.17+

Issue: https://issues.redhat.com/browse/OSDOCS-11002

Link to docs preview:
- [Installing the hosted control planes command-line interface](https://81080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-cli.html)
- [Installing the hosted control planes command-line interface by using the CLI](https://81080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-cli.html#hcp-cli-terminal_hcp-cli)
- [Installing the hosted control planes command-line interface by using the web console](https://81080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-cli.html#hcp-cli-console_hcp-cli)
- [Installing the hosted control planes command-line interface by using the gateway](https://81080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-cli.html#hcp-cli-gateway_hcp-cli)

QE review:

- [x] QE has approved this change.

Additional information:
