### PR TITLE
[internal-update] add-core-release-notes-stubs-16-17

### DIFF
--- a/release_notes/README.adoc
+++ b/release_notes/README.adoc
@@ -1,4 +1,6 @@
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 
-Release notes should be added/edited in their own PR.
+Release notes should be added or edited in their own PR.
+
+Add a release note "stub" file for each enterprise version to the `main` branch. Stubs are necessary when a writer adds a link to a release note `.adoc` file that is on the `main` branch. 

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ocp-4-16-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/common-attributes.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch that they are relevant for.
+
+Release note changes should be added or edited in their own PR.
+
+This file is here to allow builds to work.

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ocp-4-17-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/common-attributes.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch that they are relevant for.
+
+Release note changes should be added or edited in their own PR.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
Added Release Note document stubs to the `main` branch for 4.17 and 4.16.