### PR TITLE
OSDOCS#11010: HCP content migration: Importing hosted clusters

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2386,6 +2386,8 @@ Topics:
     File: hcp-cli
   - Name: Distributing hosted cluster workloads
     File: hcp-distribute-workloads
+  - Name: Manually importing a hosted cluster
+    File: hcp-manually-import
 - Name: Deploying hosted control planes
   Dir: hcp-deploy
   Topics:

--- a/hosted_control_planes/hcp-prepare/hcp-manually-import.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-manually-import.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="hcp-manually-import"]
+include::_attributes/common-attributes.adoc[]
+= Manually importing a hosted cluster
+:context: hcp-manually-import
+
+toc::[]
+
+Hosted clusters are automatically imported into the {mce-short} after the hosted control plane becomes available. You can manually enable and disable the import of hosted clusters.
+
+include::modules/hcp-manual-import-aws.adoc[leveloffset=+1]
+include::modules/hcp-disable-import.adoc[leveloffset=+1]

--- a/modules/hcp-disable-import.adoc
+++ b/modules/hcp-disable-import.adoc
@@ -1,0 +1,6 @@
+// Module included in the following assemblies:
+// * hosted-control-planes/hcp-prepare/hcp-manually-import.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-disable-import_{context}"]
+= Disabling the automatic import of hosted clusters on into the {mce-short}

--- a/modules/hcp-manual-import-aws.adoc
+++ b/modules/hcp-manual-import-aws.adoc
@@ -1,0 +1,6 @@
+// Module included in the following assemblies:
+// * hosted-control-planes/hcp-prepare/hcp-manually-import.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-manually-import-aws_{context}"]
+= Manually importing a hosted cluster on {aws-short}


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
This PR is a part of HCP content migration and modularization. Importing hosted clusters has been removed from the RHACM docs and added to the OCP docs. The content has not been changed for this PR.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11010 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
