### PR TITLE
[OSDOCS-11001]: Moving HCP enable/disable docs from RHACM to OCP

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2386,6 +2386,8 @@ Topics:
     File: hcp-cli
   - Name: Distributing hosted cluster workloads
     File: hcp-distribute-workloads
+  - Name: Enabling or disabling the hosted control planes feature
+    File: hcp-enable-disable
 - Name: Deploying hosted control planes
   Dir: hcp-deploy
   Topics:

--- a/hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="hcp-enable-disable"]
+include::_attributes/common-attributes.adoc[]
+= Enabling or disabling the {hcp} feature
+:context: hcp-enable-disable
+
+toc::[]
+
+The {hcp} feature, as well as the `hypershift-addon` managed cluster add-on, are enabled by default. If you want to disable the feature, or if you disabled it and want to manually enable it, see the following procedures.
+
+include::modules/hcp-enable-manual.adoc[leveloffset=+1]
+include::modules/hcp-enable-manual-addon.adoc[leveloffset=+2]
+
+[id="hcp-disable_{context}"]
+== Disabling the {hcp} feature
+
+You can uninstall the HyperShift Operator and disable the hosted control plane. When you disable the hosted control plane cluster feature, you must destroy the hosted cluster and the managed cluster resource on {mce-short}, as described in the _Managing hosted control plane clusters_ topics.
+
+include::modules/hcp-uninstall-operator.adoc[leveloffset=+2]
+include::modules/hcp-disable-feature.adoc[leveloffset=+2]

--- a/modules/hcp-disable-feature.adoc
+++ b/modules/hcp-disable-feature.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+// * hosted-control-planes/hcp-prepare/hcp-enable-disable.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-disable-feature_{context}"]
+= Disabling the {hcp} feature
+
+Before you disable the {hcp} feature, you must first uninstall the HyperShift Operator. 
+
+.Procedure
+
+. Run the following command to disable the {hcp} feature:
++
+[source,terminal]
+----
+$ oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": false}]}}}' <1>
+----
++
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
+
+. You can verify that the `hypershift` and `hypershift-local-hosting` features are disabled in the `MultiClusterEngine` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc get mce multiclusterengine -o yaml <1>
+----
++
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
++
+See the following example where `hypershift` and `hypershift-local-hosting` have their `enabled:` flags set to `false`:
++
+[source,yaml]
+----
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: multiclusterengine
+spec:
+  overrides:
+    components:
+    - name: hypershift
+      enabled: false
+    - name: hypershift-local-hosting
+      enabled: false
+----

--- a/modules/hcp-enable-manual-addon.adoc
+++ b/modules/hcp-enable-manual-addon.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+// * hosted-control-planes/hcp-prepare/hcp-enable-disable.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-enable-manual-addon_{context}"]
+= Manually enabling the hypershift-addon managed cluster add-on for local-cluster
+
+Enabling the hosted control planes feature automatically enables the `hypershift-addon` managed cluster add-on. If you need to enable the `hypershift-addon` managed cluster add-on manually, complete the following steps to use the `hypershift-addon` to install the HyperShift Operator on `local-cluster`.
+
+.Procedure
+
+. Create the `ManagedClusterAddon` HyperShift add-on by creating a file that resembles the following example:
++
+[source,yaml]
+----
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: hypershift-addon
+  namespace: local-cluster 
+spec:
+  installNamespace: open-cluster-management-agent-addon
+----
+
+. Apply the file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
++
+Replace `filename` with the name of the file that you created. 
+
+. Confirm that the `hypershift-addon` is installed by running the following command:
++
+[source,terminal]
+----
+$ oc get managedclusteraddons -n local-cluster hypershift-addon
+----
++
+If the add-on is installed, the output resembles the following example:
++
+[source,terminal]
+----
+NAME               AVAILABLE   DEGRADED   PROGRESSING
+hypershift-addon   True
+----
+
+Your HyperShift add-on is installed and the hosting cluster is available to create and manage hosted clusters.

--- a/modules/hcp-enable-manual.adoc
+++ b/modules/hcp-enable-manual.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+// * hosted-control-planes/hcp-prepare/hcp-enable-disable.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-enable-manual_{context}"]
+= Manually enabling the {hcp} feature
+
+If you need to manually enable {hcp}, complete the following steps.
+
+.Procedure
+
+. Run the following command to enable the feature:
++
+[source,terminal]
+----
+$ oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": true}]}}}' <1>
+----
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
+
+. Run the following command to verify that the `hypershift` and `hypershift-local-hosting` features are enabled in the `MultiClusterEngine` custom resource:
++
+[source,terminal]
+----
+$ oc get mce multiclusterengine -o yaml <1>
+----
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
++
+.Example output
+[source,yaml]
+----
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: multiclusterengine
+spec:
+  overrides:
+    components:
+    - name: hypershift
+      enabled: true
+    - name: hypershift-local-hosting
+      enabled: true
+----

--- a/modules/hcp-uninstall-operator.adoc
+++ b/modules/hcp-uninstall-operator.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+// * hosted-control-planes/hcp-prepare/hcp-enable-disable.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-uninstall-operator_{context}"]
+= Uninstalling the HyperShift Operator
+
+To uninstall the HyperShift Operator and disable the `hypershift-addon` from the `local-cluster`, complete the following steps:
+
+.Procedure
+
+. Run the following command to ensure that there is no hosted cluster running:
++
+[source,terminal]
+----
+$ oc get hostedcluster -A
+----
++
+[IMPORTANT]
+====
+If a hosted cluster is running, the HyperShift Operator does not uninstall, even if the `hypershift-addon` is disabled.
+====
+
+. Disable the `hypershift-addon` by running the following command:
++
+[source,terminal]
+----
+$ oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-local-hosting","enabled": false}]}}}' <1>
+----
++
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
++
+[NOTE]
+====
+You can also disable the `hypershift-addon` for the `local-cluster` from the {mce-short} console after disabling the `hypershift-addon`.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11011
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81100--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-enable-disable.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

NOTE FOR PEER REVIEWERS: This PR moves the enabling and disabling HCP content from the RHACM docs to the OCP docs. The content has not been changed since it was SME- and peer-reviewed by the RHACM team. This PR simply moves the content and applies OCP docs-specific formatting.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
