### PR TITLE
OSDOCS#11824: Remove the architecture diagram from the OPP doc

### DIFF
--- a/modules/opp-architecture-architecture.adoc
+++ b/modules/opp-architecture-architecture.adoc
@@ -15,8 +15,6 @@
 
 {product-title} protects and manages applications for open hybrid cloud environments and application lifecycles.
 
-image::242_OpenShift_Plus_0422.png[]
-
 {product-title} supports these additional capabilities:
 
 * Platform services


### PR DESCRIPTION
Version(s):
This PR is based on the ‘opp-docs-main’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Issue:
[OSDOCS-11824](https://issues.redhat.com/browse/OSDOCS-11824)

Link to docs preview:
[OPP description and architecture](https://81115--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture.html#opp-architecture-architecture_opp-architecture)

QE review:
- [x] QE has approved this change.

Additional information:
n/a
