### PR TITLE
OSDOCS-11680: adds relnote 4.16.10 MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -10,14 +10,12 @@ toc::[]
 
 {microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
-//TODO verify K8s version and another other relevant notes
 [id="microshift-4-16-about-this-release_{context}"]
 == About this release
 Version 4.16 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
 
-//TODO: Update OP system versions
 {microshift-short} {product-version} is supported on {op-system-base-full} or {op-system-ostree-first} 9.4.
 
 For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
@@ -45,11 +43,6 @@ See the following list for details:
 * {microshift-short} offers in-place updates on {op-system-ostree} systems with automatic system rollback capabilities and automatic back up and restore functions.
 * Updates of the RPMs on a non-OSTree system such as {op-system} are also supported.
 * See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
-
-//TODO add new features and enhancements as needed, L4 [discrete] headings
-
-//[id="microshift-4-16-installation"]
-//=== Installation
 
 [id="microshift-4-16-configuring_{context}"]
 === Configuring
@@ -113,42 +106,9 @@ During an SSL handshake between a client and a server, the cipher to use is nego
 ==== Route configuration now documented
 With this release, specific details for creating and managing supported route configurations are documented, see xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes].
 
-//[id="microshift-4-16-deprecated-and-removed"]
-//== Deprecated and removed features
-
-//Some features available in previous releases of {microshift-short} have been deprecated or removed.
-
-//Deprecated functionality is still included in {microshift-short} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {microshift-short} {product-version}, see the following table.
-
-//In the following table, features are marked with the following statuses:
-
-//* _Deprecated_
-
-//* _Removed_
-
-//.{product-title} deprecated and removed features tracker
-//[cols="5,1,1,1",options="header"]
-//|====
-//|Feature |4.14 |4.15 |4.16
-
-//|Network configuration flags
-//|Removed
-//|-
-//|-
-
-//|CIDR notation
-//|Removed
-//|-
-//|-
-//|====
-
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
 [id="microshift-4-16-bug-fixes_{context}"]
 == Bug fixes
-
-//[discrete]
-//[id="microshift-4-16-installation-bug-fixes"]
-//=== Installation
 
 [discrete]
 [id="microshift-4-16-networking-bug-fixes"]
@@ -275,5 +235,14 @@ For the latest images included with {microshift-short}, view the contents of the
 Issued: 29 August 2024
 
 {product-title} release 4.16.9 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5759[RHBA-2024:5759] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5757[RHBA-2024:5757] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-16-10-dp_{context}"]
+=== RHBA-2024:6006 - {microshift-short} 4.16.10 bug fix and enhancement advisory
+
+Issued: 3 September 2024
+
+{product-title} release 4.16.10 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6006[RHBA-2024:6006] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6004[RHSA-2024:6004] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-11680](https://issues.redhat.com/browse/OSDOCS-11680)

Link to docs preview:
[4-16-10 release notes](https://81124--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-10-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
