### PR TITLE
OSDOCS#11568: Migrating non-bare metal agent machines from ACM to OCP

### DIFF
--- a/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
@@ -6,4 +6,71 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+You can deploy {hcp} by configuring a cluster to function as a hosting cluster. The hosting cluster is an {product-title} cluster where the control planes are hosted. The hosting cluster is also known as the management cluster.
 
+[NOTE]
+====
+The management cluster is not the same thing as the _managed_ cluster. A managed cluster is a cluster that the hub cluster manages.
+====
+
+The {hcp} feature is enabled by default.
+
+The {mce-short} supports only the default `local-cluster` managed hub cluster. On {rh-rhacm-first} 2.10, you can use the `local-cluster` managed hub cluster as the hosting cluster.
+
+A _hosted cluster_ is an {product-title} cluster with its API endpoint and control plane that are hosted on the hosting cluster. The hosted cluster includes the control plane and its corresponding data plane. You can use the {mce-short} console or the `hcp` command-line interface (CLI) to create a hosted cluster.
+
+The hosted cluster is automatically imported as a managed cluster. If you want to disable this automatic import feature, see "Disabling the automatic import of hosted clusters into {mce-short}".
+
+include::modules/hcp-non-bm-prepare.adoc[leveloffset=+1]
+include::modules/hcp-non-bm-prereqs.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+
+include::modules/hcp-non-bm-firewall-port-svc-reqs.adoc[leveloffset=+2]
+include::modules/hcp-non-bm-infra-reqs.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc#recommended-etcd-practices[Recommended etcd practices]
+
+* xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#persistent-storage-using-lvms_logical-volume-manager-storage[Persistent storage using logical volume manager storage]
+
+* xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
+
+* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
+
+include::modules/hcp-non-bm-dns.adoc[leveloffset=+1]
+include::modules/hcp-non-bm-hc.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted control plane cluster]
+
+include::modules/hcp-non-bm-hc-console.adoc[leveloffset=+2]
+
+.Next steps
+
+* To access the web console, see xref:../../web_console/web-console.adoc#web-console-overview[Accessing the web console].
+
+include::modules/hcp-bm-hc-mirror.adoc[leveloffset=+2]
+
+.Next steps
+
+* To create credentials that you can reuse when you create a hosted cluster with the console, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment].
+
+* To access a hosted cluster, see xref:../../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-access_hcp-manage-bm[Accessing the hosted cluster].
+
+* To add hosts to the host inventory by using the Discovery Image, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#add-host-host-inventory[Adding hosts to the host inventory by using the Discovery Image].
+
+* To extract the {product-title} release image digest, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#configure-hosted-disconnected-digest-image[Extracting the {product-title} release image digest].
+
+include::modules/hcp-non-bm-verify.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
@@ -6,4 +6,30 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+After you deploy {hcp} on non-bare metal agent machines, you can manage a hosted cluster by completing the following tasks.
 
+include::modules/hcp-bm-access.adoc[leveloffset=+1]
+include::modules/hcp-bm-scale-np.adoc[leveloffset=+1]
+include::modules/hcp-bm-add-np.adoc[leveloffset=+2]
+include::modules/hcp-bm-autoscale.adoc[leveloffset=+2]
+include::modules/hcp-bm-autoscale-disable.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]
+
+include::modules/hcp-bm-ingress.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/metallb/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator]
+
+include::modules/hcp-bm-machine-health.adoc[leveloffset=+1]
+include::modules/hcp-bm-machine-health-disable.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[Deploying machine health checks]

--- a/modules/hcp-bm-access.adoc
+++ b/modules/hcp-bm-access.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-access_{context}"]

--- a/modules/hcp-bm-add-np.adoc
+++ b/modules/hcp-bm-add-np.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-add-np_{context}"]
@@ -53,7 +54,9 @@ hostedcluster-secrets/kubeconfig
 $ oc --kubeconfig ./hostedcluster-secrets get nodes
 ----
 
-. Verify that the number of available node pools match the number of expected node pools by entering this command:
+.Verification
+
+* Verify that the number of available node pools match the number of expected node pools by entering this command:
 +
 [source,terminal]
 ----

--- a/modules/hcp-bm-autoscale-disable.adoc
+++ b/modules/hcp-bm-autoscale-disable.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-autoscale-disable_{context}"]
@@ -10,11 +11,11 @@ To disable node auto-scaling, complete the following procedure.
 
 .Procedure
 
-* Enter the following command:
+* Enter the following command to disable node auto-scaling for the hosted cluster:
 +
 [source,terminal]
 ----
-$ oc -n <hosted-cluster-namespace> patch nodepool <hosted-cluster-name> --type=json -p '[\{"op":"remove", "path": "/spec/autoScaling"}, \{"op": "add", "path": "/spec/replicas", "value": <specify-value-to-scale-replicas>]'
+$ oc -n <hosted_cluster_namespace> patch nodepool <hosted_cluster_name> --type=json -p '[\{"op":"remove", "path": "/spec/autoScaling"}, \{"op": "add", "path": "/spec/replicas", "value": <specify_value_to_scale_replicas>]'
 ----
 +
 The command removes `"spec.autoScaling"` from the YAML file, adds `"spec.replicas"`, and sets `"spec.replicas"` to the integer value that you specify.

--- a/modules/hcp-bm-autoscale.adoc
+++ b/modules/hcp-bm-autoscale.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-autoscale_{context}"]

--- a/modules/hcp-bm-ingress.adoc
+++ b/modules/hcp-bm-ingress.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-ingress_{context}"]
@@ -158,8 +159,12 @@ $ oc apply -f metallb-loadbalancer-service.yaml
 +
 [source,bash]
 ----
-curl -kI https://console-openshift-console.apps.example.krnl.es
-
+$ curl -kI https://console-openshift-console.apps.example.krnl.es
+----
++
+.Example output
+[source,terminal]
+----
 HTTP/1.1 200 OK
 ----
 
@@ -174,11 +179,11 @@ $ oc --kubeconfig <hosted_cluster_name>.kubeconfig get clusterversion,co
 [source,terminal]
 ----
 NAME                                         VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
-clusterversion.config.openshift.io/version   4.x.y      True        False         3m32s   Cluster version is 4.x.y
+clusterversion.config.openshift.io/version   4.x.y      True        False        3m32s   Cluster version is 4.x.y
 
-NAME                                                                           VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-clusteroperator.config.openshift.io/console                                    4.x.y     True        False         False      3m50s
-clusteroperator.config.openshift.io/ingress                                    4.x.y     True        False         False      53m
+NAME                                                                             VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+clusteroperator.config.openshift.io/console                                      4.x.y     True        False         False      3m50s
+clusteroperator.config.openshift.io/ingress                                      4.x.y     True        False         False      53m
 ----
 +
-Replace `4.x.y` with the supported {product-title} version that you want to use, for example, `4.14.0-x86_64`.
+Replace `<4.x.y>` with the supported {product-title} version that you want to use, for example, `4.14.0-x86_64`.

--- a/modules/hcp-bm-machine-health-disable.adoc
+++ b/modules/hcp-bm-machine-health-disable.adoc
@@ -1,12 +1,13 @@
 // Module included in the following assemblies:
 //
 // * hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-machine-health-disable_{context}"]
 = Disabling machine health checks on bare metal
 
-To disable machine health checks for the managed cluster nodes, modify the `NodePool` resource. 
+To disable machine health checks for the managed cluster nodes, modify the `NodePool` resource.
 
 .Procedure
 

--- a/modules/hcp-bm-machine-health.adoc
+++ b/modules/hcp-bm-machine-health.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-machine-health_{context}"]

--- a/modules/hcp-bm-scale-np.adoc
+++ b/modules/hcp-bm-scale-np.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-scale-np_{context}"]

--- a/modules/hcp-non-bm-dns.adoc
+++ b/modules/hcp-non-bm-dns.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-deploy/hcp-deploy-non-bm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-non-bm-dns_{context}"]
+= Configuring DNS on non-bare metal agent machines
+
+The API Server for the hosted cluster is exposed as a `NodePort` service. A DNS entry must exist for `api.<hosted_cluster_name>.<basedomain>` that points to destination where the API Server can be reached.
+
+The DNS entry can be as simple as a record that points to one of the nodes in the managed cluster that is running the hosted control plane. The entry can also point to a load balancer that is deployed to redirect incoming traffic to the ingress pods.
+
+* If you are configuring DNS for a connected environment on an IPv4 network, see the following example DNS configuration:
++
+[source,text]
+----
+api-int.example.krnl.es.    IN A 192.168.122.22
+`*`.apps.example.krnl.es.   IN A 192.168.122.23
+----
+
+* If you are configuring DNS for a disconnected environment on an IPv6 network, see the following example DNS configuration:
++
+[source,text]
+----
+api-int.example.krnl.es.    IN A 2620:52:0:1306::7
+`*`.apps.example.krnl.es.   IN A 2620:52:0:1306::10
+----
+
+* If you are configuring DNS for a disconnected environment on a dual stack network, be sure to include DNS entries for both IPv4 and IPv6. See the following example DNS configuration:
++
+[source,text]
+----
+host-record=api-int.hub-dual.dns.base.domain.name,2620:52:0:1306::2
+address=/apps.hub-dual.dns.base.domain.name/2620:52:0:1306::3
+dhcp-host=aa:aa:aa:aa:10:01,ocp-master-0,[2620:52:0:1306::5]
+----

--- a/modules/hcp-non-bm-firewall-port-svc-reqs.adoc
+++ b/modules/hcp-non-bm-firewall-port-svc-reqs.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-deploy/hcp-deploy-non-bm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-non-bm-firewall-port-svc-reqs_{context}"]
+= Firewall, port, and service requirements for non-bare metal agent machines
+
+You must meet the firewall and port requirements so that ports can communicate between the management cluster, the control plane, and hosted clusters.
+
+[NOTE]
+====
+Services run on their default ports. However, if you use the `NodePort` publishing strategy, services run on the port that is assigned by the `NodePort` service.
+====
+
+Use firewall rules, security groups, or other access controls to restrict access to only required sources. Avoid exposing ports publicly unless necessary. For production deployments, use a load balancer to simplify access through a single IP address.
+
+A hosted control plane exposes the following services on non-bare metal agent machines:
+
+* `APIServer`
+
+** The `APIServer` service runs on port 6443 by default and requires ingress access for communication between the control plane components.
+** If you use MetalLB load balancing, allow ingress access to the IP range that is used for load balancer IP addresses.
+
+* `OAuthServer`
+
+** The `OAuthServer` service runs on port 443 by default when you use the route and ingress to expose the service.
+** If you use the `NodePort` publishing strategy, use a firewall rule for the `OAuthServer` service.
+
+* `Konnectivity`
+
+** The `Konnectivity` service runs on port 443 by default when you use the route and ingress to expose the service.
+** The `Konnectivity` agent establishes a reverse tunnel to allow the control plane to access the network for the hosted cluster. The agent uses egress to connect to the `Konnectivity` server. The server is exposed by using either a route on port 443 or a manually assigned `NodePort`.
+** If the cluster API server address is an internal IP address, allow access from the workload subnets to the IP address on port 6443.
+** If the address is an external IP address, allow egress on port 6443 to that external IP address from the nodes.
+
+* `Ignition`
+
+** The `Ignition` service runs on port 443 by default when you use the route and ingress to expose the service.
+** If you use the `NodePort` publishing strategy, use a firewall rule for the `Ignition` service.
+
+You do not need the following services on non-bare metal agent machines:
+
+* `OVNSbDb`
+* `OIDC`

--- a/modules/hcp-non-bm-hc-console.adoc
+++ b/modules/hcp-non-bm-hc-console.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-deploy/hcp-deploy-non-bm.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-non-bm-hc-console_{context}"]
+= Creating a hosted cluster on non-bare metal agent machines by using the web console
+
+You can create a hosted cluster on non-bare metal agent machines by using the {product-title} web console.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. Open the {product-title} web console and log in by entering your administrator credentials.
+
+. In the console header, select **All Clusters**.
+
+. Click **Infrastructure -> Clusters**.
+
+. Click **Create cluster  Host inventory -> Hosted control plane**.
+
++
+The **Create cluster** page is displayed.
+
+. On the **Create cluster** page, follow the prompts to enter details about the cluster, node pools, networking, and automation.
+
+As you enter details about the cluster, you might find the following tips useful:
+
+* If you want to use predefined values to automatically populate fields in the console, you can create a host inventory credential. For more information, see _Creating a credential for an on-premises environment_.
+
+* On the *Cluster details* page, the pull secret is your {product-title} pull secret that you use to access {product-title} resources. If you selected a host inventory credential, the pull secret is automatically populated.
+
+* On the *Node pools* page, the namespace contains the hosts for the node pool. If you created a host inventory by using the console, the console creates a dedicated namespace.
+
+* On the *Networking* page, you select an API server publishing strategy. The API server for the hosted cluster can be exposed either by using an existing load balancer or as a service of the `NodePort` type. A DNS entry must exist for the `api.<hosted_cluster_name>.<basedomain>` setting that points to the destination where the API server can be reached. This entry can be a record that points to one of the nodes in the management cluster or a record that points to a load balancer that redirects incoming traffic to the Ingress pods.
+
+. Review your entries and click **Create**.
+
++
+The **Hosted cluster** view is displayed.
+
+. Monitor the deployment of the hosted cluster in the **Hosted cluster** view. If you do not see information about the hosted cluster, ensure that **All Clusters** is selected, and click the cluster name. Wait until the control plane components are ready. This process can take a few minutes.
+
+. To view the node pool status, scroll to the **NodePool** section. The process to install the nodes takes about 10 minutes. You can also click **Nodes** to confirm whether the nodes joined the hosted cluster.

--- a/modules/hcp-non-bm-hc-mirror.adoc
+++ b/modules/hcp-non-bm-hc-mirror.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-non-bm-hc-mirror_{context}"]
+= Creating a hosted cluster on non-bare metal agent machines by using a mirror registry
+
+You can use a mirror registry to create a hosted cluster on non-bare metal agent machines by specifying the `--image-content-sources` flag in the `hcp create cluster` command.
+
+.Procedure
+
+. Create a YAML file to define Image Content Source Policies (ICSP). See the following example:
++
+[source,yaml]
+----
+- mirrors:
+  - brew.registry.redhat.io
+  source: registry.redhat.io
+- mirrors:
+  - brew.registry.redhat.io
+  source: registry.stage.redhat.io
+- mirrors:
+  - brew.registry.redhat.io
+  source: registry-proxy.engineering.redhat.com
+----
+
+. Save the file as `icsp.yaml`. This file contains your mirror registries.
+
+. To create a hosted cluster by using your mirror registries, run the following command:
++
+[source,terminal]
+----
+$ hcp create cluster agent \
+    --name=<hosted_cluster_name> \// <1>
+    --pull-secret=<path_to_pull_secret> \// <2>
+    --agent-namespace=<hosted_control_plane_namespace> \// <3>
+    --base-domain=<basedomain> \// <4>
+    --api-server-address=api.<hosted_cluster_name>.<basedomain> \// <5>
+    --image-content-sources icsp.yaml  \// <6>
+    --ssh-key  <path_to_ssh_key> \// <7>
+    --namespace <hosted_cluster_namespace> \// <8>
+    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image> <9>
+----
+
++
+<1> Specify the name of your hosted cluster, for instance, `example`.
+<2> Specify the path to your pull secret, for example, `/user/name/pullsecret`.
+<3> Specify your hosted control plane namespace, for example, `clusters-example`. Ensure that agents are available in this namespace by using the `oc get agent -n <hosted-control-plane-namespace>` command.
+<4> Specify your base domain, for example, `krnl.es`.
+<5> The `--api-server-address` flag defines the IP address that is used for the Kubernetes API communication in the hosted cluster. If you do not set the `--api-server-address` flag, you must log in to connect to the management cluster.
+<6> Specify the `icsp.yaml` file that defines ICSP and your mirror registries.
+<7> Specify the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
+<8> Specify your hosted cluster namespace.
+<9> Specify the supported {product-title} version that you want to use, for example, `4.14.0-x86_64`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see _Extracting the {product-title} release image digest_.

--- a/modules/hcp-non-bm-hc.adoc
+++ b/modules/hcp-non-bm-hc.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-deploy/hcp-deploy-non-bm.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-non-bm-hc_{context}"]
+= Creating a hosted cluster on non-bare metal agent machines by using the CLI
+
+When you create a hosted cluster with the Agent platform, the HyperShift Operator installs the Agent Cluster API provider in the hosted control plane namespace. You can create a hosted cluster on bare metal or import one.
+
+As you create a hosted cluster, review the following guidelines:
+
+* Each hosted cluster must have a cluster-wide unique name. A hosted cluster name cannot be the same as any existing managed cluster in order for {mce-short} to manage it.
+
+* Do not use `clusters` as a hosted cluster name.
+
+* A hosted cluster cannot be created in the namespace of a {mce-short} managed cluster.
+
+.Procedure
+
+. Create the hosted control plane namespace by entering the following command:
++
+[source,terminal]
+----
+$ oc create ns <hosted_cluster_namespace>-<hosted_cluster_name> <1>
+----
++
+<1> Replace `<hosted_cluster_namespace>` with your hosted cluster namespace name, for example, `clusters`. Replace `<hosted_cluster_name>` with your hosted cluster name.
+
+. Create a hosted cluster by entering the following command:
++
+[source,terminal]
+----
+$ hcp create cluster agent \
+  --name=<hosted_cluster_name> \// <1>
+  --pull-secret=<path_to_pull_secret> \// <2>
+  --agent-namespace=<hosted_control_plane_namespace> \// <3>
+  --base-domain=<basedomain> \// <4>
+  --api-server-address=api.<hosted_cluster_name>.<basedomain> \// <5>
+  --etcd-storage-class=<etcd_storage_class> \// <6>
+  --ssh-key  <path_to_ssh_key> \// <7>
+  --namespace <hosted_cluster_namespace> \// <8>
+  --control-plane-availability-policy SingleReplica \
+  --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release> <9>
+----
++
+<1> Specify the name of your hosted cluster, for instance, `example`.
+<2> Specify the path to your pull secret, for example, `/user/name/pullsecret`.
+<3> Specify your hosted control plane namespace, for example, `clusters-example`. Ensure that agents are available in this namespace by using the `oc get agent -n <hosted-control-plane-namespace>` command.
+<4> Specify your base domain, for example, `krnl.es`.
+<5> The `--api-server-address` flag defines the IP address that is used for the Kubernetes API communication in the hosted cluster. If you do not set the `--api-server-address` flag, you must log in to connect to the management cluster.
+<6> Verify that you have a default storage class configured for your cluster. Otherwise, you might end up with pending PVCs. Specify the etcd storage class name, for example, `lvm-storageclass`.
+<7> Specify the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
+<8> Specify your hosted cluster namespace.
+<9> Specify the supported {ocp-short} version that you want to use, for example, `4.14.0-x86_64`.
+
+.Verification
+
+* After a few moments, verify that your hosted control plane pods are up and running by entering the following command:
++
+[source,terminal]
+----
+$ oc -n <hosted_control_plane_namespace> get pods
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                             READY   STATUS    RESTARTS   AGE
+catalog-operator-6cd867cc7-phb2q                 2/2     Running   0          2m50s
+control-plane-operator-f6b4c8465-4k5dh           1/1     Running   0          4m32s
+----

--- a/modules/hcp-non-bm-infra-reqs.adoc
+++ b/modules/hcp-non-bm-infra-reqs.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-deploy/hcp-deploy-non-bm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-non-bm-infra-reqs_{context}"]
+= Infrastructure requirements for non-bare metal agent machines
+
+The Agent platform does not create any infrastructure, but it has the following infrastructure requirements:
+
+* Agents: An _Agent_ represents a host that is booted with a discovery image and is ready to be provisioned as an {product-title} node.
+
+* DNS: The API and ingress endpoints must be routable.

--- a/modules/hcp-non-bm-prepare.adoc
+++ b/modules/hcp-non-bm-prepare.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-deploy/hcp-deploy-non-bm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-non-bm-prepare_{context}"]
+= Preparing to deploy {hcp} on non-bare metal agent machines
+
+As you prepare to deploy {hcp} on bare metal, consider the following information:
+
+* You can add agent machines as a worker node to a hosted cluster by using the Agent platform. Agent machine represents a host booted with a Discovery Image and ready to be provisioned as an {product-title} node. The Agent platform is part of the central infrastructure management service. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service].
+
+* All hosts that are not bare metal require a manual boot with a Discovery Image ISO that the central infrastructure management provides.
+
+* When you scale up the node pool, a machine is created for every replica. For every machine, the Cluster API provider finds and installs an Agent that is approved, is passing validations, is not currently in use, and meets the requirements that are specified in the node pool specification. You can monitor the installation of an Agent by checking its status and conditions.
+
+* When you scale down a node pool, Agents are unbound from the corresponding cluster. Before you can reuse the Agents, you must restart them by using the Discovery image.
+
+* When you configure storage for {hcp}, consider the recommended etcd practices. To ensure that you meet the latency requirements, dedicate a fast storage device to all {hcp} etcd instances that run on each control-plane node. You can use LVM storage to configure a local storage class for hosted etcd pods. For more information, see "Recommended etcd practices" and "Persistent storage using logical volume manager storage" in the {product-title} documentation.

--- a/modules/hcp-non-bm-prereqs.adoc
+++ b/modules/hcp-non-bm-prereqs.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-deploy/hcp-deploy-non-bm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-non-bm-prereqs_{context}"]
+= Prerequisites for deploying {hcp} on non-bare metal agent machines
+
+You must review the following prerequisites before deploying {hcp} on non-bare metal agent machines:
+
+* You need the {mce} 2.5 and later installed on an {product-title} cluster. The {mce-short} is automatically installed when you install {rh-rhacm-first}. You can also install the {mce-short} without {rh-rhacm} as an Operator from the {product-title} OperatorHub.
+
+* You have at least one managed {product-title} cluster for the {mce-short}. The `local-cluster` managed hub cluster is automatically imported. See link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration] for more information about the local-cluster. You can check the status of your hub cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get managedclusters local-cluster
+----
+
+* You enabled central infrastructure management. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service].
+
+* You installed the `hcp` command-line interface.
+
+* Your hosted cluster has a cluster-wide unique name. A hosted cluster name cannot be the same as any existing managed cluster in order for the {mce-short} to manage it.
+
+* You run the hub cluster and workers on the same platform for {hcp}.

--- a/modules/hcp-non-bm-verify.adoc
+++ b/modules/hcp-non-bm-verify.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-deploy/hcp-deploy-non-bm.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-non-bm-verify_{context}"]
+= Verifying hosted cluster creation on non-bare metal agent machines
+
+After the deployment process is complete, you can verify that the hosted cluster was created successfully. Follow these steps a few minutes after you create the hosted cluster.
+
+.Procedure
+
+. Obtain the `kubeconfig` file for your new hosted cluster by entering the following command:
++
+[source,terminal]
+----
+$ oc extract -n <hosted_cluster_namespace> secret/<hosted_cluster_name>-admin-kubeconfig --to=- > kubeconfig-<hosted_cluster_name>
+----
+
+. Use the `kubeconfig` file to view the cluster Operators of the hosted cluster. Enter the following command:
++
+[source,terminal]
+----
+$ oc get co --kubeconfig=kubeconfig-<hosted_cluster_name>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+console                                    4.10.26   True        False         False      2m38s
+csi-snapshot-controller                    4.10.26   True        False         False      4m3s
+dns                                        4.10.26   True        False         False      2m52s
+----
+
+. View the running pods on your hosted cluster by entering the following command:
++
+[source,terminal]
+----
+$ oc get pods -A --kubeconfig=kubeconfig-<hosted_cluster_name>
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE                                          NAME                                                      READY   STATUS             RESTARTS        AGE
+kube-system                                        konnectivity-agent-khlqv                                  0/1     Running            0               3m52s
+openshift-cluster-samples-operator                 cluster-samples-operator-6b5bcb9dff-kpnbc                 2/2     Running            0               20m
+openshift-monitoring                               alertmanager-main-0                                       6/6     Running            0               100s
+openshift-monitoring                               openshift-state-metrics-677b9fb74f-qqp6g                  3/3     Running            0               104s
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> This PR is a part of HCP content migration and modularization. Configuring HCP using non bare metal agent machines has been removed from the RHACM docs and being added to the OCP docs. The content has not been changed for this PR. 

Note: This content is only being moved from RHACM to OCP. This content has been SME and peer reviewed. This migration PR contains the QE approval -- https://github.com/openshift/openshift-docs/pull/81125#issuecomment-2340394727

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11568
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Deploying hosted control planes on non-bare metal agent machines](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html)
- [Preparing to deploy hosted control planes on non-bare metal agent machines](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-non-bm-prepare_hcp-deploy-non-bm)
- [Prerequisites for deploying hosted control planes on non-bare metal agent machines](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-non-bm-deploy-prereq_hcp-deploy-non-bm)
- [Firewall, port, and service requirements for non-bare metal agent machines](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-firewall-port-reqs-non-bm_hcp-deploy-non-bm)
- [Infrastructure requirements for non-bare metal agent machines](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-infra-reqs-non-bm_hcp-deploy-non-bm)
- [Configuring DNS on non-bare metal agent machines](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-config-dns-non-bm_hcp-deploy-non-bm)
- [Creating a hosted cluster on non-bare metal agent machines by using the CLI](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-non-bm-hc_hcp-deploy-non-bm)
- [Creating a hosted cluster on non-bare metal agent machines by using the web console](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-create-hc-non-bm-console_hcp-deploy-non-bm)
- [Creating a hosted cluster on bare metal by using a mirror registry](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-bm-hc-mirror_hcp-deploy-non-bm)
- Assembly -- [Managing hosted control planes on non-bare metal agent machines](https://81125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-non-bm)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
