### PR TITLE
CNV#40179: Doc VMSnapshot API is now v1beta1

### DIFF
--- a/modules/virt-creating-vm-snapshot-cli.adoc
+++ b/modules/virt-creating-vm-snapshot-cli.adoc
@@ -20,7 +20,7 @@ You can create a virtual machine (VM) snapshot for an offline or online VM by cr
 +
 [source,yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1alpha1
+apiVersion: snapshot.kubevirt.io/v1beta1
 kind: VirtualMachineSnapshot
 metadata:
   name: <snapshot_name>
@@ -76,7 +76,7 @@ $ oc describe vmsnapshot <snapshot_name>
 .Example output
 [source,yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1alpha1
+apiVersion: snapshot.kubevirt.io/v1beta1
 kind: VirtualMachineSnapshot
 metadata:
   creationTimestamp: "2020-09-30T14:41:51Z"
@@ -86,7 +86,7 @@ metadata:
   name: mysnap
   namespace: default
   resourceVersion: "3897"
-  selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinesnapshots/my-vmsnapshot
+  selfLink: /apis/snapshot.kubevirt.io/v1beta1/namespaces/default/virtualmachinesnapshots/my-vmsnapshot
   uid: 28eedf08-5d6a-42c1-969c-2eda58e2a78d
 spec:
   source:

--- a/modules/virt-restoring-vm-from-snapshot-cli.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-cli.adoc
@@ -51,7 +51,7 @@ $ oc get vmrestore <vm_restore>
 .Example output
 [source, yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1alpha1
+apiVersion: snapshot.kubevirt.io/v1beta1
 kind: VirtualMachineRestore
 metadata:
 creationTimestamp: "2020-09-30T14:46:27Z"
@@ -66,7 +66,7 @@ ownerReferences:
   name: my-vm
   uid: 355897f3-73a0-4ec4-83d3-3c2df9486f4f
   resourceVersion: "5512"
-  selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinerestores/my-vmrestore
+  selfLink: /apis/snapshot.kubevirt.io/v1beta1/namespaces/default/virtualmachinerestores/my-vmrestore
   uid: 71c679a8-136e-46b0-b9b5-f57175a6a041
   spec:
     target:


### PR DESCRIPTION
Version(s): 4.17

Issue: [CNV-40179](https://issues.redhat.com/browse/CNV-40179)

Link to docs preview: 
[Creating a snapshot by using the command line](https://81128--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots.html#virt-creating-vm-snapshot-cli_virt-backup-restore-snapshots) (see one occurrence Step 1 in the Procedure and two occurrences in the Verification Example output)
[Restoring a VM from a snapshot by using the command line](https://81128--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots.html#virt-restoring-vm-from-snapshot-cli_virt-backup-restore-snapshots) (see two occurrences in Verification Example output)

QE review:
- [x] QE has approved this change.

