### PR TITLE
OSDOCS-11561: adding back ticks for user values in microshift

### DIFF
--- a/modules/microshift-adding-other-packages-to-blueprint.adoc
+++ b/modules/microshift-adding-other-packages-to-blueprint.adoc
@@ -17,21 +17,23 @@ Add the references for optional RPM packages to your OSTree blueprint to enable 
 . Edit your OSTree blueprint by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ vi <microshift_blueprint.toml> <1>
+$ vi __<microshift_blueprint.toml>__ <1>
 ----
-<1> Replace _<microshift_blueprint.toml>_ with the name of the blueprint file used for the {microshift-short} service.
+<1> Replace `_<microshift_blueprint.toml>_` with the name of the blueprint file used for the {microshift-short} service.
 
 . Add the following example text to your blueprint:
 +
 [source,text]
+[subs="+quotes"]
 ----
 [[packages]] <1>
-name = "<microshift-additional-package-name>" <2>
+name = "__<microshift-additional-package-name>__" <2>
 version = "*"
 ----
 <1> Include one stanza for each additional service that you want to add.
-<2> Replace _<microshift-additional-package-name>_ with the name the RPM for the service you want to include. For example, `microshift-olm`.
+<2> Replace `_<microshift-additional-package-name>_` with the name the RPM for the service you want to include. For example, `microshift-olm`.
 
 .Next steps
 . Add custom certificate authorities to the blueprint as needed.

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -14,8 +14,8 @@ Adding the {microshift-short} RPM package to an Image Builder blueprint enables 
 +
 [IMPORTANT]
 ====
-* Replace _<microshift_blueprint.toml>_ in the following procedures with the name of the TOML file you are using.
-* Replace _<microshift_blueprint>_ in the following procedures with the name you want to use for your blueprint.
+* Replace `_<microshift_blueprint.toml>_` in the following procedures with the name of the TOML file you are using.
+* Replace `_<microshift_blueprint>_` in the following procedures with the name you want to use for your blueprint.
 ====
 
 .Procedure
@@ -27,8 +27,8 @@ Adding the {microshift-short} RPM package to an Image Builder blueprint enables 
 [source,text]
 [subs="+quotes"]
 ----
-cat > _<microshift_blueprint.toml>_ <<EOF <1>
-name = "_<microshift_blueprint>_" <2>
+cat > __<microshift_blueprint.toml>__ <<EOF <1>
+name = "__<microshift_blueprint>__" <2>
 
 description = ""
 version = "0.0.1"
@@ -43,8 +43,8 @@ version = "*"
 enabled = ["microshift"]
 EOF
 ----
-<1> _<microshift_blueprint.toml>_ is the name of the TOML file.
-<2> _<microshift_blueprint>_ is the name of your blueprint.
+<1> The name of the TOML file.
+<2> The name of the blueprint.
 +
 [NOTE]
 ====
@@ -97,7 +97,7 @@ EOF
 ----
 $ sudo composer-cli blueprints push __<microshift_blueprint.toml>__ <1>
 ----
-<1> Replace _<microshift_blueprint.toml>_ with the name of your TOML file.
+<1> Replace `_<microshift_blueprint.toml>_` with the name of your TOML file.
 
 .Verification
 
@@ -108,7 +108,7 @@ $ sudo composer-cli blueprints push __<microshift_blueprint.toml>__ <1>
 ----
 $ sudo composer-cli blueprints depsolve __<microshift_blueprint>__ | grep microshift <1>
 ----
-<1> Replace _<microshift_blueprint>_ with the name of your blueprint.
+<1> Replace `_<microshift_blueprint>_` with the name of your blueprint.
 +
 .Example output
 +
@@ -129,4 +129,4 @@ blueprint: microshift_blueprint v0.0.1
 ----
 $ sudo composer-cli blueprints depsolve __<microshift_blueprint>__ <1>
 ----
-<1> Replace _<microshift_blueprint>_ with the name of your blueprint.
+<1> Replace `_<microshift_blueprint>_` with the name of your blueprint.

--- a/modules/microshift-audit-logs-config-proc.adoc
+++ b/modules/microshift-audit-logs-config-proc.adoc
@@ -42,22 +42,24 @@ $ sudo systemctl stop microshift
 .. Move the `/var/log/kube-apiserver` directory to your desired location by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ sudo mv /var/log/kube-apiserver <~/kube-apiserver> <1>
+$ sudo mv /var/log/kube-apiserver __<~/kube-apiserver>__ <1>
 ----
-<1> Replace _<~/kube-apiserver>_ with the path to the directory that you want to use.
+<1> Replace `_<~/kube-apiserver>_` with the path to the directory that you want to use.
 
 .. If you specified a new directory for logs, create a symlink to your custom directory at `/var/log/kube-apiserver` by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ sudo ln -s <~/kube-apiserver> /var/log/kube-apiserver <1>
+$ sudo ln -s __<~/kube-apiserver>__ /var/log/kube-apiserver <1>
 ----
-<1> Replace _<~/kube-apiserver>_ with the path to the directory that you want to use. This enables the collection of logs in sos reports.
+<1> Replace `_<~/kube-apiserver>_` with the path to the directory that you want to use. This enables the collection of logs in sos reports.
 
 . If you are configuring audit log policies on a running instance, restart {microshift-short} by entering the following command:
 +
 [source,terminal]
 ----
-$ sudo systemctl restart microsohift
+$ sudo systemctl restart microshift
 ----

--- a/modules/microshift-check-journal-logs-updates.adoc
+++ b/modules/microshift-check-journal-logs-updates.adoc
@@ -49,16 +49,18 @@ IDX  BOOT ID                          	FIRST ENTRY                 LAST ENTRY
 ** Check the journal logs for the specific boot you want by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ sudo journalctl --boot <-my_boot_ID> <1>
+$ sudo journalctl --boot __<idx_or_boot_id>__ <1>
 ----
-<1> Replace _<-my-boot-ID>_ with the number assigned to the specific boot that you want to check.
+<1> Replace `_<idx_or_boot_id>_` with the `IDX` or the `BOOT ID` number assigned to the specific boot that you want to check.
 
 ** Check the journal logs for the boot of a specific service by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ sudo journalctl --boot <-my_boot_ID> -u <service_name> <1> <2>
+$ sudo journalctl --boot __<idx_or_boot_id>__ -u __<service_name>__ <1> <2>
 ----
-<1> Replace _<-my-boot-ID>_ with the number assigned to the specific boot that you want to check.
-<2> Replace _<service_name>_ with the name of the service that you want to check.
+<1> Replace `_<idx_or_boot_id>_` with the `IDX` or the `BOOT ID` number assigned to the specific boot that you want to check.
+<2> Replace `_<service_name>_` with the name of the service that you want to check.

--- a/modules/microshift-creating-ostree-iso.adoc
+++ b/modules/microshift-creating-ostree-iso.adoc
@@ -23,7 +23,7 @@ Use the following procedure to create the ISO. The {op-system-ostree} Installer 
 ----
 $ BUILDID=$(sudo composer-cli compose start-ostree --ref "rhel/{op-system-version-major}/$(uname -m)/edge" __<microshift_blueprint>__ edge-container | awk '{print $2}') <1>
 ----
-<1> Replace _<microshift_blueprint>_ with the name of your blueprint.
+<1> Replace `_<microshift_blueprint>_` with the name of your blueprint.
 +
 This command also returns the identification (ID) of the build for monitoring.
 

--- a/modules/microshift-gitops-adding-apps.adoc
+++ b/modules/microshift-gitops-adding-apps.adoc
@@ -61,10 +61,11 @@ spec:
 . To deploy the applications defined in the YAML file, run the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ oc apply -f <my-app>.yaml <1>
+$ oc apply -f __<my_app.yaml>__ <1>
 ----
-<1> Replace _<my-app>_ with the name of your application YAML.
+<1> Replace `_<my_app.yaml>_` with the name of your application YAML.
 
 .Verification
 

--- a/modules/microshift-nw-enforcing-hsts-per-domain.adoc
+++ b/modules/microshift-nw-enforcing-hsts-per-domain.adoc
@@ -31,10 +31,11 @@ $ oc annotate route --all --all-namespaces --overwrite=true "haproxy.router.open
 * Apply HSTS to all routes in a particular namespace by running the following `oc annotate command`:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ oc annotate route --all -n <my_namespace> --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=31536000;preload;includeSubDomains" <1>
+$ oc annotate route --all -n __<my_namespace>__ --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=31536000;preload;includeSubDomains" <1>
 ----
-<1> Replace _<my_namespace> with the namespace you want to use.
+<1> Replace `_<my_namespace>_` with the namespace you want to use.
 
 .Verification
 * Review the HSTS annotations on all routes by running the following command:

--- a/modules/microshift-nw-multus-add-pod.adoc
+++ b/modules/microshift-nw-multus-add-pod.adoc
@@ -20,18 +20,19 @@ If you want to attach additional networks to a pod that is already running, you 
 
 . Add an annotation to a `Pod` YAML file. Only one of the following annotation formats can be used:
 
-.. To attach an additional network without any customization, add an annotation with the following format. Replace `<network>` with the name of the additional network to associate with the pod:
+.. To attach an additional network without any customization, add an annotation with the following format. Replace `_<network>_` with the name of the additional network to associate with the pod:
 +
 [source,yaml]
+[subs="+quotes"]
 ----
 apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    k8s.v1.cni.cncf.io/networks: <network>[,<network>,...] # <1>
+    k8s.v1.cni.cncf.io/networks: __<network>__[,__<network>__,...] # <1>
 # ...
 ----
-<1> Replace `<network>` with the name of the additional network to associate with the pod. To specify more than one additional network, separate each network with a comma. Do not include whitespace between the comma. If you specify the same additional network multiple times, that pod will have multiple network interfaces attached to that network.
+<1> Replace `_<network>_` with the name of the additional network to associate with the pod. To specify more than one additional network, separate each network with a comma. Do not include whitespace between the comma. If you specify the same additional network multiple times, that pod will have multiple network interfaces attached to that network.
 +
 .Example annotation for a bridge-type additional network
 +
@@ -70,28 +71,29 @@ metadata:
 . To create a `Pod` YAML file and add the  `NetworkAttachmentDefinition` annotation for an additional network, run the following command and use the example YAML:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ oc apply -f ./<test-bridge>.yaml <1>
+$ oc apply -f ./__<test_bridge>__.yaml <1>
 ----
-<1> Replace _<test-bridge>_ with the pod name that you want to use.
+<1> Replace `_<test_bridge>_` with the pod name that you want to use.
 +
 .Example output
 [source,terminal]
 ----
-pod/test-bridge created
+pod/test_bridge created
 ----
 +
-.Example `test-bridge` pod YAML
+.Example `test_bridge` pod YAML
 [source,yaml]
 ----
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-bridge
+  name: test_bridge
   annotations:
     k8s.v1.cni.cncf.io/networks: bridge-conf
   labels:
-    app: test-bridge
+    app: test_bridge
 spec:
   terminationGracePeriodSeconds: 0
   containers:
@@ -128,19 +130,21 @@ metadata:
 # ...
 ----
 
-. Optional: To confirm that the `NetworkAttachmentDefinition` annotation exists in a `Pod` YAML, run the following command, replacing `<name>` with the name of the pod.
+. Optional: To confirm that the `NetworkAttachmentDefinition` annotation exists in a `Pod` YAML, run the following command, replacing `_<name>_` with the name of the pod.
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ oc get pod <name> -o yaml <1>
+$ oc get pod __<name>__ -o yaml <1>
 ----
-<1> Replace _<name>_ with the pod name you want to use. In the following example, `test-bridge` is used.
+<1> Replace `_<name>_` with the pod name you want to use. In the following example, `_<test_bridge>_` is used.
 +
-In the following example, the `test-bridge` is attached to the `net1` additional network:
+In the following example, the `test_bridge` is attached to the `net1` additional network:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ oc get pod test-bridge -o yaml
+$ oc get pod __<test_bridge>__ -o yaml
 ----
 +
 .Example output
@@ -189,5 +193,5 @@ $ oc get pod
 [source,terminal]
 ----
 NAME          READY   STATUS    RESTARTS   AGE
-test-bridge   1/1     Running   0          81s
+test_bridge   1/1     Running   0          81s
 ----

--- a/modules/microshift-olm-deploy-ops-spec-ns.adoc
+++ b/modules/microshift-olm-deploy-ops-spec-ns.adoc
@@ -64,7 +64,7 @@ metadata:
 ----
 $ oc apply -f _<ns.yaml>_ <1>
 ----
-<1> Replace _<ns.yaml>_ with the name of your namespace configuration file. In this example, `olm-microshift` is used.
+<1> Replace `_<ns.yaml>_` with the name of your namespace configuration file. In this example, `olm-microshift` is used.
 +
 .Example output
 [source,terminal]
@@ -94,7 +94,7 @@ spec: <1>
 ----
 $ oc apply -f _<og.yaml>_ <1>
 ----
-<1> Replace _<og.yaml>_ with the name of your operator group configuration file.
+<1> Replace `_<og.yaml>_` with the name of your operator group configuration file.
 +
 .Example output
 [source,terminal]
@@ -130,10 +130,11 @@ spec:
 . Apply the `CatalogSource` configuration by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ oc apply -f _<my-catalog-source.yaml>_ <1>
+$ oc apply -f __<my_catalog_source.yaml>__ <1>
 ----
-<1> Replace _<my-catalog-source.yaml>_ with your catalog source configuration file name.
+<1> Replace `_<my_catalog_source.yaml>_` with your catalog source configuration file name.
 
 . To verify that the catalog source is applied, check for the `READY` state by using the following command:
 +
@@ -217,6 +218,7 @@ spec:
 . Apply the Subscription CR configuration by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
 $ oc apply -f _<my-subscription-cr.yaml>_
 ----


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-11561](https://issues.redhat.com/browse/OSDOCS-11561)

Link to docs preview:
[Adding the MicroShift service to a blueprint](https://81156--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#adding-microshift-service-to-blueprint_microshift-embed-in-rpm-ostree)
[Adding other packages to a blueprint](https://81156--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#microshift-adding-other-services-to-blueprint_microshift-embed-in-rpm-ostree)
[Creating the RHEL for Edge image](https://81156--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use.html#microshift-creating-ostree-iso_microshift-embed-rpm-ostree-offline-use)
[Configuring audit log values](https://81156--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-audit-logs-config.html#microshift-configuring-audit-log-values_microshift-audit-logs-config)
[Enforcing HTTP Strict Transport Security per-domain](https://81156--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-configuring-routes.html#microshift-nw-enforcing-hsts-per-domain_microshift-configuring-routes)
[Adding a pod to an additional network](https://81156--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus-using.html#microshift-nw-multus-add-pod_microshift-cni-multus-using)
[Creating GitOps applications on MicroShift](https://81156--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-gitops.html#microshift-gitops-adding-apps_microshift-gitops)
[Adding OLM-based Operators to a networked cluster using the global namespace](https://81156--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift_operators/microshift-operators-olm.html#microshift-OLM-deploy-Operators_microshift-operators-olm)
[Checking journal logs after updates](https://81156--ocpdocs-pr.netlify.app/microshift/latest/microshift_troubleshooting/microshift-troubleshoot-updates.html#microshift-check-journal-logs-updates_microshift-troubleshoot-updates)

QE and SME review:
- NA as only back ticks are modified. No technical changes. Internal doc work

Additional information:
This PR was created based on the comment given in the PR https://github.com/openshift/openshift-docs/pull/78516
