### PR TITLE
OSDOCS-11836: Documenting the 4.13.49 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4325,3 +4325,24 @@ $ oc adm release info 4.13.48 --pullspecs
 [id="ocp-4-13-48-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
+[id="ocp-4-13-49"]
+=== RHSA-2024:6009 - {product-title} 4.13.49 bug fix and security updates
+
+Issued: 04 September 2024
+
+{product-title} release 4.13.49, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6009[RHSA-2024:6009] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6011[RHSA-2024:6011] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.49 --pullspecs
+----
+
+[id="ocp-4-13-49-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-11836](https://issues.redhat.com/browse/OSDOCS-11836)

Link to docs preview:
[4.13.49](https://81168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-49)
