### PR TITLE
CNV#40181: Doc VMExport API now v1beta1

### DIFF
--- a/modules/virt-accessing-exported-vm-manifests.adoc
+++ b/modules/virt-accessing-exported-vm-manifests.adoc
@@ -56,7 +56,7 @@ $ oc get vmexport <export_name> -o yaml
 
 [source,yaml]
 ----
-apiVersion: export.kubevirt.io/v1alpha1
+apiVersion: export.kubevirt.io/v1beta1
 kind: VirtualMachineExport
 metadata:
   name: example-export
@@ -73,9 +73,9 @@ status:
 #...
       manifests:
       - type: all
-        url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1alpha1/namespaces/example/virtualmachineexports/example-export/external/manifests/all <1>
+        url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/external/manifests/all <1>
       - type: auth-header-secret
-        url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1alpha1/namespaces/example/virtualmachineexports/example-export/external/manifests/secret <2>
+        url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/external/manifests/secret <2>
     internal:
 #...
       manifests:
@@ -107,7 +107,7 @@ For example:
 +
 [source,terminal]
 ----
-$ curl --cacert cacert.crt https://vmexport-proxy.test.net/api/export.kubevirt.io/v1alpha1/namespaces/example/virtualmachineexports/example-export/external/manifests/secret -H "x-kubevirt-export-token:token_decode" -H "Accept:application/yaml"
+$ curl --cacert cacert.crt https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/external/manifests/secret -H "x-kubevirt-export-token:token_decode" -H "Accept:application/yaml"
 ----
 
 . Get the manifests of `type: all`, such as the `ConfigMap` and `VirtualMachine` manifests, by running the following command:
@@ -125,7 +125,7 @@ For example:
 +
 [source,terminal]
 ----
-$ curl --cacert cacert.crt https://vmexport-proxy.test.net/api/export.kubevirt.io/v1alpha1/namespaces/example/virtualmachineexports/example-export/external/manifests/all -H "x-kubevirt-export-token:token_decode" -H "Accept:application/yaml"
+$ curl --cacert cacert.crt https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/external/manifests/all -H "x-kubevirt-export-token:token_decode" -H "Accept:application/yaml"
 ----
 
 .Next steps

--- a/modules/virt-creating-virtualmachineexport.adoc
+++ b/modules/virt-creating-virtualmachineexport.adoc
@@ -32,7 +32,7 @@ The export server supports the following file formats:
 .`VirtualMachineExport` example
 [source,yaml]
 ----
-apiVersion: export.kubevirt.io/v1alpha1
+apiVersion: export.kubevirt.io/v1beta1
 kind: VirtualMachineExport
 metadata:
   name: example-export
@@ -70,7 +70,7 @@ The internal and external links for the exported volumes are displayed in the `s
 .Output example
 [source,yaml]
 ----
-apiVersion: export.kubevirt.io/v1alpha1
+apiVersion: export.kubevirt.io/v1beta1
 kind: VirtualMachineExport
 metadata:
   name: example-export
@@ -102,9 +102,9 @@ status:
       volumes:
       - formats:
         - format: raw
-          url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1alpha1/namespaces/example/virtualmachineexports/example-export/volumes/example-disk/disk.img
+          url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/volumes/example-disk/disk.img
         - format: gzip
-          url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1alpha1/namespaces/example/virtualmachineexports/example-export/volumes/example-disk/disk.img.gz
+          url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/volumes/example-disk/disk.img.gz
         name: example-disk
     internal:  <2>
       cert: |-


### PR DESCRIPTION
Version(s): 4.17

Issue: [CNV-40181](https://issues.redhat.com/browse/CNV-40181)

Link to docs preview:
[Creating a VirtualMachineExport custom resource](https://81171--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-exporting-vms.html) See updates in the examples.
[Accessing exported virtual machine manifests](https://81171--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-exporting-vms.html#virt-accessing-exported-vm-manifests_virt-exporting-vms) See updates in the examples.

QE review:
- [x] QE has approved this change.


