### PR TITLE
CNV#40180: Release note: API is now v1beta1

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -72,6 +72,9 @@ This release adds new features and enhancements related to the following compone
 [id="virt-4-17-storage"]
 === Storage
 
+//CNV-40180 Release note: API is now v1beta1
+* The `VirtualMachineSnapshot` API version is now v1beta1.
+
 [id="virt-4-17-web"]
 === Web console
 


### PR DESCRIPTION
Version(s): 4.17

Issue: [CNV-40180](https://issues.redhat.com/browse/CNV-40180)

Link to docs preview: See the note in the Storage section of the 4.17 OpenShift Virtualization release notes. (https://81176--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-17-storage)

QE review:
- [x] QE has approved this change.

