### PR TITLE
OSDOCS-11837 OCP Release Notes 4.15.30

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2740,6 +2740,37 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-30_{context}"]
+=== RHSA-2024:6013 - {product-title} 4.15.30 bug fix and security update
+
+Issued: 5 September 2024
+
+{product-title} release 4.15.30, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6013[RHSA-2024:6013] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6016[RHSA-2024:6016] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.30 --pullspecs
+----
+
+[id="ocp-4-15-30-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when running the `oc logs -f <pod>` command, the logs would not output anything after the log file was rotated. With this release, the kubelet outputs a log file after it has been rotated, and as a result the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-38861[*OCPBUGS-38861*])
+
+* Previously, an internal timeout would occur when the service account had short lived credentials. With this release, that timeout is removed, and the timeout is now controlled by the parent context. (link:https://issues.redhat.com/browse/OCPBUGS-38198[*OCPBUGS-38198*])
+
+* Previously, setting an invalid `.spec.endpoints.proxyUrl` attribute in the `ServiceMonitor` resource would result in breaking, reloading, and restarting Prometheus. This update fixes the issue by validating the `proxyUrl` attribute against invalid syntax. (link:https://issues.redhat.com/browse/OCPBUGS-36719[*OCPBUGS-36719*])
+
+* Previously, there was an error when adding parameters to the Pipeline when the resource field was added to the payload, and as a result resources were deprecated. With this update, the resource fields have been removed from the payload, and you can add parameters to the Pipeline without getting an error. (link:https://issues.redhat.com/browse/OCPBUGS-33076[*OCPBUGS-33076*])
+
+[id="ocp-4-15-30-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-15-29_{context}"]
 === RHSA-2024:5439 - {product-title} 4.15.29 bug fix and security update
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11837](https://issues.redhat.com/browse/OSDOCS-11837)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview](https://81177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-30_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links will not work until Sept. 4th. Had to change the date in the PR to Sept. 5th since there was a delay in shipping.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
