### PR TITLE
CNV#40182: Release note: VM Export API now beta

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -75,6 +75,9 @@ This release adds new features and enhancements related to the following compone
 //CNV-40180 Release note: API is now v1beta1
 * The `VirtualMachineSnapshot` API version is now v1beta1.
 
+//CNV-40182 Release note: VM Export API now beta
+* The `VirtualMachineExport` API version is now v1beta1.
+
 [id="virt-4-17-web"]
 === Web console
 


### PR DESCRIPTION
Version(s): 4.17

Issue: [CNV-40182](https://issues.redhat.com/browse/CNV-40182)

Link to docs preview: Storage section (https://81183--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-17-storage)

QE review:
- [x] QE has approved this change.

