### PR TITLE
PR for SRVCOM-3241: Update broken links in "Observability → Tracing → Tracing Requests" Section.

### DIFF
--- a/observability/tracing/serverless-tracing.adoc
+++ b/observability/tracing/serverless-tracing.adoc
@@ -1,7 +1,7 @@
-:_content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
+:_mod-docs-content-type: ASSEMBLY
 [id="serverless-tracing"]
 = Tracing requests
+include::_attributes/common-attributes.adoc[]
 :context: serverless-tracing
 
 toc::[]
@@ -13,5 +13,5 @@ include::modules/distr-tracing-product-overview.adoc[leveloffset=+1]
 [id="additional-resources_serverless-tracing"]
 [role="_additional-resources"]
 == Additional resources for {ocp-product-title}
-* link:https://docs.openshift.com/container-platform/latest/distr_tracing/distr_tracing_arch/distr-tracing-architecture.html#distr-tracing-architecture[{DTProductName} architecture]
-* link:https://docs.openshift.com/container-platform/latest/distr_tracing/distr_tracing_install/distr-tracing-installing.html#installing-distributed-tracing[Installing distributed tracing]
+* link:https://docs.openshift.com/container-platform/latest/observability/distr_tracing/distr_tracing_arch/distr-tracing-architecture.html[{DTProductName} architecture]
+* link:https://docs.openshift.com/container-platform/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.html[Installing distributed tracing]


### PR DESCRIPTION
**Affecting version:** 

- `serverless-docs-1.33`
- `serverless-docs-1.34`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3241

**Doc preview**: 

**Doc changes:** The links in the "Observability → Tracing → Tracing Requests" section under the "Additional resources for OpenShift Container Platform" in the Serverless documentation led to 404 error pages. I have added the correct links and updated the serverless documentation accordingly.

