### PR TITLE
PR for SRVKE-1520: Document "Configuring TLS encryption in Eventing" section in serverless docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -337,6 +337,8 @@ Topics:
     File: overriding-config-eventing
   - Name: High availability
     File: serverless-ha
+- Name: Configuring TLS encryption in Eventing
+  File: serverless-config-tls-encryption-eventing
 - Name: Configuring kube-rbac-proxy resources for Eventing
   File: kube-rbac-proxy-eventing
 - Name: Using ContainerSource with OpenShift Service Mesh

--- a/eventing/serverless-config-tls-encryption-eventing.adoc
+++ b/eventing/serverless-config-tls-encryption-eventing.adoc
@@ -1,0 +1,46 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-config-tls-encryption-eventing"]
+= Configuring TLS encryption in Eventing
+include::_attributes/common-attributes.adoc[]
+:context: serverless-config-tls-encryption-eventing
+
+toc::[]
+
+With the transport encryption feature, you can transport data and events over secured and encrypted HTTPS connections by using  _Transport Layer Security_ (TLS).
+
+:FeatureName: {ServerlessProductName} transport encryption for Eventing
+include::snippets/technology-preview.adoc[]
+
+The `transport-encryption` feature flag is an `enum` configuration that defines how Addressables, such as Broker, Channel, and Sink, accept events. It controls whether Addressables must accept events over HTTP or HTTPS based on the selected setting.
+
+The possible values for `transport-encryption` are as follows:
+[cols=2,options=header]
+|===
+|Value
+|Description
+
+|`disabled`
+a|
+* Addressables can accept events to HTTPS endpoints.
+* Producers can send events to HTTPS endpoints.
+
+|`permissive`
+a|
+* Addressables must accept events on both HTTP and HTTPS endpoints.
+* Addressables must advertise both HTTP and HTTPS endpoints.
+* Producers must send events to HTTPS endpoints, if available.
+
+|`strict`
+a|
+* Addressables must not accept events to non-HTTPS endpoints.
+* Addressables must only advertise HTTPS endpoints.
+|===
+
+include::modules/serverless-tls-creating-selfsigned-cluster-issuer-eventing.adoc[leveloffset=+1]
+include::modules/serverless-tls-creating-cluster-issuer-eventing.adoc[leveloffset=+1]
+include::modules/serverless-tls-enabling-transport-encrption-eventing.adoc[leveloffset=+1]
+include::modules/serverless-tls-config-additional-ca-bundles-eventing.adoc[leveloffset=+1]
+include::modules/serverless-tls-config-custom-event-sources.adoc[leveloffset=+1]
+include::modules/serverless-tls-adding-selfsigned-to-ca-bundles-eventing.adoc[leveloffset=+1]
+include::modules/serverless-tls-ensuring-seamless-ca-rotation-eventing.adoc[leveloffset=+1]
+include::modules/serverless-tls-verifying-transport-encryption-eventing.adoc[leveloffset=+1]

--- a/modules/serverless-tls-adding-selfsigned-to-ca-bundles-eventing.adoc
+++ b/modules/serverless-tls-adding-selfsigned-to-ca-bundles-eventing.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-config-tls-encryption-eventing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-tls-adding-selfsigned-to-ca-bundles-eventing_{context}"]
+= Adding a SelfSigned ClusterIssuer resource to CA trust bundles
+
+If you are using a `SelfSigned` `ClusterIssuer` resource, you can add the CA to the Eventing CA trust bundles. 
+
+.Prerequisites
+
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* You have installed the {ServerlessOperatorName}.
+* You have installed the {cert-manager-operator}.
+* You have installed the OpenShift (`oc`) CLI.
+
+.Procedure
+
+. Export the CA from the `knative-eventing-ca` secret in the {cert-manager-operator} namespace (default is `cert-manager` certificate) by running the following command:
++
+[source,terminal]
+----
+$ oc get secret -n cert-manager knative-eventing-ca -o=jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+----
+
+. Create a CA trust bundle in the `knative-eventing` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create configmap -n knative-eventing my-org-selfsigned-ca-bundle --from-file=ca.crt
+----
+
+. Label the `ConfigMap` by running the following command:
++
+[source,terminal]
+----
+$ oc label configmap -n knative-eventing my-org-selfsigned-ca-bundle networking.knative.dev/trust-bundle=true
+----

--- a/modules/serverless-tls-config-additional-ca-bundles-eventing.adoc
+++ b/modules/serverless-tls-config-additional-ca-bundles-eventing.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-config-tls-encryption-eventing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-tls-config-additional-ca-bundles-eventing_{context}"]
+= Configuring additional CA trust bundles
+
+By default, Eventing clients trust the OpenShift CA bundle configured for custom PKI. For more details, see link:https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html[Configuring a custom PKI].
+
+[NOTE]
+====
+When a new connection is established, Eventing clients automatically include these CA bundles in their trusted list.
+====
+
+.Prerequisites
+
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* You have installed the {ServerlessOperatorName}.
+* You have installed the {cert-manager-operator}.
+
+.Procedure
+
+* Create a CA bundle for Eventing as follows:
++
+[source,yaml]
+----
+kind: ConfigMap
+metadata:
+  name: <my_org_eventing_bundle> <1>
+  namespace: knative-eventing
+  labels:
+    networking.knative.dev/trust-bundle: "true"
+data: <2>
+  ca.crt: ...
+  ca1.crt: ...
+  tls.crt: ...
+----
+<1> Use a unique name to avoid conflicts with existing or future Eventing config maps.
+<2> All keys with valid PEM-encoded CA bundles are trusted by Eventing clients.

--- a/modules/serverless-tls-config-custom-event-sources.adoc
+++ b/modules/serverless-tls-config-custom-event-sources.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-config-tls-encryption-eventing.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-tls-config-custom-event-sources_{context}"]
+= Configure custom event sources to trust the Eventing CA
+
+To create a custom event source, use a SinkBinding. The SinkBinding can inject the configured CA trust bundles as a projected volume into each container by using the `knative-custom-certs` directory.
+
+In specific cases, you might inject company-specific CA trust bundles into base container images and automatically configure runtimes, such as OpenJDK or Node.js, and so on. to trust those CA bundles. In such cases, you might not need to configure your clients.
+
+By using the `my_org_eventing_bundle` config map from the previous example, with the `ca.crt`, `ca1.crt`, and `tls.crt` data keys, the `knative-custom-certs` directory has the following layout:
+
+[source,terminal]
+----
+/knative-custom-certs/ca.crt
+/knative-custom-certs/ca1.crt
+/knative-custom-certs/tls.crt
+----
+
+You can use these files to add CA trust bundles to HTTP clients that send events to Eventing.
+
+[NOTE]
+====
+Depending on the runtime, programming language, or library you use, different methods exist for configuring custom CA cert files, such as using command-line flags, environment variables, or reading the content of the files.
+====

--- a/modules/serverless-tls-creating-cluster-issuer-eventing.adoc
+++ b/modules/serverless-tls-creating-cluster-issuer-eventing.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-config-tls-encryption-eventing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-tls-creating-cluster-issuer-eventing_{context}"]
+= Creating a ClusterIssuer resource for Eventing
+
+`ClusterIssuers` are Kubernetes resources that represent certificate authorities (CAs) that can generate signed certificates by honoring certificate signing requests.
+
+.Prerequisites
+
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* You have installed the {ServerlessOperatorName}.
+* You have installed the {cert-manager-operator}.
+* You have installed the OpenShift (`oc`) CLI.
+
+.Procedure
+
+. Create the `knative-eventing-ca-issuer` `ClusterIssuer` resource as follows:
++
+Every Eventing component uses this issuer to issue their server's certs.
++
+[source,yaml]
+----
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: knative-eventing-ca-issuer
+spec:
+  ca:
+    secretName: knative-eventing-ca <1>
+----
+<1> The `secretName` value in the `cert-manager` namespace (default for {cert-manager-operator}) contains the certificate that can be used by Knative Eventing components.
++
+[NOTE]
+====
+The `ClusterIssuer` name must be `knative-eventing-ca-issuer`.
+====
+
+. Apply the `ClusterIssuer` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/modules/serverless-tls-creating-selfsigned-cluster-issuer-eventing.adoc
+++ b/modules/serverless-tls-creating-selfsigned-cluster-issuer-eventing.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-config-tls-encryption-eventing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-tls-creating-selfsigned-cluster-issuer-eventing_{context}"]
+= Creating a SelfSigned ClusterIssuer resource for Eventing
+
+`ClusterIssuers` are Kubernetes resources that represent certificate authorities (CAs) that can generate signed certificates by honoring certificate signing requests. All cert-manager certificates require a referenced issuer in a ready condition to attempt to honor the request. For more details, see link:https://cert-manager.io/docs/concepts/issuer/[Issuer].
+
+[IMPORTANT]
+====
+For simplicity, this procedure uses a `SelfSigned` issuer as the root certificate authority. For more details about `SelfSigned` issuer implications and limitations, see link:https://cert-manager.io/docs/configuration/selfsigned/[SelfSigned issuers]. If you are using a custom public key infrastructure (PKI), you must configure it so its privately signed CA certificates are recognized across the cluster. For more details about cert-manager, see link:https://cert-manager.io/docs/configuration/ca/[certificate authorities (CAs)]. You can use any other issuer that is usable for cluster-local services.
+====
+
+.Prerequisites
+
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* You have installed the {ServerlessOperatorName}.
+* You have installed the {cert-manager-operator}.
+* You have installed the OpenShift (`oc`) CLI.
+
+.Procedure
+
+. Create a `SelfSigned` `ClusterIssuer` resource as follows:
++
+[source,yaml]
+----
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: knative-eventing-selfsigned-issuer
+spec:
+  selfSigned: {}
+----
+
+. Apply the `ClusterIssuer` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Create a root certificate by using the `SelfSigned` `ClusterIssuer` resource as follows:
++
+[source,yaml]
+----
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: knative-eventing-selfsigned-ca
+  namespace: cert-manager <1>
+spec:
+  secretName: knative-eventing-ca <2>
+  isCA: true
+  commonName: selfsigned-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: knative-eventing-selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+----
+<1> Specify the {cert-manager-operator} that is used by default. 
+<2> Specify the secret where the certificate is stored. The name is later used by the `ClusterIssuer` for Eventing.
+
+. Apply the `Certificate` resource by running the following:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/modules/serverless-tls-enabling-transport-encrption-eventing.adoc
+++ b/modules/serverless-tls-enabling-transport-encrption-eventing.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-config-tls-encryption-eventing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-tls-enabling-transport-encrption-eventing_{context}"]
+= Enabling transport encrption for Knative Eventing
+
+You can enable transport encryption in `KnativeEventing` by setting the `transport-encryption` feature to `strict`.
+
+.Prerequisites
+
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* You have installed the {ServerlessOperatorName}.
+* You have installed the {cert-manager-operator}.
+* You have installed the OpenShift (`oc`) CLI.
+
+.Procedure
+
+. Enable the `transport-encryption` in `KnativeEventing` as follows:
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+
+  # Other spec fields omitted ...
+  # ...
+
+  config:
+    features:
+      transport-encryption: strict
+----
+
+. Apply the `KnativeEventing` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/modules/serverless-tls-ensuring-seamless-ca-rotation-eventing.adoc
+++ b/modules/serverless-tls-ensuring-seamless-ca-rotation-eventing.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-config-tls-encryption-eventing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-tls-ensuring-seamless-ca-rotation-eventing_{context}"]
+= Ensuring seamless CA rotation
+
+Ensuring seamless CA rotation is essential to avoid service downtime or to handle emergencies.
+
+.Prerequisites
+
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* You have installed the {ServerlessOperatorName}.
+* You have installed the {cert-manager-operator}.
+* You have installed the OpenShift (`oc`) CLI.
+
+.Procedure
+
+. Create a CA certificate.
+. Add the public key of the new CA certificate to the CA trust bundles. 
++
+Ensure that you also keep the public key of the existing CA.
+. Ensure all clients use the latest CA trust bundles.
++
+Knative Eventing components automatically reload the updated CA trust bundles. For custom workloads that consume trust bundles, reload or restart them as needed.
+. Update the `knative-eventing-ca-issuer` `ClusterIssuer` to reference the secret containing the CA certificate that you created in step 1.
+. Force `cert-manager` to renew certificates in the `knative-eventing namespace`.
++
+For more information about `cert-manager`, see link:https://cert-manager.io/docs/usage/certificate/#reissuance-triggered-by-user-actions[Reissuance triggered by user actions].
+. As soon as the CA rotation is fully completed, remove the public key of the old CA from the trust bundle config map.

--- a/modules/serverless-tls-verifying-transport-encryption-eventing.adoc
+++ b/modules/serverless-tls-verifying-transport-encryption-eventing.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-config-tls-encryption-eventing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-tls-verifying-transport-encryption-eventing_{context}"]
+= Verifying transport encryption in Eventing
+
+To confirm that transport encryption is correctly configured, you can create and test an `InMemoryChannel` resource. Follow the steps to ensure that it uses HTTPS as expected.
+
+.Prerequisites
+
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* You have installed the {ServerlessOperatorName}.
+* You have installed the {cert-manager-operator}.
+* You have installed the OpenShift (`oc`) CLI.
+
+.Procedure
+
+. Create an `InMemoryChannel` resource as follows:
++
+[source,yaml]
+----
+apiVersion: messaging.knative.dev/v1
+kind: InMemoryChannel
+metadata:
+  name: transport-encryption-test
+----
+
+. Apply the `InMemoryChannel` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. View the `InMemoryChannel` address by running the following command:
++
+[source,terminal]
+----
+$ oc get inmemorychannels.messaging.knative.dev transport-encryption-test
+----
++
+.Example output
+[source,terminal]
+----
+NAME                        URL                                                                                           AGE   READY   REASON
+transport-encryption-test   https://imc-dispatcher.knative-eventing.svc.cluster.local/default/transport-encryption-test   17s   True  
+----


### PR DESCRIPTION
**Affecting version:** 

- `serverless-docs-1.33`
- `serverless-docs-1.34`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVKE-1520

**Doc preview**: [Configuring TLS encryption in Eventing](https://81211--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/serverless-config-tls-encryption-eventing)