### PR TITLE
OCPBUGS-30568 Inheritance for Machine Config Pools

### DIFF
--- a/modules/update-using-custom-machine-config-pools-inheritance.adoc
+++ b/modules/update-using-custom-machine-config-pools-inheritance.adoc
@@ -1,0 +1,244 @@
+// Module included in the following assemblies:
+//
+// * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="update-using-custom-machine-config-pools-mcp-inheritance_{context}"]
+= Managing machine configuration inheritance for a worker pool canary
+
+
+You can configure a machine config pool (MCP) canary to inherit any `MachineConfig` assigned to an existing MCP. 
+This configuration is useful when you want to use an MCP canary to test as you update nodes one at a time for an existing MCP.
+
+.Prerequisites
+
+* You have created one or more MCPs.
+
+.Procedure
+
+. Create a secondary MCP as described in the following two steps:
++
+.. Save the following configuration file as `machineConfigPool.yaml`.
++
+.Example `machineConfigPool` YAML
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-perf
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {
+         key: machineconfiguration.openshift.io/role,
+         operator: In,
+         values: [worker,worker-perf]
+        }
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-perf: ""
+# ...
+----
++
+.. Create the new machine config pool by running the following command:
++
+[source,terminal]
+----
+$ oc create -f machineConfigPool.yaml
+----
++
+.Example output
++
+[source,terminal]
+----
+machineconfigpool.machineconfiguration.openshift.io/worker-perf created
+----
+
+. Add some machines to the secondary MCP. The following example labels the worker nodes `worker-a`, `worker-b`, and `worker-c` to the MCP `worker-perf`:
++
+[source,terminal]
+----
+$ oc label node worker-a node-role.kubernetes.io/worker-perf=''
+----
++
+[source,terminal]
+----
+$ oc label node worker-b node-role.kubernetes.io/worker-perf=''
+----
++
+[source,terminal]
+----
+$ oc label node worker-c node-role.kubernetes.io/worker-perf=''
+----
+
+. Create a new `MachineConfig` for the MCP `worker-perf` as described in the following two steps:
++
+.. Save the following `MachineConfig` example as a file called `new-machineconfig.yaml`:
++
+.Example `MachineConfig` YAML
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker-perf
+  name: 06-kdump-enable-worker-perf
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - enabled: true
+        name: kdump.service
+  kernelArguments:
+    - crashkernel=512M
+# ...
+----
++
+.. Apply the `MachineConfig` by running the following command:
++
+[source,terminal]
+----
+$ oc create -f new-machineconfig.yaml
+----
+
+. Create the new canary MCP and add machines from the MCP you created in the previous steps. The following example creates an MCP called `worker-perf-canary`, and adds machines from the `worker-perf` MCP that you previosuly created.
++
+.. Label the canary worker node `worker-a` by running the following command: 
++
+[source,terminal]
+----
+$ oc label node worker-a node-role.kubernetes.io/worker-perf-canary=''
+----
++
+.. Remove the canary worker node `worker-a` from the original MCP by running the following command: 
++
+[source,terminal]
+----
+$ oc label node worker-a node-role.kubernetes.io/worker-perf-
+----
++
+.. Save the following file as `machineConfigPool-Canary.yaml`.
++
+.Example `machineConfigPool-Canary.yaml` file
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-perf-canary
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {
+         key: machineconfiguration.openshift.io/role,
+         operator: In,
+         values: [worker,worker-perf,worker-perf-canary] <1>
+        }
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-perf-canary: ""
+----
+<1> Optional value. This example includes `worker-perf-canary` as an additional value. You can use a value in this way to configure members of an additional `MachineConfig`.
++
+.. Create the new `worker-perf-canary` by running the following command:
++
+[source,terminal]
+----
+$ oc create -f machineConfigPool-Canary.yaml
+----
++
+.Example output
+[source,terminal]
+----
+machineconfigpool.machineconfiguration.openshift.io/worker-perf-canary created
+----
+
+. Check if the `MachineConfig` is inherited in `worker-perf-canary`. 
++
+.. Verify that no MCP is degraded by running the following command:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+.Example output
+[source,terminal]
+----
+NAME                  CONFIG                                                          UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+master                rendered-master-2bf1379b39e22bae858ea1a3ff54b2ac                True      False      False      3              3                   3                     0                      5d16h
+worker                rendered-worker-b9576d51e030413cfab12eb5b9841f34                True      False      False      0              0                   0                     0                      5d16h
+worker-perf          rendered-worker-perf-b98a1f62485fa702c4329d17d9364f6a          True      False      False      2              2                   2                     0                      56m
+worker-perf-canary   rendered-worker-perf-canary-b98a1f62485fa702c4329d17d9364f6a   True      False      False      1              1                   1                     0                      44m
+----
++
+.. Verify that the machines are inherited from `worker-perf` into `worker-perf-canary`.
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME       STATUS   ROLES                        AGE     VERSION
+...
+worker-a   Ready    worker,worker-perf-canary   5d15h   v1.27.13+e709aa5
+worker-b   Ready    worker,worker-perf          5d15h   v1.27.13+e709aa5
+worker-c   Ready    worker,worker-perf          5d15h   v1.27.13+e709aa5
+----
++
+.. Verify that `kdump` service is enabled on `worker-a` by running the following command:
++
+[source,terminal]
+----
+$ systemctl status kdump.service
+----
++
+.Example output
+[source,terminal]
+----
+NAME       STATUS   ROLES                        AGE     VERSION
+...
+kdump.service - Crash recovery kernel arming
+     Loaded: loaded (/usr/lib/systemd/system/kdump.service; enabled; preset: disabled)
+     Active: active (exited) since Tue 2024-09-03 12:44:43 UTC; 10s ago
+    Process: 4151139 ExecStart=/usr/bin/kdumpctl start (code=exited, status=0/SUCCESS)
+   Main PID: 4151139 (code=exited, status=0/SUCCESS)
+----
++
+.. Verify that the MCP has updated the `crashkernel` by running the following command:
++
+[source,terminal]
+----
+$ cat /proc/cmdline
+----
++
+The output should include the updated `crashekernel` value, for example:
++
+.Example output
+[source,terminal]
+----
+crashkernel=512M
+----
+
+. Optional: If you are satisfied with the upgrade, you can return `worker-a` to `worker-perf`. 
++
+.. Return `worker-a` to `worker-perf` by running the following command:
++
+[source,terminal]
+----
+$ oc label node worker-a node-role.kubernetes.io/worker-perf=''
+----
++
+.. Remove `worker-a` from the canary MCP by running the following command: 
++
+[source,terminal]
+----
+$ oc label node worker-a node-role.kubernetes.io/worker-perf-canary-
+----

--- a/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
+++ b/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
@@ -135,6 +135,9 @@ include::modules/update-using-custom-machine-config-pools-about.adoc[leveloffset
 // Creating machine config pools to perform a canary rollout update
 include::modules/update-using-custom-machine-config-pools-mcp.adoc[leveloffset=+1]
 
+// Managing machine configuration inheritance for a worker pool canary
+include::modules/update-using-custom-machine-config-pools-inheritance.adoc[leveloffset=+1]
+
 // Pausing the machine config pools
 include::modules/update-using-custom-machine-config-pools-pause.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->OCPBUGS-30568 Inheritance for Machine Config Pools

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 
- 4.17
- 4.16
- 4.15
- 4.14
- 4.13
- 4.12
 <!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-30568
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Managing machine configuration inheritance for a worker pool canary](https://81214--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-mcp-inheritance_update-using-custom-machine-config-pools)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
