### PR TITLE
[RHACS] ROX-26010: Relax the wording about creating CRs in operator namespace

### DIFF
--- a/modules/install-central-operator-external-db.adoc
+++ b/modules/install-central-operator-external-db.adoc
@@ -32,7 +32,7 @@ For more information about {product-title-short} databases, see the link:https:/
 [WARNING]
 ====
 * If you have installed the Operator in a different namespace, {ocp} shows the name of that namespace rather than `rhacs-operator`.
-* You must install the {product-title} `Central` custom resource in its own project and not in the `rhacs-operator` and `openshift-operator` projects, or in the project in which you have installed the {product-title} Operator.
+* Red{nbsp}Hat recommends installing the {product-title} `Central` custom resource in a dedicated project. Do not install it in the project where you have installed the {product-title} Operator. Additionally, do not install it in any projects with names that begin with `kube`, `openshift`, or `redhat`, and in the `istio-system` project.
 ====
 . Enter the new project name (for example, `stackrox`), and click *Create*. Red{nbsp}Hat recommends that you use `stackrox` as the project name.
 . Create a password secret in the deployed namespace by using the {ocp} web console or the terminal.

--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -10,7 +10,8 @@ The main component of {product-title} is called Central. You can install Central
 
 [IMPORTANT]
 ====
-When you install {product-title} for the first time, you must first install the `Central` custom resource because the `SecuredCluster` custom resource installation is dependent on certificates that Central generates.
+* When you install {product-title} for the first time, you must first install the `Central` custom resource because the `SecuredCluster` custom resource installation is dependent on certificates that Central generates.
+* Red{nbsp}Hat recommends installing the {product-title} `Central` custom resource in a dedicated project. Do not install it in the project where you have installed the {product-title} Operator. Additionally, do not install it in any projects with names that begin with `kube`, `openshift`, or `redhat`, and in the `istio-system` project.
 ====
 
 .Prerequisites
@@ -21,10 +22,9 @@ When you install {product-title} for the first time, you must first install the 
 . Select the {product-title} Operator from the list of installed Operators.
 . If you have installed the Operator in the recommended namespace, {ocp} lists the project as `rhacs-operator`. Select *Project: rhacs-operator* -> *Create project*.
 +
-[WARNING]
+[NOTE]
 ====
-* If you have installed the Operator in a different namespace, {ocp} shows the name of that namespace rather than `rhacs-operator`.
-* You must install the {product-title} `Central` custom resource in its own project and not in the `rhacs-operator` and `openshift-operator` projects, or in the project in which you have installed the {product-title} Operator.
+* If you installed the Operator in a different namespace, {ocp} lists the name of that namespace instead of `rhacs-operator`.
 ====
 . Enter the new project name (for example, `stackrox`), and click *Create*. Red{nbsp}Hat recommends that you use `stackrox` as the project name.
 . Under the *Provided APIs* section, select *Central*. Click *Create Central*.

--- a/modules/install-secured-cluster-operator.adoc
+++ b/modules/install-secured-cluster-operator.adoc
@@ -14,6 +14,16 @@ endif::[]
 [role="_abstract"]
 You can install Secured Cluster services on your clusters by using the Operator, which creates the `SecuredCluster` custom resource. You must install the Secured Cluster services on every cluster in your environment that you want to monitor.
 
+[IMPORTANT]
+====
+When you install {product-title}:
+
+* If you are installing {product-title-short} for the first time, you must first install the `Central` custom resource because the `SecuredCluster` custom resource installation is dependent on certificates that Central generates.
+* Do not install `SecuredCluster` in projects whose names start with `kube`, `openshift`, or `redhat`, or in the `istio-system` project.
+* If you are installing {product-title-short} `SecuredCluster` custom resource on a cluster that also hosts Central, ensure that you install it in the same namespace as Central.
+* If you are installing {product-title} `SecuredCluster` custom resource on a cluster that does not host Central, Red{nbsp}Hat recommends that you install the {product-title} `SecuredCluster` custom resource in its own project and not in the project in which you have installed the {product-title} Operator.
+====
+
 .Prerequisites
 * If you are using {ocp}, you must install version {ocp-supported-version} or later.
 * You have installed the {product-title-short} Operator on the cluster that you want to secure, called the secured cluster.
@@ -22,6 +32,13 @@ You can install Secured Cluster services on your clusters by using the Operator,
 .Procedure
 . On the {ocp} web console for the secured cluster, go to the *Operators* -> *Installed Operators* page.
 . Click the {product-title-short} Operator.
+. If you have installed the Operator in the recommended namespace, {ocp} lists the project as `rhacs-operator`. Select *Project: rhacs-operator* -> *Create project*.
++
+[NOTE]
+====
+* If you installed the Operator in a different namespace, {ocp} lists the name of that namespace instead of `rhacs-operator`.
+====
+. Enter the new project name (for example, `stackrox`), and click *Create*. Red{nbsp}Hat recommends that you use `stackrox` as the project name.
 . Click *Secured Cluster* from the central navigation menu in the *Operator details* page.
 . Click *Create SecuredCluster*.
 . Select one of the following options in the *Configure via* field:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): *
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/ROX-26010
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- https://81215--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html
- https://81215--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html
- https://81215--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp.html

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

As explained in https://issues.redhat.com/browse/ROX-25661 the "must not" wording originated from the times when the default project for rhacs operator installation was openshift-operators. At that time this strong wording was correct. However now that the default has changed to `rhacs-operator`, it is no longer critical to avoid the operator project when creating CRs.

It is still recommended to use a separate project for the CRs (in order to avoid deadlocks in case the whole namespace, hosting both CRs and operator controller, is deleted in one stop) however in all other cases it will just work.

There are some forbidden namespaces (including `openshift-*`) that our code checks for and will refuse to reconcile CRs created there. Not sure if it's beneficial to list them here, as the check is done rather early (though not as early as we would like - i.e. at CR creation time) and explaining it in detail both bloats the docs and is more prone to bitrot. Please feel free to drop that sentence.

However the same recommendations apply to the `SecuredCluster` CR, not just `Central`. So we should probably mention them in both places, which I tried to do here.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

/cc @gaurav-nelson 

Cherrypick into:
`rhacs-docs-4.4`, `rhacs-docs-4.5`, and `rhacs-docs-4.6`