### PR TITLE
OBSDOCS-786: Fixing the capitalization of bearer token.

### DIFF
--- a/modules/accessing-metrics-outside-cluster.adoc
+++ b/modules/accessing-metrics-outside-cluster.adoc
@@ -9,7 +9,7 @@
 
 You can query Prometheus metrics from outside the cluster when monitoring your own services with user-defined projects. Access this data from outside the cluster by using the `thanos-querier` route.
 
-This access only supports using a Bearer Token for authentication.
+This access only supports using a bearer token for authentication.
 
 .Prerequisites
 

--- a/modules/monitoring-about-accessing-monitoring-web-service-apis.adoc
+++ b/modules/monitoring-about-accessing-monitoring-web-service-apis.adoc
@@ -20,7 +20,7 @@ To access Thanos Ruler and Thanos Querier service APIs, the requesting account m
 
 When you access web service API endpoints for monitoring components, be aware of the following limitations:
 
-* You can only use Bearer Token authentication to access API endpoints.
+* You can only use bearer token authentication to access API endpoints.
 * You can only access endpoints in the `/api` path for a route.
 If you try to access an API endpoint in a web browser, an `Application is not available` error occurs.
 To access monitoring features in a web browser, use the {product-title} web console to review monitoring dashboards.


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-1292](https://issues.redhat.com/browse/OBSDOCS-1292)

Link to docs preview: 
* https://81216--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-third-party-monitoring-apis

QE review:
- [x] QE has approved this change.

**Additional information:**