### PR TITLE
CNV-46221: Add link to upstream docs metric list

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -6,6 +6,7 @@
 = Virtualization metrics
 
 The following metric descriptions include example Prometheus Query Language (PromQL) queries. These metrics are not an API and might change between versions.
+For a complete list of virtualization metrics, see link:https://github.com/kubevirt/monitoring/blob/main/docs/metrics.md[KubeVirt components metrics].
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
Main, 4.14, 4.15, 4.16, 4.17

Issue:
[CNV-46221](https://issues.redhat.com/browse/CNV-46221)

[Link to docs preview](https://81219--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries.html#virt-querying-metrics_virt-prometheus-queries)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
