### PR TITLE
OCPBUGS#39198: Added note for esp hardware offload support and IPsec

### DIFF
--- a/networking/network_security/configuring-ipsec-ovn.adoc
+++ b/networking/network_security/configuring-ipsec-ovn.adoc
@@ -6,26 +6,24 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-With IPsec enabled, you can encrypt both internal pod-to-pod cluster traffic between nodes and external traffic between pods and IPsec endpoints external to your cluster. All pod-to-pod network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec in _Transport mode_.
+By enabling IPsec, you can encrypt both internal pod-to-pod cluster traffic between nodes and external traffic between pods and IPsec endpoints external to your cluster. All pod-to-pod network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec in _Transport mode_.
 
-IPsec is disabled by default. It can be enabled either during or after installing the cluster. For information about cluster installation, see xref:../../installing/overview/index.adoc#ocp-installation-overview[{product-title} installation overview].
+IPsec is disabled by default. You can enable IPsec either during or after installing the cluster. For information about cluster installation, see xref:../../installing/overview/index.adoc#ocp-installation-overview[{product-title} installation overview].
 
-[IMPORTANT]
-====
-If your cluster uses link:https://www.redhat.com/en/topics/containers/what-are-hosted-control-planes[{hcp}] for Red Hat {product-title}, IPsec is not supported for IPsec encryption of either pod-to-pod or traffic to external hosts.
-====
+The following support limitations exist for IPsec on a {product-title} cluster:
 
-[NOTE]
-====
-IPsec on {ibm-cloud-name} supports only NAT-T. Using ESP is not supported.
-====
+* On {ibm-cloud-name}, IPsec supports only NAT-T. Encapsulating Security Payload (ESP) is not supported on this platform.
+* If your cluster uses link:https://www.redhat.com/en/topics/containers/what-are-hosted-control-planes[{hcp}] for Red{nbsp}Hat {product-title}, IPsec is not supported for IPsec encryption of either pod-to-pod or traffic to external hosts.
+* Using ESP hardware offloading on any network interface is not supported if one or more of those interfaces is attached to Open vSwitch (OVS). Enabling IPsec for your cluster triggers the use of IPsec with interfaces attached to OVS. By default, {product-title} disables ESP hardware offloading on any interfaces attached to OVS. 
+* If you enabled IPsec for network interfaces that are not attached to OVS, a cluster administrator must manually disable ESP hardware offloading on each interface that is not attached to OVS.
 
-Use the procedures in the following documentation to:
+The following list outlines key tasks in the IPsec documentation:
 
-* Enable and disable IPSec after cluster installation
-* Configure IPsec encryption for traffic between the cluster and external hosts
-* Verify that IPsec encrypts traffic between pods on different nodes
+* Enable and disable IPsec after cluster installation.
+* Configure IPsec encryption for traffic between the cluster and external hosts.
+* Verify that IPsec encrypts traffic between pods on different nodes.
 
+// Modes of operation
 include::modules/nw-own-ipsec-modes.adoc[leveloffset=+1]
 
 // Uses xrefs, so must be located here
@@ -54,18 +52,29 @@ include::modules/nw-own-ipsec-required-ports.adoc[leveloffset=+1]
 
 For IPsec encryption of pod-to-pod traffic, the following sections describe which specific pod-to-pod traffic is encrypted, what kind of encryption protocol is used, and how X.509 certificates are handled. These sections do not apply to IPsec encryption between the cluster and external hosts, which you must configure manually for your specific external network infrastructure.
 
+// Types of network traffic flows encrypted by pod-to-pod IPsec
 include::modules/nw-ovn-ipsec-traffic.adoc[leveloffset=+2]
+
+// Encryption protocol and IPsec mode
 include::modules/nw-ovn-ipsec-encryption.adoc[leveloffset=+2]
+
+// Security certificate generation and rotation
 include::modules/nw-ovn-ipsec-certificates.adoc[leveloffset=+2]
 
+// IPsec encryption for external traffic
 include::modules/nw-ovn-ipsec-external.adoc[leveloffset=+1]
-// Enable & then optionally configure IPsec for external hosts
+
+// Enabling IPsec encryption
 include::modules/nw-ovn-ipsec-enable.adoc[leveloffset=+1]
+
+// Configuring IPsec encryption for external traffic
 include::modules/nw-ovn-ipsec-north-south-enable.adoc[leveloffset=+1]
 
+// Disabling IPsec encryption for an external IPsec endpoint
 include::modules/nw-ovn-ipsec-north-south-disable.adoc[leveloffset=+1]
-include::modules/nw-ovn-ipsec-disable.adoc[leveloffset=+1]
 
+// Disabling IPsec encryption
+include::modules/nw-ovn-ipsec-disable.adoc[leveloffset=+1]
 
 [id="{context}_additional-resources"]
 == Additional resources


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OCPBUGS-39198](https://issues.redhat.com/browse/OCPBUGS-39198)

Link to docs preview:
* [Configuring IPsec encryption](https://81220--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn.html)

- [x] SME has approved this change (jcaamano).
- [x] QE has approved this change (Wenxin Wei).

Additional information:
* [Slack thread in forum-ocp-sdn](https://redhat-internal.slack.com/archives/CDCP2LA9L/p1724856472885689)
* https://access.redhat.com/solutions/7086989
* [Slack thread Jaime](https://redhat-internal.slack.com/archives/C07P1PKB06Q/p1728921705306819?thread_ts=1728484934.737769&cid=C07P1PKB06Q): 
