### PR TITLE
OBSDOCS-788: Use status.ingress[].host for accessing Routes

### DIFF
--- a/modules/accessing-metrics-outside-cluster.adoc
+++ b/modules/accessing-metrics-outside-cluster.adoc
@@ -35,7 +35,7 @@ $ TOKEN=$(oc whoami -t)
 +
 [source,terminal]
 ----
-$ HOST=$(oc -n openshift-monitoring get route thanos-querier -ojsonpath={.spec.host})
+$ HOST=$(oc -n openshift-monitoring get route thanos-querier -ojsonpath={.status.ingress[].host})
 ----
 
 . Set the namespace to the namespace in which your service is running by using the following command:

--- a/modules/monitoring-accessing-third-party-monitoring-web-service-apis.adoc
+++ b/modules/monitoring-accessing-third-party-monitoring-web-service-apis.adoc
@@ -32,7 +32,7 @@ $ TOKEN=$(oc whoami -t)
 +
 [source,terminal]
 ----
-$ HOST=$(oc -n openshift-monitoring get route alertmanager-main -ojsonpath={.spec.host})
+$ HOST=$(oc -n openshift-monitoring get route alertmanager-main -ojsonpath={.status.ingress[].host})
 ----
 
 . Query the service API receivers for Alertmanager by running the following command:

--- a/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
+++ b/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
@@ -75,7 +75,7 @@ endif::openshift-dedicated,openshift-rosa[]
 +
 [source,terminal]
 ----
-$ HOST=$(oc -n openshift-monitoring get route prometheus-k8s -ojsonpath={.spec.host})
+$ HOST=$(oc -n openshift-monitoring get route prometheus-k8s -ojsonpath={.status.ingress[].host})
 ----
 +
 .. Extract an authentication token by running the following command:

--- a/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
+++ b/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
@@ -57,7 +57,7 @@ $ TOKEN=$(oc whoami -t)
 +
 [source,terminal]
 ----
-$ HOST=$(oc -n openshift-monitoring get route prometheus-k8s-federate -ojsonpath={.spec.host})
+$ HOST=$(oc -n openshift-monitoring get route prometheus-k8s-federate -ojsonpath={.status.ingress[].host})
 ----
 
 . Query metrics from the `/federate` route.


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-788](https://issues.redhat.com/browse/OBSDOCS-788)

Link to docs preview: 
* https://81221--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-third-party-monitoring-apis.html#accessing-a-monitoring-web-service-api_accessing-monitoring-apis-by-using-the-cli
* https://81221--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#accessing-metrics-from-outside-cluster_enabling-monitoring-for-user-defined-projects
* https://81221--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/troubleshooting-monitoring-issues.html#determining-why-prometheus-is-consuming-disk-space_troubleshooting-monitoring-issues

QE review:
- [x] QE has approved this change.

**Additional information:**