### PR TITLE
OCPBUGS-38757 Safe and Unsafe Sysctls in OpenShift 4.14+ Documentatio…

### DIFF
--- a/modules/nodes-safe-sysctls-list.adoc
+++ b/modules/nodes-safe-sysctls-list.adoc
@@ -52,19 +52,6 @@ a| This restricts `ICMP_PROTO` datagram sockets to users in the group range. The
 
 |`net.ipv4.ip_local_reserved_ports`
 | Specify a range of comma-separated local ports that you want to reserve for applications or services.
-
-| `net.ipv4.tcp_keepalive_time`
-| Specify the interval in seconds before the first `keepalive` probe should be sent after a connection has become idle.
-
-| `net.ipv4.tcp_fin_timeout`
-| Specify the time in seconds that a connection remains in the `FIN-WAIT-2` state before it is aborted.
-
-| `net.ipv4.tcp_keepalive_intvl`
-| Specify the interval in seconds between the `keepalive` probes. This value is multiplied by the `tcp_keepalive_probes` value to determine the total time required before it is decided that the connection is broken.
-
-| `net.ipv4.tcp_keepalive_probes`
-| Specify how many `keepalive` probes to send until it is determined that the connection is broken.
-
 |===
 
 
@@ -122,7 +109,6 @@ a| Define behavior for gratuitous ARP frames with an IPv6 address that is not al
 
 | `net.ipv6.neigh.IFNAME.retrans_time_ms`
 | Set the retransmit timer for neighbor discovery messages.
-
 |===
 
 [NOTE]


### PR DESCRIPTION
[OCPBUGS-38757]: Safe and Unsafe Sysctls in OpenShift 4.14+ Documentation Inconsistency
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15 and 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-38757
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81232--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-sysctls.html#safe_and_unsafe_sysctls_nodes-containers-using
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
