### PR TITLE
OSDOCS-11870: remove broken xref MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -44,19 +44,6 @@ Updating two minor versions in a single step is supported in 4.17. Updates for b
 //[id="microshift-4-17-configuring_{context}"]
 //=== Configuring
 
-//[id="microshift-4-17-custom-cert-auths_{context}"]
-//==== Customizable certificate authorities for the API server are supported
-
-//[id="microshift-4-17-audit-logging-config_{context}"]
-//==== Configurable policies for log file rotation and retention
-
-//[id="microshift-4-17-certificates-cleaning_{context}"]
-//==== Support for cleaning up certificates
-
-[id="microshift-4-17-workload-partitioning_{context}"]
-==== Support for workload partitioning
-With this release, workload partitioning is supported in {microshift-short}. For more information, see xref:../microshift_configuring/microshift-workload-partitioning.adoc#microshift-workload-partitioning[Workload partitioning].
-
 [id="microshift-4-17-networking_{context}"]
 === Networking
 
@@ -78,7 +65,12 @@ With this release, the resource footprint of the LVM storage driver is significa
 [id="microshift-4-17-low-latency_{context}"]
 ====  Low-latency performance for applications now available
 You can now run a {microshift-short} cluster with low-latency response rates. Using a low-latency {microshift-short} configuration with operating system tuning results in reduced application response times and can include deterministic performance. Using workload partitioning is also recommended.
-//See (crossrefs here to ll and wp)
+//TODO crossref
+
+[id="microshift-4-17-workload-partitioning_{context}"]
+==== Support for workload partitioning
+With this release, workload partitioning is supported in {microshift-short}.
+//TODO: add back crossref after LL PR merges
 
 //[id="microshift-4-17-support_{context}"]
 //=== Support


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11870](https://issues.redhat.com/browse/OSDOCS-11870)

Link to docs preview:
https://81246--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-running-apps_release-notes

QE N/A internal docs work

Additional information:
To fix https://github.com/openshift/openshift-docs/pull/81239

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
