### PR TITLE
OSSM 3.0 TP1: OSSM-8038 [DOC] Swap Kiali and Metrics in _topic_map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -20,16 +20,16 @@ Topics:
 - Name: Updating OpenShift Service Mesh
   File: ossm-updating-openshift-service-mesh
 ---
-Name: Kiali Operator provided by Red Hat
-Dir: kiali
-Distros: openshift-service-mesh
-Topics:
-- Name: Using Kiali Operator provided by Red Hat
-  File: ossm-kiali-assembly
----
 Name: Metrics
 Dir: metrics
 Distros: openshift-service-mesh
 Topics:
 - Name: Using metrics with Service Mesh
   File: ossm-metrics-assembly
+---
+Name: Kiali Operator provided by Red Hat
+Dir: kiali
+Distros: openshift-service-mesh
+Topics:
+- Name: Using Kiali Operator provided by Red Hat
+  File: ossm-kiali-assembly


### PR DESCRIPTION
**OSSM 3.0 TP1**

[OSSM-8038](https://issues.redhat.com//browse/OSSM-8038) [DOC] Swap Kiali and Metrics in _topic_map

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

**Merge PR to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**And cherry picked to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):

Technology Preview

**Service Mesh 3.0 is moving to the stand alone format and will not be cherry-picked back to OCP core branches.**

Issue:
https://issues.redhat.com/browse/OSSM-8038

Link to docs preview:

Preview did not generate for _topic_map update.

QE review:

QE approval is not required for this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
