### PR TITLE
OSDOCS-11206: Update the 4.17 About this release RN Doc section

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -24,15 +24,15 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines. {op-system-base} machines are deprecated in {product-title} 4.16 and will be removed in a future release.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517
 
-//Even-numbered release lifecycle verbiage
+//Even-numbered release lifecycle verbiage (Comment in for even-numbered releases)
 //Starting from {product-title} 4.14, the Extended Update Support (EUS) phase for even-numbered releases increases the total available lifecycle to 24 months on all supported architectures, including `x86_64`, 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures.
 //Beyond this, Red{nbsp}Hat also offers a 12-month additional EUS add-on, denoted as _Additional EUS Term 2_, that extends the total available lifecycle from 24 months to 36 months. The Additional EUS Term 2 is available on all architecture variants of {product-title}.
 
-//Odd-numbered release lifecycle verbiage
-The support lifecycle for odd-numbered releases, such as {product-title} 4.15, on all supported architectures, including `x86_64`, 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures is 18 months.
+//Odd-numbered release lifecycle verbiage (Comment in for odd-numbered releases)
+The support lifecycle for odd-numbered releases, such as {product-title} {product-version}, on all supported architectures, including `x86_64`, 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures is 18 months.
 For more information about support for all versions, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
-Commencing with the {product-version} release, Red{nbsp}Hat is simplifying the administration and management of Red{nbsp}Hat shipped cluster Operators with the introduction of three new life cycle classifications; Platform Aligned, Platform Agnostic, and Rolling Stream. These life cycle classifications provide additional ease and transparency for cluster administrators to understand the life cycle policies of each Operator and form cluster maintenance and upgrade plans with predictable support boundaries. For more information, see link:https://access.redhat.com/webassets/avalon/j/includes/session/scribe/?redirectTo=https%3A%2F%2Faccess.redhat.com%2Fsupport%2Fpolicy%2Fupdates%2Fopenshift_operators[OpenShift Operator Life Cycles].
+Commencing with the {product-title} 4.14 release, Red{nbsp}Hat is simplifying the administration and management of Red{nbsp}Hat shipped cluster Operators with the introduction of three new life cycle classifications; Platform Aligned, Platform Agnostic, and Rolling Stream. These life cycle classifications provide additional ease and transparency for cluster administrators to understand the life cycle policies of each Operator and form cluster maintenance and upgrade plans with predictable support boundaries. For more information, see link:https://access.redhat.com/webassets/avalon/j/includes/session/scribe/?redirectTo=https%3A%2F%2Faccess.redhat.com%2Fsupport%2Fpolicy%2Fupdates%2Fopenshift_operators[OpenShift Operator Life Cycles].
 
 // Added in 4.14. Language came directly from Kirsten Newcomer.
 {product-title} is designed for FIPS. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the `x86_64`, `ppc64le`, and `s390x` architectures.
@@ -450,9 +450,6 @@ For more information, see xref:../registry/configuring_registry_storage/configur
 
 [id="ocp-4-17-storage_{context}"]
 === Storage
-
-[id="ocp-4-17-oci"]
-=== {oci-first}
 
 [id="ocp-4-17-oci_{context}"]
 === Oracle(R) Cloud Infrastructure


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11206](https://issues.redhat.com/browse/OSDOCS-11206)

Link to docs preview:
* [About this release](https://81256--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-about-this-release_release-notes)

Approvals will be similar to those on the equivalent [4.16 PR](https://github.com/openshift/openshift-docs/pull/77872).

