### PR TITLE
OSDOCS-11870-2: update xrefs MicroShift 4.17.y

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -13,12 +13,12 @@ toc::[]
 //TODO verify K8s version and another other relevant notes
 [id="microshift-4-17-about-this-release_{context}"]
 == About this release
-Version 4.17 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+Version 4.17 of {product-title} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
 
 //TODO: Update OP system versions
-{microshift-short} {product-version} is supported on {op-system-base-full} or {op-system-ostree-first} 9.4.
+{microshift-short} {product-version} is supported on {op-system-base-full} 9.4.
 
 For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
 
@@ -49,8 +49,7 @@ Updating two minor versions in a single step is supported in 4.17. Updates for b
 
 [id="microshift-4-17-IPv6_{context}"]
 ==== IPv6 single and dual-stack IPv6 networking now available
-With this release, you can run {microshift-short} and your workloads with either IPv6 only or IPv4 and IPv6 dual stack networking protocols. Ingress and egress traffic can be on either IPv4 or IPv6 traffic, mixed or parallel. See xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-using-config-tools[Configuring IPv6 networking].
-//crossref to be updated
+With this release, you can run {microshift-short} and your workloads with either IPv6 only or IPv4 and IPv6 dual-stack networking protocols. Ingress and egress traffic can be on either IPv4 or IPv6 traffic, mixed or parallel. See xref:../microshift_configuring/microshift-nw-ipv6-config.adoc#microshift-nw-ipv6-config[Configuring IPv6 networking].
 
 [id="microshift-4-17-storage_{context}"]
 === Storage
@@ -64,25 +63,14 @@ With this release, the resource footprint of the LVM storage driver is significa
 
 [id="microshift-4-17-low-latency_{context}"]
 ====  Low-latency performance for applications now available
-You can now run a {microshift-short} cluster with low-latency response rates. Using a low-latency {microshift-short} configuration with operating system tuning results in reduced application response times and can include deterministic performance. Using workload partitioning is also recommended.
-//TODO crossref
+You can now run a {microshift-short} cluster with low-latency response rates. Using a low-latency {microshift-short} configuration with operating system tuning results in reduced application response times and can include deterministic performance. Using workload partitioning is also recommended. See xref:../microshift_configuring/microshift_low_latency/microshift-low-latency.adoc#microshift-low-latency[Configuring low latency] for more information.
 
 [id="microshift-4-17-workload-partitioning_{context}"]
 ==== Support for workload partitioning
-With this release, workload partitioning is supported in {microshift-short}.
-//TODO: add back crossref after LL PR merges
+With this release, workload partitioning is supported in {microshift-short}. See xref:../microshift_configuring/microshift_low_latency/microshift-workload-partitioning.adoc#microshift-workload-partitioning[Workload partitioning] for more information.
 
 //[id="microshift-4-17-support_{context}"]
 //=== Support
-
-//[id="microshift-4-17-support-updates_{context}"]
-//==== Getting a cluster ID
-
-//[id="microshift-4-17-security_{context}"]
-//=== Security and compliance
-
-//[id="microshift-4-17-ssl-medium-cipher-suites_{context}"]
-//==== SSL Medium Strength Cipher Suites now supported
 
 [id="microshift-4-17-doc-enhancements_{context}"]
 === Documentation enhancements
@@ -90,11 +78,7 @@ With this release, workload partitioning is supported in {microshift-short}.
 
 [id="microshift-4-17-data-cleanup_{context}"]
 ==== Data cleanup now documented
-With this release, the `microshift-cleanup-data` script is documented. For more information, see xref:../microshift_troubleshooting/microshift-cleanup-data.adoc#microshift-cleanup-data[Data cleanup].
-
-//[id="microshift-4-17-route-config_{context}"]
-//==== Route configuration now documented
-
+With this release, the `microshift-cleanup-data` script is documented. See xref:../microshift_troubleshooting/microshift-cleanup-data.adoc#microshift-cleanup-data[Data cleanup] for more information.
 
 [id="microshift-4-17-tech-preview_{context}"]
 == Technology preview features
@@ -106,7 +90,7 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="microshift-4-17-rhel-image-mode_{context}"]
 === {op-system-base-full} image mode Technology Preview feature
 * You can now install {microshift-short} using a `bootc` container image. Image mode for {op-system} is a technology preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
-//TODO add crossref once main PR merges
+See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
 [id="microshift-4-17-bug-fixes_{context}"]
@@ -125,8 +109,8 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //=== Support
 
 //check status for next release+
-[id="microshift-4-17-known-issues_{context}"]
-== Known issues
+//[id="microshift-4-17-known-issues_{context}"]
+//== Known issues
 
 //[id="microshift-4-17-pods-writing-files-excess-memory-limits-crash_{context}"]
 //=== Pods crash when writing files that exceed memory limits
@@ -147,11 +131,11 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
 //TODO uncomment and verify info prior to merge freeze
-[id="microshift-4-17-0-dp_{context}"]
-=== RHEA-2024:3720 - {microshift-short} 4.17.0 bug fix and security update advisory
+//[id="microshift-4-17-0-dp_{context}"]
+//=== RHEA-2024:3720 - {microshift-short} 4.17.0 bug fix and security update advisory
 
-Issued: 2024-MM-DD
+//Issued: 2024-MM-DD
 
-{product-title} release 4.17.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHEA-2024:3720[RHEA-2024:3720] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2024:3718[RHEA-2024:3718] advisory.
+//{product-title} release 4.17.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHEA-2024:3720[RHEA-2024:3720] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2024:3718[RHEA-2024:3718] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+//For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11870](https://issues.redhat.com/browse/OSDOCS-11870)

Link to docs preview:
[IPv6 link](https://81260--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-IPv6_release-notes)
[Low latency and workload partitioning](https://81260--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-running-apps_release-notes)

QE review:
- N/A links only, no technical changes

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
