### PR TITLE
OSDOCS-11869 instance type heading fix

### DIFF
--- a/modules/rosa-sdpolicy-am-aws-compute-types.adoc
+++ b/modules/rosa-sdpolicy-am-aws-compute-types.adoc
@@ -1,4 +1,3 @@
-
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-instance-types.adoc
@@ -6,8 +5,6 @@
 :_mod-docs-content-type: CONCEPT
 [id="rosa-sdpolicy-aws-instance-types_{context}"]
 = AWS x86-based instance types
-
-{product-title} offers the following worker node instance types and sizes:
 
 .General purpose
 [%collapsible]

--- a/modules/rosa-sdpolicy-instance-types.adoc
+++ b/modules/rosa-sdpolicy-instance-types.adoc
@@ -1,0 +1,39 @@
+
+// Module included in the following assemblies:
+//
+// * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:rosa-with-hcp:
+endif::[]
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-sdpolicy-instance-types_{context}"]
+= Instance types
+
+ifdef::rosa-with-hcp[]
+All {hcp-title} clusters require a minimum of 2 worker nodes. All {hcp-title} clusters support a maximum of 180 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+Single availability zone clusters require a minimum of 3 control plane nodes, 2 infrastructure nodes, and 2 worker nodes deployed to a single availability zone.
+
+Multiple availability zone clusters require a minimum of 3 control plane nodes, 3 infrastructure nodes, and 3 worker nodes. Additional nodes must be purchased in multiples of three to maintain proper node distribution.
+
+All {product-title} clusters support a maximum of 180 worker nodes.
+
+Control plane and infrastructure nodes are deployed and managed by Red{nbsp}Hat. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss. There are at least 3 control plane nodes that handle etcd- and API-related workloads. There are at least 2 infrastructure nodes that handle metrics, routing, the web console, and other workloads. You must not run any workloads on the control and infrastructure nodes. Any workloads you intend to run must be deployed on worker nodes. See the Red{nbsp}Hat Operator support section below for more information about Red{nbsp}Hat workloads that must be deployed on worker nodes.
+endif::rosa-with-hcp[]
+
+[NOTE]
+====
+Approximately one vCPU core and 1 GiB of memory are reserved on each worker node and removed from allocatable resources. This reservation of resources is necessary to run processes required by the underlying platform. These processes include system daemons such as udev, kubelet, and container runtime among others. The reserved resources also account for kernel reservations.
+
+{OCP} core systems such as audit log aggregation, metrics collection, DNS, image registry, SDN, and others might consume additional allocatable resources to maintain the stability and maintainability of the cluster. The additional resources consumed might vary based on usage.
+
+For additional information, see the link:https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved[Kubernetes documentation].
+====
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:!rosa-with-hcp:
+endif::[]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc
@@ -2,21 +2,10 @@
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-instance-types
 [id="rosa-hcp-instance-types"]
-= ROSA with HCP instance types
+= {hcp-title-first} instance types
 
 toc::[]
-
-All {hcp-title} clusters require a minimum of 2 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is not supported and can lead to data loss. 
-
-
-[NOTE]
-====
-Approximately one vCPU core and 1 GiB of memory are reserved on each worker node and removed from allocatable resources. This reservation of resources is necessary to run processes required by the underlying platform. These processes include system daemons such as udev, kubelet, and container runtime among others. The reserved resources also account for kernel reservations.
-
-{OCP} core systems such as audit log aggregation, metrics collection, DNS, image registry, SDN, and others might consume additional allocatable resources to maintain the stability and maintainability of the cluster. The additional resources consumed might vary based on usage.
-
-For additional information, see the link:https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved[Kubernetes documentation].
-====
+{hcp-title} offers the following worker node instance types and sizes:
 
 include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+1]
 

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
@@ -22,10 +22,12 @@ include::modules/rosa-sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-red-hat-operator_rosa-service-definition[Red{nbsp}Hat Operator Support]
 
 
-[id="rosa-sdpolicy-instance-types_{context}"]
-=== Instance types
+include::modules/rosa-sdpolicy-instance-types.adoc[leveloffset=+2]
 
-For more information about supported instance types, see xref:../rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-hcp-instance-types[{hcp-title} instance types].
+[role="_additional-resources"]
+.Additional Resources
+
+For a detailed listing of supported instance types, see xref:../rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-hcp-instance-types[{hcp-title} instance types].
 
 
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-instance-types.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-instance-types.adoc
@@ -1,4 +1,3 @@
-
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="rosa-instance-types"]
@@ -7,23 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Single availability zone clusters require a minimum of 3 control plane nodes, 2 infrastructure nodes, and 2 worker nodes deployed to a single availability zone.
-
-Multiple availability zone clusters require a minimum of 3 control plane nodes, 3 infrastructure nodes, and 3 worker nodes. Additional nodes must be purchased in multiples of three to maintain proper node distribution.
-
-All {product-title} clusters support a maximum of 180 worker nodes.
-
-Control plane and infrastructure nodes are deployed and managed by Red{nbsp}Hat. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss. There are at least 3 control plane nodes that handle etcd- and API-related workloads. There are at least 2 infrastructure nodes that handle metrics, routing, the web console, and other workloads. You must not run any workloads on the control and infrastructure nodes. Any workloads you intend to run must be deployed on worker nodes. See the Red{nbsp}Hat Operator support section below for more information about Red{nbsp}Hat workloads that must be deployed on worker nodes.
-
-[NOTE]
-====
-Approximately one vCPU core and 1 GiB of memory are reserved on each worker node and removed from allocatable resources. This reservation of resources is necessary to run processes required by the underlying platform. These processes include system daemons such as udev, kubelet, and container runtime among others. The reserved resources also account for kernel reservations.
-
-{OCP} core systems such as audit log aggregation, metrics collection, DNS, image registry, SDN, and others might consume additional allocatable resources to maintain the stability and maintainability of the cluster. The additional resources consumed might vary based on usage.
-
-For additional information, see the link:https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved[Kubernetes documentation].
-====
-
+{product-title} offers the following worker node instance types and sizes:
 
 include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+1]
 

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -22,10 +22,12 @@ include::modules/rosa-sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-red-hat-operator_rosa-service-definition[Red{nbsp}Hat Operator Support]
 * xref:../../rosa_cluster_admin/rosa-configuring-pid-limits.adoc#rosa-configuring-pid-limits[Configuring PID limits]
 
-[id="rosa-sdpolicy-instance-types_{context}"]
-=== Instance types
+include::modules/rosa-sdpolicy-instance-types.adoc[leveloffset=+2]
 
-For more information about supported instance types, see xref:../rosa_policy_service_definition/rosa-instance-types.adoc#rosa-instance-types[{product-title} instance types].
+[role="_additional-resources"]
+.Additional Resources
+
+For a detailed listing of supported instance types, see xref:../rosa_policy_service_definition/rosa-instance-types.adoc#rosa-instance-types[{product-title} instance types].
 
 
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR moves information regarding instance type usage in ROSA back to the Service Definition.

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11869


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

ROSA with HCP Docs

https://81267--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.html

https://81267--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-instance-types_rosa-hcp-service-definition

Rosa classic docs:

https://81267--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-instance-types.html

https://81267--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-instance-types_rosa-service-definition

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
