### PR TITLE
[SRVCOM-3270] Fix links in Dev metrics overview

### DIFF
--- a/observability/developer-metrics/serverless-developer-metrics.adoc
+++ b/observability/developer-metrics/serverless-developer-metrics.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Metrics enable developers to monitor how Knative services are performing. You can use the {ocp-product-title} monitoring stack to record and view health checks and metrics for your Knative services.
 
-You can view different metrics for {ServerlessProductName} by navigating to link:https://docs.openshift.com/container-platform/latest/monitoring/reviewing-monitoring-dashboards.html#reviewing-monitoring-dashboards-developer_reviewing-monitoring-dashboards[*Dashboards*] in the  web console *Developer* perspective.
+You can view different metrics for {ServerlessProductName} by navigating to link:https://docs.openshift.com/container-platform/latest/observability/monitoring/reviewing-monitoring-dashboards.html#reviewing-monitoring-dashboards-developer_reviewing-monitoring-dashboards[*Dashboards*] in the  web console *Developer* perspective.
 
 [WARNING]
 ====
@@ -22,6 +22,5 @@ Scraping the metrics does not affect autoscaling of a Knative service, because s
 [id="additional-resources_serverless-service-monitoring"]
 [role="_additional-resources"]
 == Additional resources for {ocp-product-title}
-* link:https://docs.openshift.com/container-platform/latest/monitoring/monitoring-overview.html#monitoring-overview[Monitoring overview]
-* link:https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html[Enabling monitoring for user-defined projects]
-* link:https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects[Specifying how a service is monitored]
+* link:https://docs.openshift.com/container-platform/latest/observability/monitoring/monitoring-overview.html#monitoring-overview[Monitoring overview]
+* link:https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html[Enabling monitoring for user-defined projects]


### PR DESCRIPTION
Version(s):
serverless-docs-1.28+

Issue:
https://issues.redhat.com/browse/SRVCOM-3270

Link to docs preview:
- https://81283--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/developer-metrics/serverless-developer-metrics.html