### PR TITLE
OSDOCS-11396 added custom ingress controller configurations to ROSA/OSD

### DIFF
--- a/modules/configuring-haproxy-interval.adoc
+++ b/modules/configuring-haproxy-interval.adoc
@@ -18,9 +18,19 @@ Setting a large value for the minimum HAProxy reload interval can cause latency 
 
 .Procedure
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * Change the minimum HAProxy reload interval of the default Ingress Controller to 15 seconds by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator patch ingresscontrollers/default --type=merge --patch='{"spec":{"tuningOptions":{"reloadInterval":"15s"}}}'
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Change the minimum HAProxy reload interval of the Ingress Controller to 15 seconds by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontrollers/<custom_ingresscontroller_name> --type=merge --patch='{"spec":{"tuningOptions":{"reloadInterval":"15s"}}}'
+----
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -16,10 +16,18 @@ You can deploy the router pod to a different compute machine set. By default, th
 
 . View the `IngressController` custom resource for the router Operator:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc get ingresscontroller default -n openshift-ingress-operator -o yaml
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc get ingresscontroller <custom_ingresscontroller_name> -n openshift-ingress-operator -o yaml
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 The command output resembles the following text:
 +
@@ -52,10 +60,18 @@ status:
 
 . Edit the `ingresscontroller` resource and change the `nodeSelector` to use the `infra` label:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc edit ingresscontroller default -n openshift-ingress-operator
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc get ingresscontroller <custom_ingresscontroller_name> -n openshift-ingress-operator -o yaml
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 [source,yaml]
 ----

--- a/modules/nw-autoscaling-ingress-controller.adoc
+++ b/modules/nw-autoscaling-ingress-controller.adoc
@@ -8,7 +8,7 @@
 
 You can automatically scale an Ingress Controller to dynamically meet routing performance or availability requirements, such as the requirement to increase throughput.
 
-The following procedure provides an example for scaling up the default Ingress Controller.
+The following procedure provides an example for scaling up the Ingress Controller.
 
 .Prerequisites
 
@@ -139,9 +139,10 @@ $ oc adm policy -n openshift-ingress-operator add-cluster-role-to-user cluster-m
 The argument `add-cluster-role-to-user` is only required if you use cross-namespace queries. The following step uses a query from the `kube-metrics` namespace which requires this argument.
 ====
 
-. Create a new `ScaledObject` YAML file, `ingress-autoscaler.yaml`, that targets the default Ingress Controller deployment:
+. Create a new `ScaledObject` YAML file, `ingress-autoscaler.yaml`, that targets the Ingress Controller deployment:
 +
 .Example `ScaledObject` definition
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 apiVersion: keda.sh/v1alpha1
@@ -177,6 +178,43 @@ spec:
 <3> The Thanos service endpoint in the `openshift-monitoring` namespace.
 <4> The Ingress Operator namespace.
 <5> This expression evaluates to however many worker nodes are present in the deployed cluster.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ingress-scaler
+spec:
+  scaleTargetRef: <1>
+    apiVersion: operator.openshift.io/v1
+    kind: IngressController
+    name: <custom_ingresscontroller_name>
+    envSourceContainerName: ingress-operator
+  minReplicaCount: 1
+  maxReplicaCount: 20 <2>
+  cooldownPeriod: 1
+  pollingInterval: 1
+  triggers:
+  - type: prometheus
+    metricType: AverageValue
+    metadata:
+      serverAddress: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091 <3>
+      namespace: openshift-ingress-operator <4>
+      metricName: 'kube-node-role'
+      threshold: '1'
+      query: 'sum(kube_node_role{role="worker",service="kube-state-metrics"})' <5>
+      authModes: "bearer"
+    authenticationRef:
+      name: keda-trigger-auth-prometheus
+----
+<1> The custom resource that you are targeting. In this case, the Ingress Controller.
+<2> Optional: The maximum number of replicas. If you omit this field, the default maximum is set to 100 replicas.
+<3> The Thanos service endpoint in the `openshift-monitoring` namespace.
+<4> The Ingress Operator namespace.
+<5> This expression evaluates to however many worker nodes are present in the deployed cluster.
+endif::openshift-rosa,openshift-dedicated[]
 +
 [IMPORTANT]
 ====
@@ -191,14 +229,22 @@ $ oc apply -f ingress-autoscaler.yaml
 ----
 
 .Verification
-* Verify that the default Ingress Controller is scaled out to match the value returned by the `kube-state-metrics` query by running the following commands:
+* Verify that the Ingress Controller is scaled out to match the value returned by the `kube-state-metrics` query by running the following commands:
 
 ** Use the `grep` command to search the Ingress Controller YAML file for replicas:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc get -n openshift-ingress-operator ingresscontroller/default -o yaml | grep replicas:
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc get ingresscontroller/<custom_ingresscontroller_name> -o yaml | grep replicas:
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 .Example output
 [source,terminal]

--- a/modules/nw-configure-ingress-access-logging.adoc
+++ b/modules/nw-configure-ingress-access-logging.adoc
@@ -22,6 +22,7 @@ Configure Ingress access logging to a sidecar.
 
 * To configure Ingress access logging, you must specify a destination using `spec.logging.access.destination`. To specify logging to a sidecar container, you must specify `Container` `spec.logging.access.destination.type`. The following example is an Ingress Controller definition that logs to a `Container` destination:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -36,6 +37,23 @@ spec:
       destination:
         type: Container
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 2
+  logging:
+    access:
+      destination:
+        type: Container
+----
+endif::openshift-rosa,openshift-dedicated[]
 
 * When you configure the Ingress Controller to log to a sidecar, the operator creates a container named `logs` inside the Ingress Controller Pod:
 +
@@ -54,6 +72,7 @@ Configure Ingress access logging to a Syslog endpoint.
 
 * To configure Ingress access logging, you must specify a destination using `spec.logging.access.destination`. To specify logging to a Syslog endpoint destination, you must specify `Syslog` for `spec.logging.access.destination.type`. If the destination type is `Syslog`, you must also specify a destination endpoint using `spec.logging.access.destination.syslog.address` and you can specify a facility using `spec.logging.access.destination.syslog.facility`. The following example is an Ingress Controller definition that logs to a `Syslog` destination:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -71,6 +90,26 @@ spec:
           address: 1.2.3.4
           port: 10514
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 2
+  logging:
+    access:
+      destination:
+        type: Syslog
+        syslog:
+          address: 1.2.3.4
+          port: 10514
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 [NOTE]
 ====
@@ -83,6 +122,7 @@ Configure Ingress access logging with a specific log format.
 
 * You can specify `spec.logging.access.httpLogFormat` to customize the log format. The following example is an Ingress Controller definition that logs to a `syslog` endpoint with IP address 1.2.3.4 and port 10514:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -101,11 +141,33 @@ spec:
           port: 10514
       httpLogFormat: '%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV'
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 2
+  logging:
+    access:
+      destination:
+        type: Syslog
+        syslog:
+          address: 1.2.3.4
+          port: 10514
+      httpLogFormat: '%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV'
+----
+endif::openshift-rosa,openshift-dedicated[]
 
 Disable Ingress access logging.
 
 * To disable Ingress access logging, leave `spec.logging` or `spec.logging.access` empty:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -118,18 +180,34 @@ spec:
   logging:
     access: null
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 2
+  logging:
+    access: null
+----
+endif::openshift-rosa,openshift-dedicated[]
 
 Allow the Ingress Controller to modify the HAProxy log length when using a sidecar.
 
 * Use `spec.logging.access.destination.syslog.maxLength` if you are using `spec.logging.access.destination.type: Syslog`.
 
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
 kind: IngressController
 metadata:
-  name: default
+  name: <custom_ingresscontroller_name>
   namespace: openshift-ingress-operator
 spec:
   replicas: 2
@@ -142,15 +220,37 @@ spec:
           maxLength: 4096
           port: 10514
 ----
-* Use `spec.logging.access.destination.container.maxLength` if you are using `spec.logging.access.destination.type: Container`.
-
-+
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
 kind: IngressController
 metadata:
-  name: default
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 2
+  logging:
+    access:
+      destination:
+        type: Syslog
+        syslog:
+          address: 1.2.3.4
+          maxLength: 4096
+          port: 10514
+----
+endif::openshift-rosa,openshift-dedicated[]
+* Use `spec.logging.access.destination.container.maxLength` if you are using `spec.logging.access.destination.type: Container`.
+
++
+ifndef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
   namespace: openshift-ingress-operator
 spec:
   replicas: 2
@@ -161,4 +261,22 @@ spec:
         container:
           maxLength: 8192
 ----
-
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 2
+  logging:
+    access:
+      destination:
+        type: Container
+        container:
+          maxLength: 8192
+----
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/nw-configuring-router-compression.adoc
+++ b/modules/nw-configuring-router-compression.adoc
@@ -20,10 +20,18 @@ Not all MIME types benefit from compression, but HAProxy still uses resources to
 . Configure the `httpCompression` field for the Ingress Controller.
 .. Use the following command to edit the `IngressController` resource:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc edit -n openshift-ingress-operator ingresscontrollers/default
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc edit -n openshift-ingress-operator ingresscontrollers/<custom_ingresscontroller_name>
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 .. Under `spec`, set the `httpCompression` policy field to `mimeTypes` and specify a list of MIME types that should have compression applied:
 +

--- a/modules/nw-customize-ingress-error-pages.adoc
+++ b/modules/nw-customize-ingress-error-pages.adoc
@@ -33,10 +33,18 @@ $ oc -n openshift-config create configmap my-custom-error-code-pages \
 
 . Patch the Ingress Controller to reference the `my-custom-error-code-pages` config map by name:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc patch -n openshift-ingress-operator ingresscontroller/default --patch '{"spec":{"httpErrorCodePages":{"name":"my-custom-error-code-pages"}}}' --type=merge
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc patch -n openshift-ingress-operator ingresscontroller/<custom_ingresscontroller_name> --patch '{"spec":{"httpErrorCodePages":{"name":"my-custom-error-code-pages"}}}' --type=merge
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 The Ingress Operator copies the `my-custom-error-code-pages` config map from the `openshift-config` namespace to the `openshift-ingress` namespace. The Operator names the config map according to the pattern, `<your_ingresscontroller_name>-errorpages`, in the `openshift-ingress` namespace.
 

--- a/modules/nw-ingress-controller-config-tuningoptions-healthcheckinterval.adoc
+++ b/modules/nw-ingress-controller-config-tuningoptions-healthcheckinterval.adoc
@@ -13,10 +13,18 @@ A cluster administrator can set the health check interval to define how long the
 .Procedure
 * Update the Ingress Controller to change the interval between back end health checks:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator patch ingresscontroller/default --type=merge -p '{"spec":{"tuningOptions": {"healthCheckInterval": "8s"}}}'
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/<custom_ingresscontroller_name> --type=merge -p '{"spec":{"tuningOptions": {"healthCheckInterval": "8s"}}}'
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 [NOTE]
 ====

--- a/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
+++ b/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
@@ -44,10 +44,18 @@ You must configure both {product-title} and the external load balancer to either
 .Procedure
 . Edit the Ingress Controller resource by entering the following command in your CLI:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator edit ingresscontroller/default
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator edit ingresscontroller/<custom_ingresscontroller_name>
+----
+endif::openshift-rosa,openshift-dedicated[]
 
 . Set the PROXY configuration:
 +

--- a/modules/nw-ingress-converting-http-header-case.adoc
+++ b/modules/nw-ingress-converting-http-header-case.adoc
@@ -26,10 +26,18 @@ As a cluster administrator, you can convert the HTTP header case by entering the
 
 .. Change the HTTP header from `host` to `Host` by running the following command:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator patch ingresscontrollers/default --type=merge --patch='{"spec":{"httpHeaders":{"headerNameCaseAdjustments":["Host"]}}}'
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontrollers/<custom_ingresscontroller_name> --type=merge --patch='{"spec":{"httpHeaders":{"headerNameCaseAdjustments":["Host"]}}}'
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 .. Create a `Route` resource YAML file so that the annotation can be applied to the application.
 +

--- a/modules/nw-ingress-custom-default-certificate-remove.adoc
+++ b/modules/nw-ingress-custom-default-certificate-remove.adoc
@@ -18,11 +18,20 @@ As an administrator, you can remove a custom certificate that you configured an 
 
 * To remove the custom certificate and restore the certificate that ships with {product-title}, enter the following command:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc patch -n openshift-ingress-operator ingresscontrollers/default \
   --type json -p $'- op: remove\n  path: /spec/defaultCertificate'
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc patch -n openshift-ingress-operator ingresscontrollers/<custom_ingresscontroller_name> \
+  --type json -p $'- op: remove\n  path: /spec/defaultCertificate'
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 There can be a delay while the cluster reconciles the new certificate configuration.
 

--- a/modules/nw-ingress-set-or-delete-http-headers.adoc
+++ b/modules/nw-ingress-set-or-delete-http-headers.adoc
@@ -19,13 +19,22 @@ The following procedure modifies the Ingress Controller to set the X-Forwarded-C
 .Procedure
 . Edit the Ingress Controller resource:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator edit ingresscontroller/default
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator edit ingresscontroller/<custom_ingresscontroller_name>
+----
+endif::openshift-rosa,openshift-dedicated[]
 
 . Replace the X-SSL-Client-Der HTTP request header with the X-Forwarded-Client-Cert HTTP request header:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -51,6 +60,34 @@ spec:
 <3> The name of the header you want to change. For a list of available headers you can set or delete, see _HTTP header configuration_.
 <4> The type of action being taken on the header. This field can have the value `Set` or `Delete`.
 <5> When setting HTTP headers, you must provide a `value`. The value can be a string from a list of available directives for that header, for example `DENY`, or it can be a dynamic value that will be interpreted using HAProxy's dynamic value syntax. In this case, a dynamic value is added.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  httpHeaders:
+    actions: <1>
+      request: <2>
+      - name: X-Forwarded-Client-Cert <3>
+        action:
+          type: Set <4>
+          set:
+           value: "%{+Q}[ssl_c_der,base64]" <5>
+      - name: X-SSL-Client-Der
+        action:
+          type: Delete
+----
+<1> The list of actions you want to perform on the HTTP headers.
+<2> The type of header you want to change. In this case, a request header.
+<3> The name of the header you want to change. For a list of available headers you can set or delete, see _HTTP header configuration_.
+<4> The type of action being taken on the header. This field can have the value `Set` or `Delete`.
+<5> When setting HTTP headers, you must provide a `value`. The value can be a string from a list of available directives for that header, for example `DENY`, or it can be a dynamic value that will be interpreted using HAProxy's dynamic value syntax. In this case, a dynamic value is added.
+endif::openshift-rosa,openshift-dedicated[]
 +
 [NOTE]
 ====

--- a/modules/nw-ingress-setting-a-custom-default-certificate.adoc
+++ b/modules/nw-ingress-setting-a-custom-default-certificate.adoc
@@ -67,11 +67,20 @@ $ oc --namespace openshift-ingress create secret tls custom-certs-default --cert
 +
 . Update the IngressController CR to reference the new certificate secret:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc patch --type=merge --namespace openshift-ingress-operator ingresscontrollers/default \
   --patch '{"spec":{"defaultCertificate":{"name":"custom-certs-default"}}}'
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc patch --type=merge --namespace openshift-ingress-operator ingresscontrollers/<custom_ingresscontroller_name> \
+  --patch '{"spec":{"defaultCertificate":{"name":"custom-certs-default"}}}'
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 . Verify the update was effective:
 +
@@ -96,6 +105,7 @@ issuer=C = US, ST = NC, L = Raleigh, O = RH, OU = OCP4, CN = example.com
 notAfter=May 10 08:32:45 2022 GM
 ----
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [TIP]
 ====
 You can alternatively apply the following YAML to set a custom default certificate:
@@ -112,6 +122,25 @@ spec:
     name: custom-certs-default
 ----
 ====
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[TIP]
+====
+You can alternatively apply the following YAML to set a custom default certificate:
+
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  defaultCertificate:
+    name: custom-certs-default
+----
+====
+endif::openshift-rosa,openshift-dedicated[]
 +
 The certificate secret name should match the value used to update the CR.
 

--- a/modules/nw-ingress-setting-max-connections.adoc
+++ b/modules/nw-ingress-setting-max-connections.adoc
@@ -13,10 +13,18 @@ A cluster administrator can set the maximum number of simultaneous connections f
 .Procedure
 * Update the Ingress Controller to change the maximum number of connections for HAProxy:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator patch ingresscontroller/default --type=merge -p '{"spec":{"tuningOptions": {"maxConnections": 7500}}}'
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/<custom_ingresscontroller_name> --type=merge -p '{"spec":{"tuningOptions": {"maxConnections": 7500}}}'
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 [WARNING]
 ====

--- a/modules/nw-ingress-setting-thread-count.adoc
+++ b/modules/nw-ingress-setting-thread-count.adoc
@@ -13,10 +13,18 @@ A cluster administrator can set the thread count to increase the amount of incom
 .Procedure
 * Update the Ingress Controller to increase the number of threads:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator patch ingresscontroller/default --type=merge -p '{"spec":{"tuningOptions": {"threadCount": 8}}}'
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/<custom_ingresscontroller_name> --type=merge -p '{"spec":{"tuningOptions": {"threadCount": 8}}}'
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 [NOTE]
 ====

--- a/modules/nw-ingress-view.adoc
+++ b/modules/nw-ingress-view.adoc
@@ -18,7 +18,15 @@ within a minute.
 
 * View the default Ingress Controller:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc describe --namespace=openshift-ingress-operator ingresscontroller/default
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc describe --namespace=openshift-ingress-operator ingresscontroller/<custom_ingresscontroller_name>
+----
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/nw-ingresscontroller-change-external.adoc
+++ b/modules/nw-ingresscontroller-change-external.adoc
@@ -33,10 +33,18 @@ $ oc -n openshift-ingress-operator patch ingresscontrollers/private --type=merge
 +
 * To check the status of the Ingress Controller, enter the following command:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator get ingresscontrollers/default -o yaml
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator get ingresscontrollers/<custom_ingresscontroller_name> -o yaml
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 ** The `Progressing` status condition indicates whether you must take further action. For example, the status condition can indicate that you need to delete the service by entering the following command:
 +

--- a/modules/nw-ne-openshift-ingress.adoc
+++ b/modules/nw-ne-openshift-ingress.adoc
@@ -9,8 +9,8 @@ When you create your {product-title} cluster, pods and services running on the c
 ifndef::openshift-rosa,openshift-dedicated[]
 The Ingress Operator makes it possible for external clients to access your service by deploying and managing one or more HAProxy-based
 link:https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/[Ingress Controllers] to handle routing. You can use the Ingress Operator to route traffic by specifying {product-title} `Route` and Kubernetes `Ingress` resources. Configurations within the Ingress Controller, such as the ability to define `endpointPublishingStrategy` type and internal load balancing, provide ways to publish Ingress Controller endpoints.
-endif::[]
+endif::openshift-rosa,openshift-dedicated[]
 
 ifdef::openshift-rosa,openshift-dedicated[]
-The Ingress Operator makes it possible for external clients to access your service by deploying and managing one or more HAProxy-based link:https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/[Ingress Controllers] to handle routing. Red Hat Site Reliability Engineers (SRE) manage the Ingress Operator for {product-title} clusters. While you cannot alter the settings for the Ingress Operator, you may view the default Ingress Controller configurations, status, and logs as well as the Ingress Operator status.
-endif::[]
+The Ingress Operator makes it possible for external clients to access your service by deploying and managing one or more HAProxy-based link:https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/[Ingress Controllers] to handle routing. Red{nbsp}Hat Site Reliability Engineers (SRE) manage the Ingress Operator for {product-title} clusters. While you cannot alter the settings for the Ingress Operator, you may use the ROSA CLI to view the default Ingress Controller configurations, status, and logs as well as the Ingress Operator status, but not edit the default configurations. You can add your own custom Ingress Controllers with their own configurations. However, custom Ingress Controllers are considered "customer managed" and are not managed by SRE. 
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/nw-route-admission-policy.adoc
+++ b/modules/nw-route-admission-policy.adoc
@@ -22,10 +22,18 @@ Allowing claims across namespaces should only be enabled for clusters with trust
 
 * Edit the `.spec.routeAdmission` field of the `ingresscontroller` resource variable using the following command:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc -n openshift-ingress-operator patch ingresscontroller/default --patch '{"spec":{"routeAdmission":{"namespaceOwnership":"InterNamespaceAllowed"}}}' --type=merge
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/<custom_ingresscontroller_name> --patch '{"spec":{"routeAdmission":{"namespaceOwnership":"InterNamespaceAllowed"}}}' --type=merge
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 .Sample Ingress Controller configuration
 [source,yaml]
@@ -39,6 +47,7 @@ spec:
 [TIP]
 ====
 You can alternatively apply the following YAML to configure the route admission policy:
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -50,4 +59,18 @@ spec:
   routeAdmission:
     namespaceOwnership: InterNamespaceAllowed
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  routeAdmission:
+    namespaceOwnership: InterNamespaceAllowed
+----
+endif::openshift-rosa,openshift-dedicated[]
 ====

--- a/modules/nw-scaling-ingress-controller.adoc
+++ b/modules/nw-scaling-ingress-controller.adoc
@@ -9,7 +9,7 @@
 Manually scale an Ingress Controller to meeting routing performance or
 availability requirements such as the requirement to increase throughput. `oc`
 commands are used to scale the `IngressController` resource. The following
-procedure provides an example for scaling up the default `IngressController`.
+procedure provides an example for scaling up the `IngressController`.
 
 [NOTE]
 ====
@@ -17,6 +17,7 @@ Scaling is not an immediate action, as it takes time to create the desired numbe
 ====
 
 .Procedure
+ifndef::openshift-rosa,openshift-dedicated[]
 . View the current number of available replicas for the default `IngressController`:
 +
 [source,terminal]
@@ -74,3 +75,63 @@ spec:
 ----
 ====
 <1> If you need a different amount of replicas, change the `replicas` value.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+. View the current number of available replicas for the `IngressController`:
++
+[source,terminal]
+----
+$ oc get -n openshift-ingress-operator ingresscontrollers/<custom_ingresscontroller_name> -o jsonpath='{$.status.availableReplicas}'
+----
++
+.Example output
+[source,terminal]
+----
+2
+----
+
+. Scale the `IngressController` to the desired number of replicas using
+the `oc patch` command. The following example scales a custom `IngressController`
+to 3 replicas:
++
+[source,terminal]
+----
+$ oc patch -n openshift-ingress-operator ingresscontroller/<custom_ingresscontroller_name> --patch '{"spec":{"replicas": 3}}' --type=merge
+----
++
+.Example output
+[source,terminal]
+----
+ingresscontroller.operator.openshift.io/<custom_ingresscontroller_name> patched
+----
+
+. Verify that the `IngressController` scaled to the number of replicas
+that you specified:
++
+[source,terminal]
+----
+$ oc get -n openshift-ingress-operator ingresscontrollers/<custom_ingresscontroller_name> -o jsonpath='{$.status.availableReplicas}'
+----
++
+.Example output
+[source,terminal]
+----
+3
+----
++
+[TIP]
+====
+You can alternatively apply the following YAML to scale an Ingress Controller to three replicas:
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ingresscontroller_name>
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 3               <1>
+----
+====
+<1> If you need a different amount of replicas, change the `replicas` value.
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/sd-ingress-responsibilities.adoc
+++ b/modules/sd-ingress-responsibilities.adoc
@@ -15,20 +15,22 @@ The following table details the components of the Ingress Operator and if Red Ha
 |Managed by
 |Default configuration?
 
-|Scaling Ingress Controller | SRE | Yes
+|Scaling Default Ingress Controller | SRE | Yes
 
 |Ingress Operator thread count | SRE | Yes
 
-|Ingress Controller access logging | SRE | Yes
+|Default Ingress Controller access logging | SRE | Yes
 
-|Ingress Controller sharding | SRE | Yes
+|Default Ingress Controller sharding | SRE | Yes
 
-|Ingress Controller route admission policy | SRE | Yes
+|Default Ingress Controller route admission policy | SRE | Yes
 
-|Ingress Controller wildcard routes | SRE | Yes
+|Default Ingress Controller wildcard routes | SRE | Yes
 
-|Ingress Controller X-Forwarded headers | SRE | Yes
+|Default Ingress Controller X-Forwarded headers | SRE | Yes
 
-|Ingress Controller route compression | SRE | Yes
+|Default Ingress Controller route compression | SRE | Yes
+
+|Custom Ingress Controller creation and configuration | Customer | Customer managed
 
 |===


### PR DESCRIPTION
Updated the description and table in the Networking docs for OSD to add custom ingress controllers. 

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+
Issue:
https://issues.redhat.com/browse/OSDOCS-11396
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
ROSA:
https://81289--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ingress-operator.html

OSD:
https://81289--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ingress-operator.html

Enterprise:
https://81289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR is fairly large, but most of it is made up of conditional duplication for the change `ingresscontroller/default` to `ingresscontroller/<custom_ingresscontroller_name>`

