### PR TITLE
MCO node disruption policy typo fixes

### DIFF
--- a/modules/machine-config-node-disruption-example.adoc
+++ b/modules/machine-config-node-disruption-example.adoc
@@ -103,7 +103,7 @@ spec:
 
 In the following example, when changes are made to the `auditd.service`	systemd unit, the MCO drains the cluster nodes, reloads the `crio.service`, reloads the systemd manager configuration, and restarts the `crio.service`.
 
-.Example node disruption policy for a configuration file change
+.Example node disruption policy for a systemd unit change
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -127,9 +127,9 @@ spec:
               serviceName: crio.service
 ----
 
-In the following example, when changes are made to the files in the `registries.conf` directory, the MCO does not drain or reboot the nodes and applies the changes with no further action.
+In the following example, when changes are made to the files in the `registries.conf` directory, such as by editing an `ImageContentSourcePolicy` (ICSP) object, the MCO does not drain or reboot the nodes and applies the changes with no further action.
 
-.Example node disruption policy for a configuration file change
+.Example node disruption policy for a registries.conf file change
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -140,6 +140,7 @@ metadata:
 # ...
 spec:
   nodeDisruptionPolicy:
+    files:  
       - actions:
         - type: None
         path: /etc/containers/registries.conf


### PR DESCRIPTION
I just noticed a couple of typos, likely copy/paste changes that I didn't update after the copy/paste

QE review:
No QE, typos only
