### PR TITLE
OSDOCS#11327: Docs for descheduler 5.1.0 including the LongLifecycle …

### DIFF
--- a/modules/nodes-descheduler-configuring-profiles.adoc
+++ b/modules/nodes-descheduler-configuring-profiles.adoc
@@ -47,9 +47,11 @@ spec:
       - my-namespace
     podLifetime: 48h                                   <3>
     thresholdPriorityClassName: my-priority-class-name <4>
-  profiles:                                            <5>
+  evictionLimits:
+    total: 20                                          <5>
+  profiles:                                            <6>
   - AffinityAndTaints
-  - TopologyAndDuplicates                              <6>
+  - TopologyAndDuplicates
   - LifecycleAndUtilization
   - EvictPodsWithLocalStorage
   - EvictPodsWithPVC
@@ -60,8 +62,8 @@ spec:
 <2> Optional: Set a list of user-created namespaces to include or exclude from descheduler operations. Use `excluded` to set a list of namespaces to exclude or use `included` to set a list of namespaces to include. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are excluded by default.
 <3> Optional: Enable a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
 <4> Optional: Specify a priority threshold to consider pods for eviction only if their priority is lower than the specified level. Use the `thresholdPriority` field to set a numerical priority threshold (for example, `10000`) or use the `thresholdPriorityClassName` field to specify a certain priority class name (for example, `my-priority-class-name`). If you specify a priority class name, it must already exist or the descheduler will throw an error. Do not set both `thresholdPriority` and `thresholdPriorityClassName`.
-<5> Add one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, and `EvictPodsWithPVC`.
-<6> Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enabling both results in a conflict.
+<5> Optional: Set the maximum number of pods to evict during each descheduler run.
+<6> Add one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, `EvictPodsWithPVC`, `CompactAndScale`, and `LongLifecycle`. Ensure that you do not enable profiles that conflict with each other.
 
 You can enable multiple profiles; the order that the profiles are specified in is not important.
 --

--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -30,30 +30,47 @@ Pods with a node affinity type of `requiredDuringSchedulingIgnoredDuringExecutio
 +
 It enables the following strategies:
 +
+--
 * `RemovePodsViolatingTopologySpreadConstraint`: finds unbalanced topology domains and tries to evict pods from larger ones when `DoNotSchedule` constraints are violated.
 * `RemoveDuplicates`: ensures that there is only one pod associated with a replica set, replication controller, deployment, or job running on same node. If there are more, those duplicate pods are evicted for better pod distribution in a cluster.
+--
++
+[WARNING]
+====
+Do not enable `TopologyAndDuplicates` with any of the following profiles: `SoftTopologyAndDuplicates` or `CompactAndScale`. Enabling these profiles together results in a conflict.
+====
 
 `LifecycleAndUtilization`:: This profile evicts long-running pods and balances resource usage between nodes.
 +
 It enables the following strategies:
 +
+--
 * `RemovePodsHavingTooManyRestarts`: removes pods whose containers have been restarted too many times.
 +
 Pods where the sum of restarts over all containers (including Init Containers) is more than 100.
 
 * `LowNodeUtilization`: finds nodes that are underutilized and evicts pods, if possible, from overutilized nodes in the hope that recreation of evicted pods will be scheduled on these underutilized nodes.
+
+** A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
+
+** A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
+
 +
-A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
-+
-A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
+Optionally, you can adjust these underutilized/overutilized threshold percentages by setting the Technology Preview field `devLowNodeUtilizationThresholds` to one the following values: `Low` for 10%/30%, `Medium` for 20%/50%, or `High` for 40%/70%. The default value is `Medium`.
 
 * `PodLifeTime`: evicts pods that are too old.
 +
 By default, pods that are older than 24 hours are removed. You can customize the pod lifetime value.
+--
++
+[WARNING]
+====
+Do not enable `LifecycleAndUtilization` with any of the following profiles: `LongLifecycle` or `CompactAndScale`. Enabling these profiles together results in a conflict.
+====
 
 `SoftTopologyAndDuplicates`:: This profile is the same as `TopologyAndDuplicates`, except that pods with soft topology constraints, such as `whenUnsatisfiable: ScheduleAnyway`, are also considered for eviction.
 +
-[NOTE]
+[WARNING]
 ====
 Do not enable both `SoftTopologyAndDuplicates` and `TopologyAndDuplicates`. Enabling both results in a conflict.
 ====
@@ -61,17 +78,39 @@ Do not enable both `SoftTopologyAndDuplicates` and `TopologyAndDuplicates`. Enab
 `EvictPodsWithLocalStorage`:: This profile allows pods with local storage to be eligible for eviction.
 
 `EvictPodsWithPVC`:: This profile allows pods with persistent volume claims to be eligible for eviction. If you are using `Kubernetes NFS Subdir External Provisioner`, you must add an excluded namespace for the namespace where the provisioner is installed.
+
+`CompactAndScale`:: This profile enables the `HighNodeUtilization` strategy, which attempts to evict pods from underutilized nodes to allow a workload to run on a smaller set of nodes. A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
++
+Optionally, you can adjust the underutilized percentage by setting the Technology Preview field `devHighNodeUtilizationThresholds` to one the following values: `Minimal` for 10%, `Modest` for 20%, or `Moderate` for 30%. The default value is `Modest`.
++
+[WARNING]
+====
+Do not enable `CompactAndScale` with any of the following profiles: `LifecycleAndUtilization`, `LongLifecycle`, or `TopologyAndDuplicates`. Enabling these profiles together results in a conflict.
+====
+
 endif::nodes[]
 ifdef::virt[]
 Use the Technology Preview `DevPreviewLongLifecycle` profile to enable the descheduler on a virtual machine. This is the only descheduler profile currently available for {VirtProductName}. To ensure proper scheduling, create VMs with CPU and memory requests for the expected load.
+endif::virt[]
 
-`DevPreviewLongLifecycle`:: This profile balances resource usage between nodes and enables the following strategies:
+// Show LongLifecycle profile both for virt and nodes
+`LongLifecycle`:: This profile balances resource usage between nodes and enables the following strategies:
 +
+--
 * `RemovePodsHavingTooManyRestarts`: removes pods whose containers have been restarted too many times and pods where the sum of restarts over all containers (including Init Containers) is more than 100. Restarting the VM guest operating system does not increase this count.
 * `LowNodeUtilization`: evicts pods from overutilized nodes when there are any underutilized nodes. The destination node for the evicted pod will be determined by the scheduler.
 ** A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
 ** A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
-endif::virt[]
+--
++
+--
+ifdef::nodes[]
+[WARNING]
+====
+Do not enable `LongLifecycle` with any of the following profiles: `LifecycleAndUtilization` or `CompactAndScale`. Enabling these profiles together results in a conflict.
+====
+endif::nodes[]
+--
 
 ifeval::["{context}" == "nodes-descheduler-about"]
 :!nodes:

--- a/nodes/scheduling/descheduler/index.adoc
+++ b/nodes/scheduling/descheduler/index.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 While the xref:../../../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[scheduler] is used to determine the most suitable node to host a new pod, the descheduler can be used to evict a running pod so that the pod can be rescheduled onto a more suitable node.
 
-:operator-name: The {descheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 // About the descheduler
 include::modules/nodes-descheduler-about.adoc[leveloffset=+1]
 

--- a/nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can run the descheduler in {product-title} by installing the {descheduler-operator} and setting the desired profiles and other customizations.
 
-:operator-name: The {descheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 // Installing the descheduler
 include::modules/nodes-descheduler-installing.adoc[leveloffset=+1]
 

--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -10,7 +10,34 @@ The {descheduler-operator} allows you to evict pods so that they can be reschedu
 
 These release notes track the development of the {descheduler-operator}.
 
-:operator-name: The {descheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
+
+[id="descheduler-operator-release-notes-5.1.0"]
+== Release notes for {descheduler-operator} 5.1.0
+
+Issued: 23 October 2024
+
+The following advisory is available for the {descheduler-operator} 5.1.0:
+
+* link:https://access.redhat.com/errata/RHSA-2024:6341[RHSA-2024:6341]
+
+[id="descheduler-operator-5.1.0-new-features"]
+=== New features and enhancements
+
+* Two new descheduler profiles are now available:
+
+** `CompactAndScale`: This profile attempts to evict pods from underutilized nodes to allow a workload to run on a smaller set of nodes.
+** `LongLifecycle`: This profile balances resource usage between nodes and enables the `RemovePodsHavingTooManyRestarts` and `LowNodeUtilization` strategies.
+
+* For the `CompactAndScale` profile, you can use the Technology Preview field `devHighNodeUtilizationThresholds` to adjust the underutilized threshold value.
+
+[id="descheduler-operator-5.1.0-bug-fixes"]
+=== Bug fixes
+
+* This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+// No known issues to list
+// [id="descheduler-operator-5.1.0-known-issues"]
+// === Known issues
+//
+// * TODO

--- a/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.adoc
@@ -8,8 +8,5 @@ toc::[]
 
 You can remove the {descheduler-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
-:operator-name: The {descheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 // Uninstalling the descheduler
 include::modules/nodes-descheduler-uninstalling.adoc[leveloffset=+1]


### PR DESCRIPTION
…profile

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+ (will go in after 4.17 GA)

Issue:
https://issues.redhat.com/browse/OSDOCS-11327

Link to docs preview:

- https://81294--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/index.html
- https://81294--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-configuring.html
- https://81294--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-release-notes.html
- https://81294--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.html
- https://81294--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.html#nodes-descheduler-profiles_virt-enabling-descheduler-evictions

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
