### PR TITLE
OCPBUGS-39340: Update gcp minimum permissions for target tcp proxies

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -230,6 +230,7 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.backendServices.list`
 * `compute.regionBackendServices.delete`
 * `compute.regionBackendServices.list`
+* `compute.regionTargetTcpProxies.list`
 * `compute.targetPools.delete`
 * `compute.targetPools.list`
 * `compute.targetTcpProxies.delete`

--- a/modules/minimum-required-permissions-upi-gcp.adoc
+++ b/modules/minimum-required-permissions-upi-gcp.adoc
@@ -234,6 +234,7 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.backendServices.list`
 * `compute.regionBackendServices.delete`
 * `compute.regionBackendServices.list`
+* `compute.regionTargetTcpProxies.list`
 * `compute.targetPools.delete`
 * `compute.targetPools.list`
 * `compute.targetTcpProxies.delete`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

OCPBUGS-39340

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18
4.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OCPBUGS-39340

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

** Add the regionTargetTcpProxies permisisons for create and destroy. The new permissions are required for CAPG installs.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
