### PR TITLE
MCO node disruption policy typo fixes 2

### DIFF
--- a/modules/machine-config-node-disruption-example.adoc
+++ b/modules/machine-config-node-disruption-example.adoc
@@ -80,7 +80,7 @@ spec:
 # ...
 ----
 
-In the following example, when changes are made to the files in the `/etc/chrony.conf` directory, the MCO reloads the `chronyd.service` on the cluster nodes.
+In the following example, when changes are made to the `/etc/chrony.conf` file, the MCO reloads the `chronyd.service` on the cluster nodes.
 
 .Example node disruption policy for a configuration file change
 [source,yaml]
@@ -127,7 +127,7 @@ spec:
               serviceName: crio.service
 ----
 
-In the following example, when changes are made to the files in the `registries.conf` directory, such as by editing an `ImageContentSourcePolicy` (ICSP) object, the MCO does not drain or reboot the nodes and applies the changes with no further action.
+In the following example, when changes are made to the `registries.conf` file, such as by editing an `ImageContentSourcePolicy` (ICSP) object, the MCO does not drain or reboot the nodes and applies the changes with no further action.
 
 .Example node disruption policy for a registries.conf file change
 [source,yaml]


### PR DESCRIPTION
Follow up of https://github.com/openshift/openshift-docs/pull/81291. A couple more typos. 