### PR TITLE
OCPSTRAT 1026:Admin-defined reboot & drain policies: Phase 2 (GA)

### DIFF
--- a/machine_configuration/machine-config-node-disruption.adoc
+++ b/machine_configuration/machine-config-node-disruption.adoc
@@ -24,14 +24,19 @@ The MCO does not validate whether a change can be successfully applied by your n
 
 For example, you can configure a node disruption policy so that sudo configurations do not require a node drain and reboot. Or, you can configure your cluster so that updates to `sshd` are applied with only a reload of that one service.
 
-:FeatureName: The node disruption policy feature
-include::snippets/technology-preview.adoc[]
-
 You can control the behavior of the MCO when making the changes to the following Ignition configuration objects:
 
 // I used this wording for the objects to match the previous section in the assembly: file:///home/mburke/openshift-docs/_preview/openshift-enterprise/mco-node-disruption-policy/post_installation_configuration/machine-configuration-tasks.html#what-can-you-change-with-machine-configs.
-* *configuration files*: You add to or update the files in the `/var` or `/etc` directory.
-* *systemd units*: You create and set the status of a systemd service or modify an existing systemd service.
+* *configuration files*: You add to or update the files in the `/var` or `/etc` directory. You can configure a policy for a specific file anywhere in the directory or for a path to a specific directory. For a path, a change or addition to any file in that directory triggers the policy.
++
+[NOTE]
+====
+If a file is included in more than one policy, only the policy with the best match to that file is applied. 
+
+For example, if you have a policy for the `/etc/` directory and a policy for the `/etc/pki/` directory, a change to the `/etc/pki/tls/certs/ca-bundle.crt` file would apply the `etc/pki` policy.
+====
+
+* *systemd units*: You create and set the status of a systemd service or modify a systemd service.
 * *users and groups*: You change SSH keys in the `passwd` section postinstallation.
 * *ICSP*, *ITMS*, *IDMS* objects: You can remove mirroring rules from an `ImageContentSourcePolicy` (ICSP), `ImageTagMirrorSet` (ITMS), and `ImageDigestMirrorSet` (IDMS) object.
 

--- a/modules/machine-config-node-disruption-example.adoc
+++ b/modules/machine-config-node-disruption-example.adoc
@@ -48,10 +48,26 @@ status:
       - actions:
         - type: Special
         path: /etc/containers/registries.conf
+      - actions:
+        - reload:
+            serviceName: crio.service
+          type: Reload
+        path: /etc/containers/registries.d
+      - actions:
+        - type: None
+        path: /etc/nmstate/openshift
+      - actions:
+        - restart:
+            serviceName: coreos-update-ca-trust.service
+          type: Restart
+        - restart:
+            serviceName: crio.service
+          type: Restart
+        path: /etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt
       sshkey:
         actions:
         - type: None
-  readyReplicas: 0
+  observedGeneration: 9
 ----
 
 In the following example, when changes are made to the SSH keys, the MCO drains the cluster nodes, reloads the `crio.service`, reloads the systemd configuration, and restarts the `crio-service`.
@@ -80,7 +96,7 @@ spec:
 # ...
 ----
 
-In the following example, when changes are made to the `/etc/chrony.conf` file, the MCO reloads the `chronyd.service` on the cluster nodes.
+In the following example, when changes are made to the `/etc/chrony.conf` file, the MCO reloads the `chronyd.service` on the cluster nodes. If files are added to or modified in the `/var/run` directory, the MCO applies the changes with no further action.
 
 .Example node disruption policy for a configuration file change
 [source,yaml]
@@ -98,7 +114,10 @@ spec:
       - reload:
           serviceName: chronyd.service
         type: Reload
-      path: /etc/chrony.conf
+        path: /etc/chrony.conf
+    - actions:
+      - type: None
+      path: /var/run
 ----
 
 In the following example, when changes are made to the `auditd.service`	systemd unit, the MCO drains the cluster nodes, reloads the `crio.service`, reloads the systemd manager configuration, and restarts the `crio.service`.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-11109

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPSTRAT-1026

Link to docs preview:

[Using node disruption policies to minimize disruption](https://81321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-node-disruption.html#machine-config-node-disruption-example_machine-configs-configure) -- Updated *configuration files* description, added note.
[Example node disruption policies](https://81321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-node-disruption.html#machine-config-node-disruption-example_machine-configs-configure)
* Default node disruption policy -- Updated the default policies example with [new defaults](https://github.com/openshift/openshift-docs/pull/81321/files#diff-9d9786849e688f7c9e7bb1e4d71682d0e7bcdf35beb591c969477557cc08521dR51-R66).
* Example node disruption policy for a configuration file change -- Added `spec.nodeDisruptionPolicy.files.actions.path` to code example and second sentence in the paragraph above. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
