### PR TITLE
[enterprise-4.15]  OCPBUGS#33606-15: Added z-stream update note for SDN to OVNK migration

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -5,7 +5,14 @@
 [id="nw-ovn-kubernetes-migration-about_{context}"]
 = Migration to the OVN-Kubernetes network plugin
 
-Migrating to the OVN-Kubernetes network plugin is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
+Migrating to the OVN-Kubernetes network plugin is a manual process that includes some downtime during which your cluster is unreachable. 
+
+[IMPORTANT]
+====
+Before you migrate your {product-title} cluster to use the OVN-Kubernetes network plugin, update your cluster to the latest z-stream release so that all the latest bug fixes apply to your cluster.
+====
+
+Although a rollback procedure is provided, the migration is intended to be a one-way process.
 
 [IMPORTANT]
 ====
@@ -16,7 +23,7 @@ Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin is 
 
 A migration to the OVN-Kubernetes network plugin is supported on the following platforms:
 
-* Bare metal hardware
+* Bare-metal hardware
 * {aws-first}
 * {gcp-first}
 * {ibm-cloud-name}

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -13,6 +13,12 @@ To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_ne
 // Migration to the OVN-Kubernetes network plugin
 include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-release[Understanding update channels and releases] 
+* xref:../../release_notes/ocp-4-15-release-notes.adoc#ocp-4-15-asynchronous-errata-updates_release-notes[Asynchronous errata updates]
+
 // How the migration process works
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
 


### PR DESCRIPTION
APPROVALS ON https://github.com/openshift/openshift-docs/pull/80521

Version(s):
4.15

Issue:
[OCPBUGS-33606](https://issues.redhat.com/browse/OCPBUGS-33606)

Link to docs preview:
* [Migrating from the OpenShift SDN network plugin](https://81331--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)

- [x] SME has approved this change (Peng Liu)
- [x] QE has approved this change (Zhanqi Zhao)

