### PR TITLE
MCO114: tlsSecurityProfile parameter for MCO & MCS

### DIFF
--- a/modules/tls-profiles-kubernetes-configuring.adoc
+++ b/modules/tls-profiles-kubernetes-configuring.adoc
@@ -15,6 +15,8 @@ To configure a TLS security profile for the control plane, edit the `APIServer` 
 * OpenShift OAuth API server
 * OpenShift OAuth server
 * etcd
+* Machine Config Operator
+* Machine Config Server
 
 If a TLS security profile is not configured, the default TLS security profile is `Intermediate`.
 
@@ -151,4 +153,19 @@ Spec:
         TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
       Min TLS Version:           VersionTLS12
  ...
+----
+
+* Verify that the TLS security profile is set in the Machine Config Server pod:
++
+[source,terminal]
+----
+$ oc logs machine-config-server-5msdv -n openshift-machine-config-operator
+----
++
+.Example output
+[source,terminal]
+----
+# ...
+I0905 13:48:36.968688       1 start.go:51] Launching server with tls min version: VersionTLS12 & cipher suites [TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256]
+# ...
 ----

--- a/security/tls-security-profiles.adoc
+++ b/security/tls-security-profiles.adoc
@@ -13,7 +13,7 @@ Cluster administrators can choose which TLS security profile to use for each of 
 * the Ingress Controller
 * the control plane
 +
-This includes the Kubernetes API server, Kubernetes controller manager, Kubernetes scheduler, OpenShift API server, OpenShift OAuth API server, OpenShift OAuth server, and etcd.
+This includes the Kubernetes API server, Kubernetes controller manager, Kubernetes scheduler, OpenShift API server, OpenShift OAuth API server, OpenShift OAuth server, etcd, the Machine Config Operator, and the Machine Config Server.
 +
 // NOTE: OpenShift controller manager are not included
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-11495

Based on what has been done for past components being configured with global TLS, I think we just need to add to the list of control plane components that use global TLS settings. For example: [etcd](https://github.com/openshift/openshift-docs/pull/35923/files).

Version(s):
4.17+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

