### PR TITLE
OBSDOCS-1241 COO 0.4.0 release notes

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -16,6 +16,62 @@ The {coo-short} complements the built-in monitoring capabilities of {product-tit
 
 These release notes track the development of the {coo-full} in {product-title}.
 
+The following table provides information about which features are available depending on the version of {coo-full} and {product-title}:
+
+[cols="1,1,1,1,1,1", options="header"]
+|===
+| COO Version   | OCP Versions       | Dashboards   | Distributed Tracing   | Logging   | Troubleshooting Panel
+
+| 0.2.0         | 4.11               | ✔            | ✘                     | ✘         | ✘ 
+| 0.3.0+        | 4.11 - 4.15        | ✔            | ✔                     | ✔         | ✘ 
+| 0.3.0+        | 4.16+              | ✔            | ✔                     | ✔         | ✔ 
+|===
+
+
+[id="cluster-observability-operator-release-notes-0-4-0_{context}"]
+== {coo-full} 0.4.0
+
+The following advisory is available for {coo-full} 0.4.0:
+
+// Test the errata link just before publishing
+* link:https://access.redhat.com/errata/RHEA-2024:6699[RHEA-2024:6699 {coo-full} 0.4.0]
+
+
+[id="cluster-observability-operator-0-4-0-new-features-enhancements_{context}"]
+=== New features and enhancements
+
+// COO-264
+==== Troubleshooting UI plugin
+
+* The troubleshooting UI panel has been improved so you can now select and focus on a specific starting signal.
+* There is more visibility into Korrel8r queries, with the option of selecting the depth.
+* Users of {product-title} version 4.17+ can access the troubleshooting UI panel from the Application Launcher {launch}. Alternatively, on versions 4.16+, you can access it in the web console by clicking on **Observe** -> **Alerting**.   
+
+//
+// For more information, see xref :../../observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin.adoc#troubleshooting-ui-plugin[troubleshooting UI plugin]
+
+// COO-263
+==== Distributed tracing UI plugin
+
+* The distributed tracing UI plugin has been enhanced, with a Gantt chart now available for exploring traces.
+//
+// For more information, see xref :../../observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc#distributed-tracing-ui-plugin[distributed tracing UI plugin]
+
+[id="cluster-observability-operator-0-4-0-bug-fixes_{context}"]
+=== Bug fixes
+
+* Previously, metrics were not available to normal users when accessed in the Developer perspective of the web console, by clicking on **Observe** -> **Logs**.
+This release resolves the issue. (link:https://issues.redhat.com/browse/COO-288[*COO-288*])
+
+* Previously, the troubleshooting UI plugin used the wrong filter for network observability.
+This release resolves the issue. (link:https://issues.redhat.com/browse/COO-299[*COO-299*])
+
+* Previously, the troubleshooting UI plugin generated an incorrect URL for pod label searches.
+This release resolves the issue. (link:https://issues.redhat.com/browse/COO-298[*COO-298*])
+
+* Previously, there was an authorization vulnerability in the Distributed tracing UI plugin.
+This release resolves the issue and the Distributed tracing UI plugin has been hardened by using only multi-tenant `TempoStack` and `TempoMonolithic` instances going forward.
+
 [id="cluster-observability-operator-release-notes-0-3-2_{context}"]
 == {coo-full} 0.3.2
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-1241](https://issues.redhat.com//browse/OBSDOCS-1241)

Link to docs preview:
https://81354--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
