### PR TITLE
[OCPBUGS-33384]: Adding commands to export proxy variables

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -40,7 +40,22 @@ $ oc debug --as-root node/<node_name>
 sh-4.4# chroot /host
 ----
 
-. If the cluster-wide proxy is enabled, be sure that you have exported the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables.
+. If the cluster-wide proxy is enabled, export the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables by running the following commands:
++
+[source,terminal]
+----
+$ export HTTP_PROXY=http://<your_proxy.example.com>:8080
+----
++
+[source,terminal]
+----
+$ export HTTPS_PROXY=https://<your_proxy.example.com>:8080
+----
++
+[source,terminal]
+----
+$ export NO_PROXY=<example.com>
+----
 
 . Run the `cluster-backup.sh` script in the debug shell and pass in the location to save the backup to.
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-33384
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81355--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Original PR, with QE and peer review complete: https://github.com/openshift/openshift-docs/pull/80848
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
