### PR TITLE
OSDOCS-11233: adds module to list update contents MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -72,6 +72,8 @@ Topics:
   File: microshift-update-rpms-ostree
 - Name: Manual updates with RPMs
   File: microshift-update-rpms-manually
+- Name: Listing update package contents
+  File: microshift-list-update-contents
 ---
 Name: Support
 Dir: microshift_support

--- a/microshift_updating/microshift-list-update-contents.adoc
+++ b/microshift_updating/microshift-list-update-contents.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-list-update-contents"]
+= Listing RPM update package contents
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-list-update-contents
+
+toc::[]
+
+You can preview the contents of a {microshift-short} RPM package update before installing.
+
+include::modules/microshift-get-rpm-release-info.adoc[leveloffset=+1]

--- a/modules/microshift-get-rpm-release-info.adoc
+++ b/modules/microshift-get-rpm-release-info.adoc
@@ -1,0 +1,102 @@
+// Module included in the following assemblies:
+//
+//microshift_updating/microshift-list-update-contents.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-get-rpm-release-info_{context}"]
+= Listing the contents of the {microshift-short} RPM release package
+
+To see the images included with a {microshift-short} release, you can list the contents of the `microshift-release-info` RPM by downloading and unpacking the RPM.
+
+.Prerequisites
+
+* You are using {op-system-base-full} or an operating system with an RPM package manager.
+* Your {microshift-short} repositories are enabled.
+
+.Procedure
+
+. Optional: List which versions of the {microshift-short} RPM are available for download by running the following command:
++
+[source,terminal]
+----
+$ sudo dnf repoquery microshift-release-info-0:4.16.* # <1>
+----
+<1> Replace the example value `4.16.*` with the major and minor release numbers you are interested in.
++
+.Example output
+[source,terminal]
+----
+Updating Subscription Management repositories.
+microshift-release-info-0:4.16.0-202406260523.p0.gc5a37df.assembly.4.16.0.el9.noarch
+microshift-release-info-0:4.16.1-202406281132.p0.g8babeb9.assembly.4.16.1.el9.noarch
+microshift-release-info-0:4.16.10-202408291007.p0.g6e4ee4d.assembly.4.16.10.el9.noarch
+microshift-release-info-0:4.16.2-202407040825.p0.g2e0407e.assembly.4.16.2.el9.noarch
+microshift-release-info-0:4.16.3-202407111123.p0.ge4206d3.assembly.4.16.3.el9.noarch
+microshift-release-info-0:4.16.4-202407191908.p0.g057a9af.assembly.4.16.4.el9.noarch
+microshift-release-info-0:4.16.5-202407250951.p0.g0afcb57.assembly.4.16.5.el9.noarch
+microshift-release-info-0:4.16.6-202408010822.p0.gc4ded66.assembly.4.16.6.el9.noarch
+microshift-release-info-0:4.16.7-202408081107.p0.g0597bb8.assembly.4.16.7.el9.noarch
+microshift-release-info-0:4.16.8-202408150851.p0.gc8a3bb1.assembly.4.16.8.el9.noarch
+microshift-release-info-0:4.16.9-202408220842.p0.gefa92a2.assembly.4.16.9.el9.noarch
+----
+
+. Download the RPM package you want by running the following command:
++
+--
+[subs="+quotes"]
+[source,terminal]
+----
+$ sudo dnf download microshift-release-info-_<release_version>_ # <1>
+----
+<1> Replace `_<release_version>_` with the numerical value of the release you are deploying, using the entire version number, for example, `4.16.0`.
+--
++
+--
+.Example output
+[subs="+quotes"]
+[source,terminal]
+----
+microshift-release-info-4.16.0.-202311101230.p0.g7dc6a00.assembly.4.16.0.el9.noarch.rpm # <1>
+----
+<1> Your output should contain the date and commit ID.
+--
+
+. Unpack the RPM package without installing it by running the following command:
++
+[subs="+quotes"]
+[source,terminal]
+----
+$ rpm2cpio _<microshift_release_info>_ | cpio -idmv # <1>
+----
+<1> Replace `_<microshift_release_info>_` with the name of the RPM package from the previous step. For example, `microshift-release-info-4.16.10-202408291007.p0.g6e4ee4d.assembly.4.16.10.el9.noarch.rpm`.
++
+.Example output
+[source,terminal]
+----
+./usr/share/microshift
+./usr/share/microshift/blueprint
+./usr/share/microshift/blueprint/blueprint-aarch64.toml
+./usr/share/microshift/blueprint/blueprint-x86_64.toml
+./usr/share/microshift/release
+./usr/share/microshift/release/release-aarch64.json
+./usr/share/microshift/release/release-x86_64.json
+----
+
+. List the contents by running the following command:
++
+[source,terminal]
+----
+$ cat ./usr/share/microshift/release/release-x86_64.json
+----
++
+.Example output
+[source,terminal]
+----
+{
+  "release": {
+    "base": "4.16.10"
+  },
+  "images": {
+    "cli": "....
+# ...
+----


### PR DESCRIPTION
Version(s):
4.16, 4.17+

Issue:
[OSDOCS-11233](https://issues.redhat.com/browse/OSDOCS-11233)

Link to docs preview:
https://81356--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-list-update-contents.html

QE review:
- [x] QE has approved this change.

Additional information:
This content is a modularization of previously approved content here: https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.16/html/installing/microshift-embed-in-rpm-ostree-for-offline-use#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
