### PR TITLE
WMCO 9.0.3 release notes

### DIFF
--- a/windows_containers/wmco_rn/windows-containers-release-notes-9-x-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-9-x-past.adoc
@@ -6,9 +6,20 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following release notes are for previous versions of the Windows Machine Config Operator.
+The following release notes are for previous versions of the Windows Machine Config Operator (WMCO).
 
 For the current version, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes-9-x.adoc#windows-containers-release-notes-9-x[Windows Machine Config Operator release notes].
+
+[id="wmco-9-0-2"]
+== Release notes for Red Hat Windows Machine Config Operator 9.0.2
+
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 9.0.2 were released in link:https://access.redhat.com/errata/RHBA-2024:2830[RHBA-2024:2830].
+
+[id="wmco-9-0-2-bug-fixes"]
+=== Bug fixes
+
+* Previously, the kubelet was unable to authenticate with private ECR registries. Beacuse of this error, the kubelet was not able to pull images from these registries. With this fix, the kubelet is able to pull images from these registries as expected. (link:https://issues.redhat.com/browse/OCPBUGS-32136[*OCPBUGS-32136*])
+
 
 [id="wmco-9-0-1"]
 == Release notes for Red Hat Windows Machine Config Operator 9.0.1

--- a/windows_containers/wmco_rn/windows-containers-release-notes-9-x.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-9-x.adoc
@@ -13,14 +13,16 @@ Windows Container Support for {product-title} enables running Windows compute no
 
 These release notes track the development of the WMCO, which provides all Windows container workload capabilities in {product-title}.
 
-[id="wmco-9-0-2"]
-== Release notes for Red Hat Windows Machine Config Operator 9.0.2
+[id="wmco-9-0-3"]
+== Release notes for Red Hat Windows Machine Config Operator 9.0.3
 
-This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 9.0.2 were released in link:https://access.redhat.com/errata/RHBA-2024:2830[RHBA-2024:2830].
+This release of the WMCO provides a security update and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 9.0.3 were released in link:https://access.redhat.com/errata/RHSA-2024:6460[RHSA-2024:6460].
 
-
-[id="wmco-9-0-2-bug-fixes"]
+[id="wmco-9-0-3-bug-fixes"]
 === Bug fixes
 
-* Previously, the kubelet was unable to authenticate with private ECR registries. Beacuse of this error, the kubelet was not able to pull images from these registries. With this fix, the kubelet is able to pull images from these registries as expected. (link:https://issues.redhat.com/browse/OCPBUGS-32136[*OCPBUGS-32136*])
+* Previously, after rotating the `kube-apiserver-to-kubelet-client-ca` certificate, the contents of the `kubetl-ca.crt` file on Windows nodes was not populated correctly. With this fix, after certificate rotation, the `kubetl-ca.crt` file contains the correct certificates. (link:https://issues.redhat.com/browse/OCPBUGS-35572[*OCPBUGS-35572*])
 
+* Previously, if reverse DNS lookup failed due to an error, such as the reverse DNS lookup services being unavailable, the WMCO would not fall back to using the VM hostname to determine if a certificate signing requests (CSR) should be approved. As a consequence, Bring-Your-Own-Host (BYOH) Windows nodes configured with an IP address would not become available. With this fix, BYOH nodes are properly added if reverse DNS is not available. (link:https://issues.redhat.com/browse/OCPBUGS-38595[*OCPBUGS-38595*])
+
+* Previously, if there were multiple service account token secrets in the WMCO namespace, the scaling of Windows nodes would fail. With this fix, the WMCO uses only the secret it creates, ignoring any other service account token secrets in the WMCO namespace. As a result, Windows nodes scale properly. (link:https://issues.redhat.com/browse/OCPBUGS-38592[*OCPBUGS-38592*])


### PR DESCRIPTION
https://errata.devel.redhat.com/docs/show/132229

Planned GA scheduled for 9/9.

Previews:
[WMCO 9.0.3 release notes](https://81372--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-9-x.html#wmco-9-0-3) -- The bug texts were all previously reviewed [with the 10.15.3 release](https://docs.openshift.com/container-platform/4.15/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x.html#wmco-10-13-2-bug-fixes).    The link to the errata will not work until the errata goes live. 
 [WMCO past releases](https://81372--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-9-x-past.html) -- Moved the [WMCO 9.0.2 release notes](https://docs.openshift.com/container-platform/4.14/windows_containers/wmco_rn/windows-containers-release-notes-9-x.html#wmco-9-0-2) to this assembly without change. No need for review.