### PR TITLE
OSDOCS-11706# Google Filestore auto delete resources

### DIFF
--- a/modules/persistent-storage-csi-google-cloud-file-delete-instances.adoc
+++ b/modules/persistent-storage-csi-google-cloud-file-delete-instances.adoc
@@ -3,25 +3,20 @@
 // * storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="persistent-storage-csi-gcp-cloud-file-delete-instances_{context}"]
+[id="persistent-storage-csi-google-cloud-file-delete-instances_{context}"]
 = Destroying clusters and GCP Filestore
 
-Typically, if you destroy a cluster, the {product-title} installer deletes all of the cloud resources that belong to that cluster. However, when a cluster is destroyed, Google Compute Platform (GCP) Filestore instances are not automatically deleted, so you must manually delete all persistent volume claims (PVCs) that use the Filestore storage class before destroying the cluster.
+Typically, if you destroy a cluster, the {product-title} installer deletes all of the cloud resources that belong to that cluster. However, due to the special nature of the Google Compute Platform (GCP) Filestore resources, the automated cleanup process might not remove all of them in some rare cases. 
+
+Therefore, Red Hat recommends that you verify that all cluster-owned Filestore resources are deleted by the uninstall process.
 
 .Procedure
-To delete all GCP Filestore PVCs:
+To ensure that all GCP Filestore PVCs have been deleted:
 
-. List all PVCs that were created using the storage class `filestore-csi`:
-+
-[source, command]
-----
-$ oc get pvc -o json -A | jq -r '.items[] | select(.spec.storageClassName == "filestore-csi")
-----
+. Access your Google Cloud account using the GUI or CLI.
 
-. Delete all of the PVCs listed by the previous command:
+. Search for any resources with the `kubernetes-io-cluster-${CLUSTER_ID}=owned` label. 
 +
-[source, command]
-----
-$ oc delete <pvc-name> <1>
-----
-<1> Replace <pvc-name> with the name of any PVC that you need to delete.
+Since the cluster ID is unique to the deleted cluster, there should not be any remaining resources with that cluster ID.
+
+. In the unlikely case there are some remaining resources, delete them.


### PR DESCRIPTION
Reference this closed PR for previous conversations, etc. https://github.com/openshift/openshift-docs/pull/80454

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11706
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81387--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.html#persistent-storage-csi-google-cloud-file-delete-instances_persistent-storage-csi-google-cloud-file
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**PTAL: @tsmetana @gcharot No QE review required.**
