### PR TITLE
OSDOCS9578: Update Boot Images for GCP GA

### DIFF
--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -16,10 +16,12 @@ This process could cause the following issues:
 * Certificate expiration issues
 * Version skew issues
 
-To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and is not supported for clusters managed by the Cluster API.
+To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and as a Technology Preview feature for Amazon Web Services (AWS) clusters. It is not supported for clusters managed by the {cluster-capi-operator}.
 
-:FeatureName: The updating boot image feature
+:FeatureName: The updating boot image feature for AWS
 include::snippets/technology-preview.adoc[]
+
+If you are not using the default user data secret, named `worker-user-data`, in your machine set, or you have modified the `worker-user-data` secret, you should not use managed boot image updates. This is because the Machine Config Operator (MCO) updates the machine set to use a managed version of the secret. By using the managed boot images feature, you are giving up the capability to customize the secret stored in the machine set object. 
 
 To view the current boot image used in your cluster, examine a machine set:
 

--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -9,9 +9,10 @@
 
 By default, {product-title} does not manage the boot image. You can configure your cluster to update the boot image whenever you update your cluster by modifying the `MachineConfiguration` object.
 
-.Prerequisites
+Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and as a Technology Preview feature for Amazon Web Services (AWS) clusters. It is not supported for clusters managed by the {cluster-capi-operator}.
 
-* You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates" in the _Additional resources_  section.
+:FeatureName: The updating boot image feature for AWS
+include::snippets/technology-preview.adoc[]
 
 .Procedure
 
@@ -78,6 +79,38 @@ $ oc label machineset.machine ci-ln-hmy310k-72292-5f87z-worker-a update-boot-ima
 ====
 
 .Verification
+
+. View the current state of the boot image updates by viewing the machine configuration object:
++
+[source,terminal]
+----
+$ oc get machine configuration <machineset_name> -n openshift-machine-api -o yaml
+----
++
+.Example machine set with the boot image reference
++
+[source,yaml]
+----
+kind: MachineConfiguration
+metadata:
+  name: cluster
+# ...
+status:
+  conditions:
+  - lastTransitionTime: "2024-09-09T13:51:37Z" <1>
+    message: Reconciled 1 of 2 MAPI MachineSets | Reconciled 0 of 0 CAPI MachineSets
+      | Reconciled 0 of 0 CAPI MachineDeployments
+    reason: BootImageUpdateConfigurationAdded
+    status: "True"
+    type: BootImageUpdateProgressing
+  - lastTransitionTime: "2024-09-09T13:51:37Z" <2>
+    message: 0 Degraded MAPI MachineSets | 0 Degraded CAPI MachineSets | 0 CAPI MachineDeployments
+    reason: BootImageUpdateConfigurationAdded
+    status: "False"
+    type: BootImageUpdateDegraded
+----
+<1> Status of the boot image update. {cluster-capi-operator} machine sets and machine deployments are not currently supported for boot image updates.  
+<2> Indicates if any boot image updates failed. If any of the updates fail, the Machine Config Operator is degraded. In this case, manual intervention might be required.    
 
 . Get the boot image version by running the following command:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-9578
https://issues.redhat.com/browse/OSDOCS-11111
https://issues.redhat.com/browse/OSDOCS-11112

Previews:
[Updated boot images](https://81396--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html) -- Updated 4th paragraph (To avoid these issues...). Added 5th paragraph (If you are not using...).
[Configuring updated boot images](https://81396--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-configuring_machine-configs-configure) -- Added 2nd paragraph and updated the TP note. Added verification step 1.

