### PR TITLE
TELCODOCS-1868: Remove TP notes

### DIFF
--- a/modules/agent-install-sample-config-bond-sriov.adoc
+++ b/modules/agent-install-sample-config-bond-sriov.adoc
@@ -6,9 +6,6 @@
 [id="agent-install-sample-config-bond-sriov_{context}"]
 = Example: Bonds and SR-IOV dual-nic node network configuration
 
-:FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 The following `agent-config.yaml` file is an example of a manifest for dual port NIC with a bond and SR-IOV interfaces:
 
 [source,yaml]

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -287,9 +287,6 @@ ifndef::ibm-z[]
 [discrete]
 === Bonding multiple SR-IOV network interfaces to a dual port NIC interface
 
-:FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 Optional: You can bond multiple SR-IOV network interfaces to a dual port NIC interface by using the `bond=` option.
 
 On each node, you must perform the following tasks:

--- a/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -8,9 +8,6 @@
 
 Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState to support dual port NIC.
 
-:FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 {VirtProductName} only supports the following bond modes:
 
 * mode=1 active-backup +

--- a/modules/nw-sriov-dual-nic-con.adoc
+++ b/modules/nw-sriov-dual-nic-con.adoc
@@ -30,6 +30,3 @@ The minimum required version of `nmstate` is:
 
 * Installer-provisioned infrastructure installation
 * User-provisioned infrastructure installation
-
-:FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
-include::snippets/technology-preview.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-1868](https://issues.redhat.com//browse/TELCODOCS-1868): Remove TP notes associated with this feature because it is GA for 4.17. 

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1868

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Link to docs preview:
- https://81406--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/preparing-to-install-on-bare-metal.html#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal 
- https://81406--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-install-sample-config-bond-sriov_preparing-to-install-with-agent-based-installer 
- https://81406--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow 
- https://81406--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#bonding-multiple-sriov-network-interfaces-to-dual-port_installing-bare-metal 

Additional information:
Missed removing these TP notes the in original PR #80046 