### PR TITLE
TELCODOCS-1868-RN

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -438,6 +438,21 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-4-17-networking_{context}"]
 === Networking
 
+[id="ocp-4-17-nw-sriov-day1-nics"]
+==== NIC partitioning for SR-IOV devices (Generally Available)
+
+With this update, the ability to enable NIC partitioning for Single Root I/O Virtualization (SR-IOV) devices at install time is Generally Available.
+
+For more information, see xref:../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal[NIC partitioning for SR-IOV devices].
+
+
+[id="ocp-4-17-nw-sriov-vfs-day2"]
+==== Host network settings for SR-IOV VFs (Generally Available)
+
+With this update, the ability to update host network settings for Single Root I/O Virtualization (SR-IOV) network virtual functions in an existing cluster is Generally Available.
+
+For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-vf-host-services_k8s_nmstate-updating-node-network-config[Node network configuration policy for virtual functions].
+
 [id="ocp-4-17-registry"]
 === Registry
 
@@ -1103,6 +1118,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
+|Host network settings for SR-IOV VFs
+|Technology Preview
+|Technology Preview
+|General Availability
+
 |Integration of MetalLB and FRR-K8s
 |Not Available
 |Technology Preview
@@ -1221,7 +1241,7 @@ In the following tables, features are marked with the following statuses:
 |Enabling NIC partitioning for SR-IOV devices
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |User-defined labels and tags for {gcp-first}
 |Technology Preview


### PR DESCRIPTION
[TELCODOCS-1868](https://issues.redhat.com//browse/TELCODOCS-1868): RN moving TP features to GA.

Version(s):
4.17

Issue:
https://issues.redhat.com/browse/TELCODOCS-1868

Link to docs preview:
https://81409--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-networking_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
