### PR TITLE
OCPBUGS#38352-16: Updated the Supported network plugin feature matrix…

### DIFF
--- a/modules/install-osp-deploy-dualstack.adoc
+++ b/modules/install-osp-deploy-dualstack.adoc
@@ -1,9 +1,16 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="install-osp-deploy-dualstack_{context}"]
 = Deploying the dual-stack cluster
+
+For dual-stack networking in {product-title} clusters, you can configure IPv4 and IPv6 address endpoints for cluster nodes. 
+
+.Prerequisites
+
+* You enabled Dynamic Host Configuration Protocol (DHCP) on the subnets.
 
 .Procedure
 
@@ -11,24 +18,19 @@
 +
 [NOTE]
 ====
-The dualstack network MTU must accommodate both the minimum MTU for IPv6, which is 1280, and the OVN-Kubernetes encapsulation overhead, which is 100.
+The dual-stack network MTU must accommodate both the minimum MTU for IPv6, which is `1280`, and the OVN-Kubernetes encapsulation overhead, which is `100`.
 ====
 +
-[NOTE]
-====
-DHCP must be enabled on the subnets.
-====
 
 . Create the API and Ingress VIPs ports.
 
 . Add the IPv6 subnet to the router to enable router advertisements. If you are using a provider network, you can enable router advertisements by adding the network as an external gateway, which also enables external connectivity.
 
-
-. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `install-config.yaml` file. The following is an example of an `install-config.yaml` file:
+. Choose one of the following `install-config.yaml` configurations:
 +
-.Example `install-config.yaml`
-
-[source, yaml]
+.. For an IPv4/IPv6 dual-stack cluster where you set IPv4 as the primary endpoint for your cluster nodes, edit the `install-config.yaml` file in a similar way to the following example:
++
+[source,yaml]
 ----
 apiVersion: v1
 baseDomain: mydomain.test
@@ -77,16 +79,14 @@ platform:
 <1> You must specify an IP address range for both the IPv4 and IPv6 address families.
 <2> Specify the virtual IP (VIP) address endpoints for the Ingress VIP services to provide an interface to the cluster.
 <3> Specify the virtual IP (VIP) address endpoints for the API VIP services to provide an interface to the cluster.
-<4> Specify the dual-stack network details that are used by all of the nodes across the cluster.
-<5> The CIDR of any subnet specified in this field must match the CIDRs listed on `networks.machineNetwork`.
+<4> Specify the dual-stack network details that all of the nodes across the cluster use for their networking needs.
+<5> The Classless Inter-Domain Routing (CIDR) of any subnet specified in this field must match the CIDRs listed on `networks.machineNetwork`.
 <6> You can specify a value for either `name` or `id`, or both.
 <7> Specifying the `network` under the `ControlPlanePort` field is optional.
 +
-Alternatively, if you want an IPv6 primary dual-stack cluster, edit the `install-config.yaml` file following the example below:
+.. For an IPv6/IPv4 dual-stack cluster where you set IPv6 as the primary endpoint for your cluster nodes, edit the `install-config.yaml` file in a similar way to the following example:
 +
-.Example `install-config.yaml`
-
-[source, yaml]
+[source,yaml]
 ----
 apiVersion: v1
 baseDomain: mydomain.test
@@ -135,17 +135,15 @@ platform:
 <1> You must specify an IP address range for both the IPv4 and IPv6 address families.
 <2> Specify the virtual IP (VIP) address endpoints for the Ingress VIP services to provide an interface to the cluster.
 <3> Specify the virtual IP (VIP) address endpoints for the API VIP services to provide an interface to the cluster.
-<4> Specify the dual-stack network details that are used by all the nodes across the cluster.
+<4> Specify the dual-stack network details that all the nodes across the cluster use for their networking needs.
 <5> The CIDR of any subnet specified in this field must match the CIDRs listed on `networks.machineNetwork`.
 <6> You can specify a value for either `name` or `id`, or both.
 <7> Specifying the `network` under the `ControlPlanePort` field is optional.
 
-[NOTE]
-====
-When using an installation host in an isolated dual-stack network, the IPv6 address may not be reassigned correctly upon reboot. 
-
-To resolve this problem on {op-system-base-full} 8, create a file called `/etc/NetworkManager/system-connections/required-rhel8-ipv6.conf` that contains the following configuration:
-
+. Optional: When you use an installation host in an isolated dual-stack network, the IPv6 address might not be reassigned correctly upon reboot. To resolve this problem on {op-system-base-full} 8, complete the following steps:
++
+.. Create a file called `/etc/NetworkManager/system-connections/required-rhel8-ipv6.conf` that includes the following configuration:
++
 [source,text]
 ----
 [connection]
@@ -154,14 +152,17 @@ type=ethernet
 addr-gen-mode=eui64
 method=auto
 ----
++
+.. Reboot the installation host.
 
-To resolve this problem on {op-system-base} 9, create a file called `/etc/NetworkManager/conf.d/required-rhel9-ipv6.conf` that contains the following configuration:
-
+. Optional: When you use an installation host in an isolated dual-stack network, the IPv6 address might not be reassigned correctly upon reboot. To resolve this problem on {op-system-base-full} 9, complete the following steps:
++
+.. Create a file called `/etc/NetworkManager/conf.d/required-rhel9-ipv6.conf` that includes the following configuration:
++
 [source,text]
 ----
 [connection]
 ipv6.addr-gen-mode=0
 ----
-
-After you create and edit the file, reboot the installation host.
-====
++
+.. Reboot the installation host.

--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -11,52 +11,35 @@
 .Default CNI network plugin feature comparison
 [cols="50%,25%,25%",options="header"]
 |===
-ifeval::["{context}" == "about-ovn-kubernetes"]
-|Feature|OVN-Kubernetes|OpenShift SDN
 
-|Egress IPs|Supported|Supported
-
-|Egress firewall ^[1]^|Supported|Supported
-
-|Egress router|Supported ^[2]^|Supported
-
-|Hybrid networking|Supported|Not supported
-
-|IPsec encryption for intra-cluster communication|Supported|Not supported
-
-|IPv6|Supported ^[3]^ ^[4]^|Not supported
-
-|Kubernetes network policy|Supported|Supported
-
-|Kubernetes network policy logs|Supported|Not supported
-
-|Hardware offloading|Supported|Not supported
-
-|Multicast|Supported|Supported
-endif::[]
-ifeval::["{context}" == "about-openshift-sdn"]
 |Feature|OpenShift SDN|OVN-Kubernetes
 
 |Egress IPs|Supported|Supported
 
-|Egress firewall ^[1]^|Supported|Supported
+|Egress firewall|Supported|Supported ^[1]^
 
 |Egress router|Supported|Supported ^[2]^
 
 |Hybrid networking|Not supported|Supported
 
-|IPsec encryption|Not supported|Supported
+|IPsec encryption for intra-cluster communication|Not supported|Supported
 
-|IPv6|Not supported|Supported ^[3]^ ^[4]^
+|IPv4 single-stack|Supported|Supported
+
+|IPv6 single-stack|Not supported|Supported ^[3]^
+
+|IPv4/IPv6 dual-stack|Not Supported|Supported ^[4]^
+
+|IPv6/IPv4 dual-stack|Not supported|Supported ^[4]^
 
 |Kubernetes network policy|Supported|Supported
 
 |Kubernetes network policy logs|Not supported|Supported
 
+|Hardware offloading|Not supported|Supported
+
 |Multicast|Supported|Supported
 
-|Hardware offloading|Not supported|Supported
-endif::[]
 |===
 [.small]
 --
@@ -64,7 +47,7 @@ endif::[]
 
 2. Egress router for OVN-Kubernetes supports only redirect mode.
 
-3. IPv6 is supported only on bare metal, vSphere, {ibm-power-name}, {ibm-z-name}, and Red Hat OpenStack clusters.
+3. IPv6 single-stack networking on a bare-metal platform.
 
-4. IPv6 single stack is not supported on {ibm-power-name}, {ibm-z-name}, and Red Hat OpenStack clusters.
+4. IPv4/IPv6 or IPv6/IPv4 dual-stack networking on bare-metal, {vmw-full} (installer-provisioned infrastructure installations only), {ibm-power-name}, {ibm-z-name}, and {rh-openstack} platforms.
 --


### PR DESCRIPTION
Version(s):
4.16 (4.15, 4.14, 4.13, and 4.12 might all need separate PRs)


For OpenStack when backporting:  ipv4 and ipv6 primary with ovn-kubernetes from 4.15 onwards; 4.14 openstack support ipv4 primary was TP on 4.14.

Issue:
[OCPBUGS-38352](https://issues.redhat.com/browse/OCPBUGS-38352)

Link to docs preview:
* [Supported network plugin feature matrix-SDN doc
](https://81419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/about-openshift-sdn.html)
* [Supported network plugin feature matrix-OVNK doc
](https://81419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html)
* [RHCOS: Deploying the dual-stack cluster](https://81419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#install-osp-deploy-dualstack_installing-openstack-installer-custom)

- [x] SME has approved this change.
- [x] QE has approved this change.

Add info:

* IPV6 access to the registry
* SPlit singlestack IPV6 and dual-stack IPV6
* Two ways exist: local mirror and ImageSourceContentPolicy on BM.
* [Creating a disconnected registry](https://docs.openshift.com/container-platform/4.16/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-mirroring-for-disconnected-registry_ipi-install-installation-workflow)
* [DRAFT - IPv6 Support Matrix](https://docs.google.com/spreadsheets/d/10wqlbN9iJsOvAAb8hbjugy9OfY9zGKYckDbEktc7O0o/edit?gid=0#gid=0)
* [Ross spreadsheet](https://docs.google.com/spreadsheets/d/17kt-Ck9UjgZDxBIPrqJLK0MrTLnjve5GP4eoOL-6twc/edit?gid=0#gid=0)
* Message [#forum-ocp-multi-arch](https://redhat.enterprise.slack.com/archives/CFFJUNP6C) for IBM confirmation. [Message sent](https://redhat-internal.slack.com/archives/CFFJUNP6C/p1728991487017609)