### PR TITLE
OSDOCS-11681: adds 4.16.11 async relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -151,7 +151,7 @@ Issued: 27 June 2024
 
 {product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0043[RHSA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-1-dp_{context}"]
 === RHBA-2024:4158 - {microshift-short} 4.16.1 bug fix and enhancement advisory
@@ -160,7 +160,7 @@ Issued: 3 July 2024
 
 {product-title} release 4.16.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4158[RHBA-2024:4158] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4156[RHSA-2024:4156] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-2-dp_{context}"]
 === RHBA-2024:4318 - {microshift-short} 4.16.2 bug fix and enhancement advisory
@@ -169,7 +169,7 @@ Issued: 9 July 2024
 
 {product-title} release 4.16.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4318[RHBA-2024:4318] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4316[RHSA-2024:4316] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-3-dp_{context}"]
 === RHBA-2024:4318 - {microshift-short} 4.16.3 bug fix and enhancement advisory
@@ -178,7 +178,7 @@ Issued: 16 July 2024
 
 {product-title} release 4.16.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4471[RHBA-2024:4471] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4469[RHSA-2024:4469] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-3-bug-fixes_{context}"]
 ==== Bug fixes
@@ -192,7 +192,7 @@ Issued: 24 July 2024
 
 {product-title} release 4.16.4 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4615[RHBA-2024:4615] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4613[RHSA-2024:4613] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-5-dp_{context}"]
 === RHBA-2024:4857 - {microshift-short} 4.16.5 bug fix and enhancement advisory
@@ -201,7 +201,7 @@ Issued: 31 July 2024
 
 {product-title} release 4.16.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4857[RHBA-2024:4857] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4855[RHBA-2024:4855] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-6-dp_{context}"]
 === RHBA-2024:4967 - {microshift-short} 4.16.6 bug fix and enhancement advisory
@@ -210,7 +210,7 @@ Issued: 6 August 2024
 
 {product-title} release 4.16.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4967[RHBA-2024:4967] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4965[RHSA-2024:4965] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-7-dp_{context}"]
 === RHBA-2024:5109 - {microshift-short} 4.16.7 bug fix and enhancement advisory
@@ -219,7 +219,7 @@ Issued: 13 August 2024
 
 {product-title} release 4.16.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:5109[RHBA-2024:5109] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5107[RHSA-2024:5107] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-8-dp_{context}"]
 === RHBA-2024:5424 - {microshift-short} 4.16.8 bug fix and enhancement advisory
@@ -227,7 +227,7 @@ Issued: 20 August 2024
 
 {product-title} release 4.16.8 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5424[RHBA-2024:5424] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5422[RHSA-2024:5422] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-9-dp_{context}"]
 === RHBA-2024:5759 - {microshift-short} 4.16.9 bug fix and enhancement advisory
@@ -236,7 +236,7 @@ Issued: 29 August 2024
 
 {product-title} release 4.16.9 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5759[RHBA-2024:5759] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5757[RHBA-2024:5757] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-16-10-dp_{context}"]
 === RHBA-2024:6006 - {microshift-short} 4.16.10 bug fix and enhancement advisory
@@ -245,4 +245,13 @@ Issued: 3 September 2024
 
 {product-title} release 4.16.10 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6006[RHBA-2024:6006] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6004[RHSA-2024:6004] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-11-dp_{context}"]
+=== RHBA-2024:6403 - {microshift-short} 4.16.11 bug fix and enhancement advisory
+
+Issued: 11 September 2024
+
+{product-title} release 4.16.11 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6403[RHBA-2024:6403] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:6401[RHBA-2024:6401] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-11681](https://issues.redhat.com/browse/OSDOCS-11681)

Link to docs preview:
[4-16-11](https://81423--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-11-dp_release-notes)

QE review:
- N/A stock text



<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
