### PR TITLE
OBSDOCS-1242 Distributed tracing UI plugin

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3070,6 +3070,8 @@ Topics:
       File: observability-ui-plugins-overview
     - Name: Dashboard UI plugin
       File: dashboard-ui-plugin
+    - Name: Distributed tracing UI plugin
+      File: distributed-tracing-ui-plugin
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/modules/coo-distributed-tracing-ui-plugin-install.adoc
+++ b/modules/coo-distributed-tracing-ui-plugin-install.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+
+// * observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coo-distributed-tracing-ui-plugin-install-_{context}"]
+= Installing the {coo-full} distributed tracing UI plugin
+
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have logged in to the {product-title} web console.
+* You have installed the {coo-full}
+
+.Procedure
+
+. In the {product-title} web console, click *Operators* -> *Installed Operators* and select {coo-full}
+. Choose the *UI Plugin* tab (at the far right of the tab list) and press *Create UIPlugin*
+. Select *YAML view*, enter the following content, and then press *Create*:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: distributed-tracing
+spec:
+  type: DistributedTracing
+----

--- a/modules/coo-distributed-tracing-ui-plugin-using.adoc
+++ b/modules/coo-distributed-tracing-ui-plugin-using.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+
+// * observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coo-distributed-tracing-ui-plugin-using_{context}"]
+= Using the {coo-full} distributed tracing UI plugin
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have logged in to the {product-title} web console.
+* You have installed the {coo-full}.
+* You have installed the {coo-full} distributed tracing UI plugin.
+* You have a `TempoStack` or `TempoMonolithic` multi-tenant instance in the cluster.
+
+.Procedure
+
+. In the Administrator perspective of the {product-title} web console, click **Observe** → **Traces**.
+. Select a `TempoStack` or `TempoMonolithic` multi-tenant instance and set a time range and query for the traces to be loaded.
++
+The traces are displayed on a scatter-plot showing the trace start time, duration, and number of spans. Underneath the scatter plot, there is a list of traces showing information such as the `Trace Name`, number of `Spans`, and `Duration`. 
+. Click on a trace name link.
++
+The trace detail page for the selected trace contains a Gantt Chart of all of the spans within the trace. Select a span to show a breakdown of the configured attributes.
+
+

--- a/observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="distributed-tracing-ui-plugin"]
+= Distributed tracing UI plugin
+include::_attributes/common-attributes.adoc[]
+:context: distributed-tracing-ui-plugin
+
+toc::[]
+
+:FeatureName: The Cluster Observability Operator
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
+The distributed tracing UI plugin adds tracing-related features to the Administrator perspective of the OpenShift web console at **Observe** → **Traces**. You can follow requests through the front end and into the backend of microservices, helping you identify code errors and performance bottlenecks in distributed systems. 
+
+include::modules/coo-distributed-tracing-ui-plugin-install.adoc[leveloffset=+1]
+
+include::modules/coo-distributed-tracing-ui-plugin-using.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-1242](https://issues.redhat.com//browse/OBSDOCS-1242)

Link to docs preview:
https://81424--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
