### PR TITLE
Enterprise#4-12 - OADP-4750: configure OADP NodeAgents on nodes with worker, infra or custom labels

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -29,9 +29,14 @@ include::modules/oadp-secrets-for-different-credentials.adoc[leveloffset=+2]
 You can configure the Data Protection Application by setting Velero resource allocations or enabling self-signed CA certificates.
 
 include::modules/oadp-setting-resource-limits-and-requests.adoc[leveloffset=+2]
-include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 
+include::snippets/oadp-nodeselector-snippet.adoc[]
+
+For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#oadp-configuring-node-agents_installing-oadp-aws[Configuring node agents and node labels].
+
+include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 include::modules/oadp-installing-dpa.adoc[leveloffset=+1]
+include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 :!installing-oadp-aws:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
@@ -29,9 +29,13 @@ include::modules/oadp-secrets-for-different-credentials.adoc[leveloffset=+2]
 You can configure the Data Protection Application by setting Velero resource allocations or enabling self-signed CA certificates.
 
 include::modules/oadp-setting-resource-limits-and-requests.adoc[leveloffset=+2]
-include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
+include::snippets/oadp-nodeselector-snippet.adoc[]
 
+For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc#oadp-configuring-node-agents_installing-oadp-azure[Configuring node agents and node labels].
+
+include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 include::modules/oadp-installing-dpa.adoc[leveloffset=+1]
+include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 :installing-oadp-azure!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
@@ -29,9 +29,14 @@ include::modules/oadp-secrets-for-different-credentials.adoc[leveloffset=+2]
 You can configure the Data Protection Application by setting Velero resource allocations or enabling self-signed CA certificates.
 
 include::modules/oadp-setting-resource-limits-and-requests.adoc[leveloffset=+2]
-include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 
+include::snippets/oadp-nodeselector-snippet.adoc[]
+
+For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc#oadp-configuring-node-agents_installing-oadp-gcp[Configuring node agents and node labels].
+
+include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 include::modules/oadp-installing-dpa.adoc[leveloffset=+1]
+include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 :installing-oadp-gcp!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
@@ -36,9 +36,14 @@ include::modules/oadp-secrets-for-different-credentials.adoc[leveloffset=+2]
 You can configure the Data Protection Application by setting Velero resource allocations or enabling self-signed CA certificates.
 
 include::modules/oadp-setting-resource-limits-and-requests.adoc[leveloffset=+2]
-include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 
+include::snippets/oadp-nodeselector-snippet.adoc[]
+
+For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#oadp-configuring-node-agents_installing-oadp-mcg[Configuring node agents and node labels].
+
+include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 include::modules/oadp-installing-dpa.adoc[leveloffset=+1]
+include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 [discrete]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -37,10 +37,15 @@ include::modules/oadp-secrets-for-different-credentials.adoc[leveloffset=+2]
 You can configure the Data Protection Application by setting Velero resource allocations or enabling self-signed CA certificates.
 
 include::modules/oadp-setting-resource-limits-and-requests.adoc[leveloffset=+2]
+
+include::snippets/oadp-nodeselector-snippet.adoc[]
+
+For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc#oadp-configuring-node-agents_installing-oadp-ocs[Configuring node agents and node labels].
+
 include::modules/oadp-odf-cpu-memory-requirements.adoc[leveloffset=+3]
 include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
-
 include::modules/oadp-installing-dpa.adoc[leveloffset=+1]
+include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]
 include::modules/oadp-creating-object-bucket-claim.adoc[leveloffset=+2]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 

--- a/backup_and_restore/application_backup_and_restore/oadp-api.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-api.adoc
@@ -201,6 +201,7 @@ link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ResticCo
 |`nodeSelector`
 |map [ link:https://pkg.go.dev/builtin#string[string] ] link:https://pkg.go.dev/builtin#string[string]
 |Defines the `nodeSelector` to be supplied to a `Velero` `podSpec` or a `Restic` `podSpec`.
+For more details, see xref:../../backup_and_restore/application_backup_and_restore/oadp-api.adoc#oadp-configuring-node-agents_oadp-api[Configuring node agents and node labels].
 
 |`tolerations`
 |[]link:https://pkg.go.dev/k8s.io/api/core/v1#Toleration[Toleration]
@@ -216,6 +217,8 @@ link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ResticCo
 |===
 
 link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#PodConfig[Complete schema definitions for the type `PodConfig`].
+
+include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]
 
 .Features
 [options="header"]

--- a/modules/oadp-configuring-node-agents.adoc
+++ b/modules/oadp-configuring-node-agents.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+// * backup_and_restore/application_backup_and_restore/oadp-api.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-configuring-node-agents_{context}"]
+= Configuring node agents and node labels
+
+The DPA of {oadp-short} uses the `nodeSelector` field to select which nodes can run the node agent. The `nodeSelector` field is the simplest recommended form of node selection constraint.
+
+Any label specified must match the labels on each node.
+
+The correct way to run the node agent on any node you choose is for you to label the nodes with a custom label:
+
+[source,terminal]
+----
+$ oc label node/<node_name> node-role.kubernetes.io/nodeAgent=""
+----
+
+Use the same custom label in the `DPA.spec.configuration.nodeAgent.podConfig.nodeSelector`, which you used for labeling nodes. For example:
+
+[source,terminal]
+----
+configuration:
+  nodeAgent:
+    enable: true
+    podConfig:
+      nodeSelector:
+        node-role.kubernetes.io/nodeAgent: ""
+----
+
+The following example is an anti-pattern of `nodeSelector` and does not work unless both labels, `'node-role.kubernetes.io/infra: ""'` and `'node-role.kubernetes.io/worker: ""'`, are on the node:
+
+[source,terminal]
+----
+    configuration:
+      nodeAgent:
+        enable: true
+        podConfig:
+          nodeSelector:
+            node-role.kubernetes.io/infra: ""
+            node-role.kubernetes.io/worker: ""
+----

--- a/modules/oadp-setting-resource-limits-and-requests.adoc
+++ b/modules/oadp-setting-resource-limits-and-requests.adoc
@@ -28,7 +28,7 @@ spec:
   configuration:
     velero:
       podConfig:
-        nodeSelector: <node selector> <1>
+        nodeSelector: <node_selector> <1>
         resourceAllocations: <2>
           limits:
             cpu: "1"

--- a/snippets/oadp-nodeselector-snippet.adoc
+++ b/snippets/oadp-nodeselector-snippet.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+Use the `nodeSelector` field to select which nodes can run the node agent. The `nodeSelector` field is the simplest recommended form of node selection constraint. Any label specified must match the labels on each node.


### PR DESCRIPTION
### CHERRY PICK

* Cherry Picked from e3ad26db5ab779b82d4f969e02dff4740fe04c0a xref: https://github.com/openshift/openshift-docs/pull/81145

    * [Error for original 4.12 cherry pick](https://github.com/openshift/openshift-docs/pull/81145#issuecomment-2332234431) 

### JIRA

* [OADP-4750](https://issues.redhat.com/browse/OADP-4750)

### Version(s):

* OCP 4.12

### PREVIEW

* [AWS - Configuring node agents and node labels](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-configuring-node-agents_installing-oadp-aws)

* [AWS - Setting Velero CPU and memory resource allocations](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-setting-resource-limits-and-requests_installing-oadp-aws)
 
* [Azure - Configuring node agents and node labels](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure#oadp-configuring-node-agents_installing-oadp-azure)

* [Azure - Setting Velero CPU and memory resource allocations](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure#oadp-setting-resource-limits-and-requests_installing-oadp-azure)

* [GCP - Configuring node agents and node labels](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp#oadp-configuring-node-agents_installing-oadp-gcp)

* [GCP - Setting Velero CPU and memory resource allocations](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp#oadp-setting-resource-limits-and-requests_installing-oadp-gcp)

* [OpenShift Virtualization - Configuring node agents and node labels](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt#oadp-configuring-node-agents_installing-oadp-kubevirt)

* [MCG - Configuring node agents and node labels](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg#oadp-configuring-node-agents_installing-oadp-mcg)

* [MCG - Setting Velero CPU and memory resource allocations](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg#oadp-setting-resource-limits-and-requests_installing-oadp-mcg)

* [ODF - Configuring node agents and node labels](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs#oadp-configuring-node-agents_installing-oadp-ocs)

* [ODF - - Setting Velero CPU and memory resource allocations](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs#oadp-setting-resource-limits-and-requests_installing-oadp-ocs)

* [APIs used with OADP  - Configuring node agents and node labels](https://81429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-api.html#oadp-configuring-node-agents_oadp-api)


### QE review:
- [ X] QE has approved this change. See [original PR](https://github.com/openshift/openshift-docs/pull/81145) for approval from Prasad and Shubham

