### PR TITLE
OSDOCS-11678: adds 4.15.31 relnote and other updates MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -38,9 +38,6 @@ This release adds improvements related to the following components and concepts.
 ** If you run cAdvisor as a standalone DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
 ** If you deploy Java applications with JDK, ensure you are using JDK 11.0.16 and later or JDK 15 and later, which fully support cgroup v2.
 
-//[id="microshift-4-15-security"]
-//=== Security and compliance
-
 [id="microshift-4-15-updating"]
 === Updating
 Updates for both minor releases and patch releases are supported.
@@ -57,16 +54,12 @@ The following list provides update details:
 ==== Version logged at start up
 Previously, {microshift-short} did not log its version at start up. The absence of version information made debugging certain scenarios difficult because the update path was unknown. Now, the {microshift-short} version is logged at start up and available with commands such as `journalctl -u microshift | grep "Version"`. (link:https://issues.redhat.com/browse/OCPBUGS-19540[*OCPBUGS-19540*])
 
-//[id="microshift-4-15-new-feat-based-on-{op-system-ostree}"]
-//==== Placeholder for new feat bases on RHEL Edge
-
 [id="microshift-4-15-installation"]
 === Installation
 
 [id="microshift-4-15-blueprint-included"]
 ==== Sample blueprints now included
-The `microshift-release-info` RPM now contains sample blueprints that can be used for image building. The blueprints include both {microshift-short} RPM packages and container image references.
-//TODO link to install section once merged
+The `microshift-release-info` RPM now contains sample blueprints that can be used for image building. The blueprints include both {microshift-short} RPM packages and container image references. See xref:../microshift_install/microshift-embed-in-rpm-ostree.adoc#adding-microshift-service-to-blueprint_microshift-embed-in-rpm-ostree[Adding the {microshift-short} service to a blueprint] for more information.
 
 [id="microshift-4-15-support"]
 === Support
@@ -74,22 +67,6 @@ The `microshift-release-info` RPM now contains sample blueprints that can be use
 [id="microshift-4-15-etcd"]
 ==== Getting the etcd version
 Previously, you could not query for the etcd version included with {microshift-short}. Now, the `microshift-etcd version` command outputs the {microshift-short} version and the base version of the etcd database. See xref:../microshift_support/microshift-etcd.adoc#microshift-etcd[The etcd service] for more information.
-
-//[id="microshift-4-15-post-installation"]
-//=== Post-installation configuration
-//With this release, configuration options have changed.
-
-//[id="microshift-4-15-changes-config-yaml"]
-//==== Configuration options changes
-
-//[id="microshift-4-15-administrator-perspective"]
-//==== Administrator Perspective
-//admin perspectives go here
-
-//[id="microshift-4-15-security"]
-//=== Security and compliance
-//
-// This content will be added post-GA, as it is asynchronous content.
 
 [id="microshift-4-15-networking"]
 === Networking
@@ -195,7 +172,7 @@ This section is updated over time to provide notes on enhancements and bug fixes
 [id="microshift-4-15-0-dp"]
 === RHSA-2023:7200 - {microshift-short} 4.15.0 bug fix and security update advisory
 
-Issued: 2024-02-27
+Issued: 27 February 2024
 
 {product-title} release 4.15.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7200[RHSA-2023:7200] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7198[RHSA-2023:7198] advisory.
 
@@ -204,7 +181,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-2-dp"]
 === RHBA-2024:1212 - {microshift-short} 4.15.2 bug fix and enhancement update advisory
 
-Issued: 2024-03-13
+Issued: 13 March 2024
 
 {product-title} release 4.15.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1212[RHBA-2024:1212] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1210[RHSA-2024:1210] advisory.
 
@@ -231,7 +208,7 @@ Adds OLM image references in dedicated file::
 [id="microshift-4-15-3-dp"]
 === RHBA-2024:1257 - {microshift-short} 4.15.3 bug fix and enhancement update advisory
 
-Issued: 2024-03-20
+Issued: 20 March 2024
 
 {product-title} release 4.15.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1257[RHBA-2024:1257] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1255[RHSA-2024:1255] advisory.
 
@@ -240,7 +217,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-5-dp"]
 === RHBA-2024:1451 - {microshift-short} 4.15.5 bug fix and enhancement update advisory
 
-Issued: 2024-03-27
+Issued: 27 March 2024
 
 {product-title} release 4.15.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1451[RHBA-2024:1451] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1449[RHSA-2024:1449] advisory.
 
@@ -256,7 +233,7 @@ Change in openshift-marketplace namespace security::
 [id="microshift-4-15-6-dp"]
 === RHSA-2024:1561 - {microshift-short} 4.15.6 bug fix and security update advisory
 
-Issued: 2024-04-02
+Issued: 2 April 2024
 
 {product-title} release 4.15.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1561[RHSA-2024:1561] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1559[RHSA-2024:1559] advisory.
 
@@ -265,7 +242,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-8-dp"]
 === RHBA-2024:1670 - {microshift-short} 4.15.8 bug fix and security update advisory
 
-Issued: 2024-04-08
+Issued: 8 April 2024
 
 {product-title} release 4.15.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1670[RHBA-2024:1670] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1668[RHSA-2024:1668] advisory.
 
@@ -274,7 +251,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-9-dp"]
 === RHBA-2024:1772 - {microshift-short} 4.15.9 bug fix and security update advisory
 
-Issued: 2024-04-16
+Issued: 16 April 2024
 
 {product-title} release 4.15.9 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1772[RHBA-2024:1772] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1770[RHSA-2024:1770] advisory.
 
@@ -283,7 +260,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-12-dp"]
 === RHSA-2024:2667 - {microshift-short} 4.15.12 bug fix and security update advisory
 
-Issued: 2024-05-09
+Issued: 9 May 2024
 
 {product-title} release 4.15.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2667[RHSA-2024:2667] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2664[RHSA-2024:2664] advisory.
 
@@ -292,7 +269,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-13-dp"]
 === RHBA-2024:2775 - {microshift-short} 4.15.13 bug fix and security update advisory
 
-Issued: 2024-05-15
+Issued: 15 May 2024
 
 {product-title} release 4.15.13 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2775[RHBA-2024:2775] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2773[RHSA-2024:2773] advisory.
 
@@ -308,7 +285,7 @@ GitOps with Argo CD documentation is now available::
 [id="microshift-4-15-14-dp"]
 === RHBA-2024:2868 - {microshift-short} 4.15.14 bug fix and security update advisory
 
-Issued: 2024-05-21
+Issued: 21 May 2024
 
 The {product-title} release 4.15.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2868[RHBA-2024:2868] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2865[RHSA-2024:2865] advisory.
 
@@ -317,7 +294,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-15-dp"]
 === RHBA-2024:3330 - {microshift-short} 4.15.15 bug fix and security update advisory
 
-Issued: 2024-05-29
+Issued: 29 May 2024
 
 The {product-title} release 4.15.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3330[RHBA-2024:3330] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3327[RHSA-2024:3327] advisory.
 
@@ -326,7 +303,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-16-dp"]
 === RHBA-2024:3490 - {microshift-short} 4.15.16 bug fix and update advisory
 
-Issued: 2024-06-05
+Issued: 5 June 2024
 
 The {product-title} release 4.15.16 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3490[RHBA-2024:3490] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3488[RHBA-2024:3488] advisory.
 
@@ -335,7 +312,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-17-dp"]
 === RHBA-2024:3675 - {microshift-short} 4.15.17 bug fix and update advisory
 
-Issued: 2024-06-11
+Issued: 11 June 2024
 
 The {product-title} release 4.15.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3675[RHBA-2024:3675] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3673[RHBA-2024:3673] advisory.
 
@@ -344,7 +321,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-18-dp"]
 === RHBA-2024:3891 - {microshift-short} 4.15.18 bug fix and security update advisory
 
-Issued: 2024-06-18
+Issued: 18 June 2024
 
 The {product-title} release 4.15.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3891[RHBA-2024:3891] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3889[RHSA-2024:3889] advisory.
 
@@ -353,7 +330,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-19-dp"]
 === RHBA-2024:4043 - {microshift-short} 4.15.19 bug fix and security update advisory
 
-Issued: 2024-06-28
+Issued: 28 June 2024
 
 The {product-title} release 4.15.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4043[RHBA-2024:4043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4041[RHSA-2024:4041] advisory.
 
@@ -362,7 +339,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-20-dp"]
 === RHBA-2024:4153 - {microshift-short} 4.15.20 bug fix and security update advisory
 
-Issued: 2024-07-02
+Issued: 2 July 2024
 
 The {product-title} release 4.15.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4153[RHBA-2024:4153] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4151[RHSA-2024:4151] advisory.
 
@@ -371,7 +348,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-21-dp"]
 === RHBA-2024:4323 - {microshift-short} 4.15.21 bug fix and enhancement advisory
 
-Issued: 2024-07-10
+Issued: 10 July 2024
 
 The {product-title} release 4.15.21 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4323[RHBA-2024:4323] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4321[RHSA-2024:4321] advisory.
 
@@ -380,7 +357,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-22-dp"]
 === RHBA-2024:4476 - {microshift-short} 4.15.22 bug fix and enhancement advisory
 
-Issued: 2024-07-18
+Issued: 18 July 2024
 
 The {product-title} release 4.15.22 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4476[RHBA-2024:4476] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4474[RHSA-2024:4474] advisory.
 
@@ -389,7 +366,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-23-dp_{context}"]
 === RHBA-2024:4701 - {microshift-short} 4.15.23 bug fix and enhancement advisory
 
-Issued: 2024-07-25
+Issued: 25 July 2024
 
 The {product-title} release 4.15.23 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4701[RHBA-2024:4701] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4699[RHSA-2024:4699] advisory.
 
@@ -398,7 +375,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-24-dp_{context}"]
 === RHBA-2024:4852 - {microshift-short} 4.15.24 bug fix and enhancement advisory
 
-Issued: 2024-07-31
+Issued: 31 July 2024
 
 The {product-title} release 4.15.24 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4852[RHBA-2024:4852] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4850[RHSA-2024:4850] advisory.
 
@@ -407,7 +384,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-25-dp_{context}"]
 === RHBA-2024:4957 - {microshift-short} 4.15.25 bug fix and enhancement advisory
 
-Issued: 2024-08-07
+Issued: 7 August 2024
 
 The {product-title} release 4.15.25 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4957[RHBA-2024:4957] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4955[RHSA-2024:4955] advisory.
 
@@ -416,7 +393,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-27-dp_{context}"]
 === RHBA-2024:5162 - {microshift-short} 4.15.27 bug fix and enhancement advisory
 
-Issued: 2024-08-13
+Issued: 13 August 2024
 
 The {product-title} release 4.15.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:5162[RHBA-2024:5162] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5160[RHSA-2024:5160] advisory.
 
@@ -425,7 +402,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-28-dp_{context}"]
 === RHBA-2024:5441 - {microshift-short} 4.15.28 bug fix and enhancement advisory
 
-Issued: 2024-08-22
+Issued: 22 August 2024
 
 The {product-title} release 4.15.28 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5441[RHBA-2024:5441] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5439[RHSA-2024:5439] advisory.
 
@@ -434,7 +411,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-29-dp_{context}"]
 === RHBA-2024:5753 - {microshift-short} 4.15.29 bug fix and enhancement advisory
 
-Issued: 2024-08-28
+Issued: 28 August 2024
 
 The {product-title} release 4.15.29 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5753[RHBA-2024:5753] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5751[RHBA-2024:5751] advisory.
 
@@ -443,9 +420,17 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-30-dp_{context}"]
 === RHBA-2024:6015 - {microshift-short} 4.15.30 bug fix and enhancement advisory
 
-Issued: 2024-09-05
+Issued: 5 September 2024
 
 The {product-title} release 4.15.30 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6015[RHBA-2024:6015] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6013[RHSA-2024:6013] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
+[id="microshift-4-15-31-dp_{context}"]
+=== RHBA-2024:6413 - {microshift-short} 4.15.31 bug fix and enhancement advisory
+
+Issued: 11 September 2024
+
+The {product-title} release 4.15.31 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6413[RHBA-2024:6413] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6409[RHSA-2024:6409] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-11678](https://issues.redhat.com/browse/OSDOCS-11678)

Link to docs preview:
[4.15.31 release note](https://81433--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-31-dp_release-notes)
[Added xref](https://81433--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-blueprint-included)

QE review:
- N/A doc text only

Additional information:
This PR also includes a backport of style manual date formatting. See https://www.ibm.com/docs/en/ibm-style?topic=measurement-dates-times#general-guidance-for-dates.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
