### PR TITLE
OSDOCS-11898: Documented the 4.15.31 zstream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2740,6 +2740,53 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-31_{context}"]
+=== RHSA-2024:6409 - {product-title} 4.15.31 bug fix and security update
+
+Issued: 11 September 2024
+
+{product-title} release 4.15.31, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6409[RHSA-2024:6409] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2024:6414[RHBA-2024:6414] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.31 --pullspecs
+----
+
+[id="ocp-4-15-31-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the `spec.noProxy` field from the cluster-wide proxy was not considered when the {cmo-first} configured proxy capabilities for Prometheus remote write endpoints. With this release, the {cmo-short} no longer configures proxy capabilities for any remote write endpoints whose URL would bypass the proxy according to the `noProxy` field. (link:https://issues.redhat.com/browse/OCPBUGS-39172[*OCPBUGS-39172*])
+
+* Previously, utlization cards displayed limit in a way that incorrectly implied a relationship between capacity and limits. With this release, the position of limit is changed to remove this implication. (link:https://issues.redhat.com/browse/OCPBUGS-39085[*OCPBUGS-39085*])
+
+* Previously, the `openvswitch` service used older cluster configurations after a cluster upgrade and this caused the `openvswitch` service to stop. With this release, the `openvswitch` service is now restarted after a cluster upgrade so that the service uses the newer cluster configurations. (link:https://issues.redhat.com/browse/OCPBUGS-34842[*OCPBUGS-34842*])
+
+* Previously, after you submitted the same value into the {vmw-first} configuration dialog, cluster nodes unintentionally rebooted. With this release, nodes reboot after you enter new values into the dialog and not the same values.(link:https://issues.redhat.com/browse/OCPBUGS-33938[*OCPBUGS-33938*])
+
+* Previously, if a virtual machine (VM) was deleted and the network interface controller (NIC) still existed for that VM, the {azure-first} VM verification check failed. With this release, the verification check can now handle this situation by gracefully processing the issue without failing. (link:https://issues.redhat.com/browse/OCPBUGS-31467[*OCPBUGS-31467*])
+
+* Previously, Red{nbsp}Hat HyperShift periodic conformance jobs failed because of changes to the core operating system. These failed jobs caused the OpenShift API deployment to fail. With this release, an update recursively copies individual trusted certificate authority (CA) certificates instead of copying a single file, so that the periodic conformance jobs succeed and the OpenShift API runs as expected link:https://issues.redhat.com/browse/OCPBUGS-38943[*OCPBUGS-38943*])
+
+* Previously, the grace period for a node to become ready was not aligned with upstream behavior. This grace period sometimes caused a node to cycle between `Ready` and `Not ready` states. With this release, the issue is fixed so that the grace period does not cause a node to cycle between the two states. (link:https://issues.redhat.com/browse/OCPBUGS-39077[*OCPBUGS-39077*])
+
+[id="ocp-4-15-31-known-issues_{context}"]
+==== Known issues
+
+* On {product-rosa}, node pools might stop scaling workloads or updating configurations for a cluster that uses the {product-version}.23 or later version of the {hcp-capital} service. Depending on the version of components that interact with your cluster, you can resolve this issue be completing the steps in one of the following Red{nbsp}Hat Knowledgebase articles:
++
+** (https://access.redhat.com/articles/7085089)[ROSA HCP clusters fail to add new nodes in MachinePool version older than {product-version}.23]
+** (https://access.redhat.com/articles/7085666)[ROSA upgrade issue mitigation for HOSTEDCP-1941]
++
+(link:https://issues.redhat.com/browse/OCPBUGS-39463[*OCPBUGS-39463*])
+
+[id="ocp-4-15-31-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-15-30_{context}"]
 === RHSA-2024:6013 - {product-title} 4.15.30 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-11898](https://issues.redhat.com/browse/OSDOCS-11898)

Link to docs preview:
* [4.15.31 z-stream release notes](https://81434--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-31_release-notes)


