### PR TITLE
OCPBUGS-38340 Configuring node power consumption and realtime process…

### DIFF
--- a/modules/cnf-configuring-workload-hints.adoc
+++ b/modules/cnf-configuring-workload-hints.adoc
@@ -9,31 +9,7 @@
 
 .Procedure
 
-. Create a `PerformanceProfile` appropriate for the environment's hardware and topology as described in the table in "Understanding workload hints". Adjust the profile to match the expected workload. In this example, we tune for the lowest possible latency.
-
-. Add the `highPowerConsumption` and `realTime` workload hints. Both are set to `true` here.
-+
-[source,yaml]
-----
-    apiVersion: performance.openshift.io/v2
-    kind: PerformanceProfile
-    metadata:
-      name: workload-hints
-    spec:
-      ...
-      workloadHints:
-        highPowerConsumption: true <1>
-        realTime: true <2>
-----
-<1> If `highPowerConsumption` is `true`, the node is tuned for very low latency at the cost of increased power consumption.
-<2> Disables some debugging and monitoring features that can affect system latency.
-
-[NOTE]
-====
-When the `realTime` workload hint flag is set to `true` in a performance profile, add the `cpu-quota.crio.io: disable` annotation to every guaranteed pod with pinned CPUs. This annotation is necessary to prevent the degradation of the process performance within the pod. If the `realTime` workload hint is not explicitly set then it defaults to `true`.
-====
-
-The following table describes how combinations of power consumption and real-time settings impact latency.
+* Create a `PerformanceProfile` appropriate for the environment's hardware and topology by using the Performance Profile Creator (PPC) tool. The following table describes the possible values set for the `power-consumption-mode` flag associated with the PPC tool and the workload hint that is applied. 
 
 .Impact of combinations of power consumption and real-time settings on latency
 [cols="1,1,1,1",options="header"]
@@ -81,3 +57,28 @@ perPodPowerManagement: true
 |Critical and non-critical workloads
 |Allows for power management per pod.
 |===
+
+.Example
+
+The following configuration is commonly used in a telco RAN DU deployment. 
+
+[source,yaml]
+----
+    apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    metadata:
+      name: workload-hints
+    spec:
+      ...
+      workloadHints:
+        realTime: true
+        highPowerConsumption: false
+        perPodPowerManagement: false <1>
+----
+<1> Disables some debugging and monitoring features that can affect system latency.
+
+[NOTE]
+====
+When the `realTime` workload hint flag is set to `true` in a performance profile, add the `cpu-quota.crio.io: disable` annotation to every guaranteed pod with pinned CPUs. This annotation is necessary to prevent the degradation of the process performance within the pod. If the `realTime` workload hint is not explicitly set, it defaults to `true`.
+====
+

--- a/scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
@@ -57,6 +57,8 @@ include::modules/cnf-configuring-power-saving-for-nodes.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-about-the-profile-creator-tool_cnf-low-latency-perf-profile[About the Performance Profile Creator]
+
 * xref:../../scalability_and_performance/low_latency_tuning/cnf-provisioning-low-latency-workloads.adoc#cnf-configuring-high-priority-workload-pods_cnf-provisioning-low-latency[Disabling power saving mode for high priority pods]
 
 * xref:../../scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus_cnf-low-latency-perf-profile[Managing device interrupt processing for guaranteed pod isolated CPUs]


### PR DESCRIPTION
[OCPBUGS-38340]: Configuring node power consumption and realtime processing with workload hints
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17, 4.16, 4.15, 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-38340
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81436--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.html#configuring-workload-hints_cnf-low-latency-perf-profile
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
