### PR TITLE
OSDOCS#11830: Networking HCP Migration

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -187,7 +187,7 @@ openshift-aro:
       name: '4'
       dir: aro/4
 openshift-rosa:
-  name: Red Hat OpenShift Service on AWS
+  name: ROSA (classic architecture)
   author: OpenShift Documentation Project <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation
@@ -200,7 +200,7 @@ openshift-rosa:
       name: ''
       dir: rosa-preview/
 openshift-rosa-hcp:
-  name: Red Hat OpenShift Service on AWS
+  name: ROSA with HCP
   author: OpenShift Documentation Project <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -327,6 +327,50 @@ Topics:
 # - Name: Backing up applications
 #   File: backing-up-applications
 ---
+Name: Networking
+Dir: networking
+Distros: openshift-rosa-hcp
+Topics:
+- Name: About networking
+  File: about-managed-networking
+- Name: Understanding the DNS Operator
+  File: dns-operator
+- Name: Understanding the Ingress Operator
+  File: ingress-operator
+# - Name: Network verification
+#   File: network-verification
+# - Name: Configuring a cluster-wide proxy during installation
+#   File: configuring-cluster-wide-proxy
+# - Name: CIDR range definitions
+#   File: cidr-range-definitions
+# - Name: Network policy
+#   Dir: network_policy
+#   Topics:
+#   - Name: About network policy
+#     File: about-network-policy
+#   - Name: Creating a network policy
+#     File: creating-network-policy
+#   - Name: Viewing a network policy
+#     File: viewing-network-policy
+#   - Name: Deleting a network policy
+#     File: deleting-network-policy
+#   - Name: Configuring multitenant isolation with network policy
+#     File: multitenant-network-policy
+- Name: OVN-Kubernetes network plugin
+  Dir: ovn_kubernetes_network_provider
+  Topics:
+  - Name: About the OpenShift SDN network plugin
+    File: about-ovn-kubernetes
+  - Name: Configuring an egress IP address
+    File: configuring-egress-ips-ovn
+# - Name: Configuring Routes
+#   Dir: routes
+#   Topics:
+#   - Name: Route configuration
+#     File: route-configuration
+#   - Name: Secured routes
+#     File: secured-routes
+---
 Name: Registry
 Dir: registry
 Distros: openshift-rosa-hcp

--- a/modules/rosa-getting-started-create-cluster-admin-user.adoc
+++ b/modules/rosa-getting-started-create-cluster-admin-user.adoc
@@ -18,7 +18,10 @@ Before configuring an identity provider, you can create a user with `cluster-adm
 
 [NOTE]
 ====
-The cluster administrator user is useful when you need quick access to a newly deployed cluster. However, consider configuring an identity provider and granting cluster administrator privileges to the identity provider users as required. For more information about setting up an identity provider for your ROSA cluster, see _Configuring an identity provider and granting cluster access_.
+The cluster administrator user is useful when you need quick access to a newly deployed cluster. However, consider configuring an identity provider and granting cluster administrator privileges to the identity provider users as required. 
+ifndef::openshift-rosa-hcp[]
+For more information about setting up an identity provider for your ROSA cluster, see _Configuring an identity provider and granting cluster access_.
+endif::openshift-rosa-hcp[]
 ====
 
 ifdef::getting-started[]

--- a/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
@@ -26,7 +26,10 @@ ifdef::quick-install[]
 * You have verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.
 * You have associated your AWS account with your Red{nbsp}Hat organization. When you associated your account, you applied the administrative permissions to the {cluster-manager} role. For detailed steps, see _Associating your AWS account with your Red{nbsp}Hat organization_.
 * You have created the required account-wide STS roles and policies. For detailed steps, see _Creating the account-wide STS roles and policies_.
-endif::[]
+ifdef::openshift-rosa-hcp[]
+* You have created a virtual private cloud (VPC) and its subnets.
+endif::openshift-rosa-hcp[]
+endif::quick-install[]
 
 .Procedure
 
@@ -34,12 +37,24 @@ endif::[]
 
 . On the *Create an OpenShift cluster* page, select *Create cluster* in the *{product-title} (ROSA)* row.
 
-. Verify that your AWS account ID is listed in the *Associated AWS accounts* drop-down menu and that the installer, support, worker, and control plane account role Amazon Resource Names (ARNs) are listed on the *Accounts and roles* page.
+. On the *Control plane* page, select 
+ifdef::openshift-rosa[]
+*Classic* to build a ROSA cluster that uses the classic architecture.
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+*Hosted* to build a ROSA cluster that uses an architecture where the control plane is decoupled from the data plane.
+endif::openshift-rosa-hcp[]
+
+. On the *Accounts and roles* page, verify that your AWS account ID is listed in the *Associated AWS accounts* drop-down menu in the *AWS infrastructure account* section. Your AWS account is used in the installer, support, worker, and control plane account role Amazon Resource Names (ARNs).
 +
 [NOTE]
 ====
 If your AWS account ID is not listed, check that you have successfully associated your AWS account with your Red{nbsp}Hat organization. If your account role ARNs are not listed, check that the required account-wide STS roles exist in your AWS account.
 ====
+ifdef::openshift-rosa-hcp[]
++
+. Verify that the correct AWS account ID is listed in the *AWS billing account* drop-down menu in the *AWS billing account* section.
+endif::openshift-rosa-hcp[]
 
 . Click *Next*.
 
@@ -49,7 +64,25 @@ If your AWS account ID is not listed, check that you have successfully associate
 ====
 Cluster creation generates a domain prefix as a subdomain for your provisioned cluster on `openshiftapps.com`. If the cluster name is less than or equal to 15 characters, that name is used for the domain prefix. If the cluster name is longer than 15 characters, the domain prefix is randomly generated as a 15-character string. To customize the subdomain, select the *Create custom domain prefix* checkbox, and enter your domain prefix name in the *Domain prefix* field.
 ====
+ifdef::openshift-rosa-hcp[]
+. On the *Cluster settings* page, choose your VPC from the *Select a VPC to install your machine pools into your selected region:<aws-region-for-cluster>*. This list includes all VPCs associated with your AWS region. 
++
+[NOTE]
+====
+You can only create a cluster in the same region as your VPC.
+====
+
+. After you select your VPC, you must select the name of the private subnet where you want to install this machine pool. The drop-down menu populates with the private subnets associated with your selected VPC.
+endif::openshift-rosa-hcp[]
+
+ifdef::openshift-rosa[]
 . To deploy a cluster quickly, leave the default options in the *Cluster settings*, *Networking*, *Cluster roles and policies*, and *Cluster updates* pages and click *Next* on each page.
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+. To deploy a cluster quickly, leave the default options in the *Cluster settings* and *Cluster updates* pages and click *Next* on each page. 
+. On the *Networking* page, if your cluster is publicly available, verify that your public subnet is listed under the *Public subnet name* drop-down menu.
+. On the *Cluster roles and policies* page, verify that your OIDC config ID is listed under *Config ID*. After you select your OIDC config ID, run the generated command to create your Operator roles. 
+endif::openshift-rosa-hcp[]
 
 . On the *Review your ROSA cluster* page, review the summary of your selections and click *Create cluster* to start the installation.
 +

--- a/modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc
@@ -39,9 +39,17 @@ endif::[]
 
 . If they do not exist in your AWS account, create the required account-wide STS roles and policies:
 +
+ifdef::openshift-rosa[]
 [source,terminal]
 ----
 $ rosa create account-roles
 ----
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+[source,terminal]
+----
+$ rosa create account-roles --hosted-cp
+----
+endif::openshift-rosa-hcp[]
 +
 Select the default values at the prompts to quickly create the roles and policies.

--- a/networking/about-managed-networking.adoc
+++ b/networking/about-managed-networking.adoc
@@ -10,13 +10,15 @@ toc::[]
 
 The following are some of the most commonly used {openshift-networking} features available on your cluster:
 
+- Cluster Network Operator for network plugin management
 - Primary cluster network provided by either of the following Container Network Interface (CNI) plugins:
   * xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin] - the default plugin
-  * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/networking/openshift-sdn-network-plugin#nw-openshift-sdn-modes_about-openshift-sdn[OpenShift SDN network plugin]- deprecated for clusters as of OpenShift 4.14
-- Cluster Network Operator for network plugin management
+ifndef::openshift-rosa-hcp[]
+  * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/networking/openshift-sdn-network-plugin#nw-openshift-sdn-modes_about-openshift-sdn[OpenShift SDN network plugin] - deprecated for clusters as of OpenShift 4.14
 
 {product-title} clusters created with OpenShift 4.11 and above use OVN-Kubernetes network plugin by default. {product-title} clusters created before OpenShift version 4.11 use the OpenShift SDN plugin after they are upgraded to OpenShift version 4.11 and above.
 
 include::snippets/sdn-deprecation-statement-managed.adoc[]
 
 You will soon be able to migrate from OpenShift SDN to OVN for clusters running on OpenShift version 4.15 and later. This migration tool is not currently available. For more information about the OpenShift SDN deprecation and the OVN migration, see the KCS article about link:https://access.redhat.com/articles/7065170[OpenShift SDN CNI removal in OCP 4.17].
+endif::openshift-rosa-hcp[]

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -4,12 +4,13 @@
 ifdef::openshift-enterprise[]
 include::_attributes/common-attributes.adoc[]
 endif::[]
-ifdef::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
-endif::[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 :context: configuring-ingress
 
 toc::[]
+
 include::modules/nw-ne-openshift-ingress.adoc[leveloffset=+1]
 
 //ifndef::openshift-rosa,openshift-dedicated[] NOTE: commenting out this ifndef to track what was in place before OSDOCS-4883.
@@ -53,7 +54,7 @@ include::modules/nw-ingress-custom-default-certificate-remove.adoc[leveloffset=+
 // Autoscaling an Ingress Controller
 include::modules/nw-autoscaling-ingress-controller.adoc[leveloffset=+2]
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
@@ -66,7 +67,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc#nodes-cma-autoscaling-custom-prometheus[Configuring the custom metrics autoscaler to use {product-title} monitoring]
 
 * xref:../nodes/cma/nodes-cma-autoscaling-custom-adding.adoc#nodes-cma-autoscaling-custom-adding[Understanding how to add custom metrics autoscalers]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/nw-scaling-ingress-controller.adoc[leveloffset=+2]
 
@@ -76,9 +77,9 @@ include::modules/nw-ingress-setting-thread-count.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-setting-internal-lb.adoc[leveloffset=+2]
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/nw-ingress-controller-configuration-gcp-global-access.adoc[leveloffset=+2]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/nw-ingress-controller-config-tuningoptions-healthcheckinterval.adoc[leveloffset=+2]
 
@@ -99,10 +100,12 @@ include::modules/nw-http2-haproxy.adoc[leveloffset=+2]
 // Configuring the PROXY protocol for an Ingress Controller
 include::modules/nw-ingress-controller-configuration-proxy-protocol.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../networking/ingress-operator.adoc#nw-configure-ingress-access-logging_configuring-ingress[Configuring Ingress access logging]
+endif::openshift-rosa-hcp[]
 
 // Specifying an alternative cluster domain using the appsDomain option
 include::modules/nw-ingress-configuring-application-domain.adoc[leveloffset=+2]
@@ -119,13 +122,13 @@ include::modules/nw-customize-ingress-error-pages.adoc[leveloffset=+2]
 include::modules/nw-ingress-setting-max-connections.adoc[leveloffset=+2]
 //endif::openshift-rosa,openshift-dedicated[] NOTE: commenting out this ifndef to track what was in place before OSDOCS-4883.
 
-ifdef::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/sd-ingress-responsibilities.adoc[leveloffset=+1]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../networking/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -39,7 +39,7 @@ include::modules/nw-ovn-kuberentes-limitations.adoc[leveloffset=+1]
 
 include::modules/nw-ovn-kubernetes-session-affinity.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
@@ -49,4 +49,4 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]
 * xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
 * xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1\]]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -13,31 +13,31 @@ include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 
 include::modules/nw-egress-ips-object.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 include::modules/nw-egress-ips-config-object.adoc[leveloffset=+1]
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/nw-egress-ips-node.adoc[leveloffset=+1]
 
 [id="configuring-egress-ips-next-steps"]
 == Next steps
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.adoc#assigning-egress-ips-ovn[Assigning egress IPs]
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * link:https://docs.openshift.com/container-platform/4.14/networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.html#assigning-egress-ips-ovn[Assigning egress IPs]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 [role="_additional-resources"]
 [id="configuring-egress-ips-additional-resources"]
 == Additional resources
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../rest_api/objects/index.adoc#labelselector-meta-v1[LabelSelector meta/v1]
 * xref:../../rest_api/objects/index.adoc#labelselectorrequirement-meta-v1[LabelSelectorRequirement meta/v1]
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * link:https://docs.openshift.com/container-platform/4.14/rest_api/objects/index.html#labelselector-meta-v1[LabelSelector meta/v1]
 * link:https://docs.openshift.com/container-platform/4.14/rest_api/objects/index.html#labelselectorrequirement-meta-v1[LabelSelectorRequirement meta/v1]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/rosa_getting_started/rosa-getting-started.adoc
+++ b/rosa_getting_started/rosa-getting-started.adoc
@@ -13,8 +13,11 @@ If you are looking for a quickstart guide for ROSA, see xref:../rosa_getting_sta
 
 Follow this getting started document to create a {product-title} (ROSA) cluster, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
 
+ifndef::openshift-rosa-hcp[]
 You can create a ROSA cluster either with or without the AWS Security Token Service (STS). The procedures in this document enable you to create a cluster that uses AWS STS. For more information about using AWS STS with ROSA clusters, see xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding-aws-sts_rosa-understanding[Using the AWS Security Token Service].
+endif::openshift-rosa-hcp[]
 
+ifndef::openshift-rosa-hcp[]
 [id="rosa-getting-started-prerequisites_{context}"]
 == Prerequisites
 
@@ -25,13 +28,15 @@ You can create a ROSA cluster either with or without the AWS Security Token Serv
 * You have reviewed the detailed xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
 
 * You have the xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[AWS service quotas that are required to run a ROSA cluster].
+endif::openshift-rosa-hcp[]
 
 include::modules/rosa-getting-started-environment-setup.adoc[leveloffset=+1]
 include::modules/rosa-getting-started-enable-rosa.adoc[leveloffset=+2]
 include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffset=+2]
 
 [id="rosa-getting-started-creating-a-cluster"]
-== Creating a ROSA cluster with STS
+ifdef::openshift-rosa[]
+== Creating a {rosa-classic} cluster with STS
 
 Choose from one of the following methods to deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS). In each scenario, you can deploy your cluster by using {cluster-manager-first} or the ROSA CLI (`rosa`):
 
@@ -39,25 +44,44 @@ Choose from one of the following methods to deploy a {product-title} (ROSA) clus
 
 * xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-a-cluster-with-customizations[*Creating a ROSA cluster with STS using customizations*]: You can create a ROSA cluster with STS using customizations. You can also choose between the `auto` and `manual` modes when creating the required STS resources.
 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+== Creating a ROSA cluster
+
+Choose from one of the following methods to deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS). In each scenario, you can deploy your cluster by using {cluster-manager-first} or the ROSA CLI (`rosa`):
+
+* xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[*Creating a {product-title} cluster with STS using the default options*]: You can create a ROSA cluster with STS quickly by using the default options and automatic STS resource creation.
+endif::openshift-rosa-hcp[]
+
 .Additional resources
 
+ifdef::openshift-rosa-hcp[]
+* For detailed steps to deploy a private ROSA cluster, see xref:../rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc#rosa-hcp-aws-privatelink-creating-cluster[Creating a private cluster on {product-title}].
+* For information about the update life cycle for ROSA, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{product-title} update life cycle].
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
 * For detailed steps to deploy a ROSA cluster without STS, see xref:../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-creating-cluster.adoc#rosa-creating-cluster[Creating a ROSA cluster without AWS STS] and xref:../rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc#rosa-aws-privatelink-creating-cluster[Creating an AWS PrivateLink cluster on ROSA].
 * For information about the account-wide IAM roles and policies that are required for ROSA deployments that use STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference].
 * For details about using the `auto` and `manual` modes to create the required STS resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-understanding-deployment-modes_rosa-sts-creating-a-cluster-with-customizations[Understanding the auto and manual deployment modes].
 * For information about the update life cycle for ROSA, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[{product-title} update life cycle].
+endif::openshift-rosa[]
 
 include::modules/rosa-getting-started-create-cluster-admin-user.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa-hcp[]
 .Additional resource
 
 * For steps to log in to the ROSA web console, see xref:../rosa_getting_started/rosa-getting-started.adoc#rosa-getting-started-access-cluster-web-console_rosa-getting-started[Accessing a cluster through the web console]
+endif::openshift-rosa-hcp[]
 
 include::modules/rosa-getting-started-configure-an-idp-and-grant-access.adoc[leveloffset=+1]
 include::modules/rosa-getting-started-configure-an-idp.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa-hcp[]
 .Additional resource
 
 * For detailed steps to configure each of the supported identity provider types, see xref:../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc#rosa-sts-config-identity-providers[Configuring identity providers for STS]
+endif::openshift-rosa-hcp[]
 
 include::modules/rosa-getting-started-grant-user-access.adoc[leveloffset=+2]
 include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+2]
@@ -65,8 +89,14 @@ include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+2
 [role="_additional-resources"]
 .Additional resources
 
+ifdef::openshift-rosa-hcp[]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-cluster-admin-role_rosa-hcp-service-definition[Cluster administration role]
+* xref:.././rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-customer-admin-user_rosa-hcp-service-definition[Customer administrator user]
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-cluster-admin-role_rosa-service-definition[Cluster administration role]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Customer administrator user]
+endif::openshift-rosa[]
 
 include::modules/rosa-getting-started-access-cluster-web-console.adoc[leveloffset=+1]
 include::modules/deploy-app.adoc[leveloffset=+1]
@@ -75,19 +105,24 @@ include::modules/rosa-getting-started-revoke-admin-privileges.adoc[leveloffset=+
 include::modules/rosa-getting-started-revoke-user-access.adoc[leveloffset=+2]
 include::modules/rosa-getting-started-deleting-a-cluster.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa-hcp[]
 [id="next-steps_{context}"]
 == Next steps
 
 * xref:../adding_service_cluster/adding-service.adoc#adding-service[Adding services to a cluster using the {cluster-manager} console]
 * xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#rosa-managing-worker-nodes[Managing compute nodes]
 * xref:../observability/monitoring/configuring-the-monitoring-stack.adoc[Configuring the monitoring stack]
+endif::openshift-rosa-hcp[]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
 
+ifdef::openshift-rosa[]
 * For more information about setting up accounts and ROSA clusters using AWS STS, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-overview-of-the-deployment-workflow[Understanding the ROSA with STS deployment workflow]
 
 * For more information about setting up accounts and ROSA clusters without using AWS STS, see xref:../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-getting-started-workflow.adoc#rosa-understanding-the-deployment-workflow[Understanding the ROSA deployment workflow]
-
-* For more information about upgrading your cluster, see xref:../upgrading/rosa-upgrading-sts.adoc#rosa-upgrading-sts[Upgrading ROSA Classic clusters]
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+* For more information about upgrading your cluster, see xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {product-title} clusters].
+endif::openshift-rosa-hcp[]

--- a/rosa_getting_started/rosa-quickstart-guide-ui.adoc
+++ b/rosa_getting_started/rosa-quickstart-guide-ui.adoc
@@ -13,6 +13,12 @@ If you are looking for a comprehensive getting started guide for {product-title}
 
 Follow this guide to quickly create a {product-title} (ROSA) cluster using {cluster-manager-first} on the {hybrid-console-url}, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
 
+//
+//
+// OSDOCS-11538: Getting Started Migration - These links go to sections that are not yet migrated to the ROSA with HCP book.
+// 
+//
+ifndef::openshift-rosa-hcp[]
 The procedures in this document enable you to create a cluster that uses AWS Security Token Service (STS). For more information about using AWS STS with ROSA clusters, see xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding-aws-sts_rosa-understanding[Using the AWS Security Token Service].
 
 image::291_OpenShift_on_AWS_Intro_1122_docs.png[{product-title}]
@@ -27,7 +33,7 @@ image::291_OpenShift_on_AWS_Intro_1122_docs.png[{product-title}]
 * You have reviewed the detailed xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
 
 * You have the xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[AWS service quotas that are required to run a ROSA cluster].
-
+endif::openshift-rosa-hcp[]
 
 //This content is pulled from rosa-getting-started-environment-setup.adoc
 include::modules/rosa-getting-started-environment-setup.adoc[leveloffset=+1]
@@ -80,13 +86,16 @@ include::modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc[leve
 [discrete]
 include::modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc[leveloffset=+2]
 
-////
 .Additional resources
 
+ifndef::openshift-rosa-hcp[]
 * For information about the account-wide IAM roles and policies that are required for ROSA deployments that use STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference].
 * For details about using the `auto` and `manual` modes to create the required STS resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-understanding-deployment-modes_rosa-sts-creating-a-cluster-with-customizations[Understanding the auto and manual deployment modes].
 * For information about the update life cycle for ROSA, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[{product-title} update life cycle].
-////
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa[]
+* For information about the update life cycle for ROSA, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{product-title} update life cycle].
+endif::openshift-rosa[]
 
 
 //This content is pulled from rosa-getting-started-create-cluster-admin-user.adoc
@@ -107,8 +116,14 @@ include::modules/rosa-getting-started-configure-an-idp.adoc[leveloffset=+2]
 
 .Additional resource
 
+//
+//
+// OSDOCS-11538: Getting Started Migration - These links go to sections that are not yet migrated to the ROSA with HCP book.
+// 
+//
+ifndef::openshift-rosa-hcp[]
 * For detailed steps to configure each of the supported identity provider types, see xref:../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc#rosa-sts-config-identity-providers[Configuring identity providers for STS].
-
+endif::openshift-rosa-hcp[]
 
 //This content is pulled from rosa-getting-started-grant-user-access.adoc
 [discrete]
@@ -122,8 +137,15 @@ include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+2
 [role="_additional-resources"]
 .Additional resources
 
+//
+//
+// OSDOCS-11538: Getting Started Migration - These links go to sections that are not yet migrated to the ROSA with HCP book.
+// 
+//
+ifndef::openshift-rosa-hcp[]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-cluster-admin-role_rosa-service-definition[Cluster administration role]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Customer administrator user]
+endif::openshift-rosa-hcp[]
 
 //This content is pulled from rosa-getting-started-access-cluster-web-console.adoc
 include::modules/rosa-getting-started-access-cluster-web-console.adoc[leveloffset=+1]
@@ -150,6 +172,12 @@ include::modules/rosa-getting-started-revoke-user-access.adoc[leveloffset=+2]
 //This content is pulled from rosa-getting-started-deleting-a-cluster.adoc
 include::modules/rosa-getting-started-deleting-a-cluster.adoc[leveloffset=+1]
 
+//
+//
+// OSDOCS-11538: Getting Started Migration - These links go to sections that are not yet migrated to the ROSA with HCP book.
+// 
+//
+ifndef::openshift-rosa-hcp[]
 [id="next-steps_{context}"]
 == Next steps
 
@@ -165,4 +193,12 @@ include::modules/rosa-getting-started-deleting-a-cluster.adoc[leveloffset=+1]
 
 * For more information about setting up accounts and ROSA clusters without using AWS STS, see xref:../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-getting-started-workflow.adoc#rosa-understanding-the-deployment-workflow[Understanding the ROSA deployment workflow].
 
-* For more information about upgrading your cluster, see xref:../upgrading/rosa-upgrading-sts.adoc#rosa-upgrading-sts[Upgrading ROSA Classic clusters].
+* For more information about upgrading your cluster, see xref:../upgrading/rosa-upgrading-sts.adoc#rosa-upgrading-sts[Upgrading {product-title} clusters].
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* For more information about upgrading your cluster, see xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {product-title} clusters].
+endif::openshift-rosa-hcp[]

--- a/rosa_getting_started/rosa-sts-getting-started-workflow.adoc
+++ b/rosa_getting_started/rosa-sts-getting-started-workflow.adoc
@@ -17,6 +17,7 @@ The AWS Security Token Service (STS) is a global web service that provides short
 
 You can follow the workflow stages outlined in this section to set up and access a ROSA cluster that uses STS.
 
+ifndef::openshift-rosa-hcp[]
 . xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[Complete the AWS prerequisites for ROSA with STS]. To deploy a ROSA cluster with STS, your AWS account must meet the prerequisite requirements.
 . xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[Review the required AWS service quotas]. To prepare for your cluster deployment, review the AWS service quotas that are required to run a ROSA cluster.
 . xref:../rosa_planning/rosa-sts-setting-up-environment.adoc#rosa-sts-setting-up-environment[Set up the environment and install ROSA using STS]. Before you create a ROSA with STS cluster, you must enable ROSA in your AWS account, install and configure the required CLI tools, and verify the configuration of the CLI tools. You must also verify that the AWS Elastic Load Balancing (ELB) service role exists and that the required AWS resource quotas are available.
@@ -30,3 +31,11 @@ You can follow the workflow stages outlined in this section to set up and access
 == Additional resources
 
 * For information about using the ROSA deployment workflow to create a cluster that does not use AWS STS, see xref:../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-getting-started-workflow.adoc#rosa-understanding-the-deployment-workflow[Understanding the ROSA deployment workflow].
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+//. xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[Complete the AWS prerequisites for ROSA with STS]. To deploy a ROSA cluster with STS, your AWS account must meet the prerequisite requirements.
+//. xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[Review the required AWS service quotas]. To prepare for your cluster deployment, review the AWS service quotas that are required to run a ROSA cluster.
+//. xref:../rosa_planning/rosa-sts-setting-up-environment.adoc#rosa-sts-setting-up-environment[Set up the environment and install ROSA using STS]. Before you create a ROSA with STS cluster, you must enable ROSA in your AWS account, install and configure the required CLI tools, and verify the configuration of the CLI tools. You must also verify that the AWS Elastic Load Balancing (ELB) service role exists and that the required AWS resource quotas are available.
+. xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Creating {product-title} clusters using the default options]. Use the ROSA CLI (`rosa`) or {cluster-manager-first} to create a cluster with STS. You can create a cluster quickly by using the default options, or you can apply customizations to suit the needs of your organization.
+. xref:../rosa_hcp/rosa-hcp-deleting-cluster.adoc#rosa-hcp-deleting-cluster[Delete a ROSA cluster]. You can delete a ROSA with STS cluster by using the ROSA CLI (`rosa`). After deleting a cluster, you can delete the STS resources by using the AWS Identity and Access Management (IAM) Console.
+endif::openshift-rosa-hcp[]

--- a/rosa_hcp/rosa-hcp-deleting-cluster.adoc
+++ b/rosa_hcp/rosa-hcp-deleting-cluster.adoc
@@ -11,7 +11,7 @@ If you want to delete a {hcp-title-first} cluster, you can use either the {clust
 include::modules/rosa-hcp-deleting-cluster.adoc[leveloffset=+1]
 
 .Troubleshooting
-* If the cluster cannot be deleted because of missing IAM roles, see xref:../support/troubleshooting/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-cluster-deletion_rosa-troubleshooting-cluster-deployments[Repairing a cluster that cannot be deleted].
+* If the cluster cannot be deleted because of missing IAM roles, see link:https://docs.openshift.com/rosa/support/troubleshooting/rosa-troubleshooting-deployments.html#rosa-troubleshooting-cluster-deletion_rosa-troubleshooting-cluster-deployments[Repairing a cluster that cannot be deleted].
 * If the cluster cannot be deleted for other reasons:
 ** Ensure that there are no add-ons for your cluster pending in the link:https://console.redhat.com/openshift[Hybrid Cloud Console].
 ** Ensure that all AWS resources and dependencies have been deleted in the Amazon Web Console.
@@ -21,13 +21,13 @@ include::modules/rosa-deleting-sts-iam-resources-account-wide.adoc[leveloffset=+
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../support/troubleshooting/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-cluster-deletion_rosa-troubleshooting-cluster-deployments[Repairing a cluster that cannot be deleted]
+* link:https://docs.openshift.com/rosa/support/troubleshooting/rosa-troubleshooting-deployments.html#rosa-troubleshooting-cluster-deletion_rosa-troubleshooting-cluster-deployments[Repairing a cluster that cannot be deleted]
 
 include::modules/rosa-deleting-account-wide-iam-roles-and-policies.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for ROSA clusters that use STS]
+* link:https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-about-iam-resources[About IAM resources for ROSA clusters that use STS]
 
 include::modules/rosa-unlinking-and-deleting-ocm-and-user-iam-roles.adoc[leveloffset=+2]

--- a/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
+++ b/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
@@ -35,4 +35,4 @@ include::modules/rosa-sts-cluster-terraform-destroy.adoc[leveloffset=+2]
 [role="_additional-resources"]
 [id="additional-resources_rosa-hcp-creating-a-cluster-quickly-terraform"]
 == Additional resources
-* xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference]
+* link:https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference]


### PR DESCRIPTION
Version(s):
`enterprise-4.17+`

Issue:
**[OSDOCS-11830](https://issues.redhat.com/browse/OSDOCS-11830)**

Link to docs preview:
- **[About networking](https://81437--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/about-managed-networking)** - ROSA Classic
- **[About networking](https://81437--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/about-managed-networking)** - ROSA with HCP
- **[Understanding the DNS Operator](https://81437--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/dns-operator.html)** - ROSA Classic
- **[Understanding the DNS Operator](https://81437--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/dns-operator.html)** - ROSA with HCP
- **[Understanding the Ingress Operator](https://81437--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ingress-operator.html)** - ROSA Classic
- **[Understanding the Ingress Operator](https://81437--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/ingress-operator.html)** - ROSA with HCP
- **AWS Load Balancer Operator**
    - [AWS Load Balancer Operator for ROSA Classic](https://81437--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/aws-load-balancer-operator.html) is still live.
    - AWS Load Balancer Operator removed from ROSA with HCP
- **OpenShift SDN CNI network provider**
    - [OpenShift SDN CNI network provider](https://81437--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/openshift_sdn/enabling-multicast.html) for ROSA Classic is still live.
    - OpenShift SDN CNI network provider was removed from ROSA with HCP
 - About the OVN-Kubernetes network plugin - ROSA Classic
 - **[About the OVN-Kubernetes network plugin](https://81437--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes)** - ROSA with HCP
 - **[Configuring an egress IP address](https://81437--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn)** - ROSA Classic
 - **[Configuring an egress IP address](https://81437--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn)** - ROSA with HCP

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Migrated the Networking book from ROSA Classic to ROSA with HCP. This PR is based on #80324 and should be merged after that PR.