### PR TITLE
OSDOCS-11882: adds module to IPv6 config MicroShift

### DIFF
--- a/microshift_configuring/microshift-nw-ipv6-config.adoc
+++ b/microshift_configuring/microshift-nw-ipv6-config.adoc
@@ -16,6 +16,8 @@ include::modules/microshift-nw-ipv6-dual-stack-config.adoc[leveloffset=+1]
 
 include::modules/microshift-nw-ipv6-dual-stack-migrating-config.adoc[leveloffset=+1]
 
+include::modules/microshift-nw-ipv6-dual-stack-reset-ipfam.adoc[leveloffset=+1]
+
 //OCP module, edit with conditionals and care
 include::modules/nw-ovn-kuberentes-limitations.adoc[leveloffset=+1]
 

--- a/modules/microshift-nw-ipv6-concept.adoc
+++ b/modules/microshift-nw-ipv6-concept.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * microshift_configuring/microshift-using-config-tools.adoc
+// * microshift_configuring/microshift-nw-ipv6-config.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-intro-ipv6_{context}"]

--- a/modules/microshift-nw-ipv6-dual-stack-config.adoc
+++ b/modules/microshift-nw-ipv6-dual-stack-config.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * microshift_configuring/microshift-using-config-tools.adoc
+// * microshift_configuring/microshift-nw-ipv6-config.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-configuring-ipv6-dual-stack-config_{context}"]
@@ -68,14 +68,14 @@ node:
 <3> Example node IP address. Must be an IPv4 address family.
 <4> Example node IP address for dual-stack configuration. Must be an IPv6 address family. Configurable only with dual-stack networking.
 
-. Complete any other configurations you require, then start {microshift-short} by running the following command:
+. Complete any other {microshift-short} configurations you require, then start {microshift-short} by running the following command:
 +
 [source,terminal]
 ----
 $ sudo systemctl start microshift
 ----
 
-. Restart any application pods or add-on services to enable dual-stack networking.
+. Reset the IP family policy for application pods and services as needed, then restart those application pods and services to enable dual-stack networking. See "Resetting the IP family policy for application pods and services" for a simple example.
 
 .Verification
 

--- a/modules/microshift-nw-ipv6-dual-stack-migrating-config.adoc
+++ b/modules/microshift-nw-ipv6-dual-stack-migrating-config.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * microshift_configuring/microshift-using-config-tools.adoc
+// * microshift_configuring/microshift-nw-ipv6-config.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-nw-ipv6-dual-stack-migrating-config_{context}"]
@@ -87,7 +87,7 @@ node:
 $ sudo systemctl restart microshift
 ----
 
-. Restart any additional services and installed applications.
+. Reset the IP family policy for application pods and services as needed, then restart those application pods and services to enable dual-stack networking. See "Resetting the IP family policy for application pods and services" for a simple example.
 
 .Verification
 

--- a/modules/microshift-nw-ipv6-dual-stack-reset-ipfam.adoc
+++ b/modules/microshift-nw-ipv6-dual-stack-reset-ipfam.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * microshift_configuring/microshift-nw-ipv6-config.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-nw-ipv6-dual-stack-reset-ipfam_{context}"]
+= Resetting the IP family policy for application pods and services
+
+The default `ipFamilyPolicy` configuration value, `PreferSingleStack`, does not automatically update in all services after you update your {microshift-short} configuration to dual-stack networking. To enable dual-stack networking in services and application pods, you must update the `ipFamilyPolicy` value.
+
+.Prerequisites
+
+* You used the {microshift-short} `config.yaml` to define a dual-stack network with an IPv6 address family.
+
+.Procedure
+
+. Set the `spec.ipFamilyPolicy` field to a valid value for dual-stack networking in your service or pod by using the following example:
++
+.Example dual-stack network configuration for a service
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+metadata:
+  name: microshift-new-service
+  labels: app: microshift-application
+spec:
+  type: NodePort
+  ipFamilyPolicy: `PreferDualStack` # <1>
+# ...
+----
+<1> Required. Valid values for dual-stack networking are `PreferDualStack` and `RequireDualStack`. The value you set depends on the requirements of your application. `PreferSingleStack` is the default value for the `ipFamilyPolicy` field.
+
+. Restart any application pods that do not have a `hostNetwork` defined. Pods that do have a `hostNetwork` defined do not need to be restarted to update the `ipFamilyPolicy` value.
+
+[NOTE]
+====
+{microshift-short} system services and pods are automatically updated when the `ipFamilyPolicy` value is updated.
+====

--- a/modules/microshift-nw-ipv6-single-stack-config.adoc
+++ b/modules/microshift-nw-ipv6-single-stack-config.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * microshift_configuring/microshift-using-config-tools.adoc
+// * microshift_configuring/microshift-nw-ipv6-config.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-configuring-ipv6-single-stack-config_{context}"]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-11882](https://issues.redhat.com/browse/OSDOCS-11882)

Link to docs preview:
[Resetting the IP family policy](https://81439--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-nw-ipv6-config.html#microshift-nw-ipv6-dual-stack-reset-ipfam_microshift-nw-ipv6-config)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
