### PR TITLE
OSDOCS-11841: migrating disconnected conversion doc

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -111,6 +111,8 @@ Name: Disconnected environments
 Dir: disconnected
 Distros: openshift-enterprise,openshift-origin
 Topics:
+- Name: Converting a connected cluster to a disconnected cluster
+  File: connected-to-disconnected
 - Name: Updating a cluster in a disconnected environment
   Dir: updating
   Topics:
@@ -683,7 +685,7 @@ Topics:
 - Name: Configuring alert notifications
   File: configuring-alert-notifications
 - Name: Converting a connected cluster to a disconnected cluster
-  File: connected-to-disconnected
+  File: converting-to-disconnected
 - Name: Enabling cluster capabilities
   File: enabling-cluster-capabilities
   Distros: openshift-origin,openshift-enterprise

--- a/disconnected/connected-to-disconnected.adoc
+++ b/disconnected/connected-to-disconnected.adoc
@@ -7,7 +7,6 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-
 There might be some scenarios where you need to convert your {product-title} cluster from a connected cluster to a disconnected cluster.
 
 A disconnected cluster, also known as a restricted cluster, does not have an active connection to the internet. As such, you must mirror the contents of your registries and installation media. You can create this mirror registry on a host that can access both the internet and your closed network, or copy images to a device that you can move across network boundaries.
@@ -16,7 +15,7 @@ This topic describes the general process for converting an existing, connected c
 
 include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 
-[id="prerequisites_connected-to-disconnected"]
+[id="prerequisites_connected-to-disconnected_{context}"]
 == Prerequisites
 
 * The `oc` client is installed.
@@ -26,7 +25,7 @@ include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 * An installed mirror registry, which is a container image registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2] in the location that will host the {product-title} cluster, such as one of the following registries:
 +
 --
-** link:https://www.redhat.com/en/technologies/cloud-computing/quay[Red Hat Quay]
+** link:https://www.redhat.com/en/technologies/cloud-computing/quay[Red{nbsp}Hat Quay]
 
 ** link:https://jfrog.com/artifactory/[JFrog Artifactory]
 
@@ -35,7 +34,7 @@ include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 ** link:https://goharbor.io/[Harbor]
 --
 +
-If you have an subscription to Red Hat Quay, see the documentation on deploying Red Hat Quay link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/[for proof-of-concept purposes] or link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index[by using the Quay Operator].
+If you have a subscription to Red{nbsp}Hat Quay, see the documentation on deploying Red{nbsp}Hat Quay link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/[for proof-of-concept purposes] or link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index[by using the Quay Operator].
 
 * The mirror repository must be configured to share images. For example, a Red Hat Quay repository requires link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/use_red_hat_quay/index#user-org-intro_use-quay[Organizations] in order to share images.
 
@@ -44,7 +43,8 @@ If you have an subscription to Red Hat Quay, see the documentation on deploying 
 include::modules/connected-to-disconnected-prepare-mirror.adoc[leveloffset=+1]
 include::modules/connected-to-disconnected-mirror-images.adoc[leveloffset=+1]
 
-.Additional information
+[role="_additional-resources"]
+.Additional resources
 
 * For more information about mirroring Operator catalogs, see xref:../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog].
 * For more information about the `oc adm catalog mirror` command, see the xref:../cli_reference/openshift_cli/administrator-cli-commands.adoc#oc-adm-catalog-mirror[OpenShift CLI administrator command reference].

--- a/post_installation_configuration/converting-to-disconnected.adoc
+++ b/post_installation_configuration/converting-to-disconnected.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="converting-to-disconnected"]
+= Converting a connected cluster to a disconnected cluster
+include::_attributes/common-attributes.adoc[]
+:context: converting-to-disconnected
+
+toc::[]
+
+There might be some scenarios where you need to convert your {product-title} cluster from a connected cluster to a disconnected cluster.
+
+A disconnected cluster, also known as a restricted cluster, does not have an active connection to the internet. As such, you must mirror the contents of your registries and installation media. You can create this mirror registry on a host that can access both the internet and your closed network, or copy images to a device that you can move across network boundaries.
+
+For information on how to convert your cluster, see the xref:../disconnected/connected-to-disconnected.adoc#converting-to-disconnected[Converting a connected cluster to a disconnected cluster] procedure in the Disconnected environments section.


### PR DESCRIPTION
[OSDOCS-11841](https://issues.redhat.com/browse/OSDOCS-11841)

Version(s): 4.17+

This PR migrates the content for converting a connected cluster to disconnected to a new section of the docs where disconnected content is to be consolidated

Link to docs preview:
https://81445--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/connected-to-disconnected.html
https://81445--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/converting-to-disconnected.html

QE review:
- [x] QE has approved this change.