### PR TITLE
[enterprise-4.12] OSDOCS#11823: Resolved merge conflict for cherry-picking to enterprise-4.12

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -139,6 +139,12 @@ etcd cannot tolerate any additional member failure when running with two members
 [source,terminal]
 ----
 $ oc delete node <node_name>
+---- 
++
+.Example command
+[source,terminal]
+----
+$ oc delete node ip-10-0-131-183.ec2.internal
 ----
 
 . Remove the old secrets for the unhealthy etcd member that was removed.


### PR DESCRIPTION
** Cherry Picked from commit id 9c59033ff45aa68f0f96d1ffd105a0ca1c1f88bb in [OSDOCS-11823](https://github.com/openshift/openshift-docs/pull/81065/commits).

Version(s):
4.12

Link to docs preview:


QE review:
- [ ] QE has approved this change.
n/a - this is a CP to enterprise 4.12
