### PR TITLE
[OSDOCS-11701]: Adding custom taints and tolerations docs to HCP

### DIFF
--- a/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc
@@ -23,3 +23,4 @@ Do not use the management cluster for your workload. Workloads must not run on n
 
 include::modules/hcp-labels-taints.adoc[leveloffset=+1]
 include::modules/hcp-priority-classes.adoc[leveloffset=+1]
+include::modules/hcp-virt-taints-tolerations.adoc[leveloffset=+1]

--- a/modules/hcp-virt-taints-tolerations.adoc
+++ b/modules/hcp-virt-taints-tolerations.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-virt-taints-tolerations_{context}"]
+= Custom taints and tolerations
+
+For {hcp} on {VirtProductName}, by default, pods for a hosted cluster tolerate the `control-plane` and `cluster` taints. However, you can also use custom taints on nodes so that hosted clusters can tolerate those taints on a per-hosted-cluster basis by setting `HostedCluster.spec.tolerations`.
+
+:FeatureName: Passing tolerations for a hosted cluster
+include::snippets/technology-preview.adoc[]
+
+.Example configuration
+[source,yaml]
+----
+  spec:
+    tolerations:
+    - effect: NoSchedule
+      key: kubernetes.io/custom
+      operator: Exists
+----
+
+You can also set tolerations on the hosted cluster while you create a cluster by using the `--tolerations` hcp CLI argument.
+
+.Example CLI argument
+[source,terminal]
+----
+--toleration="key=kubernetes.io/custom,operator=Exists,effect=NoSchedule"
+----
+
+For fine granular control of hosted cluster pod placement on a per-hosted-cluster basis, use custom tolerations with `nodeSelectors`. You can co-locate groups of hosted clusters and isolate them from other hosted clusters. You can also place hosted clusters in infra and control plane nodes.
+
+Tolerations on the hosted cluster spread only to the pods of the control plane. To configure other pods that run on the management cluster and infrastructure-related pods, such as the pods to run virtual machines, you need to use a different process.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17.z
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11701
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81450--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.html#hcp-virt-taints-tolerations_hcp-distribute-workloads
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
