### PR TITLE
Additional S3 endpoints for use with OADP

### DIFF
--- a/modules/oadp-about-backup-snapshot-locations-secrets.adoc
+++ b/modules/oadp-about-backup-snapshot-locations-secrets.adoc
@@ -16,7 +16,7 @@ You specify backup and snapshot locations and their secrets in the `DataProtecti
 [discrete]
 == Backup locations
 
-You specify AWS S3-compatible object storage as a backup location, such as Multicloud Object Gateway; Ceph RADOS Gateway, also known as Ceph Object Gateway;  or MinIO.
+You specify AWS S3-compatible object storage as a backup location, such as Multicloud Object Gateway; Red Hat Container Storage; Ceph RADOS Gateway, also known as Ceph Object Gateway; {odf-full}; or MinIO.
 
 Velero backs up {product-title} resources, Kubernetes objects, and internal images as an archive file on object storage.
 

--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -19,6 +19,8 @@ The following AWS S3 compatible object storage providers are fully supported by 
 * Amazon Web Services (AWS) S3
 * {ibm-cloud-name} Object Storage S3
 * Ceph RADOS Gateway (Ceph Object Gateway)
+* Red Hat Container Storage
+* {odf-full}
 
 [NOTE]
 ====


### PR DESCRIPTION
OADP 1.4.1, OCP 4.13+

Resolves https://issues.redhat.com/browse/OADP-2340 by adding additional S3 endpoints to those already listed in discussions of supported storage locations. 

Previews: 

- https://81462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-s3-compatible-backup-storage-providers-supported
- https://81462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-about-backup-snapshot-locations_installing-oadp-aws [repeated per platform]

Approved by OADP QA. 


