### PR TITLE
OBSDOCS-1296 Logging UI plugin

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3074,6 +3074,8 @@ Topics:
       File: distributed-tracing-ui-plugin
     - Name: Troubleshooting UI plugin
       File: troubleshooting-ui-plugin
+    - Name: Logging UI plugin
+      File: logging-ui-plugin
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/modules/coo-logging-ui-plugin-install.adoc
+++ b/modules/coo-logging-ui-plugin-install.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+
+// * observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coo-logging-ui-plugin-install_{context}"]
+= Installing the {coo-full} logging UI plugin
+
+.Prerequisites
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have logged in to the {product-title} web console.
+* You have installed the {coo-full}.
+* You have a `LokiStack` instance in you cluster.
+
+
+.Procedure
+. In the {product-title} web console, click *Operators* -> *Installed Operators* and select {coo-full}.
+. Choose the *UI Plugin* tab (at the far right of the tab list) and click *Create UIPlugin*.
+. Select *YAML view*, enter the following content, and then click *Create*:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: logging
+spec:
+  type: Logging
+  logging:
+    lokiStack:
+      name: logging-loki
+    logsLimit: 50
+    timeout: 30s
+----

--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -47,15 +47,14 @@ The following advisory is available for {coo-full} 0.4.0:
 * There is more visibility into Korrel8r queries, with the option of selecting the depth.
 * Users of {product-title} version 4.17+ can access the troubleshooting UI panel from the Application Launcher {launch}. Alternatively, on versions 4.16+, you can access it in the web console by clicking on **Observe** -> **Alerting**.   
 
-//
-// For more information, see xref :../../observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin.adoc#troubleshooting-ui-plugin[troubleshooting UI plugin]
+For more information, see xref:../../observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin.adoc#troubleshooting-ui-plugin[troubleshooting UI plugin].
 
 // COO-263
 ==== Distributed tracing UI plugin
 
 * The distributed tracing UI plugin has been enhanced, with a Gantt chart now available for exploring traces.
-//
-// For more information, see xref :../../observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc#distributed-tracing-ui-plugin[distributed tracing UI plugin]
+
+For more information, see xref:../../observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc#distributed-tracing-ui-plugin[distributed tracing UI plugin].
 
 [id="cluster-observability-operator-0-4-0-bug-fixes_{context}"]
 === Bug fixes

--- a/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
@@ -1,0 +1,36 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="logging-ui-plugin"]
+= Logging UI plugin
+include::_attributes/common-attributes.adoc[]
+:context: logging-ui-plugin
+
+toc::[]
+
+:FeatureName: The {coo-full}
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
+
+The logging UI plugin surfaces logging data in the {product-title} web console on the *Observe* -> *Logs* page. 
+You can specify filters, queries, time ranges and refresh rates, with the results displayed as a list of collapsed logs, which can then be expanded to show more detailed information for each log.
+
+When you have also deployed the Troubleshooting UI plugin on {product-title} version 4.16+, it connects to the Korrel8r service and adds direct links from the Administration perspective, from the **Observe** -> **Logs** page, to the **Observe** -> **Metrics** page with a correlated PromQL query. It also adds a **See Related Logs** link from the Administration perspective alerting detail page, at **Observe** -> **Alerting**,  to the **Observe** -> **Logs** page with a correlated filter set selected.
+
+The features of the plugin are categorized as:
+
+dev-console::	Adds the logging view to the Developer perspective.
+alerts::	Merges the web console alerts with log-based alerts defined in the Loki ruler. Adds a log-based metrics chart in the alert detail view.
+dev-alerts::	Merges the web console alerts with log-based alerts defined in the Loki ruler. Adds a log-based metrics chart in the alert detail view for the Developer perspective.
+
+
+For {coo-first} versions, the support for these features in {product-title} versions is shown in the following table:
+
+[cols="1,1,3", options="header"]
+|===
+| COO version   | OCP versions   | Features
+
+| 0.3.0+        | 4.12           | `dev-console`
+| 0.3.0+        | 4.13           | `dev-console`, `alerts`
+| 0.3.0+        | 4.14+          | `dev-console`, `alerts`, `dev-alerts`
+|===
+
+include::modules/coo-logging-ui-plugin-install.adoc[leveloffset=+1]

--- a/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.adoc
@@ -19,21 +19,28 @@ The dashboard UI plugin supports enhanced dashboards in the {product-title} web 
 You can add other Prometheus data sources from the cluster to the default dashboards, in addition to the in-cluster data source.
 This results in a unified observability experience across different data sources.
 
+For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/dashboard-ui-plugin.adoc#dashboard-ui-plugin[dashboard UI plugin] page.
+
 ["troubleshooting_{context}"]
 == Troubleshooting
 
-The troubleshooting panel UI plugin provides observability signal correlation, powered by the open source Korrel8r project.
+The troubleshooting panel UI plugin for {product-title} version 4.16+ provides observability signal correlation, powered by the open source Korrel8r project.
 You can use the troubleshooting panel available from the *Observe* -> *Alerting* page to easily correlate metrics, logs, alerts, netflows, and additional observability signals and resources, across different data stores.
 Users of {product-title} version 4.17+ can also access the troubleshooting UI panel from the Application Launcher {launch}.
 
 The output of Korrel8r is displayed as an interactive node graph. When you click on a node, you are automatically redirected to the corresponding web console page with the specific information for that node, for example, metric, log, or pod.
+
+For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin.adoc#troubleshooting-ui-plugin[troubleshooting UI plugin] page.
 
 ["distributed-tracing_{context}"]
 == Distributed tracing
 
 The distributed tracing UI plugin adds tracing-related features to the web console on the *Observe* -> *Traces* page.
 You can follow requests through the front end and into the backend of microservices, helping you identify code errors and performance bottlenecks in distributed systems.
-You can select a supported `TempoStack` multi-tenant instance running in the cluster and set a time range and query to view the trace data.
+You can select a supported `TempoStack` or `TempoMonolithic` multi-tenant instance running in the cluster and set a time range and query to view the trace data.
+
+For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc#distributed-tracing-ui-plugin[distributed tracing UI plugin] page.
+
 
 ["cluster-logging_{context}"]
 == Cluster logging
@@ -41,3 +48,4 @@ You can select a supported `TempoStack` multi-tenant instance running in the clu
 The logging UI plugin surfaces logging data in the web console on the  *Observe* -> *Logs* page. 
 You can specify filters, queries, time ranges and refresh rates. The results displayed a list of collapsed logs, which can then be expanded to show more detailed information for each log.
 
+For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[logging UI plugin] page.

--- a/observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin.adoc
@@ -9,8 +9,9 @@ toc::[]
 :FeatureName: The Cluster Observability Operator
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-The troubleshooting UI plugin provides observability signal correlation, powered by the open source Korrel8r project.
-With the troubleshooting panel that is available under *Observe* -> *Alerting*, you can easily correlate metrics, logs, alerts, netflows, and additional observability signals and resources, across different data stores. Users of {product-title} version 4.17+ can also access the troubleshooting UI panel from the Application Launcher {launch}.
+The troubleshooting UI plugin for {product-title} version 4.16+ provides observability signal correlation, powered by the open source Korrel8r project.
+With the troubleshooting panel that is available under *Observe* -> *Alerting*, you can easily correlate metrics, logs, alerts, netflows, and additional observability signals and resources, across different data stores. 
+Users of {product-title} version 4.17+ can also access the troubleshooting UI panel from the Application Launcher {launch}.
 
 When you install the troubleshooting UI plugin, a link:https://github.com/korrel8r/korrel8r[Korrel8r] service named `korrel8r` is deployed in the same namespace, and it is able to locate related observability signals and Kubernetes resources from its correlation engine.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-1296](https://issues.redhat.com//browse/OBSDOCS-1296)

Link to docs preview:
https://81464--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
