### PR TITLE
TELCODOCS#2011: Logan Beach NIC support for PTP

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-dual-nic.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-dual-nic.adoc
@@ -4,9 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-linuxptp-services-as-grandmaster-clock-dual-nic_{context}"]
-= Configuring linuxptp services as a grandmaster clock for dual E810 Westport Channel NICs
+= Configuring linuxptp services as a grandmaster clock for dual E810 NICs
 
-You can configure the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as grandmaster clock (T-GM) for dual E810 Westport Channel NICs by creating a `PtpConfig` custom resource (CR) that configures the host NICs.
+You can configure the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as a grandmaster clock (T-GM) for dual E810 NICs by creating a `PtpConfig` custom resource (CR) that configures the host NICs.
+
+You can configure the `linuxptp` services as a T-GM for the following dual E810 NICs:
+
+* Intel E810-XXVDA4T Westport Channel NICs
+* Intel E810-CQDA2T Logan Beach NICs
 
 For distributed RAN (D-RAN) use cases, you can configure PTP for dual-NICs as follows:
 
@@ -18,7 +23,7 @@ The host system clock is synchronized from the NIC that is connected to the GNSS
 
 [NOTE]
 ====
-Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as T-GM for dual Intel Westport Channel E810-XXVDA4T network interfaces.
+Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as T-GM for dual Intel E810 network interfaces.
 
 To configure PTP fast events, set appropriate values for `ptp4lOpts`, `ptp4lConf`, and `ptpClockThreshold`.
 `ptpClockThreshold` is used only when events are enabled.
@@ -27,7 +32,7 @@ See "Configuring the PTP fast event notifications publisher" for more informatio
 
 .Prerequisites
 
-* For T-GM clocks in production environments, install two Intel E810 Westport Channel NICs in the bare-metal cluster host.
+* For T-GM clocks in production environments, install two Intel E810 NICs in the bare-metal cluster host.
 
 * Install the OpenShift CLI (`oc`).
 
@@ -52,7 +57,7 @@ include::snippets/ptp_PtpConfigDualCardGmWpc.yaml[]
 +
 [NOTE]
 ====
-For E810 Westport Channel NICs, set the value for `ts2phc.nmea_serialport` to `/dev/gnss0`.
+Set the value for `ts2phc.nmea_serialport` to `/dev/gnss0`.
 ====
 
 .. Create the CR by running the following command:

--- a/modules/nw-ptp-dual-wpc-hardware-config-reference.adoc
+++ b/modules/nw-ptp-dual-wpc-hardware-config-reference.adoc
@@ -3,10 +3,10 @@
 // * networking/ptp/configuring-ptp.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="nw-ptp-dual-wpc-hardware-config-reference_{context}"]
-= Dual E810 Westport Channel NIC configuration reference
+[id="nw-ptp-dual-e810-hardware-config-reference_{context}"]
+= Dual E810 NIC configuration reference
 
-Use this information to understand how to use the link:https://github.com/openshift/linuxptp-daemon/blob/release-4.14/addons/intel/e810.go[Intel E810-XXVDA4T hardware plugin] to configure a pair of E810 network interfaces as PTP grandmaster clock (T-GM).
+Use this information to understand how to use the link:https://github.com/openshift/linuxptp-daemon/blob/release-4.14/addons/intel/e810.go[Intel E810 hardware plugin] to configure a pair of E810 network interfaces as PTP grandmaster clock (T-GM).
 
 Before you configure the dual-NIC cluster host, you must connect the two NICs with an SMA1 cable using the 1PPS faceplace connections.
 

--- a/modules/nw-ptp-e810-hardware-configuration-reference.adoc
+++ b/modules/nw-ptp-e810-hardware-configuration-reference.adoc
@@ -3,12 +3,12 @@
 // * networking/ptp/configuring-ptp.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="nw-ptp-wpc-hardware-pins-reference_{context}"]
-= Intel Westport Channel E810 hardware configuration reference
+[id="nw-ptp-e810-hardware-pins-reference_{context}"]
+= Intel E810 NIC hardware configuration reference
 
-Use this information to understand how to use the link:https://github.com/openshift/linuxptp-daemon/blob/release-4.17/addons/intel/e810.go[Intel E810-XXVDA4T hardware plugin] to configure the E810 network interface as PTP grandmaster clock.
+Use this information to understand how to use the link:https://github.com/openshift/linuxptp-daemon/blob/release-4.16/addons/intel/e810.go[Intel E810 hardware plugin] to configure the E810 network interface as PTP grandmaster clock.
 Hardware pin configuration determines how the network interface interacts with other components and devices in the system.
-The E810-XXVDA4T NIC has four connectors for external 1PPS signals: `SMA1`, `SMA2`, `U.FL1`, and `U.FL2`.
+The Intel E810 NIC has four connectors for external 1PPS signals: `SMA1`, `SMA2`, `U.FL1`, and `U.FL2`.
 
 .Intel E810 NIC hardware connectors configuration
 [width="90%", options="header"]

--- a/modules/nw-ptp-grandmaster-clock-configuration-reference.adoc
+++ b/modules/nw-ptp-grandmaster-clock-configuration-reference.adoc
@@ -18,7 +18,7 @@ The following reference information describes the configuration options for the 
 |Specify an array of `.exec.cmdline` options that configure the NIC for grandmaster clock operation. Grandmaster clock configuration requires certain PTP pins to be disabled.
 
 The plugin mechanism allows the PTP Operator to do automated hardware configuration.
-For the Intel Westport Channel NIC, when `enableDefaultConfig` is true, The PTP Operator runs a hard-coded script to do the required configuration for the NIC.
+For the Intel Westport Channel NIC or the Intel Logan Beach NIC, when the `enableDefaultConfig` field is set to `true`, the PTP Operator runs a hard-coded script to do the required configuration for the NIC.
 
 |`ptp4lOpts`
 |Specify system configuration options for the `ptp4l` service.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2011](https://issues.redhat.com/browse/TELCODOCS-2011)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Configuring linuxptp services as a grandmaster clock for dual E810 NICs](https://81467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp.html#configuring-linuxptp-services-as-grandmaster-clock-dual-nic_configuring-ptp)
- [PTP Operator](https://81467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.html#telco-ran-ptp-operator_ran-ref-design-components)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->