### PR TITLE
ROX-25866: document connectionPoolSize option for central.db

### DIFF
--- a/modules/central-configuration-options-operator.adoc
+++ b/modules/central-configuration-options-operator.adoc
@@ -114,6 +114,16 @@ If no PVC with the given name exists, it is created. The default value is `centr
 |`central.db.persistence.persistentVolumeClaim.storageClassName`
 | The name of the storage class to use for the PVC. If your cluster is not configured with a default storage class, you must provide a value for this parameter.
 
+|`central.db.connectionPoolSize.minConnections`
+| Use this parameter to override the default minimum connection pool size between Central and Central DB. The default value is 10.
+
+|`central.db.connectionPoolSize.maxConnections`
+a| Use this parameter to override the default maximum connection pool size between Central and Central DB. The default value is 90.
+Ensure that this value does not exceed the maximum number of connections supported by the Central DB:
+
+* An Operator-managed Central DB supports a maximum of 200 connections by default.
+* For external PostgreSQL databases, check the database settings or consult your cloud provider for managed databases.
+
 |`central.db.resources.limits`
 | Use this parameter to override the default resource limits for the Central DB.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.6+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/ROX-25866

Documents options introduced by this PR: https://github.com/stackrox/stackrox/pull/12607

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://81468--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp.html

QE review:
- [x] QE has approved this change. **ACS has no QE, approved by SME**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
