### PR TITLE
[enterprise-4.16+]: Fix typo in Kubernetes node ports range in network flow matrix

### DIFF
--- a/modules/network-flow-matrix.adoc
+++ b/modules/network-flow-matrix.adoc
@@ -16,7 +16,7 @@ To view or download the raw CSV content, see link:https://raw.githubusercontent.
 Additionally, consider the following dynamic port ranges when managing ingress traffic:
 
 * `9000-9999`: Host level services
-* `3000-32767`: Kubernetes node ports
+* `30000-32767`: Kubernetes node ports
 * `49152-65535`: Dynamic or private ports
 
 [NOTE]


### PR DESCRIPTION
Fix incorrect range.

https://docs.openshift.com/container-platform/4.16/networking/configuring-node-port-service-range.html
