### PR TITLE
TELCODOCS-1879 - Adding release note for PTP leap-seconds feature

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -438,6 +438,15 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-4-17-networking_{context}"]
 === Networking
 
+[id="ptp-automatic-leap-seconds-handling-for-ptp-clocks_{context}"]
+==== Automatic leap seconds handling for PTP grandmaster clocks
+
+The PTP Operator now automatically updates the leap second file by using Global Positioning System (GPS) announcements.
+
+Leap second information is stored in an automatically generated `ConfigMap` resource named `leap-configmap` in the `openshift-ptp` namespace.
+
+For more information, see xref:../networking/ptp/configuring-ptp.adoc#ptp-configuring-dynamic-leap-seconds-handling-for-tgm_configuring-ptp[Configuring dynamic leap seconds handling for PTP grandmaster clocks].
+
 [id="ocp-4-17-nw-sriov-day1-nics"]
 ==== NIC partitioning for SR-IOV devices (Generally Available)
 
@@ -957,11 +966,11 @@ BMER was deprecated in {product-title} version 4.15 and 4.16. With this release,
 [id="ocp-4-17-image-registry-bug-fixes_{context}"]
 ==== Image Registry
 
-* In {product-title} 4.14, installing a cluster with Azure AD Workload Identity was made generally available. With that feature, administrators can configure a Microsoft Azure cluster to use Azure AD Workload Identity. With Azure AD Workload Identity, cluster components use temporary security credentials that are managed outside of the cluster. 
+* In {product-title} 4.14, installing a cluster with Azure AD Workload Identity was made generally available. With that feature, administrators can configure a Microsoft Azure cluster to use Azure AD Workload Identity. With Azure AD Workload Identity, cluster components use temporary security credentials that are managed outside of the cluster.
 +
 Previously, when {product-title} was deployed on Azure clusters with Azure AD Workload Identity, storage accounts created for the cluster and the image registry had *Storage Account Key Access* enabled by default, which could pose security risks to the deployment.
 +
-With this update, shared access keys are disabled by default on new installations that use Azure AD Workload Identity, enhancing security by preventing the use of shared access keys. 
+With this update, shared access keys are disabled by default on new installations that use Azure AD Workload Identity, enhancing security by preventing the use of shared access keys.
 +
 [IMPORTANT]
 ====
@@ -1143,6 +1152,11 @@ In the following tables, features are marked with the following statuses:
 |Dual-NIC Intel E810 Westport Channel as PTP grandmaster clock
 |Technology Preview
 |General Availability
+|General Availability
+
+|Automatic leap seconds handling for PTP grandmaster clocks
+|Not Available
+|Not Available
 |General Availability
 
 |Configure the `br-ex` bridge needed by OVN-Kuberenetes using NMState


### PR DESCRIPTION
Adding 4.17 release note for PTP leap-seconds feature.

Version(s):
enterprise-4.17

Issue:
https://issues.redhat.com/browse/TELCODOCS-1879

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
