### PR TITLE
OBSDOCS-1284: Logging 5.9.6 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-9-6.adoc
+++ b/modules/logging-release-notes-5-9-6.adoc
@@ -1,0 +1,31 @@
+// module included in logging-5-9-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="cluster-logging-release-notes-5-9-6_{context}"]
+= Logging 5.9.6
+This release includes link:https://access.redhat.com/errata/RHBA-2024:6095[OpenShift Logging Bug Fix Release 5.9.6].
+
+[id="openshift-logging-5-9-6-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the collector deployment ignored secret changes, causing receivers to reject logs. With this update, the system rolls out a new pod when there is a change in the secret value, ensuring that the collector reloads the updated secrets. (link:https://issues.redhat.com/browse/LOG-5525[LOG-5525])
+
+* Before this update, the Vector could not correctly parse field values that included a single dollar sign (`$`). With this update, field values with a single dollar sign are automatically changed to two dollar signs (`$$`), ensuring proper parsing by the Vector. (link:https://issues.redhat.com/browse/LOG-5602[LOG-5602])
+
+* Before this update, the drop filter could not handle non-string values (e.g., `.responseStatus.code: 403`). With this update, the drop filter now works properly with these values. (link:https://issues.redhat.com/browse/LOG-5815[LOG-5815])
+
+* Before this update, the collector used the default settings to collect audit logs, without handling the backload from output receivers. With this update, the process for collecting audit logs has been improved to better manage file handling and log reading efficiency. (link:https://issues.redhat.com/browse/LOG-5866[LOG-5866])
+
+* Before this update, the `must-gather` tool failed on clusters with non-AMD64 architectures such as Azure Resource Manager (ARM) or PowerPC. With this update, the tool now detects the cluster architecture at runtime and uses architecture-independent paths and dependencies. The detection allows `must-gather` to run smoothly on platforms like ARM and PowerPC. (link:https://issues.redhat.com/browse/LOG-5997[LOG-5997])
+
+* Before this update, the log level was set using a mix of structured and unstructured keywords that were unclear. With this update, the log level follows a clear, documented order, starting with structured keywords. (link:https://issues.redhat.com/browse/LOG-6016[LOG-6016])
+
+* Before this update, multiple unnamed pipelines writing to the default output in the `ClusterLogForwarder` caused a validation error due to duplicate auto-generated names. With this update, the pipeline names are now generated without duplicates. (link:https://issues.redhat.com/browse/LOG-6033[LOG-6033])
+
+* Before this update, the collector pods did not have the `PreferredScheduling` annotation. With this update, the `PreferredScheduling` annotation is added to the collector daemonset. (link:https://issues.redhat.com/browse/LOG-6023[LOG-6023])
+
+[id="openshift-logging-5-9-6-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-0286[CVE-2024-0286]
+* link:https://access.redhat.com/security/cve/CVE-2024-2398[CVE-2024-2398]
+* link:https://access.redhat.com/security/cve/CVE-2024-37370[CVE-2024-37370]
+* link:https://access.redhat.com/security/cve/CVE-2024-37371[CVE-2024-37371]

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-9-6.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-9-5.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-9-4.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.9.6
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1284

Fix Version: 4.13, 4.14, 4.15, 4.16

Doc Preview: https://81473--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html#cluster-logging-release-notes-5-9-6_logging-5-9-release-notes

SME Review: @periklis 
QE Review: @kabirbhartiRH 
Peer Review: @ShaunaDiaz 