### PR TITLE
Change the image tag for openshift-migration-legacy operator

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -60,6 +60,7 @@ endif::[]
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
 :mtc-version-z: 1.8.4
+:mtc-legacy-image: 1.7
 // builds (Valid only in 4.11 and later)
 :builds-v2title: Builds for Red Hat OpenShift
 :builds-v2shortname: OpenShift Builds v2

--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -35,8 +35,7 @@ $ podman login registry.redhat.io
 +
 [source,terminal,subs="attributes+"]
 ----
-$ podman cp $(podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/operator.yml ./
+$ podman cp $(podman create registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-image}:/operator.yml ./
 ----
 
 . Replace the {mtc-full} Operator by entering the following command:
@@ -71,8 +70,7 @@ $ oc -o yaml -n openshift-migration get deployment/migration-operator | grep ima
 +
 [source,terminal,subs="attributes+"]
 ----
-$ podman cp $(podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/controller.yml ./
+$ podman cp $(podman create registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-image}):/operator.yml ./
 ----
 
 . Create the `migration-controller` object by entering the following command:


### PR DESCRIPTION
MTC 1.8.x; OCP 4.13+ 

Resolves https://issues.redhat.com/browse/MIG-1564 by changing the command in steps 2 and 7 of https://docs.redhat.com/en/documentation/openshift_container_platform/4.13/html/migrating_from_version_3_to_4/upgrading-3-4#migration-upgrading-mtc-with-legacy-operator_upgrading-3-4  .  After consulting with Dylan, it was decided to introduce a new attribute for the MTC legacy image, {mtc-legacy-image} -- whose value is currently 1.7, although the MTC version is 1.8. 

Previews:

a.  https://81481--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/upgrading-3-4.html#migration-upgrading-mtc-with-legacy-operator_upgrading-3-4 [procedure steps 2 and 7]
b.  https://81481--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/upgrading-mtc#migration-upgrading-mtc-with-legacy-operator_upgrading-mtc [procedure steps 2 and 7]

@dymurray Is the section in preview b, "Upgrading the Migration Toolkit for Containers on OpenShift Container Platform versions 4.2 to 4.5," which is in the regular MTC user guide,  still relevant? 


