### PR TITLE
OBSDOCS-1281: Logging 5.8.12 release notes

### DIFF
--- a/modules/logging-release-notes-5-8-12.adoc
+++ b/modules/logging-release-notes-5-8-12.adoc
@@ -1,0 +1,63 @@
+// module included in logging-5-8-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="cluster-logging-release-notes-5-8-12_{context}"]
+= Logging 5.8.12
+This release includes link:https://access.redhat.com/errata/RHBA-2024:6459[OpenShift Logging Bug Fix Release 5.8.12] and link:https://access.redhat.com/errata/RHBA-2024:6094[OpenShift Logging Bug Fix Release 5.8.12].
+
+[id="openshift-logging-5-8-12-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the collector used internal buffering with the `drop_newest` setting to reduce high memory usage, which caused significant log loss. With this update, the collector goes back to its default behavior, where `sink<>.buffer` is not customized. (link:https://issues.redhat.com/browse/LOG-6026[LOG-6026])
+
+[id="openshift-logging-5-8-12-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-52771[CVE-2023-52771]
+* link:https://access.redhat.com/security/cve/CVE-2023-52880[CVE-2023-52880]
+* link:https://access.redhat.com/security/cve/CVE-2024-2398[CVE-2024-2398]
+* link:https://access.redhat.com/security/cve/CVE-2024-6345[CVE-2024-6345]
+* link:https://access.redhat.com/security/cve/CVE-2024-6923[CVE-2024-6923]
+* link:https://access.redhat.com/security/cve/CVE-2024-26581[CVE-2024-26581]
+* link:https://access.redhat.com/security/cve/CVE-2024-26668[CVE-2024-26668]
+* link:https://access.redhat.com/security/cve/CVE-2024-26810[CVE-2024-26810]
+* link:https://access.redhat.com/security/cve/CVE-2024-26855[CVE-2024-26855]
+* link:https://access.redhat.com/security/cve/CVE-2024-26908[CVE-2024-26908]
+* link:https://access.redhat.com/security/cve/CVE-2024-26925[CVE-2024-26925]
+* link:https://access.redhat.com/security/cve/CVE-2024-27016[CVE-2024-27016]
+* link:https://access.redhat.com/security/cve/CVE-2024-27019[CVE-2024-27019]
+* link:https://access.redhat.com/security/cve/CVE-2024-27020[CVE-2024-27020]
+* link:https://access.redhat.com/security/cve/CVE-2024-27415[CVE-2024-27415]
+* link:https://access.redhat.com/security/cve/CVE-2024-35839[CVE-2024-35839]
+* link:https://access.redhat.com/security/cve/CVE-2024-35896[CVE-2024-35896]
+* link:https://access.redhat.com/security/cve/CVE-2024-35897[CVE-2024-35897]
+* link:https://access.redhat.com/security/cve/CVE-2024-35898[CVE-2024-35898]
+* link:https://access.redhat.com/security/cve/CVE-2024-35962[CVE-2024-35962]
+* link:https://access.redhat.com/security/cve/CVE-2024-36003[CVE-2024-36003]
+* link:https://access.redhat.com/security/cve/CVE-2024-36025[CVE-2024-36025]
+* link:https://access.redhat.com/security/cve/CVE-2024-37370[CVE-2024-37370]
+* link:https://access.redhat.com/security/cve/CVE-2024-37371[CVE-2024-37371]
+* link:https://access.redhat.com/security/cve/CVE-2024-37891[CVE-2024-37891]
+* link:https://access.redhat.com/security/cve/CVE-2024-38428[CVE-2024-38428]
+* link:https://access.redhat.com/security/cve/CVE-2024-38476[CVE-2024-38476]
+* link:https://access.redhat.com/security/cve/CVE-2024-38538[CVE-2024-38538]
+* link:https://access.redhat.com/security/cve/CVE-2024-38540[CVE-2024-38540]
+* link:https://access.redhat.com/security/cve/CVE-2024-38544[CVE-2024-38544]
+* link:https://access.redhat.com/security/cve/CVE-2024-38579[CVE-2024-38579]
+* link:https://access.redhat.com/security/cve/CVE-2024-38608[CVE-2024-38608]
+* link:https://access.redhat.com/security/cve/CVE-2024-39476[CVE-2024-39476]
+* link:https://access.redhat.com/security/cve/CVE-2024-40905[CVE-2024-40905]
+* link:https://access.redhat.com/security/cve/CVE-2024-40911[CVE-2024-40911]
+* link:https://access.redhat.com/security/cve/CVE-2024-40912[CVE-2024-40912]
+* link:https://access.redhat.com/security/cve/CVE-2024-40914[CVE-2024-40914]
+* link:https://access.redhat.com/security/cve/CVE-2024-40929[CVE-2024-40929]
+* link:https://access.redhat.com/security/cve/CVE-2024-40939[CVE-2024-40939]
+* link:https://access.redhat.com/security/cve/CVE-2024-40941[CVE-2024-40941]
+* link:https://access.redhat.com/security/cve/CVE-2024-40957[CVE-2024-40957]
+* link:https://access.redhat.com/security/cve/CVE-2024-40978[CVE-2024-40978]
+* link:https://access.redhat.com/security/cve/CVE-2024-40983[CVE-2024-40983]
+* link:https://access.redhat.com/security/cve/CVE-2024-41041[CVE-2024-41041]
+* link:https://access.redhat.com/security/cve/CVE-2024-41076[CVE-2024-41076]
+* link:https://access.redhat.com/security/cve/CVE-2024-41090[CVE-2024-41090]
+* link:https://access.redhat.com/security/cve/CVE-2024-41091[CVE-2024-41091]
+* link:https://access.redhat.com/security/cve/CVE-2024-42110[CVE-2024-42110]
+* link:https://access.redhat.com/security/cve/CVE-2024-42152[CVE-2024-42152]

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-12.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-11.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-10.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.8.12
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1281

Fix Version: 4.12, 4.13, 4.14, 4.15

Doc Preview: https://81482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html#cluster-logging-release-notes-5-8-12_logging-5-8-release-notes

SME Review: @periklis 
QE Review: @anpingli 
Peer Review: @ShaunaDiaz 