### PR TITLE
OCPBUGS-39229: Add reference IBU from ztp-site-generate

### DIFF
--- a/modules/ztp-image-based-upgrade-prep.adoc
+++ b/modules/ztp-image-based-upgrade-prep.adoc
@@ -7,6 +7,17 @@
 
 When you deploy the {lcao} on a cluster, an `ImageBasedUpgrade` CR is automatically created. You update this CR to specify the image repository of the seed image and to move through the different stages.
 
+.ImageBasedUpgrade CR in the ztp-site-generate container
+[source,yaml]
+----
+apiVersion: lca.openshift.io/v1
+kind: ImageBasedUpgrade
+metadata:
+  name: upgrade
+spec:
+  stage: Idle
+----
+
 .Prerequisites
 
 * Create policies and `ConfigMap` objects for resources used in the image-based upgrade. For more information, see "Creating ConfigMap objects for the image-based upgrade with {ztp}.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-39229
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81485--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/ztp-image-based-upgrade.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
