### PR TITLE
TELCODOCS-1862 - Adding release note for PTP events REST API v2

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -438,6 +438,22 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-4-17-networking_{context}"]
 === Networking
 
+[id="ocp-ptp-fast-events-rest-api-v2-available_{context}"]
+==== New PTP fast events REST API version 2 available
+
+A new PTP fast events O-RAN Release 3 compliant REST API version 2 is available.
+Now, you can develop PTP event consumer applications that receive host hardware PTP events directly from the PTP Operator-managed pod.
+The PTP fast events REST API v1 will be deprecated in a future release.
+
+[NOTE]
+====
+In link:https://orandownloadsweb.azurewebsites.net/download?id=344[O-RAN O-Cloud Notification API Specification for Event Consumers 3.0], the resource is defined as a hierarchical path for the subsystem that produces the notifications.
+The PTP events REST API v2 does not have a global subscription for all lower hierarchy resources contained in the resource path.
+You subscribe consumer applications to the various available event types separately.
+====
+
+For more information, see xref:../networking/ptp/ptp-cloud-events-consumer-dev-reference-v2.adoc#ptp-cloud-events-consumer-dev-reference-v2[Developing PTP event consumer applications with the REST API v2].
+
 [id="ptp-automatic-leap-seconds-handling-for-ptp-clocks_{context}"]
 ==== Automatic leap seconds handling for PTP grandmaster clocks
 
@@ -453,7 +469,6 @@ For more information, see xref:../networking/ptp/configuring-ptp.adoc#ptp-config
 With this update, the ability to enable NIC partitioning for Single Root I/O Virtualization (SR-IOV) devices at install time is Generally Available.
 
 For more information, see xref:../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal[NIC partitioning for SR-IOV devices].
-
 
 [id="ocp-4-17-nw-sriov-vfs-day2"]
 ==== Host network settings for SR-IOV VFs (Generally Available)
@@ -1155,6 +1170,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 
 |Automatic leap seconds handling for PTP grandmaster clocks
+|Not Available
+|Not Available
+|General Availability
+
+|PTP events REST API v2
 |Not Available
 |Not Available
 |General Availability


### PR DESCRIPTION
Adding release note for PTP events REST API v2

Version(s):
enterprise-4.17

Issue:
https://issues.redhat.com/browse/TELCODOCS-1862

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
