### PR TITLE
HCIDOCS-316: Add information about Metal3 database to bare-metal IPI troubleshooting

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -25,6 +25,8 @@ include::modules/bmo-about-the-baremetalhost-resource.adoc[leveloffset=+2]
 include::modules/bmo-getting-the-baremetalhost-resource.adoc[leveloffset=+2]
 // Editing a BareMetalHost resource
 include::modules/bmo-editing-a-baremetalhost-resource.adoc[leveloffset=+2]
+// Troubleshooting latency.
+include::modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc[leveloffset=+2]
 // Attaching a non-bootable ISO to a bare-metal node
 include::modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc[leveloffset=+2]
 // About the HostFirmwareSettings resource

--- a/modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc
+++ b/modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+// //installing/installing_bare_metal_ipi/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ipi-install-troubleshooothing-latency-when-deleting-a-baremetalhost-resource_{context}"]
+
+= Troubleshooting latency when deleting a BareMetalHost resource
+
+When the Bare Metal Operator (BMO) deletes a `BareMetalHost` resource, Ironic deprovisions the bare-metal host with a process called cleaning. When cleaning fails, Ironic retries the cleaning process three times, which is the source of the latency. The cleaning process might not succeed, causing the provisioning status of the bare-metal host to remain in the *deleting* state indefinitely. When this occurs, use the following procedure to disable the cleaning process.
+
+[WARNING]
+====
+Do not remove finalizers from the `BareMetalHost` resource.
+====
+
+.Procedure
+
+. If the cleaning process fails and restarts, wait for it to finish. This might take about 5 minutes.
+
+. If the provisioning status remains in the *deleting* state, disable the cleaning process by modifying the `BareMetalHost` resource and setting the `automatedCleaningMode` field to `disabled`.
+
+See "Editing a BareMetalHost resource" for additional details.


### PR DESCRIPTION
Added BMO troubleshooting module for latency on deletion. This PR replaces https://github.com/openshift/openshift-docs/pull/80775, which was QE reviewed. Entire BMO section was moved to IPI post installation configuration. 

Fixes: [HCIDOCS-316](https://issues.redhat.com//browse/HCIDOCS-316)

See https://issues.redhat.com/browse/HCIDOCS-316 for additional details.

Preview URL: https://81501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html#ipi-install-troubleshooothing-latency-when-deleting-a-baremetalhost-resource_ipi-install-post-installation-configuration

For release(s): 4.16-4.17
QE Review: 

- [x] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
