### PR TITLE
OSDOCS-11900 OCP Release Notes 4.16.11

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3355,6 +3355,44 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+[id="ocp-4-16-11_{context}"]
+=== RHBA-2024:6401 - {product-title} {product-version}.11 bug fix update
+
+Issued: 11 September 2024
+
+{product-title} release {product-version}.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:6401[RHBA-2024:6401] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:6404[RHBA-2024:6404] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.11 --pullspecs
+----
+
+[id="ocp-4-16-11-known-issues_{context}"]
+==== Known issues
+
+* {product-rosa} hosted control planes (HCP) and {product-title} clusters fail to add new nodes in MachinePool versions older than 4.15.23. As a result, some updates are blocked. To see what clusters are affected and the recommended workaround, see (link:https://access.redhat.com/articles/7085666[ROSA upgrade issue mitigation for HOSTEDCP-1941 ]). (link:https://issues.redhat.com/browse/OCPBUGS-39447[*OCPBUGS-39447*])
+
+[id="ocp-4-16-11-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the `noProxy` field from the cluster-wide Proxy wasn't taken into account while configuring proxying for the Platform Prometheus remote write endpoints. With this release, Cluster Monitoring Operator (CMO) no longer configures proxying for any remote write endpoint whose URL should bypass proxy according to `noProxy`. (link:https://issues.redhat.com/browse/OCPBUGS-39170[*OCPBUGS-39170*])
+
+* Previously, Red{nbsp}Hat HyperShift periodic conformance jobs failed because of changes to the core operating system. These failed jobs caused the OpenShift API deployment to fail. With this release, an update recursively copies individual trusted certificate authority (CA) certificates instead of copying a single file, so that the periodic conformance jobs succeed and the OpenShift API runs as expected. (link:https://issues.redhat.com/browse/OCPBUGS-38942[*OCPBUGS-38942*])
+
+* Previously, For egress IP, if an IP is assigned to an egress node and it is deleted, then pods selected by that `egressIP` might have incorrect routing information to that egress node. With this release, the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-38705[*OCPBUGS-38705*])
+
+* Previously, the installation program failed to install an {product-title} cluster in the `eu-es` (Madrid, Spain) region on a {ibm-power-server-title} platform that is configured as an `e980` system type. With this release, the installation program no longer fails to install a cluster in this environment. (link:https://issues.redhat.com/browse/OCPBUGS-38502[*OCPBUGS-38502*])
+
+[id="ocp-4-16-11-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.16.10
 [id="ocp-4-16-10_{context}"]
 === RHSA-2024:6004 - {product-title} {product-version}.10 bug fix update
@@ -3416,7 +3454,7 @@ $ oc adm release info 4.16.9 --pullspecs
 [id="ocp-4-16-9-enhancements_{context}"]
 ==== Enhancements
 
-* The Insights Operator (IO) can now collect data from the `haproxy_exporter_server_threshold` metric. 
+* The Insights Operator (IO) can now collect data from the `haproxy_exporter_server_threshold` metric.
 (link:https://issues.redhat.com/browse/OCPBUGS-38230[*OCPBUGS-38230*])
 
 [id="ocp-4-16-9-updating_{context}"]
@@ -3491,9 +3529,9 @@ $ oc adm release info 4.16.7 --pullspecs
 
 * Previously, extracting the IP address from the Cluster API Machine object only returned a single address. On {vmw-first}, the returned address would always be an IPv6 address and this caused issues with the `must-gather` implementation if the address was non-routable. With this release, the Cluster API Machine object returns all IP addresses, including IPv4, so that the `must-gather` issue no longer occurs on {vmw-full}. (link:https://issues.redhat.com/browse/OCPBUGS-37607[*OCPBUGS-37607*])
 
-* Previously, the installation program incorrectly required {aws-first} permissions for creating Identity and Access Management (IAM) roles for an {product-title} cluster that already had these roles. With this release, the installation program only requests permissions for roles not yet created. (link:https://issues.redhat.com/browse/OCPBUGS-37494[*OCPBUGS-37494*]) 
+* Previously, the installation program incorrectly required {aws-first} permissions for creating Identity and Access Management (IAM) roles for an {product-title} cluster that already had these roles. With this release, the installation program only requests permissions for roles not yet created. (link:https://issues.redhat.com/browse/OCPBUGS-37494[*OCPBUGS-37494*])
 
-* Previously, when you attempted to install a cluster on {rh-openstack-first} and you used special characters, such as the hash sign (`#`) in a cluster name, the Neutron API failed to tag a security group with the name of the cluster. This caused the installation of the cluster to fail. With this release, the installation program uses an alternative endpoint to tag security groups and this endpoint supports the use of special characters in tag names. (link:https://issues.redhat.com/browse/OCPBUGS-37492[*OCPBUGS-37492*])  
+* Previously, when you attempted to install a cluster on {rh-openstack-first} and you used special characters, such as the hash sign (`#`) in a cluster name, the Neutron API failed to tag a security group with the name of the cluster. This caused the installation of the cluster to fail. With this release, the installation program uses an alternative endpoint to tag security groups and this endpoint supports the use of special characters in tag names. (link:https://issues.redhat.com/browse/OCPBUGS-37492[*OCPBUGS-37492*])
 
 * Previously, the Dell iDRAC baseboard management controller (BMC) with the Redfish protocol caused clusters to fail on the Dell iDRAC servers. With this release, an update to the `idrac-redfish` management interface to unset the `ipxe` parameter fixed this issue. (link:https://issues.redhat.com/browse/OCPBUGS-37262[*OCPBUGS-37262*])
 
@@ -3502,7 +3540,7 @@ $ oc adm release info 4.16.7 --pullspecs
 * Previously, the DNS-based egress firewall incorrectly caused memory increases for nodes running in a cluster because of multiple retry operations. With this release, the retry logic is fixed so that DNS pods no longer leak excess memory to nodes. (link:https://issues.redhat.com/browse/OCPBUGS-37078[*OCPBUGS-37078*])
 
 ////
-* Need to confirm with MCO team is OCPBUGS-37485 is a known issue or bug fix. 
+* Need to confirm with MCO team is OCPBUGS-37485 is a known issue or bug fix.
 * OCPBUGS-37065 is internal and won't be documented. Confirmed with SME to drop the Jira
 * OCPBUGS-36937 is internal and won't be documented. Reporter is on PTO but Confirmed with assignee SME to drop it.
 * OCPBUGS-37621 is not something a customer needs to know. Confirmed with SME to drop the Jira.


### PR DESCRIPTION

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11900](https://issues.redhat.com/browse/OSDOCS-11900)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links will not work until September 10th.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
