### PR TITLE
OCPBUGS#38801: Update instructions for deleting a node

### DIFF
--- a/modules/ztp-deleting-node-using-siteconfig.adoc
+++ b/modules/ztp-deleting-node-using-siteconfig.adoc
@@ -6,7 +6,7 @@
 [id="ztp-deleting-node-siteconfig_{context}"]
 = Deleting a node by using the SiteConfig CR
 
-By using a `SiteConfig` custom resource (CR), you can delete and reprovision a node. 
+By using a `SiteConfig` custom resource (CR), you can delete and reprovision a node.
 This method is more efficient than manually deleting the node.
 
 .Prerequisites
@@ -18,7 +18,7 @@ This method is more efficient than manually deleting the node.
 
 .Procedure
 
-. Update the  `SiteConfig` CR to include the `bmac.agent-install.openshift.io/remove-agent-and-node-on-delete=true` annotation:
+. Update the `SiteConfig` CR to include the `bmac.agent-install.openshift.io/remove-agent-and-node-on-delete=true` annotation and push the changes to the Git repository:
 +
 [source,yaml]
 ----
@@ -28,7 +28,7 @@ metadata:
   name: "cnfdf20"
   namespace: "cnfdf20"
 spec:
-  Clusters:    
+  clusters:
     nodes:
     - hostname: node6
       role: "worker"
@@ -37,6 +37,19 @@ spec:
           BareMetalHost:
             bmac.agent-install.openshift.io/remove-agent-and-node-on-delete: true
 # ...
+----
+
+. Verify that the `BareMetalHost` object is annotated by running the following command:
++
+[source,yaml]
+----
+oc get bmh -n <managed-cluster-namespace> <bmh-object> -ojsonpath='{.metadata}' | jq -r '.annotations["bmac.agent-install.openshift.io/remove-agent-and-node-on-delete"]'
+----
++
+.Example output
+[source,terminal]
+----
+true
 ----
 
 . Suppress the generation of the `BareMetalHost` CR by updating the `SiteConfig` CR to include the `crSuppression.BareMetalHost` annotation:
@@ -58,7 +71,7 @@ spec:
 # ...
 ----
 
-. Push the changes to the Git repository and wait for deprovisioning to start. 
+. Push the changes to the Git repository and wait for deprovisioning to start.
 The status of the `BareMetalHost` CR should change to `deprovisioning`. Wait for the `BareMetalHost` to finish deprovisioning, and be fully deleted.
 
 .Verification
@@ -84,11 +97,11 @@ $ oc get nodes
 +
 [NOTE]
 ====
-If you are working with secrets, deleting a secret too early can cause an issue because ArgoCD needs the secret to complete resynchronization after deletion. 
+If you are working with secrets, deleting a secret too early can cause an issue because ArgoCD needs the secret to complete resynchronization after deletion.
 Delete the secret only after the node cleanup, when the current ArgoCD synchronization is complete.
 ====
 
 .Next Steps
 
-To reprovision a node, delete the changes previously added to the `SiteConfig`, push the changes to the Git repository, and wait for the synchronization to complete. 
+To reprovision a node, delete the changes previously added to the `SiteConfig`, push the changes to the Git repository, and wait for the synchronization to complete.
 This regenerates the `BareMetalHost` CR of the worker node and triggers the re-install of the node.


### PR DESCRIPTION
OCPBUGS#3880: Update instructions for deleting a node to explicitly specify that after adding the `bmac.agent-install.openshift.io/remove-agent-and-node-on-delete=true` annotation, user must push changes to git repository and verify that the annotation has been applied too.

Version(s):
4.14 +

Issue:
https://issues.redhat.com/browse/OCPBUGS-38801

Link to docs preview:
https://81511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-advanced-install-ztp.html#ztp-deleting-node-siteconfig_ztp-advanced-install-ztp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

