### PR TITLE
OSDOCS-11899: 4.14.36 RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3340,6 +3340,68 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.36
+[id="ocp-4-14-36_{context}"]
+=== RHSA-2024:6406 - {product-title} 4.14.36 bug fix and security update
+
+Issued: 11 September 2024
+
+{product-title} release 4.14.36, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6406[RHSA-2024:6406] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6412[RHSA-2024:6412] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.36 --pullspecs
+----
+
+[id="ocp-4-14-36-enhancements"]
+==== Enhancements
+
+The following enhancements are included in this z-stream release:
+
+[id="ocp-4-16-36-enhancements-_{context}"]
+===== Updating the CENTOS 8 references to CENTOS 9
+
+* CENTOS 8 has recently ended its lifecycle. This release updates the CENTOS 8 references to CENTOS 9.
+(link:https://issues.redhat.com/browse/OCPBUGS-39160[*OCPBUGS-39160*])
+
+[id="ocp-4-14-36-enhancements-collecting-ingress-controller-certificates_{context}"]
+===== Collecting Ingress Controller certificates
+
+* The Insights Operator now collects information about all Ingress Controller certificates (NotBefore and NotAfter dates). It aggregates the data into a JSON file in the path 'aggregated/ingress_controllers_certs.json'. (link:https://issues.redhat.com/browse/OCPBUGS-37673[*OCPBUGS-37673*])
+
+[id="ptp-automatic-leap-seconds-handling-for-ptp-clocks_{context}"]
+==== Automatic leap seconds handling for PTP grandmaster clocks
+
+The PTP Operator now automatically updates the leap second file by using Global Positioning System (GPS) announcements.
+
+Leap second information is stored in an automatically generated `ConfigMap` resource named `leap-configmap` in the `openshift-ptp` namespace.
+
+For more information, see xref:../networking/ptp/configuring-ptp.adoc#ptp-configuring-dynamic-leap-seconds-handling-for-tgm_configuring-ptp[Configuring dynamic leap seconds handling for PTP grandmaster clocks].
+
+[id="ocp-4-14-36-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, if a virtual machine (VM) was deleted and the network interface controller (NIC) still existed for that VM, the {azure-first} VM verification check crashed. With this release, the verification check gracefully processes the issue without crashing. (link:https://issues.redhat.com/browse/OCPBUGS-39413[*OCPBUGS-39413*])
+
+* Previously, the `spec.noProxy` field from the cluster-wide proxy was not considered when the {cmo-first} configured proxy capabilities for a Prometheus remote write endpoint. With this release, the {cmo-short} no longer configures proxy capabilities for any remote-write endpoints that have an URL that bypasses the proxy according to the `noProxy` field. (link:https://issues.redhat.com/browse/OCPBUGS-39176[*OCPBUGS-39176*])
+
+* Previously, when running `oc logs -f <pod>`, the logs would not output anything after the log file was rotated. With this release, kubelet outputs a log file after the file is rotated and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-38959[*OCPBUGS-38959*])
+
+* Previously, the {product-title} web console failed to restart a bare-metal node. This release fixes this issue so that you can restart a bare metal node by using the {product-title} web console. (link:https://issues.redhat.com/browse/OCPBUGS-38053[*OCPBUGS-38053*])
+
+* Previously, when the Cloud Credential Operator (CCO) checked if passthrough mode permissions were correct, the CCO sometimes received a response from the {gcp-first} API about an invalid permission for a project. This bug caused the CCO to enter a degraded state that, in turn, impacted the installation of the cluster. With this release, the CCO checks specifically for this error so that it diagnoses it separately without impacting the installation of the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-37823[*OCPBUGS-37823*])
+
+* Previously, the TuneD profile could unnecessarily reload an additional time after a custom resource (CR) update. With this release, the TuneD object has been removed and the TuneD profiles are carried directly in the TuneD profile Kubernetes objects. As a result, the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-37754[*OCPBUGS-37754*])
+
+[id="ocp-4-14-36-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-14-35_{context}"]
 === RHSA-2024:5433 - {product-title} 4.14.35 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-11899](https://issues.redhat.com/browse/OSDOCS-11899)

Link to docs preview:
https://81516--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-36_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (9/11)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
