### PR TITLE
OSDOCS-11955: Modules not publishing to docs.redhat

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -212,7 +212,6 @@ Topics:
     File: cloud-experts-deploying-application-s2i-deployments
   - Name: Using Source-to-Image (S2I) webhooks for automated deployment
     File: cloud-experts-deploying-s2i-webhook-cicd
-
   - Name: Integrating with AWS
     File: cloud-experts-deploying-application-integrating-aws
 ---

--- a/cloud_experts_tutorials/cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing.adoc
@@ -121,8 +121,6 @@ image::rosa-aws-and-red-hat-accounts-connection.png[]
 . If you want to link the AWS account with another Red{nbsp}Hat account than is shown on this page in Figure 9, log out from the {hybrid-console} before connecting the accounts and repeat the step of setting the account by returning to the private offer URL that is already accepted.
 +
 An AWS account can be connected with a single Red{nbsp}Hat account only. Once Red{nbsp}Hat and AWS accounts are connected, this cannot be changed by the user. If a change is needed, the user must create a support ticket.
-+
-The account linking and initial cluster deployment steps are described in more detail in xref:../cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc#aws-and-redhat-account-and-subscription-linking[AWS and Red{nbsp}Hat account and subscription linking].
 
 . Agree to the terms and conditions and then click *Connect accounts*.
 


### PR DESCRIPTION
[OSDOCS-11955](https://issues.redhat.com//browse/OSDOCS-11955): Modules not publishing to docs.redhat

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-11955

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
