### PR TITLE
[OKD] Update mirror image repository to use SCOS instead of FCOS

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -32,9 +32,16 @@ endif::[]
 
 Complete the following steps on the mirror host:
 
+ifndef::openshift-origin[]
 . Review the
 link:https://access.redhat.com/downloads/content/290/[{product-title} downloads page]
 to determine the version of {product-title} that you want to install and determine the corresponding tag on the link:https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags[Repository Tags] page.
+endif::[]
+ifdef::openshift-origin[]
+. Review the
+link:https://origin-release.ci.openshift.org[https://origin-release.ci.openshift.org]
+to determine the version of {product-title} that you want to install and determine the corresponding tag.
+endif::[]
 
 . Set the required environment variables:
 .. Export the release version:
@@ -81,7 +88,7 @@ endif::[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ PRODUCT_REPO='openshift'
+$ PRODUCT_REPO='okd'
 ----
 endif::[]
 
@@ -107,7 +114,7 @@ endif::[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ RELEASE_NAME="okd"
+$ RELEASE_NAME="scos-release"
 ----
 endif::[]
 

--- a/modules/ipi-install-mirroring-for-disconnected-registry.adoc
+++ b/modules/ipi-install-mirroring-for-disconnected-registry.adoc
@@ -23,9 +23,16 @@ endif::[]
 
 .Procedure
 
+ifndef::openshift-origin[]
 . Review the
 link:https://access.redhat.com/downloads/content/290/[{product-title} downloads page]
 to determine the version of {product-title} that you want to install and determine the corresponding tag on the link:https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags[Repository Tags] page.
+endif::[]
+ifdef::openshift-origin[]
+. Review the
+link:https://origin-release.ci.openshift.org[https://origin-release.ci.openshift.org]
+to determine the version of {product-title} that you want to install and determine the corresponding tag.
+endif::[]
 
 . Set the required environment variables:
 .. Export the release version:
@@ -72,7 +79,7 @@ endif::[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ PRODUCT_REPO='openshift'
+$ PRODUCT_REPO='okd'
 ----
 endif::[]
 
@@ -98,7 +105,7 @@ endif::[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ RELEASE_NAME="okd"
+$ RELEASE_NAME="scos-release"
 ----
 endif::[]
 


### PR DESCRIPTION
Fixes #81519.

Applies to OKD versions 4.16 and later
