### PR TITLE
HCIDOCS-419: BareMetalHost with self-signed CA certs for BMCs

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -14,7 +14,6 @@ See the following tables for the required parameters, the `hosts` parameter, and
 |===
 |Parameters |Default |Description
 
-
 | `baseDomain`
 |
 | The domain name for the cluster. For example, `example.com`.
@@ -30,7 +29,7 @@ platform:
     bootstrapExternalStaticDNS
 ----
 |
-| The static network DNS of the bootstrap node. You must set this value when deploying a cluster with static IP addresses when there is no Dynamic Host Configuration Protocol (DHCP) server on the bare-metal network. If you do not set this value, the installation program will use the value from `bootstrapExternalStaticGateway`, which causes problems when the IP address values of the gateway and DNS are different.
+| The static network DNS of the bootstrap node. You must set this value when deploying a cluster with static IP addresses when there is no Dynamic Host Configuration Protocol (DHCP) server on the bare metal network. If you do not set this value, the installation program will use the value from `bootstrapExternalStaticGateway`, which causes problems when the IP address values of the gateway and DNS are different.
 
 a| 
 ----
@@ -39,7 +38,7 @@ platform:
     bootstrapExternalStaticIP
 ----
 |
-| The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
+| The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare metal network.
 
 a| 
 ----
@@ -48,16 +47,15 @@ platform:
     bootstrapExternalStaticGateway
 ----
 |
-| The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
+| The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare metal network.
 
 | `sshKey`
 |
-| The `sshKey` configuration setting has the key in the `~/.ssh/id_rsa.pub` file required to access the control plane nodes and compute nodes. Typically, this key is from the `provisioner` node.
+| The `sshKey` parameter sets the key in the `~/.ssh/id_rsa.pub` file required to access the control plane nodes and compute nodes. Typically, this key is from the `provisioner` node.
 
 | `pullSecret`
 |
-| The `pullSecret` configuration setting has a copy of the pull secret downloaded from the link:https://console.redhat.com/openshift/install/metal/user-provisioned[Install OpenShift on Bare Metal] page when preparing the provisioner node.
-
+| The `pullSecret` parameter sets a copy of the pull secret downloaded from the link:https://console.redhat.com/openshift/install/metal/user-provisioned[Install OpenShift on Bare Metal] page when preparing the provisioner node.
 
 a|
 ----
@@ -65,8 +63,7 @@ metadata:
     name:
 ----
 |
-|The name of the {product-title} cluster. For example, `openshift`.
-
+|The {product-title} cluster name. For example, `openshift`.
 
 a|
 ----
@@ -83,8 +80,7 @@ compute:
   - name: worker
 ----
 |
-|The {product-title} cluster requires you to provide a name for compute nodes even if there are zero nodes.
-
+|The {product-title} cluster requires a name for each compute node even if there are zero nodes.
 
 a|
 ----
@@ -94,7 +90,6 @@ compute:
 |
 |Replicas sets the number of compute nodes in the {product-title} cluster.
 
-
 a|
 ----
 controlPlane:
@@ -102,7 +97,6 @@ controlPlane:
 ----
 |
 |The {product-title} cluster requires a name for control plane nodes.
-
 
 a|
 ----
@@ -112,47 +106,28 @@ controlPlane:
 |
 |Replicas sets the number of control plane nodes included as part of the {product-title} cluster.
 
-a|
-----
-arbiter:
-    name: arbiter
-----
-|
-|The {product-title} cluster requires a name for arbiter nodes.
-
-
-a|
-----
-arbiter:
-    replicas: 1
-----
-|
-|The `replicas` parameter sets the number of arbiter nodes for the {product-title} cluster.
-
-a| `provisioningNetworkInterface` |  | The name of the network interface on nodes connected to the provisioning network. For {product-title} 4.9 and later releases, use the `bootMACAddress` configuration setting to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` configuration setting to identify the name of the NIC.
-
+a| `provisioningNetworkInterface` |  | The name of the network interface on nodes connected to the provisioning network. For {product-title} 4.9 and later releases, use the `bootMACAddress` parameter to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` parameter to identify the name of the NIC.
 
 | `defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration.
 
 | `apiVIPs` | a| (Optional) The virtual IP address for Kubernetes API communication.
 
-You must either provide this setting in the `install-config.yaml` file as a reserved IP from the `MachineNetwork` parameter or preconfigured in the DNS so that the default name resolves correctly. Use the virtual IP address and not the FQDN when adding a value to the `apiVIPs` configuration setting in the `install-config.yaml` file. The primary IP address must be from the IPv4 network when using dual stack networking. If not set, the installation program uses `api.<cluster_name>.<base_domain>` to derive the IP address from the DNS.
+You must use this setting in the `install-config.yaml` file to set a reserved IP address from the IP address block specified in the `machineNetwork` parameter or preconfigure the reserved IP address in the DNS so that the default name resolves correctly. Use the virtual IP address and not the FQDN when adding a value to the `apiVIPs` parameter in the `install-config.yaml` file. The primary IP address must be from the IPv4 network when using dual stack networking. If not set, the installation program uses `api.<cluster_name>.<base_domain>` to derive the IP address from the DNS.
 
 [NOTE]
 ====
-Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or an IPv6 address for the `apiVIP` configuration setting. From {product-title} 4.12 or later, the `apiVIP` configuration setting is deprecated. Instead, use a list format for the `apiVIPs` configuration setting to specify an IPv4 address, an IPv6 address or both IP address formats.
+Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or an IPv6 address for the `apiVIP` parameter. From {product-title} 4.12 or later, the `apiVIP` parameter is deprecated. Instead, use a list format for the `apiVIPs` parameter to specify an IPv4 address, an IPv6 address or both IP address formats.
 ====
 
-
-| `disableCertificateVerification` | `False` | `redfish` and `redfish-virtualmedia` need this parameter to manage BMC addresses. The value should be `True` when using a self-signed certificate for BMC addresses.
+| `bmcCACert` | | `redfish` and `redfish-virtualmedia` need this parameter to manage BMC addresses when using self-signed certificates with `disableCertificateVerification` set to `False`.
 
 | `ingressVIPs` | a| (Optional) The virtual IP address for ingress traffic.
 
-You must either provide this setting in the `install-config.yaml` file as a reserved IP from the `MachineNetwork` parameter or preconfigured in the DNS so that the default name resolves correctly. Use the virtual IP address and not the FQDN when adding a value to the `ingressVIPs` configuration setting in the `install-config.yaml` file. The primary IP address must be from the IPv4 network when using dual stack networking. If not set, the installation program uses `test.apps.<cluster_name>.<base_domain>` to derive the IP address from the DNS.
+You must use this setting in the `install-config.yaml` file to set a reserved IP address from the IP address block specified in the `machineNetwork` parameter or preconfigure the reserved IP address in the DNS so that the default name resolves correctly. Use the virtual IP address and not the FQDN when adding a value to the `ingressVIPs` parameter in the `install-config.yaml` file. The primary IP address must be from the IPv4 network when using dual stack networking. If not set, the installation program uses `test.apps.<cluster_name>.<base_domain>` to derive the IP address from the DNS.
 
 [NOTE]
 ====
-Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or an IPv6 address for the `ingressVIP` configuration setting. In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a list format for the `ingressVIPs` configuration setting to specify an IPv4 addresses, an IPv6 addresses or both IP address formats.
+Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or an IPv6 address for the `ingressVIP` parameter. In {product-title} 4.12 and later, the `ingressVIP` parameter is deprecated. Instead, use a list format for the `ingressVIPs` parameter to specify an IPv4 addresses, an IPv6 addresses or both IP address formats.
 ====
 
 |===
@@ -181,7 +156,7 @@ platform:
 
 a|`provisioningNetworkCIDR`
 |`172.22.0.0/24`
-|The CIDR for the network to use for provisioning. The installation program requires this option when not using the default address range on the provisioning network.
+|The CIDR for the network to use for provisioning. When not using the default address range on the provisioning network, you must set this configuration parameter.
 
 |`clusterProvisioningIP`
 |The third IP address of the `provisioningNetworkCIDR`.
@@ -189,11 +164,11 @@ a|`provisioningNetworkCIDR`
 
 |`bootstrapProvisioningIP`
 |The second IP address of the `provisioningNetworkCIDR`.
-|The IP address on the bootstrap VM where the provisioning services run while the installation program is deploying the control plane (master) nodes. Defaults to the second IP address of the provisioning subnet. For example, `172.22.0.2` or `2620:52:0:1307::2`.
+|The IP address on the bootstrap VM where the provisioning services run while the installation program is deploying the control plane nodes. Defaults to the second IP address of the provisioning subnet. For example, `172.22.0.2` or `2620:52:0:1307::2`.
 
 | `externalBridge`
 | `baremetal`
-| The name of the bare-metal bridge of the hypervisor attached to the bare-metal network.
+| The name of the bare metal bridge of the hypervisor attached to the bare metal network.
 
 | `provisioningBridge`
 | `provisioning`
@@ -214,9 +189,9 @@ a|`provisioningNetworkCIDR`
 
 | `provisioningNetwork`
 |
-| The `provisioningNetwork` configuration setting determines whether the cluster uses the provisioning network. If it does, the configuration setting also determines if the cluster manages the network.
+| The `provisioningNetwork` parameter determines whether the cluster uses the provisioning network. If it does, the parameter also determines if the cluster manages the network.
 
-`Disabled`: Set this parameter to `Disabled` to disable the requirement for a provisioning network. When set to `Disabled`, you must only use virtual media based provisioning, or start the cluster by using the {ai-full}. If set to `Disabled` and using power management, BMCs must be accessible from the bare-metal network. If set to `Disabled`, you must provide two IP addresses on the bare-metal network that the installation program uses for the provisioning services.
+`Disabled`: Set this parameter to `Disabled` to disable the requirement for a provisioning network. When set to `Disabled`, you must only use virtual media based provisioning, or install the cluster by using the Assisted Installer. If `Disabled` and using power management, BMCs must be accessible from the bare metal network. If `Disabled`, you must provide two IP addresses on the bare metal network for the provisioning services to use.
 
 `Managed`: Set this parameter to `Managed`, which is the default, to fully manage the provisioning network, including DHCP, TFTP, and so on.
 
@@ -241,14 +216,13 @@ a|`provisioningNetworkCIDR`
 
 The `hosts` parameter is a list of separate bare metal assets used to build the cluster.
 
-[width="100%", cols="3,2,5",  options="header"]
+[width="100%", cols="4,1,4",  options="header"]
 .Hosts
 |===
 |Name |Default |Description
 | `name`
 |
 | The name of the `BareMetalHost` resource to associate with the details. For example, `openshift-master-0`.
-
 
 | `role`
 |
@@ -260,9 +234,43 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 | Connection details for the baseboard management controller. See the BMC addressing section for additional details.
 
 
+a|
+----
+bmc:
+    address:
+----
+|
+| The protocol and address of the BMC as a URL.
+
+a|
+----
+bmc:
+    username:
+----
+|
+| The username of the BMC.
+
+a|
+----
+bmc:
+    password:
+----
+|
+| The password of the BMC.
+
+
+a| 
+----
+bmc:
+    disableCertificateVerification:
+----
+| `False` 
+| `redfish` and `redfish-virtualmedia` need this parameter to manage BMC addresses. For {product-title} 4.16 and earlier, the value should be `True` when using a self-signed certificate. {product-title} 4.17 and later supports self-signed certificates with certificate verification when used with the `bmcCACert` parameter.
+
+
 | `bootMACAddress`
 |
-a| The MAC address of the NIC that the host uses for the provisioning network. Ironic retrieves the IP address using the `bootMACAddress` configuration setting. Then, it binds to the host.
+a| The MAC address of the NIC that the host uses for the provisioning network. Ironic retrieves the IP address by using the `bootMACAddress` parameter. Then, it binds to the host.
 
 [NOTE]
 ====

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -29,7 +29,7 @@ platform:
     bootstrapExternalStaticDNS
 ----
 |
-| The static network DNS of the bootstrap node. You must set this value when deploying a cluster with static IP addresses when there is no Dynamic Host Configuration Protocol (DHCP) server on the bare metal network. If you do not set this value, the installation program will use the value from `bootstrapExternalStaticGateway`, which causes problems when the IP address values of the gateway and DNS are different.
+| The static network DNS of the bootstrap node. You must set this value when deploying a cluster with static IP addresses when there is no Dynamic Host Configuration Protocol (DHCP) server on the bare-metal network. If you do not set this value, the installation program will use the value from `bootstrapExternalStaticGateway`, which causes problems when the IP address values of the gateway and DNS are different.
 
 a| 
 ----
@@ -38,7 +38,7 @@ platform:
     bootstrapExternalStaticIP
 ----
 |
-| The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare metal network.
+| The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
 
 a| 
 ----
@@ -47,7 +47,7 @@ platform:
     bootstrapExternalStaticGateway
 ----
 |
-| The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare metal network.
+| The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
 
 | `sshKey`
 |
@@ -168,7 +168,7 @@ a|`provisioningNetworkCIDR`
 
 | `externalBridge`
 | `baremetal`
-| The name of the bare metal bridge of the hypervisor attached to the bare metal network.
+| The name of the bare metal bridge of the hypervisor attached to the bare-metal network.
 
 | `provisioningBridge`
 | `provisioning`

--- a/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
+++ b/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
@@ -67,14 +67,14 @@ platform:
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates.
+It is recommended to have a certificate of authority for the out-of-band management addresses. For {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. For {product-title} 4.17 and later, you can include `disableCertificateVerification: False` when used in conjunction with the `bmcCACert` configuration setting. 
 
 [NOTE]
 ====
 Ensure the {product-title} cluster nodes have *AutoAttach* enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach*.
 ====
 
-The following example demonstrates a Redfish configuration that uses the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -89,6 +89,39 @@ platform:
           password: <password>
           disableCertificateVerification: True
 ----
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: False` configuration parameter along with the `bmcCACert` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: idrac-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: False
+----
+
 
 [discrete]
 == Redfish network boot for iDRAC
@@ -108,7 +141,9 @@ platform:
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if you use self-signed certificates. The following example demonstrates a Redfish configuration that uses the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+It is recommended to have a certificate of authority for the out-of-band management addresses. For {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. For {product-title} 4.17 and later, you can include `disableCertificateVerification: False` when used in conjunction with the `bmcCACert` configuration setting. 
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -123,6 +158,39 @@ platform:
           password: <password>
           disableCertificateVerification: True
 ----
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: False` configuration parameter along with the `bmcCACert` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: False
+----
+
 
 [NOTE]
 ====

--- a/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
+++ b/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
@@ -20,7 +20,7 @@ platform:
           username: <user>
           password: <password>
 ----
-<1> The `address` configuration setting specifies the protocol.
+<1> The `address` parameter specifies the protocol.
 
 For Fujitsu hardware, Red Hat supports integrated Remote Management Controller (iRMC) and IPMI.
 

--- a/modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc
+++ b/modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc
@@ -20,7 +20,7 @@ platform:
           username: <user>
           password: <password>
 ----
-<1> The `address` configuration setting specifies the protocol.
+<1> The `address` parameter specifies the protocol and the BMC IP address.
 
 For HPE integrated Lights Out (iLO), Red Hat supports Redfish virtual media, Redfish network boot, and IPMI.
 
@@ -28,9 +28,9 @@ For HPE integrated Lights Out (iLO), Red Hat supports Redfish virtual media, Red
 [width="100%", cols="1,3", options="header"]
 |====
 |Protocol|Address Format
-|Redfish virtual media| `redfish-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/1`
-|Redfish network boot| `redfish://<out-of-band-ip>/redfish/v1/Systems/1`
-|IPMI| `ipmi://<out-of-band-ip>`
+|Redfish virtual media| `redfish-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/1`
+|Redfish network boot| `redfish://<out_of_band_ip>/redfish/v1/Systems/1`
+|IPMI| `ipmi://<out_of_band_ip>`
 |====
 
 See the following sections for additional details.
@@ -48,12 +48,14 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+It is recommended to have a certificate of authority for the out-of-band management addresses. For {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. For {product-title} 4.17 and later, you can include `disableCertificateVerification: False` when used in conjunction with the `bmcCACert` parameter.
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -63,11 +65,44 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
           disableCertificateVerification: True
 ----
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: False` configuration parameter along with the `bmcCACert` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: False
+----
+
 
 [NOTE]
 ====
@@ -78,7 +113,7 @@ Redfish virtual media is not supported on 9th generation systems running iLO4, b
 [discrete]
 == Redfish network boot for HPE iLO
 
-To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installer requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
+To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installation program requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -88,12 +123,14 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+It is recommended to have a certificate of authority for the out-of-band management addresses. For {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. For {product-title} 4.17 and later, you can include `disableCertificateVerification: False` when used in conjunction with the `bmcCACert` parameter.
+ 
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -103,7 +140,39 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: True
+----
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: False` configuration parameter along with the `bmcCACert` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
           disableCertificateVerification: True

--- a/modules/ipi-install-bmc-addressing.adoc
+++ b/modules/ipi-install-bmc-addressing.adoc
@@ -8,12 +8,12 @@
 
 Most vendors support Baseboard Management Controller (BMC) addressing with the Intelligent Platform Management Interface (IPMI). IPMI does not encrypt communications. It is suitable for use within a data center over a secured or dedicated management network. Check with your vendor to see if they support Redfish network boot. Redfish delivers simple and secure management for converged, hybrid IT and the Software Defined Data Center (SDDC). Redfish is human readable and machine capable, and leverages common internet and web services standards to expose information directly to the modern tool chain. If your hardware does not support Redfish network boot, use IPMI.
 
-You can modify the BMC address during installation while the node is in the `Registering` state. If you need to modify the BMC address after the node leaves the `Registering` state, you must disconnect the node from Ironic, edit the `BareMetalHost` resource, and reconnect the node to Ironic. See the _Editing a BareMetalHost resource_ section for details.
+You can change the BMC address during installation while the node is in the `Registering` state. If you need to change the BMC address after the node leaves the `Registering` state, you must disconnect the node from Ironic, edit the `BareMetalHost` resource, and reconnect the node to Ironic. See the _Editing a BareMetalHost resource_ section for details.
 
-[discrete]
+
 == IPMI
 
-Hosts using IPMI use the `ipmi://<out-of-band-ip>:<port>` address format, which defaults to port `623` if not specified. The following example demonstrates an IPMI configuration within the `install-config.yaml` file.
+IPMI uses the `ipmi://<out_of_band_ip>:<port>` address format, which defaults to port `623` if not specified. The following example demonstrates an IPMI configuration within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -23,20 +23,20 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: ipmi://<out-of-band-ip>
+          address: ipmi://<out_of_band_ip>
           username: <user>
           password: <password>
 ----
 
 [IMPORTANT]
 ====
-The `provisioning` network is required when PXE booting using IPMI for BMC addressing. It is not possible to PXE boot hosts without a `provisioning` network. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`. See "Redfish virtual media for HPE iLO" in the "BMC addressing for HPE iLO" section or "Redfish virtual media for Dell iDRAC" in the "BMC addressing for Dell iDRAC" section for additional details.
+When PXE booting using IPMI for BMC addressing, you must use a provisioning network. It is not possible to PXE boot hosts without a provisioning network. If you deploy without a provisioning network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`. See "Redfish virtual media for HPE iLO" in the "BMC addressing for HPE iLO" section or "Redfish virtual media for Dell iDRAC" in the "BMC addressing for Dell iDRAC" section for additional details.
 ====
 
-[discrete]
+
 == Redfish network boot
 
-To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installer requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
+To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installation program requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -46,12 +46,12 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+It is recommended to have a certificate of authority for the out-of-band management addresses. On {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -61,9 +61,40 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
           disableCertificateVerification: True
 ----
 
+On {product-title} 4.17 and later, you can include `disableCertificateVerification: False` in the `bmc` configuration to verify self-signed certificates when used in conjunction with the `bmcCACert` parameter. The following example demonstrates the configuration of a BMC CA certificate.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+     hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: False
+----


### PR DESCRIPTION
Added bmcCACert contents and examples. Incorporated edits from the Vale linter.

Fixes: [HCIDOCS-419](https://issues.redhat.com//browse/HCIDOCS-419)

See https://issues.redhat.com/browse/HCIDOCS-419 for additional details.

Preview URL: https://81521--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html
https://81521--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/install-ibm-cloud-installation-workflow.html

For release(s): 4.19
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
