### PR TITLE
Network Observability 1.7 Release Notes

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -12,6 +12,106 @@ The Network Observability Operator enables administrators to observe and analyze
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
 For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
+[id="network-observability-operator-release-notes-1-7_{context}"]
+== Network Observability Operator 1.7.0
+The following advisory is available for the Network Observability Operator 1.7.0:
+
+* link:https://access.redhat.com/errata/RHSA-2024:8014[Network Observability Operator 1.7.0]
+
+[id="network-observability-operator-1.7.0-features-enhancements_{context}"]
+=== New features and enhancements
+
+[id="network-observability-operator-otel-1-7_{context}"]
+==== OpenTelemetry support
+You can now export enriched network flows to a compatible OpenTelemetry endpoint, such as the Red{nbsp}Hat build of OpenTelemetry. For more information see xref:../../observability/network_observability/configuring-operator.adoc#network-observability-enriched-flows_network_observability[Export enriched network flow data].
+
+[id="network-observability-operator-developer-perspective-1-7_{context}"]
+==== Network Observability Developer perspective
+You can now use Network Observability in the *Developer* perspective. For more information, see xref:../../observability/network_observability/network-observability-overview.adoc#no-console-integration[{product-title} console integration].
+
+[id="network-observability-operator-tcp-flags-filtering-1-7_{context}"]
+==== TCP flags filtering
+You can now use the `tcpFlags` filter to limit the volume of packets processed by the eBPF program. For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-flowcollector-flowfilter-parameters_nw-observe-network-traffic[Flow filter configuration parameters] and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-ebpf-flow-rule-filter_nw-observe-network-traffic[eBPF flow rule filter].
+
+[id="network-observability-cli-1-7_{context}"]
+==== Network Observability CLI
+The Network Observability CLI (`oc netobserv`), is now generally available. The following enhancements have been made since the 1.6 Technology Preview release:
+
+* There are now eBPF enrichment filters for packet capture similar to flow capture.
+* You can now use filter `tcp_flags` with both flow and packets capture.
+* The auto-teardown option is available when max-bytes or max-time is reached. 
+
+For more information, see xref:../../observability/network_observability/netobserv_cli/netobserv-cli-install.adoc#network-observability-netoberv-cli-about_netobserv-cli-install[Network Observability CLI] and link:https://access.redhat.com/errata/RHEA-2024:8264[Network Observability CLI 1.7.0].
+
+[id="network-observability-virtualization_{context}"]
+==== Network Observability for OpenShift Virtualization
+You can observe networking patterns on an {VirtProductName} setup by identifying eBPF-enriched network flows coming from VMs that are connected to secondary networks, such as through Open Virtual Network (OVN)-Kubernetes. For more information, see xref:../../observability/network_observability/network-observability-secondary-networks.adoc#network-observability-virtualization-config_network-observability-secondary-networks[Configuring virtual machine (VM) secondary network interfaces for Network Observability].
+
+
+[id="network-observability-network-policy-1-7_{context}"]
+==== Network policy deploys in the FlowCollector custom resource (CR)
+With this release, you can configure the `FlowCollector` CR to deploy a network policy for Network Observability. Previously, if you wanted a network policy, you had to manually create one. The option to manually create a network policy is still available. For more information, see xref:../../observability/network_observability/network-observability-network-policy.adoc#network-observability-deploy-network-policy_network_observability[Configuring an ingress network policy by using the FlowCollector custom resource].
+
+[id="network-observability-fips-compliance-1-7_{context}"]
+==== FIPS compliance
+* You can install and use the Network Observability Operator in an {product-title} cluster running in FIPS mode.
++
+--
+include::snippets/fips-snippet.adoc[]
+--
+
+[id="network-observability-dns-enhancements-1-7_{context}"]
+==== eBPF agent enhancements
+The following enhancements are available for the eBPF agent:
+
+* If the DNS service maps to a different port than `53`, you can specify this DNS tracking port using `spec.agent.ebpf.advanced.env.DNS_TRACKING_PORT`.
+* You can now use two ports for transport protocols (TCP, UDP, or SCTP) filtering rules.
+* You can now filter on transport ports with a wildcard protocol by leaving the protocol field empty.
+
+For more information, see xref:../../observability/network_observability/flowcollector-api.adoc#spec-agent-ebpf-advanced[FlowCollector API specifications]. 
+
+[id="network-observability-operator-1-7-bug-fixes_{context}"]
+=== Bug fixes
+
+* Previously, when using a {op-system-base} 9.2 real-time kernel, some of the webhooks did not work. Now, a fix is in place to check whether this {op-system-base} 9.2 real-time kernel is being used. If the kernel is being used, a warning is displayed about the features that do not work, such as packet drop and neither Round-trip Time when using `s390x` architecture. The fix is in OpenShift 4.16 and later. (link:https://issues.redhat.com/browse/NETOBSERV-1808[*NETOBSERV-1808*])
+* Previously, in the *Manage panels* dialog in the *Overview* tab, filtering on *total*, *bar*, *donut*, or *line* did not show a result. Now the available panels are correctly filtered. (link:https://issues.redhat.com/browse/NETOBSERV-1540[*NETOBSERV-1540*])
+* Previously, under high stress, the eBPF agents were susceptible to enter into a state where they generated a high number of small flows, almost not aggregated. With this fix, the aggregation process is still maintained under high stress, resulting in less flows being created. This fix improves the resource consumption not only in the eBPF agent but also in `flowlogs-pipeline` and Loki. (link:https://issues.redhat.com/browse/NETOBSERV-1564[*NETOBSERV-1564*])
+* Previously, when the `workload_flows_total` metric was enabled instead of the `namespace_flows_total` metric, the health dashboard stopped showing `By namespace` flow charts. With this fix, the health dashboard now shows the flow charts when the `workload_flows_total` is enabled. (link:https://issues.redhat.com/browse/NETOBSERV-1746[*NETOBSERV-1746*])
+* Previously, when you used the `FlowMetrics` API to generate a custom metric and later modified its labels, such as by adding a new label, the metric stopped populating and an error was shown in the `flowlogs-pipeline` logs. With this fix, you can modify the labels, and the error is no longer raised in the `flowlogs-pipeline` logs. (link:https://issues.redhat.com/browse/NETOBSERV-1748[*NETOBSERV-1748*])
+* Previously, there was an inconsistency with the default Loki `WriteBatchSize` configuration: it was set to 100 KB in the `FlowCollector` CRD default, and 10 MB in the OLM sample or default configuration. Both are now aligned to 10 MB, which generally provides better performances and less resource footprint. (link:https://issues.redhat.com/browse/NETOBSERV-1766[*NETOBSERV-1766*])
+* Previously, the eBPF flow filter on ports was ignored if you did not specify a protocol. With this fix, you can set eBPF flow filters independently on ports and or protocols. (link:https://issues.redhat.com/browse/NETOBSERV-1779[*NETOBSERV-1779*])
+* Previously, traffic from Pods to Services was hidden from the *Topology view*. Only the return traffic from Services to Pods was visible. With this fix, that traffic is correctly displayed. (link:https://issues.redhat.com/browse/NETOBSERV-1788[*NETOBSERV-1788*])
+* Previously, non-cluster administrator users that had access to Network Observability saw an error in the console plugin when they tried to filter for something that triggered auto-completion, such as a namespace. With this fix, no error is displayed, and the auto-completion returns the expected results. (link:https://issues.redhat.com/browse/NETOBSERV-1798[*NETOBSERV-1798*])
+* When the secondary interface support was added, you had to iterate multiple times to register the per network namespace with the netlink to learn about interface notifications. At the same time, unsuccessful handlers caused a leaking file descriptor because with TCX hook, unlike TC, handlers needed to be explicitly removed when the interface went down. Furthermore, when the network namespace was deleted, there was no Go close channel event to terminate the netlink goroutine socket, which caused go threads to leak. Now, there are no longer leaking file descriptors or go threads when you create or delete pods. (link:https://issues.redhat.com/browse/NETOBSERV-1805[*NETOBSERV-1805*])
+* Previously, the ICMP type and value were displaying 'n/a' in the *Traffic flows* table even when related data was available in the flow JSON. With this fix, ICMP columns display related values as expected in the flow table. (link:https://issues.redhat.com/browse/NETOBSERV-1806[*NETOBSERV-1806*])
+* Previously in the console plugin, it wasn't always possible to filter for unset fields, such as unset DNS latency. With this fix, filtering on unset fields is now possible. (link:https://issues.redhat.com/browse/NETOBSERV-1816[*NETOBSERV-1816*])
+* Previously, when you cleared filters in the OpenShift web console plugin, sometimes the filters reappeared after you navigated to another page and returned to the page with filters. With this fix, filters do not unexpectedly reappear after they are cleared. (link:https://issues.redhat.com/browse/NETOBSERV-1733[*NETOBSERV-1733*])
+
+[id="network-observability-operator-1-7-known-issues_{context}"]
+=== Known issues
+* WWhen you use the must-gather tool with Network Observability, logs are not collected when the cluster has FIPS enabled. (link:https://issues.redhat.com/browse/NETOBSERV-1830[*NETOBSERV-1830*])
+* When the `spec.networkPolicy` is enabled in the `FlowCollector`, which installs a network policy on the `netobserv` namespace, it is impossible to use the `FlowMetrics` API. The network policy blocks calls to the validation webhook. As a workaround, use the following network policy:
++
+[source,yaml]
+====
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-hostnetwork
+  namespace: netobserv
+spec:
+  podSelector:
+    matchLabels:
+      app: netobserv-operator
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/host-network: ''
+  policyTypes:
+    - Ingress
+====
+(link:https://issues.redhat.com/browse/NETOBSERV-1934[*NETOBSERV-193*])
 
 [id="network-observability-operator-release-notes-1-6_{context}"]
 == Network Observability Operator 1.6.0


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Merge only to `no-1.7`. On GA 10/21/24, Sara will open a branch to integrate `no-1.7` with `main`, and that branch will go to 4.12+.

For technical reviewers: 1.6.1 and 1.6.2 are live on docs.openshift.com but because they are on the `main` docs branch, they have not yet been rebased with this `no-1.7` branch, so you won't see them on this preview. 
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
FIPS compliance: https://issues.redhat.com/browse/OSDOCS-11078
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://81551--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-1.7.0-features-enhancements_network-observability-operator-release-notes-v0
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
