### PR TITLE
OSDOCS-11643: updates relnotes text MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -90,6 +90,7 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="microshift-4-17-rhel-image-mode_{context}"]
 === {op-system-base-full} image mode Technology Preview feature
 * You can now install {microshift-short} using a `bootc` container image. Image mode for {op-system} is a technology preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
+
 See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
@@ -130,12 +131,12 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
-//TODO uncomment and verify info prior to merge freeze
-//[id="microshift-4-17-0-dp_{context}"]
-//=== RHEA-2024:3720 - {microshift-short} 4.17.0 bug fix and security update advisory
+//TODO verify info prior to merge
+[id="microshift-4-17-1-dp_{context}"]
+=== RHEA-2024:XXXX - {microshift-short} 4.17.1 bug fix and security update advisory
 
-//Issued: 2024-MM-DD
+Issued: DD Month 2024
 
-//{product-title} release 4.17.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHEA-2024:3720[RHEA-2024:3720] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2024:3718[RHEA-2024:3718] advisory.
+{product-title} release 4.17.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:XXXX[RHEA-2024:XXXX] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2024:XXXX[RHEA-2024:XXXX] advisory.
 
-//For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11643](https://issues.redhat.com/browse/OSDOCS-11643)

Link to docs preview:
[async boilerplate text](https://81573--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-1-dp_release-notes)

QE review:
- N/A stock text and link updates

Reference:
https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.16/html/release_notes/microshift-4-16-release-notes#microshift-4-16-0-dp_release-notes 

https://access.redhat.com/errata/RHBA-2024:4158?extIdCarryOver=true&intcmp=7015Y000003t8u8QAA&sc_cid=701f2000001OH74AAG

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
