### PR TITLE
OSDOCS-11759: Adds information about OpenShift Lightspeed to ocp web console docs

### DIFF
--- a/modules/openshift-lightspeed-web-console.adoc
+++ b/modules/openshift-lightspeed-web-console.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * capabilities-web-console.adc
+
+:_mod-docs-content-type: CONCEPT
+[id="openshift-lightspeed-web-console_{context}"]
+= {ols-official} in the web console
+
+{ols-official} is a generative artificial intelligence-powered virtual assistant for {product-title}. {ols} functionality uses a natural-language interface in the {product-title} web console.
+
+This early access program exists so that customers can provide feedback on the user experience, features and capabilities, issues encountered, and any other aspects of the product so that {ols} can become more aligned with your needs when it is released and made generally available.

--- a/web_console/capabilities_products-web-console.adoc
+++ b/web_console/capabilities_products-web-console.adoc
@@ -17,6 +17,14 @@ include::modules/optional-capabilities-operators.adoc[leveloffset=+1]
 * xref:../operators/understanding/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[Understanding OperatorHub]
 * xref:../web_console/web_terminal/installing-web-terminal.adoc#installing-web-terminal[Installing the web terminal]
 
+//OpenShift LightSpeed
+include::modules/openshift-lightspeed-web-console.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/1.0tp1/html/about/ols-about-openshift-lightspeed#ols-openshift-lightspeed-overview[{ols} overview]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/1.0tp1/html/install/ols-installing-lightspeed[Installing {ols}]
+
 //pipelines
 include::modules/pipelines-web-console.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Since OCP Lightspeed is in standalone docs, we need a spot in the ocp web console docs directing people to the OLS docs for further direction.

Version(s):
4.17 and will need to be backported to 4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-11759

Link to docs preview:
https://81581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/capabilities_products-web-console.html#openshift-lightspeed-web-console_capabilities-web-console

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
