### PR TITLE
OSDOCS-11956: Multi-line Code Copy/Paste Incorrect

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
@@ -142,8 +142,7 @@ $ oc label csidriver.storage.k8s.io/secrets-store.csi.k8s.io security.openshift.
 $ SECRET_ARN=$(aws --region "$REGION" secretsmanager create-secret \
     --name MySecret --secret-string \
     '{"username":"shadowman", "password":"hunter2"}' \
-    --query ARN --output text)
-$ echo $SECRET_ARN
+    --query ARN --output text); echo $SECRET_ARN
 ----
 
 . Create an IAM Access Policy document by running the following command:
@@ -172,8 +171,7 @@ EOF
 $ POLICY_ARN=$(aws --region "$REGION" --query Policy.Arn \
 --output text iam create-policy \
 --policy-name openshift-access-to-mysecret-policy \
---policy-document file://policy.json)
-$ echo $POLICY_ARN
+--policy-document file://policy.json); echo $POLICY_ARN
 ----
 
 . Create an IAM Role trust policy document by running the following command:
@@ -212,8 +210,7 @@ EOF
 ----
 $ ROLE_ARN=$(aws iam create-role --role-name openshift-access-to-mysecret \
 --assume-role-policy-document file://trust-policy.json \
---query Role.Arn --output text)
-$ echo $ROLE_ARN
+--query Role.Arn --output text); echo $ROLE_ARN
 ----
 
 . Attach the role to the policy by running the following command:
@@ -260,7 +257,7 @@ spec:
 EOF
 ----
 
-. Create a Deployment by using our secret in the following command:
+. Create a deployment by using our secret in the following command:
 +
 [source,terminal]
 ----
@@ -292,7 +289,7 @@ spec:
 EOF
 ----
 
-. Verify the Pod has the secret mounted by running the following commandv:
+. Verify the pod has the secret mounted by running the following command:
 +
 [source,terminal]
 ----
@@ -316,13 +313,12 @@ $ oc delete project my-application
 $ helm delete -n csi-secrets-store csi-secrets-store-driver
 ----
 
-. Delete Security Context Constraints by running the following command:
+. Delete the security context constraints by running the following command:
 +
 [source,terminal]
 ----
 $ oc adm policy remove-scc-from-user privileged \
-    system:serviceaccount:csi-secrets-store:secrets-store-csi-driver
-$ oc adm policy remove-scc-from-user privileged \
+    system:serviceaccount:csi-secrets-store:secrets-store-csi-driver; oc adm policy remove-scc-from-user privileged \
     system:serviceaccount:csi-secrets-store:csi-secrets-store-provider-aws
 ----
 
@@ -339,9 +335,7 @@ https://raw.githubusercontent.com/rh-mobb/documentation/main/content/misc/secret
 [source,terminal]
 ----
 $ aws iam detach-role-policy --role-name openshift-access-to-mysecret \
-    --policy-arn $POLICY_ARN
-$ aws iam delete-role --role-name openshift-access-to-mysecret
-$ aws iam delete-policy --policy-arn $POLICY_ARN
+    --policy-arn $POLICY_ARN; aws iam delete-role --role-name openshift-access-to-mysecret; aws iam delete-policy --policy-arn $POLICY_ARN
 ----
 
 . Delete the Secrets Manager secret by running the following command:


### PR DESCRIPTION
[OSDOCS-11956](https://issues.redhat.com//browse/OSDOCS-11956): Multi-line Code Copy/Paste Incorrect

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-11956

Link to docs preview:
https://81582--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-aws-secret-manager.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
