### PR TITLE
OCPBUGS-38689 Adding module for user provided GCP service account permissions

### DIFF
--- a/installing/installing_gcp/installing-gcp-account.adoc
+++ b/installing/installing_gcp/installing-gcp-account.adoc
@@ -25,6 +25,8 @@ include::modules/minimum-required-permissions-ipi-gcp.adoc[leveloffset=+2]
 
 include::modules/minimum-required-permissions-ipi-gcp-xpn.adoc[leveloffset=+2]
 
+include::modules/minimum-required-permissions-ipi-gcp-provided-sas.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-regions.adoc[leveloffset=+1]
 
 == Next steps

--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -19,7 +19,7 @@ The installation program provisions the rest of the required infrastructure, whi
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 * You have a GCP host project which contains a shared VPC network.
 * You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster. This project, known as the service project, must be attached to the host project. For more information, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#create-shared[Attaching service projects in the GCP documentation].
-* You have a GCP service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#minimum-required-permissions-ipi-gcp-xpn[required GCP permissions] in both the host and service projects.
+* You have a GCP service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#minimum-required-permissions-ipi-gcp-xpn_installing-gcp-account[required GCP permissions] in both the host and service projects.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/modules/minimum-required-permissions-ipi-gcp-provided-sas.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-provided-sas.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-account.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="minimum-required-permissions-ipi-gcp-provided-sas_{context}"]
+= Required GCP permissions for user-provided service accounts
+
+When you are installing a cluster, the compute and control plane nodes require their own service accounts.
+By default, the installation program creates a service account for the control plane and compute nodes.
+The service account that the installation program uses requires the roles and permissions that are listed in the _Creating a service account in GCP_ section, as well as the `resourcemanager.projects.getIamPolicy` and `resourcemanager.projects.setIamPolicy` permissions.
+These permissions should be applied to the service account in the host project.
+If this approach does not meet the security requirements of your organization, you can provide a service account email address for the control plane or compute nodes in the `install-config.yaml` file.
+For more information, see the _Installation configuration parameters for GCP_ page.
+If you provide a service account for control plane nodes during an installation into a shared VPC, you must grant that service account the `roles/compute.networkUser` role in the host project.
+If you want the installation program to automatically create firewall rules when you supply the control plane service account, you must grant that service account the `roles/compute.networkAdmin` and `roles/compute.securityAdmin` roles in the host project.
+If you only supply the `roles/compute.networkUser` role, you must create the firewall rules manually.
+
+[IMPORTANT]
+====
+The following roles are required for user-provided service accounts for control plane and compute nodes respectively.
+====
+
+.Required roles	for control plane nodes
+[%collapsible]
+====
+* `roles/compute.instanceAdmin`
+* `roles/compute.networkAdmin`
+* `roles/compute.securityAdmin`
+* `roles/storage.admin`
+====
+
+.Required roles for compute nodes
+[%collapsible]
+====
+* `roles/compute.viewer`
+* `roles/storage.admin`
+* `roles/artifactregistry.reader`
+====

--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -3,7 +3,7 @@
 // * installing/installing_gcp/installing-gcp-account.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="minimum-required-permissions-ipi-gcp-xpn"]
+[id="minimum-required-permissions-ipi-gcp-xpn_{context}"]
 = Required GCP permissions for shared VPC installations
 
 When you are installing a cluster to a link:https://cloud.google.com/vpc/docs/shared-vpc[shared VPC], you must configure the service account for both the host project and the service project. If you are not installing to a shared VPC, you can skip this section.


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OCPBUGS-38689

Link to docs preview:
[Configuring a GCP project](https://81586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#minimum-required-permissions-ipi-gcp-provided-sas_installing-gcp-account)

QE review:
- [ ] QE has approved this change.