### PR TITLE
RHDEVDOCS 6161 remove the word remote from cluster resolver docs

### DIFF
--- a/create/remote-pipelines-tasks-resolvers.adoc
+++ b/create/remote-pipelines-tasks-resolvers.adoc
@@ -44,9 +44,9 @@ include::modules/op-resolver-bundle-config.adoc[leveloffset=+2]
 include::modules/op-resolver-bundle.adoc[leveloffset=+2]
 
 [id="resolver-cluster_{context}"]
-== Specifying a remote pipeline or task from the same cluster
+== Specifying a pipeline or task from the same cluster
 
-You can use the cluster resolver to specify a remote pipeline or task that is defined in a namespace on the {OCP} cluster where {pipelines-title} is running.
+You can use the cluster resolver to specify a pipeline or task that is defined in a namespace on the {OCP} cluster where {pipelines-title} is running.
 
 In particular, you can use the cluster resolver to access tasks that {pipelines-shortname} provides in its installation namespace, which is normally the `openshift-pipelines` namespace.
 

--- a/modules/op-resolver-cluster.adoc
+++ b/modules/op-resolver-cluster.adoc
@@ -4,13 +4,13 @@
 // // *openshift_pipelines/remote-pipelines-tasks-resolvers.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="resolver-cluster-specify_{context}"]
-= Specifying a remote pipeline or task using the cluster resolver
+= Specifying a pipeline or task from the same cluster using the cluster resolver
 
-When creating a pipeline run, you can specify a remote pipeline from the same cluster. When creating a pipeline or a task run, you can specify a remote task from the same cluster.
+When creating a pipeline run, you can specify a pipeline that exists on the same cluster. When creating a pipeline or a task run, you can specify a task that exists on the the same cluster.
 
 .Procedure
 
-* To specify a remote pipeline or task from the same cluster, use the following reference format in the `pipelineRef` or `taskRef` spec:
+* To specify a pipeline or task from the same cluster, use the following reference format in the `pipelineRef` or `taskRef` spec:
 +
 [source,yaml]
 ----
@@ -46,7 +46,7 @@ When creating a pipeline run, you can specify a remote pipeline from the same cl
 +
 If the pipeline or task requires additional parameters, provide these parameters in `params`.
 
-The following example pipeline run references a remote pipeline from the same cluster:
+The following example pipeline run references a pipeline from the same cluster:
 
 [source,yaml]
 ----
@@ -69,7 +69,7 @@ spec:
     value: test
 ----
 
-The following example pipeline references a remote task from the same cluster:
+The following example pipeline references a task from the same cluster:
 
 [source,yaml]
 ----
@@ -94,7 +94,7 @@ spec:
       value: test
 ----
 
-The following example task run references a remote task from the same cluster:
+The following example task run references a task from the same cluster:
 
 [source,yaml]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cp to pipelines-docs-1.11, pipelines-docs-1.12, pipelines-docs-1.13, pipelines-docs-1.14, pipelines-docs-1.15, pipelines-docs-1.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6161 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://81588--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/remote-pipelines-tasks-resolvers.html#resolver-cluster_remote-pipelines-tasks-resolvers

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
small wording fix

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
