### PR TITLE
OCPBUGS#9181: Switch OSDK init to use my.domain to match files

### DIFF
--- a/modules/osdk-hh-create-project.adoc
+++ b/modules/osdk-hh-create-project.adoc
@@ -24,14 +24,14 @@ $ mkdir -p $HOME/github.com/example/memcached-operator
 $ cd $HOME/github.com/example/memcached-operator
 ----
 
-. Run the `operator-sdk init` command to initialize the project. Use a domain of `example.com` so that all API groups are `<group>.example.com`:
+. Run the `operator-sdk init` command to initialize the project. This example uses a domain of `my.domain` so that all API groups are `<group>.my.domain`:
 +
 [source,terminal]
 ----
 $ operator-sdk init \
     --plugins=hybrid.helm.sdk.operatorframework.io \
     --project-version="3" \
-    --domain example.com \
+    --domain my.domain \
     --repo=github.com/example/memcached-operator
 ----
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-9181

4.12+

Preview:

* [Creating a project](https://81591--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-hybrid-helm.html#osdk-hh-create-project_osdk-hybrid-helm) (step 3)