### PR TITLE
RHDEVDOCS-6126 Document how to create aggregated cluster roles

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -104,6 +104,8 @@ Topics:
   File: configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
 - Name: Customizing permissions by creating user-defined cluster roles for cluster-scoped instances
   File: customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances
+- Name: Customizing permissions by creating aggregated cluster roles
+  File: customizing-permissions-by-creating-aggregated-cluster-roles
 - Name: Sharding clusters across Argo CD Application Controller replicas
   File: sharding-clusters-across-argo-cd-application-controller-replicas
 ---

--- a/argocd_instance/setting-up-argocd-instance.adoc
+++ b/argocd_instance/setting-up-argocd-instance.adoc
@@ -35,6 +35,7 @@ include::modules/gitops-configuring-common-cluster-roles-by-specifying-user-defi
 [role="_additional-resources"]
 .Additional resources 
 * xref:../declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc#customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances[Customizing permissions by creating user-defined cluster roles for cluster-scoped instances]
+* xref:../declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc#customizing-permissions-by-creating-aggregated-cluster-roles[Customizing permissions by creating aggregated cluster roles]
 
 // Enabling replicas for Argo CD server and repo server
 include::modules/gitops-enable-replicas-for-argo-cd-server.adoc[leveloffset=+1]

--- a/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
+++ b/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
@@ -57,6 +57,7 @@ include::modules/gitops-additional-permissions-for-cluster-config.adoc[leveloffs
 [role="_additional-resources"]
 .Additional resources 
 * xref:../declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc#customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances[Customizing permissions by creating user-defined cluster roles for cluster-scoped instances]
+* xref:../declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc#customizing-permissions-by-creating-aggregated-cluster-roles[Customizing permissions by creating aggregated cluster roles]
 
 // Installing OLM Operators using Red Hat OpenShift GitOps
 include::modules/gitops-installing-olm-operators-using-gitops.adoc[leveloffset=+1]

--- a/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc
+++ b/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc
@@ -1,0 +1,60 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="customizing-permissions-by-creating-aggregated-cluster-roles"]
+= Customizing permissions by creating aggregated cluster roles
+:context: customizing-permissions-by-creating-aggregated-cluster-roles
+
+toc::[]
+
+The default cluster role for the Argo CD Application Controller has a specific set of hard-coded permissions. The {gitops-title} Operator manages this cluster role, so you cannot modify it. As a cluster administrator, you can customize the permissions by using any one of the following methods:
+
+* xref:../declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc#customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances[Creating user-defined cluster roles]
+* xref:../declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc#gitops-creating-aggregated-cluster-roles_customizing-permissions-by-creating-aggregated-cluster-roles[Creating aggregated cluster roles]
+
+[id="aggregated-cluster-roles_{context}"]
+== Aggregated cluster roles
+
+By using aggregated cluster roles, you do not have to define permissions by creating new cluster roles from scratch. Instead, you can combine several cluster roles into a single one. 
+
+With {gitops-title} 1.14 and later, as a cluster administrator, you can use aggregated cluster roles and enable users to easily add user-defined permissions for Argo CD Application Controller.
+
+[IMPORTANT]
+====
+* You can create aggregated cluster roles only for the Argo CD Application Controller component of a cluster-scoped Argo CD instance.
+* Deleting the `aggregatedClusterRoles` field from the Argo CD custom resource (CR) does not delete the user-defined cluster role. You must manually delete the user-defined cluster role using the CLI or UI.
+====
+
+[id="prerequisites_{context}"]
+== Prerequisites
+
+* You understand link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles[aggregated cluster roles].
+* You have installed {gitops-title} on your {OCP} cluster.
+* You have installed the OpenShift CLI (`oc`).
+* You have installed the {gitops-title} `argocd` CLI.
+* You have installed a xref:../declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc#using-argo-cd-instance-to-manage-cluster-scoped-resources_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[cluster-scoped Argo CD instance] in your defined namespace.
+* You have validated that the user-defined cluster-scoped instance is configured with the cluster roles and cluster role bindings for the following components:
++
+** Argo CD Application Controller
+** Argo CD server
+** Argo CD ApplicationSet Controller, if ApplicationSet Controller is created
+* You have xref:../declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc#gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance_customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances[disabled the creation of the default cluster roles] for the cluster-scoped instance.
+
+// Creating aggregated cluster roles
+include::modules/gitops-creating-aggregated-cluster-roles.adoc[leveloffset=+1]
+
+// Enabling the creation of aggregated cluster roles
+include::modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../argocd_instance/setting-up-argocd-instance.adoc#setting-up-argocd-instance[Installing a user-defined Argo CD instance]
+
+// Creating user-defined cluster roles and configuring user-defined permissions for Application Controller
+include::modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../argocd_instance/setting-up-argocd-instance.adoc#setting-up-argocd-instance[Installing a user-defined Argo CD instance]
+* xref:../declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc#gitops-additional-permissions-for-cluster-config_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Adding permissions for cluster configuration]
+* xref:../declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc#customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances[Customizing permissions by creating user-defined cluster roles for cluster-scoped instances]

--- a/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
+++ b/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
@@ -70,3 +70,4 @@ include::modules/gitops-customizing-permissions-for-cluster-scoped-instances.ado
 
 * xref:../declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc#gitops-additional-permissions-for-cluster-config_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Adding permissions for cluster configuration]
 * xref:../argocd_instance/setting-up-argocd-instance.adoc#gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances_setting-up-argocd-instance[Configuring common cluster roles by specifying user-defined cluster roles for namespace-scoped instances]
+* xref:../declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc#customizing-permissions-by-creating-aggregated-cluster-roles[Customizing permissions by creating aggregated cluster roles]

--- a/modules/gitops-creating-aggregated-cluster-roles.adoc
+++ b/modules/gitops-creating-aggregated-cluster-roles.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assembly:
+//
+// * declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="gitops-creating-aggregated-cluster-roles_{context}"]
+= Creating aggregated cluster roles
+
+The process of creating aggregated cluster roles consists of the following procedures:
+
+. Enabling the creation of aggregated cluster roles
+. Creating user-defined cluster roles and configuring user-defined permissions for Application Controller
+
+[id="enable-creation-of-aggregated-cluster-roles_{context}"]
+== Enable the creation of aggregated cluster roles
+
+You can enable the creation of aggregated cluster roles by setting the value of the `.spec.aggregatedClusterRoles` field to `true` in the Argo CD custom resource (CR). When you enable the creation of aggregated cluster roles, the {gitops} Operator takes the following actions:
+
+* Creates an `<argocd_name>-<argocd_namespace>-argocd-application-controller` aggregated cluster role with a predefined `aggregationRule` field by default.
+* Creates a corresponding cluster role binding and manages it.
+* Creates and manages `view` and `admin` cluster roles for Application Controller to add user-defined permissions into the aggregated cluster role.
+
+[id="create-configure-aggregated-user-defined-permissions_{context}"]
+== Create user-defined cluster roles and configure user-defined permissions
+
+To configure user-defined permissions into the `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role and aggregated cluster role, you must create one or more user-defined cluster roles and then configure the user-defined permissions for Application Controller.
+
+[NOTE]
+====
+* The aggregated cluster role inherits permissions from the `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` and `<argocd_name>-<argocd_namespace>-argocd-application-controller-view` cluster roles.
+* The `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role inherits permissions from the user-defined cluster role.
+====

--- a/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
+++ b/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
@@ -1,0 +1,211 @@
+// Module included in the following assembly:
+//
+// * declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller_{context}"]
+= Creating user-defined cluster roles and configuring user-defined permissions for Application Controller
+
+As a cluster administrator, to add user-defined permissions to your aggregated cluster role, you must create one or more user-defined cluster roles and then configure the user-defined permissions for the Argo CD Application Controller component of a cluster-scoped Argo CD instance.
+
+.Prerequisites
+
+* You have enabled the creation of aggregated cluster roles for the Argo CD Application Controller component of a cluster-scoped Argo CD instance.
+* You have the following default cluster roles that are created and managed by the {gitops-title} Operator:
++
+** `<argocd_name>-<argocd_namespace>-argocd-application-controller` aggregated cluster role with a predefined `aggregationRule` field
+** `<argocd_name>-<argocd_namespace>-argocd-application-controller-view` with predefined `view` permissions
+** `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` with no predefined permissions
+
+.Procedure
+
+. Create a new cluster role with the required labels and permissions by using the following command:
++
+[source,terminal]
+----
+$ oc apply -n <namespace> -f <cluster_role_name>.yaml
+----
++
+where:
+
+`<namespace>`:: Specifies the name of your defined namespace.
+`<cluster_role_name>`:: Specifies the name of your defined cluster role YAML file.
++
+.Example user-defined cluster role YAML
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: 
+  name: user-application-controller # <1>
+  labels: # <2>
+    app.kubernetes.io/managed-by: spring-petclinic
+    app.kubernetes.io/name: example
+    app.kubernetes.io/part-of: argocd
+    argocd/aggregate-to-admin: 'true'
+rules: # <3>
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - configmaps
+  - verbs:
+      - '*'
+    apiGroups:
+      - compliance.openshift.io
+    resources:
+      - scansettingbindings
+----
+<1> The name of the user-defined cluster role.
+<2> The labels match the predefined list of an existing `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role.
+<3> The user-defined permissions that are to be added into the aggregated cluster role through the `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role.
++
+[TIP]
+====
+Alternatively, you can use the web console to create a user-defined cluster role from the *Administrator* perspective. You can go to *User Management* -> *Roles* -> *Create Role*, use the preceding YAML template to add permissions, and click *Create*.
+====
++
+.Example output
+[source,terminal]
+----
+clusterrole.rbac.authorization.k8s.io/user-application-controller created
+----
++
+A user-defined cluster role is created. 
+
+. Verify that the `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role inherits permissions from the user-defined cluster role by running the following command:
++
+[source,terminal]
+----
+$ oc get ClusterRole/<argocd_name>-<argocd_namespace>-argocd-application-controller-admin -o yaml
+----
++
+where:
+
+`<argocd_name>`:: Specifies the name of your user-defined cluster-scoped Argo CD instance.
+`<argocd_namespace>`:: Specifies the namespace where Argo CD is installed.
++
+.Example output
+[source,terminal]
+----
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      app.kubernetes.io/managed-by: spring-petclinic
+      argocd/aggregate-to-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocds.argoproj.io/name: example
+    argocds.argoproj.io/namespace: spring-petclinic
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"argoproj.io/v1beta1","kind":"ArgoCD","metadata":{"annotations":{},"name":"example","namespace":"spring-petclinic"},"spec":{"aggregatedClusterRoles":true}}
+  creationTimestamp: "2024-08-14T09:59:15Z"
+  labels:
+    app.kubernetes.io/managed-by: spring-petclinic
+    app.kubernetes.io/name: example
+    app.kubernetes.io/part-of: argocd
+    argocd/aggregate-to-controller: "true"
+  name: example-spring-petclinic-argocd-application-controller-admin
+  resourceVersion: "79202"
+  uid: e2d35b6f-0832-4993-8b24-915a725454f9
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - persistentvolumeclaims
+  - persistentvolumes
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - scansettingbindings
+  verbs:
+  - '*'
+----
++
+[TIP]
+====
+Alternatively, you can use the {OCP} web console to verify from the *Administrator* perspective. You can go to *User Management* -> *Roles*, use the *Filter* option, select *Cluster-wide Roles*, and search for the `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role. You must open the cluster role to check the details and configurations.
+====
+
+. Verify that the `<argocd_name>-<argocd_namespace>-argocd-application-controller` aggregated cluster role inherits permissions from the `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` and `<argocd_name>-<argocd_namespace>-argocd-application-controller-view` cluster roles by running the following command:
++
+[source,terminal]
+----
+$ oc get ClusterRole/<argocd_name>-<argocd_namespace>-argocd-application-controller -o yaml
+----
++
+where:
+
+`<argocd_name>`:: Specifies the name of your user-defined cluster-scoped Argo CD instance.
+`<argocd_namespace>`:: Specifies the namespace where Argo CD is installed.
++
+.Example output of the aggregated cluster role
+[source,terminal]
+----
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      app.kubernetes.io/managed-by: spring-petclinic
+      argocd/aggregate-to-controller: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocds.argoproj.io/name: example
+    argocds.argoproj.io/namespace: spring-petclinic
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"argoproj.io/v1beta1","kind":"ArgoCD","metadata":{"annotations":{},"name":"example","namespace":"spring-petclinic"},"spec":{"aggregatedClusterRoles":true}}
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: "2024-08-14T08:20:58Z"
+  labels:
+    app.kubernetes.io/managed-by: spring-petclinic
+    app.kubernetes.io/name: example
+    app.kubernetes.io/part-of: argocd
+  name: example-spring-petclinic-argocd-application-controller
+  resourceVersion: "79203"
+  uid: aeeb2ef5-b531-4fe3-a61a-b5ad8dd8ca6e
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - persistentvolumeclaims
+  - persistentvolumes
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - scansettingbindings
+  verbs:
+  - '*'
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - get
+  - list
+----
++
+[TIP]
+====
+Alternatively, you can use the {OCP} web console to verify from the *Administrator* perspective. You can go to *User Management* -> *Roles*, use the *Filter* option, select *Cluster-wide Roles*, and search for the aggregated cluster role. You must open the cluster role to check the details and configurations.
+====

--- a/modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc
+++ b/modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc
@@ -1,0 +1,238 @@
+// Module included in the following assembly:
+//
+// * declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-enabling-the-creation-of-aggregated-cluster-roles_{context}"]
+= Enabling the creation of aggregated cluster roles
+
+To enable the creation of aggregated cluster roles for the Argo CD Application Controller component of a cluster-scoped Argo CD instance, you must configure the corresponding field by editing the YAML file of the Argo CD custom resource (CR).
+
+.Procedure
+
+. In the Argo CD CR, set the value of the `.spec.aggregatedClusterRoles` field to `true`:
++
+.Example Argo CD CR
+[source,yaml]
+----
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example # <1>
+  namespace: spring-petclinic # <2>
+# ...
+spec:
+  aggregatedClusterRoles: true # <3>
+# ...
+----
+<1> The name of the cluster-scoped instance.
+<2> The namespace where you want to run the cluster-scoped instance.
+<3> The value set to `true` enables the creation of aggregated cluster roles. If you do not want to enable the creation of aggregated cluster roles, either do not include this line or set the value to `false`.
++
+.Example output
+[source,terminal]
+----
+argocd.argoproj.io/example configured
+----
+
+. Verify that the `Status` field of the cluster-scoped Argo CD instance shows as `Phase: Available` by running the following command:
++
+[source,terminal]
+----
+$ oc describe argocd.argoproj.io/example -n spring-petclinic
+----
++
+.Example output
+[source,terminal]
+----
+Name:         example
+Namespace:    spring-petclinic
+Labels:       <none>
+Annotations:  <none>
+API Version:  argoproj.io/v1beta1
+Kind:         ArgoCD
+Metadata:
+  Creation Timestamp:  2024-08-14T08:20:53Z
+  Finalizers:
+    argoproj.io/finalizer
+  Generation:        3
+  Resource Version:  60437
+  UID:               57940e54-d60b-4c1a-bc4a-85c81c63ab69
+Spec:
+  Aggregated Cluster Roles:  true
+...
+Status:
+  Application Controller:      Running
+  Application Set Controller:  Unknown
+  Phase:                       Available # <1>
+  Redis:                       Running
+  Repo:                        Running
+  Server:                      Running
+  Sso:                         Unknown
+Events:                        <none>
+----
+<1> The `Available` status indicates that the cluster-scoped Argo CD instance is healthy and available.
++
+[NOTE]
+====
+The {gitops-title} Operator creates the following default cluster roles and manages them:
+
+* `<argocd_name>-<argocd_namespace>-argocd-application-controller` aggregated cluster role
+* `<argocd_name>-<argocd_namespace>-argocd-application-controller-view`
+* `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` 
+====
+
+. Verify that the Operator has created the default cluster roles and cluster role bindings for the Argo CD Application Controller and Argo CD server components by running the following commands:
++
+[source,terminal]
+----
+$ oc get ClusterRoles -l app.kubernetes.io/part-of=argocd
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                           CREATED AT
+example-spring-petclinic-argocd-application-controller         2024-08-14T08:20:58Z
+example-spring-petclinic-argocd-application-controller-admin   2024-08-14T09:08:38Z
+example-spring-petclinic-argocd-application-controller-view    2024-08-14T09:08:38Z
+example-spring-petclinic-argocd-server                         2024-08-14T08:20:59Z
+----
++
+[source,terminal]
+----
+$ oc get ClusterRoleBindings -l app.kubernetes.io/part-of=argocd
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                     ROLE                                                                 AGE
+example-spring-petclinic-argocd-application-controller   ClusterRole/example-spring-petclinic-argocd-application-controller   54m
+example-spring-petclinic-argocd-server                   ClusterRole/example-spring-petclinic-argocd-server                   54m
+----
++
+The cluster role bindings for the `view` and `admin` cluster roles are not created. This is because the `view` and `admin` cluster roles only add permissions to the aggregated cluster role and do not directly configure permissions to the Argo CD Application Controller.
++
+[TIP]
+====
+Alternatively, you can use the {OCP} web console to verify from the *Administrator* perspective. You can go to *User Management* -> *Roles* and *User Management* -> *RoleBindings*, respectively. You can search for the cluster roles and cluster role bindings that have the `app.kubernetes.io/part-of:argocd` label.
+====
+
+. Verify that the aggregated cluster role is created by checking the permissions of outputs of the roles created by running the following command:
++
+[source,terminal]
+----
+$ oc get ClusterRole/<cluster_role_name> -o yaml # <1>
+----
+<1> Replace `<cluster_role_name>` with the name of the role created.
++
+.Example output of the aggregated cluster role
+[source,terminal]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocds.argoproj.io/name: example
+    argocds.argoproj.io/namespace: spring-petclinic
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"argoproj.io/v1beta1","kind":"ArgoCD","metadata":{"annotations":{},"name":"example","namespace":"spring-petclinic"},"spec":{"aggregatedClusterRoles":true}}
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: "2024-08-14T08:20:58Z"
+  labels:
+    app.kubernetes.io/managed-by: spring-petclinic
+    app.kubernetes.io/name: example
+    app.kubernetes.io/part-of: argocd 
+  name: example-spring-petclinic-argocd-application-controller # <1>
+  resourceVersion: "78640"
+  uid: aeeb2ef5-b531-4fe3-a61a-b5ad8dd8ca6e
+aggregationRule: # <2>
+  clusterRoleSelectors:
+  - matchLabels:
+      app.kubernetes.io/managed-by: spring-petclinic
+      argocd/aggregate-to-controller: "true"
+rules: [] # <3>
+----
+<1> The name of the aggregated cluster role.
+<2> The predefined list of labels indicates that the aggregated cluster role can inherit permissions from the other user-defined cluster roles.
+<3> No predefined permissions are set. However, when the Operator immediately creates a `<argocd_name>-<argocd_namespace>-argocd-application-controller-view` cluster role, the corresponding predefined `view` permissions are added into the aggregated cluster role.
++
+.Example output of the `view` cluster role
+[source,terminal]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocds.argoproj.io/name: example
+    argocds.argoproj.io/namespace: spring-petclinic
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"argoproj.io/v1beta1","kind":"ArgoCD","metadata":{"annotations":{},"name":"example","namespace":"spring-petclinic"},"spec":{"aggregatedClusterRoles":true}}
+  creationTimestamp: "2024-08-14T09:59:14Z"
+  labels: # <1>
+    app.kubernetes.io/managed-by: spring-petclinic
+    app.kubernetes.io/name: example
+    app.kubernetes.io/part-of: argocd
+    argocd/aggregate-to-controller: "true"
+  name: example-spring-petclinic-argocd-application-controller-view # <2>
+  resourceVersion: "78639"
+  uid: 068b8867-7a0c-4af3-a17a-0560a00eba41
+rules: # <3>
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - get
+  - list
+----
+<1> The labels match the predefined list of an existing aggregated cluster role.
+<2> The name of the `view` cluster role.
+<3> The predefined `view` permissions. These permissions are added into the existing aggregated cluster role.
++
+.Example output of the `admin` cluster role
+[source,terminal]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocds.argoproj.io/name: example
+    argocds.argoproj.io/namespace: spring-petclinic
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"argoproj.io/v1beta1","kind":"ArgoCD","metadata":{"annotations":{},"name":"example","namespace":"spring-petclinic"},"spec":{"aggregatedClusterRoles":true}}
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: "2024-08-14T09:59:15Z"
+  labels: # <1>
+    app.kubernetes.io/managed-by: spring-petclinic
+    app.kubernetes.io/name: example
+    app.kubernetes.io/part-of: argocd
+    argocd/aggregate-to-controller: "true"
+  name: example-spring-petclinic-argocd-application-controller-admin # <2>
+  resourceVersion: "78642"
+  uid: e2d35b6f-0832-4993-8b24-915a725454f9
+aggregationRule: # <3>
+  clusterRoleSelectors:
+  - matchLabels:
+      app.kubernetes.io/managed-by: spring-petclinic
+      argocd/aggregate-to-admin: "true"
+rules: null # <4>
+----
+<1> The labels match the predefined list of an existing aggregated cluster role.
+<2> The name of the `admin` cluster role.
+<3> The predefined list of labels indicates that the existing `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role can inherit permissions from the other user-defined cluster roles.
+<4> Specifies that no permissions are defined yet in one or more user-defined cluster roles.
++
+[TIP]
+====
+Alternatively, you can use the {OCP} web console to verify from the *Administrator* perspective. You can go to *User Management* -> *Roles*, use the *Filter* option, select *Cluster-wide Roles*, and search for the aggregated cluster role, `view`, and `admin` cluster roles. You must open the cluster role to check the details and configurations.
+====
++
+As a cluster administrator, you can now create one or more user-defined cluster roles and configure user-defined permissions for Argo CD Application Controller.


### PR DESCRIPTION
Jira issue: [RHDEVDOCS-6126](https://issues.redhat.com/browse/RHDEVDOCS-6126) 

Aligned team: DevTools 
Cherry-pick to versions: `gitops-docs-1.14`

**Docs preview:**

- [Customizing permissions by creating aggregated cluster roles](https://81594--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles)
- [Creating aggregated cluster roles](https://81594--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles#gitops-creating-aggregated-cluster-roles_customizing-permissions-by-creating-aggregated-cluster-roles)
- [Enabling the creation of aggregated cluster roles](https://81594--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles#gitops-enabling-the-creation-of-aggregated-cluster-roles_customizing-permissions-by-creating-aggregated-cluster-roles)
- [Creating user-defined cluster roles and configuring user-defined permissions for Application Controller](https://81594--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles#gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller_customizing-permissions-by-creating-aggregated-cluster-roles)
- [Additional Resources in Configuring an OpenShift cluster by deploying an application with cluster configurations](https://81594--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#gitops-additional-permissions-for-cluster-config_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)
- [Additional Resources in Customizing permissions by creating user-defined cluster roles for cluster-scoped instances](https://81594--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances#additional-resources_customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances)

SME review: Completed by @jparsai
QE review: Completed by @AdamSaleh 
Internal Peer review: Completed by @Dhruv-Soni11 
Peer review: Completed by @ShaunaDiaz 

Additional information: N/A
