### PR TITLE
HCIDOCS-470: Update IPI installer docs

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -82,6 +82,9 @@ include::modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc[leveloffset=+2]
 // BMC addressing for Fujitsu iRMC
 include::modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc[leveloffset=+2]
 
+// BMC addressing for Cisco CIMC
+include::modules/ipi-install-bmc-addressing-for-cisco-cimc.adoc[leveloffset=+2]
+
 // Root device hints
 include::modules/ipi-install-root-device-hints.adoc[leveloffset=+2]
 

--- a/modules/ipi-install-bmc-addressing-for-cisco-cimc.adoc
+++ b/modules/ipi-install-bmc-addressing-for-cisco-cimc.adoc
@@ -1,0 +1,63 @@
+// This is included in the following assemblies:
+//
+// installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="bmc-addressing-for-cisco-cimc_{context}"]
+= BMC addressing for Cisco CIMC
+
+The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: <hostname>
+        role: <master | worker>
+        bmc:
+          address: <address> <1>
+          username: <user>
+          password: <password>
+----
+<1> The `address` configuration setting specifies the protocol.
+
+For Cisco UCS UCSX-210C-M6 hardware, Red Hat supports Cisco Integrated Management Controller (CIMC).
+
+.BMC address format for Cisco CIMC
+[width="100%", cols="1,3", options="header"]
+|====
+|Protocol|Address Format
+|Redfish virtual media| `redfish-virtualmedia://<server_kvm_ip>/redfish/v1/Systems/<serial_number>`
+|====
+
+To enable Redfish virtual media for Cisco UCS UCSX-210C-M6 hardware, use `redfish-virtualmedia://` in the `address` setting. The following example demonstrates using Redfish virtual media within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish-virtualmedia://<server_kvm_ip>/redfish/v1/Systems/<serial_number>
+          username: <user>
+          password: <password>
+----
+
+While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish-virtualmedia://<server_kvm_ip>/redfish/v1/Systems/<serial_number>
+          username: <user>
+          password: <password>
+          disableCertificateVerification: True
+----

--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -31,3 +31,12 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 | 13th Generation .2+| iDRAC 8 | v2.75.75.75 or later
 
 |====
+
+
+.Firmware compatibility for Cisco UCS hardware with Redfish virtual media
+[cols="1,1,1",options="header"]
+|====
+| Model | Management | Firmware versions
+| UCS UCSX-210C-M6 | CIMC | 5.2(2) or later
+
+|====


### PR DESCRIPTION
Added Cisco firmware requirements.

Fixes: OCPBUGS-36900

See https://issues.redhat.com/browse/HCIDOCS-470 for additional details.

Preview URL: https://81595--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#bmc-addressing-for-cisco-cimc_ipi-install-installation-workflow
https://81595--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites

For release(s): 4.15-4.17
QE Review: 

- [x] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
