### PR TITLE
OSDOCS#11006: Migrating HCP docs for IBM power from ACM to OCP

### DIFF
--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
@@ -5,3 +5,38 @@ include::_attributes/common-attributes.adoc[]
 :context: hcp-deploy-ibmpower
 
 toc::[]
+
+You can deploy hosted control planes by configuring a cluster to function as a hosting cluster. The hosting cluster is an {product-title} cluster where the control planes are hosted. The hosting cluster is also known as the _management_ cluster.
+
+[NOTE]
+====
+The _management_ cluster is not the _managed_ cluster. A managed cluster is a cluster that the hub cluster manages.
+====
+
+The {mce-short} version 2.5 supports only the default `local-cluster`, which is a hub cluster that is managed, and the hub cluster as the hosting cluster.
+
+:Featurename: {hcp-capital} on {ibm-power-title}
+include::snippets/technology-preview.adoc[]
+
+To provision {hcp} on bare metal, you can use the Agent platform. The Agent platform uses the central infrastructure management service to add worker nodes to a hosted cluster. For more information, see "Enabling the central infrastructure management service".
+
+Each {ibm-power-title} host must be started with a Discovery Image that the central infrastructure management provides. After each host starts, it runs an Agent process to discover the details of the host and completes the installation. An Agent custom resource represents each host.
+
+When you create a hosted cluster with the Agent platform, HyperShift installs the Agent Cluster API provider in the hosted control plane namespace.
+
+include::modules/hcp-ibmpower-prereqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the {hcp} command-line interface]
+* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
+* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
+
+include::modules/hcp-ibmpower-infra-reqs.adoc[leveloffset=+1]
+
+include::modules/hcp-ibmpower-dns.adoc[leveloffset=+1]
+
+include::modules/hcp-bm-hc.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
@@ -6,14 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can deploy {hcp} by configuring a cluster to function as a management cluster. The management cluster is the {product-title} cluster where the control planes are hosted. The management cluster is also known as the _hosting_ cluster. 
+You can deploy {hcp} by configuring a cluster to function as a management cluster. The management cluster is the {product-title} cluster where the control planes are hosted. The management cluster is also known as the _hosting_ cluster.
 
 [NOTE]
 ====
 The _management_ cluster is not the _managed_ cluster. A managed cluster is a cluster that the hub cluster manages.
 ====
 
-You can convert a managed cluster to a management cluster by using the `hypershift` add-on to deploy the HyperShift Operator on that cluster. Then, you can start to create the hosted cluster. 
+You can convert a managed cluster to a management cluster by using the `hypershift` add-on to deploy the HyperShift Operator on that cluster. Then, you can start to create the hosted cluster.
 
 The {mce-short} 2.5 supports only the default `local-cluster`, which is a hub cluster that is managed, and the hub cluster as the management cluster.
 
@@ -33,7 +33,7 @@ include::modules/hcp-ibmz-prereqs.adoc[leveloffset=+1]
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
-// * Installing the hosted control plane command line interface
+* xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the {hcp} command-line interface]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
 
 include::modules/hcp-ibmz-infra-reqs.adoc[leveloffset=+1]
@@ -50,7 +50,7 @@ include::modules/hcp-ibmz-infraenv.adoc[leveloffset=+1]
 [id="hcp-ibmz-add-agents"]
 == Adding {ibm-z-title} agents to the InfraEnv resource
 
-To attach compute nodes to a hosted control plane, create agents that help you to scale the node pool. Adding agents in an {ibm-z-title} environment requires additional steps, which are described in detail in this section.  
+To attach compute nodes to a hosted control plane, create agents that help you to scale the node pool. Adding agents in an {ibm-z-title} environment requires additional steps, which are described in detail in this section.
 
 Unless stated otherwise, these procedures apply to both z/VM and RHEL KVM installations on {ibm-z-title} and {ibm-linuxone-title}.
 

--- a/hosted_control_planes/hcp-manage/hcp-manage-ibmpower.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-ibmpower.adoc
@@ -5,3 +5,17 @@ include::_attributes/common-attributes.adoc[]
 :context: hcp-manage-ibmpower
 
 toc::[]
+
+After you deploy {hcp} on {ibm-power-title}, you can manage a hosted cluster by completing the following tasks.
+
+include::modules/hcp-ibmpower-infraenv.adoc[leveloffset=+1]
+
+include::modules/hcp-ibmpower-add-agents.adoc[leveloffset=+1]
+
+include::modules/hcp-ibmpower-scale-np.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_ibm_z/installing-ibm-z.adoc#installation-operators-config[Initial Operator configuration]
+* xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]

--- a/modules/hcp-bm-hc.adoc
+++ b/modules/hcp-bm-hc.adoc
@@ -2,6 +2,7 @@
 //
 // * hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
 // * hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-hc_{context}"]
@@ -63,7 +64,8 @@ $ hcp create cluster agent \
 $ oc -n <hosted_control_plane_namespace> get pods
 ----
 +
-.Example
+.Example output
+[source,terminal]
 ----
 NAME                                             READY   STATUS    RESTARTS   AGE
 capi-provider-7dcf5fc4c4-nr9sq                   1/1     Running   0          4m32s

--- a/modules/hcp-ibmpower-add-agents.adoc
+++ b/modules/hcp-ibmpower-add-agents.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-manage/hcp-manage-ibmpower.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-ibmpower-add-agents_{context}"]
+= Adding {ibm-power-title} agents to the InfraEnv resource
+
+You can add agents by manually configuring the machine to start with the live ISO.
+
+.Procedure
+
+. Download the live ISO and use it to start a bare metal or a virtual machine (VM) host. You can find the URL for the live ISO in the `status.isoDownloadURL` field, in the `InfraEnv` resource. At startup, the host communicates with the Assisted Service and registers as an agent in the same namespace as the `InfraEnv` resource.
+
+. To list the agents and some of their properties, enter the following command:
++
+[source,terminal]
+----
+$ oc -n <hosted_control_plane_namespace> get agents
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   CLUSTER   APPROVED   ROLE          STAGE
+86f7ac75-4fc4-4b36-8130-40fa12602218                        auto-assign
+e57a637f-745b-496e-971d-1abbf03341ba                        auto-assign
+----
+
+. After each agent is created, you can optionally set the `installation_disk_id` and `hostname` for an agent:
+
+.. To set the `installation_disk_id` field for an agent, enter the following command:
++
+[source,terminal]
+----
+$ oc -n <hosted_control_plane_namespace> patch agent <agent_name> -p '{"spec":{"installation_disk_id":"<installation_disk_id>","approved":true}}' --type merge
+----
+
+.. To set the `hostname` field for an agent, enter the following command:
++
+[source,terminal]
+----
+$ oc -n <hosted_control_plane_namespace> patch agent <agent_name> -p '{"spec":{"hostname":"<hostname>","approved":true}}' --type merge
+----
+
+.Verification
+
+* To verify that the agents are approved for use, enter the following command:
++
+[source,terminal]
+----
+$ oc -n <hosted_control_plane_namespace> get agents
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   CLUSTER   APPROVED   ROLE          STAGE
+86f7ac75-4fc4-4b36-8130-40fa12602218             true       auto-assign
+e57a637f-745b-496e-971d-1abbf03341ba             true       auto-assign
+----

--- a/modules/hcp-ibmpower-dns.adoc
+++ b/modules/hcp-ibmpower-dns.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-ibmpower-dns_{context}"]
+= DNS configuration for {hcp} on {ibm-power-title}
+
+The API server for the hosted cluster is exposed. A DNS entry must exist for the `api.<hosted_cluster_name>.<basedomain>` entry that points to the destination where the API server is reachable.
+
+The DNS entry can be as simple as a record that points to one of the nodes in the managed cluster that is running the hosted control plane.
+
+The entry can also point to a load balancer that is deployed to redirect incoming traffic to the ingress pods.
+
+See the following example of a DNS configuration:
+
+[source,terminal]
+----
+$ cat /var/named/<example.krnl.es.zone>
+----
+
+.Example output
+[source,terminal]
+----
+$ TTL 900
+@ IN  SOA bastion.example.krnl.es.com. hostmaster.example.krnl.es.com. (
+      2019062002
+      1D 1H 1W 3H )
+  IN NS bastion.example.krnl.es.com.
+;
+;
+api                   IN A 1xx.2x.2xx.1xx <1>
+api-int               IN A 1xx.2x.2xx.1xx
+;
+;
+*.apps.<hosted-cluster-name>.<basedomain>           IN A 1xx.2x.2xx.1xx
+;
+;EOF
+----
+<1> The record refers to the IP address of the API load balancer that handles ingress and egress traffic for {hcp}.
+
+For {ibm-power-title}, add IP addresses that correspond to the IP address of the agent.
+
+.Example configuration
+[source,terminal]
+----
+compute-0              IN A 1xx.2x.2xx.1yy
+compute-1              IN A 1xx.2x.2xx.1yy
+----

--- a/modules/hcp-ibmpower-infra-reqs.adoc
+++ b/modules/hcp-ibmpower-infra-reqs.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-ibmpower-infra-reqs_{context}"]
+= {ibm-power-title} infrastructure requirements
+
+The Agent platform does not create any infrastructure, but requires the following resources for infrastructure:
+
+* Agents: An _Agent_ represents a host that is booted with a discovery image and is ready to be provisioned as an {product-title} node.
+
+* DNS: The API and Ingress endpoints must be routable.

--- a/modules/hcp-ibmpower-infraenv.adoc
+++ b/modules/hcp-ibmpower-infraenv.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-manage/hcp-manage-ibmpower.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-ibmpower-infraenv_{context}"]
+= Creating an InfraEnv resource for {hcp} on {ibm-power-title}
+
+An `InfraEnv` is a environment where hosts that are starting the live ISO can join as agents. In this case, the agents are created in the same namespace as your hosted control plane.
+
+You can create an `InfraEnv` resource for {hcp} on 64-bit x86 bare metal for {ibm-power-title} compute nodes.
+
+.Procedure
+
+. Create a YAML file to configure an `InfraEnv` resource. See the following example:
++
+[source,yaml]
+----
+apiVersion: agent-install.openshift.io/v1beta1
+kind: InfraEnv
+metadata:
+  name: <hosted_cluster_name> \// <1>
+  namespace: <hosted_control_plane_namespace> \// <2>
+spec:
+  cpuArchitecture: ppc64le
+  pullSecretRef:
+    name: pull-secret
+  sshAuthorizedKey: <path_to_ssh_public_key> <3>
+----
+<1> Replace `<hosted_cluster_name>` with the name of your hosted cluster.
+<2> Replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, for example, `clusters-hosted`.
+<3> Replace `<path_to_ssh_public_key>` with the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
+
+
+. Save the file as `infraenv-config.yaml`.
+
+. Apply the configuration by entering the following command:
++
+[source,terminal]
+----
+$ oc apply -f infraenv-config.yaml
+----
+
+. To fetch the URL to download the live ISO, which allows {ibm-power-title} machines to join as agents, enter the following command:
++
+[source,terminal]
+----
+$ oc -n <hosted_control_plane_namespace> get InfraEnv <hosted_cluster_name> -o json
+----

--- a/modules/hcp-ibmpower-prereqs.adoc
+++ b/modules/hcp-ibmpower-prereqs.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-ibmpower-prereqs_{context}"]
+= Prerequisites to configure {hcp} on {ibm-power-title}
+
+* The {mce} version 2.5 and later installed on an {product-title} cluster. The {mce-short} is automatically installed when you install {rh-rhacm-first}. You can also install the {mce-short} without {rh-rhacm} as an Operator from the {product-title} OperatorHub.
+
+* The {mce-short} must have at least one managed {product-title} cluster. The `local-cluster` managed hub cluster is automatically imported in the {mce-short} version 2.5 and later. For more information about `local-cluster`, see _Advanced configuration_ in the {rh-rhacm} documentation. You can check the status of your hub cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get managedclusters local-cluster
+----
+
+* You need a hosting cluster with at least 3 worker nodes to run the HyperShift Operator.
+
+* You need to enable the central infrastructure management service. For more information, see "Enabling the central infrastructure management service".
+
+* You need to install the hosted control plane command-line interface. For more information, see "Installing the hosted control plane command-line interface".
+
+The {hcp} feature is enabled by default. If you disabled the feature and want to manually enable it, see "Manually enabling the {hcp} feature". If you need to disable the feature, see "Disabling the {hcp} feature".

--- a/modules/hcp-ibmpower-scale-np.adoc
+++ b/modules/hcp-ibmpower-scale-np.adoc
@@ -1,0 +1,125 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-manage/hcp-manage-ibmpower.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-ibmpower-scale-np_{context}"]
+= Scaling the NodePool object for a hosted cluster on {ibm-power-title}
+
+The `NodePool` object is created when you create a hosted cluster. By scaling the `NodePool` object, you can add more compute nodes to {hcp}.
+
+.Procedure
+
+. Run the following command to scale the `NodePool` object to two nodes:
++
+[source,terminal]
+----
+$ oc -n <hosted_cluster_namespace> scale nodepool <nodepool_name> --replicas 2
+----
++
+The Cluster API agent provider randomly picks two agents that are then assigned to the hosted cluster. Those agents go through different states and finally join the hosted cluster as {product-title} nodes. The agents pass through the transition phases in the following order:
+
+* `binding`
+* `discovering`
+* `insufficient`
+* `installing`
+* `installing-in-progress`
+* `added-to-existing-cluster`
+
+. Run the following command to see the status of a specific scaled agent:
++
+[source,terminal]
+----
+$ oc -n <hosted_control_plane_namespace> get agent -o jsonpath='{range .items[*]}BMH: {@.metadata.labels.agent-install\.openshift\.io/bmh} Agent: {@.metadata.name} State: {@.status.debugInfo.state}{"\n"}{end}'
+----
++
+.Example output
+[source,terminal]
+----
+BMH: Agent: 50c23cda-cedc-9bbd-bcf1-9b3a5c75804d State: known-unbound
+BMH: Agent: 5e498cd3-542c-e54f-0c58-ed43e28b568a State: insufficient
+----
+
+. Run the following command to see the transition phases:
++
+[source,terminal]
+----
+$ oc -n <hosted_control_plane_namespace> get agent
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   CLUSTER            APPROVED       ROLE          STAGE
+50c23cda-cedc-9bbd-bcf1-9b3a5c75804d   hosted-forwarder   true           auto-assign
+5e498cd3-542c-e54f-0c58-ed43e28b568a                      true           auto-assign
+da503cf1-a347-44f2-875c-4960ddb04091   hosted-forwarder   true           auto-assign
+----
+
+. Run the following command to generate the `kubeconfig` file to access the hosted cluster:
++
+[source,terminal]
+----
+$ hcp create kubeconfig --namespace <hosted_cluster_namespace> --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
+----
+
+. After the agents reach the `added-to-existing-cluster` state, verify that you can see the {product-title} nodes by entering the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <hosted_cluster_name>.kubeconfig get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                             STATUS   ROLES    AGE      VERSION
+worker-zvm-0.hostedn.example.com Ready    worker   5m41s    v1.24.0+3882f8f
+worker-zvm-1.hostedn.example.com Ready    worker   6m3s     v1.24.0+3882f8f
+----
+
+. Enter the following command to verify that two machines were created when you scaled up the `NodePool` object:
++
+[source,terminal]
+----
+$ oc -n <hosted_control_plane_namespace> get machine.cluster.x-k8s.io
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                CLUSTER                  NODENAME                           PROVIDERID                                     PHASE     AGE   VERSION
+hosted-forwarder-79558597ff-5tbqp   hosted-forwarder-crqq5   worker-zvm-0.hostedn.example.com   agent://50c23cda-cedc-9bbd-bcf1-9b3a5c75804d   Running   41h   4.15.0
+hosted-forwarder-79558597ff-lfjfk   hosted-forwarder-crqq5   worker-zvm-1.hostedn.example.com   agent://5e498cd3-542c-e54f-0c58-ed43e28b568a   Running   41h   4.15.0
+----
+
+. Run the following command to check the cluster version:
++
+[source,terminal]
+----
+$ oc --kubeconfig <hosted_cluster_name>.kubeconfig get clusterversion
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         VERSION       AVAILABLE   PROGRESSING   SINCE   STATUS
+clusterversion.config.openshift.io/version   4.15.0        True        False         40h     Cluster version is 4.15.0
+----
+
+. Run the following command to check the Cluster Operator status:
++
+[source,terminal]
+----
+$ oc --kubeconfig <hosted_cluster_name>.kubeconfig get clusteroperators
+----
++
+For each component of your cluster, the output shows the following Cluster Operator statuses:
+
+* `NAME`
+* `VERSION`
+* `AVAILABLE`
+* `PROGRESSING`
+* `DEGRADED`
+* `SINCE`
+* `MESSAGE`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> 
This PR is a part of HCP content migration and modularization. This content is only being moved from RHACM to OCP and not changed. This content has been SME and peer reviewed. This migration PR contains the QE approval 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11006 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Deploying hosted control planes on IBM Power](https://81599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.html )
- [Prerequisites to configure hosted control planes on IBM Power](https://81599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.html#hcp-ibmpower-prereqs_hcp-deploy-ibmpower)
- [IBM Power infrastructure requirements](https://81599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.html#hcp-ibmpower-infra-reqs_hcp-deploy-ibmpower)
- [DNS configuration for hosted control planes on IBM Power](https://81599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.html#hcp-ibmpower-dns_hcp-deploy-ibmpower)
- [Creating a hosted cluster on bare metal](https://81599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.html#hcp-bm-hc_hcp-deploy-ibmpower)
- [Creating an InfraEnv resource for hosted control planes on IBM Power](https://81599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-ibmpower.html#hcp-ibmpower-infraenv_hcp-manage-ibmpower)
- [Adding IBM Power agents to the InfraEnv resource](https://81599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-ibmpower.html#hcp-ibmpower-add-agents_hcp-manage-ibmpower)
- [Scaling the NodePool object for a hosted cluster on IBM Power](https://81599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-ibmpower.html#hcp-ibmpower-scale-np_hcp-manage-ibmpower)
- [Third bullet -> Additional resources -> Prerequisites to configure hosted control planes on IBMz](https://81599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.html#hcp-ibmz-prereqs_hcp-deploy-ibmz)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
