### PR TITLE
OSDOCS#11234: Installing a cluster with the support for configuring multi-architecture compute machines

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -210,6 +210,8 @@ Topics:
       File: installing-aws-wavelength-zone
     - Name: Extending an AWS VPC cluster into an AWS Outpost
       File: installing-aws-outposts
+    - Name: Installing an AWS cluster with the support for configuring multi-architecture compute machines
+      File: installing-aws-multiarch-support
   - Name: User-provisioned infrastructure
     Dir: upi
     Distros: openshift-origin,openshift-enterprise
@@ -222,6 +224,8 @@ Topics:
       File: installing-aws-user-infra
     - Name: Installing a cluster in a restricted network with user-provisioned infrastructure
       File: installing-restricted-networks-aws
+    - Name: Installing an AWS cluster with the support for configuring multi-architecture compute machines
+      File: installing-aws-multiarch-support-upi
   - Name: Installing a three-node cluster
     File: installing-aws-three-node
   - Name: Uninstalling a cluster
@@ -339,6 +343,8 @@ Topics:
     File: installation-config-parameters-gcp
   - Name: Uninstalling a cluster on GCP
     File: uninstalling-cluster-gcp
+  - Name: Installing a GCP cluster with the support for configuring multi-architecture compute machines
+    File: installing-gcp-multiarch-support
 - Name: Installing on IBM Cloud
   Dir: installing_ibm_cloud_public
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_aws/ipi/installing-aws-multiarch-support.adoc
+++ b/installing/installing_aws/ipi/installing-aws-multiarch-support.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ipi-aws-multiarch-support"]
+= Installing a cluster with the support for configuring multi-architecture compute machines
+include::_attributes/common-attributes.adoc[]
+:context: ipi-aws-multiarch-support
+
+toc::[]
+
+An {product-title} cluster with multi-architecture compute machines supports compute machines with different architectures.
+
+[NOTE]
+====
+When you have nodes with multiple architectures in your cluster, the architecture of your image must be consistent with the architecture of the node. You must ensure that the pod is assigned to the node with the appropriate architecture and that it matches the image architecture. For more information on assigning pods to nodes, xref:../../../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc#scheduling-workloads-on-clusters-with-multi-architecture-compute-machines[Scheduling workloads on clusters with multi-architecture compute machines].
+====
+
+You can install an {aws-first} cluster with the support for configuring multi-architecture compute machines. After installing the cluster, you can add multi-architecture compute machines to the cluster in the following ways:
+
+* Adding 64-bit x86 compute machines to a cluster that uses 64-bit ARM control plane machines and already includes 64-bit ARM compute machines. In this case, 64-bit x86 is considered the secondary architecture.
+* Adding 64-bit ARM compute machines to a cluster that uses 64-bit x86 control plane machines and already includes 64-bit x86 compute machines. In this case, 64-bit ARM is considered the secondary architecture.
+
+include::snippets/about-multiarch-tuning-operator.adoc[]
+
+include::modules/installing-a-cluster-with-multiarch-support.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-launching-installer_installing-aws-customizations[Deploying the cluster]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]

--- a/installing/installing_aws/upi/installing-aws-multiarch-support-upi.adoc
+++ b/installing/installing_aws/upi/installing-aws-multiarch-support-upi.adoc
@@ -1,0 +1,31 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="upi-aws-multiarch-support"]
+= Installing a cluster with the support for configuring multi-architecture compute machines
+include::_attributes/common-attributes.adoc[]
+:context: upi-aws-multiarch-support
+
+toc::[]
+
+An {product-title} cluster with multi-architecture compute machines supports compute machines with different architectures.
+
+[NOTE]
+====
+When you have nodes with multiple architectures in your cluster, the architecture of your image must be consistent with the architecture of the node. You must ensure that the pod is assigned to the node with the appropriate architecture and that it matches the image architecture. For more information on assigning pods to nodes, see xref:../../../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc#scheduling-workloads-on-clusters-with-multi-architecture-compute-machines[Scheduling workloads on clusters with multi-architecture compute machines].
+====
+
+You can install an AWS cluster with the support for configuring multi-architecture compute machines. After installing the AWS cluster, you can add multi-architecture compute machines to the cluster in the following ways:
+
+* Adding 64-bit x86 compute machines to a cluster that uses 64-bit ARM control plane machines and already includes 64-bit ARM compute machines. In this case, 64-bit x86 is considered the secondary architecture.
+* Adding 64-bit ARM compute machines to a cluster that uses 64-bit x86 control plane machines and already includes 64-bit x86 compute machines. In this case, 64-bit ARM is considered the secondary architecture.
+
+include::snippets/about-multiarch-tuning-operator.adoc[]
+
+include::modules/installing-a-cluster-with-multiarch-support.adoc[leveloffset=+1]
+
+.Next steps
+* xref:../../../installing/installing_aws/ipi/installing-aws-localzone.adoc#installation-launching-installer_installing-aws-localzone[Deploying the cluster]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]

--- a/installing/installing_gcp/installing-gcp-multiarch-support.adoc
+++ b/installing/installing_gcp/installing-gcp-multiarch-support.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-gcp-multiarch-support"]
+= Installing a cluster with the support for configuring multi-architecture compute machines
+include::_attributes/common-attributes.adoc[]
+:context: installing-gcp-multiarch-support
+
+toc::[]
+
+An {product-title} cluster with multi-architecture compute machines supports compute machines with different architectures.
+
+[NOTE]
+====
+When you have nodes with multiple architectures in your cluster, the architecture of your image must be consistent with the architecture of the node. You must ensure that the pod is assigned to the node with the appropriate architecture and that it matches the image architecture. For more information on assigning pods to nodes, xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc#scheduling-workloads-on-clusters-with-multi-architecture-compute-machines[Scheduling workloads on clusters with multi-architecture compute machines].
+====
+
+You can install a {gcp-first} cluster with the support for configuring multi-architecture compute machines. After installing the GCP cluster, you can add multi-architecture compute machines to the cluster in the following ways:
+
+* Adding 64-bit x86 compute machines to a cluster that uses 64-bit ARM control plane machines and already includes 64-bit ARM compute machines. In this case, 64-bit x86 is considered the secondary architecture.
+* Adding 64-bit ARM compute machines to a cluster that uses 64-bit x86 control plane machines and already includes 64-bit x86 compute machines. In this case, 64-bit ARM is considered the secondary architecture.
+
+include::snippets/about-multiarch-tuning-operator.adoc[]
+
+include::modules/installing-a-cluster-with-multiarch-support.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installation-launching-installer_installing-gcp-customizations[Deploying the cluster]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]

--- a/modules/installing-a-cluster-with-multiarch-support.adoc
+++ b/modules/installing-a-cluster-with-multiarch-support.adoc
@@ -1,0 +1,56 @@
+:_mod-docs-content-type: PROCEDURE
+[id="installing-a-cluster-with-multiarch-support_{context}"]
+= Installing a cluster with multi-architecture support
+
+You can install a cluster with the support for configuring multi-architecture compute machines.
+
+.Prerequisites
+
+* You installed the {oc-first}.
+* You have the {product-title} installation program.
+* You downloaded the pull secret for your cluster.
+
+.Procedure
+
+. Check that the `openshift-install` binary is using the `multi` payload by running the following command:
++
+[source,terminal]
+----
+$ ./openshift-install version
+----
++
+.Example output
+[source,terminal]
+----
+./openshift-install 4.17.0
+built from commit abc123etc
+release image quay.io/openshift-release-dev/ocp-release@sha256:abc123wxyzetc
+release architecture multi
+default architecture amd64
+----
++
+The output must contain `release architecture multi` to indicate that the `openshift-install` binary is using the `multi` payload.
+
+. Update the `install-config.yaml` file to configure the architecture for the nodes. 
++
+.Sample `install-config.yaml` file with multi-architecture configuration
++
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.openshift.com
+compute:
+- architecture: amd64 <1>
+  hyperthreading: Enabled
+  name: worker
+  platform: {}
+  replicas: 3
+controlPlane:
+  architecture: arm64 <2>
+  name: master
+  platform: {}
+  replicas: 3
+# ...
+----
+<1> Specify the architecture of the worker node. You can set this field to either `arm64` or `amd64`.
+<2> Specify the control plane node architecture. You can set this field to either `arm64` or `amd64`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-11234](https://issues.redhat.com/browse/OSDOCS-11234)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Installing an AWS cluster with the support for configuring multi-architecture compute machines](https://81600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-multiarch-support.html)
- [Installing an AWS cluster with the support for configuring multi-architecture compute machines](https://81600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-multiarch-support-upi.html)
- [Installing a GCP cluster with the support for configuring multi-architecture compute machines](https://81600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-multiarch-support.html)


<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->