### PR TITLE
[enterprise-4.16+]: network-flow-matrix: add missing openshift-router port

### DIFF
--- a/snippets/network-flow-matrix.csv
+++ b/snippets/network-flow-matrix.csv
@@ -4,6 +4,7 @@ Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,master,FALSE
 Ingress,TCP,80,openshift-ingress,router-default,router-default,router,master,FALSE
 Ingress,TCP,111,Host system service,rpcbind,,,master,TRUE
 Ingress,TCP,443,openshift-ingress,router-default,router-default,router,master,FALSE
+Ingress,TCP,1936,openshift-ingress,router-default,router-default,router,master,FALSE
 Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
 Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
 Ingress,TCP,5050,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
@@ -51,6 +52,7 @@ Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,worker,FALSE
 Ingress,TCP,80,openshift-ingress,router-default,router-default,router,worker,FALSE
 Ingress,TCP,111,Host system service,rpcbind,,,worker,TRUE
 Ingress,TCP,443,openshift-ingress,router-default,router-default,router,worker,FALSE
+Ingress,TCP,1936,openshift-ingress,router-default,router-default,router,worker,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,worker,FALSE
 Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,worker,FALSE
 Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-proxy,worker,FALSE


### PR DESCRIPTION
The openshift-router BM port 1936 is missing in the matrix.

Documented in: https://github.com/openshift/enhancements/blob/master/dev-guide/host-port-registry.md#tcp