### PR TITLE
OCPBUGS#41281: Corrected CR reference on Ingress Controller configura…

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -6,7 +6,7 @@
 [id="nw-ingress-controller-configuration-parameters_{context}"]
 = Ingress Controller configuration parameters
 
-The `Infrastructure` custom resource (CR) includes optional configuration parameters that you can configure to meet specific needs for your organization.
+The `IngressController` custom resource (CR) includes optional configuration parameters that you can configure to meet specific needs for your organization.
 
 [cols="3a,8a",options="header"]
 |===
@@ -67,7 +67,7 @@ endif::openshift-rosa[]
 ifndef::openshift-rosa,openshift-dedicated[]
 For non-cloud environments, such as a bare-metal platform, use the `NodePortService`, `HostNetwork`, or `Private` fields to configure the endpoint publishing strategy for your Ingress Controller.
 
-If you do not set a value in one of these fields, the default value is based on binding ports specified in the `.status.platform` value in the `Infrastructure` CR.
+If you do not set a value in one of these fields, the default value is based on binding ports specified in the `.status.platform` value in the `IngressController` CR.
 endif::openshift-rosa,openshift-dedicated[]
 
 ifndef::openshift-rosa[]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-41281](https://issues.redhat.com/browse/OCPBUGS-41281)

Link to docs preview:
* [Ingress Controller configuration parameters:Dedicated](https://81604--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress)
* [Ingress Controller configuration parameters:Core](https://81604--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress)
* [Ingress Controller configuration parameters:ROSA](https://81604--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress)

- [x] SME has approved this change.
- [x] QE has approved this change.


