### PR TITLE
[enterprise-4.17] RHDEVDOCS-6089: Deprecate tech preview for Shared Resource CSI driver 

### DIFF
--- a/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
+++ b/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
@@ -6,12 +6,15 @@ You can use a `SharedSecret` object to securely access the entitlement keys of a
 
 The `SharedSecret` object allows you to share and synchronize secrets across namespaces.
 
-:FeatureName: Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[]
+[IMPORTANT]
+====
+The Shared Resource CSI Driver feature is now generally available in link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1[builds for Red Hat OpenShift 1.1]. This feature is now deprecated in the OpenShift Container Platform. To use this feature, ensure you are using builds for Red Hat OpenShift 1.1 or a more recent version.
+====
 
 .Prerequisites
 
 * You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates].
+
 * You must have permission to perform the following actions:
 ** Create build configs and start builds.
 ** Discover which `SharedSecret` CR instances are available by entering the `oc get sharedsecrets` command and getting a non-empty list back.

--- a/modules/builds-using-build-volumes.adoc
+++ b/modules/builds-using-build-volumes.adoc
@@ -72,13 +72,9 @@ ifndef::openshift-dedicated,openshift-rosa[]
 <5> Required. The driver that provides the ephemeral CSI volume.
 <6> Required. This value must be set to `true`. Provides a read-only volume.
 <7> Optional. The volume attributes of the ephemeral CSI volume. Consult the CSI driver's documentation for supported attribute keys and values.
-
-:FeatureName: Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[]
-endif::openshift-dedicated,openshift-rosa[]
 --
 
-endif::dockerstrategy[]
+endif::openshift-dedicated,openshift-rosa[]
 
 ifdef::sourcestrategy[]
 
@@ -133,11 +129,6 @@ endif::openshift-dedicated,openshift-rosa[]
 --
 
 endif::sourcestrategy[]
-
-ifndef::openshift-dedicated,openshift-rosa[]
-:FeatureName: Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[]
-endif::openshift-dedicated,openshift-rosa[]
 
 ifeval::["{context}" == "build-strategies-docker"]
 :!dockerstrategy:

--- a/modules/ephemeral-storage-additional-details-about-volumeattributes-on-shared-resource-pod-volumes.adoc
+++ b/modules/ephemeral-storage-additional-details-about-volumeattributes-on-shared-resource-pod-volumes.adoc
@@ -3,6 +3,11 @@
 [id="ephemeral-storage-additional-details-about-volumeattributes-on-shared-resource-pod-volumes_{context}"]
 = Additional details about VolumeAttributes on shared resource pod volumes
 
+[IMPORTANT]
+====
+The Shared Resource CSI Driver feature is now generally available in link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1[builds for Red Hat OpenShift 1.1]. This feature is now deprecated in the OpenShift Container Platform. To use this feature, ensure you are using builds for Red Hat OpenShift 1.1 or a more recent version.
+====
+
 [role="_abstract"]
 The following attributes affect shared resource pod volumes in various ways:
 

--- a/modules/ephemeral-storage-additional-support-limitations-for-shared-resource-csi-driver.adoc
+++ b/modules/ephemeral-storage-additional-support-limitations-for-shared-resource-csi-driver.adoc
@@ -4,6 +4,12 @@
 = Additional support limitations for the Shared Resource CSI Driver
 
 [role="_abstract"]
+
+[IMPORTANT]
+====
+The Shared Resource CSI Driver feature is now generally available in link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1[builds for Red Hat OpenShift 1.1]. This feature is now deprecated in the OpenShift Container Platform. To use this feature, ensure you are using builds for Red Hat OpenShift 1.1 or a more recent version.
+====
+
 The Shared Resource CSI Driver has the following noteworthy limitations:
 
 * The driver is subject to the limitations of Container Storage Interface (CSI) inline ephemeral volumes.

--- a/modules/ephemeral-storage-csi-inline-overview.adoc
+++ b/modules/ephemeral-storage-csi-inline-overview.adoc
@@ -12,13 +12,15 @@ This feature allows you to specify CSI volumes directly in the `Pod` specificati
 
 == Support limitations
 
+[IMPORTANT]
+====
+The Shared Resource CSI Driver feature is now generally available in link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1[builds for Red Hat OpenShift 1.1]. This feature is now deprecated in the OpenShift Container Platform. To use this feature, ensure you are using builds for Red Hat OpenShift 1.1 or a more recent version.
+====
+
 By default, {product-title} supports CSI inline ephemeral volumes with these limitations:
 
 * Support is only available for CSI drivers. In-tree and FlexVolumes are not supported.
-* The Shared Resource CSI Driver supports using inline ephemeral volumes only to access `Secrets` or `ConfigMaps` across multiple namespaces as a Technology Preview feature.
+* The Shared Resource CSI Driver supports using inline ephemeral volumes only to access `Secrets` or `ConfigMaps` across multiple namespaces as a Technology Preview feature in the OpenShift Container Platform.
 * Community or storage vendors provide other CSI drivers that support these volumes. Follow the installation instructions provided by the CSI driver provider.
 
 CSI drivers might not have implemented the inline volume functionality, including `Ephemeral` capacity. For details, see the CSI driver documentation.
-
-:FeatureName: Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[leveloffset=+0]

--- a/storage/container_storage_interface/ephemeral-storage-shared-resource-csi-driver-operator.adoc
+++ b/storage/container_storage_interface/ephemeral-storage-shared-resource-csi-driver-operator.adoc
@@ -6,18 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
 [role="_abstract"]
 As a cluster administrator, you can use the Shared Resource CSI Driver in {product-title} to provision inline ephemeral volumes that contain the contents of `Secret` or `ConfigMap` objects. This way, pods and other Kubernetes types that expose volume mounts, and {product-title} Builds can securely use the contents of those objects across potentially any namespace in the cluster. To accomplish this, there are currently two types of shared resources: a `SharedSecret` custom resource for `Secret` objects, and a `SharedConfigMap` custom resource for `ConfigMap` objects.
 
 // The Shared Resource CSI Driver in {product-title}, as opposed to the driver for upstream Kubernetes...
 
-:FeatureName: The Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
-[NOTE]
+[IMPORTANT]
 ====
-To enable the Shared Resource CSI Driver, you must xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[enable features using feature gates].
+The Shared Resource CSI Driver feature is now generally available in link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1[builds for Red Hat OpenShift 1.1]. This feature is now deprecated in the OpenShift Container Platform. To use this feature, ensure you are using builds for Red Hat OpenShift 1.1 or a more recent version.
 ====
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
* Add deprecation notice for Shared resources  CSI driver which will be removed in OpenShift 4.18.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
`4.17`

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
* https://issues.redhat.com/browse/RHDEVDOCS-6089

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
