### PR TITLE
Incremental backup support

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.adoc
@@ -62,4 +62,6 @@ The built-in Data Mover feature introduces three new API objects defined as CRDs
 
 * `BackupRepository`: Represents and manages the lifecycle of the backup repositories. OADP creates a backup repository per namespace when the first CSI snapshot backup or restore for a namespace is requested. 
 
+include::modules/oadp-incremental-backup-support.adoc[leveloffset=+1]
+
 

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
@@ -44,6 +44,7 @@ include::modules/install-and-configure-oadp-kubevirt.adoc[leveloffset=+1]
 
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]
+include::modules/oadp-incremental-backup-support.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====

--- a/modules/oadp-incremental-backup-support.adoc
+++ b/modules/oadp-incremental-backup-support.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+// backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.adoc
+// backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-about-incremental-backup-support_{context}"]
+= About incremental back up support
+
+{oadp-short} supports incremental backups of `block` and `Filesystem` persistent volumes for both containerized, and {VirtProductName} workloads. The following table summarizes the support for File System Backup (FSB), Container Storage Interface (CSI), and CSI Data Mover:
+
+[cols="5", options="header"]
+.{oadp-short} backup support matrix for containerized workloads
+|===
+| Volume mode |FSB - Restic  |FSB - Kopia | CSI | CSI Data Mover
+| Filesystem | S ^[1]^, I ^[2]^ | S ^[1]^, I ^[2]^ | S ^[1]^ | S ^[1]^, I ^[2]^
+| Block | N ^[3]^ | N ^[3]^ | S ^[1]^ | S ^[1]^, I ^[2]^
+|===
+
+[cols="5", options="header"]
+.{oadp-short} backup support matrix for {VirtProductName} workloads
+|===
+| Volume mode |FSB - Restic  |FSB - Kopia | CSI | CSI Data Mover
+| Filesystem | N ^[3]^ | N ^[3]^ | S ^[1]^ | S ^[1]^, I ^[2]^
+| Block | N ^[3]^ | N ^[3]^ | S ^[1]^ | S ^[1]^, I ^[2]^
+|===
+[.small]
+--
+. Backup supported
+. Incremental backup supported
+. Not supported
+--
+
+[NOTE]
+====
+The CSI Data Mover backups use Kopia regardless of `uploaderType`.
+====


### PR DESCRIPTION
## Jira 

* [OADP-4820](https://issues.redhat.com/browse/OADP-4820)

Added a note to express support for incremental backups 

##  Version

* OCP 4.13 → OCP 4.17

## Preview

*  [Data Mover](https://81606--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.html#oadp-about-incremental-backup-support_about-oadp-1-3-data-mover)

* [OpenShift Virtualization](https://81606--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.html#oadp-about-incremental-backup-support_installing-oadp-kubevirt)

## QE Review

* [x] QE has approved this change.
