### PR TITLE
[SRVCOM-2667] Improve the Serverless Overview page

### DIFF
--- a/about/about-serverless.adoc
+++ b/about/about-serverless.adoc
@@ -4,10 +4,9 @@ include::_attributes/common-attributes.adoc[]
 = {ServerlessProductName} overview
 :context: about-serverless
 
-
 toc::[]
 
-{ServerlessProductName} provides Kubernetes native building blocks that enable developers to create and deploy serverless, event-driven applications on {ocp-product-title}. {ServerlessProductName} is based on the open source link:https://knative.dev/docs/[Knative project], which provides portability and consistency for hybrid and multi-cloud environments by enabling an enterprise-grade serverless platform.
+{ServerlessProductName} provides Kubernetes native building blocks that enable developers to create and deploy serverless, event-driven applications on {ocp-product-title}. Serverless applications can scale up and down (to zero) on demand and be triggered by a number of event sources. {ServerlessProductName} is based on the open source link:https://knative.dev/docs/[Knative project], which provides portability and consistency for hybrid and multi-cloud environments by enabling an enterprise-grade serverless platform.
 
 
 [NOTE]
@@ -24,12 +23,77 @@ For additional information about the {ServerlessProductName} life cycle and supp
 ====
 
 // Add something about CLI tools
+[id="about-serverless-components_{context}"]
+== Components of {ServerlessProductName} 
 
+[id="about-serverless-knative-serving_{context}"]
+=== Knative Serving
+
+Knative Serving builds on Kubernetes to support deploying and serving of applications and functions as serverless containers. Serving simplifies the application deployment, dynamically scales based on in incoming traffic and supports custom rollout strategies with traffic splitting. 
+
+Knative Serving includes the following features:
+
+* Simplified deployment of serverless containers
+* Traffic-based auto-scaling, including scale-to-zero
+* Routing and network programming
+* Point-in-time application snapshots and their configurations
+
+[id="about-serverless-knative-eventing_{context}"]
+=== Knative Eventing
+
+Knative Eventing provides a platform that offers composable primitives to enable late-binding event sources and event consumers. 
+
+Knative Eventing supports the following architectural cloud-native concepts:
+
+* Services are loosely coupled during development and deployed independently to production.
+* A producer can generate events before a consumer is listening, and a consumer can express an interest in an event or class of events that are not yet being produced.
+* Services can be connected to create new applications without modifying producer or consumer, and with the ability to select a specific subset of events from a particular producer.
+
+[id="about-serverless-functions_{context}"]
+=== {FunctionsProductName}
+
+{FunctionsProductName} allows you to write functions that are deployed as Knative Services and take advantage of Knative Serving and Eventing. 
+
+{FunctionsProductName} includes the following features:
+
+* Support for the following build strategies:
+** Source-to-Image (S2I)
+** Buildpacks
+* Multiple runtimes
+* Local developer experience through the Knative (`kn`) CLI
+* Project templates
+* Support for receiving CloudEvents and plain HTTP requests
+
+[id="about-serverless-logic_{context}"]
+=== {ServerlessLogicProductName}
+
+{ServerlessLogicProductName} allows you to define declarative workflow models by using YAML or JSON files. The declarative workflow models orchestrate event-driven, serverless applications. {ServerlessLogicProductName} lets you visualize the execution of workflows, which simplifies debugging and optimization. It also includes built-in error handling and fault tolerance, making it easier to handle errors and exceptions that occur during the execution of a workflow.
+{ServerlessLogicProductName} implements the link:https://serverlessworkflow.io/[CNCF Serverless Workflow specification].
+
+[id="about-serverless-knative-cli_{context}"]
+=== Knative CLI
+
+The Knative (`kn`) CLI allows you to create Knative resources from the command line or from within Shell scripts. With its extensive help pages and autocompletion support, it frees you from memorizing the detailed structure of the Knative resource schemas. 
+
+The Knative (`kn`) CLI includes the following features:
+
+* Support for managing the following Knative Serving features: 
+** Services
+** Revisions
+** Routes
+* Support for managing the following Knative Eventing entities:
+** Sources
+** Brokers
+** Triggers
+** Channels
+** Subscriptions
+* A plugin architecture based on the design of the Kubernetes (`kubectl`) CLI tool
+* Integration of Knative into Tekton pipelines
 
 [id="additional-resources_about-serverless"]
 [role="_additional-resources"]
 == Additional resources
 
+* link:https://www.redhat.com/en/topics/cloud-native-apps/what-is-serverless[What is serverless?]
 * link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-extending-api-with-crds.html#crd-extending-api-with-crds[Extending the Kubernetes API with custom resource definitions]
 * link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html#crd-managing-resources-from-crds[Managing resources from custom resource definitions]
-* link:https://www.redhat.com/en/topics/cloud-native-apps/what-is-serverless[What is serverless?]


### PR DESCRIPTION
Version(s):
serverless-docs-1.33+

Issue:
https://issues.redhat.com/browse/SRVCOM-2667

Link to docs preview:
- https://81607--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/about-serverless.html

QE review:
- [x] QE has approved this change.

Additional information:
Updated the Overview page with the descriptions from the operator Details + Logic