### PR TITLE
OCPBUGS-36526: Remove subnet requirement from IBU seed guidelines

### DIFF
--- a/modules/cnf-image-based-upgrade-seed-image-guide.adoc
+++ b/modules/cnf-image-based-upgrade-seed-image-guide.adoc
@@ -21,7 +21,6 @@ Dual-stack networking is not supported in this release.
 * Set of Day 2 Operators, including the {lcao} and the {oadp-short} Operator
 * Disconnected registry
 * FIPS configuration
-* If the target cluster has multiple IPs and one of them belongs to the subnet that was used for creating the seed image, the upgrade fails if the target cluster's node IP does not belong to that subnet.
 
 The following configurations only have to partially match on the participating clusters:
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-36526
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81610--ocpdocs-pr.netlify.app/openshift-https://81610--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.html#cnf-image-based-upgrade-seed-image-guide_understanding-image-based-upgrade

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
