### PR TITLE
OCPBUGS-31380: Add prerequisite to IBU rollback to check for expired certs

### DIFF
--- a/edge_computing/image_based_upgrade/cnf-image-based-upgrade-base.adoc
+++ b/edge_computing/image_based_upgrade/cnf-image-based-upgrade-base.adoc
@@ -29,4 +29,9 @@ include::modules/cnf-image-based-upgrade-with-backup.adoc[leveloffset=+1]
 
 include::modules/cnf-image-based-upgrade-rollback.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-scenario-3-recovering-expired-certs_dr-recovering-expired-certs[Recovering from expired control plane certificates]
+
 include::modules/cnf-image-based-upgrade-troubleshooting.adoc[leveloffset=+1]

--- a/edge_computing/image_based_upgrade/ztp-image-based-upgrade.adoc
+++ b/edge_computing/image_based_upgrade/ztp-image-based-upgrade.adoc
@@ -41,4 +41,9 @@ include::modules/ztp-image-based-upgrade-upgrade.adoc[leveloffset=+1]
 
 include::modules/ztp-image-based-upgrade-rollback.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-scenario-3-recovering-expired-certs_dr-recovering-expired-certs[Recovering from expired control plane certificates]
+
 include::modules/cnf-image-based-upgrade-troubleshooting.adoc[leveloffset=+1]

--- a/modules/cnf-image-based-upgrade-rollback.adoc
+++ b/modules/cnf-image-based-upgrade-rollback.adoc
@@ -30,6 +30,7 @@ You can manually roll back the changes if you encounter unresolvable issues afte
 .Prerequisites
 
 * Log in to the hub cluster as a user with `cluster-admin` privileges.
+* Ensure that the control plane certificates on the original stateroot are valid. If the certificates expired, see "Recovering from expired control plane certificates".
 
 .Procedure
 

--- a/modules/ztp-image-based-upgrade-rollback.adoc
+++ b/modules/ztp-image-based-upgrade-rollback.adoc
@@ -7,6 +7,10 @@
 
 If you encounter an issue after upgrade, you can start a manual rollback.
 
+.Prerequisites
+
+* Ensure that the control plane certificates on the original stateroot are valid. If the certificates expired, see "Recovering from expired control plane certificates".
+
 .Procedure
 
 . Revert the `du-profile` or the corresponding policy-binding label to the original platform version in the `SiteConfig` CR:


### PR DESCRIPTION

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-31380
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
