### PR TITLE
OCPBUGS-36857-fix: Updated the RHEL version for vSphere

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -196,7 +196,7 @@ ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power,ibm-cloud-vpc,ipi-bare-metal[|{op-system}]
 ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere,ipi-bare-metal[|{op-system}, {op-system-base} 8.6 and later ^[3]^]
-ifdef::vsphere[|{op-system}, {op-system-base} 8.6 and later ^[2]^]
+ifdef::vsphere[|{op-system}, {op-system-base} 8.8 and later ^[2]^]
 |2
 |8 GB
 |100 GB


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OCPBUGS-36857](https://issues.redhat.com/browse/OCPBUGS-36857)

Link to docs preview:
[Minimum resource requirements for cluster installation](https://81619--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs)

- [ ] SME has approved this change.
- [ ] QE has approved this change.
