### PR TITLE
OSDOCS-11732: Add dummy device as additional network

### DIFF
--- a/modules/nw-multus-dummy-device-object.adoc
+++ b/modules/nw-multus-dummy-device-object.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-multus-dummy-device-object_{context}"]
+= Configuration for a dummy device additional network
+
+The dummy CNI plugin functions like a loopback device. The plugin is a virtual interface, and you can use the plugin to route the packets to a designated IP address. Unlike a loopback device, the IP address is arbitrary and is not restricted to the `127.0.0.0/8` address range.
+
+The following object describes the configuration parameters for the dummy CNI plugin:
+
+.Dummy device CNI plugin JSON configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`cniVersion`
+|`string`
+|The CNI specification version. The required value is `0.3.1`.
+
+|`name`
+|`string`
+|The value for the `name` parameter that you previously specified for the CNO configuration.
+
+|`type`
+|`string`
+|The name of the CNI plugin that you want to configure. The required value is `dummy`.
+
+|`ipam`
+|`object`
+|The configuration object for the IPAM CNI plugin. The plugin manages the IP address assignment for the attachment definition.
+
+|====
+
+[id="nw-multus-dummy-device-config-example_{context}"]
+== dummy configuration example
+
+The following example configures an additional network named `hostdev-net`:
+
+[source,json]
+----
+{
+  "cniVersion": "0.3.1",
+  "name": "dummy-net",
+  "type": "dummy",
+  "ipam": {
+      "type": "host-local",
+      "subnet": "10.1.1.0/24"
+  }
+}
+----

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -9,6 +9,7 @@ toc::[]
 As a cluster administrator, you can configure an additional network for your cluster. The following network types are supported:
 
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bridge-object_configuring-additional-network[Bridge]
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-dummy-device-object_configuring-additional-network[Dummy device]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-host-device-object_configuring-additional-network[Host device]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-vlan-object_configuring-additional-network[VLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[IPVLAN]
@@ -165,6 +166,9 @@ include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
 
 // Configuration for a host device additional network
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
+
+// Configure for a dummy additional network
+include::modules/nw-multus-dummy-device-object.adoc[leveloffset=+2]
 
 // Configuration for an VLAN additional network
 include::modules/nw-multus-vlan-object.adoc[leveloffset=+2]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-11732

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[Configuration for a dummy device additional network](https://81643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network#nw-multus-dummy-device-object_configuring-additional-network)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
