### PR TITLE
OSDOCS10847: Added placementGroupPartition field in machine set AWS existing placement group

### DIFF
--- a/modules/machineset-aws-existing-placement-group.adoc
+++ b/modules/machineset-aws-existing-placement-group.adoc
@@ -55,6 +55,7 @@ spec:
             availabilityZone: <zone> # <3>
             region: <region> # <4>
           placementGroupName: <placement_group> # <5>
+          placementGroupPartition: <placement_group_partition_number> # <6>
 # ...
 ----
 <1> Specify an instance type that link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types[supports EFAs].
@@ -62,12 +63,15 @@ spec:
 <3> Specify the zone, for example, `us-east-1a`.
 <4> Specify the region, for example, `us-east-1`.
 <5> Specify the name of the existing AWS placement group to deploy machines in.
+<6> Optional: Specify the partition number of the existing AWS placement group to deploy machines in. 
 
 .Verification
 
 * In the AWS console, find a machine that the machine set created and verify the following in the machine properties:
 
 ** The placement group field has the value that you specified for the `placementGroupName` parameter in the machine set.
+
+** The partition number field has the value that you specified for the `placementGroupPartition` parameter in the machine set.
 
 ** The interface type field indicates that it uses an EFA.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-10847
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machineset-aws-existing-placement-group_creating-machineset-aws
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
