### PR TITLE
OSDOCS-11372 Updated the apiVersion in the first codeblock under the …

### DIFF
--- a/modules/tls-profiles-kubelet-configuring.adoc
+++ b/modules/tls-profiles-kubelet-configuring.adoc
@@ -20,9 +20,9 @@ endif::[]
 .Sample `KubeletConfig` CR that configures the `Old` TLS security profile on worker nodes
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v1
+apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
- ...
+# ...
 spec:
   tlsSecurityProfile:
     old: {}
@@ -30,10 +30,10 @@ spec:
   machineConfigPoolSelector:
     matchLabels:
       pools.operator.machineconfiguration.openshift.io/worker: ""
-#...
+# ...
 ----
 
-You can see the ciphers and the minimum TLS version of the configured TLS security profile in the `kubelet.conf` file on a configured node.
+You can see the ciphers and the minimum TLS version of the configured TLS security profile in the `kubelet.conf` file on a configured node. 
 
 .Prerequisites
 


### PR DESCRIPTION
…Configuring the TLS security profile for the kubelet topic

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-11372

Link to docs preview:
https://81646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-tls.html
https://81646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/tls-security-profiles.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

