### PR TITLE
OSDOCS#11238: Auto-rotation of etcd signer certs

### DIFF
--- a/modules/etcd-cert-alerts-metrics-signer.adoc
+++ b/modules/etcd-cert-alerts-metrics-signer.adoc
@@ -6,10 +6,12 @@
 [id="etcd-cert-alerts-metrics-signer_{context}"]
 = etcd certificate rotation alerts and metrics signer certificates
 
-Two alert types inform users about pending `etcd` certificate expiration:
+Two alerts inform users about pending `etcd` certificate expiration:
 
 `etcdSignerCAExpirationWarning`:: Occurs 730 days until the signer expires.
 `etcdSignerCAExpirationCritical`:: Occurs 365 days until the signer expires.
+
+These alerts track the expiration date of the signer certificate authorities in the `openshift-etcd` namespace.
 
 You can rotate the certificate for the following reasons:
 

--- a/modules/removing-unused-ca-bundle.adoc
+++ b/modules/removing-unused-ca-bundle.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// security/certificate_types_descriptions/etcd-certificates.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="removing-unused-ca-bundle_{context}"]
+= Removing an unused certificate authority from the bundle
+
+A manual rotation does not immediately update the trust bundle to remove the public key of a previous signer certificate. 
+
+The public key of the signer certificate is removed at the expiration date, however if the public key must be removed before it expires, you can delete it.
+
+.Procedure
+
+. Delete the key by running the following command:
++
+[source,terminal]
+----
+$ oc delete configmap -n openshift-etcd etcd-ca-bundle
+----
+
+. Wait for the static pod rollout by running the following command. The bundle regenerates with the current signer certificate and all unknown or unused keys are deleted.
++
+[source,terminal]
+----
+$ oc adm wait-for-stable-cluster --minimum-stable-period 2m
+----
+

--- a/modules/rotating-certificate-authority.adoc
+++ b/modules/rotating-certificate-authority.adoc
@@ -6,42 +6,28 @@
 [id="rotating-certificate-authority_{context}"]
 = Rotating the etcd certificate
 
-Rotate the `etcd` certificate before it expires.
+The `etcd` certificate automatically rotates using the etcd cluster Operator. However, if a certificate must be rotated before it is automatically rotated, you can manually rotate it.
 
 .Procedure
 
-. Verify the remaining lifetime of the new signer certificate by running the following command:
+. Make a backup copy of the current signer certificate by running the following command:
 +
 [source,terminal]
 ----
-$ oc get secret -n openshift-etcd etcd-signer -ojsonpath='{.metadata.annotations.auth\.openshift\.io/certificate-not-after}'
+$ oc get secret -n openshift-etcd etcd-signer -oyaml > signer_backup_secret.yaml
 ----
 
-. If the remaining lifetime is close to the current date, re-create the signer by deleting the signer and wait for the static pod roll out.
-* Delete the signer by running the following command:
+. Delete the existing signer certificate by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete secret -n openshift-etcd etcd-signer
 ----
 
-* Wait for the static pod roll out by running the following command:
+. Wait for the static pod roll out by running the following command. The static pod roll out can take a few minutes to complete.
 +
 [source,terminal]
 ----
 $ oc wait --for=condition=Progressing=False --timeout=15m clusteroperator/etcd
 ----
 
-. After `etcd` restarts, switch the original CA in the `openshift-config` namespace with the new, rotated one in `openshift-etcd` by running the following command:
-+
-[source,terminal]
-----
-$ oc get secret etcd-signer -n openshift-etcd -ojson | jq 'del(.metadata["namespace","creationTimestamp","resourceVersion","selfLink","uid"])' | oc apply -n openshift-config -f -
-----
-
-. Wait for the cluster Operators to roll out and stabilize by running the following command:
-+
-[source,terminal]
-----
-$ oc adm wait-for-stable-cluster --minimum-stable-period 2m
-----

--- a/security/certificate_types_descriptions/etcd-certificates.adoc
+++ b/security/certificate_types_descriptions/etcd-certificates.adoc
@@ -15,6 +15,7 @@ etcd certificates are signed by the etcd-signer; they come from a certificate au
 The CA certificates are valid for 10 years. The peer, client, and server certificates are valid for three years.
 
 include::modules/rotating-certificate-authority.adoc[leveloffset=+1]
+include::modules/removing-unused-ca-bundle.adoc[leveloffset=+1]
 include::modules/etcd-cert-alerts-metrics-signer.adoc[leveloffset=+1]
 
 == Management


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-11238](https://issues.redhat.com/browse/OSDOCS-11238)

Link to docs preview:
[Rotating the etcd certificate](https://81659--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/etcd-certificates.html#rotating-certificate-authority_cert-types-etcd-certificates) Updated 9/24/2024

QE review:
- [x] QE has approved this change.
