### PR TITLE
OSDOCS-11898-fix-links

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2778,8 +2778,8 @@ $ oc adm release info 4.15.31 --pullspecs
 
 * On {product-rosa}, node pools might stop scaling workloads or updating configurations for a cluster that uses the {product-version}.23 or later version of the {hcp-capital} service. Depending on the version of components that interact with your cluster, you can resolve this issue be completing the steps in one of the following Red{nbsp}Hat Knowledgebase articles:
 +
-** (https://access.redhat.com/articles/7085089)[ROSA HCP clusters fail to add new nodes in MachinePool version older than {product-version}.23]
-** (https://access.redhat.com/articles/7085666)[ROSA upgrade issue mitigation for HOSTEDCP-1941]
+** link:https://access.redhat.com/articles/7085089[ROSA HCP clusters fail to add new nodes in MachinePool version older than {product-version}.23]
+** link:https://access.redhat.com/articles/7085666[ROSA upgrade issue mitigation for HOSTEDCP-1941]
 +
 (link:https://issues.redhat.com/browse/OCPBUGS-39463[*OCPBUGS-39463*])
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-11898](https://issues.redhat.com/browse/OSDOCS-11898)

Link to docs preview:
[4.15.31](https://81662--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-31_release-notes)

