### PR TITLE
OCPBUGS#38087: Add missing bug fix and known issue to the 4.16 z-stre…

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3627,6 +3627,8 @@ metadata:
 
 * Previously, the etcd Operator checked the health of etcd members in serial with an all-member timeout that matched the single-member timeout. That allowed one slow member check to consume the entire timeout, and cause later member checks to fail with the error `deadline-exceeded`, regardless of the health of that later member. Now, etcd checks the health of members in parallel so the health and speed of one member's check doesn't affect the other members' checks. (link:https://issues.redhat.com/browse/OCPBUGS-36489[*OCPBUGS-36489*])
 
+* Previously, you could not change the snapshot limits for the {vmw-first} Container Storage Interface (CSI) driver without enabling the `TechPreviewNoUpgrade` feature gate because of a missing API that caused a bug with the Cluster Storage Operator. With this release, the missing API is added so that you can now change the snapshot limits without having to enable the `TechPreviewNoUpgrade` feature gate. For more information about changing the snapshot limits, see xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.html#vsphere-change-max-snapshot_persistent-storage-csi-vsphere[Changing the maximum number of snapshots for vSphere] (link:https://issues.redhat.com/browse/OCPBUGS-36969[*OCPBUGS-36969*])
+
 [id="ocp-4-16-6-updating_{context}"]
 ==== Updating
 
@@ -3936,4 +3938,5 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.16.0 --pullspecs
 ----
+
 //replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OCPBUGS-38087](https://issues.redhat.com/browse/OCPBUGS-38087)

Link to docs preview:
* [4.16.6.](https://81664--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-6_release-notes)

- [x] SME approval
- [x] QE approval

Additional information:
* [Link 1](https://docs.openshift.com/container-platform/4.16/storage/container_storage_interface/persistent-storage-csi-vsphere.html#vsphere-change-max-snapshot_persistent-storage-csi-vsphere)
