### PR TITLE
OCPBUGS-41866 - Updating outdated links

### DIFF
--- a/modules/security-hosts-vms-rhcos.adoc
+++ b/modules/security-hosts-vms-rhcos.adoc
@@ -13,7 +13,7 @@ Because {product-title} {product-version} runs on {op-system} hosts, with the op
 
 * _Linux namespaces_ enable creating an abstraction of a particular global system resource to make it appear as a separate instance to processes within a namespace. Consequently, several containers can use the same computing resource simultaneously without creating a conflict. Container namespaces that are separate from the host by default include mount table, process table, network interface, user, control group, UTS, and IPC namespaces. Those containers that need direct access to host namespaces need to have elevated permissions to request that access.
 ifdef::openshift-enterprise,openshift-webscale,openshift-aro[]
-See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index[Overview of Containers in Red Hat Systems] from the {op-system-base} 8 container documentation for details on the types of namespaces.
+See link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/building_running_and_managing_containers/index[Building, running, and managing containers] from the {op-system-base} 9 container documentation for details on the types of namespaces.
 endif::[]
 
 * _SELinux_ provides an additional layer of security to keep containers isolated from each other and from the host. SELinux allows administrators to enforce mandatory access controls (MAC) for every user, application, process, and file.
@@ -25,7 +25,7 @@ Disabling SELinux on {op-system} is not supported.
 
 * _CGroups_ (control groups) limit, account for, and isolate the resource usage (CPU, memory, disk I/O, network, etc.) of a collection of processes. CGroups are used to ensure that containers on the same host are not impacted by each other.
 
-* _Secure computing mode (seccomp)_ profiles can be associated with a container to restrict available system calls. See page 94 of the link:https://access.redhat.com/articles/5059881[OpenShift Security Guide] for details about seccomp.
+* _Secure computing mode (seccomp)_ profiles can be associated with a container to restrict available system calls. See page 94 of the link:https://www.redhat.com/en/resources/openshift-security-guide-ebook[Red Hat OpenShift security guide] for details about seccomp.
 
 * Deploying containers using _{op-system}_ reduces the attack surface by minimizing the host environment and tuning it for containers. The link:https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/cri-o_runtime/index[CRI-O container engine] further reduces that attack surface by implementing only those features required by Kubernetes and {product-title} to run and manage containers, as opposed to other container engines that implement desktop-oriented standalone features.
 


### PR DESCRIPTION
Updating outdated links to RHEL 8 and Red Hat OpenShift security guide

Version(s):
enterprise-4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-41866

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE review not required.