### PR TITLE
OCPBUGS#37081: Added OVN RN update

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -908,6 +908,11 @@ With this update, you can configure the SR-IOV Network Operator to drain nodes i
 
 For more information, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#configure-sr-iov-operator-parallel-nodes_configuring-sriov-device[Configuring parallel node draining during SR-IOV network policy updates].
 
+[id="ocp-4-14-networking-OVN-IC-IP-range"]
+==== Change in the IP address range that Open Virtual Network Infrastructure Controller uses
+
+In the {product-title} 4,13 release, the `168.254.0.0/16` IP address range was the reserved IP address range that the Open Virtual Network Infrastructure Controller used for the transit switch subnet. For {product-title} {product-version}, the Open Virtual Network Infrastructure Controller uses `100.88.0.0/16` as the reserved IP address range. The `100.88.0.0/16` range must not conflict with any connected networks. See link:https://issues.redhat.com/browse/OCPBUGS-20178[OCPBUGS-20178] and xref:../networking/cidr-range-definitions.adoc[CIDR range definitions].
+
 [id="ocp-4-14-registry"]
 === Registry
 
@@ -4700,4 +4705,5 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.14.0 --pullspecs
 ----
+
 //replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OCPBUGS-37081](https://issues.redhat.com/browse/OCPBUGS-37081)

Link to docs preview:
[4.14.0](https://81666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-0-ga)

- [x] SME has approved this change. (Riccardo Ravaioli)
- [x] QE has approved this change. (Anurag Saxena)

Additional information:
* https://issues.redhat.com/browse/OCPBUGS-20178
* https://docs.openshift.com/container-platform/4.13/networking/cidr-range-definitions.html
