### PR TITLE
OSDOCS-11961: Documented the MS Azure NMSTATE Operator support RN

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -438,6 +438,13 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-4-17-networking_{context}"]
 === Networking
 
+[id="ocp-4-17-networking-azure-support-nmstate-operator_{context}"]
+==== Microsoft Azure for the Kubernetes NMState Operator
+
+Red{nbsp}Hat support exists for using the Kubernetes NMState Operator on {azure-first} but in a limited capacity. Support is limited to configuring DNS servers on your system as a postinstallation task.
+
+For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator_k8s-nmstate-operator[About the Kubernetes NMState Operator].
+
 [id="ocp-ptp-fast-events-rest-api-v2-available_{context}"]
 ==== New PTP fast events REST API version 2 available
 


### PR DESCRIPTION
Note is an exact copy of the fully-approved PR https://github.com/openshift/openshift-docs/pull/81497


Version(s):
4.17 

Issue:
[OSDOCS-11961](https://issues.redhat.com/browse/OSDOCS-11961)

Link to docs preview:
* [Microsoft Azure for the Kubernetes NMState Operator](https://81678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-networking-azure-support-nmstate-operator_release-notes)

