### PR TITLE
TELCODOCS-1861: Automatic image cleanup in container storage disk

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3228,6 +3228,8 @@ Topics:
       File: cnf-image-based-upgrade-prep-resources
     - Name: Creating ConfigMap objects for the image-based upgrade with Lifecycle Agent using GitOps ZTP
       File: ztp-image-based-upgrade-prep-resources
+    - Name: Configuring the automatic image cleanup of the container storage disk
+      File: cnf-image-based-upgrade-auto-image-cleanup
   - Name: Performing an image-based upgrade for single-node OpenShift clusters with the Lifecycle Agent
     File: cnf-image-based-upgrade-base
   - Name: Performing an image-based upgrade for single-node OpenShift clusters using GitOps ZTP

--- a/edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.adoc
+++ b/edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.adoc
@@ -72,6 +72,8 @@ include::modules/cnf-image-based-upgrade.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-auto-image-cleanup#cnf-image-based-upgrade-configure-auto-image-cleanup[Configuring the automatic image cleanup of the container storage disk]
+
 * xref:../../edge_computing/image_based_upgrade/cnf-image-based-upgrade-base.adoc#cnf-image-based-upgrade[Performing an image-based upgrade for {sno} clusters with {lcao}]
 
 * xref:../../edge_computing/image_based_upgrade/ztp-image-based-upgrade.adoc#ztp-image-based-upgrade[Performing an image-based upgrade for {sno} clusters using {ztp}]

--- a/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-auto-image-cleanup.adoc
+++ b/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-auto-image-cleanup.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cnf-image-based-upgrade-configure-auto-image-cleanup"]
+= Configuring the automatic image cleanup of the container storage disk
+include::_attributes/common-attributes.adoc[]
+:context: auto-cleanup
+
+toc::[]
+
+Configure when the {lcao} cleans up unpinned images in the `Prep` stage by setting a minimum threshold for available storage space through annotations.
+The default container storage disk usage threshold is 50%.
+
+The {lcao} does not delete images that are pinned in CRI-O or are currently used.
+The Operator selects the images for deletion by starting with dangling images and then sorting the images from oldest to newest that is determined by the image `Created` timestamp.
+
+include::modules/cnf-image-based-upgrade-configure-container-storage-image-cleanup.adoc[leveloffset=+1]
+
+include::modules/cnf-image-based-upgrade-disable-container-storage-image-cleanup.adoc[leveloffset=+1]

--- a/modules/cnf-image-based-upgrade-configure-container-storage-image-cleanup.adoc
+++ b/modules/cnf-image-based-upgrade-configure-container-storage-image-cleanup.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+// * edge_computing/image-based-upgrade/cnf-image-based-upgrade-shared-container-partition
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-image-based-upgrade-configure-threshold_{context}"]
+= Configuring the automatic image cleanup of the container storage disk
+
+Configure the minimum threshold for available storage space through annotations.
+
+.Prerequisites
+
+* Create an `ImageBasedUpgrade` CR.
+
+.Procedure
+
+. Increase the threshold to 65% by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-lifecycle-agent annotate ibu upgrade image-cleanup.lca.openshift.io/disk-usage-threshold-percent='65'
+----
+
+. (Optional) Remove the threshold override by running the following command:
++
+[source,terminal]
+----
+$ oc -n  openshift-lifecycle-agent annotate ibu upgrade image-cleanup.lca.openshift.io/disk-usage-threshold-percent-
+----

--- a/modules/cnf-image-based-upgrade-disable-container-storage-image-cleanup.adoc
+++ b/modules/cnf-image-based-upgrade-disable-container-storage-image-cleanup.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+// * edge_computing/image-based-upgrade/cnf-image-based-upgrade-shared-container-partition
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-image-based-upgrade-disable-container-storage-image-cleanup_{context}"]
+= Disable the automatic image cleanup of the container storage disk
+
+Disable the automatic image cleanup threshold.
+
+.Procedure
+
+. Disable the automatic image cleanup by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-lifecycle-agent annotate ibu upgrade image-cleanup.lca.openshift.io/on-prep='Disabled'
+----
+
+. (Optional) Enable automatic image cleanup again by running the following command:
++
+[source,terminal]
+----
+$ oc -n  openshift-lifecycle-agent annotate ibu upgrade image-cleanup.lca.openshift.io/on-prep-
+----

--- a/modules/cnf-image-based-upgrade.adoc
+++ b/modules/cnf-image-based-upgrade.adoc
@@ -56,7 +56,10 @@ For the `Prep` stage, you specify the following upgrade details in the `ImageBas
 * extra manifests to apply and custom catalog sources to retain after the upgrade, if any
 
 Then, based on what you specify, the {lcao} prepares for the upgrade without impacting the current running version.
-During this stage, the {lcao} ensures that the target cluster is ready to proceed to the `Upgrade` stage by checking if it meets certain conditions and pulls the seed image to the target cluster with additional container images specified in the seed image.
+During this stage, the {lcao} ensures that the target cluster is ready to proceed to the `Upgrade` stage by checking if it meets certain conditions.
+The Operator pulls the seed image to the target cluster with additional container images specified in the seed image.
+The {lcao} checks if there is enough space on the container storage disk and if necessary, the Operator deletes unpinned images until the disk usage is below the specified threshold.
+For more information about how to configure or disable the cleaning up of the container storage disk, see "Configuring the automatic image cleanup of the container storage disk".
 
 You also prepare backup resources with the {oadp-short} Operator's `Backup` and `Restore` CRs.
 These CRs are used in the `Upgrade` stage to reconfigure the cluster, register the cluster with {rh-rhacm}, and restore application artifacts.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1861
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- https://81688--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.html
- https://81688--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-auto-image-cleanup.html

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
