### PR TITLE
OSDOCS-11768: clarifying LVM thin pool configuration in microshift

### DIFF
--- a/modules/microshift-lvm-thin-volumes.adoc
+++ b/modules/microshift-lvm-thin-volumes.adoc
@@ -17,6 +17,11 @@ To use advanced storage features such as creating volume snapshots or volume clo
 To create Container Storage Interface (CSI) snapshots, you must configure thin volumes on the {op-system-ostree} host. The CSI does not support volume shrinking.
 ====
 
+[IMPORTANT]
+====
+When using thin provisioning, it is important that you monitor the storage pool and add more capacity as the available physical space runs out. You can configure the storage pool to auto expand when there is available space within the volume group (VG). See link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/configuring_and_managing_logical_volumes/index#creating-thinly-provisioned-logical-volumes_creating-and-managing-thin-provisioned-volumes[Creating thinly provisioned logical volumes].
+====
+
 For LVMS to manage thin logical volumes (LVs), a thin-pool `device-class` array must be specified in the `etc/lvmd.yaml` configuration file. Multiple thin-pool device classes are permitted.
 
 If additional storage pools are configured with device classes, then additional storage classes must also exist to expose the storage pools to users and workloads. To enable dynamic provisioning on a thin-pool, a `StorageClass` resource must be present on the cluster. The `StorageClass` resource specifies the source `device-class` array in the `topolvm.io/device-class` parameter.
@@ -31,7 +36,7 @@ device-classes: <2>
     spare-gb: 0 <4>
     thin-pool:
       name: thin
-      overprovision-ratio: 10 <5>
+      overprovision-ratio: 1 <5>
     type: thin <6>
     volume-group: ssd <7>
 ----
@@ -39,7 +44,7 @@ device-classes: <2>
 <2> A list of maps for the settings for each `device-class`.
 <3> String. The unique name of the `device-class`.
 <4> Unsigned 64-bit integer. Storage capacity in GB to be left unallocated in the volume group. Defaults to `0`.
-<5> If you have multiple thin-provisioned devices that share the same pool, then these devices can be over-provisioned. Over-provisioning requires a float value of 1 or greater.
+<5> Specify a float factor by which you can provision additional storage based on the available storage in the thin pool. For example, if this field is set to 10, you can provision up to 10 times the amount of available storage in the thin pool. To disable over-provisioning, set this field to `1`.
 <6> Thin provisioning is required to create volume snapshots.
 <7> String. The group where the `device-class` creates the logical volumes.
 


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-11768](https://issues.redhat.com/browse/OSDOCS-11768)

Link to docs preview:
[About LVM thin volumes](https://81709--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/volume-snapshots-microshift.html#microshift-lvm-thin-volumes_volume-snapshots-microshift)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change - Jon cope

