### PR TITLE
[OSDOCS#9716] GA OpenStack with rootVolume and etcd on local disk 

### DIFF
--- a/installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.adoc
+++ b/installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Deploying on {rh-openstack-first} with rootVolume and etcd on local disk
-include::snippets/technology-preview.adoc[]
-
 As a day 2 operation, you can resolve and prevent performance issues of your {rh-openstack-first} installation by moving etcd from a root volume (provided by OpenStack Cinder) to a dedicated ephemeral local disk.
 
 include::modules/installation-osp-local-disk-deployment.adoc[leveloffset=+1]

--- a/modules/installation-osp-local-disk-deployment.adoc
+++ b/modules/installation-osp-local-disk-deployment.adoc
@@ -8,10 +8,6 @@
 
 If you have an existing {rh-openstack} cloud, you can move etcd from that cloud to a dedicated ephemeral local disk.
 
-[WARNING]
-====
-This procedure is for testing etcd on a local disk only and should not be used on production clusters. In certain cases, complete loss of the control plane can occur. For more information, see "Overview of backup and restore operation" under "Backup and restore".
-====
 
 .Prerequisites
 
@@ -157,11 +153,6 @@ done
 
 . Create a file named `98-var-lib-etcd.yaml` by using the following YAML file:
 +
-[WARNING]
-====
-This procedure is for testing etcd on a local disk and should not be used on a production cluster. In certain cases, complete loss of the control plane can occur. For more information, see "Overview of backup and restore operation" under "Backup and restore".
-====
-+
 [%collapsible]
 ====
 [source,yaml]
@@ -238,6 +229,7 @@ spec:
 
           After=migrate-to-local-etcd.service
           Before=crio.service
+          Requisite=var-lib-etcd.mount
 
           [Service]
           Type=oneshot
@@ -260,6 +252,13 @@ spec:
 <6> Cleans up any previous migration state.
 <7> Copies and moves in separate steps to ensure atomic creation of a complete member directory.
 <8> Performs a quick check of the mount point directory before performing a full recursive relabel. If restorecon in the file path `/var/lib/etcd` cannot rename the directory, the recursive rename is not performed.
+====
++
+[WARNING]
+====
+After you apply the `98-var-lib-etcd.yaml` file to the system, do not remove it. Removing this file will break etcd members and lead to system instability.
+
+If a rollback is necessary, modify the `ControlPlaneMachineSet` object to use a flavor that does not include ephemeral disks. This change regenerates the control plane nodes without using ephemeral disks for the etcd partition, which avoids issues related to the `98-var-lib-etcd.yaml` file. It is safe to remove the `98-var-lib-etcd.yaml` file only after the update to the `ControlPlaneMachineSet` object is complete and no control plane nodes are using ephemeral disks.
 ====
 
 . Create the new `MachineConfig` object by running the following command:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9716](https://issues.redhat.com//browse/OSDOCS-9716)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81714--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: #81888 is merged. I think I'll just end up incorporating #81889 into this.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
