### PR TITLE
OSDOCS-11995: adds note to contrib guide

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1385,7 +1385,9 @@ To mark up command syntax, use the code block and wrap any replaceable values in
 
 [IMPORTANT]
 ====
-Do not italicize user-replaced values. This guideline is an exception to the link:https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values[_Red Hat supplementary style guide for product documentation_].
+In core OpenShift Container Platform documentation, do not italicize user-replaced values. This guideline is an exception to the link:https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values[_Red Hat supplementary style guide for product documentation_].
+
+Red Hat build of MicroShift documentation follows the SSG and italicizes user-replaced values.
 ====
 
 For example:


### PR DESCRIPTION
This clarifies for the teams that MicroShift does not take an exception for user-replaced values, but follows the SSG.

Issue:
https://issues.redhat.com/browse/OSDOCS-11995

Link to docs preview:
N/A


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
