### PR TITLE
[4.16] Updating date format for workloads operator RNs

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -17,7 +17,7 @@ For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_onc
 [id="run-once-duration-override-operator-release-notes-1-1-1"]
 == Run Once Duration Override Operator 1.1.1
 
-Issued: 2024-07-01
+Issued: 1 July 2024
 
 The following advisory is available for the {run-once-operator} 1.1.1: link:https://access.redhat.com/errata/RHSA-2024:1616[RHSA-2024:1616]
 

--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -15,7 +15,7 @@ For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#
 [id="descheduler-operator-release-notes-5.0.1"]
 == Release notes for {descheduler-operator} 5.0.1
 
-Issued: 2024-07-01
+Issued: 1 July 2024
 
 The following advisory is available for the {descheduler-operator} 5.0.1:
 
@@ -44,7 +44,7 @@ include::snippets/fips-snippet.adoc[]
 [id="descheduler-operator-release-notes-5.0.0"]
 == Release notes for {descheduler-operator} 5.0.0
 
-Issued: 2024-03-06
+Issued: 6 March 2024
 
 The following advisory is available for the {descheduler-operator} 5.0.0:
 

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -15,7 +15,7 @@ For more information, see xref:../../../nodes/scheduling/secondary_scheduler/ind
 [id="secondary-scheduler-operator-release-notes-1.3.0_{context}"]
 == Release notes for {secondary-scheduler-operator-full} 1.3.0
 
-Issued: 2024-07-01
+Issued: 1 July 2024
 
 The following advisory is available for the {secondary-scheduler-operator-full} 1.3.0:
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16 only

Issue:
N/A

Link to docs preview:
* https://81733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#run-once-duration-override-operator-release-notes-1-1-1
* https://81733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-release-notes.html#descheduler-operator-release-notes-5.0.1
* https://81733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html#secondary-scheduler-operator-release-notes-1.3.0_nodes-secondary-scheduler-release-notes

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
