### PR TITLE
[4.13] Updating date format for workloads operator RNs

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -17,7 +17,7 @@ For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_onc
 [id="run-once-duration-override-operator-release-notes-1-0-1"]
 == {run-once-operator} 1.0.1
 
-Issued: 2023-10-26
+Issued: 26 October 2023
 
 The following advisory is available for the {run-once-operator} 1.0.1:
 
@@ -31,7 +31,7 @@ The following advisory is available for the {run-once-operator} 1.0.1:
 [id="run-once-duration-override-operator-release-notes-1-0-0"]
 == {run-once-operator} 1.0.0
 
-Issued: 2023-05-18
+Issued: 18 May 2023
 
 The following advisory is available for the {run-once-operator} 1.0.0:
 

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -15,7 +15,7 @@ For more information, see xref:../../../nodes/scheduling/secondary_scheduler/ind
 [id="secondary-scheduler-operator-release-notes-1.1.3"]
 == Release notes for {secondary-scheduler-operator-full} 1.1.3
 
-Issued: 2023-10-26
+Issued: 26 October 2023
 
 The following advisory is available for the {secondary-scheduler-operator-full} 1.1.3:
 
@@ -42,7 +42,7 @@ The following advisory is available for the {secondary-scheduler-operator-full} 
 [id="secondary-scheduler-operator-release-notes-1.1.2"]
 == Release notes for {secondary-scheduler-operator-full} 1.1.2
 
-Issued: 2023-8-23
+Issued: 23 August 2023
 
 The following advisory is available for the {secondary-scheduler-operator-full} 1.1.2:
 
@@ -69,7 +69,7 @@ The following advisory is available for the {secondary-scheduler-operator-full} 
 [id="secondary-scheduler-operator-release-notes-1.1.1"]
 == Release notes for {secondary-scheduler-operator-full} 1.1.1
 
-Issued: 2023-5-18
+Issued: 18 May 2023
 
 The following advisory is available for the {secondary-scheduler-operator-full} 1.1.1:
 
@@ -96,7 +96,7 @@ The following advisory is available for the {secondary-scheduler-operator-full} 
 [id="secondary-scheduler-operator-release-notes-1.1.0"]
 == Release notes for {secondary-scheduler-operator-full} 1.1.0
 
-Issued: 2022-9-1
+Issued: 1 September 2022
 
 The following advisory is available for the {secondary-scheduler-operator-full} 1.1.0:
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13 only

Issue:
N/A

Link to docs preview:
* https://81736--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#run-once-duration-override-operator-release-notes-1-0-1
* https://81736--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html#secondary-scheduler-operator-release-notes-1.1.3

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
