### PR TITLE
Nodes and CRO 4.17 release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -673,22 +673,22 @@ For more information about cns-migration, see link:https://github.com/openshift/
 === Machine Config Operator
 
 [id="ocp-4-17-machine-config-operator-global-tls_{context}"]
-=== Control plane TLS security profiles supported by the MCO
+==== Control plane TLS security profiles supported by the MCO
 
 The Machine Config Operator (MCO) and Machine Config Server now use the TLS security profile that is configured for the control plane components. For more information, see xref:../security/tls-security-profiles.adoc#tls-profiles-kubernetes-configuring_tls-security-profiles[Configuring the TLS security profile for the control plane].
 
 [id="ocp-4-17-machine-config-operator-boot-image-aws_{context}"]
-=== Updated boot images for AWS now supported (Technology Preview)
+==== Updated boot images for AWS now supported (Technology Preview)
 
 Updated boot images are now supported as a Technology Preview feature for Amazon Web Services (AWS) clusters. This feature allows you configure your cluster to update the node boot image whenever you update your cluster. By default, the boot image in your cluster is not updated along with your cluster. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
 
 [id="ocp-4-17-machine-config-operator-boot-image-gcp_{context}"]
-=== Updated boot images for GCP clusters promoted to GA
+==== Updated boot images for GCP clusters promoted to GA
 
 Updated boot images has been promoted to GA for Google Cloud Platform (GCP) clusters. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
 
 [id="ocp-4-17-machine-config-operator-node-disrupt-ga_{context}"]
-=== Node disruption policies promoted to GA
+==== Node disruption policies promoted to GA
 
 Node disruption policies for Google Cloud Platform (GCP) clusters has been promoted to GA. A node disruption policy allows you to define a set of Ignition config objects changes that would require little or no disruption to your workloads. For more information, see xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes].
 
@@ -713,6 +713,29 @@ For more information, see _Configuring Capacity Reservation by using machine set
 * `--since-time`: Only return logs after a specific date, expressed in the RFC3339 format. Defaults to all logs.
 
 For a full list of flags to use with the `oc adm must-gather command`, see xref:../support/gathering-cluster-data.adoc#must-gather-flags_gathering-cluster-data[Must-gather flags].
+
+[id="ocp-4-17-nodes-userns_{context}"]
+==== Linux user namespaces now supported for pods (Technology Preview)
+
+{product-title} release {product-version} adds support for deploying pods and containers into Linux user namespaces. Running pods and containers in individual user namespaces can mitigate several vulnerabilities that a compromised container can pose to other pods and the node itself. For more information, see xref:../nodes/pods/nodes-pods-user-namespaces.adoc#nodes-pods-user-namespaces[Running pods in Linux user namespaces].
+
+[id="ocp-4-17-nodes-crio-port_{context}"]
+==== CRI-O metrics port now uses TLS
+
+{product-title} monitoring now uses a TLS-backed endpoint to fetch CRI-O container runtime metrics. These certificates are managed by the system and not the user. {product-title} monitoring queries have been updated to the new port. For information on the certificates used by monitoring, see xref:../security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc#cert-types-monitoring-and-cluster-logging-operator-component-certificates[Monitoring and OpenShift Logging Operator component certificates]. 
+
+[id="ocp-4-17-cro_{context}"]
+=== Cluster Resource Override Admission Operator
+
+[id="ocp-4-17-cro-infra_{context}"]
+==== Moving the Cluster Resource Override Operator
+
+By default, the installation process creates a Cluster Resource Override Operator pod on a worker node and two Cluster Resource Override pods on control plane nodes. You can move these pods to other nodes, such as an infrastructure node, as needed. For more information, see xref:../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-resource-override-move-infra_nodes-cluster-overcommit[Moving the Cluster Resource Override Operator pods].
+
+[id="ocp-4-17-cro-deploy_{context}"]
+=== Cluster Resource Override Operator pod is owned by a deployment object
+
+The Cluster Resource Override Operator pod is now owned by a deployment object. Previously, the Operator was owned by a daemon set object. Using a deployment for the Operator addresses a number of issues, including additional security and add the ability to run the pods on worker nodes.
 
 [id="ocp-4-17-monitoring_{context}"]
 === Monitoring
@@ -1557,6 +1580,11 @@ In the following tables, features are marked with the following statuses:
 |`MaxUnavailableStatefulSet` featureset
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|Linux user namespace support
+|Not Available
+|Not Available
 |Technology Preview
 
 |====


### PR DESCRIPTION
Release notes for Nodes and Cluster Resource Override Admission Operator. 
[Preview](https://81751--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-nodes-userns_release-notes).

Also, fixed the heading level for the MCO new features.  Currently, the new features headings are H3, should be H4.  
[Preview](https://81751--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-machine-config-operator_release-notes).
[Current docs](https://docs.openshift.com/container-platform/4.17/release_notes/ocp-4-17-release-notes.html#ocp-4-17-machine-config-operator_release-notes).