### PR TITLE
OSDOCS-11820 removing extraneous GCP CAPI deprecation notice

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1595,11 +1595,6 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Removed
 
-|Terraform infrastructure provider for {gcp-first}
-|General Availability
-|General Availability
-|Removable as Technology Preview
-
 |Installing a cluster on {alibaba} with installer-provisioned infrastructure
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-11820

Link to docs preview:

No QE required as this was duplicate content