### PR TITLE
OSDOCS-11942 adding Azure CAPI release note

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -59,6 +59,25 @@ This release adds improvements related to the following components and concepts:
 
 You can deploy {product-title} {product-version} in {azure-first} in the Spain, Central (`spaincentral`) region. For more information, see xref:../installing/installing_azure/installing-azure-account.adoc#installation-azure-regions_installing-azure-account[Supported Azure regions].
 
+[id="ocp-4-17-installation-and-update-azure-capi_{context}"]
+==== Cluster API replaces Terraform for {azure-first} installations
+In {product-title} 4.17, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on {azure-short}.
+
+[NOTE]
+====
+With the replacement of Terraform, the following permissions are required if you use a service principal with limited privileges:
+
+* `Microsoft.Network/loadBalancers/inboundNatRules/read`
+* `Microsoft.Network/loadBalancers/inboundNatRules/write`
+* `Microsoft.Network/loadBalancers/inboundNatRules/join/action`
+* `Microsoft.Network/loadBalancers/inboundNatRules/delete`
+* `Microsoft.Network/routeTables/read`
+* `Microsoft.Network/routeTables/write`
+* `Microsoft.Network/routeTables/join/action`
+
+For more information on required permissions, see xref:../installing/installing_azure/installing-azure-account.adoc#minimum-required-permissions-ipi-azure_installing-azure-account[Required Azure permissions for installer-provisioned infrastructure].
+====
+
 [id="ocp-4-17-postinstallation-configuration_{context}"]
 === Postinstallation configuration
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-11942

Link to docs preview:
https://81768--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-installation-and-update-azure-capi_release-notes

QE review:
- [x] QE has approved this change.
