### PR TITLE
OSDOCS-11890 Documenting installing Nutanix with additional disks

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -3195,6 +3195,108 @@ The name of one or more failures domains.
 |The boot type that the compute machines use. You must use the `Legacy` boot type in {product-title} {product-version}. For more information on boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment].
 |`Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
 
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        dataSourceImage:
+          name:
+|Optional. The name of the data source image for the virtual machine disk in Prism Central.
+|String
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        dataSourceImage:
+          referenceName:
+|Optional. The reference name of the data source image in the failure domain. If you use this parameter, you must configure a matching `dataSourceImage` (with the same `referenceName`) in each failure domain that the compute nodes occupy. For more information about configuring failure domains, see _Configuring failure domains_ in the _Installing a cluster on Nutanix_ page.
+|String
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        dataSourceImage:
+          uuid:
+|The UUID of the data source image in Prism Central. This value is required.
+|String
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        deviceProperties:
+          adapterType:
+|The adapter type of the disk address. If the disk type is "Disk", valid values are "SCSI", "IDE", "PCI", "SATA" or "SPAPR".
+If the disk type is "CDRom", valid values are "IDE" or "SATA".
+|String
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        deviceProperties:
+          deviceIndex:
+|The index of the disk address. Valid values are non-negative integers including 0. The device index for disks that share the same adapter type should start at 0 and increase consecutively. The default value is 0. For each virtual machine, the `Disk.SCSI.0` and `CDRom.IDE.0` indices are reserved. If you use the `Disk.SCSI` or `CDRom.IDE` disk and adapter types, the `deviceIndex` should start at 1.
+|Non-negative integer, including 0.
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        deviceProperties:
+          deviceType:
+|The disk device type. Valid values are "Disk" and "CDRom".
+|String
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        diskSize:
+|The size of the disk to attach to the virtual machine. The minimum size is 1Gb.
+|Quantity format, such as 100G or 100Gi. For more information on this format, see link:https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Format.
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        storageConfig:
+          diskMode:
+|The disk mode. Valid values are "Standard" or "Flash", and the default is "Standard".
+|String
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        storageConfig:
+          storageContainer:
+            name:
+|Optional. The name of the storage container object used by the virtual machine disk in Prism Central.
+|String
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        storageConfig:
+          storageContainer:
+            referenceName:
+|Optional. The reference name of the storage container in the failure domain. If you use this, you must configure a matching `storageContainer` (with the same `referenceName`) in each failure domain the compute nodes occupy. For more information about configuring failure domains, see _Configuring failure domains_ in the _Installing a cluster on Nutanix_ page.
+|String
+
+|compute:
+  platform:
+    nutanix:
+      dataDisks:
+        storageConfig:
+          storageContainer:
+            uuid:
+|The UUID of the storage container in Prism Central.
+|String
+
 |controlPlane:
   platform:
     nutanix:


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-11890

Link to docs preview:
https://81769--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installation-config-parameters-nutanix#installation-configuration-parameters-additional-nutanix_installation-config-parameters-nutanix

QE review:
- [x] QE has approved this change.