### PR TITLE
OCPBUGS#38430: Adding missing step to Autoscaling an Ingress Controller

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -7,6 +7,7 @@
 :OCP: OpenShift Container Platform
 :ocp-version: 4.12
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
+:oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
 :cluster-manager: OpenShift Cluster Manager
 :cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager Hybrid Cloud Console]

--- a/modules/nw-autoscaling-ingress-controller.adoc
+++ b/modules/nw-autoscaling-ingress-controller.adoc
@@ -1,57 +1,29 @@
 // Module included in the following assemblies:
 //
-// * networking/ingress-controller-configuration.adoc
+// * networking/ingress-operator.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-autoscaling-ingress-controller_{context}"]
 = Autoscaling an Ingress Controller
 
-Automatically scale an Ingress Controller to dynamically meet routing performance or availability requirements such as the requirement to increase throughput. The following procedure provides an example for scaling up the default `IngressController`.
+You can automatically scale an Ingress Controller to dynamically meet routing performance or availability requirements, such as the requirement to increase throughput.
+
+The following procedure provides an example for scaling up the default Ingress Controller.
 
 .Prerequisites
-. You have the OpenShift CLI (`oc`) installed.
-. You have access to an {product-title} cluster as a user with the `cluster-admin` role.
-. You have the Custom Metrics Autoscaler Operator installed.
+
+* You have the {oc-first} installed.
+* You have access to an {product-title} cluster as a user with the `cluster-admin` role.
+* You installed the Custom Metrics Autoscaler Operator and an associated KEDA Controller.
+** You can install the Operator by using OperatorHub on the web console. After you install the Operator, you can create an instance of `KedaController`.
 
 .Procedure
-. Create a project in the `openshift-ingress-operator` namespace by running the following command:
-+
-[source,terminal]
-----
-$ oc project openshift-ingress-operator
-----
-
-. Enable OpenShift monitoring for user-defined projects by creating and applying a config map:
-
-.. Create a new `ConfigMap` object, `cluster-monitoring-config.yaml`:
-+
-.cluster-monitoring-config.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
-data:
-  config.yaml: |
-    enableUserWorkload: true <1>
-----
-+
-<1> When set to `true`, the `enableUserWorkload` parameter enables monitoring for user-defined projects in a cluster.
-
-.. Apply the config map by running the following command:
-+
-[source,terminal]
-----
-$ oc apply -f cluster-monitoring-config.yaml
-----
 
 . Create a service account to authenticate with Thanos by running the following command:
 +
 [source,terminal]
 ----
-$ oc create serviceaccount thanos && oc describe serviceaccount thanos
+$ oc create -n openshift-ingress-operator serviceaccount thanos && oc describe -n openshift-ingress-operator serviceaccount thanos
 ----
 +
 .Example output
@@ -61,43 +33,48 @@ Name:                thanos
 Namespace:           openshift-ingress-operator
 Labels:              <none>
 Annotations:         <none>
-Image pull secrets:  thanos-dockercfg-b4l9s
-Mountable secrets:   thanos-dockercfg-b4l9s
-Tokens:              thanos-token-c422q
+Image pull secrets:  thanos-dockercfg-kfvf2
+Mountable secrets:   thanos-dockercfg-kfvf2
+Tokens:              <none>
 Events:              <none>
 ----
 
-. Define a `TriggerAuthentication` object within the `openshift-ingress-operator` namespace using the service account's token.
-
-.. Define the variable `secret` that contains the secret by running the following command:
+. Manually create the service account secret token with the following command:
 +
 [source,terminal]
 ----
-$ secret=$(oc get secret | grep thanos-token | head -n 1 | awk '{ print $1 }')
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thanos-token
+  namespace: openshift-ingress-operator
+  annotations:
+    kubernetes.io/service-account.name: thanos
+type: kubernetes.io/service-account-token
+EOF
 ----
+
+. Define a `TriggerAuthentication` object within the `openshift-ingress-operator` namespace by using the service account's token.
 
 .. Create the `TriggerAuthentication` object and pass the value of the `secret` variable to the `TOKEN` parameter:
 +
 [source,terminal]
 ----
-$ oc process TOKEN="$secret" -f - <<EOF | oc apply -f -
-apiVersion: template.openshift.io/v1
-kind: Template
-parameters:
-- name: TOKEN
-objects:
-- apiVersion: keda.sh/v1alpha1
-  kind: TriggerAuthentication
-  metadata:
-    name: keda-trigger-auth-prometheus
-  spec:
-    secretTargetRef:
-    - parameter: bearerToken
-      name: \${TOKEN}
-      key: token
-    - parameter: ca
-      name: \${TOKEN}
-      key: ca.crt
+$ oc apply -f - <<EOF
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-prometheus
+  namespace: openshift-ingress-operator
+spec:
+  secretTargetRef:
+  - parameter: bearerToken
+    name: thanos-token
+    key: token
+  - parameter: ca
+    name: thanos-token
+    key: ca.crt
 EOF
 ----
 
@@ -112,6 +89,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: thanos-metrics-reader
+  namespace: openshift-ingress-operator
 rules:
 - apiGroups:
   - ""
@@ -148,7 +126,7 @@ $ oc apply -f thanos-metrics-reader.yaml
 +
 [source,terminal]
 ----
-$ oc adm policy add-role-to-user thanos-metrics-reader -z thanos --role=namespace=openshift-ingress-operator
+$ oc adm policy -n openshift-ingress-operator add-role-to-user thanos-metrics-reader -z thanos --role-namespace=openshift-ingress-operator
 ----
 +
 [source,terminal]
@@ -170,6 +148,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: ingress-scaler
+  namespace: openshift-ingress-operator
 spec:
   scaleTargetRef: <1>
     apiVersion: operator.openshift.io/v1
@@ -184,7 +163,7 @@ spec:
   - type: prometheus
     metricType: AverageValue
     metadata:
-      serverAddress: https://<example-cluster>:9091 <3>
+      serverAddress: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091 <3>
       namespace: openshift-ingress-operator <4>
       metricName: 'kube-node-role'
       threshold: '1'
@@ -195,7 +174,7 @@ spec:
 ----
 <1> The custom resource that you are targeting. In this case, the Ingress Controller.
 <2> Optional: The maximum number of replicas. If you omit this field, the default maximum is set to 100 replicas.
-<3> The cluster address and port.
+<3> The Thanos service endpoint in the `openshift-monitoring` namespace.
 <4> The Ingress Operator namespace.
 <5> This expression evaluates to however many worker nodes are present in the deployed cluster.
 +
@@ -218,13 +197,13 @@ $ oc apply -f ingress-autoscaler.yaml
 +
 [source,terminal]
 ----
-$ oc get ingresscontroller/default -o yaml | grep replicas:
+$ oc get -n openshift-ingress-operator ingresscontroller/default -o yaml | grep replicas:
 ----
 +
 .Example output
 [source,terminal]
 ----
-replicas: 3
+  replicas: 3
 ----
 
 ** Get the pods in the `openshift-ingress` project:

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -48,13 +48,15 @@ include::modules/nw-ingress-setting-a-custom-default-certificate.adoc[leveloffse
 
 include::modules/nw-ingress-custom-default-certificate-remove.adoc[leveloffset=+2]
 
+// Autoscaling an Ingress Controller
 include::modules/nw-autoscaling-ingress-controller.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 
-* xref:../nodes/cma/nodes-cma-autoscaling-custom-install.adoc#nodes-cma-autoscaling-custom-install[Installing the custom metrics autoscaler]
+* xref:../nodes/cma/nodes-cma-autoscaling-custom-install.adoc#nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install[Installing the custom metrics autoscaler]
+
+* xref:../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 
 * xref:../nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc#nodes-cma-autoscaling-custom-trigger-auth[Understanding custom metrics autoscaler trigger authentications]
 


### PR DESCRIPTION
Cherry picked from #80875 with commit afd0298b4cd691bbc3610fdc45d7403e3bd1a7b2

Version(s):
4.12

Issue:
[OCPBUGS-38430](https://issues.redhat.com/browse/OCPBUGS-38430)

Link to docs preview:
* https://81777--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-autoscaling-ingress-controller_configuring-ingress


