### PR TITLE
[enterprise-4.15] OCPBUGS-31071: Changing catalog source name in disconnected workflow

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -22,10 +22,10 @@ To avoid this scenario, add another catalog source configuration to the `PolicyG
       remediationAction: inform
       policyName: "operator-catsrc-policy"
       metadata:
-        name: redhat-operators
+        name: redhat-operators-disconnected
       spec:
         displayName: Red Hat Operators Catalog
-        image: registry.example.com:5000/olm/redhat-operators:v{product-version}
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version}
         updateStrategy:
           registryPoll:
             interval: 1h
@@ -36,10 +36,10 @@ To avoid this scenario, add another catalog source configuration to the `PolicyG
       remediationAction: inform
       policyName: "operator-catsrc-policy"
       metadata:
-        name: redhat-operators-v2 <1>
+        name: redhat-operators-disconnected-v2 <1>
       spec:
         displayName: Red Hat Operators Catalog v2 <2>
-        image: registry.example.com:5000/olredhat-operators:<version> <3>
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version> <3>
         updateStrategy:
           registryPoll:
             interval: 1h
@@ -62,7 +62,7 @@ metadata:
   namespace: operator-namspace
 # ...
 spec:
-  source: redhat-operators-v2 <1>
+  source: redhat-operators-disconnected-v2 <1>
 # ...
 ----
 <1> Enter the name of the additional catalog source configuration that you defined in the `PolicyGenTemplate` resource.

--- a/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -39,10 +39,10 @@ spec:
       remediationAction: inform
       policyName: "operator-catsrc-policy"
       metadata:
-        name: redhat-operators
+        name: redhat-operators-disconnected
       spec:
         displayName: Red Hat Operators Catalog
-        image: registry.example.com:5000/olm/redhat-operators:v{product-version} <1>
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version} <1>
         updateStrategy: <2>
           registryPoll:
             interval: 1h
@@ -54,11 +54,11 @@ spec:
 <2> Set how frequently the Operator Lifecycle Manager (OLM) polls the index image for new Operator versions with the `registryPoll.interval` field. This change is not needed if a new index image tag is always pushed for y-stream and z-stream Operator updates. The `registryPoll.interval` field can be set to a shorter interval to expedite the update, however shorter intervals increase computational load. To counteract this, you can restore `registryPoll.interval` to the default value once the update is complete.
 <3> Last observed state of the catalog connection. The `READY` value ensures that the `CatalogSource` policy is ready, indicating that the index pod is pulled and is running. This way, {cgu-operator} upgrades the Operators based on up-to-date policy compliance states.
 
-.. This update generates one policy, `du-upgrade-operator-catsrc-policy`, to update the `redhat-operators` catalog source with the new index images that contain the desired Operators images.
+.. This update generates one policy, `du-upgrade-operator-catsrc-policy`, to update the `redhat-operators-disconnected` catalog source with the new index images that contain the desired Operators images.
 +
 [NOTE]
 ====
-If you want to use the image pre-caching for Operators and there are Operators from a different catalog source other than `redhat-operators`,  you must perform the following tasks:
+If you want to use the image pre-caching for Operators and there are Operators from a different catalog source other than `redhat-operators-disconnected`,  you must perform the following tasks:
 
 * Prepare a separate catalog source policy with the new index image or registry poll interval update for the different catalog source.
 * Prepare a separate subscription policy for the desired Operators that are from the different catalog source.


### PR DESCRIPTION
CP of https://github.com/openshift/openshift-docs/pull/80859

Version(s):
4.15

Link to docs preview:
https://81782--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-talm-updating-managed-policies.html