### PR TITLE
OSDOCS-11987: Documented the 4.12.65 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4884,3 +4884,27 @@ $ oc adm release info 4.12.64 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-65"]
+=== RHSA-2024:6642 - {product-title} 4.12.65 bug fix and security update
+
+Issued: 18 September 2024
+
+{product-title} release 4.12.65, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6642[RHSA-2024:6642] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:6644[RHBA-2024:6644] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.65 --pullspecs
+----
+
+[id="ocp-4-12-65-bug-fixes"]
+==== Bug fixes
+
+* Previously, when you received an `OVNKubernetesNorthdInactive` alert, you could not view the associated runbook. With this release, the runbook is added so you can reference it to resolve an `OVNKubernetesNorthdInactive` alert. (link:https://issues.redhat.com/browse/OCPBUGS-38905[*OCPBUGS-38905*])
+
+[id="ocp-4-12-65-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-11987](https://issues.redhat.com/browse/OSDOCS-11987)

Link to docs preview:
* [4.12.65](https://81783--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-65)

