### PR TITLE
CLID 208: Updated ImageSetConfiguration examples to include blockedImages example. 

### DIFF
--- a/modules/oc-mirror-image-set-config-examples.adoc
+++ b/modules/oc-mirror-image-set-config-examples.adoc
@@ -247,3 +247,24 @@ mirror:
  additionalImages:
    - name: registry.redhat.io/ubi9/ubi:latest
 ----
+
+[discrete]
+[id="oc-mirror-image-set-examples-blocked-images_{context}"]
+== Use case: Including the `blockedImages` parameters
+
+The following `ImageSetConfiguration` file excludes the images that return `manifest unknown` errors.
+
+This example also shows how to use the `blockedImages` parameter in the `imageSetConfiguration` file to skip mirroring an image that fails to mirror due to an `manifest unknown` error.
+
+.Example `ImageSetConfiguration` file
+[source,yaml,subs=attributes+]
+----
+apiVersion: mirror.openshift.io/v2alpha1
+kind: ImageSetConfiguration
+mirror:
+  additionalImages:
+    - name: registry.redhat.io/ubi8/ubi:latest
+    - name: registry.redhat.io/ubi8/ubi:fake
+  blockedImages:
+    - name: registry.redhat.io/ubi8/ubi:fake
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/CLID-208
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81789--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-disconnected.html#oc-mirror-image-set-examples-blocked-images_installing-mirroring-disconnected
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
