### PR TITLE
OSDOCS#11568: Fix Vale xref errors

### DIFF
--- a/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
@@ -43,7 +43,9 @@ include::modules/hcp-non-bm-infra-reqs.adoc[leveloffset=+2]
 
 * xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
+* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
+
+* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
 
@@ -53,7 +55,7 @@ include::modules/hcp-non-bm-hc.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted control plane cluster]
+* xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-manual_hcp-import[Manually importing a hosted control plane cluster]
 
 include::modules/hcp-non-bm-hc-console.adoc[leveloffset=+2]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11568
Follow up PR for https://github.com/openshift/openshift-docs/pull/81125 to fix Vale xref errors 

<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- [Infrastructure requirements for non-bare metal agent machines](https://81791--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-non-bm-infra-reqs_hcp-deploy-non-bm) -- please see 4th and 5th bullets in additional resources 
- [Creating a hosted cluster on non-bare metal agent machines by using the CLI](https://81791--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.html#hcp-non-bm-hc_hcp-deploy-non-bm) -- please see a bullet in additional resources

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required. This PR only fixes links as per Vale errors.

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
