### PR TITLE
OSDOCS-11214-clean: Remove progressed entries from 4.17 RN tables

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -656,6 +656,7 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |Removed
 
+// Do not remove the SQLite database... entry until otherwise directed by the Operator Framework PM
 |SQLite database format for Operator catalogs
 |Deprecated
 |Deprecated
@@ -832,7 +833,7 @@ In the following tables, features are marked with the following statuses:
 |OpenShift SDN network plugin
 |Deprecated
 |Deprecated
-|Deprecated
+|Removed
 
 |iptables
 |Deprecated
@@ -1119,22 +1120,12 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.15 |4.16 |4.17
 
-|Ingress Node Firewall Operator
-|General Availability
-|General Availability
-|General Availability
-
 |Advertise using L2 mode the MetalLB service from a subset of nodes, using a specific pool of IP addresses
 |Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Multi-network policies for SR-IOV networks
-|General Availability
-|General Availability
-|General Availability
-
-|OVN-Kubernetes network plugin as secondary network
 |General Availability
 |General Availability
 |General Availability
@@ -1178,11 +1169,6 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 |Technology Preview
-
-|Dual-NIC hardware as PTP boundary clock
-|General Availability
-|General Availability
-|General Availability
 
 |Dual-NIC Intel E810 PTP boundary clock with highly available system clock
 |Not Available
@@ -1239,11 +1225,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Google Filestore CSI Driver Operator
-|General Availability
-|General Availability
-|General Availability
-
 |{ibm-power-server-name} Block CSI Driver Operator
 |General Availability
 |General Availability
@@ -1251,11 +1232,6 @@ In the following tables, features are marked with the following statuses:
 
 |Read Write Once Pod access mode
 |Technology Preview
-|General Availability
-|General Availability
-
-|Build CSI Volumes in OpenShift Builds
-|General Availability
 |General Availability
 |General Availability
 
@@ -1413,27 +1389,6 @@ In the following tables, features are marked with the following statuses:
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.15 |4.16 |4.17
-
-|Driver Toolkit
-|General Availability
-|General Availability
-|General Availability
-
-|Kernel Module Management Operator
-|General Availability
-|General Availability
-|General Availability
-
-|Kernel Module Management Operator - Hub and spoke cluster support
-|General Availability
-|General Availability
-|General Availability
-
-|Node Feature Discovery
-|General Availability
-|General Availability
-|General Availability
-
 |====
 
 [discrete]
@@ -1611,16 +1566,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 |Technology Preview
-
-|Hosted control planes for {product-title} on bare metal
-|General Availability
-|General Availability
-|General Availability
-
-|Hosted control planes for {product-title} on {VirtProductName}
-|General Availability
-|General Availability
-|General Availability
 
 |Hosted control planes for {product-title} using non-bare metal agent machines
 |Technology Preview


### PR DESCRIPTION
Removed table entries with 3 consecutive GA entries (4.14, 4.15, and 4.16).

Version(s):
4.17

Issue:
* [OSDOCS-11214](https://issues.redhat.com/browse/OSDOCS-11214)

Link to docs preview:
* [Deprecated and removed features Tables](https://81796--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-deprecated-removed-features_release-notes)
* [TP Tables](https://81796--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-technology-preview-tables_release-notes)

**Notes:**
* [Storage] Lisa will be removing `Persistent storage using FlexVolume` as part of https://github.com/openshift/openshift-docs/pull/81552/files
* [Installer] The triple Deprecated entries for Installation components do not need an update.
* [Operators] SQLite database format for Operator catalogs not likely to be removed until a major release.
* [IBM] All in good shape. L. Hinson to raise a PR to move HCP to GA once the ACM GA happens.