### PR TITLE
OSDOCS-11826 ROSA/OSD increase to 249 nodes

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
@@ -60,7 +60,7 @@ For a complete list of supported instances for worker nodes see xref:../../rosa_
 Autoscaling allows you to automatically adjust the size of the cluster based on the current workload. See xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.adoc#rosa-nodes-about-autoscaling-nodes[About autoscaling nodes on a cluster] for more details.
 
 === Maximum number of worker nodes
-The maximum number of worker nodes is 180 worker nodes for each ROSA cluster. See xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] for more details on node counts.
+The maximum number of worker nodes in ROSA clusters versions 4.14.14 and later is 249. For earlier versions, the limit is 180 nodes. See xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] for more details on node counts.
 
 A list of the account-wide and per-cluster roles is provided in the xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[ROSA documentation].
 

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -105,7 +105,7 @@ Tags that are added by Red{nbsp}Hat are required for clusters to stay in complia
 |Select the additional custom security group IDs that are used with the control plane nodes created along side the cluster. The default is none selected. Only security groups associated with the selected VPC are displayed. You can select a maximum of 5 additional security groups.
 
 |`Compute nodes`
-|Specify the number of compute nodes to provision into each availability zone. Clusters deployed in a single availability zone require at least 2 nodes. Clusters deployed in multiple zones must have at least 3 nodes. The maximum number of worker nodes is 180 nodes. The default value is `2`.
+|Specify the number of compute nodes to provision into each availability zone. Clusters deployed in a single availability zone require at least 2 nodes. Clusters deployed in multiple zones must have at least 3 nodes. The maximum number of worker nodes is 249 nodes. The default value is `2`.
 
 |`Default machine pool labels (optional)`
 |Specify the labels for the default machine pool. The label format should be a comma-separated list of key-value pairs. This list will overwrite any modifications made to node labels on an ongoing basis.

--- a/modules/sd-planning-cluster-maximums.adoc
+++ b/modules/sd-planning-cluster-maximums.adoc
@@ -19,7 +19,7 @@ ifdef::openshift-dedicated[]
 endif::[]
 cluster.
 
-These guidelines are based on a cluster of 180 compute (also known as worker) nodes in a multiple availability zone configuration. For smaller clusters, the maximums are lower.
+These guidelines are based on a cluster of 249 compute (also known as worker) nodes in a multiple availability zone configuration. For smaller clusters, the maximums are lower.
 
 
 .Tested cluster maximums

--- a/modules/sd-planning-considerations.adoc
+++ b/modules/sd-planning-considerations.adoc
@@ -43,7 +43,7 @@ endif::[]
 |m5.4xlarge
 |r5.2xlarge
 
-|101 to 180
+|101 to 249
 |m5.8xlarge
 |r5.4xlarge
 |===
@@ -65,7 +65,7 @@ GCP control plane and infrastructure node size:
 |custom-16-65536
 |custom-8-65536-ext
 
-|101 to 180
+|101 to 249
 |custom-32-131072
 |custom-16-131072-ext
 |===
@@ -85,7 +85,7 @@ GCP control plane and infrastructure node size for clusters created on or after 
 |n2-standard-16
 |n2-highmem-8
 
-|101 to 180
+|101 to 249
 |n2-standard-32
 |n2-highmem-16
 |===
@@ -101,7 +101,7 @@ endif::[]
 ifdef::openshift-dedicated[]
 {product-title}
 endif::[]
-is 180.
+clusters version 4.14.14 and later is 249. For earlier versions, the limit is 180.
 ====
 
 [id="node-scaling-after-installation_{context}"]
@@ -145,7 +145,7 @@ endif::[]
 ifdef::openshift-dedicated[]
 {product-title}
 endif::[]
-is 180.
+cluster versions 4.14.14 and later is 249. For earlier versions, the limit is 180.
 
 The resizing alerts only appear after sustained periods of high utilization. Short usage spikes, such as a node temporarily going down causing the other node to scale up, do not trigger these alerts.
 ====

--- a/osd_whats_new/osd-whats-new.adoc
+++ b/osd_whats_new/osd-whats-new.adoc
@@ -17,6 +17,9 @@ With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster p
 
 [id="osd-q1-2025_{context}"]
 === Q1 2025
+
+* **Cluster node limit update.** {product-title} clusters versions 4.14.14 and greater can now scale to 249 worker nodes. This is an increase from the previous limit of 180 nodes. For more information, see xref:../osd_planning/osd-limits-scalability.adoc#osd-limits-scalability[limits and scalability].
+
 * **Red{nbsp}Hat SRE log-based alerting endpoints have been updated.** {product-title} customers who are using a firewall to control egress traffic can now remove all references to `*.osdsecuritylogs.splunkcloud.com:9997` from your firewall allowlist. {product-title} clusters still require the `http-inputs-osdsecuritylogs.splunkcloud.com:443` log-based alerting endpoint to be accessible from the cluster.
 
 [id="osd-q4-2024_{context}"]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -22,6 +22,8 @@ endif::openshift-rosa-hcp[]
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]
+* **{rosa-classic} cluster node limit update.** {rosa-classic} clusters versions 4.14.14 and greater can now scale to 249 worker nodes. This is an increase from the previous limit of 180 nodes. For more information, see xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability].
+
 [IMPORTANT]
 ====
 Egress lockdown is a Technology Preview feature.
@@ -40,6 +42,7 @@ Egress lockdown is a Technology Preview feature.
 * **Egress lockdown is now available as a Technology Preview on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-lockdown-install.adoc#rosa-hcp-egress-lockdown-install[Creating a {product-title} cluster with egress lockdown].
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa[]
+
 [id="rosa-q4-2024_{context}"]
 === Q4 2024
 


### PR DESCRIPTION
Updated info for max node size in ROSA classic and OSD to 249 at +4.14.14.

Added a RN for ROSA

Removed some ROSA mentions that were in the OSD docs.


Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11826


Link to docs preview:

Dedicated L&S update:
https://81800--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/osd-limits-scalability.html

ROSA L&S update:
https://81800--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-limits-scalability.html

Install Mention:
https://81800--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.html

Release note:
https://81800--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html#rosa-q3-2024_rosa-whats-new





QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
