### PR TITLE
OCPBUGS-38430-tweak

### DIFF
--- a/modules/nw-autoscaling-ingress-controller.adoc
+++ b/modules/nw-autoscaling-ingress-controller.adoc
@@ -35,7 +35,7 @@ Labels:              <none>
 Annotations:         <none>
 Image pull secrets:  thanos-dockercfg-kfvf2
 Mountable secrets:   thanos-dockercfg-kfvf2
-Tokens:              <none>
+Tokens:              thanos-token-c422q
 Events:              <none>
 ----
 
@@ -61,25 +61,36 @@ EOF
 ----
 
 . Define a `TriggerAuthentication` object within the `openshift-ingress-operator` namespace by using the service account's token.
-
++
+.. Define the `secret` variable that contains the secret by running the following command:
++
+[source,terminal]
+----
+$ secret=$(oc get secret -n openshift-ingress-operator | grep thanos-token | head -n 1 | awk '{ print $1 }')
+----
++
 .. Create the `TriggerAuthentication` object and pass the value of the `secret` variable to the `TOKEN` parameter:
 +
 [source,terminal]
 ----
-$ oc apply -f - <<EOF
-apiVersion: keda.sh/v1alpha1
-kind: TriggerAuthentication
-metadata:
-  name: keda-trigger-auth-prometheus
-  namespace: openshift-ingress-operator
-spec:
-  secretTargetRef:
-  - parameter: bearerToken
-    name: thanos-token
-    key: token
-  - parameter: ca
-    name: thanos-token
-    key: ca.crt
+$ oc process TOKEN="$secret" -f - <<EOF | oc apply -n openshift-ingress-operator -f -
+apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: TOKEN
+objects:
+- apiVersion: keda.sh/v1alpha1
+  kind: TriggerAuthentication
+  metadata:
+    name: keda-trigger-auth-prometheus
+  spec:
+    secretTargetRef:
+    - parameter: bearerToken
+      name: \${TOKEN}
+      key: token
+    - parameter: ca
+      name: \${TOKEN}
+      key: ca.crt
 EOF
 ----
 


### PR DESCRIPTION
Revert one step that was part of a larger backport operation.

Version(s):
4.15 to 4.12

Issue:
[OCPBUGS-38430](https://issues.redhat.com/browse/OCPBUGS-38430) and [OCPBUGS-39242](https://issues.redhat.com/browse/OCPBUGS-39242)

Link to docs preview:
* [Autoscaling an Ingress Controller-core](https://81801--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-autoscaling-ingress-controller_configuring-ingress)


- [x] SME has approved this change (Grant Spence)
- [x] QE has approved this change (Ishmam Amin/Shudi)

Additional resources:
* https://github.com/openshift/openshift-docs/pull/81772/files
* https://github.com/openshift/openshift-docs/pull/80875
