### PR TITLE
TELCODOCS-1977: Document tagging behaviour

### DIFF
--- a/modules/kmm-example-module-cr.adoc
+++ b/modules/kmm-example-module-cr.adoc
@@ -77,7 +77,7 @@ spec:
 <3> Optional: Copies `/firmware/*` into `/var/lib/firmware/` on the node.
 <4> Optional.
 <5> At least one kernel item is required.
-<6> For each node running a kernel matching the regular expression, KMM creates a `DaemonSet` resource running the image specified in `containerImage` with `${KERNEL_FULL_VERSION}` replaced with the kernel version.
+<6> For each node running a kernel matching the regular expression, KMM checks if you have included a tag or a digest. If you have not specified a tag or digest in the container image, then the validation webhook returns an error and does not apply the module.
 <7> For any other kernel, build the image using the Dockerfile in the `my-kmod` ConfigMap.
 <8> Optional.
 <9> Optional: A value for `some-kubernetes-secret` can be obtained from the build environment at `/run/secrets/some-kubernetes-secret`.


### PR DESCRIPTION
D/S Docs:[MGMT-16637] Document tagging behaviour

Jira: https://issues.redhat.com/browse/TELCODOCS-1977

Version(s): openshift-4.17

Fix version: KMMO 2.2

Link to docs preview: https://81803--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-example-cr_kernel-module-management-operator

Dev review: @ybettan 
QE review: @cdvultur
