### PR TITLE
CNV#35090_417: Release note: NEW GA Host-side USB passthrough

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -66,6 +66,9 @@ This release adds new features and enhancements related to the following compone
 [id="virt-4-17-virtualization"]
 === Virtualization
 
+//CNV-30590 NEW GA Host-side USB passthrough
+* As a cluster administrator, you can xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring-usb-host-passthrough.adoc#virt-configuring-usb-host-passthrough[expose USB devices in a cluster], making them available for virtual machine (VM) owners to assign to VMs. You expose a USB device by first enabling host passthrough and then configuring the VM to access the USB device.
+
 [id="virt-4-17-networking"]
 === Networking
 


### PR DESCRIPTION
Version(s): 4.17

Issue: [CNV-35090](https://issues.redhat.com/browse/CNV-35090?filter=12439470)

Link to docs preview: See the note under the [Virtualization](https://81835--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-17-virtualization) heading in the 4.17 release notes.

QE review:
- [x] QE has approved this change.

Additional information:

