### PR TITLE
OSDOCS-11794: ROSA CLI security refinements adding CLI output examples

### DIFF
--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -730,6 +730,44 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 ----
 ====
 
+[discrete]
+[id="rosa-sts-account-wide-roles-and-policies-example-cli-output-for-policies-attached-to-a-role_{context}"]
+==== Example CLI output for policies attached to a role 
+
+When a policy is attached to a role, the ROSA CLI displays confirmation output. The output depends on the type of policy.
+
+* If a policy is a trust policy, it outputs the content of the policy.
+** For the target role with policy attached, ROSA CLI outputs the role name and the console URL of it. 
++
+.Target role with policy attached example output
+[source,terminal]
+----
+I: Attached trust policy to role 'testrole-Worker-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Worker-Role)': ******************
+----
++
+** If the attached policy is a trust policy, ROSA CLI outputs the content of this policy.
++
+.Trust policy example output
+[source,terminal]
+----
+I: Attached trust policy to role 'test-Support-Role': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"AWS": ["arn:aws:iam::000000000000:role/RH-Technical-Support-00000000"]}}]} 
+----
+* If a policy is a permission policy, it outputs the name and public link of this policy or the ARN depending on whether or not the policy is an AWS managed policy or non-managed.
+** If the attached policy is an AWS managed policy, ROSA CLI outputs the name and public link of this policy. 
++
+.AWS managed policy example output
+[source,terminal]
+----
+I: Attached policy 'ROSASRESupportPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSASRESupportPolicy)' to role 'test-HCP-ROSA-Support-Role(https://console.aws.amazon.com/iam/home?#/roles/test-HCP-ROSA-Support-Role)' 
+----
+** If the attached policy is non-managed policy, ROSA CLI outputs the ARN of this policy. 
++
+.Non-managed policy example output
+[source,terminal]
+----
+I: Attached policy 'arn:aws:iam::000000000000:policy/testrole-Worker-Role-Policy' to role 'testrole-Worker-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Worker-Role)' 
+----
+
 .ROSA Ingress Operator IAM policy and policy file
 [cols="1,2",options="header"]
 |===


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://github.com/bmcelvee/openshift-docs/pull/new/OSDOCS-11794

Link to docs preview:
https://81844--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
