### PR TITLE
TELCODOCS-1684 - Alpha-sort Core and RAN RDS for easier updates

### DIFF
--- a/modules/telco-ran-crs-cluster-tuning.adoc
+++ b/modules/telco-ran-crs-cluster-tuning.adoc
@@ -13,9 +13,9 @@ Component,Reference CR,Optional,New in this release
 Cluster capabilities,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-example-sno-yaml[example-sno.yaml],No,No
 Disabling network diagnostics,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-disablesnonetworkdiag-yaml[DisableSnoNetworkDiag.yaml],No,No
 Monitoring configuration,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-reducemonitoringfootprint-yaml[ReduceMonitoringFootprint.yaml],No,No
+OperatorHub,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-09-openshift-marketplace-ns-yaml[09-openshift-marketplace-ns.yaml],No,No
 OperatorHub,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-defaultcatsrc-yaml[DefaultCatsrc.yaml],No,No
 OperatorHub,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-disableolmpprof-yaml[DisableOLMPprof.yaml],No,No
 OperatorHub,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-disconnectedicsp-yaml[DisconnectedICSP.yaml],No,No
 OperatorHub,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-operatorhub-yaml[OperatorHub.yaml],Yes,No
-OperatorHub,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-09-openshift-marketplace-ns-yaml[09-openshift-marketplace-ns.yaml],No,No
 |====

--- a/modules/telco-ran-crs-day-2-operators.adoc
+++ b/modules/telco-ran-crs-day-2-operators.adoc
@@ -15,33 +15,31 @@ Cluster logging,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#
 Cluster logging,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-clusterlogns-yaml[ClusterLogNS.yaml],No,No
 Cluster logging,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-clusterlogopergroup-yaml[ClusterLogOperGroup.yaml],No,No
 Cluster logging,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-clusterlogsubscription-yaml[ClusterLogSubscription.yaml],No,No
+Lifecycle Agent ,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-imagebasedupgrade-yaml[ImageBasedUpgrade.yaml],Yes,Yes
+Lifecycle Agent ,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-lcasubscription-yaml[LcaSubscription.yaml],Yes,Yes
+Lifecycle Agent ,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-lcasubscriptionns-yaml[LcaSubscriptionNS.yaml],Yes,Yes
+Lifecycle Agent ,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-lcasubscriptionopergroup-yaml[LcaSubscriptionOperGroup.yaml],Yes,Yes
 Local Storage Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storageclass-yaml[StorageClass.yaml],Yes,No
 Local Storage Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagelv-yaml[StorageLV.yaml],Yes,No
 Local Storage Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagens-yaml[StorageNS.yaml],Yes,No
 Local Storage Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storageopergroup-yaml[StorageOperGroup.yaml],Yes,No
 Local Storage Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagesubscription-yaml[StorageSubscription.yaml],Yes,No
-Lifecycle Agent ,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-imagebasedupgrade-yaml[ImageBasedUpgrade.yaml],Yes,Yes
-Lifecycle Agent ,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-lcasubscription-yaml[LcaSubscription.yaml],Yes,Yes
-Lifecycle Agent ,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-lcasubscriptionns-yaml[LcaSubscriptionNS.yaml],Yes,Yes
-Lifecycle Agent ,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-lcasubscriptionopergroup-yaml[LcaSubscriptionOperGroup.yaml],Yes,Yes
-{lvms},xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-lvmoperatorstatus-yaml[LVMOperatorStatus.yaml],No,Yes
-{lvms},xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagelvmcluster-yaml[StorageLVMCluster.yaml],No,Yes
-{lvms},xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagelvmsubscription-yaml[StorageLVMSubscription.yaml],No,Yes
-{lvms},xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagelvmsubscriptionns-yaml[StorageLVMSubscriptionNS.yaml],No,Yes
-{lvms},xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagelvmsubscriptionopergroup-yaml[StorageLVMSubscriptionOperGroup.yaml],No,Yes
+LVM Storage,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-lvmoperatorstatus-yaml[LVMOperatorStatus.yaml],No,Yes
+LVM Storage,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagelvmcluster-yaml[StorageLVMCluster.yaml],No,Yes
+LVM Storage,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagelvmsubscription-yaml[StorageLVMSubscription.yaml],No,Yes
+LVM Storage,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagelvmsubscriptionns-yaml[StorageLVMSubscriptionNS.yaml],No,Yes
+LVM Storage,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-storagelvmsubscriptionopergroup-yaml[StorageLVMSubscriptionOperGroup.yaml],No,Yes
 Node Tuning Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-performanceprofile-yaml[PerformanceProfile.yaml],No,No
 Node Tuning Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-tunedperformancepatch-yaml[TunedPerformancePatch.yaml],No,No
 PTP fast event notifications,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigboundaryforevent-yaml[PtpConfigBoundaryForEvent.yaml],Yes,Yes
-PTP fast event notifications,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigdualcardgmwpc-yaml[PtpConfigDualCardGmWpc.yaml],Yes,Yes
 PTP fast event notifications,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigforhaforevent-yaml[PtpConfigForHAForEvent.yaml],Yes,Yes
-PTP fast event notifications,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfiggmwpc-yaml[PtpConfigGmWpc.yaml],Yes,Yes
 PTP fast event notifications,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigmasterforevent-yaml[PtpConfigMasterForEvent.yaml],Yes,Yes
 PTP fast event notifications,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigslaveforevent-yaml[PtpConfigSlaveForEvent.yaml],Yes,Yes
 PTP fast event notifications,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpoperatorconfigforevent-yaml[PtpOperatorConfigForEvent.yaml],Yes,No
 PTP Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigboundary-yaml[PtpConfigBoundary.yaml],No,No
-PTP Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigdualcardgmwpc-op-yaml[PtpConfigDualCardGmWpc.yaml],No,No
+PTP Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigdualcardgmwpc-yaml[PtpConfigDualCardGmWpc.yaml],No,No
 PTP Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigforha-yaml[PtpConfigForHA.yaml],No,Yes
-PTP Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfiggmwpc-op-yaml[PtpConfigGmWpc.yaml],No,No
+PTP Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfiggmwpc-yaml[PtpConfigGmWpc.yaml],No,No
 PTP Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpconfigslave-yaml[PtpConfigSlave.yaml],No,No
 PTP Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpsubscription-yaml[PtpSubscription.yaml],No,No
 PTP Operator,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-ptpsubscriptionns-yaml[PtpSubscriptionNS.yaml],No,No

--- a/modules/telco-ran-yaml-ref-cluster-tuning.adoc
+++ b/modules/telco-ran-yaml-ref-cluster-tuning.adoc
@@ -27,6 +27,13 @@ include::snippets/ztp_DisableSnoNetworkDiag.yaml[]
 include::snippets/ztp_ReduceMonitoringFootprint.yaml[]
 ----
 
+[id="ztp-09-openshift-marketplace-ns-yaml"]
+.09-openshift-marketplace-ns.yaml
+[source,yaml]
+----
+include::snippets/ztp_09-openshift-marketplace-ns.yaml[]
+----
+
 [id="ztp-defaultcatsrc-yaml"]
 .DefaultCatsrc.yaml
 [source,yaml]
@@ -53,12 +60,5 @@ include::snippets/ztp_DisconnectedICSP.yaml[]
 [source,yaml]
 ----
 include::snippets/ztp_OperatorHub.yaml[]
-----
-
-[id="ztp-09-openshift-marketplace-ns-yaml"]
-.09-openshift-marketplace-ns.yaml
-[source,yaml]
-----
-include::snippets/ztp_09-openshift-marketplace-ns.yaml[]
 ----
 

--- a/modules/telco-ran-yaml-ref-day-2-operators.adoc
+++ b/modules/telco-ran-yaml-ref-day-2-operators.adoc
@@ -41,6 +41,34 @@ include::snippets/ztp_ClusterLogOperGroup.yaml[]
 include::snippets/ztp_ClusterLogSubscription.yaml[]
 ----
 
+[id="ztp-imagebasedupgrade-yaml"]
+.ImageBasedUpgrade.yaml
+[source,yaml]
+----
+include::snippets/ztp_ImageBasedUpgrade.yaml[]
+----
+
+[id="ztp-lcasubscription-yaml"]
+.LcaSubscription.yaml
+[source,yaml]
+----
+include::snippets/ztp_LcaSubscription.yaml[]
+----
+
+[id="ztp-lcasubscriptionns-yaml"]
+.LcaSubscriptionNS.yaml
+[source,yaml]
+----
+include::snippets/ztp_LcaSubscriptionNS.yaml[]
+----
+
+[id="ztp-lcasubscriptionopergroup-yaml"]
+.LcaSubscriptionOperGroup.yaml
+[source,yaml]
+----
+include::snippets/ztp_LcaSubscriptionOperGroup.yaml[]
+----
+
 [id="ztp-storageclass-yaml"]
 .StorageClass.yaml
 [source,yaml]
@@ -74,34 +102,6 @@ include::snippets/ztp_StorageOperGroup.yaml[]
 [source,yaml]
 ----
 include::snippets/ztp_StorageSubscription.yaml[]
-----
-
-[id="ztp-imagebasedupgrade-yaml"]
-.ImageBasedUpgrade.yaml
-[source,yaml]
-----
-include::snippets/ztp_ImageBasedUpgrade.yaml[]
-----
-
-[id="ztp-lcasubscription-yaml"]
-.LcaSubscription.yaml
-[source,yaml]
-----
-include::snippets/ztp_LcaSubscription.yaml[]
-----
-
-[id="ztp-lcasubscriptionns-yaml"]
-.LcaSubscriptionNS.yaml
-[source,yaml]
-----
-include::snippets/ztp_LcaSubscriptionNS.yaml[]
-----
-
-[id="ztp-lcasubscriptionopergroup-yaml"]
-.LcaSubscriptionOperGroup.yaml
-[source,yaml]
-----
-include::snippets/ztp_LcaSubscriptionOperGroup.yaml[]
 ----
 
 [id="ztp-lvmoperatorstatus-yaml"]
@@ -160,25 +160,11 @@ include::snippets/ztp_TunedPerformancePatch.yaml[]
 include::snippets/ztp_PtpConfigBoundaryForEvent.yaml[]
 ----
 
-[id="ztp-ptpconfigdualcardgmwpc-yaml"]
-.PtpConfigDualCardGmWpc.yaml
-[source,yaml]
-----
-include::snippets/ztp_PtpConfigDualCardGmWpc.yaml[]
-----
-
 [id="ztp-ptpconfigforhaforevent-yaml"]
 .PtpConfigForHAForEvent.yaml
 [source,yaml]
 ----
 include::snippets/ztp_PtpConfigForHAForEvent.yaml[]
-----
-
-[id="ztp-ptpconfiggmwpc-yaml"]
-.PtpConfigGmWpc.yaml
-[source,yaml]
-----
-include::snippets/ztp_PtpConfigGmWpc.yaml[]
 ----
 
 [id="ztp-ptpconfigmasterforevent-yaml"]
@@ -209,7 +195,7 @@ include::snippets/ztp_PtpOperatorConfigForEvent.yaml[]
 include::snippets/ztp_PtpConfigBoundary.yaml[]
 ----
 
-[id="ztp-ptpconfigdualcardgmwpc-op-yaml"]
+[id="ztp-ptpconfigdualcardgmwpc-yaml"]
 .PtpConfigDualCardGmWpc.yaml
 [source,yaml]
 ----
@@ -223,7 +209,7 @@ include::snippets/ztp_PtpConfigDualCardGmWpc.yaml[]
 include::snippets/ztp_PtpConfigForHA.yaml[]
 ----
 
-[id="ztp-ptpconfiggmwpc-op-yaml"]
+[id="ztp-ptpconfiggmwpc-yaml"]
 .PtpConfigGmWpc.yaml
 [source,yaml]
 ----

--- a/snippets/ztp_ImageBasedUpgrade.yaml
+++ b/snippets/ztp_ImageBasedUpgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: lca.openshift.io/v1alpha1
+apiVersion: lca.openshift.io/v1
 kind: ImageBasedUpgrade
 metadata:
   name: upgrade

--- a/snippets/ztp_LcaSubscriptionNS.yaml
+++ b/snippets/ztp_LcaSubscriptionNS.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-lifecycle-agent
-  annotations: {}
+  annotations:
+    workload.openshift.io/allowed: management
   labels:
     kubernetes.io/metadata.name: openshift-lifecycle-agent

--- a/snippets/ztp_PtpConfigForHA.yaml
+++ b/snippets/ztp_PtpConfigForHA.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   profile:
     - name: "boundary-ha"
-      ptp4lOpts: "" # <1>
+      ptp4lOpts: ""
       phc2sysOpts: "-a -r -n 24"
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10

--- a/snippets/ztp_StorageLVMSubscriptionNS.yaml
+++ b/snippets/ztp_StorageLVMSubscriptionNS.yaml
@@ -3,5 +3,6 @@ kind: Namespace
 metadata:
   name: openshift-storage
   labels:
+    workload.openshift.io/allowed: "management"
     openshift.io/cluster-monitoring: "true"
   annotations: {}


### PR DESCRIPTION
Telco RDS docs are generated from Telco RDS container images. If the CSV used to generate the build isn't alpha-sorted, subsequent docs PR are more difficult to review.

This update does not change content, just re-orders the CR lists.

Version(s):
enterprise-4.16+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1684

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE review not required.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

