### PR TITLE
OCPBUGS-36646 - Replace snippet include with code snippet in PTP docs

### DIFF
--- a/modules/ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic.adoc
+++ b/modules/ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic.adoc
@@ -118,7 +118,27 @@ For example: `haProfiles: ha-ptp-config-nic1,ha-ptp-config-nic2`
 +
 [source,yaml]
 ----
-include::snippets/ztp_PtpConfigForHA.yaml[]
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: boundary-ha
+  namespace: openshift-ptp
+  annotations: {}
+spec:
+  profile:
+    - name: "boundary-ha"
+      ptp4lOpts: "" # <1>
+      phc2sysOpts: "-a -r -n 24"
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        logReduce: "true"
+        haProfiles: "$profile1,$profile2"
+  recommend:
+    - profile: "boundary-ha"
+      priority: 4
+      match:
+        - nodeLabel: "node-role.kubernetes.io/$mcp"
 ----
 <1> Set the `ptp4lOpts` field to an empty string.
 If it is not empty, the `p4ptl` process starts with a critical error.


### PR DESCRIPTION
`boundary-ha` PtpConfig example snippet is used in two places - PTP and RDS docs. The snippet includes a callout which is not required in the RDS docs. 

Replace the snippet include with the actual YAML code in the PTP docs. 

https://issues.redhat.com/browse/OCPBUGS-36646

Version(s):
enterprise-4.16+

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE review not required.
