### PR TITLE
OSDOCS-12013 specified z-stream version to scale to 250 nodes in HCP

### DIFF
--- a/modules/rosa-sdpolicy-instance-types.adoc
+++ b/modules/rosa-sdpolicy-instance-types.adoc
@@ -14,6 +14,12 @@ endif::[]
 
 ifdef::rosa-with-hcp[]
 All {hcp-title} clusters require a minimum of 2 worker nodes. All {hcp-title} clusters support a maximum of 250 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss.
+
+[NOTE]
+====
+Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 250 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
+====
+
 endif::rosa-with-hcp[]
 ifndef::rosa-with-hcp[]
 Single availability zone clusters require a minimum of 3 control plane nodes, 2 infrastructure nodes, and 2 worker nodes deployed to a single availability zone.

--- a/modules/sd-hcp-planning-cluster-maximums.adoc
+++ b/modules/sd-hcp-planning-cluster-maximums.adoc
@@ -10,6 +10,10 @@ Consider the following tested object maximums when you plan a {hcp-title-first} 
 
 These guidelines are based on a cluster of 250 compute (also known as worker) nodes. For smaller clusters, the maximums are lower.
 
+[NOTE]
+====
+Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 250 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
+====
 
 .Tested cluster maximums
 [options="header",cols="50,50"]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 [NOTE]
 ====
-Currently, {hcp-title} supports a maximum of 250 worker nodes.
+Currently, {hcp-title} supports a maximum of 250 worker nodes. Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 250 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
 ====
 
 include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+1]


### PR DESCRIPTION
Small PR to specify the minimum required z-stream version to scale to 250 worker nodes in ROSA with HCP.
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-12013

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

HCP service def update:
https://81874--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.html

HCP service def update:
https://81874--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-instance-types_rosa-hcp-service-definition

L&S update:
https://81874--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-hcp-limits-scalability.html






QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
