### PR TITLE
[OCPBUGS#41846] Add warning to ShiftStack local docs

### DIFF
--- a/modules/installation-osp-local-disk-deployment.adoc
+++ b/modules/installation-osp-local-disk-deployment.adoc
@@ -264,9 +264,9 @@ spec:
 +
 [WARNING]
 ====
-After the `98-var-lib-etcd.yaml` file is applied to the system, do not remove it. Removing this file will result in broken etcd members.
+After you apply the `98-var-lib-etcd.yaml` file to the system, do not remove it. Removing this file will break etcd members and lead to system instability.
 
-If you must perform a rollback, change the flavor in the `ControlPlaneMachineSet` object to one that does not include the ephemeral attribute. This change regenerates the master nodes without using ephemeral disks for the etcd partition, preventing system issues related to the `98-var-lib-etcd.yaml` file.
+If a rollback is necessary, modify the `ControlPlaneMachineSet` object to use a flavor that does not include ephemeral disks. This change regenerates the control plane nodes without using ephemeral disks for the etcd partition, which avoids issues related to the `98-var-lib-etcd.yaml` file. It is safe to remove the `98-var-lib-etcd.yaml` file only after the update to the `ControlPlaneMachineSet` object is complete and no control plane nodes are using ephemeral disks.
 ====
 
 . Create the new `MachineConfig` object by running the following command:

--- a/modules/installation-osp-local-disk-deployment.adoc
+++ b/modules/installation-osp-local-disk-deployment.adoc
@@ -261,6 +261,13 @@ spec:
 <7> Copies and moves in separate steps to ensure atomic creation of a complete member directory.
 <8> Performs a quick check of the mount point directory before performing a full recursive relabel. If restorecon in the file path `/var/lib/etcd` cannot rename the directory, the recursive rename is not performed.
 ====
++
+[WARNING]
+====
+After the `98-var-lib-etcd.yaml` file is applied to the system, do not remove it. Removing this file will result in broken etcd members.
+
+If you must perform a rollback, change the flavor in the `ControlPlaneMachineSet` object to one that does not include the ephemeral attribute. This change regenerates the master nodes without using ephemeral disks for the etcd partition, preventing system issues related to the `98-var-lib-etcd.yaml` file.
+====
 
 . Create the new `MachineConfig` object by running the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-41846
](https://issues.redhat.com/browse/OCPBUGS-41846)

Link to docs preview: https://81889--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
