### PR TITLE
[OCPBUGS-36857] Update RHEL requirements for OCP 4.15+

### DIFF
--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -19,7 +19,7 @@ ifdef::openshift-origin[]
 ** Base OS: CentOS 7.4.
 endif::[]
 ifdef::openshift-enterprise,openshift-webscale[]
-** Base OS: link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/index[{op-system-base} 8.6 and later] with "Minimal" installation option.
+** Base operating system: Use link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/index[{op-system-base} 8.8 or a later version] with the minimal installation option.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
JIRA: [OCPBUGS-36857](https://issues.redhat.com/browse/OCPBUGS-36857)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
  OCP 4.15+

Link to docs preview:
* [Adding a RHEL compute machine](https://81895--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-compute-requirements_adding-rhel-compute)
* [Adding more RHEL compute machines](https://81895--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/more-rhel-compute.html#rhel-compute-requirements_more-rhel-compute)
* [Postinstallation node tasks](https://81895--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html)

- [x] SME has approved this change.
- [x] QE has approved this change.
