### PR TITLE
[MULTIARCH-3807] ABI documentation updates for 4.17

### DIFF
--- a/modules/adding-ibmz-lpar-agent.adoc
+++ b/modules/adding-ibmz-lpar-agent.adoc
@@ -34,56 +34,21 @@ random.trust_cpu=on rd.luks.options=discard
 <2> For the `ip` parameter, manually assign the IP address, as described in _Installing a cluster with z/VM on IBM Z and IBM LinuxONE_.
 <3> For installations on DASD-type disks, use `rd.dasd` to specify the DASD where {op-system-first} is to be installed. For installations on FCP-type disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed.
 <4> Specify this parameter when you use an Open Systems Adapter (OSA) or HiperSockets.
-
-. Generate the `.ins` and `initrd.img.addrsize` files by running the following Python script:
-+
-The `.ins` file is a special file that includes installation data and is present on the FTP server. It can be accessed from the HMC system.
-This file contains details such as mapping of the location of installation data on the disk or FTP server, the memory locations where the data is to be copied.
 +
 [NOTE]
 ====
-The `.ins` and `initrd.img.addrsize` files are not automatically generated as part of boot-artifacts from the installer. You must manually generate these files.
+The `.ins` and `initrd.img.addrsize` files are automatically generated for `s390x` architecture as part of boot-artifacts from the installation program and are only used when booting in an LPAR environment.
 ====
-
-.. Save the following script to a file, such as `generate-files.py`:
 +
-.Example of a Python file named `generate-files.py` file
-[source,python]
-----
-# The following commands retrieve the size of the `kernel` and `initrd`:
-KERNEL_IMG_PATH='./kernel.img'
-INITRD_IMG_PATH='./initrd.img'
-CMDLINE_PATH='./generic.prm'
-kernel_size=(stat -c%s KERNEL_IMG_PATH)
-initrd_size=(stat -c%s INITRD_IMG_PATH)
-# The following command rounds the `kernel` size up to the next megabytes (MB) boundary.
-# This value is the starting address of `initrd.img`.
-offset=(( (kernel_size + 1048575) / 1048576 * 1048576 ))
-INITRD_IMG_NAME=(echo INITRD_IMG_PATH | rev | cut -d '/' -f 1 | rev)
-# The following commands create the kernel binary patch file that contains the `initrd` address and size:
-KERNEL_OFFSET=0x00000000
-KERNEL_CMDLINE_OFFSET=0x00010480
-INITRD_ADDR_SIZE_OFFSET=0x00010408
-OFFSET_HEX=(printf '0x%08x\n' offset)
-# The following command converts the address and size to binary format:
-printf "(printf '%016x\n' $initrd_size)" | xxd -r -p > temp_size.bin
-# The following command concatenates the address and size binaries:
-cat temp_address.bin temp_size.bin > "$INITRD_IMG_NAME.addrsize"
-# The following command deletes temporary files:
-rm -rf temp_address.bin temp_size.bin
-# The following commands create the `.ins` file.
-# The file is based on the paths of the `kernel.img`, `initrd.img`, `initrd.img.addrsize`, and `cmdline` files and the memory locations where the data is to be copied.
-KERNEL_IMG_PATH KERNEL_OFFSET
-INITRD_IMG_PATH OFFSET_HEX
-INITRD_IMG_NAME.addrsize INITRD_ADDR_SIZE_OFFSET
-CMDLINE_PATH KERNEL_CMDLINE_OFFSET
-----
-
-.. Execute the script by running the following command:
-+
+.Example filesystem with LPAR boot
 [source,terminal]
 ----
-$ python3 <file_name>.py
+boot-artifacts
+    ├─ agent.s390x-generic.ins
+    ├─ agent.s390x-initrd.addrsize
+    ├─ agent.s390x-rootfs.img
+    └─ agent.s390x-kernel.img
+    └─ agent.s390x-rootfs.img
 ----
 
 . Transfer the `initrd`, `kernel`, `generic.ins`, and `initrd.img.addrsize` parameter files to the file server. For more information, see link:https://www.ibm.com/docs/en/linux-on-systems?topic=bl-booting-linux-in-lpar-mode[Booting Linux in LPAR mode] (IBM documentation).


### PR DESCRIPTION
Version(s): 4.17+

Issues: https://issues.redhat.com/browse/MULTIARCH-4995
https://issues.redhat.com/browse/OCPBUGS-41987





Link to docs preview:
https://81906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.html#adding-ibmz-lpar-agents_prepare-pxe-assets-agent


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Box note: https://ibm.ent.box.com/notes/1648415062889 


