### PR TITLE
[DOC] OSSM-8138 The documentation of Installation of control plane still has the jaeger pod in the oc get po output

### DIFF
--- a/modules/ossm-control-plane-cli.adoc
+++ b/modules/ossm-control-plane-cli.adoc
@@ -119,7 +119,6 @@ grafana-b4d59bd7-mrgbr                 2/2     Running   0          65m
 istio-egressgateway-678dc97b4c-wrjkp   1/1     Running   0          108s
 istio-ingressgateway-b45c9d54d-4qg6n   1/1     Running   0          108s
 istiod-basic-55d78bbbcd-j5556          1/1     Running   0          108s
-jaeger-67c75bd6dc-jv6k6                2/2     Running   0          65m
 kiali-6476c7656c-x5msp                 1/1     Running   0          43m
 prometheus-58954b8d6b-m5std            2/2     Running   0          66m
 ----


### PR DESCRIPTION
[DOC] [OSSM-8138](https://issues.redhat.com//browse/OSSM-8138) The documentation of Installation of control plane still has the jaeger pod in the oc get po output

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSSM-8138

Link to docs preview:
https://81907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-smcp.html#ossm-control-plane-deploy-cli_ossm-create-smcp --> Step 4 --> "You should see output similar to the following:"

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
