### PR TITLE
OSDOCS 9946: Added a noted to document the deprecated commands in oc-mirror

### DIFF
--- a/disconnected/updating/mirroring-image-repository.adoc
+++ b/disconnected/updating/mirroring-image-repository.adoc
@@ -39,6 +39,11 @@ The following steps outline the high-level workflow on how to mirror images to a
 
 .. Repeat these steps as needed to update your mirror registry.
 
+[IMPORTANT]
+====
+The `oc adm catalog mirror` and `oc adm release mirror` commands are being deprecated as their features move to `oc-mirror`. These commands will remain in the `oc` codebase but will be marked as deprecated until `oc-mirror` is fully implemented and tested.
+====
+
 Compared to using the `oc adm release mirror` command, the oc-mirror plugin has the following advantages:
 
 * It can mirror content other than container images.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-9946
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81912--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/updating/mirroring-image-repository.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
