### PR TITLE
Fix a broken xref in 4.17

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -131,7 +131,7 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 * Cluster admins can now enable CPU resource limits on a namespace in the {product-title} web console under *Overview* -> *Settings* -> *Preview features*.
 
 //CNV-22314: Safe memory overcommitment using `wasp-agent`
-* Cluster admins can now use the `wasp-agent` tool to xref:../../virt/virtual_machines/virt-configuring-higher-vm-workload-density.adoc#virt-configuring-higher-vm-workload-density[configure a higher VM workload density] in their clusters by overcommitting the amount of memory, in RAM, and assigning swap resources to VM workloads.
+* Cluster admins can now use the `wasp-agent` tool to xref:../../virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc#virt-configuring-higher-vm-workload-density[configure a higher VM workload density] in their clusters by overcommitting the amount of memory, in RAM, and assigning swap resources to VM workloads.
 
 //CNV-31997: PREVIEW - compatibility with ODF Regional DR
 * {VirtProductName} now supports compatibility with {rh-storage-first} (ODF) Regional Disaster Recovery.


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/commit/ad9f3d109b145ef39c5e70dddac44a57ec78e562 moved the location of a file in the virtualization book. When the change was cherrypicked to `enterprise-4.17`, Prow missed that there is an xref to that file in the CNV release notes. This PR fixes the xref in the CNV release notes

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: NA
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://81920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-16-technology-preview_virt-4-17-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
