### PR TITLE
OSDOCS-11550: adds 4.14.37 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -284,7 +284,7 @@ This section is updated over time to provide notes on enhancements and bug fixes
 [id="microshift-4-14-0-dp"]
 === RHSA-2023:5008 - {microshift-short} 4.14.0 bug fix and security update advisory
 
-Issued: 2023-10-31
+Issued: 31 October 2023
 
 {product-title} release 4.14.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5008[RHSA-2023:5008] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5006[RHSA-2023:5006] advisory.
 
@@ -293,7 +293,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-1-dp"]
 === RHSA-2023:6155 - {microshift-short} 4.14.1 bug fix advisory
 
-Issued: 2023-11-1
+Issued: 1 November 2023
 
 {product-title} release 4.14.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:6155[RHBA-2023:6155] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:6153[RHBA-2023:6153] advisory.
 
@@ -302,7 +302,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-2-dp"]
 === RHSA-2023:6839 - {microshift-short} 4.14.2 bug fix and security update advisory
 
-Issued: 2023-11-16
+Issued: 16 November 2023
 
 {product-title} release 4.14.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6839[RHSA-2023:6839] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:6837[RHSA-2023:6837] advisory.
 
@@ -311,7 +311,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-3-dp"]
 === RHBA-2023:7319 - {microshift-short} 4.14.3 bug fix update advisory
 
-Issued: 2023-11-21
+Issued: 21 November 2023
 
 {product-title} release 4.14.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7319[RHBA-2023:7319] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7315[RHSA-2023:7315] advisory.
 
@@ -320,7 +320,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-4-dp"]
 === RHBA-2023:7472 - {microshift-short} 4.14.4 bug fix update advisory
 
-Issued: 2023-11-29
+Issued: 29 November 2023
 
 {product-title} release 4.14.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7472[RHBA-2023:7472] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7470[RHSA-2023:7470] advisory.
 
@@ -336,7 +336,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-5-dp"]
 === RHBA-2023:7601 - {microshift-short} 4.14.5 bug fix update advisory
 
-Issued: 2023-12-05
+Issued: 5 December 2023
 
 {product-title} release 4.14.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7601[RHBA-2023:7601] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7599[RHSA-2023:7599] advisory.
 
@@ -350,7 +350,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-6-dp"]
 === RHBA-2023:7684 - {microshift-short} 4.14.6 bug fix update advisory
 
-Issued: 2023-12-12
+Issued: 12 December 2023
 
 {product-title} release 4.14.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7684[RHBA-2023:7684] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7682[RHSA-2023:7682] advisory.
 
@@ -359,7 +359,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-7-dp"]
 === RHBA-2023:7833 - {microshift-short} 4.14.7 bug fix update advisory
 
-Issued: 2024-01-03
+Issued: 3 January 2024
 
 {product-title} release 4.14.7, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7833[RHBA-2023:7833] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7831[RHSA-2023:7831] advisory.
 
@@ -368,7 +368,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-8-dp"]
 === RHBA-2024:0052 - {microshift-short} 4.14.8 bug fix update advisory
 
-Issued: 2024-01-09
+Issued: 9 January 2024
 
 {product-title} release 4.14.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0052[RHBA-2024:0052] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0050[RHSA-2024:0050] advisory.
 
@@ -377,7 +377,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-9-dp"]
 === RHBA-2024:0206 - {microshift-short} 4.14.9 bug fix update advisory
 
-Issued: 2024-01-17
+Issued: 17 January 2024
 
 {product-title} release 4.14.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0206[RHBA-2024:0206] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0204[RHSA-2024:0204] advisory.
 
@@ -386,7 +386,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-10-dp"]
 === RHSA-2024:0292 - {microshift-short} 4.14.10 bug fix update and security advisory
 
-Issued: 2024-01-24
+Issued: 24 January 2024
 
 {product-title} release 4.14.10, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0292[RHSA-2024:0292] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0290[RHSA-2024:0290] advisory.
 
@@ -395,7 +395,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-11-dp"]
 === RHBA-2024:0644 - {microshift-short} 4.14.11 bug fix update and security advisory
 
-Issued: 2024-02-07
+Issued: 7 February 2024
 
 {product-title} release 4.14.11, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0644[RHBA-2024:0644] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0642[RHSA-2024:0642] advisory.
 
@@ -404,7 +404,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-12-dp"]
 === RHBA-2024:0737 - {microshift-short} 4.14.12 bug fix update and security advisory
 
-Issued: 2024-02-13
+Issued: 13 February 2024
 
 {product-title} release 4.14.12, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0737[RHBA-2024:0737] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0735[RHSA-2024:0735] advisory.
 
@@ -413,7 +413,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-13-dp"]
 === RHBA-2024:0839 - {microshift-short} 4.14.13 bug fix update and security advisory
 
-Issued: 2024-02-20
+Issued: 20 February 2024
 
 {product-title} release 4.14.13, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0839[RHBA-2024:0839] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0837[RHSA-2024:0837] advisory.
 
@@ -427,7 +427,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-14-dp"]
 === RHBA-2024:0943 - {microshift-short} 4.14.14 bug fix update and security advisory
 
-Issued: 2024-02-28
+Issued: 28 February 2024
 
 {product-title} release 4.14.14, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0943[RHBA-2024:0943] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0941[RHSA-2024:0941] advisory.
 
@@ -436,7 +436,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-15-dp"]
 === RHBA-2024:1048 - {microshift-short} 4.14.15 bug fix update advisory
 
-Issued: 2024-03-05
+Issued: 5 March 2024
 
 {product-title} release 4.14.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1048[RHBA-2024:1048] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1046[RHBA-2024:1046] advisory.
 
@@ -445,7 +445,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-16-dp"]
 === RHBA-2024:1207 - {microshift-short} 4.14.16 bug fix update advisory
 
-Issued: 2024-03-13
+Issued: 13 March 2024
 
 {product-title} release 4.14.16 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1207[RHBA-2024:1207] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1205[RHBA-2024:1205] advisory.
 
@@ -454,7 +454,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-17-dp"]
 === RHBA-2024:1262 - {microshift-short} 4.14.17 bug fix update advisory
 
-Issued: 2024-03-20
+Issued: 20 March 2024
 
 {product-title} release 4.14.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1262[RHBA-2024:1262] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1260[RHBA-2024:1260] advisory.
 
@@ -463,7 +463,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-18-dp"]
 === RHBA-2024:1460 - {microshift-short} 4.14.18 bug fix update advisory
 
-Issued: 2024-03-27
+Issued: 27 March 2024
 
 {product-title} release 4.14.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1460[RHBA-2024:1460] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1458[RHSA-2024:1458] advisory.
 
@@ -472,7 +472,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-19-dp"]
 === RHSA-2024:1566 - {microshift-short} 4.14.19 security update and bug fix update advisory
 
-Issued: 2024-04-03
+Issued: 3 April 2024
 
 {product-title} release 4.14.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1566[RHSA-2024:1566] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1564[RHBA-2024:1564] advisory.
 
@@ -481,7 +481,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-20-dp"]
 === RHBA-2024:1682 - {microshift-short} 4.14.20 security update and bug fix update advisory
 
-Issued: 2024-04-08
+Issued: 8 April 2024
 
 {product-title} release 4.14.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1682[RHBA-2024:1682] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1681[RHSA-2024:1681] advisory.
 
@@ -490,7 +490,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-21-dp"]
 === RHBA-2024:1767 - {microshift-short} 4.14.21 bug fix and enhancement advisory
 
-Issued: 2024-04-18
+Issued: 18 April 2024
 
 {product-title} release 4.14.21 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1767[RHBA-2024:1767] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1765[RHSA-2024:1765] advisory.
 
@@ -499,7 +499,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-24-dp"]
 === RHSA-2024:2671 - {microshift-short} 4.14.24 bug fix update and security update advisory
 
-Issued: 2024-05-09
+Issued: 9 May 2024
 
 {product-title} release 4.14.24, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2671[RHSA-2024:2671] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2668[RHSA-2024:2668] advisory.
 
@@ -508,7 +508,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-25-dp"]
 === RHSA-2024:2791 - {microshift-short} 4.14.25 bug fix update and enhancements advisory
 
-Issued: 2024-05-15
+Issued: 15 May 2024
 
 {product-title} release 4.14.25, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2791[RHBA-2024:2791] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:2789[RHBA-2024:2789] advisory.
 
@@ -517,7 +517,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-26-dp"]
 === RHBA-2024:2872 - {microshift-short} 4.14.26 bug fix and security update advisory
 
-Issued: 2024-05-23
+Issued: 23 May 2024
 
 {product-title} release 4.14.26 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2872[RHBA-2024:2872] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2869[RHSA-2024:2869] advisory.
 
@@ -526,7 +526,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-27-dp"]
 === RHBA-2024:3334 - {microshift-short} 4.14.27 bug fix and enhancement advisory
 
-Issued: 2024-05-30
+Issued: 30 May 2024
 
 {product-title} release 4.14.27 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3334[RHBA-2024:3334] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3331[RHSA-2024:3331] advisory.
 
@@ -535,7 +535,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-28-dp"]
 === RHBA-2024:3525 - {microshift-short} 4.14.28 bug fix and security update advisory
 
-Issued: 2024-06-10
+Issued: 10 June 2024
 
 {product-title} release 4.14.28 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3525[RHBA-2024:3525] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3523[RHSA-2024:3523] advisory.
 
@@ -544,7 +544,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-29-dp"]
 === RHBA-2024:3699 - {microshift-short} 4.14.29 bug fix and enhancement advisory
 
-Issued: 2024-06-13
+Issued: 13 June 2024
 
 {product-title} release 4.14.29 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3699[RHBA-2024:3699] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3697[RHBA-2024:3697] advisory.
 
@@ -553,7 +553,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-30-dp"]
 === RHBA-2024:3884 - {microshift-short} 4.14.30 bug fix and security update advisory
 
-Issued: 2024-06-19
+Issued: 19 June 2024
 
 {product-title} release 4.14.30 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3884[RHBA-2024:3884] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3881[RHSA-2024:3881] advisory.
 
@@ -562,7 +562,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-31-dp"]
 === RHBA-2024:4012 - {microshift-short} 4.14.31 bug fix and security update advisory
 
-Issued: 2024-06-26
+Issued: 26 June 2024
 
 {product-title} release 4.14.31 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4012[RHBA-2024:4012] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4010[RHSA-2024:4010] advisory.
 
@@ -571,7 +571,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-32-dp_{context}"]
 === RHBA-2024:4331 - {microshift-short} 4.14.32 bug fix and security update advisory
 
-Issued: 2024-07-11
+Issued: 11 July 2024
 
 {product-title} release 4.14.32 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4331[RHBA-2024:4331] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4329[RHSA-2024:4329] advisory.
 
@@ -580,7 +580,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-33-dp_{context}"]
 === RHBA-2024:4481 - {microshift-short} 4.14.33 bug fix and security update advisory
 
-Issued: 2024-07-17
+Issued: 17 July 2024
 
 {product-title} release 4.14.33 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4481[RHBA-2024:4481] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4479[RHSA-2024:4479] advisory.
 
@@ -589,7 +589,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-34-dp_{context}"]
 === RHBA-2024:4962 - {microshift-short} 4.14.34 bug fix and security update advisory
 
-Issued: 2024-08-07
+Issued: 7 August 2024
 
 {product-title} release 4.14.34 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4962[RHBA-2024:4962] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4960[RHSA-2024:4960] advisory.
 
@@ -598,7 +598,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-35-dp_{context}"]
 === RHBA-2024:5435 - {microshift-short} 4.14.35 bug fix and security update advisory
 
-Issued: 2024-08-22
+Issued: 22 August 2024
 
 {product-title} release 4.14.35 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:5435[RHBA-2024:5435] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5433[RHSA-2024:5433] advisory.
 
@@ -607,8 +607,17 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-14-36-dp_{context}"]
 === RHBA-2024:6410 - {microshift-short} 4.14.36 bug fix and security update advisory
 
-Issued: 2024-09-12
+Issued: 12 September 2024
 
 {product-title} release 4.14.36 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:6410[RHBA-2024:6410] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6406[RHSA-2024:6406] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-37-dp_{context}"]
+=== RHBA-2024:6690 - {microshift-short} 4.14.37 bug fix and security update advisory
+
+Issued: 19 September 2024
+
+{product-title} release 4.14.37 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:6690[RHBA-2024:6690] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6689[RHSA-2024:6689] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-11550](https://issues.redhat.com/browse/OSDOCS-11550)

Link to docs preview:
[4.1.4.37 async release notes](https://81931--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-37-dp_release-notes)

QE review:
- N/A stock text, no other release notes

Additional information:
This PR also includes a backport of style manual date formatting. See https://www.ibm.com/docs/en/ibm-style?topic=measurement-dates-times#general-guidance-for-dates.