### PR TITLE
TELCODOCS-1879 - Put back PTP YAML CRs for 4.14+

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-dual-nic.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-dual-nic.adoc
@@ -46,7 +46,7 @@ See "Configuring the PTP fast event notifications publisher" for more informatio
 ====
 [source,yaml]
 ----
-include::snippets/ztp_PtpConfigDualCardGmWpc.yaml[]
+include::snippets/ptp_PtpConfigDualCardGmWpc.yaml[]
 ----
 ====
 +

--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock.adoc
@@ -41,7 +41,7 @@ Save the YAML in the `grandmaster-clock-ptp-config.yaml` file:
 ====
 [source,yaml]
 ----
-include::snippets/ztp_PtpConfigGmWpc.yaml[]
+include::snippets/ptp_PtpConfigGmWpc.yaml[]
 ----
 ====
 +

--- a/snippets/ptp_PtpConfigDualCardGmWpc.yaml
+++ b/snippets/ptp_PtpConfigDualCardGmWpc.yaml
@@ -1,5 +1,5 @@
-# The grandmaster profile is provided for testing only
-# It is not installed on production clusters
+# In this example two cards $iface_nic1 and $iface_nic2 are connected via
+# SMA1 ports by a cable and $iface_nic2 receives 1PPS signals from $iface_nic1
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
@@ -10,7 +10,7 @@ spec:
   profile:
     - name: "grandmaster"
       ptp4lOpts: "-2 --summary_interval -4"
-      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
+      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_nic1 -n 24
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10
       ptpSettings:
@@ -23,11 +23,16 @@ spec:
             LocalHoldoverTimeout: 14400
             MaxInSpecOffset: 100
           pins: $e810_pins
-          #  "$iface_master":
+          #  "$iface_nic1":
           #    "U.FL2": "0 2"
           #    "U.FL1": "0 1"
           #    "SMA2": "0 2"
-          #    "SMA1": "0 1"
+          #    "SMA1": "2 1"
+          #  "$iface_nic2":
+          #    "U.FL2": "0 2"
+          #    "U.FL1": "0 1"
+          #    "SMA2": "0 2"
+          #    "SMA1": "1 1"
           ublxCmds:
             - args: #ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
                 - "-P"
@@ -82,11 +87,11 @@ spec:
                 - "-p"
                 - "MON-HW"
               reportOutput: true
-            - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
+            - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,248
                 - "-P"
                 - "29.20"
                 - "-p"
-                - "CFG-MSG,1,38,300"
+                - "CFG-MSG,1,38,248"
               reportOutput: true
       ts2phcOpts: " "
       ts2phcConf: |
@@ -100,18 +105,30 @@ spec:
         #cat /dev/GNSS to find available serial port
         #example value of gnss_serialport is /dev/ttyGNSS_1700_0
         ts2phc.nmea_serialport $gnss_serialport
-        leapfile  /usr/share/zoneinfo/leap-seconds.list
-        [$iface_master]
+        [$iface_nic1]
         ts2phc.extts_polarity rising
         ts2phc.extts_correction 0
+        [$iface_nic2]
+        ts2phc.master 0
+        ts2phc.extts_polarity rising
+        #this is a measured value in nanoseconds to compensate for SMA cable delay
+        ts2phc.extts_correction -10
       ptp4lConf: |
-        [$iface_master]
+        [$iface_nic1]
         masterOnly 1
-        [$iface_master_1]
+        [$iface_nic1_1]
         masterOnly 1
-        [$iface_master_2]
+        [$iface_nic1_2]
         masterOnly 1
-        [$iface_master_3]
+        [$iface_nic1_3]
+        masterOnly 1
+        [$iface_nic2]
+        masterOnly 1
+        [$iface_nic2_1]
+        masterOnly 1
+        [$iface_nic2_2]
+        masterOnly 1
+        [$iface_nic2_3]
         masterOnly 1
         [global]
         #
@@ -203,7 +220,7 @@ spec:
         delay_filter_length 10
         egressLatency 0
         ingressLatency 0
-        boundary_clock_jbod 0
+        boundary_clock_jbod 1
         #
         # Clock description
         #

--- a/snippets/ptp_PtpConfigGmWpc.yaml
+++ b/snippets/ptp_PtpConfigGmWpc.yaml
@@ -1,5 +1,3 @@
-# The grandmaster profile is provided for testing only
-# It is not installed on production clusters
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
@@ -82,11 +80,11 @@ spec:
                 - "-p"
                 - "MON-HW"
               reportOutput: true
-            - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
+            - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,248
                 - "-P"
                 - "29.20"
                 - "-p"
-                - "CFG-MSG,1,38,300"
+                - "CFG-MSG,1,38,248"
               reportOutput: true
       ts2phcOpts: " "
       ts2phcConf: |
@@ -100,7 +98,6 @@ spec:
         #cat /dev/GNSS to find available serial port
         #example value of gnss_serialport is /dev/ttyGNSS_1700_0
         ts2phc.nmea_serialport $gnss_serialport
-        leapfile  /usr/share/zoneinfo/leap-seconds.list
         [$iface_master]
         ts2phc.extts_polarity rising
         ts2phc.extts_correction 0

--- a/snippets/ztp_PtpConfigDualCardGmWpc.yaml
+++ b/snippets/ztp_PtpConfigDualCardGmWpc.yaml
@@ -1,3 +1,5 @@
+# The grandmaster profile is provided for testing only
+# It is not installed on production clusters
 # In this example two cards $iface_nic1 and $iface_nic2 are connected via
 # SMA1 ports by a cable and $iface_nic2 receives 1PPS signals from $iface_nic1
 apiVersion: ptp.openshift.io/v1
@@ -87,11 +89,11 @@ spec:
                 - "-p"
                 - "MON-HW"
               reportOutput: true
-            - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,248
+            - args: #ubxtool -P 29.20 -p CFG-MSG,1,38,300
                 - "-P"
                 - "29.20"
                 - "-p"
-                - "CFG-MSG,1,38,248"
+                - "CFG-MSG,1,38,300"
               reportOutput: true
       ts2phcOpts: " "
       ts2phcConf: |
@@ -105,6 +107,7 @@ spec:
         #cat /dev/GNSS to find available serial port
         #example value of gnss_serialport is /dev/ttyGNSS_1700_0
         ts2phc.nmea_serialport $gnss_serialport
+        leapfile  /usr/share/zoneinfo/leap-seconds.list
         [$iface_nic1]
         ts2phc.extts_polarity rising
         ts2phc.extts_correction 0


### PR DESCRIPTION
In [TELCODOCS-1879](https://issues.redhat.com//browse/TELCODOCS-1879) we updated the wrong PTP CR snippet. This PR fixes that typo error. The content is actually unchanged, just the file it points to. This change is required to support 4.17 RDS updates.

Version(s):
enterprise-4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1879

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE review not required.
