### PR TITLE
OSDOCS-12028: DOcumented the 4.14.37 z-stream notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3340,6 +3340,28 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.37
+[id="ocp-4-14-37_{context}"]
+=== RHSA-2024:6689 - {product-title} 4.14.37 bug fix and security update
+
+Issued: 19 September 2024
+
+{product-title} release 4.14.37, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6689[RHSA-2024:6689] advisory. There are no RPM packages for this update.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.37 --pullspecs
+----
+
+[id="ocp-4-14-37-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.36
 [id="ocp-4-14-36_{context}"]
 === RHSA-2024:6406 - {product-title} 4.14.36 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-12028](https://issues.redhat.com/browse/OSDOCS-12028)

Link to docs preview:
[4.14.37](https://81940--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-37_release-notes)