### PR TITLE
OSDOCS-4200: permission modified for  multiple pods on same node with…

### DIFF
--- a/microshift_storage/understanding-persistent-storage-microshift.adoc
+++ b/microshift_storage/understanding-persistent-storage-microshift.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 Managing storage is a distinct problem from managing compute resources. {microshift-short} uses the Kubernetes persistent volume (PV) framework to allow cluster administrators to provision persistent storage for a cluster. Developers can use persistent volume claims (PVCs) to request PV resources without having specific knowledge of the underlying storage infrastructure.
 
+include::modules/microshift-control-permissions-security-context-constraints.adoc[leveloffset=+1]
+
 include::modules/storage-persistent-storage-overview.adoc[leveloffset=+1]
 
 [id="additional-resources_understanding-persistent-storage-microshift_{context}"]
@@ -22,6 +24,10 @@ include::modules/storage-persistent-storage-reclaim-manual.adoc[leveloffset=+2]
 include::modules/storage-persistent-storage-reclaim.adoc[leveloffset=+2]
 
 include::modules/storage-persistent-storage-pv.adoc[leveloffset=+1]
+
+include::modules/microshift-pv-rwo-access-mode-permission.adoc[leveloffset=+1]
+
+include::modules/microshift-checking-pods-mismatch.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/microshift-checking-pods-mismatch.adoc
+++ b/modules/microshift-checking-pods-mismatch.adoc
@@ -1,0 +1,161 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/understanding-persistent-storage-microshift.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-checking-pods-mismatch_{context}"]
+= Checking the pods for mismatch
+
+Check if the pods have a mismatch. Update the SELinux context if a mismatch is found by using the following procedure.
+
+[IMPORTANT]
+====
+* Replace `_<pod_name_A>_` with the name of the first pod in the following procedure.
+* Replace `_<pod_name_B>_` with the name of the second pod in the following procedure.
+* Replace `_<PVC_mountpoint>_` with the mount point within the pods.
+====
+
+.Procedure
+
+. List the mount point within the first pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc get pods -n _<pod_name_A>_ -ojsonpath='{.spec.containers[*].volumeMounts[*].mountPath}' <1>
+----
+<1> Replace `_<pod_name_A>_` with the name of the first pod.
++
+.Example output
+[source,terminal]
+----
+/files /var/run/secrets/kubernetes.io/serviceaccount
+----
+. List the mount point within the second pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc get pods -n _<pod_name_B>_ -ojsonpath='{.spec.containers[*].volumeMounts[*].mountPath}' <1>
+----
+<1> Replace `_<pod_name_B>_` with the name of the second pod.
++
+.Example output
+[source,terminal]
+----
+/files /var/run/secrets/kubernetes.io/serviceaccount
+----
+. Check the context and permissions inside the first pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc rsh _<pod_name_A>_ ls -lZah _<PVC_mountpoint>_ <1>
+----
+<1> Replace `_<pod_name_A>_` with the name of the first pod and replace `_<PVC_mountpoint>_` with the mount point within the first pod.
++
+.Example output
+[source,terminal]
+----
+total 12K
+dr-xr-xr-x.   1 root root system_u:object_r:container_file_t:s0:c398,c806   40 Feb 17 13:36 .
+dr-xr-xr-x.   1 root root system_u:object_r:container_file_t:s0:c398,c806   40 Feb 17 13:36 ..
+[...]
+----
+. Check the context and permissions inside the second pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc rsh _<pod_name_B>_ ls -lZah _<PVC_mountpoint>_ <1>
+----
+<1> Replace `_<pod_name_B>_` with the name of the second pod and replace `_<PVC_mountpoint>_` with the mount point within the second pod.
++
+.Example output
+[source,terminal]
+----
+total 12K
+dr-xr-xr-x.   1 root root system_u:object_r:container_file_t:s0:c15,c25   40 Feb 17 13:34 .
+dr-xr-xr-x.   1 root root system_u:object_r:container_file_t:s0:c15,c25   40 Feb 17 13:34 ..
+[...]
+----
+. Compare both the outputs to check if there is a mismatch of SELinux context.
+. When there is a mismatch of the SELinux content, create a new SCC and assign it to both PODs. To create a SCC see link: https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html#security-context-constraints-creating_configuring-internal-oauth[Creating security context constraints].
+. Update the SELinuxContext as shown in the following example:
++
+.Example output
+[source,terminal]
+----
+ [...]
+ securityContext:privileged
+      seLinuxOptions:MustRunAs
+        level: "s0:cXX,cYY"
+  [...]
+----
+
+.Verification
+
+. Verify that the same SCC is assigned to the first pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc describe pod _<pod_name_A>_ |grep -i scc <1>
+----
+<1> Replace `_<pod_name_A>_` with the name of the first pod.
++
+.Example output
+[source,terminal]
+----
+openshift.io/scc: restricted
+----
+. Verify that the same SCC is assigned to first second pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc describe pod _<pod_name_B>_ |grep -i scc <1>
+----
+<1> Replace `_<pod_name_B>_` with the name of the second pod.
++
+.Example output
+[source,terminal]
+----
+openshift.io/scc: restricted
+----
+. Verify that the same SELinux label is applied to first pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc exec _<pod_name_A>_ -- ls -laZ _<PVC_mountpoint>_ <1>
+----
+<1> Replace `_<pod_name_A>_` with the name of the first pod and replace `_<PVC_mountpoint>_` with the mount point within the first pod.
++
+.Example output
+[source,terminal]
+----
+total 4
+drwxrwsrwx. 2 root       1000670000 system_u:object_r:container_file_t:s0:c10,c26 19 Aug 29 18:17 .
+dr-xr-xr-x. 1 root       root       system_u:object_r:container_file_t:s0:c10,c26 61 Aug 29 18:16 ..
+-rw-rw-rw-. 1 1000670000 1000670000 system_u:object_r:container_file_t:s0:c10,c26 29 Aug 29 18:17 test1
+[...]
+----
+. Verify that the same SELinux label is applied to second pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc exec _<pod_name_B>_ -- ls -laZ _<PVC_mountpoint>_ <1>
+----
+<1> Replace `_<pod_name_B>_` with the name of the second pod and replace `_<PVC_mountpoint>_` with the mount point within the second pod.
++
+.Example output
+[source,terminal]
+----
+total 4
+drwxrwsrwx. 2 root       1000670000 system_u:object_r:container_file_t:s0:c10,c26 19 Aug 29 18:17 .
+dr-xr-xr-x. 1 root       root       system_u:object_r:container_file_t:s0:c10,c26 61 Aug 29 18:16 ..
+-rw-rw-rw-. 1 1000670000 1000670000 system_u:object_r:container_file_t:s0:c10,c26 29 Aug 29 18:17 test1
+[...]
+----

--- a/modules/microshift-control-permissions-security-context-constraints.adoc
+++ b/modules/microshift-control-permissions-security-context-constraints.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/understanding-persistent-storage-microshift.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id=microshift-control-permissions-security-context-constraints_{context}]
+= Control permissions with security context constraints
+
+You can use security context constraints (SCCs) to control permissions for the pods in your cluster. These permissions determine the actions that a pod can perform and what resources it can access. You can use SCCs to define a set of conditions that a pod must run with to be accepted into the system.
+
+For more information see link:https://docs.openshift.com/container-platform/4.16/authentication/managing-security-context-constraints.html[Managing security context constraints].
+
+[IMPORTANT]
+====
+Only RWO volume mounts are supported. SCC could be blocked if pods are not operating with the SCC contexts.
+====

--- a/modules/microshift-pv-rwo-access-mode-permission.adoc
+++ b/modules/microshift-pv-rwo-access-mode-permission.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/understanding-persistent-storage-microshift.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id=microshift-pv-rwo-access-mode-permission_{context}]
+= Persistent volumes with RWO access mode permissions
+
+Persistent volume claims (PVCs) can be created with different access modes. A PVC with the `ReadWriteOnce` (RWO) access mode set allows multiple pods on the same node to read or write into the same PV at once.
+
+There are instances when the pods of the same node are not able to read or write into the same PV. This happens when the pods in the node do not have the same SELinux context. Persistent volumes can be mounted, then later claimed by PVCs, with the RWO access mode.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-4200](https://issues.redhat.com/browse/OSDOCS-4200)

Link to docs preview:
[Control permissions with security context constraints](https://81957--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html#microshift-security-context-constraints-overview_understanding-persistent-storage-microshift)
[persistent volumes with RWO access mode permissions](https://81957--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html#microshift-pv-rwo-access-mode-permission_understanding-persistent-storage-microshift)
[Checking the pods for mismatch](https://81957--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html#microshift-checking-pods-mismatch_understanding-persistent-storage-microshift)


QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change - jon cope.


