### PR TITLE
RHDEVDOCS 6173 remove incorrect statement about task resource consumption

### DIFF
--- a/modules/op-understanding-pipelines-resource-consumption.adoc
+++ b/modules/op-understanding-pipelines-resource-consumption.adoc
@@ -7,8 +7,6 @@
 
 Each task consists of a number of required steps to be executed in a particular order defined in the `steps` field of the `Task` resource. Every task runs as a pod, and each step runs as a container within that pod.
 
-Steps are executed one at a time. The pod that executes the task only requests enough resources to run a single container image (step) in the task at a time, and thus does not store resources for all the steps in the task.
-
 The `Resources` field in the `steps` spec specifies the limits for resource consumption.
 By default, the resource requests for the CPU, memory, and ephemeral storage are set to `BestEffort` (zero) values or to the minimums set through limit ranges in that project.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cp to pipelines-docs-1.11, pipelines-docs-1.12, pipelines-docs-1.13, pipelines-docs-1.14, pipelines-docs-1.15, pipelines-docs-1.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6173

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://81964--ocpdocs-pr.netlify.app/openshift-pipelines/latest/resource/reducing-pipelines-resource-consumption.html#op-understanding-pipelines-resource-consumption_reducing-pipelines-resource-consumption

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
