### PR TITLE
OLS-1064: OLS 0.1.6 Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -11,12 +11,14 @@
 :prewrap!:
 //Red Hat
 :red-hat: Red Hat
+:rhel: Red Hat Enterprise Linux
 //OpenShift
 :ocp-product-title: OpenShift Container Platform
 :ocp-short-name: OpenShift
 :ocp-virt: OpenShift Virtualization
 :ocp-pipe: OpenShift Pipelines
 :ocp-ai: OpenShift AI
+:ocp-ai-official: Red Hat OpenShift AI
 :ossm: OpenShift Service Mesh
 //Kubernetes
 :k8s: Kubernetes

--- a/modules/ols-0-1-6-release-notes.adoc
+++ b/modules/ols-0-1-6-release-notes.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-1-6-release-notes_{context}"]
+= {ols-long} version 0.1.6
+
+Issued: 17 September 2024
+
+{ols-offical} 0.1.6 is now available on {ocp-product-title} 4.15 or later.
+
+[id="ols-0-1-6-enhancements_{context}"]
+== Enhancements
+
+The following enhancements have been made with {ols-offical} 0.1.6:
+
+* When installing the {ols-long} Operator, the *Enable Operator recommended cluster monitoring on this Namespace* check box is now selected by default on the Operator Installation User Interface. The installer applies the `openshift-lightspeed openshift.io/cluster-monitoring=true` label to the `openshift-lightspeed` namespace. Applying this label allows cluster monitoring metrics to be obtained from the Service. To disable metric collection by the cluster monitoring stack, remove the label from the `openshift-lightspeed` namespace.
+
+* Beginning in this release, {ocp-ai-official} (RHOAI) can be configured as the Large Language Model (LLM) provider.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -8,6 +8,7 @@ toc::[]
 
 The release notes highlight what is new and what has changed with each {ols-offical} release.
 
+include::modules/ols-0-1-6-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-1-5-release-notes.adoc[leveloffset=+1]
 
 // include::modules/ols-release-notes-known-issues.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OLS-1064
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://81982--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
