### PR TITLE
OADP-4872: Remove OADP 1.3 release notes from OCP 4.16

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 The release notes for {oadp-first} describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+[NOTE]
+====
+For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
+====
+
 include::modules/oadp-1-4-1-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]
@@ -23,8 +28,4 @@ include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+3]
 
 To upgrade from OADP 1.3 to 1.4, no Data Protection Application (DPA) changes are required.
 
-[id="verifying-upgrade-1-4-0_{context}"]
-=== Verifying the upgrade
-
-Verify the installation by following steps from the xref:../../../backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-2.adoc#verifying-upgrade-1-2-0_oadp-release-notes[Verifying the upgrade] section.
-
+include::modules/oadp-verifying-upgrade-1-4-0.adoc[leveloffset=+2]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+[NOTE]
+====
+For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
+====
+
 include::modules/oadp-release-notes-1-3-3.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-2.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-1.adoc[leveloffset=+1]

--- a/modules/oadp-verifying-upgrade-1-4-0.adoc
+++ b/modules/oadp-verifying-upgrade-1-4-0.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-4.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="verifying-upgrade-1-4-0_{context}"]
+= Verifying the upgrade
+
+Use the following procedure to verify the upgrade.
+
+.Procedure
+
+. Verify the installation by viewing the {oadp-first} resources by running the following command:
++
+[source,terminal]
+----
+$ oc get all -n openshift-adp
+----
++
+.Example output
++
+----
+NAME                                                     READY   STATUS    RESTARTS   AGE
+pod/oadp-operator-controller-manager-67d9494d47-6l8z8    2/2     Running   0          2m8s
+pod/restic-9cq4q                                         1/1     Running   0          94s
+pod/restic-m4lts                                         1/1     Running   0          94s
+pod/restic-pv4kr                                         1/1     Running   0          95s
+pod/velero-588db7f655-n842v                              1/1     Running   0          95s
+
+NAME                                                       TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+service/oadp-operator-controller-manager-metrics-service   ClusterIP   172.30.70.140    <none>        8443/TCP   2m8s
+
+NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+daemonset.apps/restic   3         3         3       3            3           <none>          96s
+
+NAME                                                READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/oadp-operator-controller-manager    1/1     1            1           2m9s
+deployment.apps/velero                              1/1     1            1           96s
+
+NAME                                                           DESIRED   CURRENT   READY   AGE
+replicaset.apps/oadp-operator-controller-manager-67d9494d47    1         1         1       2m9s
+replicaset.apps/velero-588db7f655                              1         1         1       96s
+----
+
+. Verify that the `DataProtectionApplication` (DPA) is reconciled by running the following command:
++
+[source,terminal]
+----
+$ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
+----
+.Example output
+[source,yaml]
++
+----
+{"conditions":[{"lastTransitionTime":"2023-10-27T01:23:57Z","message":"Reconcile complete","reason":"Complete","status":"True","type":"Reconciled"}]}
+----
+
+. Verify the `type` is set to `Reconciled`.
+
+. Verify the backup storage location and confirm that the `PHASE` is `Available` by running the following command:
++
+[source,terminal]
+----
+$ oc get backupStorageLocation -n openshift-adp
+----
+.Example output
+[source,yaml]
++
+----
+NAME           PHASE       LAST VALIDATED   AGE     DEFAULT
+dpa-sample-1   Available   1s               3d16h   true
+----


### PR DESCRIPTION
### JIRA

* [OADP-4872](https://issues.redhat.com/browse/OADP-4872)

### Version(s):

* OCP 4.15
* OCP 4.14

### Link to docs preview:

* [OADP 1.4 release notes](https://81986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html)
* [OADP 1.3 release notes](https://81986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
