### PR TITLE
OLS-866: Add YAML file to examples for granting access

### DIFF
--- a/modules/ols-granting-access-to-individual-users.adoc
+++ b/modules/ols-granting-access-to-individual-users.adoc
@@ -24,3 +24,37 @@ This procedure explains how to grant access to an individual user.
 $ oc adm policy add-cluster-role-to-user \
 lightspeed-operator-query-access <user_name>
 ----
++
+Alternatively, you can use a YAML file when granting access to an individual user by using the following command:
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user lightspeed-operator-query-access <user_name> -o yaml --dry-run
+----
++
+The terminal returns the following output:
++
+[source,yaml, subs="attributes,verbatim"]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: lightspeed-operator-query-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lightspeed-operator-query-access
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: <user_name> <1>
+----
+<1> Enter the actual user name in place of `<user_name>` before creating the object.
++
+Save the output as a YAML file, and run the following command to grant user access:
++
+[source,terminal]
+----
+$ oc create -f <yaml_filename>
+----

--- a/modules/ols-granting-access-to-user-group.adoc
+++ b/modules/ols-granting-access-to-user-group.adoc
@@ -24,3 +24,37 @@ This procedure explains how to grant access to a user group. If your cluster has
 $ oc adm policy add-cluster-role-to-group \
 lightspeed-operator-query-access <group_name>
 ----
++
+Alternatively, you can use a YAML file when granting access to a user group by using the following command:
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-group lightspeed-operator-query-access <group_name> -o yaml --dry-run
+----
++
+The terminal returns the following output:
++
+[source,yaml, subs="attributes,verbatim"]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: lightspeed-operator-query-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lightspeed-operator-query-access
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: <user_group> <1>
+----
+<1> Enter the actual user group in place of `<user_group>` before creating the object.
++
+Save the output as a YAML file, and run the following command to grant access to the user group:
++
+[source,terminal]
+----
+$ oc create -f <yaml_filename>
+----


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

Version(s): Tech Preview
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-866
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://81988--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-granting-access-to-individual-users_ols-configuring-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
