### PR TITLE
OSDOCS-11986 OCP 4.15.32 Release Notes (Sept. 18 release)

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2740,6 +2740,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-32_{context}"]
+=== RHSA-2024:6637 - {product-title} 4.15.32 bug fix and security update
+
+Issued: 18 September 2024
+
+{product-title} release 4.15.32, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6637[RHSA-2024:6637] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2024:6640[RHBA-2024:6640] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.32 --pullspecs
+----
+
+[id="ocp-4-15-32-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the Cloud Credential Operator (CCO) would produce an error when starting or restarting when there were a large number of secrets in the cluster fetched at once. With this release, the CCO fetches the secrets in batches of 100 and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41235[*OCPBUGS-41235*])
+
+* Previously, the installation program populated the `network.devices`, `template` and `workspace` fields in the `spec.template.spec.providerSpec.value` section of the {vmw-full} control plane machine set custom resource (CR).
+These fields should be set in the {vmw-short} failure domain, and the installation program populating them caused unintended behaviors. Updating these fields did not trigger an update to the control plane machines, and these fields were cleared when the control plane machine set was deleted.
++
+With this release, the installation program is updated to no longer populate values that are included in the failure domain configuration. If these values are not defined in a failure domain configuration, for instance on a cluster that is updated to {product-title} {product-version} from an earlier version, the values defined by the installation program are used. (link:https://issues.redhat.com/browse/OCPBUGS-37064[*OCPBUGS-37064*])
+
+* Previously, the `ControlPlaneMachineSet` (CPMS) checked templates and the resource pool based on the full vCenter path. This caused the CPMS to start when it was not needed. With this release, CPMS also checks the file name and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-24632[*OCPBUGS-24632*])
+
+[id="ocp-4-15-32-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-15-31_{context}"]
 === RHSA-2024:6409 - {product-title} 4.15.31 bug fix and security update
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11986](https://issues.redhat.com/browse/OSDOCS-11986)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to[ docs preview:](https://81994--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-32_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Errata links will not work until Sept. 18th. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
