### PR TITLE
OSDOCS#11885: Sigstore signature RN

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -538,12 +538,12 @@ Updated boot images are now supported as a Technology Preview feature for Amazon
 
 [id="ocp-4-17-machine-config-operator-boot-image-gcp_{context}"]
 === Updated boot images for GCP clusters promoted to GA
- 
+
 Updated boot images has been promoted to GA for Google Cloud Platform (GCP) clusters. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
 
 [id="ocp-4-17-machine-config-operator-node-disrupt-ga_{context}"]
 === Node disruption policies promoted to GA
- 
+
 Node disruption policies for Google Cloud Platform (GCP) clusters has been promoted to GA. A node disruption policy allows you to define a set of Ignition config objects changes that would require little or no disruption to your workloads. For more information, see xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes].
 
 [id="ocp-4-17-machine-management_{context}"]
@@ -600,6 +600,13 @@ With this release, all `etcd` certificates originate from a new namespace: `open
 . All certificates regenerate with the new signers.
 
 Manual rotation of signer certificates is still supported by deleting the specific secret and waiting for the status pod rollout to complete.
+
+[id="ocp-17-sigstore-verification_{context}"]
+==== Sigstore signature image verification
+
+With this release, Technology Preview clusters use Sigstore signatures to verify images that were retrieved using a pull spec that references the `quay.io/openshift-release-dev/ocp-release`repository.
+
+Currently, if you are mirroring images, you must also mirror `quay.io/openshift-release-dev/ocp-release:<release_image_digest_with_dash>.sig` Sigstore signatures in order for the image verification to succeed.
 
 [id="ocp-4-17-notable-technical-changes_{context}"]
 == Notable technical changes


### PR DESCRIPTION
[OSDOCS-11885](https://issues.redhat.com/browse/OSDOCS-11885)

Version(s): 4.17

This PR adds a release note about Sigstore image verification for core cluster images.

QE review:
- [x] QE has approved this change.

Preview: https://81997--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-17-sigstore-verification_release-notes
