### PR TITLE
RHDEVDOCS 6164 fix RN for 1.15.1 again, as chain.artifacts.pipelinerun.enable-deep-inspection allows both types

### DIFF
--- a/modules/op-release-notes-1-15.adoc
+++ b/modules/op-release-notes-1-15.adoc
@@ -460,7 +460,7 @@ With this update, {pipelines-title} General Availability (GA) 1.15.1 is availabl
 [id="new-features-1-15-1_{context}"]
 === New features
 
-* Before this update, in the `TektonConfig` CR, the `chain.artifacts.pipelinerun.enable-deep-inspection` spec supported only the `bool` value type. With this update, the `chain.artifacts.pipelinerun.enable-deep-inspection` spec supports only the `string` value type; the valid values for this spec are `"true"` and `"false"`.
+* Before this update, in the `TektonConfig` CR, the `chain.artifacts.pipelinerun.enable-deep-inspection` spec supported only the `bool` value type. With this update, the `chain.artifacts.pipelinerun.enable-deep-inspection` spec supports both the `bool` and `string` value types; if using the `string` value type, the valid values for this spec are `"true"` and `"false"`.
 
 [id="fixed-issues-1-15-1_{context}"]
 === Fixed issues


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

please cp to pipelines-docs-1.15, pipelines-docs-1.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6164

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://81999--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/op-release-notes.html#new-features-1-15-1_op-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
