### PR TITLE
OBSDOCS-1319: Update monitoring config map API reference content for …

### DIFF
--- a/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -559,7 +559,7 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the Prometheus container.
 
-|retention|string|Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `15d`.
+|retention|string|Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `24h`.
 
 |retentionSize|string|Defines the maximum amount of disk space used by data blocks plus the write-ahead log (WAL). Supported values are `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`, `EB`, and `EiB`. The default value is `nil`.
 


### PR DESCRIPTION
Update of automatically generated page.

Version(s): `enterprise-4.17` `enterprise-4.18`

Issue: [OBSDOCS-1319](https://issues.redhat.com/browse/OBSDOCS-1319)

Link to docs preview:  https://82002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html#prometheusrestrictedconfig

QE review:
- [x] QE has approved this change.

**Additional information:**