### PR TITLE
[SRVCOM-2499] Add docs on HA support using workload overrides

### DIFF
--- a/modules/serverless-config-replicas-eventing.adoc
+++ b/modules/serverless-config-replicas-eventing.adoc
@@ -45,3 +45,43 @@ spec:
   high-availability:
     replicas: 3
 ----
+
+. You can also specify the number of replicas for a specific workload.
++
+[NOTE]
+====
+Workload-specific configuration overrides the global setting for Knative Eventing.
+====
++
+.Example YAML
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  high-availability:
+    replicas: 3
+  workloads:
+  - name: mt-broker-filter
+    replicas: 3
+----
+
+. Verify that the high availability limits are respected:
++
+.Example command
+[source,terminal]
+----
+$ oc get hpa -n knative-eventing
+----
++
+.Example output
+[source,terminal]
+----
+NAME                 REFERENCE                      TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
+broker-filter-hpa    Deployment/mt-broker-filter    1%/70%    3         12        3          112s
+broker-ingress-hpa   Deployment/mt-broker-ingress   1%/70%    3         12        3          112s
+eventing-webhook     Deployment/eventing-webhook    4%/100%   3         7         3          115s
+----

--- a/modules/serverless-config-replicas-serving.adoc
+++ b/modules/serverless-config-replicas-serving.adoc
@@ -41,3 +41,42 @@ spec:
   high-availability:
     replicas: 3
 ----
+
+. You can also specify the number of replicas for a specific workload.
++
+[NOTE]
+====
+Workload-specific configuration overrides the global setting for Knative Serving.
+====
++
+.Example YAML
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  high-availability:
+    replicas: 3
+  workloads:
+  - name: webhook
+    replicas: 4
+----
+
+. Verify that the high availability limits are respected:
++
+.Example command
+[source,terminal]
+----
+$ oc get hpa -n knative-serving
+----
++
+.Example output
+[source,terminal]
+----
+NAME        REFERENCE              TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
+activator   Deployment/activator   0%/100%   3         22        3          2m24s
+webhook     Deployment/webhook     2%/100%   4         8         4          2m23s
+----


### PR DESCRIPTION
Version(s):
`serverless-docs-1.34`+

Issue:
https://issues.redhat.com/browse/SRVCOM-2499

Link to docs preview:
https://82008--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/tuning/serverless-ha.html
https://82008--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-ha-services/ha-replicas-serving.html

QE review:
- [x] QE has approved this change.