### PR TITLE
OCP monitoring 4.17 release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -571,6 +571,35 @@ For a full list of flags to use with the `oc adm must-gather command`, see xref:
 [id="ocp-4-17-monitoring_{context}"]
 === Monitoring
 
+The in-cluster monitoring stack for this release includes the following new and modified features. 
+//change the line if no features
+
+[id="ocp-4-17-monitoring-updates-to-monitoring-stack-components-and-dependencies"]
+==== Updates to monitoring stack components and dependencies
+
+This release includes the following version updates for in-cluster monitoring stack components and dependencies:
+
+* Alertmanager to 0.27.0
+* Prometheus Operator to 0.75.2
+* Prometheus to 2.53.1
+* kube-state-metrics to 2.13.0
+* node-exporter to 1.8.2
+* Thanos to 0.35.1
+
+[id="ocp-4-17-monitoring-changes-to-alerting-rules"]
+==== Changes to alerting rules
+
+[NOTE]
+====
+Red{nbsp}Hat does not guarantee backward compatibility for recording rules or alerting rules.
+====
+
+* Added the `PrometheusKubernetesListWatchFailures` alert to warn users about Prometheus and Kubernetes API failures, such as unreachable API and permissions issues, which can lead into silent service discovery failures.
+
+[id="ocp-4-17-monitoring-prometheus-updated-to-tolerate-jitters-at-scrape-time-uwm"]
+==== Updated Prometheus to tolerate jitters at scrape time for user-defined projects
+With this update, the Prometheus configuration for monitoring for user-defined projects now tolerates jitters at scrape time. This update optimizes data compression for monitoring deployments that show sub-optimal chunk compression for data storage, which reduces the disk space used by the time series database in these deployments.
+
 [id="ocp-4-17-network-observability-1-6_{context}"]
 ==== Network Observability Operator
 The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, Rolling Stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator is found in the xref:../observability/network_observability/network-observability-operator-release-notes.adoc#network-observability-rn[Network Observability release notes].


### PR DESCRIPTION
Version(s): No CP, `enterprise-4.17` only.

Issue: [OBSDOCS-1196](https://issues.redhat.com/browse/OBSDOCS-1196)

Link to docs preview: https://82009--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-monitoring_release-notes

QE review:
- [x] QE has approved this change.
