### PR TITLE
OBSDOCS-1101: Logging 6.0 Release Notes

### DIFF
--- a/modules/logging-release-notes-6-0-0.adoc
+++ b/modules/logging-release-notes-6-0-0.adoc
@@ -1,0 +1,92 @@
+// module included in logging-6-0-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-0_{context}"]
+= Logging 6.0.0
+
+This release includes link:https://access.redhat.com/errata/RHBA-2024:6693[{logging} {for} Bug Fix Release 6.0.0]
+
+[id="logging-release-notes-6-0-0-compatibility-support-matrix"]
+= Compatibility and support matrix
+
+In the table, components are marked with the following statuses:
+
+[horizontal]
+TP:: Technology Preview
+GA:: General Availability
+
+The components or features in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] status are experimental and are not intended for production use.
+
+[NOTE]
+====
+To know about compatible {product-title} versions for {logging} releases, see link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20OpenShift%20Logging[Product Life Cycles].
+====
+
+.Components support matrix
+[options="header"]
+|===
+
+| {logging} Version 6+| Component Version
+
+| Operator | `eventrouter` | `logfilemetricexporter` | `loki` | `lokistack-gateway` | `opa-openshift` | `vector`
+
+|6.0 | 0.4 (GA) | 1.1 (GA) | 3.1.0 (GA) | 0.1 (GA) | 0.1 (GA) | 0.37.1 (GA)
+
+|===
+
+[id="logging-release-notes-6-0-0-removal-notice"]
+== Removal notice
+
+* With this release, {logging} no longer supports the `ClusterLogging.logging.openshift.io` and `ClusterLogForwarder.logging.openshift.io` custom resources. Refer to the product documentation for details on the replacement features. (link:https://issues.redhat.com/browse/LOG-5803[LOG-5803])
+
+* With this release, {logging} no longer manages or deploys log storage (such as Elasticsearch), visualization (such as Kibana), or Fluentd-based log collectors. (link:https://issues.redhat.com/browse/LOG-5368[LOG-5368])
+
+[NOTE]
+====
+In order to continue to use Elasticsearch and Kibana managed by the elasticsearch-operator, the administrator must modify those object's ownerRefs before deleting the ClusterLogging resource.
+====
+
+[id="logging-release-notes-6-0-0-enhancements"]
+== New features and enhancements
+=== Log Collection
+
+* This feature introduces a new architecture for {logging} {for} by shifting component responsibilities to their relevant Operators, such as for storage, visualization, and collection. It introduces the `ClusterLogForwarder.observability.openshift.io` API for log collection and forwarding. Support for the `ClusterLogging.logging.openshift.io` and `ClusterLogForwarder.logging.openshift.io` APIs, along with the Red Hat managed Elastic stack (Elasticsearch and Kibana), is removed. Users are encouraged to migrate to the Red Hat `LokiStack` for log storage. Existing managed Elasticsearch deployments can be used for a limited time. Automated migration for log collection is not provided, so administrators need to create a new ClusterLogForwarder.observability.openshift.io specification to replace their previous custom resources. Refer to the official product documentation for more details. (link:https://issues.redhat.com/browse/LOG-3493[LOG-3493])
+
+* Before this update, the Vector collector deployments had no limits on memory and CPU usage. With this update, default requests and limits are set based on the recommendations from the Vector documentation. (link:https://issues.redhat.com/browse/LOG-4745[LOG-4745])
+
+* This enhancement brings Vector in line with the upstream Vector version v0.37.1. (link:https://issues.redhat.com/browse/LOG-5296[LOG-5296])
+
+* With this release, an alert triggers when log collectors buffer logs to the file system of a node and use over 15% of the available space. This may indicate the log collectors are facing back pressure from their outputs, and administrators should act to prevent potential issues on the cluster node. (link:https://issues.redhat.com/browse/LOG-5381[LOG-5381])
+
+* This enhancement updates the selectors for all components to use common Kubernetes labels. (link:https://issues.redhat.com/browse/LOG-5906[LOG-5906])
+
+* With this update, the collector configuration deploys as a `ConfigMap` instead of a secret. This change allows users to view and edit the configuration when the `ClusterLogForwarder` is set to `Unmanaged`. (link:https://issues.redhat.com/browse/LOG-5599[LOG-5599])
+
+* With this release, the log level for the Vector collector can be configured using an annotation on the `ClusterLogForwarder`. The log level options include trace, debug, info, warn, error, or off. (link:https://issues.redhat.com/browse/LOG-5372[LOG-5372])
+
+* This enhancement adds validation to reject configurations where Amazon CloudWatch outputs use multiple AWS roles. Previously, logs were incorrectly routed to the first AWS role defined. (link:https://issues.redhat.com/browse/LOG-5640[LOG-5640])
+
+* This enhancement removes the *Log Bytes Collected* and *Log Bytes Sent* graphs from the metrics dashboard. (link:https://issues.redhat.com/browse/LOG-5964[LOG-5964])
+
+* With this release, the must-gather functionality is updated to only capture information for inspecting Logging 6.0 components, including Vector deployments from `ClusterLogForwarder.observability.openshift.io` resources and the Red Hat managed `LokiStack` provided by the Loki Operator. (link:https://issues.redhat.com/browse/LOG-5949[LOG-5949])
+
+=== Log Storage
+
+* With this release, the responsibility for deploying the {logging} view plugin shifts from the Cluster {logging} Operator to the {coo-first}. For new log storage installations that need visualization, the {coo-full} and the associated UIPlugin resource must be deployed. Refer to the official product documentation for more details. (link:https://issues.redhat.com/browse/LOG-5461[LOG-5461])
+
+* With this update, the Azure storage secret validation now provides early warnings for specific error conditions. (link:https://issues.redhat.com/browse/LOG-4571[LOG-4571])
+
+[id="logging-release-notes-6-0-0-technology-preview-features"]
+== Technology Preview features
+
+* This release introduces a Technology Preview feature for log forwarding using OpenTelemetry. A new output type,` OTLP`, allows sending JSON-encoded log records using the OpenTelemetry data model and resource semantic conventions. (link:https://issues.redhat.com/browse/LOG-4225[LOG-4225])
+
+[id="logging-release-notes-6-0-0-bug-fixes"]
+== Bug fixes
+
+* Before this update, the `CollectorHighErrorRate` and `CollectorVeryHighErrorRate` alerts were still present. With this update, both alerts are removed in the {logging} 6.0 release but might return in a future release. (link:https://issues.redhat.com/browse/LOG-3432[LOG-3432])
+
+
+[id="logging-release-notes-6-0-0-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-34397[CVE-2024-34397]

--- a/observability/logging/logging-6.0/log6x-release-notes.adoc
+++ b/observability/logging/logging-6.0/log6x-release-notes.adoc
@@ -5,3 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: logging-6x
 
 toc::[]
+
+include::snippets/logging-compatibility-snip.adoc[]
+
+include::modules/logging-release-notes-6-0-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging 6.0.0 Release Notes

Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1101

Fix Version: 4.14+

Doc Preview: https://82065--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-release-notes.html#logging-release-notes-6-0-0_logging-6x

SME Review: @JoaoBraveCoding @cahartma @jcantrill  @xperimental 
QE Review: @kabirbhartiRH @anpingli 
Peer Review: @skrthomas 