### PR TITLE
RHDEVDOCS-5840 - Change redirects

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -328,12 +328,12 @@ AddType text/vtt                            vtt
     # Builds using Shipwright landing page
     RewriteRule ^container-platform/(4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/builds_using_shipwright/overview-openshift-builds.html /builds/latest/about/overview-openshift-builds.html  [L,R=302]
 
-    # redirect gitops latest to 1.13
+    # redirect gitops latest to 1.14
     RewriteRule ^gitops/?$ /gitops/latest [R=302]
-    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.13/$1 [NE,R=302]
+    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.14/$1 [NE,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^gitops/(1\.8|1\.9|1\.10|1\.11|1\.12|1\.13)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
+    RewriteRule ^gitops/(1\.8|1\.9|1\.10|1\.11|1\.12|1\.13|1\.14)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # GitOps landing page
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -266,6 +266,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.14">1.14</option>
               <option value="1.13">1.13</option>
               <option value="1.12">1.12</option>
               <option value="1.11">1.11</option>


### PR DESCRIPTION
**This PR is for the GitOps 1.14 release that is scheduled for September 18, 2024. Do not merge until this date.**


**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5840](https://issues.redhat.com/browse/RHDEVDOCS-5840)
-  [RHDEVDOCS 5839](https://issues.redhat.com/browse/RHDEVDOCS-5839)
-  [RHDEVDOCS 5838](https://issues.redhat.com/browse/RHDEVDOCS-5838)

**Link to docs preview:** Not applicable


**SME and QE review:** Not applicable

**Additional information:** This PR updates the redirects in the `01-commercial.conf` and  `_page_openshift.html.erb` files in the `main` for the 1.14 GitOps standalone doc. It does not alter documentation content.