### PR TITLE
OLS-908: Document supported authentications for MS Azure

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After the {ols-long} Operator is installed, configuring and deploying consists of three tasks. First, you create a credential secret using the credentials for your Large Language Model (LLM) provider. Next, you create the `OLSConfig` Custom Resource (CR) file that the Operator uses to deploy the service. Finally, you verify that the {ols-short} service is operating.
+After the {ols-long} Operator is installed, configuring and deploying {ols-long} consists of three tasks. First, you create a credential secret using the credentials for your Large Language Model (LLM) provider. Next, you create the `OLSConfig` custom resource (CR) that the Operator uses to deploy the service. Finally, you verify that the {ols-short} service is operating.
 
 [NOTE]
 ====
@@ -14,8 +14,8 @@ The instructions assume that you are installing {ols-long} using the `kubeadmin`
 ====
 
 include::modules/ols-creating-the-credentials-secret-using-web-console.adoc[leveloffset=+1]
-include::modules/ols-creating-the-credentials-secret-using-cli.adoc[leveloffset=+1]
 include::modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc[leveloffset=+1]
+include::modules/ols-creating-the-credentials-secret-using-cli.adoc[leveloffset=+1]
 include::modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc[leveloffset=+1]
 include::modules/ols-verifying-openshift-lightspeed-deployment.adoc[leveloffset=+1]
 include::modules/ols-about-lightspeed-and-role-based-access-control.adoc[leveloffset=+1]

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
@@ -17,7 +17,7 @@ The Custom Resource (CR) file contains information that the Operator uses to dep
 
 . Create an `OLSConfig` file that contains the YAML content for the LLM provider you use:
 +
-.Example OpenAI custom resource file
+.OpenAI custom resource file
 +
 [source,yaml, subs="attributes,verbatim"]
 ----
@@ -45,7 +45,7 @@ spec:
 For OpenShift AI vLLM use the same configuration as OpenAI but update the URL to point to your Virtual Large Language Model (vLLM) endpoint. If OpenShift Lightspeed operates in the same cluster as the vLLM model serving instance, you can point to the internal OpenShift service hostname instead of exposing vLLM with a route.
 ====
 +
-.Example {azure-openai} custom resource file
+.{azure-openai} custom resource file
 +
 [source,yaml, subs="attributes,verbatim"]
 ----
@@ -70,7 +70,7 @@ spec:
     logLevel: DEBUG
 ----
 +
-.Example {watsonx} custom resource file
+.{watsonx} custom resource file
 +
 [source,yaml, subs="attributes,verbatim"]
 ----

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
@@ -19,7 +19,7 @@ The Custom Resource (CR) file contains information that the Operator uses to dep
 
 . Paste the YAML content for the LLM provider you use into the text area of the web console:
 +
-.Example OpenAI custom resource file
+.OpenAI custom resource file
 +
 [source,yaml, subs="attributes,verbatim"]
 ----
@@ -42,7 +42,7 @@ spec:
     defaultProvider: myOpenai
 ----
 +
-.Example {azure-openai} custom resource file
+.{azure-openai} custom resource file
 +
 [source,yaml, subs="attributes,verbatim"]
 ----
@@ -66,7 +66,7 @@ spec:
     defaultProvider: myAzure
 ----
 +
-.Example {watsonx} custom resource file
+.{watsonx} custom resource file
 +
 [source,yaml, subs="attributes,verbatim"]
 ----

--- a/modules/ols-creating-the-credentials-secret-using-cli.adoc
+++ b/modules/ols-creating-the-credentials-secret-using-cli.adoc
@@ -1,11 +1,12 @@
 // This module is used in the following assemblies:
-// ols-configuring-openshift-lightspeed.adoc
+
+// * configure/ols-configuring-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-creating-the-credentials-secret-using-cli_{context}"]
 = Creating the credentials secret using the command line
 
-Create a file that is associated with the secret key used to access the API of your LLM provider. You can use API tokens to authenticate your LLM provider. Additionally, {azure-official} supports authentication using Entra ID.
+Create a file that is associated with the API token used to access the API of your LLM provider. Typically, you use API tokens to authenticate your LLM provider. Alternatively, {azure-official} also supports authentication using {entra-id}.
 
 .Prerequisites
 
@@ -17,9 +18,13 @@ Create a file that is associated with the secret key used to access the API of y
 
 . Create a file that contains the following YAML content:
 +
-.Example credential secret for LLM provider
+[NOTE]
+====
+The YAML parameter is always `apitoken` regardless of what the LLM provider calls the access details.
+====
 +
-[source,yaml, subs="attributes,verbatim"]
+.Credential secret for LLM provider
+[source,yaml,subs="attributes,verbatim"]
 ----
 apiVersion: v1
 kind: Secret
@@ -32,9 +37,36 @@ stringData:
 ----
 <1> The `apitoken` is not `base64` encoded.
 +
-.Example credential secret for {azure-official} {openai}
+.Credential secret for {watsonx}
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: v1
+data:
+  apitoken: NlFy 
+kind: Secret
+metadata:
+  name: watsonx-api-keys
+  namespace: openshift-lightspeed
+type: Opaque
+----
 +
-[source,yaml, subs="attributes,verbatim"]
+.Credential secret for {azure-official} {openai}
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: v1
+data:
+  apitoken: azure_token 
+kind: Secret
+metadata:
+  name: azure-api-keys
+  namespace: openshift-lightspeed
+type: Opaque
+----
++
+Alternatively, for {azure-openai} you can use {entra-id} to authenticate your LLM provider. {entra-id} users must configure the required roles for their {azure-openai} resource. For more information, see the official Microsoft link:https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/role-based-access-control#cognitive-services-openai-contributor[Cognitive Services OpenAI Contributor](Microsoft Azure OpenAI Service documentation).
++
+.Credential secret for {entra-id}
+[source,yaml,subs="attributes,verbatim"]
 ----
 apiVersion: v1
 data:

--- a/modules/ols-creating-the-credentials-secret-using-web-console.adoc
+++ b/modules/ols-creating-the-credentials-secret-using-web-console.adoc
@@ -1,11 +1,12 @@
 // This module is used in the following assemblies:
-// configure/ols-configuring-openshift-lightspeed.adoc
+
+// * configure/ols-configuring-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-creating-the-credentials-secret-using-web-console_{context}"]
 = Creating the credentials secret using the web console
 
-Create a file that is associated with the secret key used to access the API of your LLM provider. You can use API tokens to authenticate your LLM provider. Additionally, {azure-official} supports authentication using Entra ID.
+Create a file that is associated with the API token used to access the API of your LLM provider. Typically, you use API tokens to authenticate your LLM provider. Alternatively, {azure-official} also supports authentication using {entra-id}.
 
 .Prerequisites
 
@@ -15,12 +16,16 @@ Create a file that is associated with the secret key used to access the API of y
 
 .Procedure 
 
-. Click the plus button in the upper-right corner of the {ocp-short-name} web console.
+. Click *Add* in the upper-right corner of the {ocp-short-name} web console.
 
 . Paste the following YAML content into the text area:
 +
-.Example credential secret for LLM provider
+[NOTE]
+====
+The YAML parameter is always `apitoken` regardless of what the LLM provider calls the access details.
+====
 +
+.Credential secret for LLM provider
 [source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: v1
@@ -34,14 +39,36 @@ stringData:
 ----
 <1> The `apitoken` is not `base64` encoded.
 +
-[NOTE]
-====
-The YAML element is always `apitoken` regardless of what the LLM provider calls the access details.
-====
-+
-.Example credential secret for {azure-openai}
-+
+.Credential secret for {watsonx}
 [source,yaml, subs="attributes,verbatim"]
+----
+apiVersion: v1
+data:
+  apitoken: NlFy 
+kind: Secret
+metadata:
+  name: watsonx-api-keys
+  namespace: openshift-lightspeed
+type: Opaque
+----
++
+.Credential secret for {azure-official} {openai}
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: v1
+data:
+  apitoken: azure_token 
+kind: Secret
+metadata:
+  name: azure-api-keys
+  namespace: openshift-lightspeed
+type: Opaque
+----
++
+Alternatively, for {azure-openai} you can use {entra-id} to authenticate your LLM provider. {entra-id} users must configure the required roles for their {azure-openai} resource. For more information, see the official Microsoft link:https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/role-based-access-control#cognitive-services-openai-contributor[Cognitive Services OpenAI Contributor](Microsoft Azure OpenAI Service documentation).
++
+.Credential secret for {entra-id}
+[source,yaml,subs="attributes,verbatim"]
 ----
 apiVersion: v1
 data:


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OLS-908
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://82091--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-creating-the-credentials-secret-using-web-console_ols-configuring-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
