### PR TITLE
OCPBUGS-37701 adding required permissions to main Azure doc

### DIFF
--- a/modules/minimum-required-permissions-ipi-azure.adoc
+++ b/modules/minimum-required-permissions-ipi-azure.adoc
@@ -70,6 +70,13 @@ The following permissions are required for creating an {product-title} cluster o
 * `Microsoft.Network/loadBalancers/backendAddressPools/write`
 * `Microsoft.Network/loadBalancers/read`
 * `Microsoft.Network/loadBalancers/write`
+* `Microsoft.Network/loadBalancers/inboundNatRules/read`
+* `Microsoft.Network/loadBalancers/inboundNatRules/write`
+* `Microsoft.Network/loadBalancers/inboundNatRules/join/action`
+* `Microsoft.Network/loadBalancers/inboundNatRules/delete`
+* `Microsoft.Network/routeTables/read`
+* `Microsoft.Network/routeTables/write`
+* `Microsoft.Network/routeTables/join/action`
 * `Microsoft.Network/networkInterfaces/delete`
 * `Microsoft.Network/networkInterfaces/join/action`
 * `Microsoft.Network/networkInterfaces/read`


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OCPBUGS-37701 / https://issues.redhat.com/browse/OSDOCS-11942

Link to docs preview:
https://82095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#minimum-required-permissions-ipi-azure_installing-azure-account

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
