### PR TITLE
Added missing host aliases option

### DIFF
--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -76,6 +76,10 @@ a|These fields configure how Central should store its persistent data. Use a per
 
 |*Tolerations*
 |Use this parameter to configure Central to run only on specific nodes. See the `central.tolerations` parameter in the "Public configuration file" section in "Installing Central services for {product-title-short} on {osp}".
+
+|*Host Aliases*
+|Use this parameter to configure additional hostnames to resolve in the pod's hosts file.
+
 |===
 * *Scanner Component Settings*: Settings for the default scanner, also called the StackRox Scanner. See the "Scanner" table in the "Public configuration file" section in "Installing Central services for {product-title-short} on {osp}".
 * *Scanner V4 Component Settings*: Settings for the optional Scanner V4 scanner, available in version 4.4 and later. It is not currently enabled by default. You can enable both the StackRox Scanner and Scanner V4 for concurrent use. See the "Scanner V4" table in the "Public configuration file" section in "Installing Central services for {product-title-short} on {osp}".


### PR DESCRIPTION
From Slack convo:
> Hello (gain). Are we not missing HostAliases in our 4.5 documentation referring to the table listed in point 8 of Central installation: https://docs.openshift.com/acs/4.5/installing/installing_ocp/install-central-ocp.html#install-central-ocp:~:text=Central%20component%20settings%3A

Cherrypick:
- `rhacs-docs-4.5`
- `rhacs-docs-4.6`


