### PR TITLE
OSDOCS#11397: Remove outdated toc item

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -820,11 +820,21 @@ Topics:
   File: dns-operator
 - Name: Understanding the Ingress Operator
   File: ingress-operator
-- Name: OpenShift SDN default CNI network provider
-  Dir: openshift_sdn
+- Name: OpenShift OVN default CNI network provider
+  Dir: ovn_kubernetes_network_provider
   Topics:
+  - Name: About the OpenShift OVN network plugin
+    File: about-ovn-kubernetes
+# TODO OSDOCS-11397: The next file was not present in OSD initially, need to verify if it applies
+  # - Name: Configuring an egress IP address
+  #   File: configuring-egress-ips-ovn
   - Name: Enabling multicast for a project
     File: enabling-multicast
+# - Name: OpenShift SDN default CNI network provider
+#   Dir: openshift_sdn
+#   Topics:
+#   - Name: Enabling multicast for a project
+#     File: enabling-multicast
 - Name: Network verification
   File: network-verification
 - Name: Configuring a cluster-wide proxy during installation
@@ -851,11 +861,6 @@ Topics:
       File: deleting-network-policy
     - Name: Configuring multitenant isolation with network policy
       File: multitenant-network-policy
-- Name: OVN-Kubernetes network plugin
-  Dir: ovn_kubernetes_network_provider
-  Topics:
-  - Name: About the OpenShift SDN network plugin
-    File: about-ovn-kubernetes
 - Name: Configuring Routes
   Dir: routes
   Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1084,9 +1084,13 @@ Topics:
   File: ingress-operator
 - Name: AWS Load Balancer Operator
   File: aws-load-balancer-operator
-- Name: OpenShift SDN default CNI network provider
-  Dir: openshift_sdn
+- Name: OpenShift OVN default CNI network provider
+  Dir: ovn_kubernetes_network_provider
   Topics:
+  - Name: About the OpenShift OVN network plugin
+    File: about-ovn-kubernetes
+  - Name: Configuring an egress IP address
+    File: configuring-egress-ips-ovn
   - Name: Enabling multicast for a project
     File: enabling-multicast
 - Name: Network verification
@@ -1129,13 +1133,6 @@ Topics:
       File: multitenant-network-policy
   - Name: Understanding the Ingress Node Firewall Operator
     File: ingress-node-firewall-operator
-- Name: OVN-Kubernetes network plugin
-  Dir: ovn_kubernetes_network_provider
-  Topics:
-  - Name: About the OpenShift SDN network plugin
-    File: about-ovn-kubernetes
-  - Name: Configuring an egress IP address
-    File: configuring-egress-ips-ovn
 - Name: Configuring Routes
   Dir: routes
   Topics:

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1043,9 +1043,13 @@ Topics:
 #   File: ingress-operator
 # - Name: AWS Load Balancer Operator
 #   File: aws-load-balancer-operator
-# - Name: OpenShift SDN default CNI network provider
-#   Dir: openshift_sdn
+# - Name: OpenShift OVN default CNI network provider
+#   Dir: ovn_kubernetes_network_provider
 #   Topics:
+#   - Name: About the OpenShift OVN network plugin
+#     File: about-ovn-kubernetes
+#   - Name: Configuring an egress IP address
+#     File: configuring-egress-ips-ovn
 #   - Name: Enabling multicast for a project
 #     File: enabling-multicast
 # - Name: Network verification
@@ -1067,11 +1071,6 @@ Topics:
 #     File: deleting-network-policy
 #   - Name: Configuring multitenant isolation with network policy
 #     File: multitenant-network-policy
-# - Name: OVN-Kubernetes network plugin
-#   Dir: ovn_kubernetes_network_provider
-#   Topics:
-#   - Name: Configuring an egress IP address
-#     File: configuring-egress-ips-ovn
 # - Name: Configuring Routes
 #   Dir: routes
 #   Topics:


### PR DESCRIPTION
Version(s):
4.16 only; main already contains a similar change

Issue:
https://issues.redhat.com/browse/OSDOCS-11397

Link to docs preview:
- ROSA: https://82107--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes
- OSD: https://82107--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes

QE review:
- [x] QE has approved this change.