### PR TITLE
RN GitOPs 1.14redirects

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -339,7 +339,7 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent for each assembly
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes.html  [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes-1-14.html  [L,R=302]
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/understanding-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html [L,R=302]
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/installing-openshift-gitops.html /gitops/latest/installing_gitops/installing-openshift-gitops.html [L,R=302]
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/uninstalling-openshift-gitops.html /gitops/latest/removing_gitops/uninstalling-openshift-gitops.html [L,R=302]


### PR DESCRIPTION
**This PR is for the GitOps 1.14 release that is scheduled for September 18, 2024. Do not merge until this date.**


**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5840](https://issues.redhat.com/browse/RHDEVDOCS-5840)

**Link to docs preview:** Not applicable


**SME and QE review:** Not applicable

**Additional information:** This PR updates the redirects in the `01-commercial.conf` file in the `main` for the 1.14 GitOps standalone doc. It does not alter documentation content.