### PR TITLE
OBSDOCS-800: Add json formatting option to sample CLI commands in acc…

### DIFF
--- a/modules/accessing-metrics-outside-cluster.adoc
+++ b/modules/accessing-metrics-outside-cluster.adoc
@@ -54,8 +54,35 @@ $ curl -H "Authorization: Bearer $TOKEN" -k "https://$HOST/api/v1/query?" --data
 +
 The output shows the status for each application pod that Prometheus is scraping:
 +
-.Example output
+.The formatted example output
 [source,terminal]
 ----
-{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","endpoint":"web","instance":"10.129.0.46:8080","job":"prometheus-example-app","namespace":"ns1","pod":"prometheus-example-app-68d47c4fb6-jztp2","service":"prometheus-example-app"},"value":[1591881154.748,"1"]}]}}
+{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {
+        "metric": {
+          "__name__": "up",
+          "endpoint": "web",
+          "instance": "10.129.0.46:8080",
+          "job": "prometheus-example-app",
+          "namespace": "ns1",
+          "pod": "prometheus-example-app-68d47c4fb6-jztp2",
+          "service": "prometheus-example-app"
+        },
+        "value": [
+          1591881154.748,
+          "1"
+        ]
+      }
+    ],
+  }
+}
 ----
++
+[NOTE]
+====
+The formatted example output uses a filtering tool, such as `jq`, to provide the formatted indented JSON. See the link:https://stedolan.github.io/jq/manual/[jq Manual] for more information about using `jq`.
+====


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-800](https://issues.redhat.com/browse/OBSDOCS-800)

Link to docs preview: https://82119--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-third-party-monitoring-apis.html#accessing-metrics-from-outside-cluster_accessing-monitoring-apis-by-using-the-cli

QE review:
- [x] QE has approved this change.

**Additional information:**
The inclusion of jq here should be acceptable ->  we are not telling users to use jq;  but providing a better example explaining how we got it. It is beneficial to users to know about this option and to enhance readability of our doc example.