### PR TITLE
OCPBUGS#41711: Updated PromQL query for VF metrics

### DIFF
--- a/modules/sriov-network-metrics-exporter.adoc
+++ b/modules/sriov-network-metrics-exporter.adoc
@@ -17,14 +17,14 @@ The SR-IOV VF metrics that the metrics exporter reads and exposes in Prometheus 
 |====
 |Metric| Description |Example PromQL query to examine the VF metric
 
-|`sriov_vf_rx_bytes` |Received bytes per virtual function. |`sriov_vf_rx_bytes * on (pciAddr) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
-|`sriov_vf_tx_bytes` |Transmitted bytes per virtual function. |`sriov_vf_tx_bytes * on (pciAddr) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
-|`sriov_vf_rx_packets` |Received packets per virtual function. |`sriov_vf_rx_packets * on (pciAddr) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
-|`sriov_vf_tx_packets` |Transmitted packets per virtual function. |`sriov_vf_tx_packets * on (pciAddr) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
-|`sriov_vf_rx_dropped` |Dropped packets upon receipt per virtual function. |`sriov_vf_rx_dropped * on (pciAddr) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
-|`sriov_vf_tx_dropped` |Dropped packets during transmission per virtual function. |`sriov_vf_tx_dropped * on (pciAddr) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
-|`sriov_vf_rx_multicast` |Received multicast packets per virtual function. |`sriov_vf_rx_multicast * on (pciAddr) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
-|`sriov_vf_rx_broadcast` |Received broadcast packets per virtual function. |`sriov_vf_rx_broadcast * on (pciAddr) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_rx_bytes` |Received bytes per virtual function. |`sriov_vf_rx_bytes * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_tx_bytes` |Transmitted bytes per virtual function. |`sriov_vf_tx_bytes * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_rx_packets` |Received packets per virtual function. |`sriov_vf_rx_packets * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_tx_packets` |Transmitted packets per virtual function. |`sriov_vf_tx_packets * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_rx_dropped` |Dropped packets upon receipt per virtual function. |`sriov_vf_rx_dropped * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_tx_dropped` |Dropped packets during transmission per virtual function. |`sriov_vf_tx_dropped * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_rx_multicast` |Received multicast packets per virtual function. |`sriov_vf_rx_multicast * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_rx_broadcast` |Received broadcast packets per virtual function. |`sriov_vf_rx_broadcast * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
 |`sriov_kubepoddevice` |Virtual functions linked to active pods. |-
 
 |====
@@ -33,5 +33,5 @@ You can also combine these queries with the kube-state-metrics to get more infor
 
 [source,terminal]
 ----
-(sriov_vf_tx_packets * on (pciAddr)  group_left(pod,namespace)  sriov_kubepoddevice) * on (pod,namespace) group_left (label_app_kubernetes_io_name) kube_pod_labels
+(sriov_vf_tx_packets * on (pciAddr,node)  group_left(pod,namespace)  sriov_kubepoddevice) * on (pod,namespace) group_left (label_app_kubernetes_io_name) kube_pod_labels
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-41711](https://issues.redhat.com/browse/OCPBUGS-41711)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [About the SR-IOV network metrics exporter](https://82122--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html#sriov-network-metrics-exporter_configuring-sriov-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->