### PR TITLE
OSDOCS-12024: Documented the 4.16.13 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3351,6 +3351,28 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.13
+[id="ocp-4-16-13_{context}"]
+=== RHSA-2024:6687 - {product-title} {product-version}.13 bug fix update
+
+Issued: 19 September 2024
+
+{product-title} release {product-version}.13 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6687[RHSA-2024:6687] advisory. There are no RPM packages for this update.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.13 --pullspecs
+----
+
+[id="ocp-4-16-13-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.16.12
 [id="ocp-4-16-12_{context}"]
 === RHSA-2024:6632 - {product-title} {product-version}.12 bug fix and security update


### PR DESCRIPTION
Peer review approval on https://github.com/openshift/openshift-docs/pull/81934. A very odd merge conflict on the GUI but not on the terminal


Version(s):
4.16

Issue:
[OSDOCS-12024](https://issues.redhat.com/browse/OSDOCS-12024)

Link to docs preview:
[4.16.13](https://82159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-13_release-notes)

