### PR TITLE
4.17 Release Note  TELCODOCS-1867/TELCODOCS-1869 - CNF-11995 MetalLB: configurable BGP connect time

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -514,6 +514,19 @@ For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-no
 
 {product-title} {product-version} now includes CoreDNS version 1.11.3.
 
+[id="ocp-4-17-nw-metallb"]
+==== Changes to MetalLB
+
+With this update, MetalLB uses `FRR-K8s` as the default backend. 
+Previously, this was an optional feature available in Technology Preview.
+For more information, see xref:../networking/metallb/metallb-frr-k8s.adoc#metallb-configure-frr-k8s[Configuring the integration of MetalLB and FRR-K8s].
+
+MetalLB also includes a new field for the Border Gateway Protocol (BGP) peer custom resource, `connectTime`. 
+You can use this field to specify how long BGP waits between connection attempts to a neighbor.
+For more information, see xref:../networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-bgppeer-cr_configure-metallb-bgp-peers[About the BGP peer custom resource].
+
+
+
 [id="ocp-4-17-registry"]
 === Registry
 
@@ -1210,7 +1223,7 @@ In the following tables, features are marked with the following statuses:
 |Integration of MetalLB and FRR-K8s
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Dual-NIC Intel E810 PTP boundary clock with highly available system clock
 |Not Available


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> Release Note for MetalLB changes for 4.17

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issues:

- https://issues.redhat.com//browse/TELCODOCS-1867
- https://issues.redhat.com//browse/TELCODOCS-1869
 <!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Changes to MetalLB](https://82162--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-nw-metallb)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is the removal of a section Activating integration of MetalLB and FRR-K8s that is no longer needed as, from 4.17, this is the default backend.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
