### PR TITLE
[OSDOCS-11702]: Release note for HCP tolerations

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1046,10 +1046,12 @@ In this release, the firmware search path has been updated to copy the contents 
 
 In this release, if your cluster is installed on a bare metal platform, you can scale a cluster control plane up to 5 nodes as a postinstallation task. The etcd Operator scales accordingly to account for the additional control plane nodes. For more information, see xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc#etcd-node-scaling_recommended-etcd-practices[Node scaling for etcd].
 
-////
 [id="ocp-4-17-hcp_{context}"]
 === Hosted control planes
-////
+
+[id="ocp-4-17-hcp-tolerations_{context}"]
+==== Custom taints and tolerations (Technology Preview)
+For {hcp} on {VirtProductName}, you can now apply tolerations to hosted control plane pods by using the `hcp` CLI `-tolerations` argument or by using the `hc.Spec.Tolerations` API file. This feature is available as a Technology Preview feature. For more information, see xref:../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-virt-taints-tolerations_hcp-distribute-workloads[Custom taints and tolerations].
 
 [id="ocp-4-17-etcd-certificates_{context}"]
 === Security


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11702
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://82171--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-hcp-tolerations_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This has passed peer review and QE review. It will be merged after the MCE Operator release on October 29.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
