### PR TITLE
OSDOCS#11758: Add release note for CoreDNS 1.11.3

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -509,6 +509,11 @@ With this update, the ability to update host network settings for Single Root I/
 
 For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-vf-host-services_k8s_nmstate-updating-node-network-config[Node network configuration policy for virtual functions].
 
+[id="ocp-4-17-nw-coredns-1-11-3"]
+==== CoreDNS update to version 1.11.3
+
+{product-title} {product-version} now includes CoreDNS version 1.11.3.
+
 [id="ocp-4-17-registry"]
 === Registry
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11758](https://issues.redhat.com/browse/OSDOCS-11758)

Link to docs preview:
[OpenShift Container Platform release notes](https://82184--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-nw-coredns-1-11-3)

QE review:
- N/A

Additional information:
N/A