### PR TITLE
OCPBUGS-42217: Correcting Instructions to Disable Build Strategy

### DIFF
--- a/modules/builds-disabling-build-strategy-globally.adoc
+++ b/modules/builds-disabling-build-strategy-globally.adoc
@@ -15,32 +15,8 @@ To prevent access to a particular build strategy globally, log in as a user with
 +
 [source,terminal]
 ----
-$ oc edit clusterrolebinding system:build-strategy-docker-binding
+$ oc annotate clusterrolebinding.rbac system:build-strategy-docker-binding 'rbac.authorization.kubernetes.io/autoupdate=false' --overwrite
 ----
-+
-.Example output
-[source,yaml]
-----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations:
-    rbac.authorization.kubernetes.io/autoupdate: "false" <1>
-  creationTimestamp: 2018-08-10T01:24:14Z
-  name: system:build-strategy-docker-binding
-  resourceVersion: "225"
-  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/system%3Abuild-strategy-docker-binding
-  uid: 17b1f3d4-9c3c-11e8-be62-0800277d20bf
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:build-strategy-docker
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:authenticated
-----
-<1> Change the `rbac.authorization.kubernetes.io/autoupdate` annotation's value to `"false"`.
 
 . Remove the role by entering the following command:
 +
@@ -49,45 +25,14 @@ subjects:
 $ oc adm policy remove-cluster-role-from-group system:build-strategy-docker system:authenticated
 ----
 
-. Ensure the build strategy subresources are also removed from these roles:
+. Ensure the build strategy subresources are also removed from the `admin` and `edit` user roles:
 +
 [source,terminal]
 ----
-$ oc edit clusterrole admin
+$ oc get clusterrole admin -o yaml | grep "builds/docker"
 ----
 +
 [source,terminal]
 ----
-$ oc edit clusterrole edit
+$ oc get clusterrole edit -o yaml | grep "builds/docker"
 ----
-
-. For each role, specify the subresources that correspond to the resource of the strategy to disable.
-
-.. Disable the docker Build Strategy for *admin*:
-+
-[source,yaml]
-----
-kind: ClusterRole
-metadata:
-  name: admin
-...
-- apiGroups:
-  - ""
-  - build.openshift.io
-  resources:
-  - buildconfigs
-  - buildconfigs/webhooks
-  - builds/custom <1>
-  - builds/source
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-...
-----
-<1> Add `builds/custom` and `builds/source` to disable docker builds globally for users with the *admin* role.


### PR DESCRIPTION
The documentation for disabling builds by strategy was at one point updated to include inaccurate instructions [1]. When followed end to end, these instructions granted the `admin` and `edit` user roles permission to run builds with the `Source` and `Custom` build strategies. The latter build strategy is particularly dangerous, as it grants users permission to execute arbitrary commands in a privileged container.

This change restores these instructions to the original intent of verifying that the `admin` and `edit` user roles do not have permission to create Docker strategy builds. It also simplifies the instruction to add the `autoupdate=false` RBAC annotation.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1923869

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.13, 4.14, 4.15. 4.16, 4.17, 4.18

Issue: [OCPBUGS-42217](https://issues.redhat.com/browse/OCPBUGS-42217)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Needs urgent review - this is a mitigation for CVE-2024-7387

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
