### PR TITLE
Don't lint _attributes folder with Vale

### DIFF
--- a/_attributes/.vale.ini
+++ b/_attributes/.vale.ini
@@ -1,0 +1,1 @@
+# Skip Vale linting in this directory


### PR DESCRIPTION
Adding an empty `.vale.ini` to skip Vale linting in the _attributes folder.