### PR TITLE
OSDOCS-12065: Enhance explanation of machine set changes

### DIFF
--- a/modules/machineset-modifying.adoc
+++ b/modules/machineset-modifying.adoc
@@ -8,9 +8,19 @@
 [id="machineset-modifying_{context}"]
 = Modifying a compute machine set by using the CLI
 
+You can modify the configuration of a compute machine set, and then propagate the changes to the machines in your cluster by using the CLI.
+
+By updating the compute machine set configuration, you can enable features or change the properties of the machines it creates.
 When you modify a compute machine set, your changes only apply to compute machines that are created after you save the updated `MachineSet` custom resource (CR).
 The changes do not affect existing machines.
-You can replace the existing machines with new ones that reflect the updated configuration by scaling the compute machine set.
+
+[NOTE]
+====
+Changes made in the underlying cloud provider are not reflected in the `Machine` or `MachineSet` CRs.
+To adjust instance configuration in cluster-managed infrastructure, use the cluster-side resources.
+====
+
+You can replace the existing machines with new ones that reflect the updated configuration by scaling the compute machine set to create twice the number of replicas and then scaling it down to the original number of replicas.
 
 If you need to scale a compute machine set without making other changes, you do not need to delete the machines.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-12065](https://issues.redhat.com//browse/OSDOCS-12065)

Link to docs preview:
* [Modifying a compute machine set by using the CLI](https://82198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/modifying-machineset.html#machineset-modifying_modifying-machineset) (MAPI)
* [Modifying a compute machine set by using the CLI](https://82198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-managing-machines.html#machineset-modifying_cluster-api-managing-machines) (CAPI)

QE review:
- [x] QE has approved this change.

Additional information: