### PR TITLE
OSDOCS-11825: Add worker node disk size option to ROSA HCP

### DIFF
--- a/modules/configuring-machine-pool-disk-volume.adoc
+++ b/modules/configuring-machine-pool-disk-volume.adoc
@@ -3,20 +3,18 @@
 // * rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="configuring_machine_pool_disk_volume{context}"]
+[id="configuring-machine-pool-disk-volume_{context}"]
 = Configuring machine pool disk volume
 
-Machine pool disk volume size can be configured for additional flexibility. The default disk size is 300 GiB. For cluster version 4.13 or earlier, the disk size can be configured to a minimum of 128 GiB to a maximum of 1 TiB. For cluster version 4.14 and later, the disk size can be configured to a minimum of 128 GiB to a maximum of 16 TiB.
+Machine pool disk volume size can be configured for additional flexibility. The default disk size is 300 GiB.
+
+For {rosa-classic-first} clusters version 4.13 or earlier, the disk size can be configured from a minimum of 128 GiB to a maximum of 1 TiB. For version 4.14 and later, the disk size can be configured to a minimum of 128 GiB to a maximum of 16 TiB.
+
+For {hcp-title-first} clusters, the disk size can be configured from a minimum of 75 GiB to a maximum of 16,384 GiB.
 
 You can configure the machine pool disk size for your cluster by using {cluster-manager} or the ROSA CLI (`rosa`).
 
 [NOTE]
 ====
 Existing cluster and machine pool node volumes cannot be resized.
-====
-
-
-[IMPORTANT]
-====
-The default disk size is 300 GiB. For cluster version 4.13 or earlier, the disk size can be configured to a minimum of 128 GiB to a maximum of 1 TiB. For cluster version 4.14 and later, the disk size can be configured to a minimum of 128 GiB to a maximum of 16 TiB.
 ====

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -741,6 +741,13 @@ $ rosa create machinepool --cluster=<cluster_name> | <cluster_id> --replicas=<nu
 a|--cluster <cluster_name>\|<cluster_id>
 |Required: The name or ID of the cluster to which the machine pool will be added.
 
+|--disk-size
+|Set the disk volume size for the machine pool, in Gib or TiB. The default is 300 GiB.
+
+For {rosa-classic} clusters version 4.13 or earlier, the minimum disk size is 128 GiB, and the maximum is 1 TiB. For cluster version 4.14 and later, the minimum is 128 GiB, and the maximum is 16 TiB.
+
+For {hcp-title} clusters, the minimum disk size is 75 GiB, and the maximum is 16,384 GiB.
+
 |--enable-autoscaling
 |Enable or disable autoscaling of compute nodes. To enable autoscaling, use this argument with the `--min-replicas` and `--max-replicas` arguments. To disable autoscaling, use `--enable-autoscaling=false` with the `--replicas` argument.
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -13,6 +13,11 @@ toc::[]
 [id="rosa-new-changes-and-updates_{context}"]
 == New changes and updates
 
+[id="rosa-q4-2024_{context}"]
+=== Q4 2024
+
+* **Configure machine pool disk volume for {hcp-title} clusters.** You can now configure the disk volume size for machine pools in {hcp-title} clusters. The default disk size is 300 GiB, and you can configure it from a minimum of 75 GiB to a maximum of 16,384 GiB. For more information, see xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#configuring-machine-pool-disk-volume_rosa-managing-worker-nodes[Configuring machine pool disk volume].
+
 [id="rosa-q3-2024_{context}"]
 === Q3 2024
 


### PR DESCRIPTION
Version(s):
* `enterprise-4.17`+

Issue:
https://issues.redhat.com/browse/OSDOCS-11825

Link to docs preview:
* Added [`--disk-size` option](https://82207--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-create-machinepool_rosa-managing-objects-cli) to the `rosa create machinepool` command help
* [Configuring machine pool disk volume](https://82207--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#configuring-machine-pool-disk-volume_rosa-managing-worker-nodes)
* [What's new announcement](https://82207--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html#rosa-q4-2024_rosa-whats-new)

QE review:
- [x] QE has approved this change.