### PR TITLE
OSDOCS-12080: Documented the 4.17 RN for the nmstate Operator metrics

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -470,6 +470,13 @@ Red{nbsp}Hat support exists for using the Kubernetes NMState Operator on {azure-
 
 For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator_k8s-nmstate-operator[About the Kubernetes NMState Operator].
 
+[id="ocp-4-17-networking-nmstate-operator-metrics_{context}"]
+==== View metrics collected by the Kubernetes NMState Operator
+
+The Kubernetes NMState Operator, `kubernetes-nmstate-operator`, can collect metrics from the `kubernetes_nmstate_features_applied` component and expose them as ready-to-use metrics. You can view these metrics by using the *Administrator* and *Developer* perspectives.
+
+For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#viewing-stats-collected-kubernetes-nmtate-op_k8s-nmstate-operator[Viewing metrics collected by the Kubernetes NMState Operator].
+
 [id="ocp-ptp-fast-events-rest-api-v2-available_{context}"]
 ==== New PTP fast events REST API version 2 available
 


### PR DESCRIPTION
Engineer approvals on https://github.com/openshift/openshift-docs/pull/75781


Version(s):
4.17

Issue:
[OSDOCS-12080](https://issues.redhat.com/browse/OSDOCS-12080)

Link to docs preview:
[View metrics collected by the Kubernetes NMState Operator](https://82212--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-networking-nmstate-operator-metrics_release-notes)
