### PR TITLE
WIP: [MULTIARCH-4995] ABI documentation updates for 4.17

### DIFF
--- a/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
+++ b/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
@@ -38,6 +38,9 @@ include::modules/pxe-assets-ocp-agent.adoc[leveloffset=+1]
 // Manually adding IBM Z agents
 include::modules/installing-ocp-agent-ibm-z.adoc[leveloffset=+1]
 
+// Configuring network overrides in {ibm-z-title}
+include::modules/configuring-network-overrides-ibmz.adoc[leveloffset=+2]
+
 // Adding {ibm-z-title} agents with z/VM
 include::modules/installing-ocp-agent-ibm-z-zvm.adoc[leveloffset=+2]
 

--- a/modules/adding-ibmz-lpar-agent.adoc
+++ b/modules/adding-ibmz-lpar-agent.adoc
@@ -10,6 +10,7 @@ Use the following procedure to manually add {ibm-z-name} agents to your cluster 
 
 .Prerequisites
 * You have Python 3 installed.
+* A running file server with access to the Logical Partition (LPAR).
 
 .Procedure
 
@@ -27,13 +28,12 @@ ip=<ip>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> \// <2>
 rd.znet=qeth,<network_adaptor_range>,layer2=1
 rd.<disk_type>=<adapter> \// <3>
 zfcp.allow_lun_scan=0
-ai.ip_cfg_override=1 \// <4>
+ai.ip_cfg_override=1 \//
 random.trust_cpu=on rd.luks.options=discard
 ----
 <1> For the `coreos.live.rootfs_url` artifact, specify the matching `rootfs` artifact for the `kernel` and `initramfs` that you are starting. Only HTTP and HTTPS protocols are supported.
 <2> For the `ip` parameter, manually assign the IP address, as described in _Installing a cluster with z/VM on IBM Z and IBM LinuxONE_.
 <3> For installations on DASD-type disks, use `rd.dasd` to specify the DASD where {op-system-first} is to be installed. For installations on FCP-type disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed.
-<4> Specify this parameter when you use an Open Systems Adapter (OSA) or HiperSockets.
 +
 [NOTE]
 ====

--- a/modules/configuring-network-overrides-ibmz.adoc
+++ b/modules/configuring-network-overrides-ibmz.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-network-overrides-ibm_{context}"]
+= Configuring network overrides in {ibm-z-title}
+
+You can specify a static IP address on {ibm-z-title} machines that uses Logical Partition (LPAR) and z/VM. This is useful when the network devices do not have a static MAC address assigned to them. 
+
+.Procedure
+
+* If you have an existing `.parm` file, edit it to include the following entry:
++
+[source,terminal]
+----
+ai.ip_cfg_override=1
+----
++
+This parameter allows the file to add the network settings to the CoreOS installer.
++
+
+.Example `.parm` file
+[source,terminal]
+----
+rd.neednet=1 cio_ignore=all,!condev
+console=ttysclp0
+coreos.live.rootfs_url=<coreos_url> <1>
+ip=<ip>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> 
+rd.znet=qeth,<network_adaptor_range>,layer2=1
+rd.<disk_type>=<adapter> <2> 
+rd.zfcp=<adapter>,<wwpn>,<lun> random.trust_cpu=on <3>
+zfcp.allow_lun_scan=0 
+ai.ip_cfg_override=1
+ignition.firstboot ignition.platform.id=metal 
+random.trust_cpu=on
+----
+<1> For the `coreos.live.rootfs_url` artifact, specify the matching `rootfs` artifact for the `kernel` and `initramfs` that you are booting. Only HTTP and HTTPS protocols are supported.
+<2> For installations on direct access storage devices (DASD) type disks, use `rd.` to specify the DASD where {rhel-first} is to be installed. For installations on Fibre Channel Protocol (FCP) disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {rhel} is to be installed.
+<3> Specify values for `adapter`, `wwpn`, and `lun` as in the following example: `rd.zfcp=0.0.8002,0x500507630400d1e3,0x4000404600000000`.
+
+[NOTE]
+====
+The `override` parameter overrides the host's network configuration settings.
+====

--- a/modules/installing-ocp-agent-ibm-z-kvm.adoc
+++ b/modules/installing-ocp-agent-ibm-z-kvm.adoc
@@ -13,7 +13,10 @@ endif::[]
 
 Use the following procedure to manually add {ibm-z-name} agents with {op-system-base} KVM.
 Only use this procedure for {ibm-z-name} clusters with {op-system-base} KVM.
-
+[NOTE]
+====
+The `nmstateconfig` parameter must be configured for the KVM boot.
+====
 .Procedure
 
 . Boot your {op-system-base} KVM machine.

--- a/modules/installing-ocp-agent-ibm-z-zvm.adoc
+++ b/modules/installing-ocp-agent-ibm-z-zvm.adoc
@@ -9,6 +9,10 @@
 Use the following procedure to manually add {ibm-z-name} agents with z/VM.
 Only use this procedure for {ibm-z-name} clusters with z/VM.
 
+.Prerequisites
+
+* A running file server with access to the guest Virtual Machines.
+
 .Procedure
 
 . Create a parameter file for the z/VM guest:
@@ -22,6 +26,7 @@ console=ttysclp0 \
 coreos.live.rootfs_url=<rootfs_url> \ <1>
 ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1 \ <2>
 zfcp.allow_lun_scan=0 \ <3>
+ai.ip_cfg_override=1 \
 rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1 \
 rd.dasd=0.0.4411 \ <4>
 rd.zfcp=0.0.8001,0x50050763040051e3,0x4000406300000000 \ <5>

--- a/modules/installing-ocp-agent-ibm-z.adoc
+++ b/modules/installing-ocp-agent-ibm-z.adoc
@@ -19,3 +19,48 @@ Depending on your {ibm-z-name} environment, you can choose from the following op
 ====
 Currently, ISO boot support on {ibm-z-name} (`s390x``) is available only for {op-system-base-full} KVM, which provides the flexibility to choose either PXE or ISO-based installation. For installations with z/VM and Logical Partition (LPAR), only PXE boot is supported.
 ====
+
+[id="networking-reqs-ibmz_{context}"]
+== Networking requirements for {ibm-z-title}
+
+In {ibm-z-title} environments, advanced networking technologies such as Open Systems Adapter (OSA), HiperSockets, and Remote Direct Memory Access (RDMA) over Converged Ethernet (RoCE) require specific configurations that deviate from the standard network settings and those needs to be persisted for multiple boot scenarios that occur in the Agent-based Installation. 
+
+To persist these parameters during boot, the `ai.ip_cfg_override=1` parameter is required in the `paramline`. This parameter is used with the configured network cards to ensure a successful and efficient deployment on {ibm-z-title}.
+
+The following table lists the network devices that are supported on each hypervisor for the network configuration override functionality :
+
+[cols="3,2,2,2,2", options="header"]
+|====
+| Network device 
+| z/VM  
+| KVM 
+| LPAR Classic 
+| LPAR Dynamic Partition Manager (DPM)
+
+| Virtual Switch 
+| Supported ^[1]^
+| Not applicable ^[2]^ 
+| Not applicable 
+| Not applicable 
+
+| Direct attached Open Systems Adapter (OSA) 
+| Supported 
+|  Not required ^[3]^
+| Supported 
+| Not required 
+
+| RDMA over Converged Ethernet (RoCE) 
+| Not required 
+| Not required 
+| Not required 
+| Not required 
+
+| HiperSockets 
+| Supported 
+| Not required 
+| Supported 
+| Not required 
+|====
+. Supported: When the `ai.ip_cfg_override` parameter is required for the installation procedure.
+. Not Applicable: When a network card is not applicable to be used on the hypervisor.
+. Not required: When the `ai.ip_cfg_override` parameter is not required for the installation procedure.


### PR DESCRIPTION
Version(s): 4.17+

Issues: https://issues.redhat.com/browse/MULTIARCH-4995
https://issues.redhat.com/browse/OCPBUGS-41987





Link to docs preview:
https://82213--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.html#installing-ocp-agent-ibm-z_prepare-pxe-assets-agent 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Box note: https://ibm.ent.box.com/notes/1648415062889
