### PR TITLE
Re-arranging steps for `oc adm wait-for-stable-cluster` command

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -530,15 +530,6 @@ The `etcd` redeployment starts.
 +
 When the `etcd` cluster Operator performs a redeployment, the existing nodes are started with new pods similar to the initial bootstrap scale up.
 
-. Monitor the `etcd` instances by running:
-+
-[source,terminal]
-----
-$ oc adm wait-for-stable-cluster
-----
-+
-This process can take up to 15 minutes.
-
 . Turn the quorum guard back on by entering:
 +
 [source,terminal]
@@ -651,6 +642,15 @@ AllNodesAtLatestRevision
 <1> In this example, the latest revision number is `7`.
 +
 If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
+
+. Monitor the platform Operators by running:
++
+[source,terminal]
+----
+$ oc adm wait-for-stable-cluster
+----
++
+This process can take up to 15 minutes.
 
 . Verify that all control plane hosts have started and joined the cluster.
 +


### PR DESCRIPTION
oc adm wait-for-stable-cluster this needs to be run after all required cluster operator force rollout.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

4.16 and 4.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OCPBUGS-42250

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://82214--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html
https://82214--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
