### PR TITLE
OSDOCS-11880: adds async relnote 4.16.33 MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -261,3 +261,12 @@ Issued: 17 September 2024
 {product-title} release 4.16.12 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6634[RHBA-2024:6634] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6632[RHSA-2024:6632] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-13-dp_{context}"]
+=== RHBA-2024:6688 - {microshift-short} 4.16.13 bug fix and enhancement advisory
+
+Issued: 19 September 2024
+
+{product-title} release 4.16.13 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6688[RHBA-2024:6688] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6687[RHSA-2024:6687] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-11880](https://issues.redhat.com/browse/OSDOCS-11880)

Link to docs preview:
[4-16-33 release note](https://82218--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-13-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
