### PR TITLE
OSDOCS-12008: adds 4.15.34 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -452,3 +452,12 @@ Issued: 19 September 2024
 The {product-title} release 4.15.33 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6686[RHBA-2024:6686] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6685[RHSA-2024:6685] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-34-dp_{context}"]
+=== RHBA-2024:6820 - {microshift-short} 4.15.34 bug fix and enhancement advisory
+
+Issued: 25 September 2024
+
+The {product-title} release 4.15.34 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6820[RHBA-2024:6820] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6818[RHSA-2024:6818] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12008](https://issues.redhat.com/browse/OSDOCS-12008)

Link to docs preview:
[4-15-34](https://82219--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-34-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
