### PR TITLE
OSDOCS-12002: adds 4.16.34 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -270,3 +270,12 @@ Issued: 19 September 2024
 {product-title} release 4.16.13 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6688[RHBA-2024:6688] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6687[RHSA-2024:6687] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-14-dp_{context}"]
+=== RHBA-2024:6826 - {microshift-short} 4.16.14 bug fix and enhancement advisory
+
+Issued: 24 September 2024
+
+{product-title} release 4.16.14 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6826[RHBA-2024:6826] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6824[RHSA-2024:6824] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12002](https://issues.redhat.com/browse/OSDOCS-12002)

Link to docs preview:
[4-16-14](https://82222--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-14-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
