### PR TITLE
OSDOCS#45846 - Updating CentOS references

### DIFF
--- a/modules/virt-autoupdate-custom-bootsource.adoc
+++ b/modules/virt-autoupdate-custom-bootsource.adoc
@@ -34,25 +34,22 @@ metadata:
 spec:
   dataImportCronTemplates:
   - metadata:
-      name: centos7-image-cron
+      name: centos-stream9-image-cron
       annotations:
-        cdi.kubevirt.io/storage.bind.immediate.requested: "true" <1>
-      labels:
-        instancetype.kubevirt.io/default-preference: centos.7
-        instancetype.kubevirt.io/default-instancetype: u1.medium
+        cdi.kubevirt.io/storage.bind.immediate.requested: "true" <1>      
     spec:
       schedule: "0 */12 * * *" <2>
       template:
         spec:
           source:
             registry: <3>
-              url: docker://quay.io/containerdisks/centos:7-2009
+              url: docker://quay.io/containerdisks/centos-stream:9
           storage:
             resources:
               requests:
                 storage: 30Gi
       garbageCollect: Outdated
-      managedDataSource: centos7 <4>
+      managedDataSource: centos-stream9 <4>
 ----
 <1> This annotation is required for storage classes with `volumeBindingMode` set to `WaitForFirstConsumer`.
 <2> Schedule for the job specified in cron format.

--- a/modules/virt-verify-status-bootsource-update.adoc
+++ b/modules/virt-verify-status-bootsource-update.adoc
@@ -34,17 +34,17 @@ status:
   - metadata:
       annotations:
         cdi.kubevirt.io/storage.bind.immediate.requested: "true"
-      name: centos-7-image-cron
+      name: centos-9-image-cron
     spec:
       garbageCollect: Outdated
-      managedDataSource: centos7
+      managedDataSource: centos-stream9
       schedule: 55 8/12 * * *
       template:
         metadata: {}
         spec:
           source:
             registry:
-              url: docker://quay.io/containerdisks/centos:7-2009
+              url: docker://quay.io/containerdisks/centos-stream:9
           storage:
             resources:
               requests:
@@ -59,7 +59,7 @@ status:
       name: user-defined-dic
     spec:
       garbageCollect: Outdated
-      managedDataSource: user-defined-centos-stream8
+      managedDataSource: user-defined-centos-stream9
       schedule: 55 8/12 * * *
       template:
         metadata: {}
@@ -67,7 +67,7 @@ status:
           source:
             registry:
               pullMethod: node
-              url: docker://quay.io/containerdisks/centos-stream:8
+              url: docker://quay.io/containerdisks/centos-stream:9
           storage:
             resources:
               requests:


### PR DESCRIPTION
Version(s):
4.17 and later

Issue:
https://issues.redhat.com/browse/CNV-45846

Link to docs preview:
https://82225--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-automatic-bootsource-updates.html
https://82225--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/storage/virt-automatic-bootsource-updates.html

QE review:
- [x] QE has approved this change.
