### PR TITLE
Clean output folders before the smoketest build and validate steps

### DIFF
--- a/scripts/prow-smoke-test.sh
+++ b/scripts/prow-smoke-test.sh
@@ -76,16 +76,22 @@ if [ $# -eq 0 ]; then
 fi
 
 if [[ "$TEST" == "--preview" || "$TEST" == "-p" ]] && [[ -z "$DISTRO" ]]; then
+    # Clean output folder
+    rm -rf ./_preview/
     echo ""
     echo "🚧 Building with openshift-enterprise distro..."
     $CONTAINER_ENGINE run --rm -it -v "$(pwd)":${CONTAINER_WORKDIR}${SELINUX_LABEL} $CONTAINER_IMAGE asciibinder build -d "$DISTRO"
 
 elif [[ "$TEST" == "--preview" || "$TEST" == "-p" ]] && [[ -n "$DISTRO" ]]; then
+    # Clean output folder
+    rm -rf ./_preview/
     echo ""
     echo "🚧 Building $DISTRO distro..."
     $CONTAINER_ENGINE run --rm -it -v "$(pwd)":${CONTAINER_WORKDIR}${SELINUX_LABEL} $CONTAINER_IMAGE asciibinder build -d "$DISTRO"
 
 elif [[ "$TEST" == "--validate" || "$TEST" == "-v" ]]; then
+    # Clean output folder
+    rm -rf ./drupal_build/
     echo ""
     echo "🚧 Validating the docs..."
     $CONTAINER_ENGINE run --rm -it -v "$(pwd)":${CONTAINER_WORKDIR}${SELINUX_LABEL} $CONTAINER_IMAGE sh -c 'scripts/check-asciidoctor-build.sh && python3 build_for_portal.py --distro '${DISTRO}' --product "'"${PRODUCT_NAME}"'" --version '${VERSION}' --no-upstream-fetch && python3 makeBuild.py'


### PR DESCRIPTION
Better to clean output folders every run since having other older distro folders can cause the validate step to report errors from other distros.

**This change does not affect Prow CI, only local builds with prow-smoke-test**