### PR TITLE
OCPBUGS#33927: Add long-lived token/secret step to OLM policy scoping

### DIFF
--- a/modules/olm-policy-scoping-operator-install.adoc
+++ b/modules/olm-policy-scoping-operator-install.adoc
@@ -19,6 +19,9 @@ Using this example, a cluster administrator can confine a set of Operators to a 
 
 . Create a new namespace:
 +
+.Example command that creates a `Namespace` object
+[%collapsible]
+====
 [source,terminal]
 ----
 $ cat <<EOF | oc create -f -
@@ -28,9 +31,15 @@ metadata:
   name: scoped
 EOF
 ----
+====
 
-. Allocate permissions that you want the Operator(s) to be confined to. This involves creating a new service account, relevant role(s), and role binding(s).
+. Allocate permissions that you want the Operator(s) to be confined to. This involves creating a new service account, relevant role(s), and role binding(s) in the newly created, designated namespace:
+
+.. Create a service account by running the following command:
 +
+.Example command that creates a `ServiceAccount` object
+[%collapsible]
+====
 [source,terminal]
 ----
 $ cat <<EOF | oc create -f -
@@ -41,9 +50,39 @@ metadata:
   namespace: scoped
 EOF
 ----
+====
+
+.. Create a secret by running the following command:
 +
-The following example grants the service account permissions to do anything in the designated namespace for simplicity. In a production environment, you should create a more fine-grained set of permissions:
+.Example command that creates a long-lived API token `Secret` object
+[%collapsible]
+====
+[source,terminal]
+----
+$ cat <<EOF | oc create -f -
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token <1>
+metadata:
+  name: scoped
+  namespace: scoped
+  annotations:
+    kubernetes.io/service-account.name: scoped
+EOF
+----
+<1> The secret must be a long-lived API token, which is used by the service account.
+====
+
+.. Create a role by running the following command.
 +
+[WARNING]
+====
+In this example, the role grants the service account permissions to do anything in the designated namespace for demonostration purposes only. In a production environment, you should create a more fine-grained set of permissions. For more information, see "Fine-grained permissions".
+====
++
+.Example command that creates `Role` and `RoleBinding` objects
+[%collapsible]
+====
 [source,terminal]
 ----
 $ cat <<EOF | oc create -f -
@@ -72,11 +111,13 @@ subjects:
   namespace: scoped
 EOF
 ----
+====
 
-. Create an `OperatorGroup` object in the designated namespace. This Operator group targets the designated namespace to ensure that its tenancy is confined to it.
+. Create an `OperatorGroup` object in the designated namespace by running the following command. This Operator group targets the designated namespace to ensure that its tenancy is confined to it. In addition, Operator groups allow a user to specify a service account.
 +
-In addition, Operator groups allow a user to specify a service account. Specify the service account created in the previous step:
-+
+.Example command that creates an `OperatorGroup` object
+[%collapsible]
+====
 [source,terminal]
 ----
 $ cat <<EOF | oc create -f -
@@ -86,32 +127,37 @@ metadata:
   name: scoped
   namespace: scoped
 spec:
-  serviceAccountName: scoped
+  serviceAccountName: scoped <1>
   targetNamespaces:
   - scoped
 EOF
 ----
-+
-Any Operator installed in the designated namespace is tied to this Operator group and therefore to the service account specified.
+<1> Specify the service account created in the previous step. Any Operator installed in the designated namespace is tied to this Operator group and therefore to the service account specified.
+====
 
 . Create a `Subscription` object in the designated namespace to install an Operator:
 +
+.Example command that creates a `Subscription` object
+[%collapsible]
+====
 [source,terminal]
 ----
 $ cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: etcd
+  name: openshift-cert-manager-operator
   namespace: scoped
 spec:
-  channel: singlenamespace-alpha
-  name: etcd
+  channel: stable-v1
+  name: openshift-cert-manager-operator
   source: <catalog_source_name> <1>
   sourceNamespace: <catalog_source_namespace> <2>
 EOF
 ----
-<1> Specify a catalog source that already exists in the designated namespace or one that is in the global catalog namespace.
-<2> Specify a namespace where the catalog source was created.
+<1> Specify a catalog source that already exists in the designated namespace or one that is in the global catalog namespace, for example `redhat-operators`.
+<2> Specify a namespace where the catalog source was created, for example `openshift-marketplace` for the `redhat-operators` catalog.
+====
 +
 Any Operator tied to this Operator group is confined to the permissions granted to the specified service account. If the Operator requests permissions that are outside the scope of the service account, the installation fails with relevant errors.
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-33927

Preview:

* [Scoping Operator installations](https://82232--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-creating-policy.html#olm-policy-scoping-operator-install_olm-creating-policy): Newly added step 4, and general clean-up of this oldish procedure per latest guidelines.