### PR TITLE
[OSDOCS-12058]Review of cp and infra node size/scaling AND removal of ROSA references from OSD docs

### DIFF
--- a/modules/sd-planning-considerations.adoc
+++ b/modules/sd-planning-considerations.adoc
@@ -115,19 +115,26 @@ Postinstallation scaling requirements for control plane and infrastructure nodes
 
 The resizing alert is triggered for the control plane nodes in a cluster when the following occurs:
 
-* Control plane nodes sustain over 66% utilization on average in a classic ROSA cluster.
+* Control plane nodes sustain over 66% utilization on average in a cluster.
 +
 [NOTE]
 ====
-The maximum number of compute nodes on ROSA is 180.
+The maximum number of compute nodes on
+ifdef::openshift-rosa[]
+ROSA
+endif::[]
+ifdef::openshift-dedicated[]
+{product-title}
+endif::[]
+is 180.
 ====
 
 .Rules for infrastructure node resizing alerts
 
 Resizing alerts are triggered for the infrastructure nodes in a cluster when it has high-sustained CPU or memory utilization. This high-sustained utilization status is:
 
-* Infrastructure nodes sustain over 50% utilization on average in a classic ROSA cluster with a single availability zone using 2 infrastructure nodes.
-* Infrastructure nodes sustain over 66% utilization on average in a classic ROSA cluster with multiple availability zones using 3 infrastructure nodes.
+* Infrastructure nodes sustain over 50% utilization on average in a cluster with a single availability zone using 2 infrastructure nodes.
+* Infrastructure nodes sustain over 66% utilization on average in a cluster with multiple availability zones using 3 infrastructure nodes.
 +
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-12058
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://82239--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/osd-limits-scalability.html
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
