### PR TITLE
OSDOCS#10927: Adding support for secrets store with GCP

### DIFF
--- a/modules/secrets-store-aws.adoc
+++ b/modules/secrets-store-aws.adoc
@@ -15,15 +15,15 @@ endif::[]
 [id="secrets-store-aws_{context}"]
 = Mounting secrets from {secrets-store-provider}
 
-You can use the {secrets-store-operator} to mount secrets from {secrets-store-provider} to a CSI volume in {product-title}. To mount secrets from {secrets-store-provider}, your cluster must be installed on AWS and use AWS Security Token Service (STS).
+You can use the {secrets-store-operator} to mount secrets from {secrets-store-provider} to a Container Storage Interface (CSI) volume in {product-title}. To mount secrets from {secrets-store-provider}, your cluster must be installed on AWS and use AWS Security Token Service (STS).
 
 .Prerequisites
 
 * Your cluster is installed on AWS and uses AWS Security Token Service (STS).
-* You have installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
-* You have configured {secrets-store-provider} to store the required secrets.
-* You have extracted and prepared the `ccoctl` binary.
-* You have installed the `jq` CLI tool.
+* You installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
+* You configured {secrets-store-provider} to store the required secrets.
+* You extracted and prepared the `ccoctl` binary.
+* You installed the `jq` CLI tool.
 * You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
@@ -328,11 +328,11 @@ $ oc create -f deployment.yaml
 
 * Verify that you can access the secrets from {secrets-store-provider} in the pod volume mount:
 
-.. List the secrets in the pod mount:
+.. List the secrets in the pod mount by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec busybox-<hash> -n my-namespace -- ls /mnt/secrets-store/
+$ oc exec my-aws-deployment-<hash> -n my-namespace -- ls /mnt/secrets-store/
 ----
 +
 .Example output
@@ -346,11 +346,11 @@ testParameter
 endif::aws-systems-manager-parameter-store[]
 ----
 
-.. View a secret in the pod mount:
+.. View a secret in the pod mount by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec busybox-<hash> -n my-namespace -- cat /mnt/secrets-store/testSecret
+$ oc exec my-aws-deployment-<hash> -n my-namespace -- cat /mnt/secrets-store/testSecret
 ----
 +
 .Example output

--- a/modules/secrets-store-azure.adoc
+++ b/modules/secrets-store-azure.adoc
@@ -6,14 +6,14 @@
 [id="secrets-store-azure_{context}"]
 = Mounting secrets from Azure Key Vault
 
-You can use the {secrets-store-operator} to mount secrets from Azure Key Vault to a CSI volume in {product-title}. To mount secrets from Azure Key Vault, your cluster must be installed on Microsoft Azure.
+You can use the {secrets-store-operator} to mount secrets from Azure Key Vault to a Container Storage Interface (CSI) volume in {product-title}. To mount secrets from Azure Key Vault, your cluster must be installed on Microsoft Azure.
 
 .Prerequisites
 
 * Your cluster is installed on Azure.
-* You have installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
-* You have configured Azure Key Vault to store the required secrets.
-* You have installed the Azure CLI (`az`).
+* You installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
+* You configured Azure Key Vault to store the required secrets.
+* You installed the Azure CLI (`az`).
 * You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
@@ -283,11 +283,11 @@ $ oc create -f deployment.yaml
 
 * Verify that you can access the secrets from Azure Key Vault in the pod volume mount:
 
-.. List the secrets in the pod mount:
+.. List the secrets in the pod mount by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec busybox-<hash> -n my-namespace -- ls /mnt/secrets-store/
+$ oc exec my-azure-deployment-<hash> -n my-namespace -- ls /mnt/secrets-store/
 ----
 +
 .Example output
@@ -296,11 +296,11 @@ $ oc exec busybox-<hash> -n my-namespace -- ls /mnt/secrets-store/
 secret1
 ----
 
-.. View a secret in the pod mount:
+.. View a secret in the pod mount by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec busybox-<hash> -n my-namespace -- cat /mnt/secrets-store/secret1
+$ oc exec my-azure-deployment-<hash> -n my-namespace -- cat /mnt/secrets-store/secret1
 ----
 +
 .Example output

--- a/modules/secrets-store-google.adoc
+++ b/modules/secrets-store-google.adoc
@@ -1,0 +1,307 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-secrets-store.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="secrets-store-google_{context}"]
+= Mounting secrets from Google Secret Manager
+
+You can use the {secrets-store-operator} to mount secrets from Google Secret Manager to a Container Storage Interface (CSI) volume in {product-title}. To mount secrets from Google Secret Manager, your cluster must be installed on {gcp-first}.
+
+.Prerequisites
+
+* You installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
+* You configured Google Secret Manager to store the required secrets.
+* You created a service account key named `key.json` from your Google Cloud service account.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Install the Google Secret Manager provider:
+
+.. Create a YAML file with the following configuration for the provider resources:
++
+.Example `gcp-provider.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-gcp
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-secrets-store-provider-gcp-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-secrets-store-provider-gcp-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-secrets-store-provider-gcp
+    namespace: openshift-cluster-csi-drivers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-secrets-store-provider-gcp-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-secrets-store-provider-gcp
+  namespace: openshift-cluster-csi-drivers
+  labels:
+    app: csi-secrets-store-provider-gcp
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-gcp
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-gcp
+    spec:
+      serviceAccountName: csi-secrets-store-provider-gcp
+      initContainers:
+      - name: chown-provider-mount
+        image: busybox
+        command:
+        - chown
+        - "1000:1000"
+        - /etc/kubernetes/secrets-store-csi-providers
+        volumeMounts:
+        - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+          name: providervol
+        securityContext:
+          privileged: true
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      containers:
+        - name: provider
+          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:a493a78bbb4ebce5f5de15acdccc6f4d19486eae9aa4fa529bb60ac112dd6650
+          securityContext:
+            privileged: true
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: TARGET_DIR
+              value: "/etc/kubernetes/secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+              mountPropagation: None
+              readOnly: false
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /live
+              port: 8095
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 30
+      volumes:
+        - name: providervol
+          hostPath:
+            path: /etc/kubernetes/secrets-store-csi-providers
+      tolerations:
+        - key: kubernetes.io/arch
+          operator: Equal
+          value: amd64
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/os: linux
+----
+
+.. Grant privileged access to the `csi-secrets-store-provider-gcp` service account by running the following command:
++
+[source,terminal]
+----
+$ oc adm policy add-scc-to-user privileged -z csi-secrets-store-provider-gcp -n openshift-cluster-csi-drivers
+----
+
+.. Create the provider resources by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f gcp-provider.yaml
+----
+
+. Grant permission to read the Google Secret Manager secret:
+
+.. Create a new project by running the following command:
++
+[source,terminal]
+----
+$ oc new-project my-namespace
+----
+
+.. Label the `my-namespace` namespace for pod security admission by running the following command:
++
+[source,terminal]
+----
+$ oc label ns my-namespace security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged --overwrite
+----
+
+.. Create a service account for the pod deployment:
++
+[source,terminal]
+----
+$ oc create serviceaccount my-service-account --namespace=my-namespace
+----
+
+.. Create a generic secret from the `key.json` file by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic secrets-store-creds -n my-namespace --from-file=key.json <1>
+----
+<1> You created this `key.json` file from the Google Secret Manager.
+
+.. Apply the `secrets-store.csi.k8s.io/used=true` label to allow the provider to find this `nodePublishSecretRef` secret:
++
+[source,terminal]
+----
+$ oc -n my-namespace label secret secrets-store-creds secrets-store.csi.k8s.io/used=true
+----
+
+. Create a secret provider class to define your secrets store provider:
+
+.. Create a YAML file that defines the `SecretProviderClass` object:
++
+.Example `secret-provider-class-gcp.yaml`
+[source,yaml]
+----
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: my-gcp-provider                        <1>
+  namespace: my-namespace                      <2>
+spec:
+  provider: gcp                                <3>
+  parameters:                                  <4>
+    secrets: |
+      - resourceName: "projects/my-project/secrets/testsecret1/versions/1"
+        path: "testsecret1.txt"
+----
+<1> Specify the name for the secret provider class.
+<2> Specify the namespace for the secret provider class.
+<3> Specify the provider as `gcp`.
+<4> Specify the provider-specific configuration parameters.
+
+.. Create the `SecretProviderClass` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f secret-provider-class-gcp.yaml
+----
+
+. Create a deployment to use this secret provider class:
+
+.. Create a YAML file that defines the `Deployment` object:
++
+.Example `deployment.yaml`
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-gcp-deployment                              <1>
+  namespace: my-namespace                              <2>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-storage
+  template:
+    metadata:
+      labels:
+        app: my-storage
+    spec:
+      serviceAccountName: my-service-account           <3>
+      containers:
+      - name: busybox
+        image: k8s.gcr.io/e2e-test-images/busybox:1.29
+        command:
+          - "/bin/sleep"
+          - "10000"
+        volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+      volumes:
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "my-gcp-provider"   <4>
+            nodePublishSecretRef:
+              name: secrets-store-creds                <5>
+----
+<1> Specify the name for the deployment.
+<2> Specify the namespace for the deployment. This must be the same namespace as the secret provider class.
+<3> Specify the service account you created.
+<4> Specify the name of the secret provider class.
+<5> Specify the name of the Kubernetes secret that contains the service principal credentials to access Google Secret Manager.
+
+.. Create the `Deployment` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f deployment.yaml
+----
+
+.Verification
+
+* Verify that you can access the secrets from Google Secret Manager in the pod volume mount:
+
+.. List the secrets in the pod mount by running the following command:
++
+[source,terminal]
+----
+$ oc exec my-gcp-deployment-<hash> -n my-namespace -- ls /mnt/secrets-store/
+----
++
+.Example output
+[source,terminal]
+----
+testsecret1
+----
+
+.. View a secret in the pod mount by running the following command:
++
+[source,terminal]
+----
+$ oc exec my-gcp-deployment-<hash> -n my-namespace -- cat /mnt/secrets-store/testsecret1
+----
++
+.Example output
+[source,terminal]
+----
+<secret_value>
+----

--- a/modules/secrets-store-providers.adoc
+++ b/modules/secrets-store-providers.adoc
@@ -11,4 +11,5 @@ The following secrets store providers are available for use with the {secrets-st
 * AWS Secrets Manager
 * AWS Systems Manager Parameter Store
 * Azure Key Vault
+* Google Secret Manager
 * HashiCorp Vault

--- a/modules/secrets-store-vault.adoc
+++ b/modules/secrets-store-vault.adoc
@@ -6,7 +6,7 @@
 [id="secrets-store-vault_{context}"]
 = Mounting secrets from HashiCorp Vault
 
-You can use the {secrets-store-operator} to mount secrets from HashiCorp Vault to a CSI volume in {product-title}.
+You can use the {secrets-store-operator} to mount secrets from HashiCorp Vault to a Container Storage Interface (CSI) volume in {product-title}.
 
 [IMPORTANT]
 ====
@@ -20,8 +20,8 @@ Other cloud providers might work, but have not been tested yet. Additional cloud
 
 .Prerequisites
 
-* You have installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
-* You have installed Helm.
+* You installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
+* You installed Helm.
 * You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
@@ -361,7 +361,7 @@ $ oc create -f deployment.yaml
 +
 [source,terminal]
 ----
-$ oc exec busybox-<hash> -n my-namespace -- ls /mnt/secrets-store/
+$ oc exec busybox-deployment-<hash> -n my-namespace -- ls /mnt/secrets-store/
 ----
 +
 .Example output
@@ -374,7 +374,7 @@ testSecret1
 +
 [source,terminal]
 ----
-$ oc exec busybox-<hash> -n my-namespace -- cat /mnt/secrets-store/testSecret1
+$ oc exec busybox-deployment-<hash> -n my-namespace -- cat /mnt/secrets-store/testSecret1
 ----
 +
 .Example output

--- a/nodes/pods/nodes-pods-secrets-store.adoc
+++ b/nodes/pods/nodes-pods-secrets-store.adoc
@@ -33,6 +33,7 @@ After installing the {secrets-store-operator}, you can mount secrets from one of
 * xref:../../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-aws_nodes-pods-secrets-store[AWS Secrets Manager]
 * xref:../../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-aws_nodes-pods-secrets-store-parameter-store[AWS Systems Manager Parameter Store]
 * xref:../../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-azure_nodes-pods-secrets-store[Azure Key Vault]
+* xref:../../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-google_nodes-pods-secrets-store[Google Secret Manager]
 * xref:../../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-vault_nodes-pods-secrets-store[HashiCorp Vault]
 
 // Mounting secrets from AWS Secrets Manager
@@ -63,6 +64,9 @@ include::modules/secrets-store-aws.adoc[leveloffset=+2]
 
 // Mounting secrets from Azure Key Vault
 include::modules/secrets-store-azure.adoc[leveloffset=+2]
+
+// Mounting secrets from Google Secret Manager
+include::modules/secrets-store-google.adoc[leveloffset=+2]
 
 // Mounting secrets from HashiCorp Vault
 include::modules/secrets-store-vault.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-12063

Link to docs preview:
https://82241--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store#secrets-store-google_nodes-pods-secrets-store

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
