### PR TITLE
[enterprise-4.16+]: network-flow-matrix: add missing baremetal provisioning ports

### DIFF
--- a/snippets/network-flow-matrix.csv
+++ b/snippets/network-flow-matrix.csv
@@ -9,7 +9,10 @@ Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
 Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
 Ingress,TCP,5050,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
 Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecure-readyz,master,FALSE
+Ingress,TCP,6180,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
+Ingress,TCP,6183,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6385,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
+Ingress,TCP,6388,openshift-machine-api,metal3-state,metal3,metal3-httpd,master,FALSE
 Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserver,master,FALSE
 Ingress,TCP,8080,openshift-network-operator,,network-operator,network-operator,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE


### PR DESCRIPTION
The baremetal provisioning ports should be documented to allow scalability, they are needed when adding more nodes to the cluster.

Documented in: https://github.com/openshift/enhancements/blob/master/dev-guide/host-port-registry.md#tcp