### PR TITLE
OCPBUGS-42310: Add new role to list of roles for compute nodes

### DIFF
--- a/modules/installation-gcp-permissions.adoc
+++ b/modules/installation-gcp-permissions.adoc
@@ -53,9 +53,10 @@ The following roles are applied to the service accounts that the control plane a
 |`roles/compute.securityAdmin`
 |`roles/storage.admin`
 |`roles/iam.serviceAccountUser`
-.2+|Compute
+.3+|Compute
 |`roles/compute.viewer`
 |`roles/storage.admin`
+|`roles/artifactregistry.reader`
 |===
 
 ifeval::["{context}" == "installing-gcp-user-infra"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
OCPBUGS-42310: Add new role to list of roles for compute nodes

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16, 4.17, 4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-42310

Preview:
https://82254--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-permissions_installing-gcp-account

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
Added the role "roles/artifactregistry.reader" as a required role for compute nodes.
