### PR TITLE
[RHACS] [4.5 and later versions] ROX-24749: Updating Deleting global resources documentation - Uninstall section

### DIFF
--- a/modules/delete-acs-global-resources.adoc
+++ b/modules/delete-acs-global-resources.adoc
@@ -1,37 +1,64 @@
 // Module included in the following assemblies:
 //
 // * installing/uninstall-acs.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="delete-acs-global-resources_{context}"]
 = Deleting global resources
 
 [role="_abstract"]
-You can delete the global resources that {product-title} creates, by using the {ocp} or Kubernetes command-line interface.
+You can delete the global resources that {rh-rhacs-first} creates by using the {ocp} or Kubernetes command-line interface (CLI).
 
 .Procedure
-* Delete global resources:
-** On {ocp}:
-+
+
+* To delete the global resources by using the {ocp} CLI, perform the following steps:
+
+.. Retrieve all the StackRox-related cluster roles, cluster role bindings, roles, role bindings, and PSPs, and then delete them by running the following command:
++ 
 [source,terminal]
 ----
 $ oc get clusterrole,clusterrolebinding,role,rolebinding,psp -o name | grep stackrox | xargs oc delete --wait
 ----
++
+[NOTE]
+====
+You might receive the `error: the server doesn't have a resource type "psp"` error message in {product-title-short} 4.4 and later versions because the pod security policies (PSPs) are deprecated. The PSPs were removed from Kubernetes in version 1.25, except for clusters with older Kubernetes versions.
+====
+
+.. Delete the custom security context constraints (SCCs) labeled with `app.kubernetes.io/name=stackrox` by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete scc -l "app.kubernetes.io/name=stackrox"
 ----
 +
+[NOTE]
+====
+You might receive the `No resources found` error message in {product-title-short} 4.4 and later versions because the custom SCCs with this label are no longer used in these versions.
+====
+
+.. Delete the `ValidatingWebhookConfiguration` object named `stackrox` by running the following command:
++
 [source,terminal]
 ----
 $ oc delete ValidatingWebhookConfiguration stackrox
 ----
-** On Kubernetes:
+
+* To delete the global resources by using the Kubernetes CLI, perform the following steps:
+
+.. Retrieve all the StackRox-related cluster roles, cluster role bindings, roles, role bindings, and PSPs, and then delete them by running the following command:
 +
 [source,terminal]
 ----
 $ kubectl get clusterrole,clusterrolebinding,role,rolebinding,psp -o name | grep stackrox | xargs kubectl delete --wait
 ----
++
+[NOTE]
+====
+You might receive the `error: the server doesn't have a resource type "psp"` error message in {product-title-short} 4.4 and later versions because the pod security policies (PSPs) are deprecated. The PSPs were removed from Kubernetes in version 1.25, except for clusters with older Kubernetes versions.
+====
+
+.. Delete the `ValidatingWebhookConfiguration` object named `stackrox` by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.5+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-24749
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://82260--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/uninstall-acs.html#delete-acs-global-resources_uninstall-acs
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Merge into `rhacs-docs-main` and cherry-pick to:
    - `rhacs-docs-4.6`
    - `rhacs-docs-4.5`
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->