### PR TITLE
OCPBUGS-31402: Fixing addtion typo

### DIFF
--- a/modules/ztp-precaching-ztp-config.adoc
+++ b/modules/ztp-precaching-ztp-config.adoc
@@ -208,7 +208,7 @@ OPTIONS:
 [id="ztp-pre-caching-config-nodes-ignitionconfigoverride_{context}"]
 == Understanding the nodes.ignitionConfigOverride field
 
-Similarly to `clusters.ignitionConfigOverride`, the `nodes.ignitionConfigOverride` field allows the addtion of configurations in Ignition format to the `coreos-installer` utility, but at the {product-title} installation stage.
+Similarly to `clusters.ignitionConfigOverride`, the `nodes.ignitionConfigOverride` field allows the addition of configurations in Ignition format to the `coreos-installer` utility, but at the {product-title} installation stage.
 When the {op-system} is written to disk, the extra configuration included in the {ztp} discovery ISO is no longer available. During the discovery stage, the extra configuration is stored in the memory of the live OS.
 
 [NOTE]


### PR DESCRIPTION
OCPBUGS-31402: Fixing addtion whoopsie

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-31402

Link to docs preview:
https://82265--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-precaching-tool.html#ztp-pre-caching-config-nodes-ignitionconfigoverride_pre-caching

Additional information:
Typo, no QE.