### PR TITLE
TELCODOCS-1983: Clarifying 8 vCPU units

### DIFF
--- a/modules/install-sno-additional-requirements-for-installing-sno-on-a-cloud-provider.adoc
+++ b/modules/install-sno-additional-requirements-for-installing-sno-on-a-cloud-provider.adoc
@@ -11,7 +11,7 @@ The documentation for installer-provisioned installation on cloud providers is b
 
 * A high availability cluster requires a temporary bootstrap machine, three control plane machines, and at least two compute machines. For a {sno} cluster, you need only a temporary bootstrap machine and one cloud instance for the control plane node and no worker nodes.
 
-* The minimum resource requirements for high availability cluster installation include a control plane node with 4 vCPUs and 100GB of storage. For a {sno} cluster, you must have a minimum of 8 vCPU cores and 120GB of storage.
+* The minimum resource requirements for high availability cluster installation include a control plane node with 4 vCPUs and 100GB of storage. For a {sno} cluster, you must have a minimum of 8 vCPUs and 120GB of storage.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 = Additional requirements for installing {sno-okd} on a cloud provider

--- a/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
+++ b/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
@@ -33,14 +33,14 @@ Installing {product-title} on a single node is supported on bare metal and link:
 [options="header"]
 |====
 |Profile|vCPU|Memory|Storage
-|Minimum|8 vCPU cores|16 GB of RAM| 120 GB
+|Minimum|8 vCPUs|16 GB of RAM| 120 GB
 |====
 +
 [NOTE]
 ====
-* One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio:
-+
-(threads per core × cores) × sockets = vCPUs
+One vCPU equals one physical core. However, if you enable simultaneous multithreading (SMT), or Hyper-Threading, use the following formula to calculate the number of vCPUs that represent one physical core:
+
+* (threads per core × cores) × sockets = vCPUs
 
 * Adding Operators during the installation process might increase the minimum resource requirements.
 ====

--- a/modules/installing-sno-requirements-for-installing-single-node-openshift.adoc
+++ b/modules/installing-sno-requirements-for-installing-single-node-openshift.adoc
@@ -15,14 +15,14 @@ Installing {product-title} on a single node alleviates some of the requirements 
 [options="header"]
 |====
 |Profile|vCPU|Memory|Storage
-|Minimum|8 vCPU cores|32GB of RAM| 120GB
+|Minimum|8 vCPU|32GB of RAM| 120GB
 |====
 +
 [NOTE]
 ====
-One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio:
+One vCPU equals one physical core. However, if you enable simultaneous multithreading (SMT), or Hyper-Threading, use the following formula to calculate the number of vCPUs that represent one physical core:
 
-(threads per core × cores) × sockets = vCPUs
+* (threads per core × cores) × sockets = vCPUs
 ====
 +
 The server must have a Baseboard Management Controller (BMC) when booting with virtual media.

--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -55,9 +55,9 @@ Recommended cluster resources for the following topologies:
 [options="header"]
 |====
 |Topology|Number of control plane nodes|Number of compute nodes|vCPU|Memory|Storage
-|Single-node cluster|1|0|8 vCPU cores|16 GB of RAM| 120 GB
-|Compact cluster|3|0 or 1|8 vCPU cores|16 GB of RAM|120 GB
-|HA cluster|3|2 and above |8 vCPU cores|16 GB of RAM|120 GB
+|Single-node cluster|1|0|8 vCPUs|16 GB of RAM| 120 GB
+|Compact cluster|3|0 or 1|8 vCPUs|16 GB of RAM|120 GB
+|HA cluster|3|2 and above |8 vCPUs|16 GB of RAM|120 GB
 |====
 
 

--- a/modules/ztp-install-sno-hardware-reqs.adoc
+++ b/modules/ztp-install-sno-hardware-reqs.adoc
@@ -11,12 +11,12 @@ Running vDU application workloads requires a bare-metal host with sufficient res
 [options="header"]
 |====
 |Profile|vCPU|Memory|Storage
-|Minimum|4 to 8 vCPU cores|32GB of RAM| 120GB
+|Minimum|4 to 8 vCPU|32GB of RAM| 120GB
 |====
 
 [NOTE]
 ====
-One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or Hyper-Threading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio:
+One vCPU equals one physical core. However, if you enable simultaneous multithreading (SMT), or Hyper-Threading, use the following formula to calculate the number of vCPUs that represent one physical core:
 
 * (threads per core × cores) × sockets = vCPUs
 ====


### PR DESCRIPTION
[TELCODOCS-1983](https://issues.redhat.com//browse/TELCODOCS-1983): Clarifying 8 vCPU units

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1983

Link to docs preview:
- https://82269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#additional-requirements-for-installing-sno-on-a-cloud-provider_install-sno-installing-sno-with-the-assisted-installer
- https://82269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-preparing-to-install-sno.html#install-sno-requirements-for-installing-on-a-single-node_install-sno-preparing
- https://82269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html#ztp-install-sno-hardware-reqs_sno-configure-for-vdu
- https://82269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#recommended-resources-for-topologies
- https://82269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html#ztp-install-sno-hardware-reqs_sno-configure-for-vdu

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
