### PR TITLE
RHDEVDOCS_6178 update docinfo files

### DIFF
--- a/argocd_application_sets/docinfo.xml
+++ b/argocd_application_sets/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Argo CD application sets</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
-<subtitle>Managing the application set resources in non-control plane namespaces.</subtitle>
+<subtitle>Managing the application set resources in non-control plane namespaces</subtitle>
 <abstract>
     <para>This document provides information about how to enable and manage the application set resources in non-control plane namespaces.</para>
 </abstract>

--- a/argocd_applications/docinfo.xml
+++ b/argocd_applications/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Argo CD applications</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
-<subtitle>Creating and deploying applications on the OpenShift cluster by using the Argo CD dashboard, oc tool, or GitOps CLI.</subtitle>
+<subtitle>Creating and deploying applications on the OpenShift cluster by using the Argo CD dashboard, oc tool, or GitOps CLI</subtitle>
 <abstract>
     <para>This document provides instructions for creating and deploying your applications to the OpenShift cluster by using the Argo CD dashboard, oc tool, or GitOps CLI. It also discusses how to verify the self-healing behavior in Argo CD and how to enable and manage the application resources in non-control plane namespaces.</para>
 </abstract>

--- a/argocd_instance/docinfo.xml
+++ b/argocd_instance/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Argo CD instance</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
-<subtitle>Installing and deploying Argo CD instances, enabling notifications with an Argo CD instance, and configuring the NotificationsConfiguration CR.</subtitle>
+<subtitle>Installing and deploying Argo CD instances, enabling notifications with an Argo CD instance, and configuring the NotificationsConfiguration CR</subtitle>
 <abstract>
     <para>This document provides instructions for installing and deploying Argo CD instances to manage cluster configurations or deploy applications. It also discusses about how to enable notifications for an Argo CD instance and configure the NotificationsConfiguration custom resource (CR).</para>
 </abstract>

--- a/declarative_clusterconfig/docinfo.xml
+++ b/declarative_clusterconfig/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Declarative cluster configuration</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
-<subtitle>Configuring an OpenShift cluster with cluster configurations by using OpenShift GitOps and creating and synchronizing applications in the default and code mode by using the GitOps CLI.</subtitle>
+<subtitle>Configuring an OpenShift cluster with cluster configurations by using OpenShift GitOps and creating and synchronizing applications in the default and code mode by using the GitOps CLI</subtitle>
 <abstract>
     <para>This document provides instructions for configuring Argo CD to recursively sync the content of a Git directory with an application that contains custom configurations for your cluster. It also discusses about how to create and synchronize applications in the default and code mode by using the GitOps CLI.</para>
 </abstract>

--- a/gitops_cli_argocd/docinfo.xml
+++ b/gitops_cli_argocd/docinfo.xml
@@ -1,7 +1,7 @@
 <title>GitOps CLI (argocd) reference</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
-<subtitle>Configuring the GitOps CLI and logging in to the Argo CD server in the default mode.</subtitle>
+<subtitle>Configuring the GitOps CLI and logging in to the Argo CD server in the default mode</subtitle>
 <abstract>
     <para>This document provides information about how to configure the GitOps CLI and log in to the Argo CD server in the default mode. It also discusses about the basic GitOps argocd commands.</para>
 </abstract>

--- a/installing_gitops/docinfo.xml
+++ b/installing_gitops/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Installing GitOps</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
-<subtitle>Installing the Openshift GitOps Operator, logging in to the Argo CD instance, and installing the GitOps CLI.</subtitle>
+<subtitle>Installing the OpenShift GitOps Operator, logging in to the Argo CD instance, and installing the GitOps CLI</subtitle>
 <abstract>
     <para>This document provides information about sizing requirements and prerequisites for installing the OpenShift GitOps Operator. It also discusses how to install the OpenShift GitOps Operator, log in to the Argo CD instance, and install the GitOps CLI.</para>
 </abstract>

--- a/observability/docinfo.xml
+++ b/observability/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>{product-version}</productnumber>
 <subtitle>Using observability features to view Argo CD logs and monitor the performance and health of Argo CD and application resources</subtitle>
 <abstract>
-    <para>This document details how to use OpenShift Logging with OpenShift GitOps and monitor the performance of Argo CD instances, application health status, and Argo CD custom resource workloads.</para>
+    <para>This document provides instructions about how to use OpenShift Logging with OpenShift GitOps and monitor the performance of Argo CD instances, application health status, and Argo CD custom resource workloads.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat OpenShift Documentation Team</orgname>


### PR DESCRIPTION
Version(s): `gitops-docs-1.13` and later

Issue: [RHDEVDOCS-6178](https://issues.redhat.com/browse/RHDEVDOCS-6178)

Link to docs preview: Not applicable
Peer review: @mramendi 

SME and QE review: Not applicable

QE review:
- [x] QE has approved this change.

**Additional information:** Technical PR to move the doc info XML files to GitHub from GitLab. No changes to the doc content.