### PR TITLE
Adds a limitation to private storage endpoint on azure feature

### DIFF
--- a/modules/registry-configuring-private-storage-endpoint-azure.adoc
+++ b/modules/registry-configuring-private-storage-endpoint-azure.adoc
@@ -26,4 +26,8 @@ The following limitations apply when configuring a private storage endpoint on A
 
 * When configuring the Image Registry Operator to use a private storage endpoint, public network access to the storage account is disabled. Consequently, pulling images from the registry outside of {product-title} only works by setting `disableRedirect: true` in the registry Operator configuration. With redirect enabled, the registry redirects the client to pull images directly from the storage account, which will no longer work due to disabled public network access. For more information, see "Disabling redirect when using a private storage endpoint on Azure".
 
+* Due to a change in storage account naming in {product-title} {product-version}, the Azure File Container Storage Interface (CSI) driver now alphabetically matches storage account of the Image Registry Operator. With this change, there is a known issue where the Azure File CSI driver fails to mount all volumes when the image registry is configured as private. The mount failures occur because the CSI driver tries to use the storage account of the Image Registry Operator, which is not configured to allow connections from worker subnets.
++
+As a temporary workaround, the image registry should not be configured as private when using the Azure File CSI driver. This is a known issue and will be fixed in a future version of {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-42308[*OCPBUGS-42308*])
+
 * This operation cannot be undone by the Image Registry Operator.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-42308

Link to docs preview:
https://82276--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-private-cluster.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
