### PR TITLE
Rhdevdocs 6178 docinfo files 1.10 and 1.9

### DIFF
--- a/accesscontrol_usermanagement/docinfo.xml
+++ b/accesscontrol_usermanagement/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Access control and user management</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Configuring user authentication and access controls for users and namespaces</subtitle>
+<abstract>
+    <para>This document provides instructions for changing and managing user level access and resource requests. It also discusses how to configure role-based access control and single sign-on authentication providers to manage multiple users, permissions, Argo CD resources, and instances in the cluster.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/argo_rollouts/docinfo.xml
+++ b/argo_rollouts/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Argo Rollouts</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Using Argo Rollouts for progressive delivery</subtitle>
+<abstract>
+    <para>This document provides instructions for using Argo Rollouts to encapsulate all the required definitions for a declarative rollout strategy. It also discusses how to manage and automate progressive delivery of deployments as part of the GitOps workflow.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/argocd_applications/docinfo.xml
+++ b/argocd_applications/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Argo CD applications</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Creating and deploying applications on the OpenShift cluster by using the Argo CD dashboard or oc tool</subtitle>
+<abstract>
+    <para>This document provides instructions for creating and deploying your applications to the OpenShift cluster either by using the Argo CD dashboard or by using the oc tool. It also discusses how to verify the self-healing behavior in Argo CD.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/argocd_instance/docinfo.xml
+++ b/argocd_instance/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Argo CD instance</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Installing and deploying Argo CD instances</subtitle>
+<abstract>
+    <para>This document provides instructions for installing and deploying Argo CD instances to manage cluster configurations or deploy applications.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/declarative_clusterconfig/docinfo.xml
+++ b/declarative_clusterconfig/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Declarative cluster configuration</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Configuring an OpenShift cluster with cluster configurations by using OpenShift GitOps</subtitle>
+<abstract>
+    <para>This document provides instructions for configuring Argo CD to recursively sync the content of a Git directory with an application that contains custom configurations for your cluster.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/gitops_workloads_infranodes/docinfo.xml
+++ b/gitops_workloads_infranodes/docinfo.xml
@@ -1,0 +1,11 @@
+<title>GitOps workloads on infrastructure nodes</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Running GitOps control plane workloads on infrastructure nodes</subtitle>
+<abstract>
+    <para>This document provides instructions for running certain workloads on infrastructure nodes that are installed by OpenShift GitOps. It also discusses how to move the default workloads to the infrastructure nodes.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/installing_gitops/docinfo.xml
+++ b/installing_gitops/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Installing GitOps</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Installing the OpenShift GitOps Operator and logging in to the Argo CD instance</subtitle>
+<abstract>
+    <para>This document provides information about sizing requirements and prerequisites for installing the OpenShift GitOps Operator. It also discusses how to install the OpenShift GitOps Operator and log in to the Argo CD instance.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/managing_resource/docinfo.xml
+++ b/managing_resource/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Managing resource use</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Configuring resource requests and limits for Argo CD workloads</subtitle>
+<abstract>
+    <para>This document provides instructions for configuring workloads with resource requests and limits. It also discusses how to patch Argo CD instance to update the resource requirements for all or any of the workloads after installation.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/observability/docinfo.xml
+++ b/observability/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Observability</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Using observability features to view Argo CD logs and monitor the performance and health of Argo CD and application resources</subtitle>
+<abstract>
+    <para>This document provides instructions about how to use OpenShift Logging with OpenShift GitOps and monitor the performance of Argo CD instances, application health status, and Argo CD custom resource workloads.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/release_notes/docinfo.xml
+++ b/release_notes/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Release notes</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Highlights of what is new and what has changed with this OpenShift GitOps release</subtitle>
+<abstract>
+    <para>The release notes for OpenShift GitOps summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/removing_gitops/docinfo.xml
+++ b/removing_gitops/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Removing GitOps</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Removing OpenShift GitOps Operator from your cluster</subtitle>
+<abstract>
+    <para>This document provides instructions for deleting the Argo CD instances added to the default namespace of the OpenShift GitOps Operator. It also discusses how to remove the OpenShift GitOps Operator from your cluster.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/securing_openshift_gitops/docinfo.xml
+++ b/securing_openshift_gitops/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Security</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Using security features to configure secure communication and protect the possibly sensitive data in transit</subtitle>
+<abstract>
+    <para>This document provides instructions for using the Transport Layer Security (TLS) encryption with the OpenShift GitOps. It also discusses how to configure secure communication with Redis to protect the possibly sensitive data in transit.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/troubleshooting_gitops_issues/docinfo.xml
+++ b/troubleshooting_gitops_issues/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Troubleshooting</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Troubleshooting topics for OpenShift GitOps and your cluster</subtitle>
+<abstract>
+    <para>This document provides information about how to troubleshoot issues in OpenShift GitOps.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/understanding_openshift_gitops/docinfo.xml
+++ b/understanding_openshift_gitops/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Understanding OpenShift GitOps</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Introduction to OpenShift GitOps</subtitle>
+<abstract>
+    <para>This document provides an overview of OpenShift GitOps and its features.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
Version(s): `gitops-docs-1.10` and `gitops-docs-1.9` 

Issue: [RHDEVDOCS-6178](https://issues.redhat.com/browse/RHDEVDOCS-6178)

Link to docs preview: Not applicable
Peer review: @mramendi 

SME and QE review: Not applicable

QE review:
- [x] QE has approved this change.

**Additional information:** Technical PR to move the doc info XML files to GitHub from GitLab. No changes to the doc content.