### PR TITLE
No Jira: Minor housekeeping for HCP docs

### DIFF
--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -9,6 +9,12 @@ toc::[]
 If you encounter issues with {hcp}, see the following information to guide you through troubleshooting.
 
 include::modules/hosted-control-planes-troubleshooting.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../hosted_control_planes/hcp-prepare/hcp-cli.adoc[Installing the {hcp} command-line interface]
+
 include::modules/hcp-must-gather-dc.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/hosted_control_planes/hcp_high_availability/hcp-backup-restore-aws.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-backup-restore-aws.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can back up and restore etcd on a hosted cluster on {aws-first} to fix failures.
 
-:FeatureName: Hosted control planes on the {aws-short} platform
-include::snippets/technology-preview.adoc[]
-
 include::modules/backup-etcd-hosted-cluster.adoc[leveloffset=+1]
 
 include::modules/restoring-etcd-snapshot-hosted-cluster.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-aws.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-aws.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can recover a hosted cluster to the same region within {aws-first}. For example, you need disaster recovery when the upgrade of a management cluster fails and the hosted cluster is in a read-only state.
 
-:FeatureName: Hosted control planes
-include::snippets/technology-preview.adoc[]
-
 The disaster recovery process involves the following steps:
 
 . Backing up the hosted cluster on the source management cluster

--- a/modules/hosted-control-planes-troubleshooting.adoc
+++ b/modules/hosted-control-planes-troubleshooting.adoc
@@ -29,7 +29,7 @@ Although the output does not contain any secret objects from the cluster, it can
 
 * You need the `name` value for the `HostedCluster` resource and the namespace where the CR is deployed.
 
-* You must have the `hcp` command line interface installed. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the {hcp} command line interface].
+* You must have the `hcp` command-line interface installed. For more information, see "Installing the {hcp} command-line interface".
 
 * You must have the OpenShift CLI (`oc`) installed.
 

--- a/modules/sriov-operator-hosted-control-planes.adoc
+++ b/modules/sriov-operator-hosted-control-planes.adoc
@@ -7,15 +7,12 @@
 [id="sriov-operator-hosted-control-planes_{context}"]
 = Deploying the SR-IOV Operator for {hcp}
 
-:FeatureName: {hcp-capital} on the AWS platform
-include::snippets/technology-preview.adoc[]
-
 [role="_abstract"]
 After you configure and deploy your hosting service cluster, you can create a subscription to the SR-IOV Operator on a hosted cluster. The SR-IOV pod runs on worker machines rather than the control plane.
 
 .Prerequisites
 
-You must configure and deploy the hosted cluster on AWS. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring the hosting cluster on AWS (Technology Preview)].
+You must configure and deploy the hosted cluster on AWS.
 
 .Procedure
 

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -29,5 +29,4 @@ include::modules/advanced-node-tuning-hosted-cluster.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
-For more information about {hcp}, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#hosted-control-planes-intro[{hcp-capital}].
+* xref:../hosted_control_planes/index.adoc#hosted-control-planes-overview[{hcp-capital} overview]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: No Jira - this PR fixes incorrect links and removes an outdated TP boilerplate statement
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Gathering information to troubleshoot hosted control planes](https://82288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting.html#hosted-control-planes-troubleshooting_hcp-troubleshooting) (updated link to point to OCP docs instead of RHACM docs)
- [Advanced node tuning for hosted clusters](https://82288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator#advanced-node-tuning-hosted-cluster_node-tuning-operator) (updated link to point to OCP docs instead of RHACM docs)
- [Deploying the SR-IOV Operator for hosted control planes](https://82288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-machine-config#sriov-operator-hosted-control-planes_hcp-machine-config) (removing link and removing outdated TP boilerplate)
- [Backing up and restoring etcd on AWS](https://82288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-backup-restore-aws) (removing outdated TP boilerplate)
- [Disaster recovery for a hosted cluster in AWS](https://82288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-aws) (removing outdated TP boilerplate)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
