### PR TITLE
OSDOCS-12055 OCP 4.15.34 Release Notes (9/25 release)

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2745,6 +2745,52 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-34_{context}"]
+=== RHSA-2024:6818 - {product-title} 4.15.34 bug fix and security update
+
+Issued: 25 September 2024
+
+{product-title} release 4.15.34, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6818[RHSA-2024:6818] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2024:6821[RHBA-2024:6821] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.34 --pullspecs
+----
+
+[id="ocp-4-15-34-enhancements_{context}"]
+==== Enhancements
+
+The following enhancement is included in this z-stream release:
+
+[id="ocp-4-15-34-IO-new-metric_{context}"]
+===== Insights Operator collects new metric
+
+* The Insights Operator (IO) can now collect data from the `haproxy_exporter_server_threshold` metric.
+(link:https://issues.redhat.com/browse/OCPBUGS-38593[*OCPBUGS-38593*])
+
+[id="ocp-4-15-34-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when the Operator Lifecycle Manager (OLM) evaluated a potential update, it used the dynamic client list for all custom resource (CR) instances in the cluster.  For clusters with a large number of CRs, that could result in timeouts from the apiserver and stranded updates. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41819[*OCPBUGS-41819*])
+
+* Previously, if you created a hosted cluster by using a proxy for the purposes of making the cluster reach a control plane from a compute node, the compute node would be unavailable to the cluster. With this release, the proxy settings are updated for the node so that the node can use a proxy to successfully communicate with the control plane. (link:https://issues.redhat.com/browse/OCPBUGS-41947[*OCPBUGS-41947*])
+
+* Previously, an `AdditionalTrustedCA` field that was specified in the Hosted Cluster image configuration was not reconciled into the `openshift-config` namespace as expected and the component was not available. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41809[*OCPBUGS-41809*])
+
+* Previously, when you created a `LoadBalancer` service for the Ingress Operator, a log message was generated that stated the change was not effective. This log message should only trigger for a change to an Infra custom resource. With this release, this log message is no longer generated when you create a `LoadBalancer` service for the Ingress Operator. (link:https://issues.redhat.com/browse/OCPBUGS-41635[*OCPBUGS-41635*])
+
+* Previously, if an IP address was assigned to an egress node and was deleted, then pods selected by that egress IP address might have had incorrect routing information to that egress node. With this release, the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41340[*OCPBUGS-41340*])
+
+* Previously, proxying for Operators that run in the control plane of a hosted cluster was done through proxy settings on the Konnectivity agent pod that runs in the data plane. As a consequence, it was not possible to distinguish whether proxying was needed based on application protocol. For parity with {product-title}, IDP communication through HTTPS or HTTP should be proxied, but LDAP communication should not be proxied. This type of proxying also ignores `NO_PROXY` entries that rely on host names because by the time traffic reaches the Konnectivity agent, only the destination IP address is available. With this release, in hosted clusters, proxy is invoked in the control plane by `konnectivity-https-proxy` and `konnectivity-socks5-proxy`, and proxying traffic is stopped from the Konnectivity agent. As a result, traffic that is destined for LDAP servers is no longer proxied. Other HTTPS or HTTPS traffic is proxied correctly. The `NO_PROXY` setting is honored when you specify hostnames. (link:https://issues.redhat.com/browse/OCPBUGS-38065[*OCPBUGS-38065*])
+
+[id="ocp-4-15-34-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-15-33_{context}"]
 === RHSA-2024:6685 - {product-title} 4.15.33 bug fix and security update
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-12055](https://issues.redhat.com/browse/OSDOCS-12055)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to[ docs preview:](https://82291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-34_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links will not work until September 25.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
