### PR TITLE
OSDOCS-11630: update RHDE page for Microshift 4.17.z release

### DIFF
--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -46,32 +46,22 @@ The latest release notes for each product that is part of {product-title} are av
 ^|9.4
 ^|4.17
 ^|Generally Available
-^|4.17.0&#8594;4.17.z and 4.16&#8594;4.17
+^|4.17.1&#8594;4.17.z
 
 ^|9.4
 ^|4.16
 ^|Generally Available
-^|4.16.0&#8594;4.16.z, 4.14&#8594;4.16, 4.15&#8594;4.16 and 4.16&#8594;4.17
+^|4.16.0&#8594;4.16.z, 4.16&#8594;4.17
 
 ^|9.2, 9.3
 ^|4.15
 ^|Generally Available
-^|4.15.0&#8594;4.15.z, 4.14&#8594;4.15 and 4.15&#8594;4.16
+^|4.15.0&#8594;4.15.z, 4.15&#8594;4.16
 
 ^|9.2, 9.3
 ^|4.14
 ^|Generally Available
-^|4.14.0&#8594;4.14.z, 4.14&#8594;4.15 and 4.14&#8594;4.16
-
-^|9.2
-^|4.13
-^|Technology Preview
-^|None
-
-^|8.7
-^|4.12
-^|Developer Preview
-^|None
+^|4.14.0&#8594;4.14.z, 4.14&#8594;4.15, 4.14&#8594;4.16
 |===
 
 [id="device-edge-compatibility-ansible_{context}"]


### PR DESCRIPTION
Version(s):
N/A (no CPs, version "4" is for Pantheon only; versionless branch in the repo)
Can be merged, but Pantheon sync is EMBARGOED for after OCP 4.17 GA when the rest of the docs are published.

Issue:
[OSDOCS-11630](https://issues.redhat.com/browse/OSDOCS-11630)

Link to docs preview:
[Red Hat Device Edge product release compatibility matrix](https://82294--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.
