### PR TITLE
OSDOCS-12077 GCP BYO service account RN

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -70,8 +70,8 @@ With this update, the user-defined labels and tags for {gcp-first} is Generally 
 
 For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-user-defined-labels-and-tags_installing-gcp-customizations[Managing user-defined labels and tags for GCP].
 
-
-==== Deploy {azure-short} in the Spain region
+[id="ocp-4-17-installation-and-update-azure-spain_{context}"]
+==== Installing a cluster on {azure-short} in the Central Spain region
 
 You can deploy {product-title} {product-version} in {azure-first} in the Spain, Central (`spaincentral`) region. For more information, see xref:../installing/installing_azure/installing-azure-account.adoc#installation-azure-regions_installing-azure-account[Supported Azure regions].
 
@@ -93,6 +93,13 @@ With the replacement of Terraform, the following permissions are required if you
 
 For more information on required permissions, see xref:../installing/installing_azure/installing-azure-account.adoc#minimum-required-permissions-ipi-azure_installing-azure-account[Required Azure permissions for installer-provisioned infrastructure].
 ====
+
+[id="ocp-4-17-installation-and-update-gcp-service-account_{context}"]
+==== Installing a cluster on {gcp-full} by using an existing service account
+
+With this update, you can install a cluster on {gcp-short} by using an existing service account, allowing you to minimize the permissions that you grant to the service account the installation program uses. You can specify this service account in the `compute.platform.gcp.serviceAccount` and `controlPlane.platform.gcp.serviceAccount` parameters in the `install-config.yaml` file. For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters_installation-config-parameters-gcp[Available installation configuration parameters for GCP].
+
+[id="ocp-4-17-installation-and-update-aws-iam_{context}"]
 ==== Installing a cluster on {aws-short} by using an existing IAM profile
 
 With this release, you can install {product-title} on {aws-first} by using an existing identity and access management (IAM) instance profile. For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-optional-aws_installation-config-parameters-aws[Optional {aws-short} configuration parameters].
@@ -1271,7 +1278,7 @@ In the following tables, features are marked with the following statuses:
 === Deprecated features
 
 [id="ocp-4-17-preserveBootstrapIgnition-deprecated_{context}"]
-==== The `preserveBootstrapIgnition` parameter for {aws-short} 
+==== The `preserveBootstrapIgnition` parameter for {aws-short}
 
 The `preserveBootstrapIgnition` parameter for {aws-short} in the `install-config.yaml` file has been deprecated. You can use the `bestEffortDeleteIgnition` parameter instead.
 (link:https://issues.redhat.com/browse/OCPBUGS-33661[*OCPBUGS-33661*])
@@ -1411,13 +1418,13 @@ Starting in {product-title} 4.17, RukPak is now removed and relevant functionali
 
 * Previously, the AWS cloud controller manager within a hosted control plane that was running on a proxied management cluster would not use the proxy for cloud API communication. With this release, the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-37832[*OCPBUGS-37832*])
 
-* Previously, proxying for Operators that run in the control plane of a hosted cluster was performed through proxy settings on the Konnectivity agent pod that runs in the data plane. It was not possible to distinguish if proxying was needed based on application protocol. 
+* Previously, proxying for Operators that run in the control plane of a hosted cluster was performed through proxy settings on the Konnectivity agent pod that runs in the data plane. It was not possible to distinguish if proxying was needed based on application protocol.
 +
-For parity with {product-title}, IDP communication via HTTPS or HTTP should be proxied, but LDAP communication should not be proxied. This type of proxying also ignores `NO_PROXY` entries that rely on host names because by the time traffic reaches the Konnectivity agent, only the destination IP address is available. 
+For parity with {product-title}, IDP communication via HTTPS or HTTP should be proxied, but LDAP communication should not be proxied. This type of proxying also ignores `NO_PROXY` entries that rely on host names because by the time traffic reaches the Konnectivity agent, only the destination IP address is available.
 +
 With this release, in hosted clusters, proxy is invoked in the control plane via `konnectivity-https-proxy` and `konnectivity-socks5-proxy`, and proxying traffic is stopped from the Konnectivity agent. As a result, traffic that is destined for LDAP servers is no longer proxied. Other HTTPS or HTTPS traffic is proxied correctly. The `NO_PROXY` setting is honored when you specify hostnames. (link:https://issues.redhat.com/browse/OCPBUGS-37052[*OCPBUGS-37052*])
 
-* Previously, proxying for IDP communication occurred in the Konnectivity agent. By the time traffic reached Konnectivity, its protocol and hostname were no longer available. As a consequence, proxying was not done correctly for the OAUTH server pod. It did not distinguish between protocols that require proxying (http/s) and protocols that do not (ldap://). In addition, it did not honor the `no_proxy` variable that is configured in the `HostedCluster.spec.configuration.proxy` spec. 
+* Previously, proxying for IDP communication occurred in the Konnectivity agent. By the time traffic reached Konnectivity, its protocol and hostname were no longer available. As a consequence, proxying was not done correctly for the OAUTH server pod. It did not distinguish between protocols that require proxying (http/s) and protocols that do not (ldap://). In addition, it did not honor the `no_proxy` variable that is configured in the `HostedCluster.spec.configuration.proxy` spec.
 +
 With this release, you can configure the proxy on the Konnectivity sidecar of the OAUTH server so that traffic is routed appropriately, honoring your `no_proxy` settings. As a result, the OAUTH server can communicate properly with identity providers when a proxy is configured for the hosted cluster. (link:https://issues.redhat.com/browse/OCPBUGS-36932[*OCPBUGS-36932*])
 
@@ -1457,7 +1464,7 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 * Previously, the installation program attempted to download the OVA on {vmw-first} whether the template field was defined or not. With this update, the issue is resolved. The installation program verifies if the template field is defined. If the template field is not defined, the OVA is downloaded. If the template field is defined, the OVA is not downloaded. (link:https://issues.redhat.com/browse/OCPBUGS-39240[*OCPBUGS-39240*])
 
 * Previously, enabling custom feature gates sometimes caused installation on an AWS cluster to fail if the feature gate `ClusterAPIInstallAWS=true` was not enabled. With this release, the `ClusterAPIInstallAWS=true` feature gate is not required.
-(link:https://issues.redhat.com/browse/OCPBUGS-34708[*OCPBUGS-34708*]) 
+(link:https://issues.redhat.com/browse/OCPBUGS-34708[*OCPBUGS-34708*])
 
 * Previously, some processes could be left running if the installation program exited due to infrastructure provisioning failures. With this update, all installation-related processes are terminated when the installation program terminates. (link:https://issues.redhat.com/browse/OCPBUGS-36378[*OCPBUGS-36378*])
 
@@ -1465,7 +1472,7 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 
 * Previously, long cluster names were trimmed without warning the user. With this update, the installation program warns the user when trimming long cluster names. (link:https://issues.redhat.com/browse/OCPBUGS-33840[*OCPBUGS-33840*])
 
-* Previously, the `openshift-install` CLI sometimes failed to connect to the bootstrap node when collecting bootstrap gather logs. The installation program reported an error message such as `The bootstrap machine did not execute the release-image.service systemd unit`. With this release and after the bootstrap gather logs issue occurs, the installation program now reports `Invalid log bundle or the bootstrap machine could not be reached and bootstrap logs were not collected`, which is a more accurate error message. (link:https://issues.redhat.com/browse/OCPBUGS-34953[*OCPBUGS-34953*]) 
+* Previously, the `openshift-install` CLI sometimes failed to connect to the bootstrap node when collecting bootstrap gather logs. The installation program reported an error message such as `The bootstrap machine did not execute the release-image.service systemd unit`. With this release and after the bootstrap gather logs issue occurs, the installation program now reports `Invalid log bundle or the bootstrap machine could not be reached and bootstrap logs were not collected`, which is a more accurate error message. (link:https://issues.redhat.com/browse/OCPBUGS-34953[*OCPBUGS-34953*])
 
 * Previously, when installing a cluster on {aws-short}, subnets that the installation program created were incorrectly tagged with the `kubernetes.io/cluster/<clusterID>: shared` tag. With this update, these subnets are correctly tagged with the `kubernetes.io/cluster/<clusterID>: owned` tag. (link:https://issues.redhat.com/browse/OCPBUGS-36904[*OCPBUGS-36904*])
 
@@ -1494,7 +1501,7 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 * Previously, when installing a cluster with the Agent-based installer, the assisted-installer process could timeout when attempting to add control plane nodes to the cluster. With this update, the assisted-installer process loads fresh data from the assisted-service process, preventing the timeout. (link:https://issues.redhat.com/browse/OCPBUGS-36779[*OCPBUGS-36779*])
 
 * Previously, when the {vmw-full} vCenter cluster contained an ESXi host that did not have a standard port group defined and the installation program tried to select that host to import the OVA, the import failed and the error “Invalid Configuration for device '0'” was presented.
-With this release, the installation program verifies whether a standard port group for an ESXi host is defined and, if not, continues until it locates an ESXi host with a defined standard port group or presents an error message if it fails to locate one, resolving the issue. 
+With this release, the installation program verifies whether a standard port group for an ESXi host is defined and, if not, continues until it locates an ESXi host with a defined standard port group or presents an error message if it fails to locate one, resolving the issue.
  (link:https://issues.redhat.com/browse/OCPBUGS-38560[*OCPBUGS-38560*])
 
 * Previously, extracting the IP address from the Cluster API Machine object only returned a single IP address. On {vmw-first}, the returned address would always be an IPv6 address and this caused issues with the `must-gather` implementation if the address was non-routable. With this release, the Cluster API Machine object returns all IP addresses, including IPv4, so that the `must-gather` issue no longer occurs on {vmw-full}. (link:https://issues.redhat.com/browse/OCPBUGS-37607[*OCPBUGS-37607*])
@@ -1509,7 +1516,7 @@ With this release, the installation program verifies whether a standard port gro
 
 * Previously, when setting `platform.openstack.controlPlanePort.network` without a `fixedIPs` value, the installation program would output a misleading error message about the network missing subnets. With this release, the installation program validates that the `install-config` field `controlPlanePort` has a valid subnet filter set because it is a required value. (link:https://issues.redhat.com/browse/OCPBUGS-37104[*OCPBUGS-37104*])
 
-* Previously, adding IPv6 support for user-provisioned installation platforms caused an issue with naming {rh-openstack-first} resources, especially when you run two user-provisioned installation clusters on the same {rh-openstack-first} platform. This happened because the two clusters share the same names for network, subnets, and router resources. With this release, all the resources names for a cluster remain unique for that cluster so no interfere occurs. (link:https://issues.redhat.com/browse/OCPBUGS-33973[*OCPBUGS-33973*]) 
+* Previously, adding IPv6 support for user-provisioned installation platforms caused an issue with naming {rh-openstack-first} resources, especially when you run two user-provisioned installation clusters on the same {rh-openstack-first} platform. This happened because the two clusters share the same names for network, subnets, and router resources. With this release, all the resources names for a cluster remain unique for that cluster so no interfere occurs. (link:https://issues.redhat.com/browse/OCPBUGS-33973[*OCPBUGS-33973*])
 
 * Previously, when installing a cluster on {ibm-power-server-name} with installer-provisioned infrastructure, the installation could fail due to load balancer timeouts. With this update, the installation program waits for the load balancer to be available instead of timing out. (link:https://issues.redhat.com/browse/OCPBUGS-34869[*OCPBUGS-34869*])
 
@@ -1563,7 +1570,7 @@ With this release, the installation program verifies whether a standard port gro
 * Previously, if machine config pools (MCP) had a higher `maxUnavailable` value than the cluster's number of unavailable nodes, cordoned nodes were able to be erroneously selected as an update candidate. This fix adds a node readiness check in the node controller so that cordoned nodes are queued for an update. (link:https://issues.redhat.com/browse/OCPBUGS-33397[*OCPBUGS-33397*])
 
 * Previously, nodes could be drained twice if the node was queued multiple times in the drain controller. This behaviour might have been due to increased activity on the node object by on-cluster layering functionality. With this fix, a node queued for drain only drains once. (link:https://issues.redhat.com/browse/OCPBUGS-33134[*OCPBUGS-33134*])
-	
+
 * Previously, a potential panic was seen in Machine Config Controller and Machine Build Controller objects if a de-reference accidentally deleted `MachineOSConfig/MachineOSBuild` to read the build status. The panic is controlled with additional error conditions to warn for allowed MachineOSConfig deletions. (link:https://issues.redhat.com/browse/OCPBUGS-33129[*OCPBUGS-33129*])
 
 * Previously, after upgrading from {product-title} 4.1 or 4.2 to version 4.15, some machines could get stuck during provisioning and never became available. This was because the `machine-config-daemon-firstboot` service was failing due to an incompatible `machine-config-daemon` binary on those nodes. With this release, the correct `machine-config-daemon` binary is copied to nodes before booting. (link:https://issues.redhat.com/browse/OCPBUGS-28974[*OCPBUGS-28974*])
@@ -2441,7 +2448,7 @@ As a temporary workaround, the image registry should not be configured as privat
 
 * When installing a cluster on {azure-short}, the installation fails if a customer-managed encryption key is specified. (link:https://issues.redhat.com/browse/OCPBUGS-42349[*OCPBUGS-42349*])
 
-* When an error occurs during mirroring Operators and additional images, the log message "Generating Catalog Source" might still appear, even if no files are generated. (link:https://issues.redhat.com/browse/OCPBUGS-42503[*OCPBUGS-42503*]) 
+* When an error occurs during mirroring Operators and additional images, the log message "Generating Catalog Source" might still appear, even if no files are generated. (link:https://issues.redhat.com/browse/OCPBUGS-42503[*OCPBUGS-42503*])
 
 [id="ocp-telco-ran-4-17-known-issues_{context}"]
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-12077

Link to docs preview:
https://82298--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-installation-and-update-gcp-service-account_release-notes

QE review:
- [x] QE has approved this change.

Also added 2 missing ID's and reworded a related release note