### PR TITLE
OSDOCS-12075 adding GCP N4 Machine series release note

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -83,7 +83,12 @@ For more information on required permissions, see xref:../installing/installing_
 ====
 ==== Installing a cluster on {aws-short} by using an existing IAM profile
 
-With this release, you can install {product-title} on {aws-first} by using an existing identity and access management (IAM) instance profile. For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-optional-aws_installation-config-parameters-aws[Optional {aws-short} configuration parameters].
+With this release, you can install {product-title} on {aws-first} by using an existing identity and access management (IAM) instance profile. For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-optional-aws_installation-config-parameters-aws[Optional {aws-short} configuration parameters].
+
+[id="ocp-4-17-installation-and-update-gcp-n4_{context}"]
+==== Installing a cluster on {gcp-short} using the N4 machine series
+
+With this release, you can deploy a cluster on {gcp-short} using the link:https://cloud.google.com/compute/docs/general-purpose-machines#n4_series[N4 machine series] for compute or control plane machines. The supported disk type of N4 machine series is `hyperdisk-balanced`. For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-gcp[Installation configuration parameters for GCP].
 
 [id="ocp-4-17-postinstallation-configuration_{context}"]
 === Postinstallation configuration
@@ -1418,12 +1423,12 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |RWX/RWO SELinux Mount
-|Not Available 
+|Not Available
 |Not Available
 |Developer Preview
 
 |Migrating CNS Volumes Between Datastores
-|Not Available 
+|Not Available
 |Not Available
 |Developer Preview
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-12075

Link to docs preview:
https://82300--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-installation-and-update-gcp-n4_release-notes

QE review:
- [x] QE has approved this change.
