### PR TITLE
OSDOCS-12075 updating GCP disk types

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2192,7 +2192,7 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
       osDisk:
         diskType:
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type].
-|The default disk type for all machines. Control plane nodes must use the `pd-ssd` disk type. Compute nodes can use the `pd-ssd`, `pd-balanced`, or `pd-standard` disk types.
+|The default disk type for all machines. Valid values are `pd-balanced`, `pd-ssd`, `pd-standard`, or `hyperdisk-balanced`. The default value is `pd-ssd`. Control plane machines cannot use the `pd-standard` disk type, so if you specify `pd-standard` as the default machine platform disk type, you must specify a different disk type using the `controlPlane.platform.gcp.osDisk.diskType` parameter.
 
 |platform:
   gcp:
@@ -2357,7 +2357,7 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
       osDisk:
         diskType:
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for control plane machines.
-|Control plane machines must use the `pd-ssd` disk type, which is the default.
+|Valid values are `pd-balanced`, `pd-ssd`, or `hyperdisk-balanced`. The default value is `pd-ssd`.
 
 |controlPlane:
   platform:
@@ -2469,7 +2469,7 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
       osDisk:
         diskType:
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for compute machines.
-|`pd-ssd`, `pd-standard`, or `pd-balanced`. The default is `pd-ssd`.
+|Valid values are `pd-balanced`, `pd-ssd`, `pd-standard`, or `hyperdisk-balanced`. The default value is `pd-ssd`.
 
 |compute:
   platform:


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-12075

Link to docs preview:
https://82303--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp.html#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp

QE review:
- [x] QE has approved this change.
