### PR TITLE
OSDOCS#11757: Adding nodes release note

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -786,6 +786,14 @@ For a full list of flags to use with the `oc adm must-gather command`, see xref:
 
 {product-title} monitoring now uses a TLS-backed endpoint to fetch CRI-O container runtime metrics. These certificates are managed by the system and not the user. {product-title} monitoring queries have been updated to the new port. For information on the certificates used by monitoring, see xref:../security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc#cert-types-monitoring-and-cluster-logging-operator-component-certificates[Monitoring and OpenShift Logging Operator component certificates].
 
+[id="ocp-4-17-adding-nodes-to-on-prem_{context}"]
+==== Adding compute nodes to on-premise clusters
+
+With this release, you can add compute nodes by using the {oc-first} to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
+This process can be used regardless of how you installed your cluster.
+
+For more information, see xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster].
+
 [id="ocp-4-17-cro_{context}"]
 === Cluster Resource Override Admission Operator
 


### PR DESCRIPTION
[OSDOCS-11757](https://issues.redhat.com/browse/OSDOCS-11757)

Version(s): 4.17

This PR adds a release note for a new feature about adding nodes to on-premise clusters

QE review:
- [x] QE has approved this change.

Preview: https://82306--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-adding-nodes-to-on-prem_release-notes

"More information" link depends on #80845 to get merged first