### PR TITLE
Updated the HCP migration to include the ROSA Tutorals and Learning sections

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -63,9 +63,45 @@ Distros: openshift-rosa-hcp
 Topics:
 - Name: Creating a cluster workshop
   Dir: creating_cluster_workshop
+  Distros: openshift-rosa-hcp
   Topics:
   - Name: Deploying a cluster
     File: cloud-experts-getting-started-hcp-for-hcp
+  - Name: Creating an admin user
+    File: cloud-experts-getting-started-admin
+  - Name: Setting up an identity provider
+    File: cloud-experts-getting-started-idp
+  - Name: Granting admin rights
+    File: cloud-experts-getting-started-admin-rights
+  - Name: Accessing your cluster
+    File: cloud-experts-getting-started-accessing
+---
+Name: Tutorials
+Dir: cloud_experts_tutorials
+Distros: openshift-rosa-hcp
+Topics:
+- Name: Tutorials overview
+  File: index
+- Name: ROSA with HCP activation and account linking
+  File: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
+- Name: ROSA with HCP private offer acceptance and sharing
+  File: cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing
+- Name: Getting started with ROSA
+  Dir: cloud-experts-getting-started
+  Distros: openshift-rosa-hcp
+  Topics:
+  - Name: Obtaining support
+    File: cloud-experts-getting-started-support
+- Name: Deploying an application
+  Dir: cloud-experts-deploying-application
+  Distros: openshift-rosa-hcp
+  Topics:
+  - Name: Introduction
+    File: cloud-experts-deploying-application-intro
+  - Name: Prerequisites
+    File: cloud-experts-deploying-application-prerequisites
+  - Name: Lab Overview
+    File: cloud-experts-deploying-application-lab-overview
 ---
 Name: Install ROSA with HCP clusters
 Dir: rosa_hcp

--- a/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-prerequisites.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-prerequisites.adoc
@@ -13,11 +13,23 @@ toc::[]
 
 . A Provisioned ROSA cluster
 +
-This lab assumes you have access to a successfully provisioned a ROSA cluster. If you have not yet created a ROSA cluster, see xref:../../rosa_getting_started/rosa-quickstart-guide-ui.adoc#rosa-getting-started-prerequisites_rosa-quickstart-guide-ui[Red{nbsp}Hat OpenShift Service on AWS quick start guide] for more information.
+This lab assumes you have access to a successfully provisioned a ROSA cluster. If you have not yet created a ROSA cluster, see 
+ifdef::openshift-rosa-hcp[]
+link:https://docs.openshift.com/rosa/rosa_getting_started/rosa-quickstart-guide-ui.html#rosa-getting-started-prerequisites_rosa-quickstart-guide-ui[Red{nbsp}Hat OpenShift Service on AWS quick start guide] for more information.
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+xref:../../rosa_getting_started/rosa-quickstart-guide-ui.adoc#rosa-getting-started-prerequisites_rosa-quickstart-guide-ui[Red{nbsp}Hat OpenShift Service on AWS quick start guide] for more information.
+endif::openshift-rosa-hcp[]
 
 . The OpenShift Command Line Interface (CLI)
 +
-For more information, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[Getting started with the OpenShift CLI].
+For more information, see 
+ifdef::openshift-rosa-hcp[]
+link:https://docs.openshift.com/rosa/cli_reference/openshift_cli/getting-started-cli.html#cli-getting-started[Getting started with the OpenShift CLI].
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[Getting started with the OpenShift CLI].
+endif::openshift-rosa-hcp[]
 
 . A GitHub Account
 +

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-admin-rights.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-admin-rights.adoc
@@ -17,7 +17,13 @@ Red{nbsp}Hat offers two types of admin privileges:
 
 * `dedicated-admin`: `dedicated-admin` privileges allow the admin user to complete most administrative tasks with certain limitations to prevent cluster damage. It is best practice to use `dedicated-admin` when elevated privileges are needed.
 
-For more information on admin privileges, see the xref:../../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-create-cluster-admins_rosa-sts-accessing-cluster[administering a cluster] documentation.
+For more information on admin privileges, see the 
+ifdef::openshift-rosa-hcp[]
+link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.html#rosa-create-cluster-admins_rosa-sts-accessing-cluster[administering a cluster] documentation.
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+xref:../../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-create-cluster-admins_rosa-sts-accessing-cluster[administering a cluster] documentation.
+endif::openshift-rosa-hcp[]
 
 == Using the ROSA CLI
 

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-admin.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-admin.adoc
@@ -13,7 +13,13 @@ Creating an administration (admin) user allows you to access your cluster quickl
 
 [NOTE]
 ====
-An admin user works well in this tutorial setting. For actual deployment, use a xref:../../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[formal identity provider] to access the cluster and grant the user admin privileges.
+An admin user works well in this tutorial setting. For actual deployment, use a 
+ifdef::openshift-rosa-hcp[]
+link:https://docs.openshift.com/rosa/authentication/sd-configuring-identity-providers.html#sd-configuring-identity-providers[formal identity provider] to access the cluster and grant the user admin privileges.
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+xref:../../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[formal identity provider] to access the cluster and grant the user admin privileges.
+endif::openshift-rosa-hcp[]
 ====
 
 . Run the following command to create the admin user:
@@ -80,4 +86,10 @@ oc get all -n openshift-apiserver
 +
 Only an admin user can run this command without errors.
 
-. You can now use the cluster as an admin user, which will suffice for this tutorial. For actual deployment, it is highly recommended to set up an identity provider, which is explained in the xref:../../cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-idp.adoc#cloud-experts-getting-started-idp[next tutorial].
+. You can now use the cluster as an admin user, which will suffice for this tutorial. For actual deployment, it is highly recommended to set up an identity provider, which is explained in the 
+ifdef::openshift-rosa-hcp[]
+link:https://docs.openshift.com/rosa/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-idp.html#cloud-experts-getting-started-idp[next tutorial].
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+xref:../../cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-idp.adoc#cloud-experts-getting-started-idp[next tutorial].
+endif::openshift-rosa-hcp[]

--- a/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
@@ -140,7 +140,13 @@ image::rosa-cli-ui-12.png[]
 
 [IMPORTANT]
 ====
-Make sure that you have the most recent ROSA command line interface (CLI) and AWS CLI installed and have completed the ROSA prerequisites covered in the previous section. See xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[Help with ROSA CLI setup] and link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
+Make sure that you have the most recent ROSA command line interface (CLI) and AWS CLI installed and have completed the ROSA prerequisites covered in the previous section. See 
+ifdef::openshift-rosa-hcp[]
+link:https://docs.openshift.com/rosa/cli_reference/rosa_cli/rosa-get-started-cli.html#rosa-get-started-cli[Help with ROSA CLI setup] and link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[Help with ROSA CLI setup] and link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
+endif::openshift-rosa-hcp[]
 ====
 
 . Initiate the cluster deployment using the `rosa create cluster` command. You can click the *copy* button on the link:https://console.redhat.com/openshift/create/rosa/getstarted[Set up Red{nbsp}Hat OpenShift Service on AWS (ROSA) console page] and paste the command in your terminal. This launches the cluster creation process in interactive mode:

--- a/rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-admin-rights.adoc
+++ b/rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-admin-rights.adoc
@@ -17,7 +17,13 @@ Red{nbsp}Hat offers two types of admin privileges:
 
 * `dedicated-admin`: `dedicated-admin` privileges allow the admin user to complete most administrative tasks with certain limitations to prevent cluster damage. It is best practice to use `dedicated-admin` when elevated privileges are needed.
 
-For more information on admin privileges, see the xref:../../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-create-cluster-admins_rosa-sts-accessing-cluster[administering a cluster] documentation.
+For more information on admin privileges, see the 
+ifdef::openshift-rosa-hcp[]
+link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.html#rosa-create-cluster-admins_rosa-sts-accessing-cluster[administering a cluster] documentation.
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+xref:../../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-create-cluster-admins_rosa-sts-accessing-cluster[administering a cluster] documentation.
+endif::openshift-rosa-hcp[]
 
 == Using the ROSA CLI
 

--- a/rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-admin.adoc
+++ b/rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-admin.adoc
@@ -13,7 +13,13 @@ Creating an administration (admin) user allows you to access your cluster quickl
 
 [NOTE]
 ====
-An admin user works well in this tutorial setting. For actual deployment, use a xref:../../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[formal identity provider] to access the cluster and grant the user admin privileges.
+An admin user works well in this tutorial setting. For actual deployment, use a 
+ifdef::openshift-rosa-hcp[]
+link:https://docs.openshift.com/rosa/authentication/sd-configuring-identity-providers.html#sd-configuring-identity-providers[formal identity provider] to access the cluster and grant the user admin privileges.
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+xref:../../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[formal identity provider] to access the cluster and grant the user admin privileges.
+endif::openshift-rosa-hcp[]
 ====
 
 . Run the following command to create the admin user:
@@ -80,4 +86,4 @@ oc get all -n openshift-apiserver
 +
 Only an admin user can run this command without errors.
 
-. You can now use the cluster as an admin user, which will suffice for this tutorial. For actual deployment, it is highly recommended to set up an identity provider, which is explained in the xref:../../cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-idp.adoc#cloud-experts-getting-started-idp[next tutorial].
+. You can now use the cluster as an admin user, which will suffice for this tutorial. For actual deployment, it is highly recommended to set up an identity provider, which is explained in the xref:../../rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-idp.adoc#cloud-experts-getting-started-idp[next tutorial].

--- a/rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-idp.adoc
+++ b/rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-idp.adoc
@@ -9,7 +9,13 @@ toc::[]
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2023-11-28
 
-To log in to your cluster, set up an identity provider (IDP). This tutorial uses GitHub as an example IDP. See the full list of xref:../../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc#understanding-idp-supported_rosa-sts-config-identity-providers[IDPs supported by ROSA].
+To log in to your cluster, set up an identity provider (IDP). This tutorial uses GitHub as an example IDP. See the full list of 
+ifdef::openshift-rosa-hcp[]
+link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.html#understanding-idp-supported_rosa-sts-config-identity-providers[IDPs supported by ROSA].
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+xref:../../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc#understanding-idp-supported_rosa-sts-config-identity-providers[IDPs supported by ROSA].
+endif::openshift-rosa-hcp[]
 
 * To view all IDP options, run the following command:
 +


### PR DESCRIPTION
This PR updates the Learning and Tutorial sections of the ROSA with HCP migration:

![image](https://github.com/user-attachments/assets/fe91ab70-d42b-41cc-acf3-18eda7b80232)

- **[Password-protected preview](https://docs.openshift.com/rosa-hcp/rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-hcp-for-hcp.html)**
- **[Working branch preview](https://file.corp.redhat.com/eponvell/Learning-HCP/rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-hcp-for-hcp.html)**