### PR TITLE
OSDOCS#11670 Fix cron scaler limitations note for CMA 2.14.1

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-trigger-cron.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-cron.adoc
@@ -10,11 +10,6 @@ You can scale pods based on a time range.
 
 When the time range starts, the custom metrics autoscaler scales the pods associated with an object from the configured minimum number of pods to the specified number of desired pods. At the end of the time range, the pods are scaled back to the configured minimum. The time period must be configured in link:https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#writing-a-cronjob-spec[cron format]. 
 
-[NOTE]
-====
-The custom metrics autoscaler with Cron trigger scales pods based only on the specified times and cannot scale pods on a daily, weekly, monthly, or yearly schedule.
-====
-
 The following example scales the pods associated with this scaled object from `0` to `100` from 6:00 AM to 6:30 PM India Standard Time.
 
 .Example scaled object with a Cron trigger


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-11670

Removed note from the docs that was based on ambiguous upstream docs. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
