### PR TITLE
[enterprise-4.17] Update 4.17 RN tracker tables for Operator Framework

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1244,6 +1244,13 @@ BMER was deprecated in {product-title} version 4.15 and 4.16. With this release,
 ==== OpenShift SDN network plugin (Removed)
 OpenShift SDN network plugin was deprecated in 4.15 and 4.16. With this release, the SDN network plugin is no longer supported and the content has been removed from the documentation.
 
+[id="ocp-4-17-rukpak_{context}"]
+==== Removal of RukPak (Technology Preview)
+
+RukPak was introduced as a Technology Preview feature in {product-title} 4.12. Starting in {product-title} 4.14, it was used as a component in the Technology Preview of {olmv1-first}.
+
+Starting in {product-title} 4.17, RukPak is now removed and relevant functionality relied upon by {olmv1} has been moved to other components.
+
 [id="ocp-4-17-future-deprecation"]
 === Notice of future deprecation
 
@@ -1800,7 +1807,7 @@ In the following tables, features are marked with the following statuses:
 |RukPak
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|Removed
 
 |Platform Operators
 |Technology Preview


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-11224

Preview:

* [Removal of RukPak (Technology Preview)](https://82309--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-rukpak_release-notes)