### PR TITLE
[enterprise-4.17] Update 4.17 RN for new Extensions guide, OSDK version bump

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -71,6 +71,16 @@ This release introduces the following updates to the *Administrator* perspective
 
 This release introduces the following updates to the *Developer* perspective of the web console:
 
+[id="ocp-4-17-extensions_{context}"]
+=== Extensions ({olmv1})
+
+[id="ocp-4-17-extensions-new-guide_{context}"]
+==== {olmv1-first} documentation moved to new Extensions guide (Technology Preview)
+
+The documentation for {olmv1}, which has been in Technology Preview starting in {product-title} 4.14, is now moved and reworked as a separate guide called xref:../extensions/index.adoc#olmv1-about[Extensions]. Previously, {olmv1} documentation was a subsection of the existing xref:../operators/index.adoc#operators-overview[Operators] guide, which otherwise documents the {olmv0} feature set.
+
+The updated location and guide name reflect a more focused documentation experience and aims to differentiate between {olmv1} and {olmv0}.
+
 [id="ocp-4-17-openshift-cli_{context}"]
 === OpenShift CLI (oc)
 
@@ -479,10 +489,15 @@ For more information, see xref:../registry/configuring_registry_storage/configur
 === Oracle(R) Cloud Infrastructure
 
 [id="ocp-4-17-olm_{context}"]
-=== Operator lifecycle
+=== Operator lifecycle ({olmv0})
+
+[id="ocp-4-17-olm-extensions-guide_{context}"]
+==== {olmv1-first} documentation moved to new Extensions guide (Technology Preview)
+
+For more information, see the new features and enhancements section for xref:../release_notes/ocp-4-17-release-notes.adoc#ocp-4-17-extensions_release-notes[Extensions].
 
 [id="ocp-4-17-osdk_{context}"]
-=== Operator development
+=== Operator development ({olmv0})
 
 [id="ocp-4-17-builds_{context}"]
 === Builds
@@ -546,6 +561,29 @@ Manual rotation of signer certificates is still supported by deleting the specif
 //[id="ocp-4-17-cluster-cloud-controller-manager-operator"]
 //=== Cloud controller managers for additional cloud providers
 //
+
+[discrete]
+[id="ocp-4-17-operator-sdk-1-36-1_{context}"]
+=== Operator SDK 1.36.1
+
+{product-title} {product-version} supports Operator SDK 1.36.1. See xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Installing the Operator SDK CLI] to install or update to this latest version.
+
+[NOTE]
+====
+Operator SDK 1.36.1 now supports Kubernetes 1.29 and uses a {op-system-base-full} 9 base image.
+====
+
+If you have Operator projects that were previously created or maintained with Operator SDK 1.31.0, update your projects to keep compatibility with Operator SDK 1.36.1.
+
+* xref:../operators/operator_sdk/golang/osdk-golang-updating-projects.adoc#osdk-upgrading-projects_osdk-golang-updating-projects[Updating Go-based Operator projects]
+
+* xref:../operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc#osdk-upgrading-projects_osdk-ansible-updating-projects[Updating Ansible-based Operator projects]
+
+* xref:../operators/operator_sdk/helm/osdk-helm-updating-projects.adoc#osdk-upgrading-projects_osdk-helm-updating-projects[Updating Helm-based Operator projects]
+
+* xref:../operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc#osdk-upgrading-projects_osdk-hybrid-helm-updating-projects[Updating Hybrid Helm-based Operator projects]
+
+* xref:../operators/operator_sdk/java/osdk-java-updating-projects.adoc#osdk-upgrading-projects_osdk-java-updating-projects[Updating Java-based Operator projects]
 
 [id="ocp-4-17-deprecated-removed-features_{context}"]
 == Deprecated and removed features


### PR DESCRIPTION
* New Extensions book: https://issues.redhat.com/browse/OSDOCS-11728
* OSDK 1.36.1 version bump: https://issues.redhat.com/browse/OSDOCS-11817

Preview: 

* New ["Extensions" section](https://82310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes#ocp-4-17-extensions_release-notes), which has an entry about the new location/guide: https://82310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-olm-extensions-guide_release-notes
* New entry in the existing "Operator lifecycle" section, which I've now appended with "(legacy OLM)", to forward the reader to the new "Extensions" section for more info, so that we're not just duplicating the same info in two places: https://82310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-olm-extensions-guide_release-notes
* Added [Operator SDK 1.36.1 version bump](https://82310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-operator-sdk-1-36-1_release-notes) to "Notable technical changes"