### PR TITLE
OSDOCS-12054: 4.16.14 z-stream RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3356,6 +3356,68 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.14
+[id="ocp-4-16-14_{context}"]
+=== RHSA-2024:6824 - {product-title} {product-version}.14 bug fix and security update
+
+Issued: 24 September 2024
+
+{product-title} release {product-version}.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6824[RHSA-2024:6824] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6827[RHSA-2024:6827] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.14 --pullspecs
+----
+
+[id="ocp-4-16-14-enhancements_{context}"]
+==== Enhancements
+
+The following enhancement is included in this z-stream release:
+
+[id="ocp-4-16-14-insight-operator-collecting-cr-data"]
+===== Collecting data from the {rh-openstack-first} on OpenStack Services cluster resources with the Insight Operator 
+
+* Insight Operator can collect data from the following Red Hat OpenStack on OpenShift Services (RHOSO) cluster resources: `OpenStackControlPlane`, `OpenStackDataPlaneNodeSet`, `OpenStackDataPlaneDeployment`, and `OpenStackVersions`. (link:https://issues.redhat.com/browse/OCPBUGS-38021[*OCPBUGS-38021*])
+
+[id="ocp-4-16-14-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when Operator Lifecycle Manager (OLM) evaluated a potential upgrade, it used the dynamic client list for all custom resource (CR) instances in the cluster. For clusters with a large number of CRs, that could result in timeouts from the API server and stranded upgrades. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41677[*OCPBUGS-41677*])
+
+* Previously, if the Hosted Cluster (HC) `controllerAvailabilityPolicy` value was `SingleReplica`, networking components with `podAntiAffinity` would block the rollout. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41555[*OCPBUGS-41555*])
+
+* Previously, when deploying a cluster into an Amazon Virtual Private Cloud (VPC) with multiple CIDR blocks, the installation program failed. With this release, network settings are updated to support VPCs with multiple CIDR blocks.
+(link:https://issues.redhat.com/browse/OCPBUGS-39496[*OCPBUGS-39496*]) 
+
+* Previously, the order of an Ansible playbook was modified to run before the `metadata.json` file was created, which caused issues with older versions of Ansible. With this release, the playbook is more tolerant of missing files and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-39287[*OCPBUGS-39287*]) 
+
+* Previously, during the same scrape, Prometheus would drop samples from the same series and only consider one of them, even when they had different timestamps. When this issue occurred continuously, it triggered the `PrometheusDuplicateTimestamps` alert. With this release, all samples are now ingested if they meet the other conditions. (link:https://issues.redhat.com/browse/OCPBUGS-39179[*OCPBUGS-39179*])
+
+* Previously, when a folder was undefined and the datacenter was located in a datacenter folder, an incorrect folder structure was created starting from the root of the vCenter server. By using the Govmomi `DatacenterFolders.VmFolder`, it used the an incorrect path. With this release, the folder structure uses the datacenter inventory path and joins it with the virtual machine (VM) and cluster ID value, and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-39082[*OCPBUGS-39082*])
+
+* Previously, the installation program failed to install an {product-title} cluster in the `eu-es` (Madrid, Spain) region on a {ibm-power-server-title} platform that was configured as an `e980` system type. With this release, the installation program no longer fails to install a cluster in this environment. (link:https://issues.redhat.com/browse/OCPBUGS-38502[*OCPBUGS-38502*])
+
+* Previously, proxying for IDP communication occurred in the Konnectivity agent. By the time traffic reached Konnectivity, its protocol and hostname were no longer available. As a consequence, proxying was not done correctly for the OAUTH server pod. It did not distinguish between protocols that require proxying (HTTP/S) and protocols that do not (LDAP). In addition, it did not honor the `no_proxy` variable that is configured in the `HostedCluster.spec.configuration.proxy` spec.
++
+With this release, you can configure the proxy on the Konnectivity sidecar of the OAUTH server so that traffic is routed appropriately, honoring your `no_proxy` settings. As a result, the OAUTH server can communicate properly with identity providers when a proxy is configured for the hosted cluster. (link:https://issues.redhat.com/browse/OCPBUGS-38058[*OCPBUGS-38058*])
+
+* Previously, if you created a hosted cluster by using a proxy for the purposes of making the cluster reach a control plane from a compute node, the compute node would be unavailable to the cluster. With this release, the proxy settings are updated for the node so that the node can use a proxy to successfully communicate with the control plane. (link:https://issues.redhat.com/browse/OCPBUGS-37937[*OCPBUGS-37937*])
+
+* Previously introduced IPv6 support with UPI type installation caused an issue with naming OpenStack resources, which manifests itself on creating two UPI installations on the same OpenStack cloud. The outcome of this will set network, subnets, and routers to have the same name, which will interfere with one setup and prevent deployment of the other. Now, all the names for mentioned resources will be unique per OpenShift deployment. (link:https://issues.redhat.com/browse/OCPBUGS-36855[*OCPBUGS-36855*])
+
+* Previously, some safe `sysctls` were erroneously omitted from the allow list. With this release, the `sysctls` are added back to the allow list and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-29403[*OCPBUGS-29403*])
+
+* Previously, when an {product-title} cluster was upgraded from version 4.14 to 4.15, the vCenter cluster field was not populated in the configuration form of the UI. The infrastructure cluster resource did not have information for upgraded clusters. With this release, the UI uses the `cloud-provider-config` config map for the vCenter cluster value and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41619[*OCPBUGS-41619*])
+
+[id="ocp-4-16-14-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.16.13
 [id="ocp-4-16-13_{context}"]
 === RHSA-2024:6687 - {product-title} {product-version}.13 bug fix update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12054](https://issues.redhat.com/browse/OSDOCS-12054)

Link to docs preview:
https://82313--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-14_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (9/24/24)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
