### PR TITLE
OCPBUGS-31318: Fixing xref

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -279,7 +279,7 @@ spec:
     node-role.kubernetes.io/worker-rt: ""
 ----
 
-For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/nodes/index#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors].
+For more information, see _Placing pods on specific nodes using node selectors_.
 
 [id="node-tuning-operator-scheduling-workload-onto-worker-with-real-time-capabilities_{context}"]
 == Scheduling a workload onto a worker with real-time capabilities

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -20,7 +20,9 @@ include::modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc[level
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about recommended firmware configuration, see xref:../scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc#ztp-du-firmware-config-reference_vdu-config-ref[Recommended firmware configuration for vDU cluster hosts].
+* xref:../scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc#ztp-du-firmware-config-reference_vdu-config-ref[Recommended firmware configuration for vDU cluster hosts].
+
+* xref:../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors].
 
 include::modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc[leveloffset=+2]
 


### PR DESCRIPTION
OCPBUGS-31318: Fixing xref

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-31318

Link to docs preview:
https://82326--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#node-tuning-operator-assigning-proper-node-selector_cnf-master

Additional information:
Typo, no QE.

This only effects 4.13 and 4.12. This module does not exist in later versions. So I am making the fix directly in the 4.13 branch. Is this ok? And can it be backported to 4.12 or do I need a separate PR? Thanks!
