### PR TITLE
OSDOCS-11989:Update OADP ROSA docs with uninstalling info

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1235,7 +1235,7 @@ Name: Backing up and restoring applications
 Dir: rosa_backing_up_and_restoring_applications
 Distros: openshift-rosa
 Topics:
-- Name: Installing OADP on ROSA with STS
+- Name: Backing up applications
   File: backing-up-applications
 ---
 Name: Nodes

--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -56,7 +56,7 @@ $ oc -n openshift-adp create secret generic cloud-credentials \
 +
 [NOTE]
 ====
-In {product-title} versions 4.14 and later, the OADP Operator supports a new standardized {sts-short} workflow through the Operator Lifecycle Manager (OLM)
+In {product-title} versions 4.15 and later, the OADP Operator supports a new standardized {sts-short} workflow through the Operator Lifecycle Manager (OLM)
 and Cloud Credentials Operator (CCO). In this workflow, you do not need to create the above
 secret, you only need to supply the role ARN during the installation of OLM-managed operators using the {product-title} web console, for more information see _Installing from OperatorHub using the web console_.
 

--- a/rosa_backing_up_and_restoring_applications/backing-up-applications.adoc
+++ b/rosa_backing_up_and_restoring_applications/backing-up-applications.adoc
@@ -15,7 +15,7 @@ This is a two stage process:
 
 include::modules/oadp-preparing-aws-credentials.adoc[leveloffset=+1]
 
-include::modules/oadp-installing-oadp-rosa-sts.adoc[leveloffset=+1]
+include::modules/installing-oadp-rosa-sts.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="oadp-addtl-resources_{context}"]
@@ -23,20 +23,31 @@ include::modules/oadp-installing-oadp-rosa-sts.adoc[leveloffset=+1]
 
 * xref:../rosa_backing_up_and_restoring_applications/backing-up-applications.adoc#oadp-preparing-aws-credentials_rosa-backing-up-applications[Preparing AWS credentials]
 
+//Added the following two modules to make a more complete guide.
+
+[id="oadp-rosa-backing-up-and-cleaning-example"]
+== Backing up workloads on OADP with ROSA STS
+
+include::modules/performing-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]
+
+include::modules/cleanup-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]
+
 [id="rosa-backing-up-applications-known-issues"]
 == Known issues
-.Restic, Kopia, and DataMover are not supported or recommended
 
-* link:https://issues.redhat.com/browse/OADP-1054[CloudStorage: openshift-adp-controller-manager crashloop seg fault with Restic enabled]
-* (Affects OADP 1.1.x_ only): link:https://issues.redhat.com/browse/OADP-1055[CloudStorage: bucket is removed on CS CR delete, although it doesn't have "oadp.openshift.io/cloudstorage-delete": "true"]
+* Restic, Kopia, and DataMover are not supported or recommended.
+* link:https://issues.redhat.com/browse/OADP-1054[CloudStorage: openshift-adp-controller-manager crashloop seg fault with Restic enabled].
+* (Affects OADP 1.1.x_ only): link:https://issues.redhat.com/browse/OADP-1055[CloudStorage: bucket is removed on CS CR delete, although it doesn't have "oadp.openshift.io/cloudstorage-delete": "true"].
 
 [role="_additional-resources"]
 [id="additional-resources_rosa-backing-up-applications"]
 == Additional resources
 
-* link:https://docs.openshift.com/rosa/rosa_architecture/rosa-understanding.html[Understanding ROSA with STS]
-* link:https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-getting-started-workflow.html[Getting started with ROSA STS]
-* link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html[Creating a ROSA cluster with STS]
-* link:https://docs.openshift.com/container-platform/4.13/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html[About installing OADP]
-* link:https://docs.openshift.com/container-platform/4.13/storage/container_storage_interface/persistent-storage-csi.html[Configuring CSI volumes]
-* link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-storage_rosa-service-definition[ROSA storage options]
+* For information about ROSA architecture, see xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding-about_rosa-understanding[Understanding ROSA].
+* For information about the prerequisites to installing ROSA with STS, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
+* For steps to deploy a ROSA cluster using manual mode, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster using customizations].
+* For more information about the AWS Identity Access Management (IAM) resources required to deploy {product-title} with STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for clusters that use STS].
+* For more information about OADP, see link:https://docs.openshift.com/container-platform/4.13/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html[About installing OADP].
+* For more information about CSI volumes, see link:https://docs.openshift.com/container-platform/4.13/storage/container_storage_interface/persistent-storage-csi.html[Configuring CSI volumes].
+* For more information about storage options for ROSA, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-storage_rosa-service-definition[ROSA storage options].
+* For steps to contact Red{nbsp}Hat Support for assistance, see xref:../support/getting-support.adoc#getting-support[Getting support for Red{nbsp}Hat OpenShift Service on AWS].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
[OSDOCS#11989](https://issues.redhat.com/browse/OSDOCS-11989)

Link to docs preview:

- [Backing up applications](https://82331--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_backing_up_and_restoring_applications/backing-up-applications.html)
- [Backing up applications on ROSA clusters using OADP](https://82331--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html)

Peer reviewer:
- [x] Peer reviewer has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Reviewers**:
 This PR replaces what is currently in the ROSA OADP ([Backing up applications](https://docs.openshift.com/rosa/rosa_backing_up_and_restoring_applications/backing-up-applications.html)) docs:

- Preparing AWS credentials for OADP
- Installing the OADP Operator and providing the IAM role

with what exists in the OCP ROSA OADP docs ([Backing up applications on ROSA clusters using OADP](https://docs.openshift.com/container-platform/4.16/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html)) so just reusing the same content:

- Preparing AWS credentials for OADP (this procedure remains the same)
- Installing the OADP Operator and providing the IAM role (this procedure is more complete )
- Example: Backing up workload on OADP ROSA STS, with an optional cleanup (new procedure)
- Cleaning up a cluster after a backup with OADP and ROSA STS (new procedure)

This PR also replaces the ROSA links with xrefs in the **Additional resources** section.
