### PR TITLE
TELCODOCS-336 - Deploying host firmware settings with ZTP release note

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -705,6 +705,16 @@ In this release, if your cluster is installed on a bare metal platform, you can 
 [id="ocp-4-17-edge-computing_{context}"]
 === Edge computing
 
+[id="ocp-4-17-edge-computing-managing-firmware-with-ztp_{context}"]
+==== Managing host firmware settings with {ztp}
+
+You can now configure host firmware settings for managed clusters that you deploy with {ztp}.
+You save host profile YAML files alongside `SiteConfig` custom resources (CRs) that you use to deploy the managed clusters.
+{ztp} uses the host profiles to configure firmware settings in the managed cluster hosts during deployment.
+On the hub cluster, you can use `FirmwareSchema` CRs to discover managed cluster host firmware schema, and `HostFirmwareSettings` CRs and retrieve managed clusters firmware settings.
+
+For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-configuring-host-firmware-with-gitops-ztp_ztp-deploying-far-edge-sites[Managing host firmware settings with {ztp}].
+
 [id="ocp-4-17-hcp_{context}"]
 === Hosted control planes
 
@@ -1418,12 +1428,12 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |RWX/RWO SELinux Mount
-|Not Available 
+|Not Available
 |Not Available
 |Developer Preview
 
 |Migrating CNS Volumes Between Datastores
-|Not Available 
+|Not Available
 |Not Available
 |Developer Preview
 


### PR DESCRIPTION
Adds release note for doing host firmware settings via GitOps ZTP

Version(s):
4.17

Issue:
https://issues.redhat.com/browse/TELCODOCS-336

Link to docs preview:
https://82333--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-edge-computing-managing-firmware-with-ztp_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
