### PR TITLE
OSDOCS-12109:Added FIPS info for creating ROSA cluster using UI

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
@@ -43,7 +43,7 @@ If your AWS account ID is not listed, check that you have successfully associate
 
 . Click *Next*.
 
-. On the *Cluster details* page, enter a *Cluster name*. Leave the default values in the remaining fields and click *Next*.
+. On the *Cluster details* page, provide a name for your cluster in the *Cluster name* field. Leave the default values in the remaining fields and click *Next*.
 +
 [NOTE]
 ====

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -203,22 +203,11 @@ To customize the subdomain, select the *Create custom domain prefix* checkbox, a
 .. Select a cloud provider region from the *Region* drop-down menu.
 .. Select a *Single zone* or *Multi-zone* configuration.
 .. Leave *Enable user workload monitoring* selected to monitor your own projects in isolation from Red{nbsp}Hat Site Reliability Engineer (SRE) platform metrics. This option is enabled by default.
-.. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption. With this option, the etcd key values are encrypted, but not the keys. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
-+
-[NOTE]
-====
-By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Consider enabling etcd encryption only if you specifically require it for your use case.
-====
-.. Optional: Select *Encrypt persistent volumes with customer keys* if you want to provide your own AWS Key Management Service (KMS) key Amazon Resource Name (ARN). The key is used for encryption of persistent volumes in your cluster.
-+
-[IMPORTANT]
-====
-Only persistent volumes (PVs) created from the default storage class are encrypted by default.
-
-PVs created by using any other storage class are only encrypted if the storage class is configured to be encrypted.
-====
-+
-... Optional. To create a customer managed KMS key, follow the procedure for link:https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html#create-symmetric-cmk[Creating symmetric encryption KMS keys].
+.. Optional: Expand *Advanced Encryption* to make changes to encryption settings.
+... Accept the default setting *Use default KMS Keys* to use your default AWS KMS key, or select *Use Custom KMS keys* to use a custom KMS key.
+.... With *Use Custom KMS keys* selected, enter the AWS Key Management Service (KMS) custom key Amazon Resource Name (ARN) ARN in the *Key ARN* field.
+The key is used for encrypting all control plane, infrastructure, worker node root volumes, and persistent volumes in your cluster. 
+.... Optional: To create a customer managed KMS key, follow the procedure for link:https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html#create-symmetric-cmk[Creating symmetric encryption KMS keys].
 +
 [IMPORTANT]
 ====
@@ -233,7 +222,18 @@ For more information about the policies and permissions that the cluster Operato
 
 After you create your Operator roles, you must edit the _Key Policy_ in the link:https://console.aws.amazon.com/kms[*Key Management Service (KMS)* page of the AWS Console] to add the roles.
 ====
-
+... Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
++
+[NOTE]
+====
+If *Enable FIPS cryptography* is selected, *Enable additional etcd encryption* is enabled by default and cannot be disabled. You can select *Enable additional etcd encryption* without selecting *Enable FIPS cryptography*.
+====
+... Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption. With this option, the etcd key values are encrypted, but the keys are not. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
++
+[NOTE]
+====
+By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Consider enabling etcd encryption only if you specifically require it for your use case.
+====
 .. Click *Next*.
 
 . On the *Default machine pool* page, select a *Compute node instance type*.
@@ -382,7 +382,7 @@ You can review the end-of-life dates in the update life cycle documentation for 
 +
 [NOTE]
 ====
-In the event of critical security concerns that significantly impact the security or stability of a cluster, Red{nbsp}Hat Site Reliability Engineering (SRE) might schedule automatic updates to the latest z-stream version that is not impacted. The updates are applied within 48 hours after customer notifications are provided. For a description of the critical impact security rating, see link:https://access.redhat.com/security/updates/classification[Understanding Red{nbsp}Hat security ratings].
+If there are critical security concerns that significantly impact the security or stability of a cluster, Red{nbsp}Hat Site Reliability Engineering (SRE) might schedule automatic updates to the latest z-stream version that is not impacted. The updates are applied within 48 hours after customer notifications are provided. For a description of the critical impact security rating, see link:https://access.redhat.com/security/updates/classification[Understanding Red{nbsp}Hat security ratings].
 ====
 
 . Review the summary of your selections and click *Create cluster* to start the cluster installation.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
[OSDOCS-12109](https://issues.redhat.com/browse/OSDOCS-12109)

Link to docs preview:

- https://82357--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart-guide-ui.html

- https://82357--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html

- https://82357--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-ocm_rosa-sts-creating-a-cluster-with-customizations

SME review:
- [x] SME has approved this change.

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
**Reviewers: The changes to these docs includes adding a new **Enable FIPS Cryptography** field in the creation of a ROSA Classic cluster using the UI workflow, as well as adding new information that came with the design changes.

These changes are currently in stage.

The **Enable FIPS Cryptography** field also needs to be added to the create a cluster using the ROSA CLI docs. I will create a separate ticket for this as I think there are other fields that need to be updated.**
