### PR TITLE
TRACING-4559: clarify replication factor

### DIFF
--- a/modules/distr-tracing-tempo-config-default.adoc
+++ b/modules/distr-tracing-tempo-config-default.adoc
@@ -45,7 +45,7 @@ managementState: managed # <21>
 <5> Contains all of the configuration parameters of the TempoStack instance. When a common definition for all Tempo components is required, define it in the `spec` section. When the definition relates to an individual component, place it in the `spec.template.<component>` section.
 <6> Storage is specified at instance deployment. See the installation page for information about storage options for the instance.
 <7> Defines the compute resources for the Tempo container.
-<8> Configuration for the replication factor.
+<8> Integer value for the number of ingesters that must acknowledge the data from the distributors before accepting a span.
 <9> Configuration options for retention of traces.
 <10> Configuration options for the Tempo `distributor` component.
 <11> Configuration options for the Tempo `ingester` component.


### PR DESCRIPTION
Version(s):  4.18, 4.17, 4.16, 4.15, 4.14, 4.13, 4.12
Issue: [TRACING-4559](https://issues.redhat.com//browse/TRACING-4559)

Link to docs preview:  https://82367--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.html

QE review:
- [x] QE has approved this change.

Additional information: this can be added to the latest version of the documentation since it applies to the current RHOSDT version too.