### PR TITLE
TELCODOCS-1872: Docs and RN: CNF-11917 Expose MTU for vfio-pci SR-IOV devices to Pod (GA) - Release Notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -729,7 +729,12 @@ MetalLB also includes a new field for the Border Gateway Protocol (BGP) peer cus
 You can use this field to specify how long BGP waits between connection attempts to a neighbor.
 For more information, see xref:../networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-bgppeer-cr_configure-metallb-bgp-peers[About the BGP peer custom resource].
 
+[id="ocp-4-17-expose-mtu_{context}"]
+==== Exposing MTU for vfio-pci SR-IOV devices
 
+With this release, maximum transmission unit (MTU) on virtual function using the `vfio-pci` driver is available in the network-status pod annotation, and inside the container. 
+
+For more information, see xref:../networking/hardware_networks/add-pod.adoc#nw-sriov-expose-mtu_configuring-sr-iov[Exposing MTU for vfio-pci SR-IOV devices to pod].
 
 [id="ocp-4-17-registry"]
 === Registry


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1872: Docs and RN: [CNF-11917](https://issues.redhat.com//browse/CNF-11917) Expose MTU for vfio-pci SR-IOV devices to Pod (GA)

Applies to OCP version : 4.17

Preview: [Release Notes - Exposing MTU for vfio-pci SR-IOV devices to pod](https://82376--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-expose-mtu)

Dev review to be completed by @SchSeba
QE review to be completed by @evgenLevin
Peer review to be completed by @StephenJamesSmith

Thank you.