### PR TITLE
OSDOCS-11760: Admin/Dev console 4.17 release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -141,15 +141,46 @@ For more information, see xref:../installing/installing_aws/ipi/installing-aws-o
 [id="ocp-4-17-web-console_{context}"]
 === Web console
 
+[id="ocp-4-17-ocp-lightspeed_{context}"]
+==== {ols} Operator is available in the web console
+
+Starting with {product-title} 4.16, {ols} Operator is available for use in the web console. With this release, a hover button was added to help you discover {ols}. Once you click the hover button, the chat window appears with instructions on how to enable and install {ols} on the cluster. You can hide the {ols} button when changing the default user preferences.
+
+//https://github.com/openshift/openshift-docs/pull/81581
+//For more information, see xref:../web_console/capabilities_products-web-console.html#openshift-lightspeed-web-console_capabilities-web-console[Enhancing your experience in the {product-title} web console by using {ols-official}].
+
 [id="ocp-4-17-administrator-perspective_{context}"]
 ==== Administrator perspective
 
 This release introduces the following updates to the *Administrator* perspective of the web console:
 
+* Deprecated Operators are displayed in the OperatorHub before and after installation along with a warning notification that the Operator is deprecated.
+* You can check contnet of the configuration files for `MachineConfig` objects without having to manually retrieve its contents.
+* An alert was added to the *Operator details* page and the *Operator installation* page if your cluster is on {gcp-first} with Workload Identity Foundation (WIF).
+* A page for ShipWright `BuildStrategy` was added to the *Shipwright* page with a `ClusterBuildStrategy` and `BuildStrategy` tab.
+
+[id="ocp-4-17-customize-create-project-modal-dyanmic-plugin"]
+===== Customize the *Create project* modal using dynamic plugins
+
+With this release, a new extension point was added, so dynamic plugin creators can pass a component that renders in place of the default *Create Project* modal.
+
+For more information on {product-title} Console dynamic plugin SDK extensions, see xref:../web_console/dynamic-plugin/dynamic-plugins-reference.adoc#dynamic-plugin-sdk-extensions_dynamic-plugins-reference[Dynamic plugin extension types].
+
+[id="ocp-4-17-console-functional-external-oidc-issuer"]
+===== External OpenID Connect (OIDC) token issuer is now functional in the web console
+
+With this update, the web console works as expected when internal `oauth-server` resource and `oauth-apiserver` resource are removed and replaced with an external OpenID Connect (OIDC) issuer.
+
 [id="ocp-4-17-developer-perspective_{context}"]
 ==== Developer Perspective
 
 This release introduces the following updates to the *Developer* perspective of the web console:
+
+* When you use one of the add flows to create a new deployment, the *Import from Git* or *Container images* automatically opens them in the sidebar.
+* You can easily select the desired *Git Type* without having to use the list if {product-title} is unable to identify its type.
+* *Import from Git* supports GitEA, an open-source alternitve to GitHub.
+* A warning notification displays on the *Topology* page if the `PodDisruptionBudget` limit is reached.
+* When importing applications through the *Import from Git* flows you can use Shipwright Build strategies such as S2I, buildpack, and buildah strategy for building the image.
 
 [id="ocp-4-17-extensions_{context}"]
 === Extensions ({olmv1})
@@ -2300,6 +2331,20 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
+[discrete]
+=== Monitoring Technology Preview features
+
+.Monitoring Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.15 |4.16 |4.17
+
+|{ols-official} in the {product-title} web console
+| Not Available
+| Developer Preview
+| Developer Preview
+
+|====
 
 [discrete]
 === {rh-openstack-first} Technology Preview features


### PR DESCRIPTION
Combines addition of Addmin and dev console release notes

Version(s):
4.17

Issue:
[Web console 4.17 release notes](https://issues.redhat.com/browse/OSDOCS-11760)

Link to docs preview:
https://82377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-web-console_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
