### PR TITLE
Removed note that was related to OADP 1.1.z

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -10,11 +10,6 @@ toc::[]
 Frequent backups might consume storage on the backup storage location. Check the frequency of backups, retention time, and the amount of data of the persistent volumes (PVs) if using non-local backups, for example, S3 buckets.
 Because all taken backup remains until expired, also check the time to live (TTL) setting of the schedule.
 
-[NOTE]
-====
-There might be known issues with supported storage classes, for example, CSI backups might fail due to a Ceph limitation. For more information, see xref:../../../backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-1.adoc#known-issues_oadp-release-notes[Known issues].
-====
-
 You can back up applications by creating a `Backup` custom resource (CR). For more information, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#oadp-creating-backup-cr-doc[Creating a Backup CR].
 
 * The `Backup` CR creates backup files for Kubernetes resources and internal images on S3 object storage.


### PR DESCRIPTION
Version(s):
OADP 1.4.1
OCP 4.15

Issue:
[OADP-1793](https://issues.redhat.com/browse/OADP-1793)

In this PR, I've removed the note, which relates to a known issue in OADP 1.1.z, and is no longer a valid admonition. 
This is related to the merged [PR](https://github.com/openshift/openshift-docs/pull/80245).

