### PR TITLE
HCIDOCS-453: OCP clusters now support IPv6 CIDR format in the noProxy portion of proxy config

### DIFF
--- a/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
+++ b/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
@@ -6,8 +6,12 @@
 [id='ipi-install-setting-proxy-settings-within-install-config_{context}']
 = Setting proxy settings
 
-To deploy an {product-title} cluster using a proxy, make the following changes to the `install-config.yaml` file.
+To deploy an {product-title} cluster while using a proxy, make the following changes to the `install-config.yaml` file.
 
+.Procedure
+
+. Add proxy values under the `proxy` key mapping:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -17,23 +21,18 @@ proxy:
   httpsProxy: https://USERNAME:PASSWORD@proxy.example.com:PORT
   noProxy: <WILDCARD_OF_DOMAIN>,<PROVISIONING_NETWORK/CIDR>,<BMC_ADDRESS_RANGE/CIDR>
 ----
-
++
 The following is an example of `noProxy` with values.
-
++
 [source,yaml]
 ----
 noProxy: .example.com,172.22.0.0/24,10.10.0.0/24
 ----
 
-With a proxy enabled, set the appropriate values of the proxy in the corresponding key/value pair.
-
+. With a proxy enabled, set the appropriate values of the proxy in the corresponding key/value pair.
++
 Key considerations:
-
++
 * If the proxy does not have an HTTPS proxy, change the value of `httpsProxy` from `https://` to `http://`.
-* If using a provisioning network, include it in the `noProxy` setting, otherwise the installer will fail.
+* If the cluster uses a provisioning network, include it in the `noProxy` setting, otherwise the installation program fails.
 * Set all of the proxy settings as environment variables within the provisioner node. For example, `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
-
-[NOTE]
-====
-When provisioning with IPv6, you cannot define a CIDR address block in the `noProxy` settings. You must define each address separately.
-====


### PR DESCRIPTION
Removed a note admonition, because the issue was fixed in 4.17. Incorporated vale feedback.

Fixes: [HCIDOCS-453](https://issues.redhat.com//browse/HCIDOCS-453)

See https://issues.redhat.com/browse/HCIDOCS-453 for additional details.

Preview URL: https://82394--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-setting-proxy-settings-within-install-config_ipi-install-installation-workflow

For release(s): 4.17-4.18
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
