### PR TITLE
OSDOCS#11326: Release notes for OSSO 1.3.1

### DIFF
--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -12,10 +12,29 @@ These release notes track the development of the {secondary-scheduler-operator-f
 
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
 
+[id="secondary-scheduler-operator-release-notes-1.3.1_{context}"]
+== Release notes for {secondary-scheduler-operator-full} 1.3.1
+
+Issued: 3 October 2024
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.3.1:
+
+* link:https://access.redhat.com/errata/RHEA-2024:7073[RHEA-2024:7073]
+
+[id="secondary-scheduler-1.3.1-bug-fixes_{context}"]
+=== Bug fixes
+
+* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+[id="secondary-scheduler-operator-1.3.1-known-issues_{context}"]
+=== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
+
 [id="secondary-scheduler-operator-release-notes-1.3.0_{context}"]
 == Release notes for {secondary-scheduler-operator-full} 1.3.0
 
-Issued: 2024-07-01
+Issued: 1 July 2024
 
 The following advisory is available for the {secondary-scheduler-operator-full} 1.3.0:
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16 +

Issue:
https://issues.redhat.com/browse/OSDOCS-11326

Link to docs preview:
https://82395--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html#secondary-scheduler-operator-release-notes-1.3.1_nodes-secondary-scheduler-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:


**The link to the advisory won't work until the day of the release**

To be merged 3 October 2024