### PR TITLE
OSDOCS-11217 removing GCP CAPI from deprecated table

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -560,11 +560,11 @@ For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-no
 [id="ocp-4-17-nw-metallb"]
 ==== Changes to MetalLB
 
-With this update, MetalLB uses `FRR-K8s` as the default backend. 
+With this update, MetalLB uses `FRR-K8s` as the default backend.
 Previously, this was an optional feature available in Technology Preview.
 For more information, see xref:../networking/metallb/metallb-frr-k8s.adoc#metallb-configure-frr-k8s[Configuring the integration of MetalLB and FRR-K8s].
 
-MetalLB also includes a new field for the Border Gateway Protocol (BGP) peer custom resource, `connectTime`. 
+MetalLB also includes a new field for the Border Gateway Protocol (BGP) peer custom resource, `connectTime`.
 You can use this field to specify how long BGP waits between connection attempts to a neighbor.
 For more information, see xref:../networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-bgppeer-cr_configure-metallb-bgp-peers[About the BGP peer custom resource].
 
@@ -933,11 +933,6 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Removed
 |Removed
-
-|Terraform infrastructure provider for {gcp-first}
-|General Availability
-|Removable as Technology Preview
-|Removable as Technology Preview
 
 |Installing a cluster on {alibaba} with installer-provisioned infrastructure
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-11217

Link to docs preview:
https://82402--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-deprecated-removed-features_release-notes

QE review:
QE not needed, as this removal is doc only. same change was made for 4.16 in https://github.com/openshift/openshift-docs/pull/81767