### PR TITLE
OSDOCS#12081: Adding OADP to OKE table

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -286,6 +286,7 @@ s| Feature s| {oke} s| {product-title} s| Operator name
 | Embedded OperatorHub | Included | Included | N/A
 | Embedded Marketplace | Included | Included | N/A
 | Quay Compatibility (not included) | Included | Included | N/A
+| OpenShift API for Data Protection (OADP) | Included | Included | OADP Operator
 | RHEL Software Collections and RHT SSO Common Service (included) | Included | Included | N/A
 | Embedded Registry | Included | Included | N/A
 | Helm | Included | Included | N/A


### PR DESCRIPTION
[OSDOCS-12081](https://issues.redhat.com/browse/OSDOCS-12081) 

Version(s): 4.14+

This PR adds OADP to the list of features supported on OKE

QE review:
- [x] QE has approved this change.

Preview: [Feature summary](https://82403--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/oke_about.html#feature-summary)
