### PR TITLE
Replacing deprecated 'oc sa' commands with 'oc create token' commands

### DIFF
--- a/modules/migration-migrating-applications-api.adoc
+++ b/modules/migration-migrating-applications-api.adoc
@@ -45,7 +45,7 @@ EOF
 +
 [source,terminal]
 ----
-$ oc sa get-token migration-controller -n openshift-migration | base64 -w 0
+$ oc create token migration-controller -n openshift-migration | base64 -w 0
 ----
 
 . Create a `MigCluster` CR manifest for each remote cluster:

--- a/modules/migration-migrating-on-prem-to-cloud.adoc
+++ b/modules/migration-migrating-on-prem-to-cloud.adoc
@@ -105,7 +105,7 @@ $ oc get service -n <namespace>
 +
 [source,terminal]
 ----
-# oc sa get-token -n openshift-migration migration-controller
+# oc create token migration-controller -n openshift-migration
 ----
 
 . Open the {mtc-short} web console and add the source cluster, using the following values:

--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -89,7 +89,7 @@ ifdef::upgrading-3-4[]
 +
 [source,terminal]
 ----
-$ oc sa get-token migration-controller -n openshift-migration
+$ oc create token migration-controller -n openshift-migration
 ----
 
 .. In the {mtc-short} web console, click *Clusters*.

--- a/modules/service-accounts-as-oauth-clients.adoc
+++ b/modules/service-accounts-as-oauth-clients.adoc
@@ -22,7 +22,7 @@ When using a service account as an OAuth client:
 +
 [source,terminal]
 ----
-$ oc sa get-token <service_account_name>
+$ oc create token <service_account_name>
 ----
 
 * To get `WWW-Authenticate` challenges, set an


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-8098

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
