### PR TITLE
CMA 2.14.1-467 release notes

### DIFF
--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -10,6 +10,31 @@ The following release notes are for previous versions of the Custom Metrics Auto
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+[id="nodes-pods-autoscaling-custom-rn-2141_{context}"]
+== Custom Metrics Autoscaler Operator 2.14.1-454 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.14.1-454 provides a CVE, a new feature, and bug fixes for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHBA-2024:5865[RHBA-2024:5865].
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2141-new_{context}"]
+=== New features and enhancements
+
+[id="nodes-pods-autoscaling-custom-rn-2141-new-ca_{context}"]
+==== Support for the Cron trigger with the Custom Metrics Autoscaler Operator
+
+The Custom Metrics Autoscaler Operator can now use the Cron trigger to scale pods based on an hourly schedule. When your specified time frame starts, the Custom Metrics Autoscaler Operator scales pods to your desired amount. When the time frame ends, the Operator scales back down to the previous level.
+
+For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc#nodes-cma-autoscaling-custom-trigger-cron_nodes-cma-autoscaling-custom-trigger[Understanding the Cron trigger].
+
+[id="nodes-pods-autoscaling-custom-rn-2141-bugs_{context}"]
+=== Bug fixes
+
+* Previously, if you made changes to audit configuration parameters in the `KedaController` custom resource, the `keda-metrics-server-audit-policy` config map would not get updated. As a consequence, you could not change the audit configuration parameters after the initial deployment of the Custom Metrics Autoscaler. With this fix, changes to the audit configuration now render properly in the config map, allowing you to change the audit configuration any time after installation. (link:https://issues.redhat.com/browse/OCPBUGS-32521[*OCPBUGS-32521*])
+
 [id="nodes-pods-autoscaling-custom-rn-2131_{context}"]
 == Custom Metrics Autoscaler Operator 2.13.1 release notes
 

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -47,27 +47,17 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |General availability
 |===
 
-[id="nodes-pods-autoscaling-custom-rn-2141_{context}"]
-== Custom Metrics Autoscaler Operator 2.14.1 release notes
+[id="nodes-pods-autoscaling-custom-rn-2141-467_{context}"]
+== Custom Metrics Autoscaler Operator 2.14.1-467 release notes
 
-This release of the Custom Metrics Autoscaler Operator 2.14.1-454 provides a CVE, a new feature, and bug fixes for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHBA-2024:5865[RHBA-2024:5865].
+This release of the Custom Metrics Autoscaler Operator 2.14.1-467 provides a CVE and a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-2024:7348[RHSA-2024:7348].
 
 [IMPORTANT]
 ====
 Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
 ====
 
-[id="nodes-pods-autoscaling-custom-rn-2141-new_{context}"]
-=== New features and enhancements
-
-[id="nodes-pods-autoscaling-custom-rn-2141-new-ca_{context}"]
-==== Support for the Cron trigger with the Custom Metrics Autoscaler Operator
-
-The Custom Metrics Autoscaler Operator can now use the Cron trigger to scale pods based on an hourly schedule. When your specified time frame starts, the Custom Metrics Autoscaler Operator scales pods to your desired amount. When the time frame ends, the Operator scales back down to the previous level.
-
-For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc#nodes-cma-autoscaling-custom-trigger-cron_nodes-cma-autoscaling-custom-trigger[Understanding the Cron trigger].
-
-[id="nodes-pods-autoscaling-custom-rn-2141-bugs_{context}"]
+[id="nodes-pods-autoscaling-custom-rn-2141-467-bugs_{context}"]
 === Bug fixes
 
-* Previously, if you made changes to audit configuration parameters in the `KedaController` custom resource, the `keda-metrics-server-audit-policy` config map would not get updated. As a consequence, you could not change the audit configuration parameters after the initial deployment of the Custom Metrics Autoscaler. With this fix, changes to the audit configuration now render properly in the config map, allowing you to change the audit configuration any time after installation. (link:https://issues.redhat.com/browse/OCPBUGS-32521[*OCPBUGS-32521*])
+* Previously, the root file system of the Custom Metrics Autoscaler Operator pod was writable, which is unnecessary and could present security issues. This update makes the pod root file system read-only, which addresses the potential security issue. (link:https://issues.redhat.com/browse/OCPBUGS-37989[*OCPBUGS-37989*])


### PR DESCRIPTION
Errata: https://errata.devel.redhat.com/docs/show/138512

Peer reviewer: 
The errata link will not work until the release goes GA, planned for 9/30.

Previews:
[Custom Metrics Autoscaler Operator 2.14.1-467 release notes](https://82413--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn#nodes-pods-autoscaling-custom-rn-2141-467_nodes-cma-autoscaling-custom-rn)
The [2.14.1-454 release notes](https://82413--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.html#nodes-pods-autoscaling-custom-rn-2141_nodes-cma-autoscaling-custom-rn-past) were moved from [current release notes](https://docs.openshift.com/container-platform/4.16/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2141_nodes-cma-autoscaling-custom-rn) to past release notes. **NO CHANGE TO THE TEXT.** 