### PR TITLE
OCPBUGS-41766: Fix typo in oc create commands

### DIFF
--- a/modules/cnf-image-based-upgrade-prep-catalogsource.adoc
+++ b/modules/cnf-image-based-upgrade-prep-catalogsource.adoc
@@ -31,7 +31,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc create configmap example-catalogsources-cm --from-file=example-catalogsources.yaml=<path_to_catalogsource_cr> -n openshift-lifecycle-agent
+$ oc create configmap example-catalogsources-cm --from-file=<path_to_catalogsource_cr> -n openshift-lifecycle-agent
 ----
 
 . Patch the `ImageBasedUpgrade` CR by running the following command:

--- a/modules/cnf-image-based-upgrade-prep-extramanifests.adoc
+++ b/modules/cnf-image-based-upgrade-prep-extramanifests.adoc
@@ -52,7 +52,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc create configmap example-extra-manifests-cm --from-file=example-extra-manifests.yaml=<path_to_extramanifest> -n openshift-lifecycle-agent
+$ oc create configmap example-extra-manifests-cm --from-file=<path_to_extramanifests> -n openshift-lifecycle-agent
 ----
 
 . Patch the `ImageBasedUpgrade` CR by running the following command:

--- a/modules/cnf-image-based-upgrade-prep-oadp.adoc
+++ b/modules/cnf-image-based-upgrade-prep-oadp.adoc
@@ -58,7 +58,7 @@ The same version of the applications must function on both the current and the t
 +
 [source,terminal]
 ----
-$ oc create configmap oadp-cm-example --from-file=example-oadp-resources.yaml=<path_to_oadp_crs> -n openshift-adp
+$ oc create configmap oadp-cm-example --from-file=<path_to_oadp_crs> -n openshift-adp
 ----
 
 . Patch the `ImageBasedUpgrade` CR by running the following command:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-41766
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://82432--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-prep-resources.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
