### PR TITLE
OSDOCS#12123: Describe the --render Usage

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2412,7 +2412,7 @@ Topics:
     File: hcp-sizing-guidance
   - Name: Overriding resouce utilization measurements
     File: hcp-override-resource-util
-  - Name: Installing the hosted control plane command line interface
+  - Name: Installing the hosted control plane command-line interface
     File: hcp-cli
   - Name: Distributing hosted cluster workloads
     File: hcp-distribute-workloads

--- a/modules/advanced-node-tuning-hosted-cluster.adoc
+++ b/modules/advanced-node-tuning-hosted-cluster.adoc
@@ -50,24 +50,30 @@ The `.spec.recommend.match` field is intentionally left blank. In this case, thi
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$MGMT_KUBECONFIG" create -f tuned-hugepages.yaml
+$ oc --kubeconfig="<management_cluster_kubeconfig>" create -f tuned-hugepages.yaml <1>
 ----
+<1> Replace `<management_cluster_kubeconfig>` with the name of your management cluster `kubeconfig` file.
 
 . Create a `NodePool` manifest YAML file, customize the upgrade type of the `NodePool`, and reference the `ConfigMap` object that you created in the `spec.tuningConfig` section. Create the `NodePool` manifest and save it in a file named `hugepages-nodepool.yaml` by using the `hcp` CLI:
 +
-[source,yaml]
+[source,terminal]
 ----
-    NODEPOOL_NAME=hugepages-example
-    INSTANCE_TYPE=m5.2xlarge
-    NODEPOOL_REPLICAS=2
-
-    hcp create nodepool aws \
-      --cluster-name $CLUSTER_NAME \
-      --name $NODEPOOL_NAME \
-      --node-count $NODEPOOL_REPLICAS \
-      --instance-type $INSTANCE_TYPE \
-      --render > hugepages-nodepool.yaml
+$ hcp create nodepool aws \
+  --cluster-name <hosted_cluster_name> \// <1>
+  --name <nodepool_name> \// <2>
+  --node-count <nodepool_replicas> \// <3>
+  --instance-type <instance_type> \// <4>
+  --render > hugepages-nodepool.yaml
 ----
+<1> Replace `<hosted_cluster_name>` with the name of your hosted cluster.
+<2> Replace `<nodepool_name>` with the name of your node pool.
+<3> Replace `<nodepool_replicas>` with the number of your node pool replicas, for example, `2`.
+<4> Replace `<instance_type>` with the instance type, for example, `m5.2xlarge`.
++
+[NOTE]
+====
+The `--render` flag in the `hcp create` command does not render the secrets. To render the secrets, you must use both the `--render` and the `--render-sensitive` flags in the `hcp create` command.
+====
 
 . In the `hugepages-nodepool.yaml` file, set `.spec.management.upgradeType` to `InPlace`, and set `.spec.tuningConfig` to reference the `tuned-hugepages` `ConfigMap` object that you created.
 +
@@ -97,7 +103,7 @@ To avoid the unnecessary re-creation of nodes when you apply the new `MachineCon
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$MGMT_KUBECONFIG" create -f hugepages-nodepool.yaml
+$ oc --kubeconfig="<management_cluster_kubeconfig>" create -f hugepages-nodepool.yaml
 ----
 
 .Verification
@@ -108,7 +114,7 @@ After the nodes are available, the containerized TuneD daemon calculates the req
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" get tuned.tuned.openshift.io -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="<hosted_cluster_kubeconfig>" get tuned.tuned.openshift.io -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output
@@ -124,7 +130,7 @@ rendered             123m
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" get profile.tuned.openshift.io -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="<hosted_cluster_kubeconfig>" get profile.tuned.openshift.io -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output
@@ -143,7 +149,7 @@ Both of the worker nodes in the new `NodePool` have the `openshift-node-hugepage
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" debug node/nodepool-1-worker-1 -- chroot /host cat /proc/cmdline
+$ oc --kubeconfig="<hosted_cluster_kubeconfig>" debug node/nodepool-1-worker-1 -- chroot /host cat /proc/cmdline
 ----
 +
 .Example output

--- a/modules/restoring-etcd-snapshot-hosted-cluster.adoc
+++ b/modules/restoring-etcd-snapshot-hosted-cluster.adoc
@@ -10,6 +10,11 @@ If you have a snapshot of etcd from your hosted cluster, you can restore it. Cur
 
 To restore an etcd snapshot, you modify the output from the `create cluster --render` command and define a `restoreSnapshotURL` value in the etcd section of the `HostedCluster` specification.
 
+[NOTE]
+====
+The `--render` flag in the `hcp create` command does not render the secrets. To render the secrets, you must use both the `--render` and the `--render-sensitive` flags in the `hcp create` command.
+====
+
 .Prerequisites
 
 You took an etcd snapshot on a hosted cluster.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12123
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://82438--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-backup-restore-aws.html#restoring-etcd-snapshot-hosted-cluster_hcp-backup-restore-aws

- https://82438--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator.html#advanced-node-tuning-hosted-cluster_node-tuning-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
