### PR TITLE
OSSM- 7920 OSSM 2.6.2 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -167,7 +167,7 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.1
+:SMProductVersion: 2.6.2
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-4-11.adoc
+++ b/modules/ossm-release-2-4-11.adoc
@@ -1,0 +1,36 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-4-11_{context}"]
+= {SMProductName} version 2.4.11
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.2, addresses Common Vulnerabilities and Exposures (CVEs), and is supported on {product-title} 4.14 and later.
+
+[id=ossm-release-2-4-11-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Kiali Server
+|1.65.16
+|===
+
+[id="ossm-fixed-issues-2-4-11_{context}"]
+== Fixed issues
+
+* https://issues.redhat.com/browse/OSSM-8001[OSSM-8001] Previously, when the `runAsUser` and `runAsGroup` parameters were set to the same value in pods, the proxy GID was incorrectly set to match the container's GID, causing traffic interception issues with iptables rules applied by Istio CNI. Now, containers can have the same value for the `runAsUser` and `runAsGroup` parameters, and iptables rules apply correctly.
+
+* https://issues.redhat.com/browse/OSSM-8074[OSSM-8074] Previously, the {KialiProduct} failed to install the Kiali Server when a {SMProductShortName} had a numeric-only namespace (e.g., `12345`). Now, namespaces with only numerals work correctly.
+
+//add horizontal line rule/line break to help user visually understand that 2.6, 2.5.3, and 2.4.9 are a separate, different release.
+'''

--- a/modules/ossm-release-2-5-5.adoc
+++ b/modules/ossm-release-2-5-5.adoc
@@ -1,0 +1,34 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-5-5_{context}"]
+= {SMProductName} version 2.5.5
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.2, addresses Common Vulnerabilities and Exposures (CVEs), and is supported on {product-title} 4.14 and later.
+
+
+[id=ossm-release-2-5-5-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.18.7
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali Server
+|1.73.15
+|===
+
+[id="ossm-fixed-issues-2-5-5_{context}"]
+== Fixed issues
+
+* https://issues.redhat.com/browse/OSSM-8001[OSSM-8001] Previously, when the `runAsUser` and `runAsGroup` parameters were set to the same value in pods, the proxy GID was incorrectly set to match the container's GID, causing traffic interception issues with iptables rules applied by Istio CNI. Now, containers can have the same value for the `runAsUser` and `runAsGroup` parameters, and iptables rules apply correctly.
+
+* https://issues.redhat.com/browse/OSSM-8074[OSSM-8074] Previously, the {KialiProduct} failed to install the Kiali Server when a {SMProductShortName} had a numeric-only namespace (e.g., `12345`). Now, namespaces with only numerals work correctly.

--- a/modules/ossm-release-2-6-0.adoc
+++ b/modules/ossm-release-2-6-0.adoc
@@ -17,7 +17,6 @@ This release of {SMProductName} includes versions 2.5.3 and 2.4.9, adds new feat
 
 This release ends maintenance support for {SMProductName} version 2.3. If you are using {SMProductShortName} version 2.3, you should update to a supported version.
 
-include::snippets/ossm-current-version-support-snippet.adoc[]
 //FIPS messaging verified with Matt Werner, CS, OCP on 06/27/2024 via Slack. It is also the same FIPS messaging currently used by Serverless.
 //Per Scott Dodson on 07/15/204 via Slack, confirmed that RHEL 2.9 has been submitted for FIPS validation. Admonition updated accordingly.
 //Per Kirsten Newcomer on 07/16/2024 via Slack, FIPS messaging for Service Mesh has been changed. Jamie (PM) has agreed with change.

--- a/modules/ossm-release-2-6-1.adoc
+++ b/modules/ossm-release-2-6-1.adoc
@@ -9,8 +9,6 @@ Module included in the following assemblies:
 
 This release of {SMProductName} includes 2.6.1, 2.5.4, and 2.4.10; addresses Common Vulnerabilities and Exposures (CVEs); contains a bug fix; and is supported on {product-title} 4.14 and later.
 
-include::snippets/ossm-current-version-support-snippet.adoc[]
-
 The most current version of the {KialiProduct} can be used with all supported versions of {SMProductName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource.  The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
 [id=ossm-release-2-6-1-components_{context}]

--- a/modules/ossm-release-2-6-2.adoc
+++ b/modules/ossm-release-2-6-2.adoc
@@ -1,0 +1,46 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-2_{context}"]
+= {SMProductName} version 2.6.2
+
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.2, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.2, 2.5.5 and 2.4.11.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.14 and later.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+The most current version of the {KialiProduct} can be used with all supported versions of {SMProductName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id=ossm-release-2-6-2-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.7
+
+|Kiali Server
+|1.73.15
+|===
+
+[id="ossm-new-features-2-6-2_{context}"]
+== New features
+
+* The {cert-manager-operator} is now supported on {ibm-power-title}, {ibm-z-title}, and {ibm-linuxone-name}.
+
+[id="ossm-fixed-issues-2-6-2_{context}"]
+== Fixed issues
+
+* https://issues.redhat.com/browse/OSSM-8099[OSSM-8099] Previously, there was an issue supporting persistent session labels when the endpoints were in the draining phase. Now, there is a method of handling draining endpoints for the stateful header sessions.
+
+* https://issues.redhat.com/browse/OSSM-8001[OSSM-8001] Previously, when `runAsUser` and `runAsGroup` were set to the same value in pods, the proxy GID was incorrectly set to match the container's GID, causing traffic interception issues with iptables rules applied by Istio CNI. Now, containers can have the same value for runAsUser and runAsGroup, and iptables rules apply correctly.
+
+* https://issues.redhat.com/browse/OSSM-8074[OSSM-8074] Previously, the Kiali Operator failed to install the Kiali server when a {SMProductShortName} had a numeric-only namespace (e.g., `12345`). Now, namespaces with only numerals work correctly.

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -10,6 +10,12 @@ toc::[]
 
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
+include::modules/ossm-release-2-6-2.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-5-5.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-4-11.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-1.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-5-4.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.2 (At Stage): Release Notes, Known Issues and Bug Fixes

Doc JIRA: https://issues.redhat.com/browse/OSSM-7920

Fix Version: 4.14+

Doc Preview: https://82442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-2_ossm-release-notes

SME Review: @yxun 
QE Review: @mkralik3 
Peer Review: @lpettyjo 