### PR TITLE
OSDOCS-12049 multi-arch upgrades

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,13 +16,15 @@ toc::[]
 [id="rosa-q3-2024_{context}"]
 === Q3 2024
 
+* **{hcp-title} multi-architecture cluster update.** {hcp-title-first} clusters created before 25 July, 2024 will migrate to a multi-architecture image on their next upgrade allowing you to use {AWS} Arm-based Graviton instance types for your workloads. For more information, see xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-upgrade-options_rosa-hcp-upgrading[Upgrading ROSA with HCP clusters].
+
 * **{hcp-title} cluster node limit update.** {hcp-title} clusters can now scale to 250 worker nodes. This is an increase from the previous limit of 180 nodes. For more information, see xref:../rosa_planning/rosa-hcp-limits-scalability.adoc#tested-cluster-maximums-hcp-sd_rosa-hcp-limits-scalability[ROSA with HCP limits and scalability].
 
 * **IMDSv2 support in {hcp-title}.** You can now enforce the use of the IMDSv2 endpoint for default machine pool worker nodes on new {hcp-title} clusters and for new machine pools on existing clusters. For more information, see xref:../rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc#rosa-hcp-creating-a-cluster-quickly-terraform[Creating a default ROSA cluster using Terraform].
 
 * **Upgrade multiple nodes simultaneously.** You can now configure a machine pool to upgrade multiple nodes simultaneously. Two new machine pool parameters, `max-surge` and `max-unavailable`, give you greater control over how machine pool upgrades occur. For more information, see xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading ROSA with HCP clusters].
 
-* **{hcp-title} Graviton (ARM) instance types.** You can now use {AWS} Arm-based Graviton instance types for your workloads in {hcp-title-first} clusters created after 24 July, 2024, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-sdpolicy-aws-instance-types-graviton_rosa-hcp-instance-types[AWS Graviton (ARM) instance types].
+* **{hcp-title} Graviton Arm-based instance types.** You can now use {AWS} Arm-based Graviton instance types for your workloads in {hcp-title-first} clusters created after 24 July, 2024. For more information, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-sdpolicy-aws-instance-types-graviton_rosa-hcp-instance-types[AWS Graviton Arm-based instance types].
 
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.42[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 

--- a/upgrading/rosa-hcp-upgrading.adoc
+++ b/upgrading/rosa-hcp-upgrading.adoc
@@ -27,6 +27,12 @@ The life cycle page includes release definitions, support and upgrade requiremen
 
 Upgrades are manually initiated or automatically scheduled. Red Hat Site Reliability Engineers (SREs) monitor upgrade progress and remedy any issues encountered.
 
+//The following note should be removed when the entire HCP fleet is confirmed multi-arch
+[NOTE]
+====
+If your control plane is not currently multi-architecture enabled, the upgrade process will first migrate the cluster to a multi-architecture image and then apply the version upgrade. Multi-architecture clusters are capable of running both x86-based and Arm-based workloads. Clusters created after 25 July, 2024 are multi-architecture enabled by default. 
+====
+
 include::modules/rosa-hcp-upgrading-cli-control-plane.adoc[leveloffset=+1]
 
 include::modules/rosa-hcp-upgrading-cli-machinepool.adoc[leveloffset=+1]


### PR DESCRIPTION
Added a note to the upgrade section describing the multi-arch upgrade process for existing clusters. 
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-12049

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Update in upgrade section:
https://82455--ocpdocs-pr.netlify.app/openshift-rosa/latest/upgrading/rosa-hcp-upgrading.html#rosa-lifecycle-policy_rosa-hcp-upgrading

RN
https://82455--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes#rosa-q3-2024_rosa-whats-new


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
