### PR TITLE
OCPBUGS#33115: Update backup/restore, disaster recovery for HCP

### DIFF
--- a/modules/hcp-recover-failing-etcd-pods.adoc
+++ b/modules/hcp-recover-failing-etcd-pods.adoc
@@ -14,7 +14,7 @@ Each etcd pod of a 3-node cluster has its own persistent volume claim (PVC) to s
 +
 [source,terminal]
 ----
-$ oc get pods -l app=etcd -n <hosted_control_plane_namespace>
+$ oc get pods -l app=etcd -n openshift-etcd
 ----
 +
 .Example output
@@ -32,7 +32,7 @@ The failing etcd pod might have the `CrashLoopBackOff` or `Error` status.
 +
 [source,terminal]
 ----
-$ oc delete pvc/<etcd_pvc_name> pod/<etcd_pod_name> --wait=false
+$ oc delete pods etcd-2 -n openshift-etcd
 ----
 
 .Verification
@@ -41,7 +41,7 @@ $ oc delete pvc/<etcd_pvc_name> pod/<etcd_pod_name> --wait=false
 +
 [source,terminal]
 ----
-$ oc get pods -l app=etcd -n <hosted_control_plane_namespace>
+$ oc get pods -l app=etcd -n openshift-etcd
 ----
 +
 .Example output

--- a/modules/hosted-cluster-etcd-status.adoc
+++ b/modules/hosted-cluster-etcd-status.adoc
@@ -14,19 +14,24 @@ You can check the status of the etcd cluster health by logging into any etcd pod
 +
 [source,terminal]
 ----
-$ oc rsh -n <hosted_control_plane_namespace> -c etcd <etcd_pod_name>
+$ oc rsh -n openshift-etcd -c etcd <etcd_pod_name>
 ----
 
 . Print the health status of an etcd cluster by entering the following command:
 +
 [source,terminal]
 ----
-sh-4.4$ etcdctl endpoint health --cluster -w table
+sh-4.4# etcdctl endpoint status -w table
 ----
 +
 .Example output
 [source,terminal]
 ----
-ENDPOINT                                                HEALTH  TOOK        ERROR
-https://etcd-0.etcd-discovery.clusters-hosted.svc:2379  true    9.117698ms
++------------------------------+-----------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+|          ENDPOINT            |       ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
++------------------------------+-----------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
+| https://192.168.1xxx.20:2379 | 8fxxxxxxxxxx    |  3.5.12 |  123 MB |     false |      false |        10 |     180156 |             180156 |        |
+| https://192.168.1xxx.21:2379 | a5xxxxxxxxxx    |  3.5.12 |  122 MB |     false |      false |        10 |     180156 |             180156 |        |
+| https://192.168.1xxx.22:2379 | 7cxxxxxxxxxx    |  3.5.12 |  124 MB |      true |      false |        10 |     180156 |             180156 |        |
++-----------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
 ----


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OCPBUGS-33115](https://issues.redhat.com/browse/OCPBUGS-33115)

Link to docs preview:
[Recovering an unhealthy etcd cluster](https://82468--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.html) 

QE review:
- [x] QE has approved this change.

Additional information:
N/A