### PR TITLE
CNV-32743: Adding placeholder text for CNV asynchronous release

### DIFF
--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -10,11 +10,11 @@ toc::[]
 Documentation for {VirtProductName} will be available for {product-title} {product-version} in the near future.
 
 ifdef::openshift-origin[]
-In the meantime, the link:https://docs.okd.io/4.15/virt/about_virt/about-virt.html[{VirtProductName} 4.15 documentation] is available as part of the {product-title} 4.15 documentation.
+In the meantime, the link:https://docs.okd.io/4.16/virt/about_virt/about-virt.html[{VirtProductName} 4.16 documentation] is available as part of the {product-title} 4.16 documentation.
 endif::[]
 
 ifdef::openshift-enterprise[]
-In the meantime, the link:https://docs.openshift.com/container-platform/4.15/virt/about_virt/about-virt.html[{VirtProductName} 4.15 documentation] is available as part of the {product-title} 4.15 documentation.
+In the meantime, the link:https://docs.openshift.com/container-platform/4.16/virt/about_virt/about-virt.html[{VirtProductName} 4.16 documentation] is available as part of the {product-title} 4.16 documentation.
 endif::[]
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-32743](https://issues.redhat.com//browse/CNV-32743)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://82469--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: OpenShift Virtualization will go GA after core OCP. This PR adds placeholder text to the about-virt.adoc file to prepare for CNV asynchronous release from OCP.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
