### PR TITLE
OSDOCS-11301 updating AWS AMIs for 4.17

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,97 +23,97 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-018de6b1be470b7e6`
+|`ami-019b3e090bb062842`
 
 |`ap-east-1`
-|`ami-092f09a4c8aacf56a`
+|`ami-0cb76d97f77cda0a1`
 
 |`ap-northeast-1`
-|`ami-001c9fc85b77505f4`
+|`ami-0d7d4b329e5403cfb`
 
 |`ap-northeast-2`
-|`ami-0a5d7f1966d88fba3`
+|`ami-02d3789d532feb517`
 
 |`ap-northeast-3`
-|`ami-085a2726ceb4f5eeb`
+|`ami-08b82c4899109b707`
 
 |`ap-south-1`
-|`ami-03f2c19071fb6eab3`
+|`ami-0c184f8b5ad8af69d`
 
 |`ap-south-2`
-|`ami-0c82522890979d94b`
+|`ami-0b0525037b9a20e9a`
 
 |`ap-southeast-1`
-|`ami-06e5b9d16ead6c55c`
+|`ami-0dbee0006375139a7`
 
 |`ap-southeast-2`
-|`ami-0ccd429129fbf6bc0`
+|`ami-043072b1af91be72f`
 
 |`ap-southeast-3`
-|`ami-096f9b4d41116d95c`
+|`ami-09d8bbf16b228139e`
 
 |`ap-southeast-4`
-|`ami-0b511ab55f9f7d052`
+|`ami-01c6b29e9c57b434b`
 
 |`ca-central-1`
-|`ami-0e357287c651be1f2`
+|`ami-06fda1fa0b65b864b`
 
 |`ca-west-1`
-|`ami-0b1692e5776740901`
+|`ami-0141eea486b5e2c43`
 
 |`eu-central-1`
-|`ami-08b13fb388ba5610d`
+|`ami-0f407de515454fdd0`
 
 |`eu-central-2`
-|`ami-04777298b55045ea9`
+|`ami-062cfad83bc7b71b8`
 
 |`eu-north-1`
-|`ami-05421993a4ee567b9`
+|`ami-0af77aba6aebb5086`
 
 |`eu-south-1`
-|`ami-00959341869d34746`
+|`ami-04d9da83bc9f854fc`
 
 |`eu-south-2`
-|`ami-0a745b610522a87cc`
+|`ami-035d487abf54f0af7`
 
 |`eu-west-1`
-|`ami-0e48f85ec57bd7baa`
+|`ami-043dd3b788dbaeb1c`
 
 |`eu-west-2`
-|`ami-0c015b1387acddc5e`
+|`ami-0c7d0f90a4401b723`
 
 |`eu-west-3`
-|`ami-01e466af77a95b93d`
+|`ami-039baa878e1def55f`
 
 |`il-central-1`
-|`ami-0a1b706793b54d087`
+|`ami-07d305bf03b2148de`
 
 |`me-central-1`
-|`ami-09d58e8b2099ae5bc`
+|`ami-0fc457e8897ccb41a`
 
 |`me-south-1`
-|`ami-0f9c259bc4346599c`
+|`ami-0af99a751cf682b90`
 
 |`sa-east-1`
-|`ami-06277517d966881a3`
+|`ami-04a7300f64ee01d68`
 
 |`us-east-1`
-|`ami-05483066c3caaccf5`
+|`ami-01b53f2824bf6d426`
 
 |`us-east-2`
-|`ami-0c704ce516493a479`
+|`ami-0565349610e27bd41`
 
 |`us-gov-east-1`
-|`ami-0695b2cbdd1ec4d48`
+|`ami-0020504fa043fe41d`
 
 |`us-gov-west-1`
-|`ami-004404a0eaa427b39`
+|`ami-036798bce4722d3c2`
 
 |`us-west-1`
-|`ami-0aaa56637063be772`
+|`ami-0147c634ad692da52`
 
 |`us-west-2`
-|`ami-0870c7a3d5ef4d2b3`
+|`ami-0c65d71e89d43aa90`
 
 |===
 
@@ -126,97 +126,97 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-0d96d447d3df14f4e`
+|`ami-0e585ef53405bebf5`
 
 |`ap-east-1`
-|`ami-010236402dfba1717`
+|`ami-05f32f1715bb51bda`
 
 |`ap-northeast-1`
-|`ami-08feeb6d9068bb12e`
+|`ami-05ecb62bab0c50e52`
 
 |`ap-northeast-2`
-|`ami-0772082c119147205`
+|`ami-0a3ffb2c07c9e4a8d`
 
 |`ap-northeast-3`
-|`ami-05bcbb13493d0516f`
+|`ami-0ae6746ea17d1042c`
 
 |`ap-south-1`
-|`ami-0034a539e8adcb817`
+|`ami-00deb5b08c86060b8`
 
 |`ap-south-2`
-|`ami-0fc56b7c53c38ff70`
+|`ami-047a47d5049781e03`
 
 |`ap-southeast-1`
-|`ami-0b50a0e92a58f3ad8`
+|`ami-09cb598f0d36fde4c`
 
 |`ap-southeast-2`
-|`ami-0697a9174ae206182`
+|`ami-01fe8a7538500f24c`
 
 |`ap-southeast-3`
-|`ami-05ae309319a7ad504`
+|`ami-051b3f67dd787d5e9`
 
 |`ap-southeast-4`
-|`ami-00500414843baa657`
+|`ami-04d2e14a9eef40143`
 
 |`ca-central-1`
-|`ami-05e76bf99d3b0d4c8`
+|`ami-0f66973ff12d09356`
 
 |`ca-west-1`
-|`ami-099fc953c221ec590`
+|`ami-0c9f3e2f0470d6d0b`
 
 |`eu-central-1`
-|`ami-0d2e2698884020b71`
+|`ami-0a79af8849b425a8a`
 
 |`eu-central-2`
-|`ami-0a96ba21ddee01719`
+|`ami-0f9f66951c9709471`
 
 |`eu-north-1`
-|`ami-0ab8a1070d0b1d9a5`
+|`ami-0670362aa7eb9032d`
 
 |`eu-south-1`
-|`ami-0d0465299a8b196c1`
+|`ami-031b24b970eae750b`
 
 |`eu-south-2`
-|`ami-07d5aa3c6d468c738`
+|`ami-0734d2ed55c00a46c`
 
 |`eu-west-1`
-|`ami-08e7d209f26c09c80`
+|`ami-0a9af75c2649471c0`
 
 |`eu-west-2`
-|`ami-0c8336d4e2c1f13cb`
+|`ami-0b84155a3672ac44e`
 
 |`eu-west-3`
-|`ami-085d804b98acf0648`
+|`ami-02b51442c612818d4`
 
 |`il-central-1`
-|`ami-02ce030e36aeb7643`
+|`ami-0d2c47a297d483ce4`
 
 |`me-central-1`
-|`ami-0dea3ac466040b77f`
+|`ami-0ef3005246bd83b07`
 
 |`me-south-1`
-|`ami-02ef2a46887b9786d`
+|`ami-0321ca1ee89015eda`
 
 |`sa-east-1`
-|`ami-0d19817d31b2399f9`
+|`ami-0e63f1103dc71d8ae`
 
 |`us-east-1`
-|`ami-04859c888566a2c2f`
+|`ami-0404da96615c73bec`
 
 |`us-east-2`
-|`ami-02f7e4a5dc66361bb`
+|`ami-04c3bd7be936f728f`
 
 |`us-gov-east-1`
-|`ami-067ef782980ea96ad`
+|`ami-0d30bc0b99b153247`
 
 |`us-gov-west-1`
-|`ami-0ce67540c1bb2319d`
+|`ami-0ee006f84d6aa5045`
 
 |`us-west-1`
-|`ami-0a09c5d2f287718a3`
+|`ami-061bfd61d5cfd7aa6`
 
 |`us-west-2`
-|`ami-06b94e64e595f6cee`
+|`ami-05ffb8f6f18b8e3f8`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-11301

Link to docs preview:
https://82471--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra

QE review:
- [x] QE has approved this change.
