### PR TITLE
OSDOCS-12128: SDN support removal for prepping cluster update

### DIFF
--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -24,6 +24,16 @@ Learn more about administrative tasks that cluster admins must perform to succes
 Without the correct micro-architecture requirements, the update process will fail. Make sure you purchase the appropriate subscription for each architecture. For more information, see link:https://access.redhat.com/products/red-hat-enterprise-linux#addl-arch[Get Started with Red Hat Enterprise Linux - additional architectures]
 ====
 
+[id="sdn-support-removal"]
+== SDN support removal
+
+OpenShift SDN network plugin was deprecated in versions 4.15 and 4.16. With this release, the SDN network plugin is no longer supported and the content has been removed from the documentation.
+
+[IMPORTANT]
+====
+It is not possible to update a cluster to {product-title} 4.17 if it is using the OpenShift SDN network plugin. You must migrate to the OVN-Kubernetes plugin before upgrading to {product-title} 4.17. 
+====
+
 [id="kube-api-removals_{context}"]
 == Kubernetes API removals
 


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12128

Link to docs preview:
https://82493--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#sdn-support-removal

QE review:
N/A

Additional information:
Adding content from @JoeAldinger to the "Preparing to update a cluster" section of docs. See https://github.com/openshift/openshift-docs/pull/81504 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
