### PR TITLE
MIG-1651: Adding Support Matrix to MTC

### DIFF
--- a/migration_toolkit_for_containers/about-mtc.adoc
+++ b/migration_toolkit_for_containers/about-mtc.adoc
@@ -2,6 +2,7 @@
 [id="about-mtc"]
 = About the Migration Toolkit for Containers
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: about-mtc
 
 toc::[]
@@ -24,6 +25,7 @@ See xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
 * Automating your migration with migration hooks and the {mtc-short} API.
 * Configuring your migration plan to exclude resources, support large-scale migrations, and enable automatic PV resizing for direct volume migration.
 
+include::modules/migration-mtc-support.adoc[leveloffset=+1]
 include::modules/migration-terminology.adoc[leveloffset=+1]
 include::modules/migration-mtc-workflow.adoc[leveloffset=+1]
 include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]

--- a/modules/migration-mtc-support.adoc
+++ b/modules/migration-mtc-support.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/about-mtc.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-support_{context}"]
+= {mtc-short} 1.8 support
+
+* {mtc-short} 1.8.3 and earlier using {oadp-short} 1.3.z is supported on all {OCP-short} versions 4.15 and earlier.
+
+* {mtc-short} 1.8.4 and later using {oadp-short} 1.3.z is currently supported on all {OCP-short} versions 4.15 and earlier.
+
+* {mtc-short} 1.8.4 and later using {oadp-short} 1.4.z is currently supported on all supported {OCP-short} versions 4.13 and later.


### PR DESCRIPTION
### JIRA

* [MIG-1651](https://issues.redhat.com/browse/MIG-1651)

### Version(s):

* OCP 4.12+

### Link to docs preview:

* [MTC 1.8 support matrix](https://82498--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/about-mtc.html#migration-mtc-support_about-mtc)
### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
