### PR TITLE
OCPBUGS#29653: Added note about the --overwrite flag

### DIFF
--- a/modules/security-context-constraints-psa-opting.adoc
+++ b/modules/security-context-constraints-psa-opting.adoc
@@ -10,7 +10,7 @@ You can enable or disable automatic pod security admission synchronization for m
 
 [IMPORTANT]
 ====
-You cannot enable pod security admission synchronization on 
+You cannot enable pod security admission synchronization on
 ifndef::openshift-dedicated,openshift-rosa[]
 some
 endif::openshift-dedicated,openshift-rosa[]
@@ -20,6 +20,8 @@ system-created namespaces. For more information, see _Pod security admission syn
 .Procedure
 
 * For each namespace that you want to configure, set a value for the `security.openshift.io/scc.podSecurityLabelSync` label:
++
+--
 ** To disable pod security admission label synchronization in a namespace, set the value of the `security.openshift.io/scc.podSecurityLabelSync` label to `false`.
 +
 Run the following command:
@@ -37,3 +39,9 @@ Run the following command:
 ----
 $ oc label namespace <namespace> security.openshift.io/scc.podSecurityLabelSync=true
 ----
+--
++
+[NOTE]
+====
+Use the `--overwrite` flag to overwrite the value if this label is already set on the namespace.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-29653

Link to docs preview:
https://82499--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/understanding-and-managing-pod-security-admission.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
