### PR TITLE
OCPBUGS#34919: Added service account to deployment

### DIFF
--- a/modules/secrets-store-aws.adoc
+++ b/modules/secrets-store-aws.adoc
@@ -295,6 +295,7 @@ spec:
       labels:
         app: my-storage
     spec:
+      serviceAccountName: aws-provider
       containers:
       - name: busybox
         image: k8s.gcr.io/e2e-test-images/busybox:1.29


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-34919

Link to docs preview:
https://82503--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-aws_nodes-pods-secrets-store

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
