### PR TITLE
[rosa_hcp_migration] Updates XREF links

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -142,6 +142,8 @@ Name: Install ROSA with HCP clusters
 Dir: rosa_hcp
 Distros: openshift-rosa-hcp
 Topics:
+- Name: ROSA with HCP quick start guide
+  File: rosa-hcp-quickstart-guide
 - Name: Creating ROSA with HCP clusters using the default options
   File: rosa-hcp-sts-creating-a-cluster-quickly
 - Name: Creating ROSA with HCP clusters using a custom AWS KMS encryption key

--- a/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-prerequisites.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-prerequisites.adoc
@@ -13,13 +13,12 @@ toc::[]
 
 . A Provisioned ROSA cluster
 +
-This lab assumes you have access to a successfully provisioned a ROSA cluster. If you have not yet created a ROSA cluster, see 
 ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_getting_started/rosa-quickstart-guide-ui.html#rosa-getting-started-prerequisites_rosa-quickstart-guide-ui[Red{nbsp}Hat OpenShift Service on AWS quick start guide] for more information.
+This lab assumes you have access to a successfully provisioned a ROSA cluster. If you have not yet created a ROSA cluster, see xref:../../rosa_hcp/rosa-hcp-quickstart-guide.adoc#rosa-getting-started-environment-setup_rosa-hcp-quickstart-guide[ROSA with HCP quick start guide] for more information.
 endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../../rosa_getting_started/rosa-quickstart-guide-ui.adoc#rosa-getting-started-prerequisites_rosa-quickstart-guide-ui[Red{nbsp}Hat OpenShift Service on AWS quick start guide] for more information.
-endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
+This lab assumes you have access to a successfully provisioned a ROSA cluster. If you have not yet created a ROSA cluster, see xref:../../rosa_getting_started/rosa-quickstart-guide-ui.adoc#rosa-getting-started-environment-setup_rosa-quickstart-guide-ui[ROSA quick start guide] for more information.
+endif::openshift-rosa[]
 
 . The OpenShift Command Line Interface (CLI)
 +
@@ -34,3 +33,7 @@ endif::openshift-rosa-hcp[]
 . A GitHub Account
 +
 Use your existing GitHub account or register at link:https://github.com/signup[https://github.com/signup].
+
+include::modules/rosa-sts-understanding-aws-account-association.adoc[leveloffset=+2]
+[discrete]
+include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]

--- a/modules/rosa-getting-started-deleting-a-cluster.adoc
+++ b/modules/rosa-getting-started-deleting-a-cluster.adoc
@@ -14,7 +14,12 @@ ifeval::["{context}" == "rosa-quickstart"]
 :quickstart:
 endif::[]
 
+ifdef::openshift-rosa-hcp[]
+You can delete a ROSA cluster by using the {product-title} (ROSA) CLI, `rosa`. You can also use the ROSA CLI to delete the AWS Identity and Access Management (IAM) account-wide roles, the cluster-specific Operator roles, and the OpenID Connect (OIDC) provider. To delete the account-wide inline and Operator policies, you can use the AWS IAM Console.
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
 You can delete a ROSA cluster that uses the AWS Security Token Service (STS) by using the {product-title} (ROSA) CLI, `rosa`. You can also use the ROSA CLI to delete the AWS Identity and Access Management (IAM) account-wide roles, the cluster-specific Operator roles, and the OpenID Connect (OIDC) provider. To delete the account-wide inline and Operator policies, you can use the AWS IAM Console.
+endif::openshift-rosa-hcp[]
 
 [IMPORTANT]
 ====
@@ -77,7 +82,13 @@ $ rosa delete account-roles --prefix <prefix> --mode auto <1>
 ----
 <1> You must include the `--<prefix>` argument. Replace `<prefix>` with the prefix of the account-wide roles to delete. If you did not specify a custom prefix when you created the account-wide roles, specify the default prefix, `ManagedOpenShift`.
 
+ifdef::openshift-rosa-hcp[]
+. Delete the account-wide inline and Operator IAM policies that you created for ROSA deployments:
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
 . Delete the account-wide inline and Operator IAM policies that you created for ROSA deployments that use STS:
+endif::openshift-rosa-hcp[]
++
 .. Log in to the link:https://console.aws.amazon.com/iamv2/home#/home[AWS IAM Console].
 .. Navigate to *Access management* -> *Policies* and select the checkbox for one of the account-wide policies.
 .. With the policy selected, click on *Actions* -> *Delete* to open the delete policy dialog.

--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -4,12 +4,6 @@
 // * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
 // * rosa_getting_started/rosa-quickstart-guide-ui.adoc
 
-ifeval::["{context}" == "rosa-hcp-sts-creating-a-cluster-quickly"]
-:rosa-hcp:
-endif::[]
-ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
-:rosa-classic:
-endif::[]
 ifeval::["{context}" == "rosa-classic-creating-a-cluster-quickly-terraform"]
 :tf-classic:
 endif::[]
@@ -23,21 +17,21 @@ endif::[]
 
 ifndef::tf-classic,tf-hcp[]
 You can quickly create a
-ifdef::rosa-hcp[]
-{hcp-title}
-endif::rosa-hcp[]
-ifndef::rosa-hcp[]
-{product-title} (ROSA)
-endif::rosa-hcp[]
-cluster with the {sts-first} by using the default installation options. The following summary describes the default cluster specifications.
+ifdef::openshift-rosa-hcp[]
+{product-title} cluster by using the default installation options.
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
+{product-title} (ROSA) cluster with the {sts-first} by using the default installation options.
+endif::openshift-rosa[]
+The following summary describes the default cluster specifications.
 endif::tf-classic,tf-hcp[]
 
-ifdef::rosa-hcp[]
-.Default {hcp-title} cluster specifications
-endif::rosa-hcp[]
-ifdef::rosa-classic[]
+ifdef::openshift-rosa-hcp[]
+.Default {product-title} cluster specifications
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
 .Default ROSA with STS cluster specifications
-endif::rosa-classic[]
+endif::openshift-rosa[]
 
 [cols=".^1,.^3a",options="header"]
 |===
@@ -66,13 +60,13 @@ ifdef::tf-classic,tf-hcp[]
 endif::tf-classic,tf-hcp[]
 ifndef::tf-classic,tf-hcp[]
 * Default cluster version: Latest
-ifndef::rosa-hcp[]
+ifdef::openshift-rosa[]
 * Default AWS region for installations using the {cluster-manager-first} {hybrid-console-second}: us-east-1 (US East, North Virginia)
-endif::rosa-hcp[]
-ifdef::rosa-hcp[]
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
 * Default AWS region for installations using the ROSA CLI (`rosa`): Defined by your `aws` CLI configuration
 * Default EC2 IMDS endpoints (both v1 and v2) are enabled
-endif::rosa-hcp[]
+endif::openshift-rosa-hcp[]
 * Availability: Single zone for the data plane
 endif::tf-classic,tf-hcp[]
 ifndef::rosa-hcp,tf-hcp[]
@@ -83,14 +77,14 @@ endif::rosa-hcp,tf-hcp[]
 |Encryption
 |* Cloud storage is encrypted at rest
 * Additional etcd encryption is not enabled
-ifndef::rosa-hcp,tf-hcp[]
+ifdef::openshift-rosa,tf-classic[]
 * The default AWS Key Management Service (KMS) key is used as the encryption key for persistent data
-endif::rosa-hcp,tf-hcp[]
-ifdef::rosa-hcp,tf-hcp[]
-* AWS Key Management Service (KMS) key encryption is not enabled by default.
-endif::rosa-hcp,tf-hcp[]
+endif::openshift-rosa,tf-classic[]
+ifdef::openshift-rosa-hcp,tf-hcp[]
+* AWS Key Management Service (KMS) key encryption is not enabled by default
+endif::openshift-rosa-hcp,tf-hcp[]
 
-ifndef::rosa-hcp,tf-hcp[]
+ifdef::openshift-rosa,tf-classic[]
 |Control plane node configuration
 |* Control plane node instance type: m5.2xlarge (8 vCPU, 32 GiB RAM)
 * Control plane node count: 3
@@ -98,7 +92,7 @@ ifndef::rosa-hcp,tf-hcp[]
 |Infrastructure node configuration
 |* Infrastructure node instance type: r5.xlarge (4 vCPU, 32 GiB RAM)
 * Infrastructure node count: 2
-endif::rosa-hcp,tf-hcp[]
+endif::openshift-rosa,tf-classic[]
 
 |Compute node machine pool
 |* Compute node instance type: m5.xlarge (4 vCPU 16, GiB RAM)
@@ -120,9 +114,9 @@ ifdef::tf-classic,tf-hcp[]
 * Cluster privacy: public or private
 * You can choose to create a new VPC during the Terraform cluster creation process.
 endif::tf-classic,tf-hcp[]
-ifdef::rosa-hcp[]
+ifdef::openshift-rosa[]
 * You must have configured your own Virtual Private Cloud (VPC)
-endif::rosa-hcp[]
+endif::openshift-rosa[]
 * No cluster-wide proxy is configured
 
 |Classless Inter-Domain Routing (CIDR) ranges
@@ -139,12 +133,12 @@ ifndef::tf-classic,tf-hcp[]
 endif::tf-classic,tf-hcp[]
 * Host prefix: /23
 +
-ifdef::rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
 [NOTE]
 ====
-When using {hcp-title}, the static IP address `172.20.0.1` is reserved for the internal Kubernetes API address. The machine, pod, and service CIDRs ranges must not conflict with this IP address.
+The static IP address `172.20.0.1` is reserved for the internal Kubernetes API address. The machine, pod, and service CIDRs ranges must not conflict with this IP address.
 ====
-endif::rosa-hcp[]
+endif::openshift-rosa-hcp[]
 
 |Cluster roles and policies
 |* Mode used to create the Operator roles and the OpenID Connect (OIDC) provider: `auto`
@@ -166,12 +160,6 @@ endif::tf-classic,tf-hcp[]
 
 |===
 
-ifeval::["{context}" == "rosa-hcp-sts-creating-a-cluster-quickly"]
-:!rosa-hcp:
-endif::[]
-ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
-:!rosa-classic:
-endif::[]
 ifeval::["{context}" == "rosa-classic-creating-a-cluster-quickly-terraform"]
 :!tf-classic:
 endif::[]

--- a/nodes/index.adoc
+++ b/nodes/index.adoc
@@ -34,13 +34,13 @@ image::295_OpenShift_Nodes_Overview_1222.png[Overview of control plane and worke
 
 The read operations allow an administrator or a developer to get information about nodes in an {product-title} cluster.
 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
+ifndef::openshift-enterprise,openshift-rosa-hcp,openshift-rosa[]
 * xref:../nodes/nodes/nodes-nodes-viewing.adoc#nodes-nodes-viewing-listing_nodes-nodes-viewing[List all the nodes in a cluster].
 * Get information about a node, such as memory and CPU usage, health, status, and age.
 * xref:../nodes/nodes/nodes-nodes-viewing.adoc#nodes-nodes-viewing-listing-pods_nodes-nodes-viewing[List pods running on a node].
-endif::openshift-rosa-hcp,openshift-rosa[]
+endif::openshift-enterprise,openshift-rosa-hcp,openshift-rosa[]
 
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifndef::openshift-enterprise,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [discrete]
 === Management operations
 
@@ -54,7 +54,7 @@ through several tasks:
 * xref:../nodes/nodes/nodes-nodes-managing-max-pods.adoc#nodes-nodes-managing-max-pods-proc_nodes-nodes-managing-max-pods[Configure the number of pods that can run on a node] based on the number of processor cores on the node, a hard limit, or both.
 * Reboot a node gracefully using xref:../nodes/nodes/nodes-nodes-rebooting.adoc#nodes-nodes-rebooting-affinity_nodes-nodes-rebooting[pod anti-affinity].
 * xref:../nodes/nodes/nodes-nodes-working.adoc#deleting-nodes[Delete a node from a cluster] by scaling down the cluster using a compute machine set. To delete a node from a bare-metal cluster, you must first drain all pods on the node and then manually delete the node.
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+endif::openshift-enterprise,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 [discrete]
 === Enhancement operations
@@ -62,16 +62,16 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 {product-title} allows you to do more than just access and manage nodes; as an administrator, you can perform the following tasks on nodes to make the cluster more efficient, application-friendly, and to provide a better environment for your developers.
 
 * Manage node-level tuning for high-performance applications that require some level of kernel tuning by 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
+ifndef::openshift-enterprise,openshift-rosa-hcp,openshift-rosa[]
 xref:../nodes/nodes/nodes-node-tuning-operator.adoc#nodes-node-tuning-operator[using the Node Tuning Operator].
 * xref:../nodes/jobs/nodes-pods-daemonsets.adoc#nodes-pods-daemonsets[Run background tasks on nodes automatically with daemon sets]. You can create and use daemon sets to create shared storage, run a logging pod on every node, or deploy a monitoring agent on all nodes.
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+endif::openshift-enterprise,openshift-rosa-hcp,openshift-rosa[]
+ifndef::openshift-enterprise,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * Enable TLS security profiles on the node to protect communication between the kubelet and the Kubernetes API server.
 * xref:../nodes/nodes/nodes-nodes-garbage-collection.adoc#nodes-nodes-garbage-collection[Free node resources using garbage collection]. You can ensure that your nodes are running efficiently by removing terminated containers and the images not referenced by any running pods.
 * xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-managing[Add kernel arguments to a set of nodes].
 * Configure an {product-title} cluster to have worker nodes at the network edge (remote worker nodes). For information on the challenges of having remote worker nodes in an {product-title} cluster and some recommended approaches for managing pods on a remote worker node, see xref:../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers[Using remote worker nodes at the network edge].
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+endif::openshift-enterprise,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifdef::openshift-rosa-hcp,openshift-rosa[]
 * link:https://docs.openshift.com/rosa/nodes/jobs/nodes-pods-daemonsets.html#nodes-pods-daemonsets[Run background tasks on nodes automatically with daemon sets]. You can create and use daemon sets to create shared storage, run a logging pod on every node, or deploy a monitoring agent on all nodes.
 endif::openshift-rosa-hcp,openshift-rosa[]

--- a/rosa_architecture/about-hcp.adoc
+++ b/rosa_architecture/about-hcp.adoc
@@ -8,8 +8,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 //IMPORTANT!!!
 //This page includes information from "Understanding ROSA" (rosa-architecture-rosa-understanding) and "What is ROSA" (cloud-experts-getting-started-what-is-rosa). I have intentionally deleted those two modules from the HCP topic map in an effort to condense our introductory materials.
 
-
-
 toc::[]
 
 ROSA is a fully-managed turnkey application platform that allows you to focus on what matters most, delivering value to your customers by building and deploying applications. Red{nbsp}Hat and AWS SRE experts manage the underlying platform so you do not have to worry about infrastructure management. ROSA provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, and other services to further accelerate the building and delivering of differentiating experiences to your customers.
@@ -49,13 +47,7 @@ endif::openshift-rosa[]
 * *AWS service integration:* AWS has a robust portfolio of cloud services, such as compute, storage, networking, database, analytics, and machine learning. All of these services are directly accessible through ROSA. This makes it easier to build, operate, and scale globally and on-demand through a familiar management interface.
 * *Maximum availability:* Deploy clusters across multiple availability zones in supported regions to maximize availability and maintain high availability for your most demanding mission-critical applications and data.
 * *Optimized clusters:* Choose from memory-optimized, compute-optimized, or general purpose EC2 instance types with clusters sized to meet your needs.
-* *Global availability:* Refer to the 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition[product regional availability page] to see where ROSA is available globally.
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-service-definition[product regional availability page] to see where ROSA is available globally.
-endif::openshift-rosa[]
+* *Global availability:* Refer to the xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[product regional availability page] to see where ROSA is available globally.
 
 include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+1]
 
@@ -84,12 +76,7 @@ ifndef::openshift-rosa-hcp[]
 xref:../rosa_backing_up_and_restoring_applications/backing-up-applications.adoc#rosa-backing-up-applications[Back up and restore]
 endif::openshift-rosa-hcp[]
 | 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html#rosa-hcp-life-cycle[{hcp-title} life cycle]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
 xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{hcp-title} life cycle]
-endif::openshift-rosa-hcp[]
 | 
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/architecture/rosa-architecture-models.html#rosa-architecture-models[{hcp-title} architecture]
@@ -105,19 +92,9 @@ ifndef::openshift-rosa-hcp[]
 xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding process and security]
 endif::openshift-rosa-hcp[]
 | 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-hcp-service-definition[{hcp-title} service definition]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
 xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-hcp-service-definition[{hcp-title} service definition]
-endif::openshift-rosa-hcp[]
-| 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html#rosa-life-cycle[Updates lifecycle]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[Updates lifecycle]
-endif::openshift-rosa-hcp[]
+|
+xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[Updates lifecycle]
 | 
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/rosa_planning/rosa-limits-scalability.html#rosa-limits-scalability[Limits and scalability]
@@ -150,12 +127,7 @@ ifndef::openshift-rosa-hcp[]
 xref:../architecture/rosa-architecture-models.adoc#rosa-architecture-models[{hcp-title} architecture]
 endif::openshift-rosa-hcp[]
 | 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-sts-creating-a-cluster-quickly[Installing {hcp-title}]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
 xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Installing {hcp-title}]
-endif::openshift-rosa-hcp[]
 | 
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/observability/logging/cluster-logging.html#cluster-logging[Logging]
@@ -175,12 +147,7 @@ endif::openshift-rosa-hcp[]
 
 | link:https://learn.openshift.com/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[OpenShift Interactive Learning Portal]
 | 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/storage/index.html#storage-overview[Storage]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
 xref:../storage/index.adoc#storage-overview[Storage]
-endif::openshift-rosa-hcp[]
 | 
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/observability/monitoring/monitoring-overview.html#monitoring-overview_virt-monitoring-overview[Monitoring overview]
@@ -189,12 +156,7 @@ ifndef::openshift-rosa-hcp[]
 xref:../observability/monitoring/monitoring-overview.adoc#monitoring-overview_virt-monitoring-overview[Monitoring overview]
 endif::openshift-rosa-hcp[]
 | 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html#rosa-hcp-life-cycle[{hcp-title} life cycle]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
 xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{hcp-title} life cycle]
-endif::openshift-rosa-hcp[]
 |
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-responsibility-matrix[ROSA responsibility matrix]
@@ -226,12 +188,7 @@ ifndef::openshift-rosa-hcp[]
 xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-understand-availability.adoc#rosa-policy-understand-availability[About availability]
 endif::openshift-rosa-hcp[]
 | 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/upgrading/rosa-hcp-upgrading.html#rosa-hcp-upgrading[Upgrading]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
 xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading]
-endif::openshift-rosa-hcp[]
 |
 |
 

--- a/rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
+++ b/rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
@@ -37,24 +37,12 @@ Security features for AWS STS include:
 
 [id="components-specific-to-rosa-hcp-with-sts"]
 == Components of {hcp-title}
-* *AWS infrastructure* - The infrastructure required for the cluster including the Amazon EC2 instances, Amazon EBS storage, and networking components. See 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-aws-compute-types_rosa-service-definition[AWS compute types] to see the supported instance types for compute nodes and link:https://docs.openshift.com/rosa/rosa_planning/rosa-sts-aws-prereqs.html#rosa-ec2-instances_rosa-sts-aws-prereqs[provisioned AWS infrastructure] for more information on cloud resource configuration.
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-aws-compute-types_rosa-service-definition[AWS compute types] to see the supported instance types for compute nodes and xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-ec2-instances_rosa-sts-aws-prereqs[provisioned AWS infrastructure] for more information on cloud resource configuration.
-endif::openshift-rosa-hcp[]
+* *AWS infrastructure* - The infrastructure required for the cluster including the Amazon EC2 instances, Amazon EBS storage, and networking components. See link:https://docs.openshift/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-aws-compute-types_rosa-service-definition[AWS compute types] to see the supported instance types for compute nodes and link:https://docs.openshift/rosa/rosa_planning/rosa-sts-aws-prereqs.html#rosa-ec2-instances_rosa-sts-aws-prereqs[provisioned AWS infrastructure] for more information on cloud resource configuration.
 * *AWS STS* - A method for granting short-term, dynamic tokens to provide users the necessary permissions to temporarily interact with your AWS account resources.
 * *OpenID Connect (OIDC)* - A mechanism for cluster Operators to authenticate with AWS, assume the cluster roles through a trust policy, and obtain temporary credentials from AWS IAM STS to make the required API calls.
 * *Roles and policies* - The roles and policies used by {hcp-title} can be divided into account-wide roles and policies and Operator roles and policies.
 +
-The policies determine the allowed actions for each of the roles. See 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-about-iam-resources[About IAM resources for ROSA clusters that use STS] for more details about the individual roles and policies and link:https://docs.openshift.com/rosa/rosa_planning/rosa-sts-ocm-role.html#rosa-sts-ocm-role[ROSA IAM role resource] for more details about trust policies.
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for ROSA clusters that use STS] for more details about the individual roles and policies and xref:../rosa_planning/rosa-sts-ocm-role.adoc#rosa-sts-ocm-role[ROSA IAM role resource] for more details about trust policies.
-endif::openshift-rosa-hcp[]
+The policies determine the allowed actions for each of the roles. See link:https://docs.openshift/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-about-iam-resources[About IAM resources for ROSA clusters that use STS] for more details about the individual roles and policies and link:https://docs.openshift/rosa/rosa_planning/rosa-sts-ocm-role.html#rosa-sts-ocm-role[ROSA IAM role resource] for more details about trust policies.
 +
 --
 ** The account-wide roles are:
@@ -108,14 +96,7 @@ Deploying a {hcp-title} cluster follows the following steps:
 
 During the cluster creation process, the ROSA CLI creates the required JSON files for you and outputs the commands you need. If desired, the ROSA CLI can also run the commands for you.
 
-The ROSA CLI can automatically create the roles for you, or you can manually create them by using the `--mode manual` or `--mode auto` flags. For further details about deployment, see 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster with customizations].
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster with customizations].
-endif::openshift-rosa-hcp[]
-//Change the above xref when we have HCP specific docs
+The ROSA CLI can automatically create the roles for you, or you can manually create them by using the `--mode manual` or `--mode auto` flags. For further details about deployment, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster with customizations].
 
 [id="hcp-sts-process"]
 == {hcp-title} workflow

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc
@@ -11,26 +11,16 @@ include::modules/life-cycle-overview.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-ifdef::openshift-rosa-hcp[]
-* link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-service-definition[{product-title} service definition]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-service-definition[{product-title} service definition]
-endif::openshift-rosa-hcp[]
+* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-hcp-service-definition[{product-title} service definition]
 
 include::modules/life-cycle-definitions.adoc[leveloffset=+1]
 include::modules/life-cycle-major-versions.adoc[leveloffset=+1]
 include::modules/life-cycle-minor-versions.adoc[leveloffset=+1]
 
+
 [role="_additional-resources"]
 .Additional resources
-
-ifdef::openshift-rosa-hcp[]
-* link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html#rosa-limited-support_rosa-life-cycle[{product-title} limited support status]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-limited-support_rosa-life-cycle[{product-title} limited support status]
-endif::openshift-rosa-hcp[]
+* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-limited-support_rosa-hcp-life-cycle[{product-title} limited support status]
 
 include::modules/life-cycle-patch-versions.adoc[leveloffset=+1]
 include::modules/life-cycle-limited-support.adoc[leveloffset=+1]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
@@ -19,25 +19,14 @@ include::modules/rosa-sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional Resources
 
-ifdef::openshift-rosa-hcp[]
-* link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-red-hat-operator_rosa-service-definition[Red{nbsp}Hat Operator Support]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-red-hat-operator_rosa-service-definition[Red{nbsp}Hat Operator Support]
-endif::openshift-rosa-hcp[]
+* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-red-hat-operator_rosa-hcp-service-definition[Red{nbsp}Hat Operator Support]
 
 include::modules/rosa-sdpolicy-instance-types.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional Resources
 
-For a detailed listing of supported instance types, see 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_policy_service_definition/rosa-hcp-instance-types.html#rosa-hcp-instance-types[{hcp-title} instance types].
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-hcp-instance-types[{hcp-title} instance types].
-endif::openshift-rosa-hcp[]
+For a detailed listing of supported instance types, see xref:../rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-hcp-instance-types[{hcp-title} instance types].
 
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]
 
@@ -81,10 +70,4 @@ ifndef::openshift-rosa-hcp[]
 xref:../rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding process and security for ROSA] for the latest compliance information.
 endif::openshift-rosa-hcp[]
 
-* See 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[ROSA life cycle]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[ROSA life cycle]
-endif::openshift-rosa-hcp[]
+* See xref:../rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[ROSA life cycle]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
@@ -20,21 +20,11 @@ include::modules/rosa-customer-access.adoc[leveloffset=+1]
 include::modules/rosa-access-approval-review.adoc[leveloffset=+1]
 include::modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the AWS IAM roles used by the cluster Operators, see 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-operator-roles_rosa-sts-about-iam-resources[Cluster-specific Operator IAM role reference].
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-operator-roles_rosa-sts-about-iam-resources[Cluster-specific Operator IAM role reference].
-endif::openshift-rosa-hcp[]
+* For more information about the AWS IAM roles used by the cluster Operators, see xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-operator-roles_rosa-sts-about-iam-resources[Cluster-specific Operator IAM role reference].
 
-* For more information about the policies and permissions that the cluster Operators require, see 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation].
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation].
+* For more information about the policies and permissions that the cluster Operators require, see xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation].
 endif::openshift-rosa-hcp[]

--- a/rosa_hcp/rosa-hcp-quickstart-guide.adoc
+++ b/rosa_hcp/rosa-hcp-quickstart-guide.adoc
@@ -1,0 +1,60 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="rosa-hcp-quickstart-guide"]
+= {product-title} quick start guide
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-hcp-quickstart-guide
+
+toc::[]
+
+Follow this guide to quickly create a {product-title} (ROSA) cluster using the command-line interface (CLI), grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
+
+[discrete]
+include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+2]
+
+include::modules/rosa-getting-started-environment-setup.adoc[leveloffset=+1]
+[discrete]
+include::modules/rosa-getting-started-enable-rosa.adoc[leveloffset=+2]
+[discrete]
+include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffset=+2]
+
+.Next steps
+
+Before you can use the {cluster-manager} {hybrid-console-second} to deploy ROSA clusters, you must associate your AWS account with your Red{nbsp}Hat organization and create the required account-wide STS roles and policies. For information on how your AWS and Red Hat accounts interact, see xref:../cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-prerequisites.adoc#rosa-sts-understanding-aws-account-association_cloud-experts-deploying-application-prerequisites[Understanding AWS account association]
+
+include::modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+1]
+
+[id="rosa-hcp-quickstart-creating-vpc"]
+== Creating a Virtual Private Cloud for your {hcp-title} clusters
+
+You must have a Virtual Private Cloud (VPC) to create {hcp-title} cluster. You can use the following methods to create a VPC:
+
+* Create a VPC by using a Terraform template
+* Manually create the VPC resources in the AWS console
+
+[NOTE]
+====
+The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use. You should also ensure that when you use this Terraform script it is in the same region that you intend to install your cluster. In these examples, use `us-east-2`.
+====
+
+[discrete]
+include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=1]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-quickstart-vpc-terraform"]
+.Additional resources
+
+* See the link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC] repository for a detailed list of all options available when customizing the VPC for your needs.
+
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+1]
+include::modules/rosa-operator-config.adoc[leveloffset=+1]
+include::modules/rosa-hcp-sts-creating-a-cluster-cli.adoc[leveloffset=+1]
+include::modules/rosa-getting-started-grant-user-access.adoc[leveloffset=+1]
+include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+1]
+include::modules/rosa-getting-started-access-cluster-web-console.adoc[leveloffset=+1]
+include::modules/deploy-app.adoc[leveloffset=+1]
+include::modules/rosa-getting-started-revoking-admin-privileges-and-user-access.adoc[leveloffset=+1]
+[discrete]
+include::modules/rosa-getting-started-revoke-admin-privileges.adoc[leveloffset=+2]
+[discrete]
+include::modules/rosa-getting-started-revoke-user-access.adoc[leveloffset=+2]
+include::modules/rosa-getting-started-deleting-a-cluster.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR repairs the links to the **[Introduction to ROSA](https://82513--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/)** and **[Learning about ROSA](https://82513--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/cloud-experts-getting-started-hcp-for-hcp)** sections of the ROSA with HCP migration.

This PR also updates the **[ROSA with HCP quick start](https://82513--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-quickstart-guide.html)** guide.