### PR TITLE
RHDEVDOCS 6174 Set unsupported doc versions on layered products in d.o.c

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -45,11 +45,11 @@
 
     unsupported_versions_acs = ["3.65", "3.66", "3.67", "3.68", "3.69", "3.70", "3.71", "3.72", "3.73", "3.74", "4.0", "4.1", "4.2", "4.3"];
 
-    unsupported_versions_serverless = [];
+    unsupported_versions_serverless = ["1.28", "1.29", "1.30", "1.31"];
 
-    unsupported_versions_pipelines = ["1.10"];
+    unsupported_versions_pipelines = ["1.10", "1.11", "1.12"];
 
-    unsupported_versions_gitops = [];
+    unsupported_versions_gitops = ["1.8", "1.9", "1.10", "1.11"];
 
     unsupported_versions_builds = [];
 
@@ -126,7 +126,7 @@
 
         <span>
           <div class="alert alert-danger" role="alert" id="support-alert">
-            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/pipelines/latest/about/understanding-openshift-pipelines.html" style="color: #545454 !important" class="link-primary">latest Pipelines docs</a>.
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/pipelines/latest/about/about-pipelines.html" style="color: #545454 !important" class="link-primary">latest Pipelines docs</a>.
           </div>
         </span>
 
@@ -147,7 +147,7 @@
 
         <span>
           <div class="alert alert-danger" role="alert" id="support-alert">
-            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/gitops/latest/release_notes/gitops-release-notes.html" style="color: #545454 !important" class="link-primary">latest GitOps docs</a>.
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html" style="color: #545454 !important" class="link-primary">latest GitOps docs</a>.
           </div>
         </span>
 
@@ -242,7 +242,7 @@
               <option value="1.28">1.28</option>
             </select>
         <% elsif (distro_key == "openshift-pipelines") %>
-            <a href="https://docs.openshift.com/pipelines/<%= version %>/about/op-release-notes.html">
+            <a href="https://docs.openshift.com/pipelines/<%= version %>/about/about-pipelines.html">
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
@@ -262,7 +262,7 @@
               <option value="1.1">1.1</option>
             </select>
         <% elsif (distro_key == "openshift-gitops") %>
-            <a href="https://docs.openshift.com/gitops/<%= version %>/release_notes/gitops-release-notes.html">
+            <a href="https://docs.openshift.com/gitops/<%= version %>/understanding_openshift_gitops/about-redhat-openshift-gitops.html">
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
main only

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6174

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
N/A

QE review:
N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This is a technical PR to ensure that docs.openshift.com displays an "unsupported version" warning when you view an unsupported version of the documentation set for GitOps, Pipelines, or Serverless, per https://access.redhat.com/support/policy/updates/openshift_operators as of September 25, 2004.

Documentation content is not affected, therefore, QE review and doc previews are not applicable.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
