### PR TITLE
OSDOCS-11208-storage-nodes: Documented node and storage bug fixes 4.17

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1232,6 +1232,8 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-17-deprecated-features_{context}"]
 === Deprecated features
 
+* In {product-title} {product-version}, `kube-apiserver` no longer gets a valid cloud configuration object. As a result, the `PersistentVolumeLabel` admission plugin rejects in-tree Google Compute Engine (GCE) PD PVs, or persistent disk persistent volumes, that do not have the correct topology. (link:https://issues.redhat.com/browse/OCPBUGS-34544[*OCPBUGS-34544*])
+
 [id="ocp-4-17-removed-features_{context}"]
 === Removed features
 
@@ -1445,9 +1447,19 @@ metadata:
 [id="ocp-4-17-node-bug-fixes_{context}"]
 ==== Node
 
+* Previously, the Container Runtime Config controller did not detect whether a mirror configuration was in use before adding the scope from a `ClusterImagePolicy` CR to the `/etc/containers/registries.d/sigstore-registries.yaml` file. As a consequence, image verification failed with a `Not looking for sigstore attachments` message. With this fix, images are pulled from the mirror registry as expected. (link:https://issues.redhat.com/browse/OCPBUGS-36344[*OCPBUGS-36344*])
+
+* Previously, a group ID was not added to the `/etc/group` directory within a container when the `spec.securityContext.runAsGroup` attribute was set in the pod specification. With this release, this issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-39478[*OCPBUGS-39478*])
+
+* Previously, because of a critical regression on RHEL 9.4 kernels earlier than `5.14.0-427.26.1.el9_4`, the `mglru` feature had memory management disabled. In this release, the regression issue is fixed so that the `mglru` feature is now enabled in {product-title} {product-version}. (link:https://issues.redhat.com/browse/OCPBUGS-35436[*OCPBUGS-35436*])
+
 [discrete]
 [id="ocp-4-17-node-tuning-operator-bug-fixes_{context}"]
 ==== Node Tuning Operator (NTO)
+
+* Previously, due to an internal bug, the Node Tuning Operator incorrectly computed CPU masks for interrupt and network-handling CPU affinity if a machine had more than 256 CPUs. This prevented proper CPU isolation on those machines and resulted in `systemd` unit failures. With this release, the Node Tuning Operator computes the masks correctly. (link:https://issues.redhat.com/browse/OCPBUGS-39164[*OCPBUGS-39164*]) 
+
+* Previously, the Open vSwitch (OVS) pinning procedure set the CPU affinity of the main thread, but other CPU threads did not pick up this affinity if they had already been created. As a consequence, some OVS threads did not run on the correct CPU set, which might interfere with the performance of pods with a Quality of Service (QoS) class of `Guaranteed`. With this update, the OVS pinning procedure updates the affinity of all the OVS threads, ensuring that all OVS threads run on the correct CPU set. (link:https://issues.redhat.com/browse/OCPBUGS-35347[*OCPBUGS-35347*])
 
 [discrete]
 [id="ocp-4-17-openshift-cli-bug-fixes_{context}"]
@@ -1473,6 +1485,7 @@ metadata:
 [id="ocp-4-17-storage-bug-fixes_{context}"]
 ==== Storage
 
+* Previously, the Secrets Store Container Storage Interface (CSI) Driver on {hcp} clusters failed to mount secrets because of an issue when using the {hcp} command-line interface, `hcp`, to create OpenID Connect (OIDC) infrastructure on {aws-full}. With this release, the issue has been fixed so that the driver can now mount volumes. (link:https://issues.redhat.com/browse/OCPBUGS-18711[*OCPBUGS-18711*])
 
 [discrete]
 [id="ocp-4-17-windows-containers-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11208](https://issues.redhat.com/browse/OSDOCS-11208)

Link to docs preview:
* [Networking bug fixes](https://82531--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-bug-fixes_release-notes)
