### PR TITLE
OSDOCS-11208-dev-console: Documented dev console bug fixes 4.17

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1313,6 +1313,18 @@ Starting in {product-title} 4.17, RukPak is now removed and relevant functionali
 [id="ocp-4-17-dev-console-bug-fixes_{context}"]
 ==== Developer Console
 
+* Previously, on some browsers, some icons in the samples catalog were stretched, making it hard to read. With this update, the icons were resized correctly, and now the icons are no longer stretched and easier to read. (link:https://issues.redhat.com/browse/OCPBUGS-34516[*OCPBUGS-34516*])
+
+* Previously, s2i build strategy was not explicitly mentioned in the `func.yml`. Therefore you could not create {ServerlessProductName} functions with the repository. Additionally, error messages were not available if s2i is not mentioned or if `func.yml`. As a result, identifying the reason of failures was not apparent. With this update, if the s2i build strategy is not mentioned, users can still create a function. If it is not s2i, users cannot create a function. The error messages are now different for both the cases. (link:https://issues.redhat.com/browse/OCPBUGS-33733[*OCPBUGS-33733*])
+
+* Previously, when using a Quick Start guided tour in the {product-title} web console, it took multiple clicks of the *Next* button to skip to the next step if the `check your work` dialog was ignored. With this update, it only takes one click, regardless of the state of the `check your work` box. (link:https://issues.redhat.com/browse/OCPBUGS-25929[*OCPBUGS-25929*])
+
+[discrete]
+[id="ocp-4-17-driver-toolkit-bug-fixes_{context}"]
+==== Driver ToolKit (DTK)
+
+* Previously, DTK incorrectly included the same values for the `KERNEL_VERSION` and `RT_KERNEL_VERSION` environment variables. With this update, the `RT_KERNEL_VERSION` is displayed correctly. (link:https://issues.redhat.com/browse/OCPBUGS-33699[*OCPBUGS-33699*])
+
 [discrete]
 [id="ocp-4-17-cloud-etcd-operator-bug-fixes_{context}"]
 ==== etcd Cluster Operator


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11208](https://issues.redhat.com/browse/OSDOCS-11208)

Link to docs preview:
* [Developer Console](https://82532--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-bug-fixes_release-notes)
