### PR TITLE
Adding GCP as available to use with the  SSCSI operator

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -986,6 +986,14 @@ include::snippets/developer-preview.adoc[]
 
 For more information about cns-migration, see link:https://github.com/openshift/vmware-vsphere-csi-driver-operator/blob/master/docs/cns-migration.md[Moving CNS volumes between datastores].
 
+[id="ocp-4-17-storage-secrets-store-csi-driver-gcp_{context}"]
+==== Google Secret Manager is now available for the {secrets-store-operator} (Technology Preview)
+You can now use the {secrets-store-operator} to mount secrets from Google Secret Manager to a Container Storage Interface (CSI) volume in {product-title}. The {secrets-store-operator} is available as a Technology Preview feature.
+
+For the full list of available secrets store providers, see xref:../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-providers_nodes-pods-secrets-store[Secrets store providers].
+
+For information about using the {secrets-store-operator} to mount secrets from Google Secret Manager, see xref:../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-google_nodes-pods-secrets-store[Mounting secrets from Google Secret Manager].
+
 ////
 [id="ocp-4-17-oci"]
 === {oci-first}


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-12063

Link to docs preview:
https://82555--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-storage-secrets-store-csi-driver-gcp_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**The last link won't jump to the GCP section until #82241 merges**

This probably won't make 4.17 GA
