### PR TITLE
[WIP] OLS-913: Document the OLSConfig CRD configuration options

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -6,7 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After the {ols-long} Operator is installed, configuring and deploying {ols-long} consists of three tasks. First, you create a credential secret using the credentials for your Large Language Model (LLM) provider. Next, you create the `OLSConfig` custom resource (CR) that the Operator uses to deploy the service. Finally, you verify that the {ols-short} service is operating.
+After the {ols-long} Operator is installed, configuring and deploying consists of three tasks:
+
+* Create a credential secret using the credentials for your Large Language Model (LLM) provider. 
+* Create the `OLSConfig` Custom Resource (CR) file that the Operator uses to deploy the service. 
+* Verify that the {ols-short} service is operating.
 
 [NOTE]
 ====
@@ -14,9 +18,11 @@ The instructions assume that you are installing {ols-long} using the `kubeadmin`
 ====
 
 include::modules/ols-creating-the-credentials-secret-using-web-console.adoc[leveloffset=+1]
-include::modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc[leveloffset=+1]
 include::modules/ols-creating-the-credentials-secret-using-cli.adoc[leveloffset=+1]
-include::modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc[leveloffset=+1]
+include::modules/ols-about-lightspeed-custom-resource-definition.adoc[leveloffset=+1]
+include::modules/ols-custom-resource-definition-file-parameters.adoc[leveloffset=+2]
+include::modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc[leveloffset=+2]
+include::modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc[leveloffset=+2]
 include::modules/ols-verifying-openshift-lightspeed-deployment.adoc[leveloffset=+1]
 include::modules/ols-about-lightspeed-and-role-based-access-control.adoc[leveloffset=+1]
 include::modules/ols-granting-access-to-individual-users.adoc[leveloffset=+2]

--- a/modules/ols-about-lightspeed-custom-resource-definition.adoc
+++ b/modules/ols-about-lightspeed-custom-resource-definition.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+
+// * about/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ols-about-lightspeed-custom-resource-definition_{context}"]
+= About the Lightspeed Custom Resource
+
+When you install the {ols-long} Operator, the `OLSConfig` Custom Resource Definition (CRD) gets installed in the {ocp-product-title} cluster. You can create a cluster-scoped custom resource named `cluster` to configure {ols-long} with your Large Language Model provider.
+
+You can configure the `OLSConfig` CR by using either the {ocp-product-title} web console or the CLI.

--- a/modules/ols-custom-resource-definition-file-parameters.adoc
+++ b/modules/ols-custom-resource-definition-file-parameters.adoc
@@ -1,0 +1,405 @@
+// Module included in the following assemblies:
+
+// * about/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-custom-resource-definition-file-parameters_{context}"]
+= Lightspeed Custom Resource Definition specification
+
+The following tables provide information about the `OLSConfig` Custom Resource Definition (CRD) specification 
+
+.{ols-short} CRD parameters for Large Language Model (LLM) providers
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+  llm:
+    providers:
+      name:
+|Name of the LLM provider.
+|String
+|yes
+
+|spec:
+  llm:
+    providers:
+      type:
+|LLM provider type.
+|azure_openai, openai, watsonx, rhoai_vllm, rhelai_vllm
+|yes
+
+|spec:
+  llm:
+    providers:
+      url:
+|URL for API provider. The URL must start with `https://`.
+|URL
+|No
+
+|spec:
+  llm:
+    providers:
+      deploymentName:
+|Name of the {azure-openai} deployment.
+|string
+|No
+
+|spec:
+  llm:
+    providers:
+      projectID:
+|The {watsonx} project ID.
+|string
+|No
+
+|spec:
+  llm:
+    providers:
+      credentialsSecretRef:
+|The name of the secret object that stores the API provider credentials
+|string
+|Yes
+
+|spec:
+  llm:
+    providers:
+      models:
+|List of models from the Large Language Model (LLM) provider that you want {ols-long} to use. At least one model is required.
+|string
+|Yes
+|===
+
+.{ols-short} CRD parameters for Large Language Models
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+  llm:
+    providers:
+      models:
+        name:
+|Model name.
+|string
+|yes
+
+|spec:
+  llm:
+    providers:
+      models:
+        url:
+|URL for the API model. The URL must start with `https://`.
+|URL
+|No
+
+|spec:
+  llm:
+    providers:
+      models:
+        contextWindowSize:
+|Defines the size of the context window that the LLM model uses for conversations. The default setting is specific to each LLM provider model. Verify the size of the context window for the specific model you are using. The minimum value that this parameter can accept is `1024`. If this parameter is not set, the default value is `8192`.
+|Integer
+|No
+
+|spec:
+  llm:
+    providers:
+      models:
+        parameters:
+|API parameters for the model. Most parameters are unique for each model.
+|Dictionary
+|No
+|===
+
+.{ols-short} CRD parameters for Large Language Model (LLM) provider model parameters
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+  llm:
+    providers:
+      maxTokensForResponse:
+|Maximum number of response tokens that the LLM provider uses. If this parameter is not set, the default value is `1024`.
+|Integer
+|No
+|===
+
+.CRD OLSSpec parameters
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+  ols:
+    defaultModel:
+|The name of the default model.
+|String
+|Yes
+
+|spec:
+  ols:
+    defaultProvider:
+|Provider that the model uses by default.
+|String
+|No
+
+|spec:
+  ols:
+    logLevel:
+|The log level. The default is `Info`
+|DEBUG,INFO, WARNING, ERROR, CRITICAL
+|No
+
+|spec:
+  ols:
+    queryFilters:
+|Contains the list of query filters.
+|Array or string.
+|No
+|===
+
+.{ols-short} query filter CRD parameters
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+  ols:
+    queryFilters:
+      name:
+|Filter name.
+|String
+|No
+
+|spec:
+  ols:
+    queryFilters:
+      name:
+        pattern:
+|Filter pattern.
+|regexp
+|No
+
+|spec:
+  ols:
+    queryFilters:
+      replaceWith:
+|Replacement for matching query. 
+|String
+|No
+|===
+
+.{ols-short} deployment CRD parameters
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+   ols:
+     deployment:
+       replicas:
+|Specifies the number of {ols-short} pods. The default is 1.
+|Integer
+|No
+|===
+
+.{ols-short} deployment data collector CRD parameters
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+   ols:
+     deployment:
+       dataCollector:
+         limits:
+|Specifies the maximum amount of compute resources allocated for the container.
+|Integer or string
+|No
+
+|spec:
+   ols:
+     deployment:
+       dataColector:
+         requests:
+|Specifies the minimum amount of compute resources allocated for the container.  If this parameter is omitted, the value of the `Limits` parameter defines the minimum amount for the compute resources. Otherwise the parameter defaults to an implementation-defined value. `Requests` cannot exceed `Limits`.  
+|Integer or string
+|No
+|===
+
+.{ols-short} deployment API resource CRD parameters
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+   ols:
+     deployment:
+       api:
+         resources:
+           requests:
+|The minimum amount of compute resources required by the container. If `requests` is omitted the container defaults to the value of the `limits` parameter. If `limits` is not set the container uses an implementation-defined value.
+|Integer or string.
+|No
+|===
+
+.{ols-short} deployment API tolerations CRD parameters
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+   ols:
+     deployment:
+       api:
+         tolerations:
+           effect:
+|Indicates the taint effect to match so that a pod is not rejected by a node. If the parameter is empty all taint effects must match so that a pod is not rejected.
+|NoSchedule, PreferNoSchedule and NoExecute
+|No
+
+|spec:
+   ols:
+     deployment:
+       api:
+         tolerations:
+           key:
+|Specifies the condition being imposed when you apply a taint to a node. If the parameter is empty, the Operator must be `Exists`. These configuration settings match all values and all keys.
+|String
+|No
+
+|spec:
+   ols:
+     deployment:
+       api:
+         tolerations:
+           operator:
+|Represents the relationship between the taint key and the value. The default for this parameter is `Equal`. `Exists` is equivalent to a wildcard for value, so that a pod tolerates all taints of a particular category.
+|Exists, Equal
+|No
+
+|spec:
+   ols:
+     deployment:
+       api:
+         tolerations:
+           tolerationSeconds:
+|Represents the period of time the toleration tolerates the taint. This parameter is not set by default, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+|Integer
+|No
+
+|spec:
+   ols:
+     deployment:
+       api:
+         tolerations:
+           value:
+|Specifies the taint value the toleration matches to. If the operator parameter is set to `Exists` the value should be empty. Otherwise, the value should be a regular string.
+|String
+|No
+|===
+
+.{ols-short} deployment console resources CRD parameters
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+   ols:
+     deployment:
+       console:
+         resources:
+           claims:
+|Lists the names of resources defined in `spec.resourceClaims` that the container uses.
+|List
+|No
+
+|spec:
+   ols:
+     deployment:
+       console:
+         resources:
+           liimts:
+|Describes the maximum amount of compute resources allocated for the container.  
+|Integration or strings
+|No
+
+|spec:
+   ols:
+     deployment:
+       console:
+         resources:
+           requests:
+|The minimum amount of compute resources required by the container. If omitted, the container either defaults to the value of the `Limits` parameter or uses an implementation-defined value. `Requests` cannot exceed `Limits`.  
+|Integration or strings
+|No
+|===
+
+.{ols-short} deployment console tolerations CRD parameters
+[options="header"]
+[cols="l, 4, 1, 1"]
+|===
+|Parameter |Description |Values |Required
+
+|spec:
+   ols:
+     deployment:
+       console:
+         tolerations:
+           effect:
+|Indicates the taint effect to match. Empty means match all taint effects.  When specified, the allowed values are `NoSchedule`, `PreferNoSchedule` and `NoExecute`.
+|String
+|No
+
+|spec:
+   ols:
+     deployment:
+       console:
+         tolerations:
+           key:
+|Key is the taint key that the toleration applies to. If the key is empty, the `operator`` parameter must be set to `Exists`. This setting matches all values and all keys.
+|String
+|No
+
+|spec:
+   ols:
+     deployment:
+       console:
+         tolerations:
+           operator:
+|Represents the relationship between the key and the value.  Valid operators are `Exists` and `Equal`. The default setting is `Equal`. `Exists` is equivalent to a wildcard value so that a pod can tolerate all taints of a particular category.
+|String
+|No
+
+|spec:
+   ols:
+     deployment:
+       console:
+         tolerations:
+           tolerationSeconds:
+|Represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+|Integer
+|No
+
+|spec:
+   ols:
+     deployment:
+       console:
+         tolerations:
+           value:
+|The taint value the toleration matches to. If the `operator` parameter is set to `Exists`, the value should be empty. Otherwise, the value should be a regular string.
+|String
+|No
+|===


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Issue: https://issues.redhat.com/browse/OLS-913
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://82574--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-about-lightspeed-custom-resource-definition_ols-configuring-openshift-lightspeed


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
