### PR TITLE
MCO 4.17 release notes fix node disruption error

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -734,7 +734,7 @@ Updated boot images has been promoted to GA for Google Cloud Platform (GCP) clus
 [id="ocp-4-17-machine-config-operator-node-disrupt-ga_{context}"]
 ==== Node disruption policies promoted to GA
 
-Node disruption policies for Google Cloud Platform (GCP) clusters has been promoted to GA. A node disruption policy allows you to define a set of Ignition config objects changes that would require little or no disruption to your workloads. For more information, see xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes].
+The node disruption policies feature has been promoted to GA. A node disruption policy allows you to define a set of Ignition config objects changes that would require little or no disruption to your workloads. For more information, see xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes].
 
 [id="ocp-4-17-machine-management_{context}"]
 === Machine management


### PR DESCRIPTION
Fix copy/paste error in the 4.17 release note for the node disruption feature. 

Preview: [Node disruption policies promoted to GA](https://82599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-machine-config-operator-node-disrupt-ga_release-notes)