### PR TITLE
OSDOCS-11794: ROSA CLI security refinements adding CLI output examples - UPDATE

### DIFF
--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -730,6 +730,44 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 ----
 ====
 
+[discrete]
+[id="rosa-sts-account-wide-roles-and-policies-example-cli-output-for-policies-attached-to-a-role_{context}"]
+==== Example CLI output for policies attached to a role 
+
+When a policy is attached to a role, the ROSA CLI displays a confirmation output. The output depends on the type of policy.
+
+* If the policy is a trust policy, the ROSA CLI outputs the role name and the content of the policy.
+** For the target role with policy attached, ROSA CLI outputs the role name and the console URL of the target role. 
++
+.Target role with policy attached example output
+[source,terminal]
+----
+I: Attached trust policy to role 'testrole-Worker-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Worker-Role)': ******************
+----
++
+** If the attached policy is a trust policy, the ROSA CLI outputs the content of this policy.
++
+.Trust policy example output
+[source,terminal]
+----
+I: Attached trust policy to role 'test-Support-Role': {"Version": "2012-10-17", "Statement": [{"Action": ["sts:AssumeRole"], "Effect": "Allow", "Principal": {"AWS": ["arn:aws:iam::000000000000:role/RH-Technical-Support-00000000"]}}]} 
+----
+* If the policy is a permission policy, the ROSA CLI outputs the name and public link of this policy or the ARN depending on whether or not the policy is an AWS managed policy or customer-managed policy.
+** If the attached policy is an AWS managed policy, the ROSA CLI outputs the name and public link of this policy and the role it is attached to.
++
+.AWS managed policy example output
+[source,terminal]
+----
+I: Attached policy 'ROSASRESupportPolicy(https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSASRESupportPolicy)' to role 'test-HCP-ROSA-Support-Role(https://console.aws.amazon.com/iam/home?#/roles/test-HCP-ROSA-Support-Role)' 
+----
+** If the attached policy is an AWS managed policy, the ROSA CLI outputs the name and public link of this policy and the role it is attached to.
++
+.Customer-managed policy example output
+[source,terminal]
+----
+I: Attached policy 'arn:aws:iam::000000000000:policy/testrole-Worker-Role-Policy' to role 'testrole-Worker-Role(https://console.aws.amazon.com/iam/home?#/roles/testrole-Worker-Role)' 
+----
+
 .ROSA Ingress Operator IAM policy and policy file
 [cols="1,2",options="header"]
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
[OSDOCS-11794](https://issues.redhat.com/browse/OSDOCS-11794)

Link to docs preview:
[About IAM resources for ROSA clusters that use STS](https://82601--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is an update from PR #81844 with the changes recommended.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
