### PR TITLE
RHDEVDOCS 6185 redirects for release notes for GitOps and Pipelines

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -340,8 +340,8 @@ AddType text/vtt                            vtt
 
     # GitOps release notes version switch
 
-    RewriteRule ^gitops/1\.(8|9|10|11|12|13)/release_notes/gitops-release-notes?(.*).html gitops/1.$1/release_notes/gitops-release-notes.html
-    RewriteRule ^gitops/1\.(14|15|16)/release_notes/gitops-release-notes?(.*).html gitops/1.$1/release_notes/gitops-release-notes-1-$1.html
+    RewriteRule ^gitops/1\.(8|9|10|11|12|13)/release_notes/gitops-release-notes-1-([0-9]+)\.html$ gitops/1.$1/release_notes/gitops-release-notes.html [L,R=302]
+    RewriteRule ^gitops/1\.(14|15|16)/release_notes/gitops-release-notes?(.*)\.html$ gitops/1.$1/release_notes/gitops-release-notes.html [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent for each assembly
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes-1-14.html  [L,R=302]
@@ -386,6 +386,13 @@ AddType text/vtt                            vtt
     # Pipelines handling unversioned and latest links
     RewriteRule ^pipelines/?$ /pipelines/latest [R=302]
     RewriteRule ^pipelines/latest/?(.*)$ /pipelines/1\.15/$1 [NE,R=302]
+
+    # Pipelines release notes version switch
+
+    RewriteRule ^pipelines/1\.(10|11|12|13|14|15)/release_notes/op-release-notes-1-([0-9]+)\.html$ pipelines/1.$1/about/op-release-notes.html [L,R=302]
+    RewriteRule ^pipelines/1\.(16|17|17)/release_notes/op-release-notes?(.*)\.html$ pipelines/1.$1/release_notes/pipelines-release-notes.html [L,R=302]
+    RewriteRule ^pipelines/1\.(16|17|17)/anput/op-release-notes\.html$ pipelines/1.$1/release_notes/pipelines-release-notes.html [L,R=302]
+
 
     # Pipelines landing page
 

--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -338,6 +338,11 @@ AddType text/vtt                            vtt
     # GitOps landing page
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
+    # GitOps release notes version switch
+
+    RewriteRule ^gitops/1\.(8|9|10|11|12|13)/release_notes/gitops-release-notes?(.*).html gitops/1.$1/release_notes/gitops-release-notes.html
+    RewriteRule ^gitops/1\.(14|15|16)/release_notes/gitops-release-notes?(.*).html gitops/1.$1/release_notes/gitops-release-notes-1-$1.html
+
     # redirect any links to existing OCP embedded content to standalone equivalent for each assembly
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes-1-14.html  [L,R=302]
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/understanding-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html [L,R=302]

--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -341,7 +341,9 @@ AddType text/vtt                            vtt
     # GitOps release notes version switch
 
     RewriteRule ^gitops/1\.(8|9|10|11|12|13)/release_notes/gitops-release-notes-1-([0-9]+)\.html$ gitops/1.$1/release_notes/gitops-release-notes.html [L,R=302]
-    RewriteRule ^gitops/1\.(14|15|16)/release_notes/gitops-release-notes?(.*)\.html$ gitops/1.$1/release_notes/gitops-release-notes.html [L,R=302]
+    RewriteRule ^gitops/1\.14/release_notes/gitops-release-notes-1-14\.html$ - [L]
+    RewriteRule ^gitops/1\.15/release_notes/gitops-release-notes-1-15\.html$ - [L]
+    RewriteRule ^gitops/1\.(14|15)/release_notes/gitops-release-notes?(.*)\.html$ gitops/1.$1/release_notes/gitops-release-notes-1-$1.html [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent for each assembly
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes-1-14.html  [L,R=302]
@@ -390,8 +392,10 @@ AddType text/vtt                            vtt
     # Pipelines release notes version switch
 
     RewriteRule ^pipelines/1\.(10|11|12|13|14|15)/release_notes/op-release-notes-1-([0-9]+)\.html$ pipelines/1.$1/about/op-release-notes.html [L,R=302]
-    RewriteRule ^pipelines/1\.(16|17|17)/release_notes/op-release-notes?(.*)\.html$ pipelines/1.$1/release_notes/pipelines-release-notes.html [L,R=302]
-    RewriteRule ^pipelines/1\.(16|17|17)/anput/op-release-notes\.html$ pipelines/1.$1/release_notes/pipelines-release-notes.html [L,R=302]
+    RewriteRule ^pipelines/1\.16/release_notes/op-release-notes-1-16\.html$ - [L]
+    RewriteRule ^pipelines/1\.17/release_notes/op-release-notes-1-17\.html$ - [L]
+    RewriteRule ^pipelines/1\.(16|17)/release_notes/op-release-notes?(.*)\.html$ pipelines/1.$1/release_notes/pipelines-release-notes-1-$1.html [L,R=302]
+
 
 
     # Pipelines landing page


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
main only

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6185

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
n/a

QE review:
n/a
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This is a technical PR adding redirects for Release Notes for GitOps, so that version switching works. It covers two future versions of GitOps too. It does not affect documentation text, so doc preview and QE approval are not applicable.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
