### PR TITLE
OSDOCS-11208-missing1

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -969,8 +969,7 @@ For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.ad
 
 * The Insights Operator now collects the `haproxy_exporter_server_threshold` metric. (link:https://issues.redhat.com/browse/OCPBUGS-36687[*OCPBUGS-36687*])
 
-* Previously, the Insights Operator gathered information about all Ingress Controller certificates, including their `NotBefore` and `NotAfter` dates. This data is now compiled into a `JSON` file located at `aggregated/ingress_controllers_certs.json` for easier monitoring of certificate validity across the cluster.
-(link:https://issues.redhat.com/browse/OCPBUGS-35727[*OCPBUGS-35727*])
+* Previously, the Insights Operator gathered information about all Ingress Controller certificates, including their `NotBefore` and `NotAfter` dates. This data is now compiled into a `JSON` file located at `aggregated/ingress_controllers_certs.json` for easier monitoring of certificate validity across the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-35727[*OCPBUGS-35727*])
 
 [id="ocp-4-17-etcd-certificates_{context}"]
 === Security
@@ -1370,12 +1369,14 @@ In the following tables, features are marked with the following statuses:
 === Deprecated features
 
 [id="ocp-4-17-preserveBootstrapIgnition-deprecated_{context}"]
-==== The `preserveBootstrapIgnition` parameter for {aws-short}
+==== The preserveBootstrapIgnition parameter for {aws-short}
 
-The `preserveBootstrapIgnition` parameter for {aws-short} in the `install-config.yaml` file has been deprecated. You can use the `bestEffortDeleteIgnition` parameter instead.
-(link:https://issues.redhat.com/browse/OCPBUGS-33661[*OCPBUGS-33661*])
+The `preserveBootstrapIgnition` parameter for {aws-short} in the `install-config.yaml` file has been deprecated. You can use the `bestEffortDeleteIgnition` parameter instead. (link:https://issues.redhat.com/browse/OCPBUGS-33661[*OCPBUGS-33661*])
 
-* In {product-title} {product-version}, `kube-apiserver` no longer gets a valid cloud configuration object. As a result, the `PersistentVolumeLabel` admission plugin rejects in-tree Google Compute Engine (GCE) PD PVs, or persistent disk persistent volumes, that do not have the correct topology. (link:https://issues.redhat.com/browse/OCPBUGS-34544[*OCPBUGS-34544*])
+[id="ocp-4-17-kube-apiserver-deprecated_{context}"]
+==== kube-apiserver no longer gets a valid cloud configuration object
+
+In {product-title} {product-version}, `kube-apiserver` no longer gets a valid cloud configuration object. As a result, the `PersistentVolumeLabel` admission plugin rejects in-tree Google Compute Engine (GCE) persistent disk persistent volumes (PD PVs), that do not have the correct topology. (link:https://issues.redhat.com/browse/OCPBUGS-34544[*OCPBUGS-34544*])
 
 [id="ocp-4-17-removed-features_{context}"]
 === Removed features
@@ -1422,17 +1423,19 @@ Starting in {product-title} 4.17, RukPak is now removed and relevant functionali
 //Telco Edge / TALO
 //Telco Edge / ZTP
 
+////
 [discrete]
 [id="ocp-4-17-api-auth-bug-fixes_{context}"]
 ==== API Server and Authentication
+////
 
 [discrete]
 [id="ocp-4-17-bare-metal-hardware-bug-fixes_{context}"]
 ==== Bare Metal Hardware Provisioning
 
-* Previously, attempting to configure RAID on specific hardware models by using Redfish might have resulted in the following error: "The attribute StorageControllers/Name is missing from the resource." With this update, the validation logic no longer requires the `Name` field, because it is not mandated by the Redfish standard. (link:https://issues.redhat.com/browse/OCPBUGS-38465[*OCPBUGS-38465*])
+* Previously, attempting to configure RAID on specific hardware models by using Redfish might have resulted in the following error: `The attribute StorageControllers/Name is missing from the resource`. With this update, the validation logic no longer requires the `Name` field, because the field is not mandated by the Redfish standard. (link:https://issues.redhat.com/browse/OCPBUGS-38465[*OCPBUGS-38465*])
 
-* Previously, the management interface for the iDRAC9 Redfish management interface in the Redfish Bare Metal Operator (BMO) module was incorrectly set to iPXE. This caused the error "Could not find the following interface in the 'ironic.hardware.interfaces.management' entrypoint: ipxe." and deployment failed on Dell Remote Access Controller (iDRAC)-based servers. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-37261[*OCPBUGS-37261*])
+* Previously, the management interface for the iDRAC9 Redfish management interface in the Redfish Bare Metal Operator (BMO) module was incorrectly set to iPXE. This caused the error `Could not find the following interface in the ironic.hardware.interfaces.management entrypoint: ipxe` and the deployment failed on Dell Remote Access Controller (iDRAC)-based servers. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-37261[*OCPBUGS-37261*])
 
 [discrete]
 [id="ocp-4-17-builds-bug-fixes_{context}"]
@@ -1440,23 +1443,25 @@ Starting in {product-title} 4.17, RukPak is now removed and relevant functionali
 
 * Previously, builds could not set the `GIT_LFS_SKIP_SMUDGE` environment variable and use its value when cloning the source code. This caused builds to fail for some Git repositories with LFS files. With this release, the build is able to set this environment variable and use it during the `git clone` step of the build, which resolves the issue. (link:https://issues.redhat.com/browse/OCPBUGS-33215[*OCPBUGS-33215*])
 
+* Previously, if the developer or cluster admin used lowercase environment variable names for proxy information, these environment variables were carried into the build output container image. At runtime, the proxy settings were active and had to be unset. With this release, lowercase versions of the `_PROXY` environment variables are prevented from leaking into built container images. Now, `buildDefaults` are only kept during the build and settings created for the build process only are removed before pushing the image in the registry. (link:https://issues.redhat.com/browse/OCPBUGS-12699[*OCPBUGS-12699*])
+
 [discrete]
 [id="ocp-4-17-cloud-compute-bug-fixes_{context}"]
 ==== Cloud Compute
 
 * Previously, a machine controller failed to save the {vmw-full} task ID of an instance template clone operation. This caused the machine to go into the `Provisioning` state and to power off. With this release, the {vmw-full} machine controller can detect and recover from this state. (link:https://issues.redhat.com/browse/OCPBUGS-1735[*OCPBUGS-1735*])
 
-* Previously, the `machine-api` Operator reacted when it deleted a server that was in an `ERROR` state. This happened because the server did not pass a port list. With this release, deleting a machine stuck in an `ERROR` state does not cause an Operator reaction. (link:https://issues.redhat.com/browse/OCPBUGS-34155[*OCPBUGS-34155*])
+* Previously, the `machine-api` Operator reacted when it deleted a server that was in an `ERROR` state. This happened because the server did not pass a port list. With this release, deleting a machine stuck in an `ERROR` state does not cause an Operator reaction. (link:https://issues.redhat.com/browse/OCPBUGS-33806[*OCPBUGS-33806*])
 
 * Previously, you could not configure capacity reservation on a {azure-first} Workload Identity cluster because of missing permissions. With this release, the `Microsoft.Compute/capacityReservationGroups/deploy/action` permission is added as a default credential request in the `<infra-name>-openshift-machine-api-azure-cloud-credentials` custom role, so that you can now configure capacity reservation as expected. (link:https://issues.redhat.com/browse/OCPBUGS-37154[*OCPBUGS-37154*])
 
-* Previously, an optional internal function of the cluster autoscaler caused repeated log entries when it was not implemented. The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-33932[*OCPBUGS-33932*])
+* Previously, an optional internal function of the cluster autoscaler caused repeated log entries when it was not implemented. The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-33592[*OCPBUGS-33592*])
 
 * Previously, a node associated with a restarting machine briefly having a status of `Ready=Unknown` triggered the `UnavailableReplicas` condition in the Control Plane Machine Set Operator. This condition caused the Operator to enter the `Available=False` state and trigger alerts because that state indicates a nonfunctional component that requires immediate administrator intervention. This alert should not have been triggered for the brief and expected unavailabilty during a restart. With this release, a grace period for node unreadiness is added to avoid triggering unnecessary alerts. (link:https://issues.redhat.com/browse/OCPBUGS-20061[*OCPBUGS-20061*])
 
 * Previously, when an {product-title} cluster was installed with no capabilities and later enabled the Build capability, the related Build cluster configuration custom resource definition (CRD) was not created. With this release, the Build cluster configuration CRD and its default instance are created. This allows the Build capability to be fully configured and customized. (link:https://issues.redhat.com/browse/OCPBUGS-34395[*OCPBUGS-34395*])
 
-* Previously, role bindings related to the Image Registry, Build, and `DeploymentConfig` capabilities were created in every namespace, even if the the capabilities were disabled. With this release, role bindings is only created if the capability is enabled on the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-34077[*OCPBUGS-34077*])
+* Previously, role bindings related to the Image Registry, Build, and `DeploymentConfig` capabilities were created in every namespace, even if the capabilities were disabled. With this release, role bindings is only created if the capability is enabled on the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-34077[*OCPBUGS-34077*])
 
 [discrete]
 [id="ocp-4-17-cloud-cred-operator-bug-fixes_{context}"]
@@ -1466,7 +1471,7 @@ Starting in {product-title} 4.17, RukPak is now removed and relevant functionali
 
 * Previously, the Cloud Credential Operator reported an error when the `awsSTSIAMRoleARN` role was not present on a cluster that used manual mode with AWS Security Token Service. With this release, the Cloud Credential Operator no longer reports this as an error. (link:https://issues.redhat.com/browse/OCPBUGS-33566[*OCPBUGS-33566*])
 
-* Previously, when checking whether passthrough permissions are sufficient, the Cloud Credential Operator sometimes received a response from the Google Cloud Platform API that a permission is invalid for a project. This response caused the Operator to become degraded and installation to fail. With this release, the Operator is updated to handle this error gracefully. (link:https://issues.redhat.com/browse/OCPBUGS-36140[*OCPBUGS-36140*])
+* Previously, when checking whether passthrough permissions are sufficient, the Cloud Credential Operator sometimes received a response from the {gcp-first} API that a permission is invalid for a project. This response caused the Operator to become degraded and installation to fail. With this release, the Operator is updated to handle this error gracefully. (link:https://issues.redhat.com/browse/OCPBUGS-36140[*OCPBUGS-36140*])
 
 [discrete]
 [id="ocp-4-17-cluster-version-operator-bug-fixes_{context}"]
@@ -1496,6 +1501,8 @@ Starting in {product-title} 4.17, RukPak is now removed and relevant functionali
 
 * Previous versions of the etcd Operator checked the health of etcd members in serial with an all-member timeout that matched the single-member timeout. As a result, one slow member check could consume the entire timeout and cause later member checks to fail, regardless of the health of that later member. In this release, the etcd Operator checks the health of members in parallel, so the health and speed of one member's check does not affect the other members' checks. (link:https://issues.redhat.com/browse/OCPBUGS-36301[*OCPBUGS-36301*])
 
+* Previously, the health checks for the etcd Operator were not ordered. As a consequence, the health check sometimes failed even though all etcd members were healthy. The health-check failure triggered a scale-down event that caused the Operator to prematurely remove a healthy member. With this release, the health checks in the Operator are ordered. As a result, the health checks correctly reflect the health of etcd members and an incorrect scale-down event does not occur. (link:https://issues.redhat.com/browse/OCPBUGS-36462[*OCPBUGS-36462*])
+
 [discrete]
 [id="ocp-hosted-control-planes-bug-fixes_{context}"]
 ==== Hosted control planes
@@ -1510,7 +1517,7 @@ Starting in {product-title} 4.17, RukPak is now removed and relevant functionali
 
 * Previously, the Konnectivity proxy agent in a hosted cluster always sent all TCP traffic through an HTTP/S proxy. It also ignored host names in the `NO_PROXY` configuration because it only received resolved IP addresses in its traffic. As a consequence, traffic that was not meant to be proxied, such as LDAP traffic, was proxied regardless of configuration. With this release, proxying is completed at the source (control plane) and the Konnectivity agent proxying configuration is removed. As a result, traffic that is not meant to be proxied, such as LDAP traffic, is not proxied anymore. The `NO_PROXY` configuration that includes host names is honored. (link:https://issues.redhat.com/browse/OCPBUGS-38637[*OCPBUGS-38637*])
 
-* Previously, the `azure-disk-csi-driver-controller` image was not getting appropriate override values when using `registryOverride`. This was intentional so as to avoid propagating the values to the `azure-disk-csi-driver` data plane images. With this update, the issue is resolved by adding a separate image override value. As a result, the `azure-disk-csi-driver-controller` can be used with `registryOverride` and no longer affects `azure-disk-csi-driver` data plane images. (link:https://issues.redhat.com/browse/OCPBUGS-38183[*OCPBUGS*])
+* Previously, the `azure-disk-csi-driver-controller` image was not getting appropriate override values when using `registryOverride`. This was intentional so as to avoid propagating the values to the `azure-disk-csi-driver` data plane images. With this update, the issue is resolved by adding a separate image override value. As a result, the `azure-disk-csi-driver-controller` can be used with `registryOverride` and no longer affects `azure-disk-csi-driver` data plane images. (link:https://issues.redhat.com/browse/OCPBUGS-38183[*OCPBUGS-38183*])
 
 * Previously, the AWS cloud controller manager within a hosted control plane that was running on a proxied management cluster would not use the proxy for cloud API communication. With this release, the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-37832[*OCPBUGS-37832*])
 
@@ -1520,7 +1527,7 @@ For parity with {product-title}, IDP communication via HTTPS or HTTP should be p
 +
 With this release, in hosted clusters, proxy is invoked in the control plane via `konnectivity-https-proxy` and `konnectivity-socks5-proxy`, and proxying traffic is stopped from the Konnectivity agent. As a result, traffic that is destined for LDAP servers is no longer proxied. Other HTTPS or HTTPS traffic is proxied correctly. The `NO_PROXY` setting is honored when you specify hostnames. (link:https://issues.redhat.com/browse/OCPBUGS-37052[*OCPBUGS-37052*])
 
-* Previously, proxying for IDP communication occurred in the Konnectivity agent. By the time traffic reached Konnectivity, its protocol and hostname were no longer available. As a consequence, proxying was not done correctly for the OAUTH server pod. It did not distinguish between protocols that require proxying (http/s) and protocols that do not (ldap://). In addition, it did not honor the `no_proxy` variable that is configured in the `HostedCluster.spec.configuration.proxy` spec.
+* Previously, proxying for IDP communication occurred in the Konnectivity agent. By the time traffic reached Konnectivity, its protocol and hostname were no longer available. As a consequence, proxying was not done correctly for the OAUTH server pod. It did not distinguish between protocols that require proxying (`http/s`) and protocols that do not (`ldap://`). In addition, it did not honor the `no_proxy` variable that is configured in the `HostedCluster.spec.configuration.proxy` spec.
 +
 With this release, you can configure the proxy on the Konnectivity sidecar of the OAUTH server so that traffic is routed appropriately, honoring your `no_proxy` settings. As a result, the OAUTH server can communicate properly with identity providers when a proxy is configured for the hosted cluster. (link:https://issues.redhat.com/browse/OCPBUGS-36932[*OCPBUGS-36932*])
 
@@ -1528,13 +1535,19 @@ With this release, you can configure the proxy on the Konnectivity sidecar of th
 
 * Previously, deploying a `hostedCluster` in a disconnected environment required setting the `hypershift.openshift.io/control-plane-operator-image` annotation. With this update, the annotation is no longer needed. Additionally, the metadata inspector works as expected during the hosted Operator reconciliation, and `OverrideImages` is populated as expected. (link:https://issues.redhat.com/browse/OCPBUGS-34734[*OCPBUGS-34734*])
 
-* Previously, hosted clusters on AWS leveraged their VPC's primary CIDR range to generate security group rules on the data plane. As a consequence, if you installed a hosted cluster into an AWS VPC with multiple CIDR ranges, the generated security group rules could be insufficient. With this update, security group rules are generated based on the provided machine CIDR range to resolve this issue. (link:https://issues.redhat.com/browse/OCPBUGS-34274[*OCPBUGS-34274*])
+* Previously, hosted clusters on {aws-short} leveraged their VPC's primary CIDR range to generate security group rules on the data plane. As a consequence, if you installed a hosted cluster into an AWS VPC with multiple CIDR ranges, the generated security group rules could be insufficient. With this update, security group rules are generated based on the provided machine CIDR range to resolve this issue. (link:https://issues.redhat.com/browse/OCPBUGS-34274[*OCPBUGS-34274*])
 
 * Previously, the OpenShift Cluster Manager container did not have the right TLS certificates. As a consequence, you could not use image streams in disconnected deployments. With this release, the TLS certificates are added as projected volumes to resolve this issue. (link:https://issues.redhat.com/browse/OCPBUGS-31446[*OCPBUGS-31446*])
 
 [discrete]
 [id="ocp-4-17-image-registry-bug-fixes_{context}"]
 ==== Image Registry
+
+* Previously, the internal image registry would not correctly authenticate users on clusters configured with external OpenID Connect (OIDC) users. Consequently, this made it impossible for users to push or pull images to and from the internal image registry. With this update, the internal image registry starts by using the `SelfSubjectReview` API, dropping use of the `openshift specific user` API, which is not available on clusters configured with external OIDC users. As a result, it is now possible to successfully authenticate with the internal image registry again. (link:https://issues.redhat.com/browse/OCPBUGS-35335[*OCPBUGS-35335*])
+
+* Previously, the image registry was unable to run due to a permissions error in the certificate directory. This issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-38885[*OCPBUGS-38885*])
+
+* Previously, when enabling `virtualHostedStyle` with `regionEndpoint` set in image registry Operator config, the image registry would ignore the virtual hosted style config and would fail to start. This update fixes the issue by using a new upstream distribution configuration, which is force path style, in favor of the downstream only version, which is virtual hosted style. (link:https://issues.redhat.com/browse/OCPBUGS-32710[*OCPBUGS-32710*])
 
 * In {product-title} 4.14, installing a cluster with {entra-first} was made generally available. With this feature, administrators can configure a Microsoft Azure cluster to use {entra-short}. With {entra-short}, cluster components use temporary security credentials that are managed outside of the cluster.
 +
@@ -1555,12 +1568,13 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 [id="ocp-4-17-installer-bug-fixes_{context}"]
 ==== Installer
 
+* Previously, extracting the IP address from the Cluster API Machine object only returned a single address. On {vmw-first}, the returned address would always be an IPv6 address and this caused issues with the `must-gather` implementation if the address was non-routable. With this release, the Cluster API Machine object returns all IP addresses, including IPv4, so that the `must-gather` issue no longer occurs on {vmw-full}. (link:https://issues.redhat.com/browse/OCPBUGS-37427[*OCPBUGS-37427*])
+
 * Previously, when installing a cluster on {ibm-cloud-name} into an existing VPC, the installation program retrieved an unsupported VPC region. Attempting to install into a supported VPC region that follows the unsupported VPC region alphabetically caused the installation program to crash. With this release, the installation program is updated to ignore any VPC regions that are not fully available during resource lookups. (link:https://issues.redhat.com/browse/OCPBUGS-14963[*OCPBUGS-14963*])
 
 * Previously, the installation program attempted to download the OVA on {vmw-first} whether the template field was defined or not. With this update, the issue is resolved. The installation program verifies if the template field is defined. If the template field is not defined, the OVA is downloaded. If the template field is defined, the OVA is not downloaded. (link:https://issues.redhat.com/browse/OCPBUGS-39240[*OCPBUGS-39240*])
 
-* Previously, enabling custom feature gates sometimes caused installation on an AWS cluster to fail if the feature gate `ClusterAPIInstallAWS=true` was not enabled. With this release, the `ClusterAPIInstallAWS=true` feature gate is not required.
-(link:https://issues.redhat.com/browse/OCPBUGS-34708[*OCPBUGS-34708*])
+* Previously, enabling custom feature gates sometimes caused installation on an AWS cluster to fail if the feature gate `ClusterAPIInstallAWS=true` was not enabled. With this release, the `ClusterAPIInstallAWS=true` feature gate is not required. (link:https://issues.redhat.com/browse/OCPBUGS-34708[*OCPBUGS-34708*])
 
 * Previously, some processes could be left running if the installation program exited due to infrastructure provisioning failures. With this update, all installation-related processes are terminated when the installation program terminates. (link:https://issues.redhat.com/browse/OCPBUGS-36378[*OCPBUGS-36378*])
 
@@ -1596,9 +1610,7 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 
 * Previously, when installing a cluster with the Agent-based installer, the assisted-installer process could timeout when attempting to add control plane nodes to the cluster. With this update, the assisted-installer process loads fresh data from the assisted-service process, preventing the timeout. (link:https://issues.redhat.com/browse/OCPBUGS-36779[*OCPBUGS-36779*])
 
-* Previously, when the {vmw-full} vCenter cluster contained an ESXi host that did not have a standard port group defined and the installation program tried to select that host to import the OVA, the import failed and the error “Invalid Configuration for device '0'” was presented.
-With this release, the installation program verifies whether a standard port group for an ESXi host is defined and, if not, continues until it locates an ESXi host with a defined standard port group or presents an error message if it fails to locate one, resolving the issue.
- (link:https://issues.redhat.com/browse/OCPBUGS-38560[*OCPBUGS-38560*])
+* Previously, when the {vmw-full} vCenter cluster contained an ESXi host that did not have a standard port group defined and the installation program tried to select that host to import the OVA, the import failed and the error `Invalid Configuration for device 0` was reported. With this release, the installation program verifies whether a standard port group for an ESXi host is defined and, if not, continues until it locates an ESXi host with a defined standard port group, or reports an error message if it fails to locate one, resolving the issue. (link:https://issues.redhat.com/browse/OCPBUGS-38560[*OCPBUGS-38560*])
 
 * Previously, extracting the IP address from the Cluster API Machine object only returned a single IP address. On {vmw-first}, the returned address would always be an IPv6 address and this caused issues with the `must-gather` implementation if the address was non-routable. With this release, the Cluster API Machine object returns all IP addresses, including IPv4, so that the `must-gather` issue no longer occurs on {vmw-full}. (link:https://issues.redhat.com/browse/OCPBUGS-37607[*OCPBUGS-37607*])
 
@@ -1640,14 +1652,15 @@ With this release, the installation program verifies whether a standard port gro
 
 * Previously, in some Hypershift hosted clusters, the IO archive contained the hostname even with network obfuscation enabled. This issue has been resolved, and IO archives no longer contain hostnames when they are obfuscated. (link:https://issues.redhat.com/browse/OCPBUGS-33082[*OCPBUGS-33082*])
 
+////
 [discrete]
 [id="ocp-4-17-kube-controller-bug-fixes_{context}"]
 ==== Kubernetes Controller Manager
 
-
 [discrete]
 [id="ocp-4-17-kube-scheduler-bug-fixes_{context}"]
 ==== Kubernetes Scheduler
+////
 
 [discrete]
 [id="ocp-4-17-machine-config-operator-bug-fixes_{context}"]
@@ -1677,6 +1690,8 @@ With this release, the installation program verifies whether a standard port gro
 [id="ocp-4-17-management-console-bug-fixes_{context}"]
 ==== Management Console
 
+* Previously, the *Cluster overview* page included a `View all steps in documentation` link that resulted in a 404 error for {product-rosa} and {product-dedicated} clusters. With this update, the link does not appear for {product-rosa} and {product-dedicated} clusters. (link:https://issues.redhat.com/browse/OCPBUGS-37054[*OCPBUGS-37054*])
+
 * Previously, a warning was not provided when you were on a {gcp-first} cluster that supports {gcp-wid-short} and that the Operator supports it. With this release, logic was added to support {gcp-wid-short} and Federated Identity Operator installs, so now you are alerted when you are on a {gcp-short} cluster. (link:https://issues.redhat.com/browse/OCPBUGS-38591[*OCPBUGS-38591*])
 
 * Previously, the version number text in the *Updates* graph on the *Cluster Settings* page appeared as black text on a dark background when using Firefox in dark mode. With this update, the text appears as white text. (link:https://issues.redhat.com/browse/OCPBUGS-38427[*OCPBUGS-38427*])
@@ -1692,8 +1707,6 @@ With this release, the installation program verifies whether a standard port gro
 * Previously, the *OperandDetails* page displayed information for the first CRD that matched by name. After this fix, the *OperandDetails* page displays information for the CRD that matches by name and the version of the operand. (link:https://issues.redhat.com/browse/OCPBUGS-34901[*OCPBUGS-34901*])
 
 * Previously, one inactive or idle browser tab caused session expiration for all other tabs. With this change, activity in any tab will prevent session expiration even if there is one inactive or idle browser tab. (link:https://issues.redhat.com/browse/OCPBUGS-34387[*OCPBUGS-34387*])
-
-* Previously, the `Display Admission Webhook` warning implementation presented issues with some incorrect code. With this release, the unnecessary warning message has been removed. (link:https://issues.redhat.com/browse/OCPBUGS-35940[*OCPBUGS-34316*])
 
 * Previously, text areas were not resizable. With this update, you are now able to resize text areas. (link:https://issues.redhat.com/browse/OCPBUGS-34200[*OCPBUGS-34200*])
 
@@ -1881,7 +1894,7 @@ With this update, the plugin checks the local cache during the disk-to-mirror pr
 [id="ocp-4-17-olm-bug-fixes_{context}"]
 ==== Operator Lifecycle Manager (OLM)
 
-* Previously, clusters with many custom resources (CRs) experienced timeouts from the API server and stranded updates where the only workaround was to uninstall and then reinstall the stranded Operators. This occurred because OLM evaluated potential updates by using a dynamic client lister. With this fix, OLM uses a paging lister for custom resource definitions (CRDs) to avoid timeouts and stranded updates. (link:https://issues.redhat.com/browse/OCPBUGS-41549[*OCPBUGS-47549*])
+* Previously, clusters with many custom resources (CRs) experienced timeouts from the API server and stranded updates where the only workaround was to uninstall and then reinstall the stranded Operators. This occurred because OLM evaluated potential updates by using a dynamic client lister. With this fix, OLM uses a paging lister for custom resource definitions (CRDs) to avoid timeouts and stranded updates. (link:https://issues.redhat.com/browse/OCPBUGS-41549[*OCPBUGS-41549*])
 
 * Previously, catalog source pods could not recover from a cluster node failure when the `registryPoll` parameter was unset. With this fix, OLM updates its logic for checking for dead pods. As a result, catalog source pods now recover from node failures as expected. (link:https://issues.redhat.com/browse/OCPBUGS-39574[*OCPBUGS-39574*])
 
@@ -1895,17 +1908,27 @@ With this update, the plugin checks the local cache during the disk-to-mirror pr
 
 * Previously, the Catalog Operator sometimes attempted to connect to deleted catalog sources that were stored in the cache. With this fix, the Catalog Operator queries a client to list the catalog sources on a cluster. (link:https://issues.redhat.com/browse/OCPBUGS-8659[*OCPBUGS-8659*])
 
+////
 [discrete]
 [id="ocp-4-17-openshift-api-server-bug-fixes_{context}"]
 ==== OpenShift API server
+////
 
 [discrete]
 [id="ocp-4-17-rhcos-bug-fixes_{context}"]
 ==== {op-system-first}
 
+* Previously, LUKS encryption on a system using 512 emulation disks caused provisioning to fail at the `ignition-ostree-growfs` step of the process because of an alignment bug in `sfdisk` when growing a partition. With this release, the `ignition-ostree-growfs` script can now detect this situation and fix the alignment automatically. As a result, the system no longer fails during provisioning. (link:https://issues.redhat.com/browse/OCPBUGS-35410[*OCPBUGS-35410*])
+
+* Previously, a bug in the `growpart` utility caused a LUKS device to become locked and unable to open. This prevented the system from booting and entering into an emergency mode. With this release, the call to the `growpart` utility is removed and the system successfully boots without issue. (link:https://issues.redhat.com/browse/OCPBUGS-33124[*OCPBUGS-33124*])
+
+* Previously, if a new deployment was done at the OSTree level on the host, which is identical to the current deployment but on a different stateroot, OSTree saw them as equal. This behavior prevented updating the bootloader when the `set-default` command was invoked, because OSTree did not recognize the two stateroots as a differentiating factor for deployments. With this release, the OSTree logic is modified to consider the stateroots. As a result, this allows OSTree to properly set the default deployment to a new deployment that has different stateroots. (link:https://issues.redhat.com/browse/OCPBUGS-30276[*OCPBUGS-30276*])
+
+////
 [discrete]
 [id="ocp-4-17-scalability-and-performance-bug-fixes_{context}"]
 ==== Scalability and performance
+////
 
 [discrete]
 [id="ocp-4-17-storage-bug-fixes_{context}"]
@@ -1913,9 +1936,11 @@ With this update, the plugin checks the local cache during the disk-to-mirror pr
 
 * Previously, the Secrets Store Container Storage Interface (CSI) Driver on {hcp} clusters failed to mount secrets because of an issue when using the {hcp} command-line interface, `hcp`, to create OpenID Connect (OIDC) infrastructure on {aws-full}. With this release, the issue has been fixed so that the driver can now mount volumes. (link:https://issues.redhat.com/browse/OCPBUGS-18711[*OCPBUGS-18711*])
 
+////
 [discrete]
 [id="ocp-4-17-windows-containers-bug-fixes_{context}"]
 ==== Windows containers
+////
 
 [id="ocp-4-17-technology-preview-tables_{context}"]
 == Technology Preview features status
@@ -2636,7 +2661,7 @@ As a temporary workaround, the image registry should not be configured as privat
 
 [id="ocp-hosted-control-planes-4-17-known-issues_{context}"]
 
-* Deploying a self-managed private hosted cluster on AWS fails because the `bootstrap-kubeconfig` file uses an incorrect KAS port. As a result, the AWS instances are provisioned, but cannot join the hosted cluster as nodes. (link:https://issues.redhat.com/browse/OCPBUGS-31840[*OCPBUGS-31840*])
+* Deploying a self-managed private hosted cluster on {aws-short} fails because the `bootstrap-kubeconfig` file uses an incorrect KAS port. As a result, the {aws-short} instances are provisioned, but cannot join the hosted cluster as nodes. (link:https://issues.redhat.com/browse/OCPBUGS-31840[*OCPBUGS-31840*])
 
 [id="ocp-4-17-asynchronous-errata-updates_{context}"]
 == Asynchronous errata updates


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11208](https://issues.redhat.com/browse/OSDOCS-11208)

Link to docs preview:
* [4.17 Bug fixes](https://82618--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-bug-fixes_release-notes)
