### PR TITLE
4-17-notes-final-tidy

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -49,154 +49,18 @@ The scope of support for layered and dependent components of {product-title} cha
 
 This release adds improvements related to the following components and concepts:
 
-[id="ocp-4-17-rhcos_{context}"]
-=== {op-system-first}
+[id="ocp-4-17-cro_{context}"]
+=== Cluster Resource Override Admission Operator
 
-[id="ocp-4-17-rhcos-rhel-9-4-packages_{context}"]
-==== {op-system} uses {op-system-base} 9.4
-{op-system} uses {op-system-base-full} 9.4 packages in {product-title} {product-version}. These packages ensure that your {product-title} instance receives the latest fixes, features, enhancements, hardware support, and driver updates.
+[id="ocp-4-17-cro-infra_{context}"]
+==== Moving the Cluster Resource Override Operator
 
-[id="ocp-4-17-rhcos-dnf_{context}"]
-==== Support for the DNF package manager
-With this release, you can now use DNF to install additional packages to your customized {op-system-first} builds. For more information, see xref:../machine_configuration/mco-coreos-layering.adoc[{op-system-first} layering].
+By default, the installation process creates a Cluster Resource Override Operator pod on a worker node and two Cluster Resource Override pods on control plane nodes. You can move these pods to other nodes, such as an infrastructure node, as needed. For more information, see xref:../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-resource-override-move-infra_nodes-cluster-overcommit[Moving the Cluster Resource Override Operator pods].
 
-[id="ocp-4-17-installation-and-update_{context}"]
-=== Installation and update
+[id="ocp-4-17-cro-deploy_{context}"]
+==== Cluster Resource Override Operator pod is owned by a deployment object
 
-[id="ocp-4-17-installation-gcp-user-defined-label-tags_{context}"]
-==== User-defined labels and tags for GCP
-
-With this update, the user-defined labels and tags for {gcp-first} is Generally Available.
-
-For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-user-defined-labels-and-tags_installing-gcp-customizations[Managing user-defined labels and tags for GCP].
-
-[id="ocp-4-17-installation-and-update-azure-spain_{context}"]
-==== Installing a cluster on {azure-short} in the Central Spain region
-
-[id="ocp-4-17-installing-a-cluster-with-multiarch-support_{context}"]
-==== Installing a cluster with the support for configuring multi-architecture compute machines
-
-With this release, you can install an {aws-first} cluster and {gcp-first} cluster with the support for configuring multi-architecture compute machines. While installing the cluster, you can specify different CPU architectures for the control plane and compute machines in the following ways:
-
-* 64-bit x86 compute machines and 64-bit ARM control plane machines
-* 64-bit ARM compute machines and 64-bit x86 control plane machines
-
-An {product-title} cluster with multi-architecture compute machines supports compute machines with different architectures. For more information, see the following documentation:
-
-* xref:../installing/installing_aws/ipi/installing-aws-multiarch-support.adoc#installing-a-cluster-with-multiarch-support_ipi-aws-multiarch-support[Installing an AWS cluster on IPI with the support for configuring multi-architecture compute machines]
-* xref:../installing/installing_aws/upi/installing-aws-multiarch-support-upi.adoc#installing-a-cluster-with-multiarch-support_upi-aws-multiarch-support[Installing an AWS cluster on UPI with the support for configuring multi-architecture compute machines]
-* xref:../installing/installing_gcp/installing-gcp-multiarch-support.html#installing-a-cluster-with-multiarch-support_installing-gcp-multiarch-support[Installing a GCP cluster with the support for configuring multi-architecture compute machines]
-
-==== Deploy {azure-short} in the Spain region
-
-You can deploy {product-title} {product-version} in {azure-first} in the Spain, Central (`spaincentral`) region. For more information, see xref:../installing/installing_azure/installing-azure-account.adoc#installation-azure-regions_installing-azure-account[Supported Azure regions].
-
-[id="ocp-4-17-installation-and-update-azure-capi_{context}"]
-==== Cluster API replaces Terraform for {azure-first} installations
-In {product-title} 4.17, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on {azure-short}.
-
-[NOTE]
-====
-With the replacement of Terraform, the following permissions are required if you use a service principal with limited privileges:
-
-* `Microsoft.Network/loadBalancers/inboundNatRules/read`
-* `Microsoft.Network/loadBalancers/inboundNatRules/write`
-* `Microsoft.Network/loadBalancers/inboundNatRules/join/action`
-* `Microsoft.Network/loadBalancers/inboundNatRules/delete`
-* `Microsoft.Network/routeTables/read`
-* `Microsoft.Network/routeTables/write`
-* `Microsoft.Network/routeTables/join/action`
-
-For more information on required permissions, see xref:../installing/installing_azure/installing-azure-account.adoc#minimum-required-permissions-ipi-azure_installing-azure-account[Required Azure permissions for installer-provisioned infrastructure].
-====
-
-[id="ocp-4-17-installation-and-update-gcp-service-account_{context}"]
-==== Installing a cluster on {gcp-full} by using an existing service account
-
-With this update, you can install a cluster on {gcp-short} by using an existing service account, allowing you to minimize the permissions that you grant to the service account the installation program uses. You can specify this service account in the `compute.platform.gcp.serviceAccount` and `controlPlane.platform.gcp.serviceAccount` parameters in the `install-config.yaml` file. For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters_installation-config-parameters-gcp[Available installation configuration parameters for GCP].
-
-[id="ocp-4-17-installation-and-update-aws-iam_{context}"]
-==== Installing a cluster on {aws-short} by using an existing IAM profile
-
-With this release, you can install {product-title} on {aws-first} by using an existing identity and access management (IAM) instance profile. For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-optional-aws_installation-config-parameters-aws[Optional {aws-short} configuration parameters].
-
-[id="ocp-4-17-installation-and-update-gcp-n4_{context}"]
-==== Installing a cluster on {gcp-short} using the N4 machine series
-
-With this release, you can deploy a cluster on {gcp-short} using the link:https://cloud.google.com/compute/docs/general-purpose-machines#n4_series[N4 machine series] for compute or control plane machines. The supported disk type of N4 machine series is `hyperdisk-balanced`. For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-gcp[Installation configuration parameters for GCP].
-
-[id="ocp-4-17-installation-and-update-gcp-capi_{context}"]
-==== Cluster API replaces Terraform for {gcp-first} installations
-
-With this release, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on {gcp-short}.
-
-[id="installation-and-update-shiftstack-compact_{context}"]
-==== Three-node cluster support for {rh-openstack}
-
-Deploying a three-node cluster on installer-provisioned infrastructure is now supported on {rh-openstack-first}.
-
-For more information, see xref:../installing/installing_openstack/installing-openstack-three-node.adoc#installing-openstack-three-node[Installing a three-node cluster on OpenStack].
-
-[id="ocp-4-17-deploying-osp-with-root-volume-etcd-on-local-disk"]
-==== Deploying {rh-openstack-first} with root volume and etcd on local disk (Generally Available)
-
-You can now move etcd from a root volume (Cinder) to a dedicated ephemeral local disk as a Day 2 deployment with this generally available feature.
-
-For more information, see xref:../installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.adoc#deploying-openstack-with-rootvolume-etcd-on-local-disk[Deploying on OpenStack with rootVolume and etcd on local disk].
-
-[id="ocp-4-17-installation-aws-outposts-deprecated_{context}"]
-==== Announcement of the deprecation of extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud
-
-With this release, extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud is deprecated. The ability to deploy compute nodes into AWS Outposts after installation, as an extension of an existing {product-title} cluster operating in a public AWS region, will be removed with the release of {product-title} version 4.20.
-
-For more information, see xref:../installing/installing_aws/ipi/installing-aws-outposts.html#installing-aws-outposts[Extending an AWS VPC cluster into an AWS Outpost].
-
-[id="ocp-4-17-postinstallation-configuration_{context}"]
-=== Postinstallation configuration
-
-[id="ocp-4-17-web-console_{context}"]
-=== Web console
-
-[id="ocp-4-17-ocp-lightspeed_{context}"]
-==== {ols} Operator is available in the web console
-
-Starting with {product-title} 4.16, {ols} Operator is available for use in the web console. With this release, a hover button was added to help you discover {ols}. Once you click the hover button, the chat window appears with instructions on how to enable and install {ols} on the cluster. You can hide the {ols} button when changing the default user preferences.
-
-//https://github.com/openshift/openshift-docs/pull/81581
-//For more information, see xref:../web_console/capabilities_products-web-console.html#openshift-lightspeed-web-console_capabilities-web-console[Enhancing your experience in the {product-title} web console by using {ols-official}].
-
-[id="ocp-4-17-administrator-perspective_{context}"]
-==== Administrator perspective
-
-This release introduces the following updates to the *Administrator* perspective of the web console:
-
-* Deprecated Operators are displayed in the OperatorHub before and after installation along with a warning notification that the Operator is deprecated.
-* You can check contnet of the configuration files for `MachineConfig` objects without having to manually retrieve its contents.
-* An alert was added to the *Operator details* page and the *Operator installation* page if your cluster is on {gcp-first} with Workload Identity Foundation (WIF).
-* A page for ShipWright `BuildStrategy` was added to the *Shipwright* page with a `ClusterBuildStrategy` and `BuildStrategy` tab.
-
-[id="ocp-4-17-customize-create-project-modal-dyanmic-plugin"]
-===== Customize the *Create project* modal using dynamic plugins
-
-With this release, a new extension point was added, so dynamic plugin creators can pass a component that renders in place of the default *Create Project* modal.
-
-For more information on {product-title} Console dynamic plugin SDK extensions, see xref:../web_console/dynamic-plugin/dynamic-plugins-reference.adoc#dynamic-plugin-sdk-extensions_dynamic-plugins-reference[Dynamic plugin extension types].
-
-[id="ocp-4-17-console-functional-external-oidc-issuer"]
-===== External OpenID Connect (OIDC) token issuer is now functional in the web console
-
-With this update, the web console works as expected when internal `oauth-server` resource and `oauth-apiserver` resource are removed and replaced with an external OpenID Connect (OIDC) issuer.
-
-[id="ocp-4-17-developer-perspective_{context}"]
-==== Developer Perspective
-
-This release introduces the following updates to the *Developer* perspective of the web console:
-
-* When you use one of the add flows to create a new deployment, the *Import from Git* or *Container images* automatically opens them in the sidebar.
-* You can easily select the desired *Git Type* without having to use the list if {product-title} is unable to identify its type.
-* *Import from Git* supports GitEA, an open-source alternitve to GitHub.
-* A warning notification displays on the *Topology* page if the `PodDisruptionBudget` limit is reached.
-* When importing applications through the *Import from Git* flows you can use Shipwright Build strategies such as S2I, buildpack, and buildah strategy for building the image.
+The Cluster Resource Override Operator pod is now owned by a deployment object. Previously, the Operator was owned by a daemon set object. Using a deployment for the Operator addresses a number of issues, including additional security and add the ability to run the pods on worker nodes.
 
 [id="ocp-4-17-extensions_{context}"]
 === Extensions ({olmv1})
@@ -204,7 +68,7 @@ This release introduces the following updates to the *Developer* perspective of 
 [id="ocp-4-17-extensions-new-guide_{context}"]
 ==== {olmv1-first} documentation moved to new Extensions guide (Technology Preview)
 
-The documentation for {olmv1}, which has been in Technology Preview starting in {product-title} 4.14, is now moved and reworked as a separate guide called xref:../extensions/index.adoc#olmv1-about[Extensions]. Previously, {olmv1} documentation was a subsection of the existing xref:../operators/index.adoc#operators-overview[Operators] guide, which otherwise documents the {olmv0} feature set.
+The documentation for {olmv1}, which has been in Technology Preview starting in {product-title} 4.14, is now moved and reworked as a separate guide called xref:../extensions/index.adoc#olmv1-about[Extensions]. Previously, {olmv1} documentation was a subsection of the existing xref:../operators/index.adoc#operators-overview[Operators Overview] guide, which otherwise documents the {olmv0} feature set.
 
 The updated location and guide name reflect a more focused documentation experience and aims to differentiate between {olmv1} and {olmv0}.
 
@@ -243,15 +107,45 @@ include::snippets/olmv1-operator-conditions-support.adoc[]
 include::snippets/olmv1-known-issue-private-registries.adoc[]
 ====
 
-[id="ocp-4-17-openshift-cli_{context}"]
-=== OpenShift CLI (oc)
+[id="ocp-4-17-edge-computing_{context}"]
+=== Edge computing
 
-[id="ocp-4-17-openshift-cli-oc-mirror-kubevirt_{context}"]
-==== oc-mirror to include the HyperShift KubeVirt CoreOS container
+[id="ocp-4-17-edge-computing-managing-firmware-with-ztp_{context}"]
+==== Managing host firmware settings with {ztp}
 
-With this release, oc-mirror now includes the {op-system-first} image for the HyperShift KubeVirt provider when mirroring the {product-title} release payload.
+You can now configure host firmware settings for managed clusters that you deploy with {ztp}.
+You save host profile YAML files alongside `SiteConfig` custom resources (CRs) that you use to deploy the managed clusters.
+{ztp} uses the host profiles to configure firmware settings in the managed cluster hosts during deployment.
+On the hub cluster, you can use `FirmwareSchema` CRs to discover managed cluster host firmware schema, and `HostFirmwareSettings` CRs and retrieve managed clusters firmware settings.
 
-The `kubeVirtContainer` flag, which is set to false by default, must be set to `true` in the `imageSetConfig.yaml` file to extract the KubeVirt Container {op-system}. This ensures support for disconnected environments by including the required image for KubeVirt virtual machines acting as nodes for hosted clusters.
+For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-configuring-host-firmware-with-gitops-ztp_ztp-deploying-far-edge-sites[Managing host firmware settings with {ztp}].
+
+[id="ocp-4-17-image-based-upgrade-enhancements_{context}"]
+==== Image-based upgrade enhancements
+
+With this release, the image-based upgrade introduces the following enhancements:
+
+* Simplifies the upgrade process for a large group of managed clusters by adding the `ImageBasedGroupUpgrade` API on the hub
+* Labels the managed clusters for action completion when using the `ImageBasedGroupUpgrade` API
+* Improves seed cluster validation before the seed image generation
+* Automatically cleans up the container storage disk if usage reaches a certain threshold on the managed clusters
+* Adds comprehensive event history in the new `status.history` field of the `ImageBasedUpgrade` CR
+
+For more information about the `ImageBasedGroupUpgrade` API, see xref:../edge_computing/image_based_upgrade/ztp-image-based-upgrade.adoc#ztp-image-based-upgrade-concept_ztp-gitops[Managing the image-based upgrade at scale using the ImageBasedGroupUpgrade CR on the hub].
+
+[id="ocp-4-17-disk-encryption_{context}"]
+==== Disk encryption with TPM and PCR protection (Technology Preview)
+
+With this release, you can enable disk encryption with Trusted Platform Module (TPM) and Platform Configuration Registers (PCRs) protection. You can use the `diskEncryption` field in the `SiteConfig` custom resource (CR) to configure the disk encryption. Configuring the `SiteConfig` CR enables disk encryption at the time of cluster installation.
+
+For more information, see xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-configuring-disk-encryption-with-pcr-protection_sno-configure-for-vdu[Enabling disk encryption with TPM and PCR protection]
+
+[id="ocp-4-17-config-ipsec-encryption_{context}"]
+==== IPsec encryption for multi-node clusters using {ztp} and SiteConfig resources
+
+You can now enable IPsec encryption in managed multi-node clusters that you deploy with {ztp} and {rh-rhacm-first}. You can encrypt traffic between the managed cluster and IPsec endpoints external to the managed cluster. All network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec in Transport mode.
+
+For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-configuring-ipsec-using-ztp-and-siteconfig-for-mno_ztp-deploying-far-edge-sites[Configuring IPsec encryption for multi-node clusters using {ztp} and SiteConfig resources]
 
 [id="ocp-4-17-ibm-z_{context}"]
 === {ibm-z-title} and {ibm-linuxone-title}
@@ -632,8 +526,248 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 |Supported
 |====
 
+[id="ocp-4-17-insights-operator-enhancements_{context}"]
+=== Insights Operator
+
+* The Insights Operator now collects the `haproxy_exporter_server_threshold` metric. (link:https://issues.redhat.com/browse/OCPBUGS-36687[*OCPBUGS-36687*])
+
+* Previously, the Insights Operator gathered information about all Ingress Controller certificates, including their `NotBefore` and `NotAfter` dates. This data is now compiled into a `JSON` file located at `aggregated/ingress_controllers_certs.json` for easier monitoring of certificate validity across the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-35727[*OCPBUGS-35727*])
+
+[id="ocp-4-17-installation-and-update_{context}"]
+=== Installation and update
+
+[id="ocp-4-17-installation-gcp-user-defined-label-tags_{context}"]
+==== User-defined labels and tags for GCP
+
+With this update, the user-defined labels and tags for {gcp-first} is Generally Available.
+
+For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-user-defined-labels-and-tags_installing-gcp-customizations[Managing user-defined labels and tags for GCP].
+
+[id="ocp-4-17-installation-and-update-azure-spain_{context}"]
+==== Installing a cluster on {azure-short} in the Central Spain region
+
+You can now install an {product-title} cluster on {azure-short} in the Central Spain region, `spaincentral`.
+
+For more information, see xref:../installing/installing_azure/installing-azure-account.adoc#installation-azure-regions_installing-azure-account[Supported {azure-short} regions]
+
+[id="ocp-4-17-installing-a-cluster-with-multiarch-support_{context}"]
+==== Installing a cluster with the support for configuring multi-architecture compute machines
+
+With this release, you can install an {aws-first} cluster and {gcp-first} cluster with the support for configuring multi-architecture compute machines. While installing the cluster, you can specify different CPU architectures for the control plane and compute machines in the following ways:
+
+* 64-bit x86 compute machines and 64-bit ARM control plane machines
+* 64-bit ARM compute machines and 64-bit x86 control plane machines
+
+An {product-title} cluster with multi-architecture compute machines supports compute machines with different architectures. For more information, see the following documentation:
+
+* xref:../installing/installing_aws/ipi/installing-aws-multiarch-support.adoc#installing-a-cluster-with-multiarch-support_ipi-aws-multiarch-support[Installing a cluster with multi-architecture support ({aws-short}: Installer-provisioned infrastructure)]
+* xref:../installing/installing_aws/upi/installing-aws-multiarch-support-upi.adoc#installing-a-cluster-with-multiarch-support_upi-aws-multiarch-support[Installing a cluster with multi-architecture support ({aws-short}: User-provisioned infrastructure)]
+* xref:../installing/installing_gcp/installing-gcp-multiarch-support.html#installing-a-cluster-with-multiarch-support_installing-gcp-multiarch-support[Installing a cluster with multi-architecture support ({gcp-short})]
+
+==== Deploy {azure-short} in the Spain region
+
+You can deploy {product-title} {product-version} in {azure-first} in the Spain, Central (`spaincentral`) region. For more information, see xref:../installing/installing_azure/installing-azure-account.adoc#installation-azure-regions_installing-azure-account[Supported Azure regions].
+
+[id="ocp-4-17-installation-and-update-azure-capi_{context}"]
+==== Cluster API replaces Terraform for {azure-first} installations
+In {product-title} 4.17, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on {azure-short}.
+
+[NOTE]
+====
+With the replacement of Terraform, the following permissions are required if you use a service principal with limited privileges:
+
+* `Microsoft.Network/loadBalancers/inboundNatRules/read`
+* `Microsoft.Network/loadBalancers/inboundNatRules/write`
+* `Microsoft.Network/loadBalancers/inboundNatRules/join/action`
+* `Microsoft.Network/loadBalancers/inboundNatRules/delete`
+* `Microsoft.Network/routeTables/read`
+* `Microsoft.Network/routeTables/write`
+* `Microsoft.Network/routeTables/join/action`
+
+For more information on required permissions, see xref:../installing/installing_azure/installing-azure-account.adoc#minimum-required-permissions-ipi-azure_installing-azure-account[Required Azure permissions for installer-provisioned infrastructure].
+====
+
+[id="ocp-4-17-installation-and-update-gcp-service-account_{context}"]
+==== Installing a cluster on {gcp-full} by using an existing service account
+
+With this update, you can install a cluster on {gcp-short} by using an existing service account, allowing you to minimize the permissions that you grant to the service account the installation program uses. You can specify this service account in the `compute.platform.gcp.serviceAccount` and `controlPlane.platform.gcp.serviceAccount` parameters in the `install-config.yaml` file. For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters_installation-config-parameters-gcp[Available installation configuration parameters for {gcp-short}].
+
+[id="ocp-4-17-installation-and-update-aws-iam_{context}"]
+==== Installing a cluster on {aws-short} by using an existing IAM profile
+
+With this release, you can install {product-title} on {aws-first} by using an existing identity and access management (IAM) instance profile. For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-optional-aws_installation-config-parameters-aws[Optional {aws-short} configuration parameters].
+
+[id="ocp-4-17-installation-and-update-gcp-n4_{context}"]
+==== Installing a cluster on {gcp-short} using the N4 machine series
+
+With this release, you can deploy a cluster on {gcp-short} using the link:https://cloud.google.com/compute/docs/general-purpose-machines#n4_series[N4 machine series] for compute or control plane machines. The supported disk type of N4 machine series is `hyperdisk-balanced`. For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-gcp[Installation configuration parameters for GCP].
+
+[id="ocp-4-17-installation-and-update-gcp-capi_{context}"]
+==== Cluster API replaces Terraform for {gcp-first} installations
+
+With this release, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on {gcp-short}.
+
+[id="installation-and-update-shiftstack-compact_{context}"]
+==== Three-node cluster support for {rh-openstack}
+
+Deploying a three-node cluster on installer-provisioned infrastructure is now supported on {rh-openstack-first}.
+
+For more information, see xref:../installing/installing_openstack/installing-openstack-three-node.adoc#installing-openstack-three-node[Installing a three-node cluster on OpenStack].
+
+[id="ocp-4-17-deploying-osp-with-root-volume-etcd-on-local-disk"]
+==== Deploying {rh-openstack-first} with root volume and etcd on local disk (Generally Available)
+
+You can now move etcd from a root volume (Cinder) to a dedicated ephemeral local disk as a Day 2 deployment with this generally available feature.
+
+For more information, see xref:../installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.adoc#deploying-openstack-with-rootvolume-etcd-on-local-disk[Deploying on OpenStack with rootVolume and etcd on local disk].
+
+[id="ocp-4-17-installation-aws-outposts-deprecated_{context}"]
+==== Announcement of the deprecation of extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud
+
+With this release, extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud is deprecated. The ability to deploy compute nodes into AWS Outposts after installation, as an extension of an existing {product-title} cluster operating in a public AWS region, will be removed with the release of {product-title} version 4.20.
+
+For more information, see xref:../installing/installing_aws/ipi/installing-aws-outposts.html#installing-aws-outposts[Extending an AWS VPC cluster into an AWS Outpost].
+
+[id="ocp-4-17-olm_{context}"]
+=== Operator lifecycle
+
+[id="ocp-4-17-olm-extensions-guide_{context}"]
+==== {olmv1-first} documentation moved to new Extensions guide (Technology Preview)
+
+For more information, see the new features and enhancements section for xref:../release_notes/ocp-4-17-release-notes.adoc#ocp-4-17-extensions_release-notes[Extensions].
+
+[id="ocp-4-17-osdk_{context}"]
+=== Operator development
+
+[id="ocp-4-17-osdk-cco-gcp_{context}"]
+==== Token authentication for Operators on cloud providers: {gcp-wid-short}
+
+With this release, Operators managed by Operator Lifecycle Manager (OLM) can support token authentication when running on {gcp-first} clusters configured for {gcp-wid-short}. Updates to the Cloud Credential Operator (CCO) enable semi-automated provisioning of certain short-term credentials, provided that the Operator author has enabled their Operator to support {gcp-wid-short}.
+
+For more information, see xref:../operators/operator_sdk/token_auth/osdk-cco-gcp.adoc#osdk-cco-gcp[CCO-based workflow for OLM-managed Operators with {gcp-wid-short}].
+
+[id="ocp-4-17-openshift-cli_{context}"]
+=== OpenShift CLI (oc)
+
+[id="ocp-4-17-openshift-cli-oc-mirror-kubevirt_{context}"]
+==== oc-mirror to include the HyperShift KubeVirt CoreOS container
+
+With this release, oc-mirror now includes the {op-system-first} image for the HyperShift KubeVirt provider when mirroring the {product-title} release payload.
+
+The `kubeVirtContainer` flag, which is set to false by default, must be set to `true` in the `imageSetConfig.yaml` file to extract the KubeVirt Container {op-system}. This ensures support for disconnected environments by including the required image for KubeVirt virtual machines acting as nodes for hosted clusters.
+
+[id="ocp-4-17-machine-config-operator_{context}"]
+=== Machine Config Operator
+
+[id="ocp-4-17-machine-config-operator-global-tls_{context}"]
+==== Control plane TLS security profiles supported by the MCO
+
+The Machine Config Operator (MCO) and Machine Config Server now use the TLS security profile that is configured for the control plane components. For more information, see xref:../security/tls-security-profiles.adoc#tls-profiles-kubernetes-configuring_tls-security-profiles[Configuring the TLS security profile for the control plane].
+
+[id="ocp-4-17-machine-config-operator-boot-image-aws_{context}"]
+==== Updated boot images for AWS now supported (Technology Preview)
+
+Updated boot images are now supported as a Technology Preview feature for Amazon Web Services (AWS) clusters. This feature allows you configure your cluster to update the node boot image whenever you update your cluster. By default, the boot image in your cluster is not updated along with your cluster. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
+
+[id="ocp-4-17-machine-config-operator-boot-image-gcp_{context}"]
+==== Updated boot images for GCP clusters promoted to GA
+
+Updated boot images has been promoted to GA for Google Cloud Platform (GCP) clusters. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
+
+[id="ocp-4-17-machine-config-operator-node-disrupt-ga_{context}"]
+==== Node disruption policies promoted to GA
+
+The node disruption policies feature has been promoted to GA. A node disruption policy allows you to define a set of Ignition config objects changes that would require little or no disruption to your workloads. For more information, see xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes].
+
+[id="ocp-4-17-machine-management_{context}"]
+=== Machine management
+
+[id="ocp-4-17-enhancements-azure-res-cap_{context}"]
+==== Configuring Capacity Reservation by using machine sets
+
+{product-title} release {product-version} introduces support for on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.
+For more information, see _Configuring Capacity Reservation by using machine sets_ for xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-capacity-reservation_creating-machineset-azure[compute] or xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#machineset-azure-capacity-reservation_cpmso-config-options-azure[control plane] machine sets.
+
+[id="ocp-4-17-monitoring_{context}"]
+=== Monitoring
+
+The in-cluster monitoring stack for this release includes the following new and modified features.
+//change the line if no features
+
+[id="ocp-4-17-monitoring-updates-to-monitoring-stack-components-and-dependencies"]
+==== Updates to monitoring stack components and dependencies
+
+This release includes the following version updates for in-cluster monitoring stack components and dependencies:
+
+* Alertmanager to 0.27.0
+* Prometheus Operator to 0.75.2
+* Prometheus to 2.53.1
+* kube-state-metrics to 2.13.0
+* node-exporter to 1.8.2
+* Thanos to 0.35.1
+
+[id="ocp-4-17-monitoring-changes-to-alerting-rules"]
+==== Changes to alerting rules
+
+[NOTE]
+====
+Red{nbsp}Hat does not guarantee backward compatibility for recording rules or alerting rules.
+====
+
+* Added the `PrometheusKubernetesListWatchFailures` alert to warn users about Prometheus and Kubernetes API failures, such as unreachable API and permissions issues, which can lead into silent service discovery failures.
+
+[id="ocp-4-17-monitoring-prometheus-updated-to-tolerate-jitters-at-scrape-time-uwm"]
+==== Updated Prometheus to tolerate jitters at scrape time for user-defined projects
+With this update, the Prometheus configuration for monitoring for user-defined projects now tolerates jitters at scrape time. This update optimizes data compression for monitoring deployments that show sub-optimal chunk compression for data storage, which reduces the disk space used by the time series database in these deployments.
+
+[id="ocp-4-17-network-observability-1-6_{context}"]
+==== Network Observability Operator
+The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, Rolling Stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator is found in the xref:../observability/network_observability/network-observability-operator-release-notes.adoc#network-observability-rn[Network Observability release notes].
+
+[id="ocp-4-17-nodes_{context}"]
+=== Nodes
+
+[id="ocp-4-17-enhancements-nodes-crio-wipe_{context}"]
+==== New CRIO command behavior
+Beginning in {product-title} 4.17, when a node is rebooted, the `crio wipe` command checks that the CRI-O binary exited cleanly. Those images that did not exit cleanly are targeted as corrupted and removed. This behavior prevents CRI-O from failing to start due to half-pulled images or other unsynced files. In {product-title} 4.15 and 4.16, the `crio wipe` command removed all images when a node was rebooted. The `crio wipe` command’s new behavior increases efficiency while still reducing the risk of image corruption when a node is rebooted.
+
+[id="ocp-4-17-must-gather-new-flags_{context}"]
+==== New flags added for must-gather command
+
+{product-title} release {product-version} adds two new flags for use with the `oc adm must-gather` command to limit the timespan of the information gathered. Only one of the following flags can be used at a time. Plugins are encouraged but not required to support these flags.
+
+* `--since`: Only return logs newer than a relative duration, such as 5s, 2m, or 3h. Defaults to all logs.
+* `--since-time`: Only return logs after a specific date, expressed in the RFC3339 format. Defaults to all logs.
+
+For a full list of flags to use with the `oc adm must-gather command`, see xref:../support/gathering-cluster-data.adoc#must-gather-flags_gathering-cluster-data[Must-gather flags].
+
+[id="ocp-4-17-nodes-userns_{context}"]
+==== Linux user namespaces now supported for pods (Technology Preview)
+
+{product-title} release {product-version} adds support for deploying pods and containers into Linux user namespaces. Running pods and containers in individual user namespaces can mitigate several vulnerabilities that a compromised container can pose to other pods and the node itself. For more information, see xref:../nodes/pods/nodes-pods-user-namespaces.adoc#nodes-pods-user-namespaces[Running pods in Linux user namespaces].
+
+[id="ocp-4-17-nodes-crio-port_{context}"]
+==== CRI-O metrics port now uses TLS
+
+{product-title} monitoring now uses a TLS-backed endpoint to fetch CRI-O container runtime metrics. These certificates are managed by the system and not the user. {product-title} monitoring queries have been updated to the new port. For information on the certificates used by monitoring, see xref:../security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc#cert-types-monitoring-and-cluster-logging-operator-component-certificates[Monitoring and OpenShift Logging Operator component certificates].
+
+[id="ocp-4-17-adding-nodes-to-on-prem_{context}"]
+==== Adding compute nodes to on-premise clusters
+
+With this release, you can add compute nodes by using the {oc-first} to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
+This process can be used regardless of how you installed your cluster.
+
+For more information, see xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster].
+
+////
+[id="ocp-4-17-postinstallation-configuration_{context}"]
+=== Postinstallation configuration
+////
+
+////
 [id="ocp-4-17-auth_{context}"]
 === Authentication and authorization
+////
 
 [id="ocp-4-17-networking_{context}"]
 === Networking
@@ -653,7 +787,7 @@ The host system clock is synchronized from the NIC that is connected to the Glob
 
 With this release, you can query the Single Root I/O Virtualization (SR-IOV) virtual function (VF) metrics by using the {product-title} web console to monitor the networking activity of the SR-IOV pods. When you query the SR-IOV VF metrics by using the web console, the SR-IOV network metrics exporter fetches and returns the VF network statistics along with the name and namespace of the pod that the VF is attached to.
 
-For more information, see xref:../networking/hardware_networks/configuring-sriov-operator.adoc#sriov-operator-metrics_configuring-sriov-operator[Enabling the SR-IOV network metrics exporter]
+For more information, see xref:../networking/hardware_networks/configuring-sriov-operator.adoc#sriov-operator-metrics_configuring-sriov-operator[Enabling the SR-IOV network metrics exporter].
 
 [id="ocp-4-17-networking-azure-support-nmstate-operator_{context}"]
 ==== Microsoft Azure for the Kubernetes NMState Operator
@@ -746,6 +880,17 @@ A new, optional configuration parameter, `chunkSizeMiB`, is now available for de
 
 For more information, see xref:../registry/configuring_registry_storage/configuring-registry-storage-aws-user-infrastructure.adoc#registry-operator-configuration-resource-overview-aws-s3_configuring-registry-storage-aws-user-infrastructure[Image Registry Operator configuration parameters for AWS S3].
 
+[id="ocp-4-17-rhcos_{context}"]
+=== {op-system-first}
+
+[id="ocp-4-17-rhcos-rhel-9-4-packages_{context}"]
+==== {op-system} uses {op-system-base} 9.4
+{op-system} uses {op-system-base-full} 9.4 packages in {product-title} {product-version}. These packages ensure that your {product-title} instance receives the latest fixes, features, enhancements, hardware support, and driver updates.
+
+[id="ocp-4-17-rhcos-dnf_{context}"]
+==== Support for the DNF package manager
+With this release, you can now use DNF to install additional packages to your customized {op-system-first} builds. For more information, see xref:../machine_configuration/mco-coreos-layering.adoc[{op-system-first} image layering].
+
 [id="ocp-4-17-storage_{context}"]
 === Storage
 
@@ -758,7 +903,7 @@ Amazon Web Services (AWS) Elastic File Service (EFS) usage metrics allow you to 
 Turning on these metrics can lead to performance degradation because the CSI driver walks through the whole volume. Therefore, this option is disabled by default. Administrators must explicitly enable this feature.
 ====
 
-For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#aws-efs-storage-csi-usage-metrics[Amazon Elastic File CSI Storage usage metrics].
+For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#aws-efs-storage-csi-usage-metrics[{aws-short} EFS storage CSI usage metrics].
 
 [id="ocp-4-17-storage-control-vol-mode-conversion"]
 ==== Preventing unauthorized volume mode conversion is generally available
@@ -816,6 +961,7 @@ include::snippets/developer-preview.adoc[]
 
 For more information about cns-migration, see link:https://github.com/openshift/vmware-vsphere-csi-driver-operator/blob/master/docs/cns-migration.md[Moving CNS volumes between datastores].
 
+////
 [id="ocp-4-17-oci"]
 === {oci-first}
 
@@ -825,199 +971,23 @@ For more information about cns-migration, see link:https://github.com/openshift/
 [id="ocp-4-17-olm_{context}"]
 === Operator lifecycle
 
-[id="ocp-4-17-olm-extensions-guide_{context}"]
-==== {olmv1-first} documentation moved to new Extensions guide (Technology Preview)
-
-For more information, see the new features and enhancements section for xref:../release_notes/ocp-4-17-release-notes.adoc#ocp-4-17-extensions_release-notes[Extensions].
-
-[id="ocp-4-17-osdk_{context}"]
-=== Operator development
-
-[id="ocp-4-17-osdk-cco-gcp_{context}"]
-==== Token authentication for Operators on cloud providers: {gcp-wid-short}
-
-With this release, Operators managed by Operator Lifecycle Manager (OLM) can support token authentication when running on {gcp-first} clusters configured for {gcp-wid-short}. Updates to the Cloud Credential Operator (CCO) enable semi-automated provisioning of certain short-term credentials, provided that the Operator author has enabled their Operator to support {gcp-wid-short}.
-
-For more information, see xref:../operators/operator_sdk/token_auth/osdk-cco-gcp.adoc#osdk-cco-gcp[CCO-based workflow for OLM-managed Operators with {gcp-wid-short}].
-
-
 [id="ocp-4-17-builds_{context}"]
 === Builds
 
-[id="ocp-4-17-machine-config-operator_{context}"]
-=== Machine Config Operator
-
-[id="ocp-4-17-machine-config-operator-global-tls_{context}"]
-==== Control plane TLS security profiles supported by the MCO
-
-The Machine Config Operator (MCO) and Machine Config Server now use the TLS security profile that is configured for the control plane components. For more information, see xref:../security/tls-security-profiles.adoc#tls-profiles-kubernetes-configuring_tls-security-profiles[Configuring the TLS security profile for the control plane].
-
-[id="ocp-4-17-machine-config-operator-boot-image-aws_{context}"]
-==== Updated boot images for AWS now supported (Technology Preview)
-
-Updated boot images are now supported as a Technology Preview feature for Amazon Web Services (AWS) clusters. This feature allows you configure your cluster to update the node boot image whenever you update your cluster. By default, the boot image in your cluster is not updated along with your cluster. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
-
-[id="ocp-4-17-machine-config-operator-boot-image-gcp_{context}"]
-==== Updated boot images for GCP clusters promoted to GA
-
-Updated boot images has been promoted to GA for Google Cloud Platform (GCP) clusters. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
-
-[id="ocp-4-17-machine-config-operator-node-disrupt-ga_{context}"]
-==== Node disruption policies promoted to GA
-
-The node disruption policies feature has been promoted to GA. A node disruption policy allows you to define a set of Ignition config objects changes that would require little or no disruption to your workloads. For more information, see xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes].
-
-[id="ocp-4-17-machine-management_{context}"]
-=== Machine management
-
-[id="ocp-4-17-enhancements-azure-res-cap_{context}"]
-==== Configuring Capacity Reservation by using machine sets
-
-{product-title} release {product-version} introduces support for on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.
-For more information, see _Configuring Capacity Reservation by using machine sets_ for xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-capacity-reservation_creating-machineset-azure[compute] or xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#machineset-azure-capacity-reservation_cpmso-config-options-azure[control plane] machine sets.
-
-[id="ocp-4-17-nodes_{context}"]
-=== Nodes
-
-[id="ocp-4-17-enhancements-nodes-crio-wipe_{context}"]
-==== New CRIO command behavior
-Beginning in {product-title} 4.17, when a node is rebooted, the `crio wipe` command checks that the CRI-O binary exited cleanly. Those images that did not exit cleanly are targeted as corrupted and removed. This behavior prevents CRI-O from failing to start due to half-pulled images or other unsynced files. In {product-title} 4.15 and 4.16, the `crio wipe` command removed all images when a node was rebooted. The `crio wipe` command’s new behavior increases efficiency while still reducing the risk of image corruption when a node is rebooted.
-
-[id="ocp-4-17-must-gather-new-flags_{context}"]
-==== New flags added for must-gather command
-
-{product-title} release {product-version} adds two new flags for use with the `oc adm must-gather` command to limit the timespan of the information gathered. Only one of the following flags can be used at a time. Plugins are encouraged but not required to support these flags.
-
-* `--since`: Only return logs newer than a relative duration, such as 5s, 2m, or 3h. Defaults to all logs.
-* `--since-time`: Only return logs after a specific date, expressed in the RFC3339 format. Defaults to all logs.
-
-For a full list of flags to use with the `oc adm must-gather command`, see xref:../support/gathering-cluster-data.adoc#must-gather-flags_gathering-cluster-data[Must-gather flags].
-
-[id="ocp-4-17-nodes-userns_{context}"]
-==== Linux user namespaces now supported for pods (Technology Preview)
-
-{product-title} release {product-version} adds support for deploying pods and containers into Linux user namespaces. Running pods and containers in individual user namespaces can mitigate several vulnerabilities that a compromised container can pose to other pods and the node itself. For more information, see xref:../nodes/pods/nodes-pods-user-namespaces.adoc#nodes-pods-user-namespaces[Running pods in Linux user namespaces].
-
-[id="ocp-4-17-nodes-crio-port_{context}"]
-==== CRI-O metrics port now uses TLS
-
-{product-title} monitoring now uses a TLS-backed endpoint to fetch CRI-O container runtime metrics. These certificates are managed by the system and not the user. {product-title} monitoring queries have been updated to the new port. For information on the certificates used by monitoring, see xref:../security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc#cert-types-monitoring-and-cluster-logging-operator-component-certificates[Monitoring and OpenShift Logging Operator component certificates].
-
-[id="ocp-4-17-adding-nodes-to-on-prem_{context}"]
-==== Adding compute nodes to on-premise clusters
-
-With this release, you can add compute nodes by using the {oc-first} to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
-This process can be used regardless of how you installed your cluster.
-
-For more information, see xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster].
-
-[id="ocp-4-17-cro_{context}"]
-=== Cluster Resource Override Admission Operator
-
-[id="ocp-4-17-cro-infra_{context}"]
-==== Moving the Cluster Resource Override Operator
-
-By default, the installation process creates a Cluster Resource Override Operator pod on a worker node and two Cluster Resource Override pods on control plane nodes. You can move these pods to other nodes, such as an infrastructure node, as needed. For more information, see xref:../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-resource-override-move-infra_nodes-cluster-overcommit[Moving the Cluster Resource Override Operator pods].
-
-[id="ocp-4-17-cro-deploy_{context}"]
-=== Cluster Resource Override Operator pod is owned by a deployment object
-
-The Cluster Resource Override Operator pod is now owned by a deployment object. Previously, the Operator was owned by a daemon set object. Using a deployment for the Operator addresses a number of issues, including additional security and add the ability to run the pods on worker nodes.
-
-[id="ocp-4-17-monitoring_{context}"]
-=== Monitoring
-
-The in-cluster monitoring stack for this release includes the following new and modified features.
-//change the line if no features
-
-[id="ocp-4-17-monitoring-updates-to-monitoring-stack-components-and-dependencies"]
-==== Updates to monitoring stack components and dependencies
-
-This release includes the following version updates for in-cluster monitoring stack components and dependencies:
-
-* Alertmanager to 0.27.0
-* Prometheus Operator to 0.75.2
-* Prometheus to 2.53.1
-* kube-state-metrics to 2.13.0
-* node-exporter to 1.8.2
-* Thanos to 0.35.1
-
-[id="ocp-4-17-monitoring-changes-to-alerting-rules"]
-==== Changes to alerting rules
-
-[NOTE]
-====
-Red{nbsp}Hat does not guarantee backward compatibility for recording rules or alerting rules.
-====
-
-* Added the `PrometheusKubernetesListWatchFailures` alert to warn users about Prometheus and Kubernetes API failures, such as unreachable API and permissions issues, which can lead into silent service discovery failures.
-
-[id="ocp-4-17-monitoring-prometheus-updated-to-tolerate-jitters-at-scrape-time-uwm"]
-==== Updated Prometheus to tolerate jitters at scrape time for user-defined projects
-With this update, the Prometheus configuration for monitoring for user-defined projects now tolerates jitters at scrape time. This update optimizes data compression for monitoring deployments that show sub-optimal chunk compression for data storage, which reduces the disk space used by the time series database in these deployments.
-
-[id="ocp-4-17-network-observability-1-6_{context}"]
-==== Network Observability Operator
-The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, Rolling Stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator is found in the xref:../observability/network_observability/network-observability-operator-release-notes.adoc#network-observability-rn[Network Observability release notes].
 
 [id="ocp-4-17-scalability-and-performance_{context}"]
 === Scalability and performance
+////
 
 [id="ocp-4-17-etcd-4-5-nodes_{context}"]
 ==== Node scaling for etcd
 
 In this release, if your cluster is installed on a bare metal platform, you can scale a cluster to up to 5 nodes as a post-installation task. The etcd Operator scales accordingly to account for the additional node. For more information, see xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc#etcd-node-scaling_recommended-etcd-practices[Node scaling for etcd].
 
-[id="ocp-4-17-edge-computing_{context}"]
-=== Edge computing
-
-[id="ocp-4-17-edge-computing-managing-firmware-with-ztp_{context}"]
-==== Managing host firmware settings with {ztp}
-
-You can now configure host firmware settings for managed clusters that you deploy with {ztp}.
-You save host profile YAML files alongside `SiteConfig` custom resources (CRs) that you use to deploy the managed clusters.
-{ztp} uses the host profiles to configure firmware settings in the managed cluster hosts during deployment.
-On the hub cluster, you can use `FirmwareSchema` CRs to discover managed cluster host firmware schema, and `HostFirmwareSettings` CRs and retrieve managed clusters firmware settings.
-
-For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-configuring-host-firmware-with-gitops-ztp_ztp-deploying-far-edge-sites[Managing host firmware settings with {ztp}].
-
-[id="ocp-4-17-image-based-upgrade-enhancements_{context}"]
-==== Image-based upgrade enhancements
-
-With this release, the image-based upgrade introduces the following enhancements:
-
-* Simplifies the upgrade process for a large group of managed clusters by adding the `ImageBasedGroupUpgrade` API on the hub
-* Labels the managed clusters for action completion when using the `ImageBasedGroupUpgrade` API
-* Improves seed cluster validation before the seed image generation
-* Automatically cleans up the container storage disk if usage reaches a certain threshold on the managed clusters
-* Adds comprehensive event history in the new `status.history` field of the `ImageBasedUpgrade` CR
-
-For more information about the `ImageBasedGroupUpgrade` API, see xref:../edge_computing/image_based_upgrade/ztp-image-based-upgrade.adoc#ztp-image-based-upgrade-concept_ztp-gitops[Managing the image-based upgrade at scale using the ImageBasedGroupUpgrade CR on the hub].
-
-[id="ocp-4-17-disk-encryption_{context}"]
-==== Disk encryption with TPM and PCR protection (Technology Preview)
-
-With this release, you can enable disk encryption with Trusted Platform Module (TPM) and Platform Configuration Registers (PCRs) protection. You can use the `diskEncryption` field in the `SiteConfig` custom resource (CR) to configure the disk encryption. Configuring the `SiteConfig` CR enables disk encryption at the time of cluster installation.
-
-For more information, see xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-configuring-disk-encryption-with-pcr-protection_sno-configure-for-vdu[Enabling disk encryption with TPM and PCR protection]
-
-[id="ocp-4-17-config-ipsec-encryption_{context}"]
-==== IPsec encryption for multi-node clusters using {ztp} and SiteConfig resources
-
-You can now enable IPsec encryption in managed multi-node clusters that you deploy with {ztp} and {rh-rhacm-first}. You can encrypt traffic between the managed cluster and IPsec endpoints external to the managed cluster. All network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec in Transport mode.
-
-For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-configuring-ipsec-using-ztp-and-siteconfig-for-mno_ztp-deploying-far-edge-sites[Configuring IPsec encryption for multi-node clusters using {ztp} and SiteConfig resources]
-
-
+////
 [id="ocp-4-17-hcp_{context}"]
 === Hosted control planes
-
-[id="ocp-4-17-insights-operator-enhancements_{context}"]
-=== Insights Operator enhancements
-
-* The Insights Operator now collects the `haproxy_exporter_server_threshold` metric. (link:https://issues.redhat.com/browse/OCPBUGS-36687[*OCPBUGS-36687*])
-
-* Previously, the Insights Operator gathered information about all Ingress Controller certificates, including their `NotBefore` and `NotAfter` dates. This data is now compiled into a `JSON` file located at `aggregated/ingress_controllers_certs.json` for easier monitoring of certificate validity across the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-35727[*OCPBUGS-35727*])
+////
 
 [id="ocp-4-17-etcd-certificates_{context}"]
 === Security
@@ -1036,9 +1006,53 @@ Manual rotation of signer certificates is still supported by deleting the specif
 [id="ocp-17-sigstore-verification_{context}"]
 ==== Sigstore signature image verification
 
-With this release, Technology Preview clusters use Sigstore signatures to verify images that were retrieved using a pull spec that references the `quay.io/openshift-release-dev/ocp-release`repository.
+With this release, Technology Preview clusters use Sigstore signatures to verify images that were retrieved using a pull spec that references the `quay.io/openshift-release-dev/ocp-release` repository.
 
 Currently, if you are mirroring images, you must also mirror `quay.io/openshift-release-dev/ocp-release:<release_image_digest_with_dash>.sig` Sigstore signatures in order for the image verification to succeed.
+
+[id="ocp-4-17-web-console_{context}"]
+=== Web console
+
+[id="ocp-4-17-ocp-lightspeed_{context}"]
+==== {ols} Operator is available in the web console
+
+Starting with {product-title} 4.16, {ols} Operator is available for use in the web console. With this release, a hover button was added to help you discover {ols}. Once you click the hover button, the chat window appears with instructions on how to enable and install {ols} on the cluster. You can hide the {ols} button when changing the default user preferences.
+
+//https://github.com/openshift/openshift-docs/pull/81581
+//For more information, see xref:../web_console/capabilities_products-web-console.html#openshift-lightspeed-web-console_capabilities-web-console[Enhancing your experience in the {product-title} web console by using {ols-official}].
+
+[id="ocp-4-17-administrator-perspective_{context}"]
+==== Administrator perspective
+
+This release introduces the following updates to the *Administrator* perspective of the web console:
+
+* Deprecated Operators are displayed in the OperatorHub before and after installation along with a warning notification that the Operator is deprecated.
+* You can check contnet of the configuration files for `MachineConfig` objects without having to manually retrieve its contents.
+* An alert was added to the *Operator details* page and the *Operator installation* page if your cluster is on {gcp-first} with Workload Identity Foundation (WIF).
+* A page for ShipWright `BuildStrategy` was added to the *Shipwright* page with a `ClusterBuildStrategy` and `BuildStrategy` tab.
+
+[id="ocp-4-17-customize-create-project-modal-dyanmic-plugin"]
+===== Customize the *Create project* modal using dynamic plugins
+
+With this release, a new extension point was added, so dynamic plugin creators can pass a component that renders in place of the default *Create Project* modal.
+
+For more information on {product-title} Console dynamic plugin SDK extensions, see xref:../web_console/dynamic-plugin/dynamic-plugins-reference.adoc#dynamic-plugin-sdk-extensions_dynamic-plugins-reference[Dynamic plugin extension types].
+
+[id="ocp-4-17-console-functional-external-oidc-issuer"]
+===== External OpenID Connect (OIDC) token issuer is now functional in the web console
+
+With this update, the web console works as expected when internal `oauth-server` resource and `oauth-apiserver` resource are removed and replaced with an external OpenID Connect (OIDC) issuer.
+
+[id="ocp-4-17-developer-perspective_{context}"]
+==== Developer Perspective
+
+This release introduces the following updates to the *Developer* perspective of the web console:
+
+* When you use one of the add flows to create a new deployment, the *Import from Git* or *Container images* automatically opens them in the sidebar.
+* You can easily select the desired *Git Type* without having to use the list if {product-title} is unable to identify its type.
+* *Import from Git* supports GitEA, an open-source alternitve to GitHub.
+* A warning notification displays on the *Topology* page if the `PodDisruptionBudget` limit is reached.
+* When importing applications through the *Import from Git* flows you can use Shipwright Build strategies such as S2I, buildpack, and buildah strategy for building the image.
 
 [id="ocp-4-17-notable-technical-changes_{context}"]
 == Notable technical changes
@@ -1091,59 +1105,18 @@ In the following tables, features are marked with the following statuses:
 * _Removed_
 
 [discrete]
-[id="ocp-4-17-operators-dep-rem_{context}"]
-=== Operator lifecycle and development deprecated and removed features
+[id="ocp-4-17-bare-metal-dep-rem_{context}"]
+=== Bare metal monitoring deprecated and removed features
 
-.Operator lifecycle and development deprecated and removed tracker
+.Bare Metal Event Relay Operator tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.15 |4.16 |4.17
 
-|Operator SDK
-|General Availability
+|Bare Metal Event Relay Operator
 |Deprecated
 |Deprecated
-
-|Scaffolding tools for Ansible-based Operator projects
-|General Availability
-|Deprecated
-|Deprecated
-
-|Scaffolding tools for Helm-based Operator projects
-|General Availability
-|Deprecated
-|Deprecated
-
-|Scaffolding tools for Go-based Operator projects
-|General Availability
-|Deprecated
-|Deprecated
-
-|Scaffolding tools for Hybrid Helm-based Operator projects
-|Technology Preview
-|Deprecated
-|Deprecated
-
-|Scaffolding tools for Java-based Operator projects
-|Technology Preview
-|Deprecated
-|Deprecated
-
-|Platform Operators
-|Technology Preview
 |Removed
-|Removed
-
-|Plain bundles
-|Technology Preview
-|Removed
-|Removed
-
-// Do not remove the SQLite database... entry until otherwise directed by the Operator Framework PM
-|SQLite database format for Operator catalogs
-|Deprecated
-|Deprecated
-|Deprecated
 |====
 
 [discrete]
@@ -1159,28 +1132,6 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Deprecated
 |Deprecated
-
-|====
-
-[discrete]
-[id="ocp-4-17-monitoring-dep-rem_{context}"]
-=== Monitoring deprecated and removed features
-
-.Monitoring deprecated and removed tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.15 |4.16 |4.17
-
-|`dedicatedServiceMonitors` setting that enables dedicated service monitors for core platform monitoring
-|Deprecated
-|Removed
-|Removed
-
-|`prometheus-adapter` component that queries resource metrics from Prometheus and exposes them in the metrics API
-|Deprecated
-|Removed
-|Removed
-
 |====
 
 [discrete]
@@ -1241,18 +1192,62 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 |Deprecated
-
 |====
 
 [discrete]
-[id="ocp-4-17-clusters-dep-rem_{context}"]
-=== Updating clusters deprecated and removed features
+[id="ocp-4-17-operators-dep-rem_{context}"]
+=== Operator lifecycle and development deprecated and removed features
 
-.Updating clusters deprecated and removed tracker
+.Operator lifecycle and development deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.15 |4.16 |4.17
 
+|Operator SDK
+|General Availability
+|Deprecated
+|Deprecated
+
+|Scaffolding tools for Ansible-based Operator projects
+|General Availability
+|Deprecated
+|Deprecated
+
+|Scaffolding tools for Helm-based Operator projects
+|General Availability
+|Deprecated
+|Deprecated
+
+|Scaffolding tools for Go-based Operator projects
+|General Availability
+|Deprecated
+|Deprecated
+
+|Scaffolding tools for Hybrid Helm-based Operator projects
+|Technology Preview
+|Deprecated
+|Deprecated
+
+|Scaffolding tools for Java-based Operator projects
+|Technology Preview
+|Deprecated
+|Deprecated
+
+|Platform Operators
+|Technology Preview
+|Removed
+|Removed
+
+|Plain bundles
+|Technology Preview
+|Removed
+|Removed
+
+// Do not remove the SQLite database... entry until otherwise directed by the Operator Framework PM
+|SQLite database format for Operator catalogs
+|Deprecated
+|Deprecated
+|Deprecated
 |====
 
 [discrete]
@@ -1272,22 +1267,37 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Removed
 |Removed
-
 |====
 
 [discrete]
-=== Storage deprecated and removed features
+[id="ocp-4-17-monitoring-dep-rem_{context}"]
+=== Monitoring deprecated and removed features
 
-.Storage deprecated and removed tracker
+.Monitoring deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.15 |4.16 |4.17
 
-|AliCloud Disk CSI Driver Operator
-|General Availability
+|`dedicatedServiceMonitors` setting that enables dedicated service monitors for core platform monitoring
+|Deprecated
 |Removed
 |Removed
 
+|`prometheus-adapter` component that queries resource metrics from Prometheus and exposes them in the metrics API
+|Deprecated
+|Removed
+|Removed
+|====
+
+////
+[discrete]
+[id="ocp-4-17-clusters-dep-rem_{context}"]
+=== Updating clusters deprecated and removed features
+
+.Updating clusters deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.15 |4.16 |4.17
 |====
 
 [discrete]
@@ -1298,6 +1308,7 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.15 |4.16 |4.17
 |====
+////
 
 [discrete]
 [id="ocp-4-17-networking-dep-rem_{context}"]
@@ -1320,25 +1331,19 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[discrete]
-[id="ocp-4-17-web-console-dep-rem_{context}"]
-=== Web console deprecated and removed features
 
-.Web console deprecated and removed tracker
+[discrete]
+=== Storage deprecated and removed features
+
+.Storage deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.15 |4.16 |4.17
 
-|Patternfly 4
-|Deprecated
-|Deprecated
-|Deprecated
-
-|React Router 5
-|Deprecated
-|Deprecated
-|Deprecated
-
+|AliCloud Disk CSI Driver Operator
+|General Availability
+|Removed
+|Removed
 |====
 
 [discrete]
@@ -1369,9 +1374,9 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Deprecated
 |Deprecated
-
 |====
 
+////
 [discrete]
 [id="ocp-4-17-cli-dep-rem_{context}"]
 === OpenShift CLI (oc) deprecated and removed features
@@ -1379,6 +1384,27 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.15 |4.16 |4.17
 
+|====
+////
+
+[discrete]
+[id="ocp-4-17-web-console-dep-rem_{context}"]
+=== Web console deprecated and removed features
+
+.Web console deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.15 |4.16 |4.17
+
+|Patternfly 4
+|Deprecated
+|Deprecated
+|Deprecated
+
+|React Router 5
+|Deprecated
+|Deprecated
+|Deprecated
 |====
 
 [discrete]
@@ -1394,23 +1420,6 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 |Deprecated
-
-|====
-
-[discrete]
-[id="ocp-4-17-bare-metal-dep-rem_{context}"]
-=== Bare metal monitoring deprecated and removed features
-
-.Bare Metal Event Relay Operator tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.15 |4.16 |4.17
-
-|Bare Metal Event Relay Operator
-|Deprecated
-|Deprecated
-|Removed
-
 |====
 
 [id="ocp-4-17-deprecated-features_{context}"]
@@ -1425,6 +1434,11 @@ The `preserveBootstrapIgnition` parameter for {aws-short} in the `install-config
 ==== kube-apiserver no longer gets a valid cloud configuration object
 
 In {product-title} {product-version}, `kube-apiserver` no longer gets a valid cloud configuration object. As a result, the `PersistentVolumeLabel` admission plugin rejects in-tree Google Compute Engine (GCE) persistent disk persistent volumes (PD PVs), that do not have the correct topology. (link:https://issues.redhat.com/browse/OCPBUGS-34544[*OCPBUGS-34544*])
+
+[id="ocp-4-17-web-console-patternfly_{context}"]
+==== kube-apiserver no longer gets a valid cloud configuration object
+
+In {product-title} 4.16, Patternfly 4 and React Router 5 were deprecated. The deprecated static remains the same for {product-title} {product-version}. All plugins should migrate to Patternfly 5 and React Router 6 as soon as possible. (link:https://issues.redhat.com/browse/OCPBUGS-34538[*OCPBUGS-34538*])
 
 [id="ocp-4-17-removed-features_{context}"]
 === Removed features
@@ -1445,8 +1459,10 @@ RukPak was introduced as a Technology Preview feature in {product-title} 4.12. S
 
 Starting in {product-title} 4.17, RukPak is now removed and relevant functionality relied upon by {olmv1} has been moved to other components.
 
+////
 [id="ocp-4-17-future-deprecation"]
 === Notice of future deprecation
+////
 
 [id="ocp-4-17-bug-fixes_{context}"]
 == Bug fixes
@@ -1597,9 +1613,7 @@ With this release, you can configure the proxy on the Konnectivity sidecar of th
 
 * Previously, when enabling `virtualHostedStyle` with `regionEndpoint` set in image registry Operator config, the image registry would ignore the virtual hosted style config and would fail to start. This update fixes the issue by using a new upstream distribution configuration, which is force path style, in favor of the downstream only version, which is virtual hosted style. (link:https://issues.redhat.com/browse/OCPBUGS-32710[*OCPBUGS-32710*])
 
-* In {product-title} 4.14, installing a cluster with {entra-first} was made generally available. With this feature, administrators can configure a Microsoft Azure cluster to use {entra-short}. With {entra-short}, cluster components use temporary security credentials that are managed outside of the cluster.
-+
-Previously, when {product-title} was deployed on Azure clusters with {entra-short}, storage accounts created for the cluster and the image registry had *Storage Account Key Access* enabled by default, which could pose security risks to the deployment.
+* Previously, when {product-title} was deployed on Azure clusters with {entra-short}, storage accounts created for the cluster and the image registry had *Storage Account Key Access* enabled by default, which could pose security risks to the deployment.
 +
 With this update, shared access keys are disabled by default on new installations that use {entra-short}, enhancing security by preventing the use of shared access keys.
 +
@@ -1611,12 +1625,6 @@ Shared access keys should only be disabled if the cluster is configured to use {
 For existing storage accounts created before this update, shared access keys are not automatically disabled. Administrators must manually disable shared access key support on these storage accounts to prevent the use of shared keys. For more information about disabling shared access keys, see link:https://learn.microsoft.com/en-us/azure/storage/common/shared-key-authorization-prevent?tabs=portal[Prevent Shared Key authorization for an Azure Storage account].
 +
 link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
-
-* Previously, the image registry was unable to run due to a permissions error in the certificate directory. This issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-38885[*OCPBUGS-38885*])
-
-* Previously, the internal image registry did not correctly authenticate users on clusters configured with external OIDC users because the internal image registry used the `user.openshift.io` and `oauth.openshift.io` APIs, which are not available on clusters configured with external OIDC users. Consequently, it was impossible for users to push or pull images to and from the internal image registry. With this update, the internal image registry uses the `SelfSubjectReview` API and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-35335[*OCPBUGS-35335*])
-
-* Previously, when enabling the `virtualHostedStyle` configuration with `regionEndpoint` set in the Image Registry Operator configuration, the image registry ignored the `virtualHostedStyle` configuration and failed to start. This update fixes the issue by using a new upstream distribution configuration, which uses force path style URLs, in favor of the downstream-only version, which is `virtualHostedStyle`. (link:https://issues.redhat.com/browse/OCPBUGS-32710[*OCPBUGS-32710*])
 
 [discrete]
 [id="ocp-4-17-installer-bug-fixes_{context}"]
@@ -1646,7 +1654,7 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 
 * Previously, when templates are defined for each failure domain, the installation program required an external connection to download the OVA in {vmw-full}. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-39239[*OCPBUGS-39239*])
 
-* Previously, installing a cluster with a DHCP network on Nutanix caused a failure. With this release, this issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-38934[*OCPBUGS-38934*])
+* Previously, installing a cluster with a Dynamic Host Configuration Protocol (DHCP) network on Nutanix caused a failure. With this release, this issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-38934[*OCPBUGS-38934*])
 
 * Previously, due to an EFI Secure Boot failure in the SCOS, when the FCOS pivoted to the SCOS the virtual machine (VM) failed to boot. With this release, the Secure Boot is disabled only when the Secure Boot is enabled in the `coreos.ovf` configuration file, and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-37736[*OCPBUGS-37736*])
 
@@ -1668,7 +1676,7 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 
 * Previously, extracting the IP address from the Cluster API Machine object only returned a single IP address. On {vmw-first}, the returned address would always be an IPv6 address and this caused issues with the `must-gather` implementation if the address was non-routable. With this release, the Cluster API Machine object returns all IP addresses, including IPv4, so that the `must-gather` issue no longer occurs on {vmw-full}. (link:https://issues.redhat.com/browse/OCPBUGS-37607[*OCPBUGS-37607*])
 
-* Previously, when installing a cluster on {aws-short}, EKS messages could appear in the installation logs even when EKS was meant to be disabled. With this update, EKS log messages have been disabled. (link:https://issues.redhat.com/browse/OCPBUGS-35752[*OCPBUGS-35752*])
+* Previously, when installing a cluster on {aws-short}, Elastic Kubernetes Service (EKS) messages could appear in the installation logs even when EKS was meant to be disabled. With this update, EKS log messages have been disabled. (link:https://issues.redhat.com/browse/OCPBUGS-35752[*OCPBUGS-35752*])
 
 * Previously, unexpected output would appear in the terminal when creating an installer-provisioned infrastructure cluster. With this release, the issue has been resolved and the unexpected output no longer shows. (link:https://issues.redhat.com/browse/OCPBUGS-35547[*OCPBUGS-35547*])
 
@@ -1720,7 +1728,7 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 [id="ocp-4-17-machine-config-operator-bug-fixes_{context}"]
 ==== Machine Config Operator
 
-* Previously, in a cluster that runs {product-title} 4.16 with the Telco RAN DU reference configuration, long duration `cyclictest` or `timerlat` tests could fail with maximum latencies detected above `20`us. This issue occured because the `psi` kernel command line argument was being set to `1` by default when cgroup v2 is enabled. With this release, the issue is fixed by setting `psi=0` in the kernel arguments when enabling cgroup v2. The `cyclictest` latency issue reported in link:https://issues.redhat.com/browse/OCPBUGS-34022[*OCPBUGS-34022*] is now also fixed. (link:https://issues.redhat.com/browse/OCPBUGS-37271[*OCPBUGS-37271*])
+* Previously, in a cluster that runs {product-title} 4.16 with the Telco RAN DU reference configuration, long duration `cyclictest` or `timerlat` tests could fail with maximum latencies detected above `20` us. This issue occured because the `psi` kernel command line argument was being set to `1` by default when cgroup v2 is enabled. With this release, the issue is fixed by setting `psi=0` in the kernel arguments when enabling cgroup v2. The `cyclictest` latency issue reported in link:https://issues.redhat.com/browse/OCPBUGS-34022[*OCPBUGS-34022*] is now also fixed. (link:https://issues.redhat.com/browse/OCPBUGS-37271[*OCPBUGS-37271*])
 
 * Previously, if a cluster admin creates a new `MachineOSConfig` object that references a legacy pull secret, the canonicalized version of this secret that gets created is not updated whenever the original pull secret changes. With this release, the issue is resolved.
 (link:https://issues.redhat.com/browse/OCPBUGS-34079[*OCPBUGS-34079*])
@@ -1764,7 +1772,7 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 
 * Previously, text areas were not resizable. With this update, you are now able to resize text areas. (link:https://issues.redhat.com/browse/OCPBUGS-34200[*OCPBUGS-34200*])
 
-* Previously, the Console Operator was not able to tolerate the absence of the ingress capability. With this update, the Console Operator configuration API has been enhanced with the possibility to add alternative ingress for the environments where the ingress cluster capability is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-33787[OCPBUGS-33787*])
+* Previously, the Console Operator was not able to tolerate the absence of the ingress capability. With this update, the Console Operator configuration API has been enhanced with the possibility to add alternative ingress for the environments where the ingress cluster capability is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-33787[*OCPBUGS-33787*])
 
 * Previously, the *Debug container* link was not displayed for pods with a `Completed` status. With this change, the link now appears. (link:https://issues.redhat.com/browse/OCPBUGS-33631[*OCPBUGS-33631*])
 
@@ -1780,11 +1788,11 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 
 * Previously, perspective switching was not properly handled. With this update, perspectives that are passed with URL search parameters or plugin route page extensions now correctly switch the perspective and retain the correct URL path. (link:https://issues.redhat.com/browse/OCPBUGS-19048[*OCPBUGS-19048*])
 
+////
 [discrete]
 [id="ocp-4-17-monitoring-bug-fixes_{context}"]
 ==== Monitoring
-
-* Previously, the `config-reloader` of Prometheus for user-defined projects would fail if unset environment variables were used in the `ServiceMonitor` configuration, which resulted in Prometheus pod failure. With this release, the reloader no longer fails when an unset environment variable is encountered. Instead, unset environment variables are left as they are, while set environment variables are expanded as usual. Any expansion errors, suppressed or otherwise, can be tracked through the `reloader_config_environment_variable_expansion_errors` variable. (link:https://issues.redhat.com/browse/OCPBUGS-23252[*OCPBUGS-23252*])
+////
 
 [discrete]
 [id="ocp-4-17-networking-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11213](https://issues.redhat.com/browse/OSDOCS-11213)

Link to docs preview:
[4.17.0](https://82620--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html)

