### PR TITLE
OSDOCS-11641 HCP 500 Node Limit Increase

### DIFF
--- a/modules/rosa-sdpolicy-instance-types.adoc
+++ b/modules/rosa-sdpolicy-instance-types.adoc
@@ -13,11 +13,11 @@ endif::[]
 = Instance types
 
 ifdef::rosa-with-hcp[]
-All {hcp-title} clusters require a minimum of 2 worker nodes. All {hcp-title} clusters support a maximum of 250 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss.
+All {hcp-title} clusters require a minimum of 2 worker nodes. All {hcp-title} clusters support a maximum of 500 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss.
 
 [NOTE]
 ====
-Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 250 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
+Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 500 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
 ====
 
 endif::rosa-with-hcp[]

--- a/modules/sd-hcp-planning-cluster-maximums.adoc
+++ b/modules/sd-hcp-planning-cluster-maximums.adoc
@@ -8,11 +8,11 @@
 
 Consider the following tested object maximums when you plan a {hcp-title-first} cluster installation. The table specifies the maximum limits for each tested type in a {hcp-title} cluster.
 
-These guidelines are based on a cluster of 250 compute (also known as worker) nodes. For smaller clusters, the maximums are lower.
+These guidelines are based on a cluster of 500 compute (also known as worker) nodes. For smaller clusters, the maximums are lower.
 
 [NOTE]
 ====
-Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 250 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
+Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 500 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
 ====
 
 .Tested cluster maximums

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 [NOTE]
 ====
-Currently, {hcp-title} supports a maximum of 250 worker nodes. Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 250 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
+Currently, {hcp-title} supports a maximum of 500 worker nodes. Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 500 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
 ====
 
 include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+1]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -18,7 +18,7 @@ toc::[]
 
 * **{hcp-title} multi-architecture cluster update.** {hcp-title-first} clusters created before 25 July, 2024 will migrate to a multi-architecture image on their next upgrade allowing you to use {AWS} Arm-based Graviton instance types for your workloads. For more information, see xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-upgrade-options_rosa-hcp-upgrading[Upgrading ROSA with HCP clusters].
 
-* **{hcp-title} cluster node limit update.** {hcp-title} clusters can now scale to 250 worker nodes. This is an increase from the previous limit of 180 nodes. For more information, see xref:../rosa_planning/rosa-hcp-limits-scalability.adoc#tested-cluster-maximums-hcp-sd_rosa-hcp-limits-scalability[ROSA with HCP limits and scalability].
+* **{hcp-title} cluster node limit update.** {hcp-title} clusters can now scale to 500 worker nodes. This is an increase from the previous limit of 250 nodes. For more information, see xref:../rosa_planning/rosa-hcp-limits-scalability.adoc#tested-cluster-maximums-hcp-sd_rosa-hcp-limits-scalability[ROSA with HCP limits and scalability].
 
 * **IMDSv2 support in {hcp-title}.** You can now enforce the use of the IMDSv2 endpoint for default machine pool worker nodes on new {hcp-title} clusters and for new machine pools on existing clusters. For more information, see xref:../rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc#rosa-hcp-creating-a-cluster-quickly-terraform[Creating a default ROSA cluster using Terraform].
 


### PR DESCRIPTION
Updated the HCP docs for the new node limit of 500.

Version(s):
4.16+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-11641

Link to docs preview:

Service def updates:

https://82624--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition#rosa-sdpolicy-instance-types_rosa-hcp-service-definition

https://82624--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.html

L & S update
https://82624--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-hcp-limits-scalability.html

Release Note:
https://82624--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html



QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
