### PR TITLE
OCPBUGS#42541: Removing TP in heading.

### DIFF
--- a/modules/nw-sriov-dual-nic-con.adoc
+++ b/modules/nw-sriov-dual-nic-con.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-sriov-dual-nic-con_{context}"]
-= NIC partitioning for SR-IOV devices (Technology Preview)
+= NIC partitioning for SR-IOV devices
 
 {product-title} can be deployed on a server with a dual port network interface card (NIC).
 You can partition a single, high-speed dual port NIC into multiple virtual functions (VFs) and enable SR-IOV.


### PR DESCRIPTION
OCPBUGS-42541: Removing TP in heading. There is a remaining mention of Tech Preview in a heading that was missed for https://issues.redhat.com//browse/TELCODOCS-1868

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-42541

Link to docs preview:
https://file.corp.redhat.com/rohennes/OCPBUGS-42541//installing/installing_bare_metal/preparing-to-install-on-bare-metal.html#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal

Additional information:
Typo no QE