### PR TITLE
adding redirect for EUS-to-EUS update assembly

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -278,6 +278,9 @@ AddType text/vtt                            vtt
     # redirect for scalability and performance per Shane Lovern 7/19
     RewriteRule ^container-platform/4\.13/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.html /container-platform/4.13/scalability_and_performance/enabling-workload-partitioning.html [NE,R=302]
 
+    # redirect for eus-to-eus update renaming to control-plane only update
+    RewriteRule ^container-platform/(4\.14|4\.15|4\.16|4\.17)/updating/updating_a_cluster/eus-eus-update.html /container-platform/$1/updating/updating_a_cluster/control-plane-only-update.html [NE,R=302]
+
     # CNV scenarios based redirect
     RewriteRule ^container-platform/4\.8/virt/learn_more_about_ov.html /container-platform/4.8/virt/virt-learn-more-about-openshift-virtualization.html [NE,R=301]
 


### PR DESCRIPTION
`main` only

This PR adds a redirect link for 4.14+ docs from the old EUS-to-EUS update assembly to the renamed control plane only update assembly
