### PR TITLE
OSDOCS-12009: adds 4.15.35 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -461,3 +461,12 @@ Issued: 25 September 2024
 The {product-title} release 4.15.34 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6820[RHBA-2024:6820] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6818[RHSA-2024:6818] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-35-dp_{context}"]
+=== RHBA-2024:7181 - {microshift-short} 4.15.35 bug fix and enhancement advisory
+
+Issued: 2 October 2024
+
+The {product-title} release 4.15.35 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7181[RHBA-2024:7181] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7179[RHSA-2024:7179] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12009](https://issues.redhat.com/browse/OSDOCS-12009)

Link to docs preview:
[4-15-35-dp_release-notes](https://82649--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-35-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
