### PR TITLE
OCPBUGS-30019-v4.15: Correct links from OCP to ODF docs for v4.15

### DIFF
--- a/modules/deploy-red-hat-openshift-container-storage.adoc
+++ b/modules/deploy-red-hat-openshift-container-storage.adoc
@@ -9,57 +9,57 @@
 |See the following {rh-storage-first} documentation:
 
 |What's new, known issues, notable bug fixes, and Technology Previews
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/4.12_release_notes[OpenShift Data Foundation 4.12 Release Notes]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/4.15_release_notes[OpenShift Data Foundation 4.15 Release Notes]
 
 |Supported workloads, layouts, hardware and software requirements, sizing and scaling recommendations
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/planning_your_deployment[Planning your OpenShift Data Foundation 4.12 deployment]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/planning_your_deployment[Planning your OpenShift Data Foundation 4.15 deployment]
 
 |Instructions on deploying {rh-storage} to use an external Red Hat Ceph Storage cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/deploying_openshift_data_foundation_in_external_mode[Deploying OpenShift Data Foundation 4.12 in external mode]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/deploying_openshift_data_foundation_in_external_mode[Deploying OpenShift Data Foundation 4.15 in external mode]
 
 |Instructions on deploying {rh-storage} to local storage on bare metal infrastructure
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/deploying_openshift_data_foundation_using_bare_metal_infrastructure[Deploying OpenShift Data Foundation 4.12 using bare metal infrastructure]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/deploying_openshift_data_foundation_using_bare_metal_infrastructure[Deploying OpenShift Data Foundation 4.15 using bare metal infrastructure]
 
 |Instructions on deploying {rh-storage} on Red Hat {product-title} VMware vSphere clusters
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/deploying_openshift_data_foundation_on_vmware_vsphere[Deploying OpenShift Data Foundation 4.12 on VMware vSphere]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/deploying_openshift_data_foundation_on_vmware_vsphere[Deploying OpenShift Data Foundation 4.15 on VMware vSphere]
 
 |Instructions on deploying {rh-storage} using Amazon Web Services for local or cloud storage
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/deploying_openshift_data_foundation_using_amazon_web_services[Deploying OpenShift Data Foundation 4.12 using Amazon Web Services]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/deploying_openshift_data_foundation_using_amazon_web_services[Deploying OpenShift Data Foundation 4.15 using Amazon Web Services]
 
 |Instructions on deploying and managing {rh-storage} on existing Red Hat {product-title} Google Cloud clusters
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/deploying_and_managing_openshift_data_foundation_using_google_cloud[Deploying and managing OpenShift Data Foundation 4.12 using Google Cloud]
+|link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.15/html/deploying_openshift_data_foundation_using_google_cloud/index[Deploying and managing OpenShift Data Foundation 4.15 using Google Cloud]
 
 |Instructions on deploying and managing {rh-storage} on existing Red Hat {product-title} Azure clusters
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/deploying_openshift_data_foundation_using_microsoft_azure/index[Deploying and managing OpenShift Data Foundation 4.12 using Microsoft Azure]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/deploying_openshift_data_foundation_using_microsoft_azure/index[Deploying and managing OpenShift Data Foundation 4.15 using Microsoft Azure]
 
 |Instructions on deploying {rh-storage} to use local storage on {ibm-power-name} infrastructure
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html-single/deploying_openshift_data_foundation_using_ibm_power/index[Deploying OpenShift Data Foundation on {ibm-power-name}]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html-single/deploying_openshift_data_foundation_using_ibm_power/index[Deploying OpenShift Data Foundation using {ibm-power-name}]
 
 |Instructions on deploying {rh-storage} to use local storage on {ibm-z-name} infrastructure
 |link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/deploying_openshift_data_foundation_using_ibm_z_infrastructure/index[Deploying OpenShift Data Foundation on {ibm-z-name} infrastructure]
 
 |Allocating storage to core services and hosted applications in {rh-storage-first}, including snapshot and clone
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/managing_and_allocating_storage_resources[Managing and allocating resources]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/managing_and_allocating_storage_resources[Managing and allocating resources]
 
 |Managing storage resources across a hybrid cloud or multicloud environment using the Multicloud Object Gateway (NooBaa)
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/managing_hybrid_and_multicloud_resources[Managing hybrid and multicloud resources]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/managing_hybrid_and_multicloud_resources[Managing hybrid and multicloud resources]
 
 |Safely replacing storage devices for {rh-storage-first}
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/replacing_devices[Replacing devices]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/replacing_devices[Replacing devices]
 
 |Safely replacing a node in a {rh-storage-first} cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/replacing_nodes[Replacing nodes]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/replacing_nodes[Replacing nodes]
 
 |Scaling operations in {rh-storage-first}
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/scaling_storage[Scaling storage]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/scaling_storage[Scaling storage]
 
-|Monitoring a {rh-storage-first} 4.12 cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/monitoring_openshift_data_foundation[Monitoring Red Hat OpenShift Data Foundation 4.12]
+|Monitoring a {rh-storage-first} 4.15 cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/monitoring_openshift_data_foundation[Monitoring Red Hat OpenShift Data Foundation 4.15]
 
 |Resolve issues encountered during operations
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/troubleshooting_openshift_data_foundation[Troubleshooting OpenShift Data Foundation 4.12]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/troubleshooting_openshift_data_foundation[Troubleshooting OpenShift Data Foundation 4.15]
 
 |Migrating your {product-title} cluster from version 3 to version 4
-|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/migrating_from_version_3_to_4/index[Migration]
+|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/migrating_from_version_3_to_4/index[Migration]
 
 |===


### PR DESCRIPTION
Version(s): 4.15

Issue: https://issues.redhat.com/browse/OCPBUGS-30019

Link to docs preview: https://82655--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/post-install-storage-configuration.html#post-install-deploy-OCS

QE review:

- [ ] QE has approved this change.
Additional information:

PTAL: @kalexand-rh @sjhala-ccs @amulmule @tamireran @duanwei33
