### PR TITLE
OSDOCS-12136 OCP 4.16.15 release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3356,6 +3356,46 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-16-15_{context}"]
+=== RHSA-2024:7174 - {product-title} {product-version}.15 bug fix and security update
+
+Issued: 2 October 2024
+
+{product-title} release {product-version}.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:7174[RHSA-2024:7174] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:7177[RHBA-2024:7177] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.15 --pullspecs
+----
+
+[id="ocp-4-16-15-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, a local patch to kube-proxy caused OpenShift SDN to add a duplicate copy of a particular rule to the iptables ruleset each time it resynchronized. The synchronization would slow down and eventually trigger the `NodeProxyApplySlow` alert. With this release, the kube-proxy patch has been fixed and the alert no longer appears. (link:https://issues.redhat.com/browse/OCPBUGS-42159[*OCPBUGS-42159*])
+
+* Previously, when the Node Tuning Operator (NTO) was configured by using PerformanceProfiles it would create an ocp-tuned-one-shot systemd service. The systemd service would run prior to kubelet and blocked execution. The systemd service invokes Podman which uses an NTO image. But, when the NTO image was not present, Podman still tried to fetch the image and it would fail. With this release, support is added for cluster-wide proxy environment variables defined in `/etc/mco/proxy.env`. Now, Podman pulls NTO images in environments which need to use proxies for out-of-cluster connections. (link:https://issues.redhat.com/browse/OCPBUGS-42061[*OCPBUGS-42061*])
+
+* Previously, a change in the ordering of the TextInput parameters for PatternFly v4 and v5 caused the `until` field to be improperly filled and was not editable. With this release, the `until` field is editable so you can input the correct information. (link:https://issues.redhat.com/browse/OCPBUGS-41996[*OCPBUGS-41996*])
+
+* Previously, when templates were defined for each failure domain, the installation program required an external connection to download the OVA in vSphere. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41885[*OCPBUGS-41885*])
+
+* Previously, when installing a cluster on bare metal using installer provisioned infrastructure, the installation could time out if the network to the bootstrap virtual machine is slow. With this update, the timeout duration has been increased to cover a wider range of network performance scenarios. (link:https://issues.redhat.com/browse/OCPBUGS-41845[*OCPBUGS-41845*])
+
+* Previously, when a hosted cluster proxy was configured and it used an identity provider (IDP) that had an http or https endpoint, the host name of the IDP was unresolved before sending it through the proxy. Consequently, host names that could only be resolved by the data plane failed to resolve for IDPs. With this update, a DNS lookup is performed before sending IPD traffic through the `konnectivity` tunnel. As a result, IDPs with host names that can only be resolved by the data plane can be verified by the Control Plane Operator. (link:https://issues.redhat.com/browse/OCPBUGS-41372[*OCPBUGS-41372*])
+
+* Previously, due to an internal bug, if a machine had more than 256 CPUs, the Node Tuning Operator (NTO) incorrectly computed CPU masks for interrupt and network handling CPU affinity. This prevented proper CPU isolation on those machines and resulted in `systemd` unit failures. With this release, the NTO computes the masks correctly.(link:https://issues.redhat.com/browse/OCPBUGS-39377[*OCPBUGS-39377*])
+
+* Previously, when users provided public subnets while using existing subnets and creating a private cluster, the installation program occasionally exposed on the public internet the load balancers that were created in public subnets. This invalidated the reason for a private cluster. With this release, the issue is resolved by displaying a warning during a private installation that providing public subnets might break the private clusters and, to prevent this, users must fix their inputs. (link:https://issues.redhat.com/browse/OCPBUGS-38964[*OCPBUGS-38964*])
+
+[id="ocp-4-16-15-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.16.14
 [id="ocp-4-16-14_{context}"]
 === RHSA-2024:6824 - {product-title} {product-version}.14 bug fix and security update
@@ -3379,7 +3419,7 @@ $ oc adm release info 4.16.14 --pullspecs
 The following enhancement is included in this z-stream release:
 
 [id="ocp-4-16-14-insight-operator-collecting-cr-data"]
-===== Collecting data from the {rh-openstack-first} on OpenStack Services cluster resources with the Insight Operator 
+===== Collecting data from the {rh-openstack-first} on OpenStack Services cluster resources with the Insight Operator
 
 * Insight Operator can collect data from the following Red Hat OpenStack on OpenShift Services (RHOSO) cluster resources: `OpenStackControlPlane`, `OpenStackDataPlaneNodeSet`, `OpenStackDataPlaneDeployment`, and `OpenStackVersions`. (link:https://issues.redhat.com/browse/OCPBUGS-38021[*OCPBUGS-38021*])
 
@@ -3391,9 +3431,9 @@ The following enhancement is included in this z-stream release:
 * Previously, if the Hosted Cluster (HC) `controllerAvailabilityPolicy` value was `SingleReplica`, networking components with `podAntiAffinity` would block the rollout. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41555[*OCPBUGS-41555*])
 
 * Previously, when deploying a cluster into an Amazon Virtual Private Cloud (VPC) with multiple CIDR blocks, the installation program failed. With this release, network settings are updated to support VPCs with multiple CIDR blocks.
-(link:https://issues.redhat.com/browse/OCPBUGS-39496[*OCPBUGS-39496*]) 
+(link:https://issues.redhat.com/browse/OCPBUGS-39496[*OCPBUGS-39496*])
 
-* Previously, the order of an Ansible playbook was modified to run before the `metadata.json` file was created, which caused issues with older versions of Ansible. With this release, the playbook is more tolerant of missing files and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-39287[*OCPBUGS-39287*]) 
+* Previously, the order of an Ansible playbook was modified to run before the `metadata.json` file was created, which caused issues with older versions of Ansible. With this release, the playbook is more tolerant of missing files and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-39287[*OCPBUGS-39287*])
 
 * Previously, during the same scrape, Prometheus would drop samples from the same series and only consider one of them, even when they had different timestamps. When this issue occurred continuously, it triggered the `PrometheusDuplicateTimestamps` alert. With this release, all samples are now ingested if they meet the other conditions. (link:https://issues.redhat.com/browse/OCPBUGS-39179[*OCPBUGS-39179*])
 


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-12136](https://issues.redhat.com/browse/OSDOCS-12136)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview](https://82664--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-15_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links will not work until October 2nd.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
