### PR TITLE
HCIDOCS-139: Fix nohup command in network config for IPI/bare metal installation

### DIFF
--- a/modules/ipi-install-configuring-networking.adoc
+++ b/modules/ipi-install-configuring-networking.adoc
@@ -17,7 +17,7 @@ You can also configure networking from the web console.
 
 .Procedure
 
-. Export the bare-metal network NIC name:
+. Export the bare-metal network NIC name by running the following command:
 +
 [source,terminal]
 ----
@@ -30,6 +30,8 @@ $ export PUB_CONN=<baremetal_nic_name>
 ====
 The SSH connection might disconnect after executing these steps.
 ====
+
+.. For a network using DHCP, run the following command:
 +
 [source,terminal]
 ----
@@ -39,20 +41,38 @@ $ sudo nohup bash -c "
     # RHEL 8.1 appends the word \"System\" in front of the connection, delete in case it exists
     nmcli con down \"System $PUB_CONN\"
     nmcli con delete \"System $PUB_CONN\"
-    nmcli connection add ifname baremetal type bridge con-name baremetal bridge.stp no
+    nmcli connection add ifname baremetal type bridge <con_name> baremetal bridge.stp no <1>
     nmcli con add type bridge-slave ifname \"$PUB_CONN\" master baremetal
     pkill dhclient;dhclient baremetal
 "
 ----
+<1> Replace `<con_name>` with the connection name.
 
-. Optional: If you are deploying with a provisioning network, export the provisioning network NIC name:
+.. For a network using static IP addressing and no DHCP network, run the following command:
++
+[source,terminal]
+----
+$ sudo nohup bash -c "
+    nmcli con down \"$PUB_CONN\"
+    nmcli con delete \"$PUB_CONN\"
+    # RHEL 8.1 appends the word \"System\" in front of the connection, delete in case it exists
+    nmcli con down \"System $PUB_CONN\"
+    nmcli con delete \"System $PUB_CONN\"
+    nmcli connection add ifname baremetal type bridge con-name baremetal bridge.stp no ipv4.method manual ipv4.addr "x.x.x.x/yy" ipv4.gateway "a.a.a.a" ipv4.dns "b.b.b.b" <1>
+    nmcli con add type bridge-slave ifname \"$PUB_CONN\" master baremetal
+    nmcli con up baremetal
+"
+----
+<1> Replace `<con_name>` with the connection name. Replace `x.x.x.x/yy` with the IP address and CIDR for the network. Replace `a.a.a.a` with the network gateway. Replace `b.b.b.b` with the IP address of the DNS server. 
+
+. Optional: If you are deploying with a provisioning network, export the provisioning network NIC name by running the following command:
 +
 [source,terminal]
 ----
 $ export PROV_CONN=<prov_nic_name>
 ----
 
-. Optional: If you are deploying with a provisioning network, configure the provisioning network:
+. Optional: If you are deploying with a provisioning network, configure the provisioning network by running the following command:
 +
 [source,terminal]
 ----
@@ -69,34 +89,35 @@ $ sudo nohup bash -c "
 +
 [NOTE]
 ====
-The ssh connection might disconnect after executing these steps.
+The SSH connection might disconnect after executing these steps.
 
-The IPv6 address can be any address as long as it is not routable via the bare-metal network.
+The IPv6 address can be any address that is not routable through the bare-metal network.
 
 Ensure that UEFI is enabled and UEFI PXE settings are set to the IPv6 protocol when using IPv6 addressing.
 ====
 
-. Optional: If you are deploying with a provisioning network, configure the IPv4 address on the provisioning network connection:
+. Optional: If you are deploying with a provisioning network, configure the IPv4 address on the provisioning network connection by running the following command:
 +
 [source,terminal]
 ----
 $ nmcli connection modify provisioning ipv4.addresses 172.22.0.254/24 ipv4.method manual
 ----
 
-. `ssh` back into the `provisioner` node (if required):
+. SSH back into the `provisioner` node (if required) by running the following command:
 +
 [source,terminal]
 ----
 # ssh kni@provisioner.<cluster-name>.<domain>
 ----
 
-. Verify the connection bridges have been properly created:
+. Verify that the connection bridges have been properly created by running the following command:
 +
 [source,terminal]
 ----
 $ sudo nmcli con show
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME               UUID                                  TYPE      DEVICE


### PR DESCRIPTION
Added static IP example.

Fixes: [HCIDOCS-139](https://issues.redhat.com//browse/HCIDOCS-139)

See https://issues.redhat.com/browse/HCIDOCS-139 for additional details.

Preview URL:

For release(s): 4.12-4.18
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
