### PR TITLE
OBSDOCS-1270 - Removal of 5.x docs from 4.17 topic map.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2835,15 +2835,15 @@ Topics:
   Dir: logging
   Distros: openshift-enterprise,openshift-origin
   Topics:
-  - Name: Release notes
-    Dir: logging_release_notes
-    Topics:
-    - Name: Logging 5.9
-      File: logging-5-9-release-notes
-    - Name: Logging 5.8
-      File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
+#  - Name: Release notes
+#    Dir: logging_release_notes
+#    Topics:
+#    - Name: Logging 5.9
+#      File: logging-5-9-release-notes
+#    - Name: Logging 5.8
+#      File: logging-5-8-release-notes
+#    - Name: Logging 5.7
+#      File: logging-5-7-release-notes
   - Name: Logging 6.0
     Dir: logging-6.0
     Topics:
@@ -2861,110 +2861,107 @@ Topics:
         File: log6x-visual
 #      - Name: API reference 6.0
 #        File: log6x-api-reference
-  - Name: Support
-    File: cluster-logging-support
-  - Name: Troubleshooting logging
-    Dir: troubleshooting
-    Topics:
-    - Name: Viewing Logging status
-      File: cluster-logging-cluster-status
-    - Name: Troubleshooting log forwarding
-      File: log-forwarding-troubleshooting
-    - Name: Troubleshooting logging alerts
-      File: troubleshooting-logging-alerts
-    - Name: Viewing the status of the Elasticsearch log store
-      File: cluster-logging-log-store-status
-  - Name: About Logging
-    File: cluster-logging
-  - Name: Installing Logging
-    File: cluster-logging-deploying
-  - Name: Updating Logging
-    File: cluster-logging-upgrading
-    Distros: openshift-enterprise,openshift-origin
-  - Name: Visualizing logs
-    Dir: log_visualization
-    Topics:
-    - Name: About log visualization
-      File: log-visualization
-    - Name: Log visualization with the web console
-      File: log-visualization-ocp-console
-    - Name: Viewing cluster dashboards
-      File: cluster-logging-dashboards
-    - Name: Log visualization with Kibana
-      File: logging-kibana
-  - Name: Configuring your Logging deployment
-    Dir: config
-    Distros: openshift-enterprise,openshift-origin
-    Topics:
-    - Name: Configuring CPU and memory limits for Logging components
-      File: cluster-logging-memory
-    - Name: Configuring systemd-journald for Logging
-      File: cluster-logging-systemd
-  - Name: Log collection and forwarding
-    Dir: log_collection_forwarding
-    Topics:
-    - Name: About log collection and forwarding
-      File: log-forwarding
-    - Name: Log output types
-      File: logging-output-types
-    - Name: Enabling JSON log forwarding
-      File: cluster-logging-enabling-json-logging
-    - Name: Configuring log forwarding
-      File: configuring-log-forwarding
-    - Name: Configuring the logging collector
-      File: cluster-logging-collector
-    - Name: Collecting and storing Kubernetes events
-      File: cluster-logging-eventrouter
-  - Name: Log storage
-    Dir: log_storage
-    Topics:
-    - Name: About log storage
-      File: about-log-storage
-    - Name: Installing log storage
-      File: installing-log-storage
-    - Name: Configuring the LokiStack log store
-      File: cluster-logging-loki
-    - Name: Configuring the Elasticsearch log store
-      File: logging-config-es-store
-  - Name: Logging alerts
-    Dir: logging_alerts
-    Topics:
-    - Name: Default logging alerts
-      File: default-logging-alerts
-    - Name: Custom logging alerts
-      File: custom-logging-alerts
-  - Name: Performance and reliability tuning
-    Dir: performance_reliability
-    Topics:
-    - Name: Flow control mechanisms
-      File: logging-flow-control-mechanisms
-    - Name: Filtering logs by content
-      File: logging-content-filtering
-    - Name: Filtering logs by metadata
-      File: logging-input-spec-filtering
-  - Name: Scheduling resources
-    Dir: scheduling_resources
-    Topics:
-    - Name: Using node selectors to move logging resources
-      File: logging-node-selectors
-    - Name: Using tolerations to control logging pod placement
-      File: logging-taints-tolerations
-  - Name: Uninstalling Logging
-    File: cluster-logging-uninstall
-  - Name: Exported fields
-    File: cluster-logging-exported-fields
-    Distros: openshift-enterprise,openshift-origin
-  - Name: API reference
-    Dir: api_reference
-    Topics:
+#  - Name: Support
+#    File: cluster-logging-support
+#  - Name: Troubleshooting logging
+#    Dir: troubleshooting
+#    Topics:
+#    - Name: Viewing Logging status
+#      File: cluster-logging-cluster-status
+#    - Name: Troubleshooting log forwarding
+#      File: log-forwarding-troubleshooting
+#    - Name: Troubleshooting logging alerts
+#      File: troubleshooting-logging-alerts
+#      File: cluster-logging-log-store-status
+#  - Name: About Logging
+#    File: cluster-logging
+#  - Name: Installing Logging
+#    File: cluster-logging-deploying
+#  - Name: Updating Logging
+#    File: cluster-logging-upgrading
+#    Distros: openshift-enterprise,openshift-origin
+#  - Name: Visualizing logs
+#    Topics:
+#    - Name: About log visualization
+#      File: log-visualization
+#    - Name: Log visualization with the web console
+#      File: log-visualization-ocp-console
+#    - Name: Viewing cluster dashboards
+#      File: cluster-logging-dashboards
+#    - Name: Log visualization with Kibana
+#      File: logging-kibana
+#  - Name: Configuring your Logging deployment
+#    Dir: config
+#    Distros: openshift-enterprise,openshift-origin
+#    Topics:
+#    - Name: Configuring CPU and memory limits for Logging components
+#      File: cluster-logging-memory
+#    - Name: Configuring systemd-journald for Logging
+#      File: cluster-logging-systemd
+#  - Name: Log collection and forwarding
+#    Dir: log_collection_forwarding
+#    Topics:
+#    - Name: About log collection and forwarding
+#      File: log-forwarding
+#    - Name: Log output types
+#      File: logging-output-types
+#    - Name: Enabling JSON log forwarding
+#      File: cluster-logging-enabling-json-logging
+#    - Name: Configuring log forwarding
+#      File: configuring-log-forwarding
+#    - Name: Configuring the logging collector
+#      File: cluster-logging-collector
+#    - Name: Collecting and storing Kubernetes events
+#      File: cluster-logging-eventrouter
+#  - Name: Log storage
+#    Dir: log_storage
+#    Topics:
+#    - Name: About log storage
+#      File: about-log-storage
+#      File: installing-log-storage
+#  - Name: Configuring the LokiStack log store
+#      File: cluster-logging-loki
+#    - Name: Configuring the Elasticsearch log store
+#      File: logging-config-es-store
+#  - Name: Logging alerts
+#    Dir: logging_alerts
+#    Topics:
+#    - Name: Default logging alerts
+#      File: default-logging-alerts
+#    - Name: Custom logging alerts
+#      File: custom-logging-alerts
+#  - Name: Performance and reliability tuning
+#    Dir: performance_reliability
+#    Topics:
+#    - Name: Flow control mechanisms
+#      File: logging-flow-control-mechanisms
+#    - Name: Filtering logs by content
+#      File: logging-content-filtering
+#    - Name: Filtering logs by metadata
+#      File: logging-input-spec-filtering
+#  - Name: Scheduling resources
+#    Dir: scheduling_resources
+#    Topics:
+#    - Name: Using node selectors to move logging resources
+#      File: logging-node-selectors
+#    - Name: Using tolerations to control logging pod placement
+#      File: logging-taints-tolerations
+#  - Name: Uninstalling Logging
+#    File: cluster-logging-uninstall
+#  - Name: Exported fields
+#    File: cluster-logging-exported-fields
+#    Distros: openshift-enterprise,openshift-origin
+#  - Name: API reference
+#    Dir: api_reference
+#    Topics:
   #  - Name: 5.8 Logging API reference
   #    File: logging-5-8-reference
   #  - Name: 5.7 Logging API reference
   #    File: logging-5-7-reference
-    - Name: 5.6 Logging API reference
-      File: logging-5-6-reference
-  - Name: Glossary
-    File: logging-common-terms
+#    - Name: 5.6 Logging API reference
+#      File: logging-5-6-reference
+#  - Name: Glossary
+#    File: logging-common-terms
 - Name: Distributed tracing
   Dir: distr_tracing
   Distros: openshift-enterprise

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1214,120 +1214,118 @@ Topics:
     File: troubleshooting-monitoring-issues
   - Name: Config map reference for the Cluster Monitoring Operator
     File: config-map-reference-for-the-cluster-monitoring-operator
-- Name: Logging
-  Dir: logging
-  Distros: openshift-dedicated
-  Topics:
-  - Name: Release notes
-    Dir: logging_release_notes
-    Topics:
-    - Name: Logging 5.9
-      File: logging-5-9-release-notes
-    - Name: Logging 5.8
-      File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
-  - Name: Support
-    File: cluster-logging-support
-  - Name: Troubleshooting logging
-    Dir: troubleshooting
-    Topics:
-    - Name: Viewing Logging status
-      File: cluster-logging-cluster-status
-    - Name: Troubleshooting log forwarding
-      File: log-forwarding-troubleshooting
-    - Name: Troubleshooting logging alerts
-      File: troubleshooting-logging-alerts
-    - Name: Viewing the status of the Elasticsearch log store
-      File: cluster-logging-log-store-status
-  - Name: About Logging
-    File: cluster-logging
-  - Name: Installing Logging
-    File: cluster-logging-deploying
-  - Name: Updating Logging
-    File: cluster-logging-upgrading
-  - Name: Visualizing logs
-    Dir: log_visualization
-    Topics:
-    - Name: About log visualization
-      File: log-visualization
-    - Name: Log visualization with the web console
-      File: log-visualization-ocp-console
-    - Name: Viewing cluster dashboards
-      File: cluster-logging-dashboards
-    - Name: Log visualization with Kibana
-      File: logging-kibana
-  - Name: Configuring your Logging deployment
-    Dir: config
-    Topics:
-    - Name: Configuring CPU and memory limits for Logging components
-      File: cluster-logging-memory
-    #- Name: Configuring systemd-journald and Fluentd
-    #  File: cluster-logging-systemd
-  - Name: Log collection and forwarding
-    Dir: log_collection_forwarding
-    Topics:
-    - Name: About log collection and forwarding
-      File: log-forwarding
-    - Name: Log output types
-      File: logging-output-types
-    - Name: Enabling JSON log forwarding
-      File: cluster-logging-enabling-json-logging
-    - Name: Configuring log forwarding
-      File: configuring-log-forwarding
-    - Name: Configuring the logging collector
-      File: cluster-logging-collector
-    - Name: Collecting and storing Kubernetes events
-      File: cluster-logging-eventrouter
-  - Name: Log storage
-    Dir: log_storage
-    Topics:
-    - Name: About log storage
-      File: about-log-storage
-    - Name: Installing log storage
-      File: installing-log-storage
-    - Name: Configuring the LokiStack log store
-      File: cluster-logging-loki
-    - Name: Configuring the Elasticsearch log store
-      File: logging-config-es-store
-  - Name: Logging alerts
-    Dir: logging_alerts
-    Topics:
-    - Name: Default logging alerts
-      File: default-logging-alerts
-    - Name: Custom logging alerts
-      File: custom-logging-alerts
-  - Name: Performance and reliability tuning
-    Dir: performance_reliability
-    Topics:
-    - Name: Flow control mechanisms
-      File: logging-flow-control-mechanisms
-    - Name: Filtering logs by content
-      File: logging-content-filtering
-    - Name: Filtering logs by metadata
-      File: logging-input-spec-filtering
-  - Name: Scheduling resources
-    Dir: scheduling_resources
-    Topics:
-    - Name: Using node selectors to move logging resources
-      File: logging-node-selectors
-    - Name: Using tolerations to control logging pod placement
-      File: logging-taints-tolerations
-  - Name: Uninstalling Logging
-    File: cluster-logging-uninstall
-  - Name: Exported fields
-    File: cluster-logging-exported-fields
-  - Name: API reference
-    Dir: api_reference
-    Topics:
+#- Name: Logging
+#  Dir: logging
+#  Distros: openshift-dedicated
+#  Topics:
+#  - Name: Release notes
+#    Dir: logging_release_notes
+#    Topics:
+#    - Name: Logging 5.9
+#      File: logging-5-9-release-notes
+#    - Name: Logging 5.8
+#      File: logging-5-8-release-notes
+#    - Name: Logging 5.7
+#      File: logging-5-7-release-notes
+#  - Name: Support
+#    File: cluster-logging-support
+#  - Name: Troubleshooting logging
+#    Dir: troubleshooting
+#    Topics:
+#    - Name: Viewing Logging status
+#      File: cluster-logging-cluster-status
+#    - Name: Troubleshooting log forwarding
+#      File: log-forwarding-troubleshooting
+#    - Name: Troubleshooting logging alerts
+#      File: troubleshooting-logging-alerts
+#    - Name: Viewing the status of the Elasticsearch log store
+#      File: cluster-logging-log-store-status
+#  - Name: About Logging
+#    File: cluster-logging
+#  - Name: Installing Logging
+#    File: cluster-logging-deploying
+#  - Name: Updating Logging
+#    File: cluster-logging-upgrading
+#  - Name: Visualizing logs
+#    Dir: log_visualization
+#    Topics:
+#    - Name: About log visualization
+#      File: log-visualization
+#    - Name: Log visualization with the web console
+#      File: log-visualization-ocp-console
+#    - Name: Viewing cluster dashboards
+#      File: cluster-logging-dashboards
+#    - Name: Log visualization with Kibana
+#      File: logging-kibana
+#  - Name: Configuring your Logging deployment
+#    Dir: config
+#    Topics:
+#    - Name: Configuring CPU and memory limits for Logging components
+#      File: cluster-logging-memory
+#    #- Name: Configuring systemd-journald and Fluentd
+#    #  File: cluster-logging-systemd
+#    Dir: log_collection_forwarding
+#   Topics:
+#    - Name: About log collection and forwarding
+#      File: log-forwarding
+#    - Name: Log output types
+#    - Name: Enabling JSON log forwarding
+#    File: cluster-logging-enabling-json-logging
+#  - Name: Configuring log forwarding
+#      File: configuring-log-forwarding
+#    - Name: Configuring the logging collector
+#      File: cluster-logging-collector
+#    - Name: Collecting and storing Kubernetes events
+#      File: cluster-logging-eventrouter
+#  - Name: Log storage
+#    Dir: log_storage
+#    Topics:
+#    - Name: About log storage
+#      File: about-log-storage
+#    - Name: Installing log storage
+#      File: installing-log-storage
+#    - Name: Configuring the LokiStack log store
+#      File: cluster-logging-loki
+#    - Name: Configuring the Elasticsearch log store
+#      File: logging-config-es-store
+#  - Name: Logging alerts
+#    Dir: logging_alerts
+#    Topics:
+#    - Name: Default logging alerts
+#      File: default-logging-alerts
+#    - Name: Custom logging alerts
+#      File: custom-logging-alerts
+#  - Name: Performance and reliability tuning
+#    Dir: performance_reliability
+#    Topics:
+#    - Name: Flow control mechanisms
+#      File: logging-flow-control-mechanisms
+#    - Name: Filtering logs by content
+#      File: logging-content-filtering
+#    - Name: Filtering logs by metadata
+#      File: logging-input-spec-filtering
+#  - Name: Scheduling resources
+#    Dir: scheduling_resources
+#    Topics:
+#    - Name: Using node selectors to move logging resources
+#      File: logging-node-selectors
+#    - Name: Using tolerations to control logging pod placement
+#      File: logging-taints-tolerations
+#  - Name: Uninstalling Logging
+#    File: cluster-logging-uninstall
+#  - Name: Exported fields
+#    File: cluster-logging-exported-fields
+#  - Name: API reference
+#    Dir: api_reference
+#    Topics:
   #  - Name: 5.8 Logging API reference
   #    File: logging-5-8-reference
   #  - Name: 5.7 Logging API reference
   #    File: logging-5-7-reference
-    - Name: 5.6 Logging API reference
-      File: logging-5-6-reference
-  - Name: Glossary
-    File: logging-common-terms
+#    - Name: 5.6 Logging API reference
+#      File: logging-5-6-reference
+#  - Name: Glossary
+#    File: logging-common-terms
 ---
 Name: Service Mesh
 Dir: service_mesh
@@ -1697,5 +1695,3 @@ Topics:
 #  - Name: Collecting OKD Virtualization data for community report
 #    File: virt-collecting-virt-data
 #    Distros: openshift-origin
-
-

--- a/adding_service_cluster/adding-service.adoc
+++ b/adding_service_cluster/adding-service.adoc
@@ -21,9 +21,3 @@ include::modules/adding-service-existing.adoc[leveloffset=+1]
 include::modules/access-service.adoc[leveloffset=+1]
 include::modules/deleting-service.adoc[leveloffset=+1]
 //include::modules/deleting-service-cli.adoc[leveloffset=+1]
-
-ifdef::openshift-rosa[]
-[role="_additional-resources"]
-== Additional resources
-* xref:../observability/logging/log_collection_forwarding/configuring-log-forwarding.adoc#cluster-logging-collector-log-forward-cloudwatch_configuring-log-forwarding[Forwarding logs to Amazon CloudWatch]
-endif::[]

--- a/adding_service_cluster/rosa-available-services.adoc
+++ b/adding_service_cluster/rosa-available-services.adoc
@@ -16,7 +16,6 @@ include::modules/aws-cloudwatch.adoc[leveloffset=+1]
 .Additional resources
 
 * link:https://aws.amazon.com/cloudwatch/[Amazon CloudWatch product information]
-* xref:../observability/logging/log_collection_forwarding/configuring-log-forwarding.adoc#cluster-logging-collector-log-forward-cloudwatch_configuring-log-forwarding[Forwarding logs to Amazon CloudWatch]
 
 include::modules/osd-rhoam.adoc[leveloffset=+1]
 

--- a/architecture/index.adoc
+++ b/architecture/index.adoc
@@ -25,7 +25,6 @@ endif::openshift-dedicated,openshift-rosa[]
 * For more information on storage, see xref:../storage/index.adoc#index[{product-title} storage].
 * For more information on authentication, see xref:../authentication/index.adoc#index[{product-title} authentication].
 * For more information on Operator Lifecycle Manager (OLM), see xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[OLM].
-* For more information on logging, see xref:../observability/logging/cluster-logging.adoc#cluster-logging[About Logging].
 // Topic not included in the OSD/ROSA docs
 ifndef::openshift-dedicated,openshift-rosa[]
 * For more information on over-the-air (OTA) updates, see xref:../updating/understanding_updates/intro-to-updates.adoc#understanding-openshift-updates[Introduction to OpenShift updates].

--- a/cicd/gitops/viewing-argo-cd-logs.adoc
+++ b/cicd/gitops/viewing-argo-cd-logs.adoc
@@ -10,7 +10,9 @@ You can view the Argo CD logs with {logging}. {logging-uc} visualizes the logs o
 
 include::modules/gitops-storing-and-retrieving-argo-cd-logs.adoc[leveloffset=+1]
 
+////
 [role="_additional-resources"]
 [id="additional-resources_viewing-argo-cd-logs"]
 == Additional resources
-* xref:../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploy-console_cluster-logging-deploying[Installing {logging} using the web console]
+* xref :../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploy-console_cluster-logging-deploying[Installing {logging} using the web console]
+////

--- a/cicd/pipelines/viewing-pipeline-logs-using-the-openshift-logging-operator.adoc
+++ b/cicd/pipelines/viewing-pipeline-logs-using-the-openshift-logging-operator.adoc
@@ -23,9 +23,11 @@ Before trying to view pipeline logs in a Kibana dashboard, ensure the following:
 
 include::modules/op-viewing-pipeline-logs-in-kibana.adoc[leveloffset=+1]
 
+////
 [role="_additional-resources"]
 [id="additional-resources_viewing-pipeline-logs-using-the-openshift-logging-operator"]
 == Additional resources
-* xref:../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploying[Installing OpenShift Logging]
-* xref:../../observability/logging/log_visualization/log-visualization.adoc#log-visualization-resource-logs_log-visualization[Viewing logs for a resource]
-* xref:../../observability/logging/log_visualization/logging-kibana.adoc#logging-kibana[Log visualization with Kibana]
+* xref :../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploying[Installing OpenShift Logging]
+* xref :../../observability/logging/log_visualization/log-visualization.adoc#log-visualization-resource-logs_log-visualization[Viewing logs for a resource]
+* xref :../../observability/logging/log_visualization/logging-kibana.adoc#logging-kibana[Log visualization with Kibana]
+////

--- a/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-logging.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-logging.adoc
@@ -16,15 +16,15 @@ There are various methods to view your logs in {product-rosa} (ROSA). Use the fo
 ====
 ROSA is not preconfigured with a logging solution.
 ====
-
+////
 .Prerequisites
 
-* Set up a logging solution before viewing your logs. See the xref:../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploying[Installing logging] documentation for more information.
+* Set up a logging solution before viewing your logs. See the xref :../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploying[Installing logging] documentation for more information.
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/logging/cluster-logging.adoc#cluster-logging[Cluster logging]
-
+* xref :../../observability/logging/cluster-logging.adoc#cluster-logging[Cluster logging]
+////
 == Forwarding logs to CloudWatch
 
 Install the logging add-on service to forward the logs to AWS CloudWatch.
@@ -126,7 +126,7 @@ pod/ostoy-frontend-679cb85695-5cn7x <1>
 pod/ostoy-microservice-86b4c6f559-p594d
 ----
 <1> The pod name is `ostoy-frontend-679cb85695-5cn7x`.
-+  
++
 . Run the following command to see both the `stdout` and `stderr` messages:
 +
 [source,terminal]

--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -130,5 +130,3 @@ include::modules/nodes-cluster-resource-override-move-infra.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../observability/monitoring/configuring-the-monitoring-stack.adoc#moving-monitoring-components-to-different-nodes_configuring-the-monitoring-stack[Moving monitoring components to different nodes]
-* xref:../observability/logging/scheduling_resources/logging-node-selectors.adoc#logging-node-selectors[Using node selectors to move logging resources]
-* xref:../observability/logging/scheduling_resources/logging-taints-tolerations.adoc#cluster-logging-logstore-tolerations_logging-taints-tolerations[Using taints and tolerations to control logging pod placement]

--- a/migrating_from_ocp_3_to_4/index.adoc
+++ b/migrating_from_ocp_3_to_4/index.adoc
@@ -14,7 +14,7 @@ Before migrating from {product-title} 3 to 4, you can check xref:../migrating_fr
 
 * xref:../architecture/architecture.adoc#architecture[Architecture]
 * xref:../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
-* xref:../storage/index.adoc#index[Storage], xref:../networking/understanding-networking.adoc#understanding-networking[network], xref:../observability/logging/cluster-logging.adoc#cluster-logging[logging], xref:../security/index.adoc#index[security], and xref:../observability/monitoring/monitoring-overview.adoc#monitoring-overview[monitoring considerations]
+* xref:../storage/index.adoc#index[Storage], xref:../networking/understanding-networking.adoc#understanding-networking[network], xref:../security/index.adoc#index[security], and xref:../observability/monitoring/monitoring-overview.adoc#monitoring-overview[monitoring considerations]
 
 [id="mtc-3-to-4-overview-planning-network-considerations-mtc"]
 == Planning network considerations

--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -193,21 +193,15 @@ Review the following logging changes to consider when transitioning from {produc
 
 {product-title} 4 provides a simple deployment mechanism for OpenShift Logging, by using a Cluster Logging custom resource.
 
-For more information, see xref:../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploying_cluster-logging-deploying[Installing OpenShift Logging].
-
 [discrete]
 ==== Aggregated logging data
 
 You cannot transition your aggregate logging data from {product-title} 3.11 into your new {product-title} 4 cluster.
 
-For more information, see xref:../observability/logging/cluster-logging.adoc#cluster-logging-about_cluster-logging[About OpenShift Logging].
-
 [discrete]
 ==== Unsupported logging configurations
 
 Some logging configurations that were available in {product-title} 3.11 are no longer supported in {product-title} {product-version}.
-
-For more information on the explicitly unsupported logging cases, see the xref:../observability/logging/cluster-logging-support.adoc#cluster-logging-support[logging support documentation].
 
 [id="migration-preparing-security"]
 === Security considerations

--- a/observability/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-updating.adoc
+++ b/observability/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-updating.adoc
@@ -16,7 +16,7 @@ During an update, the {DTProductName} Operators upgrade the managed {DTShortName
 
 [IMPORTANT]
 ====
-If you have not already updated your {es-op} as described in xref:../../../observability/logging/cluster-logging-upgrading.adoc#cluster-logging-upgrading[Updating OpenShift Logging], complete that update before updating your {JaegerName} Operator.
+If you have not already updated your {es-op}, complete that update before updating your {JaegerName} Operator.
 ====
 
 [role="_additional-resources"]
@@ -25,4 +25,3 @@ If you have not already updated your {es-op} as described in xref:../../../obser
 
 * xref:../../../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager concepts and resources]
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators]
-* xref:../../../observability/logging/cluster-logging-upgrading.adoc#cluster-logging-upgrading[Updating OpenShift Logging]

--- a/observability/index.adoc
+++ b/observability/index.adoc
@@ -42,8 +42,6 @@ For more information, see xref:../observability/monitoring/monitoring-overview.a
 == Logging
 Collect, visualize, forward, and store log data to troubleshoot issues, identify performance bottlenecks, and detect security threats. In logging 5.7 and later versions, users can configure the LokiStack deployment to produce customized alerts and recorded metrics.
 
-For more information, see xref:../observability/logging/cluster-logging.adoc#cluster-logging[About Logging].
-
 ifdef::openshift-enterprise,openshift-origin[]
 [id="distr-tracing-architecture-index_{context}"]
 == Distributed tracing
@@ -69,4 +67,3 @@ Monitor the power usage of workloads and identify the most power-consuming names
 
 For more information, see xref:../observability/power_monitoring/power-monitoring-overview.adoc#power-monitoring-overview[Power monitoring overview].
 endif::[]
-

--- a/observability/logging/cluster-logging.adoc
+++ b/observability/logging/cluster-logging.adoc
@@ -11,40 +11,40 @@ As a cluster administrator, you can deploy {logging} on an {product-title} clust
 
 include::snippets/logging-kibana-dep-snip.adoc[]
 
-{product-title} cluster administrators can deploy {logging} by using Operators. For information, see xref:../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploying[Installing {logging}].
+{product-title} cluster administrators can deploy {logging} by using Operators. For information, see xref :../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploying[Installing {logging}].
 
 The Operators are responsible for deploying, upgrading, and maintaining {logging}. After the Operators are installed, you can create a `ClusterLogging` custom resource (CR) to schedule {logging} pods and other resources necessary to support {logging}. You can also create a `ClusterLogForwarder` CR to specify which logs are collected, how they are transformed, and where they are forwarded to.
 
 [NOTE]
 ====
-Because the internal {product-title} Elasticsearch log store does not provide secure storage for audit logs, audit logs are not stored in the internal Elasticsearch instance by default. If you want to send the audit logs to the default internal Elasticsearch log store, for example to view the audit logs in Kibana, you must use the Log Forwarding API as described in xref:../../observability/logging/log_storage/logging-config-es-store.adoc#cluster-logging-elasticsearch-audit_logging-config-es-store[Forward audit logs to the log store].
+Because the internal {product-title} Elasticsearch log store does not provide secure storage for audit logs, audit logs are not stored in the internal Elasticsearch instance by default. If you want to send the audit logs to the default internal Elasticsearch log store, for example to view the audit logs in Kibana, you must use the Log Forwarding API as described in xref :../../observability/logging/log_storage/logging-config-es-store.adoc#cluster-logging-elasticsearch-audit_logging-config-es-store[Forward audit logs to the log store].
 ====
 
 include::modules/logging-architecture-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/logging/log_visualization/log-visualization-ocp-console.adoc#log-visualization-ocp-console[Log visualization with the web console]
+* xref :../../observability/logging/log_visualization/log-visualization-ocp-console.adoc#log-visualization-ocp-console[Log visualization with the web console]
 
 include::modules/cluster-logging-about.adoc[leveloffset=+1]
 
 ifdef::openshift-rosa,openshift-dedicated[]
 include::modules/cluster-logging-cloudwatch.adoc[leveloffset=+1]
-For information, see xref:../../observability/logging/log_collection_forwarding/log-forwarding.adoc#about-log-collection_log-forwarding[About log collection and forwarding].
+For information, see xref :../../observability/logging/log_collection_forwarding/log-forwarding.adoc#about-log-collection_log-forwarding[About log collection and forwarding].
 endif::[]
 
 include::modules/cluster-logging-json-logging-about.adoc[leveloffset=+2]
 
 include::modules/cluster-logging-collecting-storing-kubernetes-events.adoc[leveloffset=+2]
 
-For information, see xref:../../observability/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc#cluster-logging-eventrouter[About collecting and storing Kubernetes events].
+For information, see xref :../../observability/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc#cluster-logging-eventrouter[About collecting and storing Kubernetes events].
 
 include::modules/cluster-logging-troubleshoot-logging.adoc[leveloffset=+2]
 
 include::modules/cluster-logging-export-fields.adoc[leveloffset=+2]
 
-For information, see xref:../../observability/logging/cluster-logging-exported-fields.adoc#cluster-logging-exported-fields[About exporting fields].
+For information, see xref :../../observability/logging/cluster-logging-exported-fields.adoc#cluster-logging-exported-fields[About exporting fields].
 
 include::modules/cluster-logging-eventrouter-about.adoc[leveloffset=+2]
 
-For information, see xref:../../observability/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc#cluster-logging-eventrouter[Collecting and storing Kubernetes events].
+For information, see xref :../../observability/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc#cluster-logging-eventrouter[Collecting and storing Kubernetes events].

--- a/observability/logging/log_collection_forwarding/log-forwarding.adoc
+++ b/observability/logging/log_collection_forwarding/log-forwarding.adoc
@@ -35,7 +35,7 @@ To use the multi log forwarder feature, you must create a service account and cl
 
 [IMPORTANT]
 ====
-In order to support multi log forwarding in additional namespaces other than the `openshift-logging` namespace, you must xref:../../../observability/logging/cluster-logging-upgrading.adoc#logging-operator-upgrading-all-ns_cluster-logging-upgrading[update the {clo} to watch all namespaces]. This functionality is supported by default in new {clo} version 5.8 installations.
+In order to support multi log forwarding in additional namespaces other than the `openshift-logging` namespace, you must update the {clo} to watch all namespaces]. This functionality is supported by default in new {clo} version 5.8 installations.
 ====
 
 include::modules/log-collection-rbac-permissions.adoc[leveloffset=+3]

--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -11,7 +11,7 @@ The {loki-op} integrates a gateway that implements multi-tenancy and authenticat
 
 [NOTE]
 ====
-The {loki-op} can also be used for xref:../../observability/logging/log_storage/cluster-logging-loki.adoc#cluster-logging-loki[configuring the LokiStack log store]. The Network Observability Operator requires a dedicated LokiStack separate from the {logging}.
+The {loki-op} can also be used for configuring the LokiStack log store]. The Network Observability Operator requires a dedicated LokiStack separate from the {logging}.
 ====
 
 include::modules/network-observability-without-loki.adoc[leveloffset=+1]
@@ -24,9 +24,9 @@ include::modules/network-observability-loki-install.adoc[leveloffset=+1]
 include::modules/network-observability-loki-secret.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference] 
+* xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]
-* xref:../../observability/logging/log_storage/installing-log-storage.adoc#logging-loki-storage_installing-log-storage[Loki object storage]
+//* xref :../../observability/logging/log_storage/installing-log-storage.adoc#logging-loki-storage_installing-log-storage[Loki object storage]
 
 include::modules/network-observability-lokistack-create.adoc[leveloffset=+2]
 include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+2]

--- a/observability/otel/otel-forwarding-telemetry-data.adoc
+++ b/observability/otel/otel-forwarding-telemetry-data.adoc
@@ -11,7 +11,9 @@ You can use the OpenTelemetry Collector to forward your telemetry data.
 include::modules/otel-forwarding-traces.adoc[leveloffset=+1]
 include::modules/otel-forwarding-logs-to-tempostack.adoc[leveloffset=+1]
 
+////
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../logging/log_storage/installing-log-storage.adoc#installing-log-storage[Installing LokiStack log storage]
+////

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -296,14 +296,6 @@ include::modules/infrastructure-moving-registry.adoc[leveloffset=+2]
 
 include::modules/infrastructure-moving-monitoring.adoc[leveloffset=+2]
 
-[id="custer-tasks-moving-logging-resources"]
-=== Moving {logging} resources
-
-For information about moving {logging} resources, see:
-
-* xref:../observability/logging/scheduling_resources/logging-node-selectors.adoc#logging-node-selectors[Using node selectors to move logging resources]
-* xref:../observability/logging/scheduling_resources/logging-taints-tolerations.adoc#cluster-logging-logstore-tolerations_logging-taints-tolerations[Using taints and tolerations to control logging pod placement]
-
 include::modules/cluster-autoscaler-about.adoc[leveloffset=+1]
 include::modules/cluster-autoscaler-cr.adoc[leveloffset=+2]
 :FeatureName: cluster autoscaler

--- a/rosa_architecture/about-hcp.adoc
+++ b/rosa_architecture/about-hcp.adoc
@@ -78,7 +78,7 @@ Use the following sections to find content to help you learn about and use {hcp-
 
 | xref:../architecture/rosa-architecture-models.adoc#rosa-architecture-models[{hcp-title} architecture]
 | xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Installing {hcp-title}]
-| xref:../observability/logging/cluster-logging.adoc#cluster-logging[Logging]
+| 
 | xref:../support/index.adoc#support-overview[Getting Support]
 
 | link:https://learn.openshift.com/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[OpenShift Interactive Learning Portal]

--- a/rosa_architecture/index.adoc
+++ b/rosa_architecture/index.adoc
@@ -271,8 +271,6 @@ Use the Cluster Version Operator (CVO) to upgrade your {product-title} cluster. 
 
 === Observe a cluster
 
-- **xref:../observability/logging/cluster-logging.adoc#cluster-logging[OpenShift Logging]**: Learn about logging and configure different logging components, such as log storage, log collectors, and the logging web console plugin.
-
 - **xref:../observability/distr_tracing/distr_tracing_arch/distr-tracing-architecture.adoc#distr-tracing-architecture[Red Hat OpenShift distributed tracing platform]**: Store and visualize large volumes of requests passing through distributed systems, across the whole stack of microservices, and under heavy loads. Use the distributed tracing platform for monitoring distributed transactions, gathering insights into your instrumented services, network profiling, performance and latency optimization, root cause analysis, and troubleshooting the interaction between components in modern cloud-native microservices-based applications.
 
 // xreffing to the installation page until further notice because OTEL content is currently planned for internal restructuring across pages that is likely to result in renamed page files

--- a/rosa_architecture/learn_more_about_openshift.adoc
+++ b/rosa_architecture/learn_more_about_openshift.adoc
@@ -47,7 +47,6 @@ Use the following sections to find content to help you learn about and use {prod
 
 | xref:../architecture/architecture.adoc#architecture[Architecture]
 | xref:../machine_configuration/index.adoc#machine-config-overview[Machine configuration overview]
-| xref:../observability/logging/cluster-logging.adoc#cluster-logging[Logging]
 | link:https://access.redhat.com/articles/4217411[OpenShift Knowledgebase articles]
 
 | link:https://learn.openshift.com/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[OpenShift Interactive Learning Portal]
@@ -88,7 +87,6 @@ Use the following sections to find content to help you learn about and use {prod
 | link:https://access.redhat.com/articles/4217411[OpenShift Knowledgebase articles]
 
 |
-| xref:../observability/logging/cluster-logging.adoc#cluster-logging[Logging]
 | link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[{product-title} Life Cycle]
 
 |

--- a/scalability_and_performance/optimization/optimizing-storage.adoc
+++ b/scalability_and_performance/optimization/optimizing-storage.adoc
@@ -35,4 +35,4 @@ include::modules/optimizing-storage-azure.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="admission-plug-ins-additional-resources"]
 == Additional resources
-* xref:../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store]
+* xref :../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store]

--- a/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-design-components.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-design-components.adoc
@@ -68,7 +68,7 @@ include::modules/telco-core-logging.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../observability/logging/cluster-logging.adoc#cluster-logging[About logging]
+// p* xref :../../../observability/logging/cluster-logging.adoc#cluster-logging[About logging]
 
 include::modules/telco-core-power-management.adoc[leveloffset=+1]
 

--- a/security/audit-log-view.adoc
+++ b/security/audit-log-view.adoc
@@ -32,5 +32,3 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * link:https://github.com/kubernetes/apiserver/blob/master/pkg/apis/audit/v1/types.go#L72[API audit log event structure]
 * xref:../security/audit-log-policy-config.adoc#audit-log-policy-config[Configuring the audit log policy]
 endif::[]
-* xref:../observability/logging/log_collection_forwarding/log-forwarding.adoc#log-forwarding[About log forwarding]
-

--- a/security/container_security/security-monitoring.adoc
+++ b/security/container_security/security-monitoring.adoc
@@ -25,5 +25,5 @@ include::modules/security-monitoring-audit-logging.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../nodes/clusters/nodes-containers-events.adoc#nodes-containers-events[List of system events]
-* xref:../../observability/logging/cluster-logging.adoc#cluster-logging[Understanding OpenShift Logging]
+* xref :../../observability/logging/cluster-logging.adoc#cluster-logging[Understanding OpenShift Logging]
 * xref:../../security/audit-log-view.adoc#audit-log-view[Viewing audit logs]

--- a/service_mesh/v1x/ossm-custom-resources.adoc
+++ b/service_mesh/v1x/ossm-custom-resources.adoc
@@ -42,7 +42,7 @@ include::modules/ossm-jaeger-config-elasticsearch-v1x.adoc[leveloffset=+2]
 include::modules/ossm-jaeger-config-es-cleaner-v1x.adoc[leveloffset=+2]
 
 ifdef::openshift-enterprise[]
-For more information about configuring Elasticsearch with {product-title}, see  xref:../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store].
+For more information about configuring Elasticsearch with {product-title}, see  xref :../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store].
 endif::[]
 
 include::modules/ossm-cr-threescale.adoc[leveloffset=+1]

--- a/service_mesh/v1x/preparing-ossm-installation.adoc
+++ b/service_mesh/v1x/preparing-ossm-installation.adoc
@@ -42,7 +42,7 @@ include::modules/ossm-installation-activities.adoc[leveloffset=+1]
 ifdef::openshift-enterprise[]
 [WARNING]
 ====
-See xref:../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store] for details on configuring the default Jaeger parameters for Elasticsearch in a production environment.
+See xref :../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store] for details on configuring the default Jaeger parameters for Elasticsearch in a production environment.
 ====
 
 == Next steps

--- a/service_mesh/v2x/ossm-reference-jaeger.adoc
+++ b/service_mesh/v2x/ossm-reference-jaeger.adoc
@@ -44,7 +44,7 @@ include::modules/distr-tracing-config-sampling.adoc[leveloffset=+2]
 include::modules/distr-tracing-config-storage.adoc[leveloffset=+2]
 
 ifdef::openshift-enterprise[]
-For more information about configuring Elasticsearch with {product-title}, see xref:../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store] or xref:../../observability/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-configuring.adoc#distr-tracing-jaeger-configuring[Configuring and deploying distributed tracing].
+For more information about configuring Elasticsearch with {product-title}, see xref :../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store] or xref:../../observability/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-configuring.adoc#distr-tracing-jaeger-configuring[Configuring and deploying distributed tracing].
 
 //TO DO For information about connecting to an external Elasticsearch instance, see xref:../../observability/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-configuring.adoc#jaeger-config-external-es_jaeger-deploying[Connecting to an existing Elasticsearch instance].
 endif::[]

--- a/support/index.adoc
+++ b/support/index.adoc
@@ -125,11 +125,15 @@ endif::openshift-rosa,openshift-dedicated[]
 ** Investigate why user-defined metrics are unavailable.
 ** Determine why Prometheus is consuming a lot of disk space.
 
-* xref:../observability/logging/cluster-logging.adoc#cluster-logging[Logging issues]: A cluster administrator can follow the procedures in the "Support" and "Troubleshooting logging" sections to resolve logging issues:
+////
+----
+* xref :../observability/logging/cluster-logging.adoc#cluster-logging[Logging issues]: A cluster administrator can follow the procedures in the "Support" and "Troubleshooting logging" sections to resolve logging issues:
 
-** xref:../observability/logging/troubleshooting/cluster-logging-cluster-status.adoc#cluster-logging-clo-status_cluster-logging-cluster-status[Viewing the status of the {clo}]
-** xref:../observability/logging/troubleshooting/cluster-logging-cluster-status.adoc#cluster-logging-clo-status-comp_cluster-logging-cluster-status[Viewing the status of {logging} components]
-** xref:../observability/logging/troubleshooting/troubleshooting-logging-alerts.adoc#troubleshooting-logging-alerts[Troubleshooting logging alerts]
-** xref:../observability/logging/cluster-logging-support.adoc#cluster-logging-must-gather-collecting_cluster-logging-support[Collecting information about your logging environment by using the `oc adm must-gather` command]
+** xref :../observability/logging/troubleshooting/cluster-logging-cluster-status.adoc#cluster-logging-clo-status_cluster-logging-cluster-status[Viewing the status of the {clo}]
+** xref :../observability/logging/troubleshooting/cluster-logging-cluster-status.adoc#cluster-logging-clo-status-comp_cluster-logging-cluster-status[Viewing the status of {logging} components]
+** xref :../observability/logging/troubleshooting/troubleshooting-logging-alerts.adoc#troubleshooting-logging-alerts[Troubleshooting logging alerts]
+** xref :../observability/logging/cluster-logging-support.adoc#cluster-logging-must-gather-collecting_cluster-logging-support[Collecting information about your logging environment by using the `oc adm must-gather` command]
+----
+////
 
 * xref:../support/troubleshooting/diagnosing-oc-issues.adoc#diagnosing-oc-issues[{oc-first} issues]: Investigate {oc-first} issues by increasing the log level.

--- a/virt/support/virt-troubleshooting.adoc
+++ b/virt/support/virt-troubleshooting.adoc
@@ -83,8 +83,8 @@ include::modules/virt-loki-log-queries.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources for LokiStack and LogQL
-* xref:../../observability/logging/log_storage/about-log-storage.adoc#about-log-storage[About log storage]
-* xref:../../observability/logging/log_storage/installing-log-storage.adoc#cluster-logging-loki-deploy_installing-log-storage[Deploying the LokiStack]
+* xref :../../observability/logging/log_storage/about-log-storage.adoc#about-log-storage[About log storage]
+//* xref :../../observability/logging/log_storage/installing-log-storage.adoc#cluster-logging-loki-deploy_installing-log-storage[Deploying the LokiStack]
 * link:https://grafana.com/docs/loki/latest/logql/log_queries/[LogQL log queries] in the Grafana documentation
 
 include::modules/virt-common-error-messages.adoc[leveloffset=+1]

--- a/welcome/about-hcp.adoc
+++ b/welcome/about-hcp.adoc
@@ -53,7 +53,7 @@ Use the following sections to find content to help you learn about and use {hcp-
 
 | xref:../architecture/rosa-architecture-models.adoc#rosa-architecture-models[{hcp-title} architecture]
 | xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Installing {hcp-title}]
-| xref:../observability/logging/cluster-logging.adoc#cluster-logging[Logging]
+// | xref :../observability/logging/cluster-logging.adoc#cluster-logging[Logging]
 | xref:../support/index.adoc#support-overview[Getting Support]
 
 | link:https://learn.openshift.com/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[OpenShift Interactive Learning Portal]
@@ -61,7 +61,7 @@ Use the following sections to find content to help you learn about and use {hcp-
 | xref:../observability/monitoring/monitoring-overview.adoc#monitoring-overview_virt-monitoring-overview[Monitoring overview]
 | xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{hcp-title} life cycle]
 
-| 
+|
 | xref:../rosa_backing_up_and_restoring_applications/backing-up-applications.adoc#rosa-backing-up-applications[Back up and restore]
 |
 |

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -199,8 +199,8 @@ a|* xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-cr
 |===
 |Learn about {product-title} |Optional additional resources
 
-| xref:../observability/logging/cluster-logging.adoc#cluster-logging[OpenShift Logging]
-|
+// | //xref :../observability/logging/cluster-logging.adoc#cluster-logging[OpenShift Logging]
+// |
 
 | xref:../observability/distr_tracing/distr_tracing_arch/distr-tracing-architecture.adoc#distr-tracing-architecture[{jaegername}]
 |
@@ -250,7 +250,7 @@ a|* xref:../observability/monitoring/monitoring-overview.adoc#monitoring-overvie
 | link:https://access.redhat.com/articles/4217411[OpenShift Knowledgebase articles]
 
 |
-| xref:../observability/logging/cluster-logging.adoc#cluster-logging[Logging]
+// | xref :../observability/logging/cluster-logging.adoc#cluster-logging[Logging]
 | link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[{product-title} Life Cycle]
 
 |


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OBSDOCS-1270](https://issues.redhat.com//browse/OBSDOCS-1270)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: n/a topic map change only. 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 4.17 only supports Logging 6.0. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
