### PR TITLE
[OCPBUGS-42560] Update command to add the configmap in nodepool

### DIFF
--- a/modules/configuring-node-pools-for-hcp.adoc
+++ b/modules/configuring-node-pools-for-hcp.adoc
@@ -50,7 +50,7 @@ data:
 +
 [source,yaml]
 ----
-$ oc edit nodepool <node_pool_name> --namespace <hosted_cluster_namespace>
+$ oc edit nodepool <nodepool_name> --namespace <hosted_cluster_namespace>
 ----
 .Example output
 +

--- a/modules/configuring-node-pools-for-hcp.adoc
+++ b/modules/configuring-node-pools-for-hcp.adoc
@@ -50,9 +50,23 @@ data:
 +
 [source,yaml]
 ----
-spec:
-  config:
-    - name: ${CONFIGMAP_NAME}
+$ oc edit nodepool <node_pool_name> --namespace <hosted_cluster_namespace>
+----
+.Example output
++
+[source,yaml]
+----
+apiVersion: hypershift.openshift.io/v1alpha1
+kind: NodePool
+metadata:
+# ...
+  name: nodepool-1
+  namespace: clusters
+# ...
+  spec:
+    config:
+      - name: ${CONFIGMAP_NAME}
+# ...
 ----
 
 //.Verification


### PR DESCRIPTION
Updated command to add the configmap in nodepool

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16, 4.15,4.14
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-42560

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://82680--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-machine-config.html
https://82680--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-hosted-control-planes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
