### PR TITLE
OBSDOCS-1301: Logging Z-Stream Release Notes - 5.6.24

### DIFF
--- a/modules/logging-release-notes-5-6-24.adoc
+++ b/modules/logging-release-notes-5-6-24.adoc
@@ -1,0 +1,31 @@
+// module included in logging-5-6-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="cluster-logging-release-notes-5-6-24_{context}"]
+= Logging 5.6.24
+This release includes link:https://access.redhat.com/errata/RHBA-2024:7323[OpenShift Logging Bug Fix Release 5.6.24].
+
+[id="openshift-logging-5-6-24-bug-fixes_{context}"]
+== Bug fixes
+
+None.
+
+[id="openshift-logging-5-6-24-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-2398[CVE-2024-2398]
+* link:https://access.redhat.com/security/cve/CVE-2024-4032[CVE-2024-4032]
+* link:https://access.redhat.com/security/cve/CVE-2024-6104[CVE-2024-6104]
+* link:https://access.redhat.com/security/cve/CVE-2024-6232[CVE-2024-6232]
+* link:https://access.redhat.com/security/cve/CVE-2024-6345[CVE-2024-6345]
+* link:https://access.redhat.com/security/cve/CVE-2024-6923[CVE-2024-6923]
+* link:https://access.redhat.com/security/cve/CVE-2024-30203[CVE-2024-30203]
+* link:https://access.redhat.com/security/cve/CVE-2024-30205[CVE-2024-30205]
+* link:https://access.redhat.com/security/cve/CVE-2024-39331[CVE-2024-39331]
+* link:https://access.redhat.com/security/cve/CVE-2024-45490[CVE-2024-45490]
+* link:https://access.redhat.com/security/cve/CVE-2024-45491[CVE-2024-45491]
+* link:https://access.redhat.com/security/cve/CVE-2024-45492[CVE-2024-45492]
+
+[NOTE]
+====
+For detailed information on Red Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#moderate[Severity ratings].
+====

--- a/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-6-24.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-6-23.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-6-22.adoc[leveloffset=+1]


### PR DESCRIPTION
--------

:warning: Note from @jeana-redhat  :warning:

This is reviewed and approved for merge, **do not merge until Satyajeet indicates the advisory is live.** 

--------

Change type: Doc update; Logging Z-Stream Release Notes - 5.6.24
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1301

Fix Version: 4.12, 4.13

Doc Preview: https://82682--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-6-release-notes.html#cluster-logging-release-notes-5-6-24_logging-5-6-release-notes

SME review completed: @periklis 
QE review completed: @anpingli 
Peer review completed: @mburke5678