### PR TITLE
OBSDOCS-1303: Logging Z-Stream Release Notes - 5.9.7

### DIFF
--- a/modules/logging-release-notes-5-9-7.adoc
+++ b/modules/logging-release-notes-5-9-7.adoc
@@ -1,0 +1,30 @@
+// module included in logging-5-9-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="cluster-logging-release-notes-5-9-7_{context}"]
+= Logging 5.9.7
+This release includes link:https://access.redhat.com/errata/RHBA-2024:7324[OpenShift Logging Bug Fix Release 5.9.7].
+
+
+[id="openshift-logging-5-9-7-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the `clusterlogforwarder.spec.outputs.http.timeout` parameter was not applied to the Fluentd configuration when Fluentd was used as the collector type, causing HTTP timeouts to be misconfigured. With this update, the `clusterlogforwarder.spec.outputs.http.timeout` parameter is now correctly applied, ensuring Fluentd honors the specified timeout and handles HTTP connections according to the user’s configuration. (link:https://issues.redhat.com/browse/LOG-6125[LOG-6125])
+
+* Before this update, the TLS section was added without verifying the broker URL schema, resulting in SSL connection errors if the URLs did not start with `tls`. With this update, the TLS section is now added only if the broker URLs start with `tls`, preventing SSL connection errors. (link:https://issues.redhat.com/browse/LOG-6041[LOG-6041])
+
+[id="openshift-logging-5-9-7-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-6104[CVE-2024-6104]
+* link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+* link:https://access.redhat.com/security/cve/CVE-2024-34397[CVE-2024-34397]
+* link:https://access.redhat.com/security/cve/CVE-2024-45296[CVE-2024-45296]
+* link:https://access.redhat.com/security/cve/CVE-2024-45490[CVE-2024-45490]
+* link:https://access.redhat.com/security/cve/CVE-2024-45491[CVE-2024-45491]
+* link:https://access.redhat.com/security/cve/CVE-2024-45492[CVE-2024-45492]
+* link:https://access.redhat.com/security/cve/CVE-2024-45801[CVE-2024-45801]
+
+[NOTE]
+====
+For detailed information on Red Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#moderate[Severity ratings].
+====

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-9-7.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-9-6.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-9-5.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.9.7
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1303

Fix Version: 4.13, 4.14, 4.15, 4.16

Doc Preview: https://82683--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html#cluster-logging-release-notes-5-9-7_logging-5-9-release-notes

SME review completed: @periklis 
QE review completed: @kabirbhartiRH
Peer review completed: @mramendi 