### PR TITLE
OBSDOCS-1302: Logging Z-Stream Release Notes - 5.8.13

### DIFF
--- a/modules/logging-release-notes-5-8-13.adoc
+++ b/modules/logging-release-notes-5-8-13.adoc
@@ -1,0 +1,70 @@
+// module included in logging-5-8-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="cluster-logging-release-notes-5-8-13_{context}"]
+= Logging 5.8.13
+This release includes link:https://access.redhat.com/errata/RHSA-2024:7237[OpenShift Logging Bug Fix Release 5.8.13] and link:https://access.redhat.com/errata/RHBA-2024:7230[OpenShift Logging Bug Fix Release 5.8.13].
+
+[id="openshift-logging-5-8-13-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the `clusterlogforwarder.spec.outputs.http.timeout` parameter was not applied to the Fluentd configuration when Fluentd was used as the collector type, causing HTTP timeouts to be misconfigured. With this update, the `clusterlogforwarder.spec.outputs.http.timeout` parameter is now correctly applied, ensuring that Fluentd honors the specified timeout and handles HTTP connections according to the user’s configuration. (link:https://issues.redhat.com/browse/LOG-5210[LOG-5210])
+
+* Before this update, the Elasticsearch Operator did not issue an alert to inform users about the upcoming removal, leaving existing installations unsupported without notice. With this update, the Elasticsearch Operator will trigger a continuous alert on {product-title} version 4.16 and later, notifying users of its removal from the catalog in November 2025. (link:https://issues.redhat.com/browse/LOG-5966[LOG-5966])
+
+* Before this update, the Red Hat OpenShift Logging Operator was unavailable on {product-title} version 4.16 and later, preventing Telco customers from completing their certifications for the upcoming Logging 6.0 release. With this update, the Red Hat OpenShift Logging Operator is now available on {product-title} versions 4.16 and 4.17, resolving the issue. (link:https://issues.redhat.com/browse/LOG-6103[LOG-6103])
+
+* Before this update, the Elasticsearch Operator was not available in the {product-title} versions 4.17 and 4.18, preventing the installation of ServiceMesh, Kiali, and Distributed Tracing. With this update, the Elasticsearch Operator properties have been expanded for {product-title} versions 4.17 and 4.18, resolving the issue and allowing ServiceMesh, Kiali, and Distributed Tracing operators to install their stacks. (link:https://issues.redhat.com/browse/LOG-6134[LOG-6134])
+
+[id="openshift-logging-5-8-13-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-52463[CVE-2023-52463]
+* link:https://access.redhat.com/security/cve/CVE-2023-52801[CVE-2023-52801]
+* link:https://access.redhat.com/security/cve/CVE-2024-6104[CVE-2024-6104]
+* link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+* link:https://access.redhat.com/security/cve/CVE-2024-26629[CVE-2024-26629]
+* link:https://access.redhat.com/security/cve/CVE-2024-26630[CVE-2024-26630]
+* link:https://access.redhat.com/security/cve/CVE-2024-26720[CVE-2024-26720]
+* link:https://access.redhat.com/security/cve/CVE-2024-26886[CVE-2024-26886]
+* link:https://access.redhat.com/security/cve/CVE-2024-26946[CVE-2024-26946]
+* link:https://access.redhat.com/security/cve/CVE-2024-34397[CVE-2024-34397]
+* link:https://access.redhat.com/security/cve/CVE-2024-35791[CVE-2024-35791]
+* link:https://access.redhat.com/security/cve/CVE-2024-35797[CVE-2024-35797]
+* link:https://access.redhat.com/security/cve/CVE-2024-35875[CVE-2024-35875]
+* link:https://access.redhat.com/security/cve/CVE-2024-36000[CVE-2024-36000]
+* link:https://access.redhat.com/security/cve/CVE-2024-36019[CVE-2024-36019]
+* link:https://access.redhat.com/security/cve/CVE-2024-36883[CVE-2024-36883]
+* link:https://access.redhat.com/security/cve/CVE-2024-36979[CVE-2024-36979]
+* link:https://access.redhat.com/security/cve/CVE-2024-38559[CVE-2024-38559]
+* link:https://access.redhat.com/security/cve/CVE-2024-38619[CVE-2024-38619]
+* link:https://access.redhat.com/security/cve/CVE-2024-39331[CVE-2024-39331]
+* link:https://access.redhat.com/security/cve/CVE-2024-40927[CVE-2024-40927]
+* link:https://access.redhat.com/security/cve/CVE-2024-40936[CVE-2024-40936]
+* link:https://access.redhat.com/security/cve/CVE-2024-41040[CVE-2024-41040]
+* link:https://access.redhat.com/security/cve/CVE-2024-41044[CVE-2024-41044]
+* link:https://access.redhat.com/security/cve/CVE-2024-41055[CVE-2024-41055]
+* link:https://access.redhat.com/security/cve/CVE-2024-41073[CVE-2024-41073]
+* link:https://access.redhat.com/security/cve/CVE-2024-41096[CVE-2024-41096]
+* link:https://access.redhat.com/security/cve/CVE-2024-42082[CVE-2024-42082]
+* link:https://access.redhat.com/security/cve/CVE-2024-42096[CVE-2024-42096]
+* link:https://access.redhat.com/security/cve/CVE-2024-42102[CVE-2024-42102]
+* link:https://access.redhat.com/security/cve/CVE-2024-42131[CVE-2024-42131]
+* link:https://access.redhat.com/security/cve/CVE-2024-45490[CVE-2024-45490]
+* link:https://access.redhat.com/security/cve/CVE-2024-45491[CVE-2024-45491]
+* link:https://access.redhat.com/security/cve/CVE-2024-45492[CVE-2024-45492]
+* link:https://access.redhat.com/security/cve/CVE-2024-2398[CVE-2024-2398]
+* link:https://access.redhat.com/security/cve/CVE-2024-4032[CVE-2024-4032]
+* link:https://access.redhat.com/security/cve/CVE-2024-6232[CVE-2024-6232]
+* link:https://access.redhat.com/security/cve/CVE-2024-6345[CVE-2024-6345]
+* link:https://access.redhat.com/security/cve/CVE-2024-6923[CVE-2024-6923]
+* link:https://access.redhat.com/security/cve/CVE-2024-30203[CVE-2024-30203]
+* link:https://access.redhat.com/security/cve/CVE-2024-30205[CVE-2024-30205]
+* link:https://access.redhat.com/security/cve/CVE-2024-39331[CVE-2024-39331]
+* link:https://access.redhat.com/security/cve/CVE-2024-45490[CVE-2024-45490]
+* link:https://access.redhat.com/security/cve/CVE-2024-45491[CVE-2024-45491]
+* link:https://access.redhat.com/security/cve/CVE-2024-45492[CVE-2024-45492]
+
+[NOTE]
+====
+For detailed information on Red Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#moderate[Severity ratings].
+====

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-13.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-12.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-11.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.8.13
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1302

Fix Version: 4.12, 4.13, 4.14, 4.15

Doc Preview: https://82689--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html#cluster-logging-release-notes-5-8-13_logging-5-8-release-notes

SME review completed: @periklis 
QE review completed: @anpingli 
Peer review completed: @mburke5678 