### PR TITLE
OSDOCS-12181:Added FIPS cryptography option in create classic cluster  ROSA CLI workflow.

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -237,24 +237,27 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for th
 ? Multiple availability zones (optional): No <9>
 ? AWS region: us-east-1
 ? PrivateLink cluster (optional): No
+? Machine CIDR: 10.0.0.0/16
+? Service CIDR: 172.30.0.0/16
+? Pod CIDR: 10.128.0.0/14
 ? Install into an existing VPC (optional): Yes <10>
+? Subnet IDs (optional):
 ? Select availability zones (optional): No
 ? Enable Customer Managed key (optional): No <11>
 ? Compute nodes instance type (optional):
 ? Enable autoscaling (optional): No
 ? Compute nodes: 2
+? Worker machine pool labels (optional):
+? Host prefix: 23
 ? Additional Security Group IDs (optional): <12>
 ? > [*]  sg-0e375ff0ec4a6cfa2 ('sg-1')
 ? > [ ]  sg-0e525ef0ec4b2ada7 ('sg-2')
-? Machine CIDR: 10.0.0.0/16
-? Service CIDR: 172.30.0.0/16
-? Pod CIDR: 10.128.0.0/14
-? Host prefix: 23
-? Encrypt etcd data (optional): No <13>
+? Enable FIPS support: No <13>
+? Encrypt etcd data: No <14>
 ? Disable Workload monitoring (optional): No
 I: Creating cluster '<cluster_name>'
 I: To create this cluster again in the future, you can run:
-   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.17.0 --additional-compute-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-infra-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-control-plane-security-group-ids sg-0e375ff0ec4a6cfa2 --replicas 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <14>
+   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.17.0 --additional-compute-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-infra-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-control-plane-security-group-ids sg-0e375ff0ec4a6cfa2 --replicas 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <15>
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
 I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
@@ -308,14 +311,15 @@ PVs created by using any other storage class are still encrypted, but the PVs ar
 ====
 
 <12> Optional: You can select additional custom security groups to use in your cluster. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups for the default machine pools after you create the machine pool. For more information, see the requirements for _Security groups_ under _Additional resources_.
-<13> Optional: Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted but not the keys.
+<13> Optional: Enable this option if you require your cluster to be FIPS validated. Selecting this option means the encrypt etcd data option is enabled by default and cannot be disabled. You can encrypt etcd data without enabling FIPS support.
+<14> Optional: Enable this option if your use case only requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted but not the keys.
 +
 [IMPORTANT]
 ====
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Red{nbsp}Hat recommends that you enable etcd encryption only if you specifically require it for your use case.
 ====
 +
-<14> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
+<15> The output includes a custom command that you can run to create another cluster with the same configuration.
 --
 +
 As an alternative to using the `--interactive` mode, you can specify the customization options directly when you run the `rosa create cluster` command. Run the `rosa create cluster --help` command to view a list of available CLI options, or see _create cluster_ in _Managing objects with the ROSA CLI_.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12181

Link to docs preview:
[Creating a cluster with customizations using the CLI](https://82690--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
