### PR TITLE
OCPBUGS#42583: Updating metric labels

### DIFF
--- a/modules/nw-metallb-metrics.adoc
+++ b/modules/nw-metallb-metrics.adoc
@@ -12,28 +12,28 @@
 |===
 | Name | Description
 
-| `metallb_bfd_control_packet_input`
+| `frrk8s_bfd_control_packet_input`
 | Counts the number of BFD control packets received from each BFD peer.
 
-| `metallb_bfd_control_packet_output`
+| `frrk8s_bfd_control_packet_output`
 | Counts the number of BFD control packets sent to each BFD peer.
 
-| `metallb_bfd_echo_packet_input`
+| `frrk8s_bfd_echo_packet_input`
 | Counts the number of BFD echo packets received from each BFD peer.
 
-| `metallb_bfd_echo_packet_output`
+| `frrk8s_bfd_echo_packet_output`
 | Counts the number of BFD echo packets sent to each BFD.
 
-| `metallb_bfd_session_down_events`
+| `frrk8s_bfd_session_down_events`
 | Counts the number of times the BFD session with a peer entered the `down` state.
 
-| `metallb_bfd_session_up`
+| `frrk8s_bfd_session_up`
 | Indicates the connection state with a BFD peer. `1` indicates the session is `up` and `0` indicates the session is `down`.
 
-| `metallb_bfd_session_up_events`
+| `frrk8s_bfd_session_up_events`
 | Counts the number of times the BFD session with a peer entered the `up` state.
 
-| `metallb_bfd_zebra_notifications`
+| `frrk8s_bfd_zebra_notifications`
 | Counts the number of BFD Zebra notifications for each BFD peer.
 
 |===
@@ -43,40 +43,40 @@
 |===
 | Name | Description
 
-| `metallb_bgp_announced_prefixes_total`
+| `frrk8s_bgp_announced_prefixes_total`
 | Counts the number of load balancer IP address prefixes that are advertised to BGP peers. The terms _prefix_ and _aggregated route_ have the same meaning.
 
-| `metallb_bgp_session_up`
+| `frrk8s_bgp_session_up`
 | Indicates the connection state with a BGP peer. `1` indicates the session is `up` and `0` indicates the session is `down`.
 
-| `metallb_bgp_updates_total`
+| `frrk8s_bgp_updates_total`
 | Counts the number of BGP update messages sent to each BGP peer.
 
-| `metallb_bgp_opens_sent`
+| `frrk8s_bgp_opens_sent`
 | Counts the number of BGP open messages sent to each BGP peer.
 
-| `metallb_bgp_opens_received`
+| `frrk8s_bgp_opens_received`
 | Counts the number of BGP open messages received from each BGP peer.
 
-| `metallb_bgp_notifications_sent`
+| `frrk8s_bgp_notifications_sent`
 | Counts the number of BGP notification messages sent to each BGP peer.
 
-| `metallb_bgp_updates_total_received`
+| `frrk8s_bgp_updates_total_received`
 | Counts the number of BGP update messages received from each BGP peer.
 
-| `metallb_bgp_keepalives_sent`
+| `frrk8s_bgp_keepalives_sent`
 | Counts the number of BGP keepalive messages sent to each BGP peer.
 
-| `metallb_bgp_keepalives_received`
+| `frrk8s_bgp_keepalives_received`
 | Counts the number of BGP keepalive messages received from each BGP peer.
 
-| `metallb_bgp_route_refresh_sent`
+| `frrk8s_bgp_route_refresh_sent`
 | Counts the number of BGP route refresh messages sent to each BGP peer.
 
-| `metallb_bgp_total_sent`
+| `frrk8s_bgp_total_sent`
 | Counts the number of total BGP messages sent to each BGP peer.
 
-| `metallb_bgp_total_received`
+| `frrk8s_bgp_total_received`
 | Counts the number of total BGP messages received from each BGP peer.
 
 |===


### PR DESCRIPTION
OCPBUGS#42583: Updating naming convention for some metrics for MetalLB. This was missed for 4.17 planned updates so looking to merge ASAP for 4.17
Related RN: #82694 

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-42583

Link to docs preview:
https://82692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-troubleshoot-support.html#nw-metallb-metrics_metallb-troubleshoot-support

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
