### PR TITLE
[SRVKS-1282] Fix links in Integrating Serverless with the cost management service

### DIFF
--- a/integrations/serverless-cost-management-integration.adoc
+++ b/integrations/serverless-cost-management-integration.adoc
@@ -6,19 +6,19 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-introduction-cost-management#about-cost-management_getting-started[Cost management] is an {ocp-product-title} service that enables you to better understand and track costs for clouds and containers. It is based on the open source link:https://project-koku.github.io/[Koku] project.
+link:https://docs.redhat.com/en/documentation/cost_management_service/1-latest/html/getting_started_with_cost_management/index[Cost management] is an {ocp-product-title} service that enables you to better understand and track costs for clouds and containers. It is based on the open source link:https://project-koku.github.io/[Koku] project.
 
 [id="prerequisites_serverless-cost-management-integration"]
 == Prerequisites
 
 * You have cluster administrator permissions.
 
-* You have set up cost management and added an link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/adding_an_openshift_container_platform_source_to_cost_management/index[{ocp-product-title} source].
+* You have set up cost management and added an link:https://docs.redhat.com/en/documentation/cost_management_service/1-latest/html/integrating_openshift_container_platform_data_into_cost_management/index[{ocp-product-title} source].
 
 include::modules/serverless-cost-management-labels.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_serverless-cost-management-integration"]
 == Additional resources
-* link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-installing-cost-management#configure-tagging-next-step_configuring[Configure tagging for your sources]
-* link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-using-cost-management#cost-explorer-next-step_using-cost-management[Use the Cost Explorer to visualize your costs]
+* link:https://docs.redhat.com/en/documentation/cost_management_service/1-latest/html-single/managing_cost_data_using_tagging/index#why-use-tags_planning-your-tagging-strategy[Managing cost data using tagging]
+* link:https://docs.redhat.com/en/documentation/cost_management_service/1-latest/html-single/visualizing_your_costs_using_cost_explorer/index[Visualizing your costs using cost explorer]

--- a/modules/serverless-cost-management-labels.adoc
+++ b/modules/serverless-cost-management-labels.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: REFERENCE
 [id="serverless-cost-management-labels_{context}"]
-= Using labels for cost management queries
+= Labels for cost management queries
 
 Labels, also known as _tags_ in cost management, can be applied for nodes, namespaces or pods. Each label is a key and value pair. You can use a combination of multiple labels to generate reports. You can access reports about costs by using the link:https://console.redhat.com/openshift/cost-management/[Red Hat hybrid console].
 


### PR DESCRIPTION
Version(s):
serverless-docs-1.30+

Issue:
https://issues.redhat.com/browse/SRVKS-1282

Link to docs preview:
https://82693--ocpdocs-pr.netlify.app/openshift-serverless/latest/integrations/serverless-cost-management-integration.html

Additional information: