### PR TITLE
OCPBUGS-42583: RN for naming convention MetalLB metrics

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -872,6 +872,16 @@ With this release, maximum transmission unit (MTU) on virtual function using the
 
 For more information, see xref:../networking/hardware_networks/add-pod.adoc#nw-sriov-expose-mtu_configuring-sr-iov[Exposing MTU for vfio-pci SR-IOV devices to pod].
 
+[id="ocp-4-17-nw-metallb-metric-labels"]
+==== MetalLB metrics naming update
+
+With this release, the naming convention for MetalLB BGP and BFD metrics was updated:
+
+* The naming for BGP metrics was updated from `metallb_bgp_<metric_name>` to `frrk8s_bgp_<metric_name>`.
+* The naming for BFD metrics was updated from `metallb_bfd_<metric_name>` to `frrk8s_bfd_<metric_name>`.
+
+To view all the metrics in the new format, see xref:../networking/metallb/metallb-troubleshoot-support.adoc#nw-metallb-metrics_metallb-troubleshoot-support[MetalLB metrics for BGP and BFD].
+
 [id="ocp-4-17-registry"]
 === Registry
 


### PR DESCRIPTION
OCPBUGS#42583: RN for naming convention MetalLB metrics. 
Related content changes: #82692 

Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OCPBUGS-42583

Link to docs preview:
https://82694--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-nw-metallb-metric-labels

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
