### PR TITLE
OCPBUGS-34995-FIZX: Updated the Expanding the node port range doc for…

### DIFF
--- a/modules/nw-nodeport-service-range-edit.adoc
+++ b/modules/nw-nodeport-service-range-edit.adoc
@@ -6,37 +6,36 @@
 [id="nw-nodeport-service-range-edit_{context}"]
 = Expanding the node port range
 
-You can expand the node port range for the cluster.
+You can expand the node port range for your cluster. However, after you install your {product-title} cluster, you cannot contract the node port range on either side.
 
 [IMPORTANT]
 ====
-You can expand the node port range into the protected port range, which is between 0 and 32767. However, after expansion, you cannot change the range. Attempting to change the range returns the following error:
-`The Network "cluster" is invalid: spec.serviceNodePortRange: Invalid value: "30000-32767": new service node port range 30000-32767 does not completely cover the previous range 0-32767`. 
-
-Before making changes, ensure that the new range you set is appropriate for your cluster.
+Before you expand a node port range, consider that Red{nbsp}Hat has not performed testing outside the default port range of `30000-32768`. For ranges outside the default port range, ensure that you test to verify the expanding node port range does not impact your cluster. If you expanded the range and a port allocation issue occurs, create a new cluster and set the required range for it. 
 ====
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* Log in to the cluster with a user with `cluster-admin` privileges.
+* Installed the {oc-first}.
+* Logged in to the cluster as a user with `cluster-admin` privileges.
+* You ensured that your cluster infrastructure allows access to the ports that exist in the extended range. For example, if you expand the node port range to `30000-32900`, your firewall or packet filtering configuration must allow the inclusive port range of `30000-32900`.
 
 .Procedure
 
-. To expand the node port range, enter the following command. Replace `<port>` with the largest port number in the new range.
+* Expand the range for the `serviceNodePortRange` parameter in the `network.config.openshift.io` object that your cluster uses to manage traffic for pods by entering the following command in your command-line interface (CLI):
 +
 [source,terminal]
 ----
 $ oc patch network.config.openshift.io cluster --type=merge -p \
   '{
     "spec":
-      { "serviceNodePortRange": "30000-<port>" }
+      { "serviceNodePortRange": "<port_range>" } <1>
   }'
 ----
+<1> Where `<port_range>` is your expanded range, such as `30000-32900`.
 +
 [TIP]
 ====
-You can alternatively apply the following YAML to update the node port range:
+You can also apply the following YAML to update the node port range:
 
 [source,yaml]
 ----
@@ -45,7 +44,8 @@ kind: Network
 metadata:
   name: cluster
 spec:
-  serviceNodePortRange: "30000-<port>"
+  serviceNodePortRange: "<port_range>"
+# ...
 ----
 ====
 +
@@ -55,7 +55,9 @@ spec:
 network.config.openshift.io/cluster patched
 ----
 
-. To confirm that the configuration is active, enter the following command. It can take several minutes for the update to apply.
+.Verification
+
+* To confirm a successful configuration, enter the following command. The update can take several minutes to apply.
 +
 [source,terminal]
 ----
@@ -67,5 +69,5 @@ $ oc get configmaps -n openshift-kube-apiserver config \
 .Example output
 [source,terminal]
 ----
-"service-node-port-range":["30000-33000"]
+"service-node-port-range":["30000-32900"]
 ----

--- a/networking/configuring-node-port-service-range.adoc
+++ b/networking/configuring-node-port-service-range.adoc
@@ -6,15 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can expand the available node port range. If your cluster uses of a large number of node ports, you might need to increase the number of available ports.
+During cluster installation, you can configure the node port range to meet the requirements of your cluster. After cluster installation, only a cluster administrator can expand the range as a postinstallation task. If your cluster uses a large number of node ports, consider increasing the available port range according to the requirements of your cluster.
 
-The default port range is `30000-32767`. You can never reduce the port range, even if you first expand it beyond the default range.
+[IMPORTANT]
+====
+Before you expand a node port range, consider that Red{nbsp}Hat has not performed testing outside the default port range of `30000-32768`. For ranges outside the default port range, ensure that you test to verify the expanding node port range does not impact your cluster. If you expanded the range and a port allocation issue occurs, create a new cluster and set the required range for it. 
+====
 
-[id="configuring-node-port-service-range-prerequisites"]
-== Prerequisites
+If you do not set a node port range during cluster installation, the default range of `30000-32768` applies to your cluster. In this situation, you can expand the range on either side, but you must preserve `30000-32768` within your new port range.
 
-- Your cluster infrastructure must allow access to the ports that you specify within the expanded range. For example, if you expand the node port range to `30000-32900`, the inclusive port range of `32768-32900` must be allowed by your firewall or packet filtering configuration.
+[IMPORTANT]
+====
+If you expand the node port range and {oc-first} stops working because of a port conflict with the OpenShift API server, you must create a new cluster.
+Ensure that the new node port range does not overlap with any ports already in use by host processes or pods that are configured with host networking.
+====
 
+// Expanding the node port range
 include::modules/nw-nodeport-service-range-edit.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-34995](https://issues.redhat.com/browse/OCPBUGS-34995)

Link to docs preview:
[Configuring the node port service range](https://82695--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring-node-port-service-range.html)

- [x] SME has approved this change (Bryce Palmer/Ben Bennett).
- [x] QE has approved this change (Rahul Gangwar).
- [X] TAM has approved this change.

Add resources:

* https://kubernetes.io/docs/reference/networking/ports-and-protocols/
