### PR TITLE
OSSM-8195: Create docinfo.xml files for service mesh mirroring process with Pantheon

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -14,11 +14,14 @@
 :ocp-short-name: OpenShift
 //service mesh v3
 :SMProductName: Red Hat OpenShift Service Mesh
+:SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
-:SMPluginShort: OSSMC plugin
+:SMProductVersion: 3.0
 //Kiali
 :KialiProduct: Kiali Operator provided by Red Hat
+//Console
+:SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
+:SMPluginShort: OSSMC plugin
 //Istio
 :istio: Istio
 //ROSA

--- a/about/docinfo.xml
+++ b/about/docinfo.xml
@@ -1,0 +1,12 @@
+<title>About</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>About {SMProduct}</subtitle>
+<abstract>
+    <para>This document provides an overview of {SMProduct} features.
+    </para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/install/docinfo.xml
+++ b/install/docinfo.xml
@@ -1,0 +1,12 @@
+<title>Installing</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Installing {SMProduct}</subtitle>
+<abstract>
+    <para>This documentation provides information about installing {SMProduct} {SMProductVersion}.
+    </para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/kiali/docinfo.xml
+++ b/kiali/docinfo.xml
@@ -1,0 +1,12 @@
+<title>Kiali Operator provided by Red Hat</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Using the {KialiProduct}</subtitle>
+<abstract>
+    <para>This documentation provides information about the {KialiProduct}, and how to view the data that flows through your application.
+    </para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/metrics/docinfo.xml
+++ b/metrics/docinfo.xml
@@ -1,0 +1,12 @@
+<title>Metrics</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Using metrics with {SMProductShortName}</subtitle>
+<abstract>
+    <para>This documentation provides information about how you can monitor the in-cluster health and performance of your applications.
+    </para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/ossm-release-notes/docinfo.xml
+++ b/ossm-release-notes/docinfo.xml
@@ -1,0 +1,12 @@
+<title>Release Notes</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>{SMProduct} Release Notes</subtitle>
+<abstract>
+    <para>This documentation provides information about each {SMProduct} release.
+    </para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/update/docinfo.xml
+++ b/update/docinfo.xml
@@ -1,0 +1,12 @@
+<title>Updating</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Updating {SMProduct}</subtitle>
+<abstract>
+    <para>This documentation provides information about how to update {SMProduct} {SMProductVersion}.
+    </para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

https://issues.redhat.com/browse/OSSM-8195
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
