### PR TITLE
OBSDOCS-1355/TRACING-4456: Improve the docs about the zPages extension

### DIFF
--- a/observability/otel/otel-collector/otel-collector-extensions.adoc
+++ b/observability/otel/otel-collector/otel-collector-extensions.adoc
@@ -425,8 +425,7 @@ include::snippets/technology-preview.adoc[]
 [id="zpages-extension_{context}"]
 == zPages Extension
 
-The zPages Extension provides an HTTP endpoint that serves live data for debugging instrumented components in real time. This extension is especially useful for in-process diagnostics, offering insight into traces and metrics without relying on an external backend. zPages allow users to monitor and troubleshoot the behavior of the OpenTelemetry Collector and other components by displaying diagnostic information directly through the provided endpoint.
-
+The zPages Extension provides an HTTP endpoint that serves live data for debugging instrumented components in real time. You can use this extension for in-process diagnostics and insights into traces and metrics without relying on an external backend. With this extension, you can monitor and troubleshoot the behavior of the OpenTelemetry Collector and related components by watching the diagnostic information at the provided endpoint.
 
 :FeatureName: The zPages Extension
 include::snippets/technology-preview.adoc[]
@@ -455,25 +454,24 @@ include::snippets/technology-preview.adoc[]
           exporters: [debug]
 # ...
 ----
+<1> Specify the HTTP endpoint for serving the zPages extension. The default is `localhost:55679`.
 
-<1> HTTP endpoint where zPages will be served. Default is `localhost:55679`.
-
-The {OTELOperator} will not expose this route in any way since the purpose of this extension is to be used as a way to troubleshoot. You can access the HTTP endpoint by forwarding the port:
+The {OTELOperator} does not expose this route. To access the HTTP endpoint, forward the port:
 
 [source,terminal]
 ----
-oc port-forward pod/$(oc get pod -l app.kubernetes.io/name=instance-collector -o=jsonpath='{.items[0].metadata.name}') 55679
+$ oc port-forward pod/$(oc get pod -l app.kubernetes.io/name=instance-collector -o=jsonpath='{.items[0].metadata.name}') 55679
 ----
 
 Now, you can visit `http://localhost:55679/debug/servicez` in yor browser to get the zPages information.
 
 The Collector offers the following zPages for diagnostics:
 
-* ServiceZ: provides an overview of the collector services and offers links to the `pipelinez`, `extensionz`, and `featurez` zPages. This page also displays information about the build version and runtime. Example URL: `http://localhost:55679/debug/servicez`.
-* PipelineZ: offers detailed information about the active pipelines within the collector. It shows the pipeline type, whether data is modified, and the associated receivers, processors, and exporters for each pipeline. Example URL: `http://localhost:55679/debug/pipelinez`.
-* ExtensionZ: shows the currently active extensions within the collector. Example URL: `http://localhost:55679/debug/extensionz`.
-* FeatureZ: displays the feature gates enabled in the collector along with their status and description. Example URL: `http://localhost:55679/debug/featurez`.
-* TraceZ: allows users to view spans categorized by latency, such as in time ranges like `(0us, 10us, 100us, 1ms, 10ms, 100ms, 1s, 10s, 1m]`. This page also allows for quick inspection of error samples. Example URL: `http://localhost:55679/debug/tracez`.
+*ServiceZ*:: provides an overview of the collector services and offers links to the `pipelinez`, `extensionz`, and `featurez` zPages. This page also displays information about the build version and runtime. Example URL: `http://localhost:55679/debug/servicez`.
+*PipelineZ*:: offers detailed information about the active pipelines within the collector. It shows the pipeline type, whether data is modified, and the associated receivers, processors, and exporters for each pipeline. Example URL: `http://localhost:55679/debug/pipelinez`.
+*ExtensionZ*:: shows the currently active extensions within the collector. Example URL: `http://localhost:55679/debug/extensionz`.
+*FeatureZ*:: displays the feature gates enabled in the collector along with their status and description. Example URL: `http://localhost:55679/debug/featurez`.
+*TraceZ*:: allows users to view spans categorized by latency, such as in time ranges like `(0us, 10us, 100us, 1ms, 10ms, 100ms, 1s, 10s, 1m]`. This page also allows for quick inspection of error samples. Example URL: `http://localhost:55679/debug/tracez`.
 
 [role="_additional-resources"]
 [id="additional-resources_otel-collector-extensions_{context}"]

--- a/observability/otel/otel-collector/otel-collector-extensions.adoc
+++ b/observability/otel/otel-collector/otel-collector-extensions.adoc
@@ -425,9 +425,8 @@ include::snippets/technology-preview.adoc[]
 [id="zpages-extension_{context}"]
 == zPages Extension
 
-The zPages Extension provides an HTTP endpoint for extensions that serve zPages. At the endpoint, this extension serves live data for debugging instrumented components. All core exporters and receivers provide some zPages instrumentation.
+The zPages Extension provides an HTTP endpoint that serves live data for debugging instrumented components in real time. This extension is especially useful for in-process diagnostics, offering insight into traces and metrics without relying on an external backend. zPages allow users to monitor and troubleshoot the behavior of the OpenTelemetry Collector and other components by displaying diagnostic information directly through the provided endpoint.
 
-zPages are useful for in-process diagnostics without having to depend on a back end to examine traces or metrics.
 
 :FeatureName: The zPages Extension
 include::snippets/technology-preview.adoc[]
@@ -446,18 +445,35 @@ include::snippets/technology-preview.adoc[]
         protocols:
           http: {}
     exporters:
-      otlp:
+      debug:
 
     service:
       extensions: [zpages]
       pipelines:
         traces:
           receivers: [otlp]
-          exporters: [otlp]
+          exporters: [debug]
 # ...
 ----
 
-<1> Specifies the HTTP endpoint that serves zPages. Use `localhost:` to make it available only locally, or `":"` to make it available on all network interfaces. The default is `localhost:55679`.
+<1> HTTP endpoint where zPages will be served. Default is `localhost:55679`.
+
+The {OTELOperator} will not expose this route in any way since the purpose of this extension is to be used as a way to troubleshoot. You can access the HTTP endpoint by forwarding the port:
+
+[source,terminal]
+----
+oc port-forward pod/$(oc get pod -l app.kubernetes.io/name=instance-collector -o=jsonpath='{.items[0].metadata.name}') 55679
+----
+
+Now, you can visit `http://localhost:55679/debug/servicez` in yor browser to get the zPages information.
+
+The Collector offers the following zPages for diagnostics:
+
+* ServiceZ: provides an overview of the collector services and offers links to the `pipelinez`, `extensionz`, and `featurez` zPages. This page also displays information about the build version and runtime. Example URL: `http://localhost:55679/debug/servicez`.
+* PipelineZ: offers detailed information about the active pipelines within the collector. It shows the pipeline type, whether data is modified, and the associated receivers, processors, and exporters for each pipeline. Example URL: `http://localhost:55679/debug/pipelinez`.
+* ExtensionZ: shows the currently active extensions within the collector. Example URL: `http://localhost:55679/debug/extensionz`.
+* FeatureZ: displays the feature gates enabled in the collector along with their status and description. Example URL: `http://localhost:55679/debug/featurez`.
+* TraceZ: allows users to view spans categorized by latency, such as in time ranges like `(0us, 10us, 100us, 1ms, 10ms, 100ms, 1s, 10s, 1m]`. This page also allows for quick inspection of error samples. Example URL: `http://localhost:55679/debug/tracez`.
 
 [role="_additional-resources"]
 [id="additional-resources_otel-collector-extensions_{context}"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16, 4.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1355

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
