### PR TITLE
OSDOCS-12100: Fixed links for Baseline Ingress Controller (router) pe…

### DIFF
--- a/scalability_and_performance/optimization/routing-optimization.adoc
+++ b/scalability_and_performance/optimization/routing-optimization.adoc
@@ -10,9 +10,9 @@ The {product-title} HAProxy router can be scaled or configured to optimize perfo
 
 include::modules/baseline-router-performance.adoc[leveloffset=+1]
 
-For more information on Ingress sharding, see xref:../../networking/ingress-operator.adoc#nw-ingress-sharding-route-labels_configuring-ingress[Configuring Ingress Controller sharding by using route labels] and xref:../../networking/ingress-operator.adoc#nw-ingress-sharding-namespace-labels_configuring-ingress[Configuring Ingress Controller sharding by using namespace labels].
+For more information on Ingress sharding, see xref:../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc#nw-ingress-sharding-route-labels_configuring-ingress-cluster-traffic-ingress-controller[Configuring Ingress Controller sharding by using route labels] and xref:../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc#nw-ingress-sharding-namespace-labels_configuring-ingress-cluster-traffic-ingress-controller[Configuring Ingress Controller sharding by using namespace labels].
 
-You can modify the Ingress Controller deployment using the information provided in xref:../../networking/ingress-operator.adoc#nw-ingress-setting-thread-count[Setting Ingress Controller thread count] for threads and xref:../../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters] for timeouts, and other tuning configurations in the Ingress Controller specification.
+You can modify the Ingress Controller deployment by using the information provided in xref:../../networking/ingress-operator.adoc#nw-ingress-setting-thread-count_configuring-ingress[Setting Ingress Controller thread count] for threads and xref:../../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters] for timeouts, and other tuning configurations in the Ingress Controller specification.
 
 include::modules/ingress-liveness-readiness-startup-probes.adoc[leveloffset=+1]
 include::modules/configuring-haproxy-interval.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-12100](https://issues.redhat.com/browse/OSDOCS-12100)

Link to docs preview:
* [Baseline Ingress Controller (router) performance](https://82726--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/optimization/routing-optimization.html)
