### PR TITLE
[OSDOCS-12177] removing firewall prereqs

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -77,14 +77,6 @@ endif::[]
 |443
 |Provides core container images.
 
-|`quayio-production-s3.s3.amazonaws.com`
-|443
-|Provides core container images.
-
-|`cart-rhcos-ci.s3.amazonaws.com`
-|443
-|Provides {op-system-first} images.
-
 |`openshift.org`
 |443
 |Provides {op-system-first} images.

--- a/modules/rosa-hcp-firewall-prerequisites.adoc
+++ b/modules/rosa-hcp-firewall-prerequisites.adoc
@@ -48,10 +48,6 @@ endif::rosa-classic-sts[]
 |443
 |Provides core container images.
 
-|`quayio-production-s3.s3.amazonaws.com`
-|443
-|Provides core container images.
-
 |`registry.redhat.io`
 |443
 |Provides core container images.


### PR DESCRIPTION
[OSDOCS-12177] removing firewall prereqs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12177

Link to docs preview:
https://82742--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs.html
https://82742--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html
https://82742--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
