### PR TITLE
[DOCS] OSSM-8201- 2.5.x release notes Istio version update

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -34,7 +34,7 @@ The most current version of the {SMProductName} Operator can be used with all su
 |Component |Version
 
 |Istio
-|1.18.5
+|1.18.7
 
 |Envoy Proxy
 |1.26.8
@@ -63,7 +63,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |Component |Version
 
 |Istio
-|1.18.5
+|1.18.7
 
 |Envoy Proxy
 |1.26.8
@@ -85,7 +85,7 @@ This release ends maintenance support for OpenShift {SMProductShortName} version
 |Component |Version
 
 |Istio
-|1.18.5
+|1.18.7
 
 |Envoy Proxy
 |1.26.8


### PR DESCRIPTION
Change type: Doc update; [DOC] OSSM 2.5.x release notes Istio version update

Doc JIRA: https://issues.redhat.com/browse/OSSM-8201

Fix Version: 4.13 and 4.12

Doc Preview: https://82749--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-ossm-2-5

Note: Created 2 PRs to avoid merge conflicts since the release notes were restructured in 4.14+. This PR aims to make changes to 4.13 and 4.12

QE Review: @mkralik3 
Peer Review: @snarayan-redhat 