### PR TITLE
[DOCS] OSSM-8201- 2.5.x release notes Istio version update

### DIFF
--- a/modules/ossm-release-2-5-2.adoc
+++ b/modules/ossm-release-2-5-2.adoc
@@ -26,7 +26,7 @@ This release is supported on {product-title} 4.12 and later.
 |Component |Version
 
 |Istio
-|1.18.5
+|1.18.7
 
 |Envoy Proxy
 |1.26.8

--- a/modules/ossm-release-2-5-3.adoc
+++ b/modules/ossm-release-2-5-3.adoc
@@ -16,7 +16,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |Component |Version
 
 |Istio
-|1.18.5
+|1.18.7
 
 |Envoy Proxy
 |1.26.8

--- a/modules/ossm-release-2-5-4.adoc
+++ b/modules/ossm-release-2-5-4.adoc
@@ -16,7 +16,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |Component |Version
 
 |Istio
-|1.18.5
+|1.18.7
 
 |Envoy Proxy
 |1.26.8

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -37,7 +37,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |Component |Version
 
 |Istio
-|1.18.5
+|1.18.7
 
 |Envoy Proxy
 |1.26.8
@@ -59,7 +59,7 @@ This release ends maintenance support for OpenShift {SMProductShortName} version
 |Component |Version
 
 |Istio
-|1.18.5
+|1.18.7
 
 |Envoy Proxy
 |1.26.8


### PR DESCRIPTION
Change type: Doc update; [DOC] OSSM 2.5.x release notes Istio version update

Doc JIRA: https://issues.redhat.com/browse/OSSM-8201

Fix Version: 4.14+

Doc Preview: https://82751--ocpdocs-pr.netlify.app/openshift-dedicated/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-ossm-2-5

Note: Created 2 PRs to avoid merge conflicts since the release notes were restructured in 4.14+. This PR aims to make changes to 4.14+

QE Review: @matejvasek 
Peer Review: @snarayan-redhat 