### PR TITLE
RHDEVDOCS-6172: Minor changes in the Argo CD CR properties table

### DIFF
--- a/modules/gitops-argo-cd-properties.adoc
+++ b/modules/gitops-argo-cd-properties.adoc
@@ -12,71 +12,70 @@ The Argo CD Custom Resource consists of the following properties:
 |===
 |Name |Description |Default |Properties
 
-|`applicationInstanceLabelKey` |The `metadata.label` key name where Argo CD injects the app name as a tracking label.|`app.kubernetes.io/instance` |
-
 |`aggregatedClusterRoles` |Use aggregated cluster roles for the Argo CD Application Controller component of a cluster-scoped instance.|`false` |
 
-|`applicationSet` |The ApplicationSet Controller configuration options. | `_<object>_`
-a|* `<image>` - The container image for the ApplicationSet Controller. This property overrides the `ARGOCD_APPLICATIONSET_IMAGE` environment variable.
-  * `<version>` - The tag to use with the `applicationSet` container image.
-  * `<enabled>` - The flag to use to enable the ApplicationSet Controller during the Argo CD installation.
-  * `<env>` - Specify the environment for ApplicationSet Controller pods.
-  * `<resources>` - The container compute resources.
-  * `<logLevel>` - The log level used by the Argo CD Application Controller component. Valid options are `debug`, `info`, `error`, and `warn`.
-  * `<logFormat>` - The log format used by the Argo CD Application Controller component. Valid options are `text` and `json`.
-  * `<parallelismLimit>` - The kubectl parallelism limit to set for the controller (the `--kubectl-parallelism-limit` flag).
-  * `sourceNamespaces` - The list of non-control plane namespaces for creating and managing Argo CD `ApplicationSet` resources in target namespaces.
-  * `scmProviders` - The URLs of the allowed Source Code Manager (SCM) providers.
-  * `<scmRootCAConfigMap>` - The name of the config map that stores the Gitlab SCM Provider's TLS certificate that will be mounted on the Application Set Controller at the "/app/tls/scm/cert" path.
-  * `<webhookServer>` - Defines the available options for the ApplicationSet webhook server.
-  * `annotations` - List of custom annotations to add to pods deployed by the Operator. This field is optional.
+|`applicationInstanceLabelKey` |The `metadata.label` key name where Argo CD injects the app name as a tracking label.|`app.kubernetes.io/instance` |
+
+|`applicationSet` |The ApplicationSet Controller configuration options. | `_object_`
+a|* `annotations` - List of custom annotations to add to pods deployed by the Operator. This field is optional.
+  * `enabled` - The flag to use to enable the ApplicationSet Controller during the Argo CD installation.
+  * `env` - Specify the environment for ApplicationSet Controller pods.
+  * `extraCommandArgs` - List of additional arguments added to the existing arguments set by the Operator for the `ApplicationSet` workload.
+  * `image` - The container image for the ApplicationSet Controller. This property overrides the `ARGOCD_APPLICATIONSET_IMAGE` environment variable.
   * `labels` - List of custom labels to add to pods deployed by the Operator. This field is optional.
+  * `logLevel` - The log level used by the Argo CD Application Controller component. Valid options are `debug`, `info`, `error`, and `warn`.
+  * `logFormat` - The log format used by the Argo CD Application Controller component. Valid options are `text` and `json`.
+  * `parallelismLimit` - The kubectl parallelism limit to set for the controller (the `--kubectl-parallelism-limit` flag).
+  * `resources` - The container compute resources.
+  * `scmProviders` - The URLs of the allowed Source Code Manager (SCM) providers.
+  * `scmRootCAConfigMap` - The name of the config map that stores the Gitlab SCM Provider's TLS certificate that will be mounted on the Application Set Controller at the "/app/tls/scm/cert" path.
+  * `sourceNamespaces` - The list of non-control plane namespaces for creating and managing Argo CD `ApplicationSet` resources in target namespaces.
+  * `version` - The tag to use with the `applicationSet` container image.
   * `volumes` - List of addition volumes configured for the Argo CD `ApplicationSet` Controller component. This field is optional.
   * `volumeMounts` - List of addition volume mounts configured for the Argo CD `ApplicationSet` Controller component. This field is optional.
-  * `extraCommandArgs` - List of additional arguments added to the existing arguments set by the Operator for the `ApplicationSet` workload.
+  * `webhookServer` - Defines the available options for the ApplicationSet webhook server.
 
-|`banner` |Adds a UI banner message.|`__<object>__`
-a|* `<banner.content>` - The banner message content. This content is required if a banner is displayed.
-  * `<banner.url>` - An optional banner message link URL.
+|`banner` |Adds a UI banner message.|`__object__`
+a|* `banner.content` - The banner message content. This content is required if a banner is displayed.
+  * `banner.url` - An optional banner message link URL.
 
-|`configManagementPlugins`    |Adds a configuration management plugin.| `__<empty>__` |
+|`configManagementPlugins`    |Adds a configuration management plugin.| `__empty__` |
 
 |`controller`    |Argo CD Application Controller options.| `__<object>__`
-a|* `<processors.operation>` - The number of operation processors.
-  * `<processors.status>` - The number of status processors.
-  * `<resources>` - The container compute resources.
-  * `<logLevel>` - The log level used by the Argo CD Application Controller component. Valid options are `debug`, `info`, `error`, and `warn`.
-  * `<appSync>` - AppSync is used to control the sync frequency of Argo CD applications.
-  * `<sharding.enabled>` - Enable sharding on the Argo CD Application Controller component. Use this property to manage a large number of clusters and relieve memory pressure on the controller component.
-  * `<sharding.replicas>` - The number of replicas that are used to support sharding of the Argo CD Application Controller.
-  * `<sharding.dynamicScalingEnabled>` - Enables the dynamic scaling of the Argo CD Application Controller component. Use this property if you want the Operator to scale the number of replicas based on the number of clusters the controller component is managing. If you set this property to `true`, it overrides the configuration of the `sharding.enabled` and `sharding.replicas` properties.
-  * `<sharding.minShards>` - The minimum number of Argo CD Application Controller replicas.
-  * `<sharding.maxShards>` - The maximum number of Argo CD Application Controller replicas.
-  * `<sharding.clustersPerShard>` - The number of clusters that need to be managed by each shard. When the replica count reaches the `maxShards`, the shards manage more than one cluster.
-  * `<env>` - Environment to set for the application controller workloads.
-  * `<sourceNamespaces>` - List of non-control plane namespaces for creating and managing Argo CD `Application` resources in target namespaces.
-  * `<extraCommandArgs>` - List of arguments added to the existing arguments set by the Operator.
-  * `annotations` - List of custom annotations to add to pods deployed by the Operator. This field is optional.
+a|* `annotations` - List of custom annotations to add to pods deployed by the Operator. This field is optional.
+  * `appSync` - AppSync is used to control the sync frequency of Argo CD applications.
+  * `env` - Environment to set for the application controller workloads.
+  * `extraCommandArgs` - List of arguments added to the existing arguments set by the Operator.
+  * `initContainers` - List of `init` containers for the ArgoCD Application Controller component. This field is optional.
   * `labels` - List of custom labels to add to pods deployed by the Operator. This field is optional.
+  * `logLevel` - The log level used by the Argo CD Application Controller component. Valid options are `debug`, `info`, `error`, and `warn`.
+  * `processors.operation` - The number of operation processors.
+  * `processors.status` - The number of status processors.
+  * `resources` - The container compute resources.
+  * `sidecarContainers` - List of `sidecar` containers for the ArgoCD Application Controller component. This field is optional.
+  * `sharding.enabled` - Enable sharding on the Argo CD Application Controller component. Use this property to manage a large number of clusters and relieve memory pressure on the controller component.
+  * `sharding.replicas` - The number of replicas that are used to support sharding of the Argo CD Application Controller.
+  * `sharding.dynamicScalingEnabled` - Enables the dynamic scaling of the Argo CD Application Controller component. Use this property if you want the Operator to scale the number of replicas based on the number of clusters the controller component is managing. If you set this property to `true`, it overrides the configuration of the `sharding.enabled` and `sharding.replicas` properties.
+  * `sharding.minShards` - The minimum number of Argo CD Application Controller replicas.
+  * `sharding.maxShards` - The maximum number of Argo CD Application Controller replicas.
+  * `sharding.clustersPerShard` - The number of clusters that need to be managed by each shard. When the replica count reaches the `maxShards`, the shards manage more than one cluster.
   * `volumes` - List of addition volumes configured for the Argo CD Application Controller component. This field is optional.
   * `volumeMounts` - List of addition volume mounts configured for the Argo CD Application Controller component. This field is optional.
-  * `initContainers` - List of `init` containers for the ArgoCD Application Controller component. This field is optional.
-  * `sidecarContainers` - List of `sidecar` containers for the ArgoCD Application Controller component. This field is optional.
 
 |`disableAdmin`    |Disables the built-in admin user.|`false` |
 
 |`defaultClusterScopedRoleDisabled` |Disables the creation of default cluster roles for a cluster-scoped instance.|`false` |
 
-|`extraConfig`    |Add any supplementary Argo CD settings to the `argocd-cm` config map that cannot be configured directly within the Argo CD custom resource.|`__<empty>__` |
+|`extraConfig`    |Add any supplementary Argo CD settings to the `argocd-cm` config map that cannot be configured directly within the Argo CD custom resource.|`__empty__` |
 
-|`gaTrackingID`    |Use a Google Analytics tracking ID.|`__<empty>__` |
+|`gaTrackingID`    |Use a Google Analytics tracking ID.|`__empty__` |
 
 |`gaAnonymizeUsers`    |Enable hashed usernames sent to Google Analytics.|`false` |
 
-|`ha`    |High-availability options.| `__<object>__`
-a|* `<enabled>` - Toggle high-availability support globally for Argo CD.
-  * `<redisProxyImage>` - The Redis HAProxy container image. This property overrides the `ARGOCD_REDIS_HA_PROXY_IMAGE` environment variable.
-  * `<redisProxyVersion>` - The tag to use for the Redis HAProxy container image.
+|`ha`    |High-availability options.| `__object__`
+a|* `enabled` - Toggle high-availability support globally for Argo CD.
+  * `redisProxyImage` - The Redis HAProxy container image. This property overrides the `ARGOCD_REDIS_HA_PROXY_IMAGE` environment variable.
+  * `redisProxyVersion` - The tag to use for the Redis HAProxy container image.
 
 |`helpChatURL`    |URL for getting chat help (this is typically your Slack channel for support).|`https://mycorp.slack.com/argo-cd` |
 
@@ -84,110 +83,112 @@ a|* `<enabled>` - Toggle high-availability support globally for Argo CD.
 
 |`image`    |The container image for all Argo CD components. This overrides the `ARGOCD_IMAGE` environment variable.|`argoproj/argocd` |
 
-|`import`    |Import configuration options for Argo CD.| `__<object>__`
-a|* `<name>` - The name of an `ArgoCDExport` resource from which data can be imported.
-  * `<namespace>` - The namespace for the `ArgoCDExport` resource referenced by `name` field. If this field is not set, the namespace of `ArgoCDExport` resource is set to the same namespace as Argo CD by default.
+|`import`    |Import configuration options for Argo CD.| `__object__`
+a|* `name` - The name of an `ArgoCDExport` resource from which data can be imported.
+  * `namespace` - The namespace for the `ArgoCDExport` resource referenced by `name` field. If this field is not set, the namespace of `ArgoCDExport` resource is set to the same namespace as Argo CD by default.
 
-|`ingress`    |Ingress configuration options.| `__<object>__` |
+|`ingress`    |Ingress configuration options.| `__object__` |
 
-|`initialRepositories`    |Initial Git repositories to configure Argo CD to use upon creation of the cluster.|`__<empty>__` |
+|`initialRepositories`    |Initial Git repositories to configure Argo CD to use upon creation of the cluster.|`__empty__` |
 
-|`initialSSHKnownHosts`    |Defines the initial SSH Known Hosts data for Argo CD to use at cluster creation to connect to Git repositories through SSH.| `__<default_Argo_CD_Known_Hosts>__`
-a|* `<Excludedefaulthosts>` - Indicates whether you want to add the default list of SSH Known Hosts provided by Argo CD.
-  * `<keys>` - Describes a custom set of SSH Known Hosts that you want to incorporate into your Argo CD server.
+|`initialSSHKnownHosts`    |Defines the initial SSH Known Hosts data for Argo CD to use at cluster creation to connect to Git repositories through SSH.| `__default_Argo_CD_Known_Hosts__`
+a|* `excludedefaulthosts` - Indicates whether you want to add the default list of SSH Known Hosts provided by Argo CD.
+  * `keys` - Describes a custom set of SSH Known Hosts that you want to incorporate into your Argo CD server.
 
-|`kustomizeBuildOptions`    |The build options and parameters to use with `kustomize build`.|`__<empty>__` |
+|`kustomizeBuildOptions`    |The build options and parameters to use with `kustomize build`.|`__empty__` |
 
-|`kustomizeVersions`    |Defines a list of `Kustomize` versions that are configured in the Argo CD repo server container image.|`__<empty>__`
-a|* `<path>` - The path of the `Kustomize` version in the file system of the Argo CD repo server container image.
-  * `<version>` - The `Kustomize` version in the `vX.Y.Z` format configured in the Argo CD repo server container image.
+|`kustomizeVersions`    |Defines a list of `Kustomize` versions that are configured in the Argo CD repo server container image.|`__empty__`
+a|* `path` - The path of the `Kustomize` version in the file system of the Argo CD repo server container image.
+  * `version` - The `Kustomize` version in the `vX.Y.Z` format configured in the Argo CD repo server container image.
 
-|`monitoring`    |Defines the workload status monitoring configuration for your instance.| `__<object>__`
-a|* `<disableMetrics>` - Configure this field to enable or disable the collection of metrics for your instance.
-  * `<enabled>` - Indicates whether the workload status monitoring is enabled for your instance.
+|`monitoring`    |Defines the workload status monitoring configuration for your instance.| `__object__`
+a|* `disableMetrics` - Configure this field to enable or disable the collection of metrics for your instance.
+  * `enabled` - Indicates whether the workload status monitoring is enabled for your instance.
 
-|`notifications`    |Notifications Controller configuration options.|`__<object>__`
-a|* `<enabled>` - The toggle to start the Notifications Controller.
-  * `<env>` -  The environment to set for the Notifications Controller workloads.
-  * `<image>` - The container image for all Argo CD components. This property overrides the `ARGOCD_IMAGE` environment variable.
-  * `<version>` - The tag to use with the Notifications container image.
-  * `<replicas>` - The number of replicas to be run for the Notifications Controller.
-  * `<resources>` - The container compute resources.
-  * `<logLevel>` - The log level used by the Argo CD Application Controller component. Valid options are `debug`, `info`, `error`, and `warn`.
+|`notifications`    |Notifications Controller configuration options.|`__object__`
+a|* `enabled` - The toggle to start the Notifications Controller.
+  * `env` -  The environment to set for the Notifications Controller workloads.
+  * `image` - The container image for all Argo CD components. This property overrides the `ARGOCD_IMAGE` environment variable.
+  * `logLevel` - The log level used by the Argo CD Application Controller component. Valid options are `debug`, `info`, `error`, and `warn`.
+  * `replicas` - The number of replicas to be run for the Notifications Controller.
+  * `resources` - The container compute resources.
+  * `version` - The tag to use with the Notifications container image.
 
-|`nodePlacement` |Defines `NodeSelectors` and `Tolerations` for Argo CD workloads.|`__<empty>__`
-a|* `<nodeSelector>` - 	A map of key-value pairs for node selection.
-  * `<tolerations>` - Tolerations allow pods to create a schedule for nodes with matching taints.
+|`nodePlacement` |Defines `NodeSelectors` and `Tolerations` for Argo CD workloads.|`__empty__`
+a|* `nodeSelector` - 	A map of key-value pairs for node selection.
+  * `tolerations` - Tolerations allow pods to create a schedule for nodes with matching taints.
 
-|`oidcConfig` |The OIDC configuration as an alternative to Dex.|`__<empty>__` |
+|`oidcConfig` |The OIDC configuration as an alternative to Dex.|`__empty__` |
 
-|`repositoryCredentials`    |Git repository credential templates to configure Argo CD to use at cluster creation.| `__<empty>__` |
+|`prometheus` |Prometheus configuration options.|`__object__`
+a|* `enabled` - Toggle Prometheus support globally for Argo CD.
+  * `host` - The hostname to use for `Ingress` or `Route` resources.
+  * `ingress` - Toggles ingress for Prometheus.
+  * `route` - Route configuration options.
+  * `size` - The replica count for the Prometheus `StatefulSet`.
 
-|`prometheus` |Prometheus configuration options.|`__<object>__`
-a|* `<enabled>` - Toggle Prometheus support globally for Argo CD.
-  * `<host>` - The hostname to use for `Ingress` or `Route` resources.
-  * `<ingress>` - Toggles ingress for Prometheus.
-  * `<route>` - Route configuration options.
-  * `<size>` - The replica count for the Prometheus `StatefulSet`.
+|`rbac` |RBAC configuration options.|`__object__`
+a|* `defaultPolicy` - The `policy.default` property in the `argocd-rbac-cm` config map. The name of the default role that Argo CD falls back to when authorizing API requests.
+  * `policy` - The `policy.csv` property in the `argocd-rbac-cm` config map. This property includes CSV data about user-defined RBAC policies and role definitions.
+  * `policyMatcher` - The `policy.matchMode` property in the `argocd-rbac-cm` config map. This property has two options: 'glob' for glob matcher and 'regex' for regex matcher.
+  * `scopes` - The scopes property in the `argocd-rbac-cm` config map. Controls which OIDC scopes to examine during RBAC enforcement, in addition to sub scope.
 
-|`rbac` |RBAC configuration options.|`__<object>__`
-a|* `<defaultPolicy>` - The `policy.default` property in the `argocd-rbac-cm` config map. The name of the default role that Argo CD falls back to when authorizing API requests.
-  * `<policy>` - The `policy.csv` property in the `argocd-rbac-cm` config map. This property includes CSV data about user-defined RBAC policies and role definitions.
-  * `<policyMatcher>` - The `policy.matchMode` property in the `argocd-rbac-cm` config map. This property has two options: 'glob' for glob matcher and 'regex' for regex matcher.
-  * `<scopes>` - The scopes property in the `argocd-rbac-cm` config map. Controls which OIDC scopes to examine during RBAC enforcement, in addition to sub scope.
+|`redis` |Redis configuration options.|`__object__`
+a|* `autotls` - Use the provider to create the Redis server's TLS certificate. Only the `openshift` value is currently available.
+  * `disableTLSVerification` - Defines whether the Redis server should be accessed using strict TLS validation.
+  * `image` - The container image for Redis. This overrides the `ARGOCD_REDIS_IMAGE` environment variable.
+  * `resources` - The container compute resources.
+  * `version` - The tag to use with the Redis container image.
 
-|`redis` |Redis configuration options.|`__<object>__`
-a|* `<autotls>` - Use the provider to create the Redis server's TLS certificate. Only the `openshift` value is currently available.
-  * `<disableTLSVerification>` - Defines whether the Redis server should be accessed using strict TLS validation.
-  * `<image>` - The container image for Redis. This overrides the `ARGOCD_REDIS_IMAGE` environment variable.
-  * `<resources>` - The container compute resources.
-  * `<version>` - The tag to use with the Redis container image.
+|`repositoryCredentials`    |Git repository credential templates to configure Argo CD to use at cluster creation.| `__empty__` |
 
-|`resourceHealthChecks` |Customize resource health check behavior.|`__<empty>__` |
-|`resourceIgnoreDifferences` |Customize resource ignore difference behavior.|`__<empty>__` |
+|`resourceActions` |Customize resource action behavior.|`__empty__` |
 
-|`resourceActions` |Customize resource action behavior.|`__<empty>__` |
+|`resourceExclusions` |Completely ignore entire classes of resource group.|`__empty__` |
 
-|`resourceExclusions` |Completely ignore entire classes of resource group.|`__<empty>__` |
+|`resourceInclusions` |The configuration to identify which resource group/kinds are applied.|`__empty__` |
 
-|`resourceInclusions` |The configuration to identify which resource group/kinds are applied.|`__<empty>__` |
+|`resourceHealthChecks` |Customize resource health check behavior.|`__empty__` |
+|`resourceIgnoreDifferences` |Customize resource ignore difference behavior.|`__empty__` |
 
-|`resourceTrackingMethod` |The field used by Argo CD to monitor its managed resources.|`__<label>__` |
+|`resourceTrackingMethod` |The field used by Argo CD to monitor its managed resources.|`__label__` |
 
 |`server` |Argo CD Server configuration options.|`__<object>__`
-a|* `<autoscale>` - Server autoscale configuration options.
-  * `<extraCommandArgs>` - List of arguments added to the existing arguments set by the Operator.
-  * `<grpc>` - gRPC configuration options.
-  * `<host>` - The hostname used for `Ingress` or `Route` resources.
-  * `<ingress>` - Ingress configuration for the Argo CD server component.
-  * `<insecure>` - Toggles the insecure flag for Argo CD server.
-  * `<resources>` - The container compute resources.
-  * `<replicas>` - The number of replicas for the Argo CD server. Must be greater than or equal to `0`. If `autoscale` is enabled, `replicas` is ignored.
-  * `<route>` - Route configuration options.
-  * `<service.Type>` - The `serviceType` used for the service resource.
-  * `<logLevel>` - The log level to be used by the Argo CD server component. Valid options are  `debug`, `info`, `error`, and `warn`.
-  * `<logFormat>` - The log format used by the Argo CD server component. Valid options are `text` and `json`.
-  * `<env>` - Environment to set for the server workloads.
-  * `<enabled>` - The flag to enable Argo CD server during the Argo CD installation.
+a|* `annotations` - List of custom annotations to add to pods deployed by the Operator. This field is optional.
+  * `autoscale` - Server autoscale configuration options.
+  * `env` - Environment to set for the server workloads.
+  * `enabled` - The flag to enable Argo CD server during the Argo CD installation.
+  * `enableRolloutsUI` - When the parameter is set to `true`, the parameter enables the Argo Rollouts UI extension in Argo CD. The default value is set to `false`.
+  * `extraCommandArgs` - List of arguments added to the existing arguments set by the Operator.
+  * `grpc` - gRPC configuration options.
+  * `host` - The hostname used for `Ingress` or `Route` resources.
+  * `initContainers` - List of `init` containers for the Argo CD Application Controller component. This field is optional.
+  * `ingress` - Ingress configuration for the Argo CD server component.
+  * `insecure` - Toggles the insecure flag for Argo CD server.
+  * `labels` - List of custom labels to add to pods deployed by the Operator. This field is optional.
+  * `logLevel` - The log level to be used by the Argo CD server component. Valid options are  `debug`, `info`, `error`, and `warn`.
+  * `logFormat` - The log format used by the Argo CD server component. Valid options are `text` and `json`.
+  * `resources` - The container compute resources.
+  * `replicas` - The number of replicas for the Argo CD server. Must be greater than or equal to `0`. If `autoscale` is enabled, `replicas` is ignored.
+  * `route` - Route configuration options.
+  * `service.Type` - The `serviceType` used for the service resource.
+  * `sidecarContainers` - List of `sidecar` containers for the Argo CD Application Controller component. This field is optional.
   * `volumes` - List of addition volumes configured for the Argo CD Application Controller component. This field is optional.
   * `volumeMounts` - List of addition volume mounts configured for the Argo CD Application Controller component. This field is optional.
-  * `initContainers` - List of `init` containers for the Argo CD Application Controller component. This field is optional.
-  * `sidecarContainers` - List of `sidecar` containers for the Argo CD Application Controller component. This field is optional.
-  * `annotations` - List of custom annotations to add to pods deployed by the Operator. This field is optional.
-  * `labels` - List of custom labels to add to pods deployed by the Operator. This field is optional.
-  * `enableRolloutsUI` - When the parameter is set to `true`, the parameter enables the Argo Rollouts UI extension in Argo CD. The default value is set to `false`.
 
-|`sso` |Single Sign-on options.|`__<object>__`
-a|* `<keycloak>` - Configuration options for Keycloak SSO provider.
-  * `<dex>` - Configuration options for Dex SSO provider.
-  * `<provider>` - The name of the provider used to configure Single Sign-on. Currently, the supported options are Dex and Keycloak.
+|`sourceNamespaces` |Specifies the namespaces within which you can create application resources.|`string` |
+
+|`sso` |Single Sign-on options.|`__object__`
+a|* `dex` - Configuration options for Dex SSO provider.
+  * `keycloak` - Configuration options for Keycloak SSO provider.
+  * `provider` - The name of the provider used to configure Single Sign-on. Currently, the supported options are Dex and Keycloak.
   
 |`statusBadgeEnabled` |Enable application status badge.|`true` |
 
-|`tls` |TLS configuration options.|`__<object>__`
-a|* `<ca.configMapName>` - The name of the `ConfigMap` which contains the CA certificate.
-  * `<ca.secretName>` - The name of the secret which contains the CA certificate and key.
-  * `<initialCerts>` - Initial set of certificates in the `argocd-tls-certs-cm` config map for connecting Git repositories through HTTPS.
+|`tls` |TLS configuration options.|`__object__`
+a|* `ca.configMapName` - The name of the `ConfigMap` which contains the CA certificate.
+  * `ca.secretName` - The name of the secret which contains the CA certificate and key.
+  * `initialCerts` - Initial set of certificates in the `argocd-tls-certs-cm` config map for connecting Git repositories through HTTPS.
 
 |`usersAnonymousEnabled` |Enables anonymous user access.|`true` |
 

--- a/modules/gitops-repo-server-properties.adoc
+++ b/modules/gitops-repo-server-properties.adoc
@@ -11,25 +11,25 @@ The following properties are available for configuring the repo server component
 [options="header"]
 |===
 |Name |Default | Description
-|`resources` |`__<empty>__` |The container compute resources.
-|`mountsatoken` |`false` |Defines whether the `serviceaccount` token should be mounted to the repo-server pod.
-|`serviceaccount` |`""` |The name of the `serviceaccount` to use with the repo-server pod.
-|`verifytls` |`false` |Defines whether to enforce strict TLS checking on all components when communicating with repo server.
+|`annotations` | `__empty__` |List of custom annotations to add to pods deployed by the Operator. This field is optional.
 |`autotls` |`""` |Provider to use to set up TLS for the repo-server's gRPC TLS certificate. Currently, only the `openshift` value is acceptable.
+|`env` | `__empty__` |The environment to set for the Repo server workloads.
+|`enabled` | `__empty__` |Flag that enables the Repo server during Argo CD installation.
+|`execTimeout` | `180` |Execution timeout in seconds for rendering tools, for example, Helm or Kustomize.
+|`extraRepoCommandArgs` | `__empty__` | Passes command-line arguments to the Repo server workload. The command-line arguments are added to the list of arguments set by the Operator.
+|`initContainers` | `__empty__` |The number of `init` containers in the Argo CD Application Controller component. This field is optional.
 |`image` | `argoproj/argocd` |The container image for Argo CD Repo server. This propery overrides the `ARGOCD_REPOSERVER_IMAGE` environment variable.
-|`version` | same as `.spec.Version` |The tag to use with the Argo CD Repo server.
+|`labels` | `__empty__` |List of custom labels to add to pods deployed by the Operator. This field is optional.
 |`logLevel` | `info` |The log level used by the Argo CD Repo server. Valid options are `debug`, `info`, `error`, and `warn`.
 |`logFormat` | `text` |The log format to be used by the Argo CD repo server. Valid options are `text` and `json`.
-|`execTimeout` | `180` |Execution timeout in seconds for rendering tools, for example, Helm or Kustomize.
-|`env` | `__<empty>__` |The environment to set for the Repo server workloads.
-|`enabled` | `__<empty>__` |Flag that enables the Repo server during Argo CD installation.
-|`extraRepoCommandArgs` | `__<empty>__` | Passes command-line arguments to the Repo server workload. The command-line arguments are added to the list of arguments set by the Operator.
-|`initContainers` | `__<empty>__` |The number of `init` containers in the Argo CD Application Controller component. This field is optional.
-|`sidecarContainers` | `__<empty>__` |The number of `sidecar` containers in the Argo CD Application Controller component. This field is optional.
-|`volumes` | `__<empty>__` |Configures additional volumes used for the Repo server deployment. This field is optional.
-|`volumeMounts` | `__<empty>__` |Configures additional volume mounts used for the Repo server deployment. This field is optional.
-|`replicas` | `__<empty>__` |The number of replicas for the Argo CD Repo server. Must be greater than or equal to `0`.
-|`remote` | `__<empty>__` |Specifies the remote URL of the Repo server container.
-|`annotations` | `__<empty>__` |List of custom annotations to add to pods deployed by the Operator. This field is optional.
-|`labels` | `__<empty>__` |List of custom labels to add to pods deployed by the Operator. This field is optional.
+|`mountsatoken` |`false` |Defines whether the `serviceaccount` token should be mounted to the repo-server pod.
+|`remote` | `__empty__` |Specifies the remote URL of the Repo server container.
+|`replicas` | `__empty__` |The number of replicas for the Argo CD Repo server. Must be greater than or equal to `0`.
+|`resources` |`__empty__` |The container compute resources.
+|`serviceaccount` |`""` |The name of the `serviceaccount` to use with the repo-server pod.
+|`sidecarContainers` | `__empty__` |The number of `sidecar` containers in the Argo CD Application Controller component. This field is optional.
+|`verifytls` |`false` |Defines whether to enforce strict TLS checking on all components when communicating with repo server.
+|`version` | same as `.spec.Version` |The tag to use with the Argo CD Repo server.
+|`volumes` | `__empty__` |Configures additional volumes used for the Repo server deployment. This field is optional.
+|`volumeMounts` | `__empty__` |Configures additional volume mounts used for the Repo server deployment. This field is optional.
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.13, GitOps 1.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6172

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Changed the properties in both tables alphabetically.
Added the `sourceNamespaces` property in the Argo CD custom resource properties table
Removed the `<` and `>` signs from all the user-defined values in both the tables.

[Argo CD custom resource properties](https://82753--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @svghadi 
QE review: @varshab1210 
Peer review: @mburke5678 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
