### PR TITLE
removing old configuration fluentd: {} in create-cluster-logging-cli.…

### DIFF
--- a/modules/create-cluster-logging-cli.adoc
+++ b/modules/create-cluster-logging-cli.adoc
@@ -60,7 +60,6 @@ spec:
       replicas: 1
   collection:
     type: fluentd <10>
-    fluentd: {}
 ----
 <1> The name must be `instance`.
 <2> The OpenShift Logging management state. In some cases, if you change the OpenShift Logging defaults, you must set this to `Unmanaged`.


### PR DESCRIPTION
**removing old configuration fluentd: {} in create-cluster-logging-cli.adoc**

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> https://issues.redhat.com/browse/OBSDOCS-1363?filter=-2


* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

**Version(s):**
<!--- Specify the version or versions of OpenShift your PR applies to. --> 4.16 (if Elastiscsearch and fluentd are planed to be retained in 4.17 too, let me know will correct this PR accordingly  )

**Issue:**
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->  https://issues.redhat.com/browse/OBSDOCS-1363?filter=-2

**Link to docs preview:**
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

**QE review:**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

In below doc's code section 
https://docs.openshift.com/container-platform/4.16/observability/logging/cluster-logging-deploying.html#logging-es-deploy-console_cluster-logging-deploying
Config for fluentd is given as below[A] 

```
  collection:
    type: fluentd 
    fluentd: {} 
```
In doc https://docs.openshift.com/container-platform/4.16/observability/logging/config/cluster-logging-memory.html

format is mentioned as below[B] 

```
collection:
    resources: 
      limits:
        memory: 736Mi
      requests:
        cpu: 200m
        memory: 736Mi
    type: fluentd 
```
This is creating confusion at CU's end

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**_Note: If any issues arise in this PR and a new PR needs to be created, I would appreciate the opportunity to do it myself for learning purposes. Thank you in advance for understanding!_**