### PR TITLE
TELCODOCS-2052 - Update Cluster logging for Telco SNO clusters

### DIFF
--- a/modules/ztp-sno-du-configuring-logging-locally-and-forwarding.adoc
+++ b/modules/ztp-sno-du-configuring-logging-locally-and-forwarding.adoc
@@ -1,23 +1,64 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+// * edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="ztp-sno-du-configuring-logging-locally-and-forwarding_{context}"]
 = Cluster logging and log forwarding
 
-{sno-caps} clusters that run DU workloads require logging and log forwarding for debugging. The following `ClusterLogging` and `ClusterLogForwarder` custom resources (CRs) are required.
+{sno-caps} clusters that run DU workloads require logging and log forwarding for debugging.
+The following custom resources (CRs) are required.
 
-.Recommended cluster logging configuration (`ClusterLogging.yaml`)
-[source,yaml]
-----
-include::snippets/ztp_ClusterLogging.yaml[]
-----
-
-.Recommended log forwarding configuration (`ClusterLogForwarder.yaml`)
+[id="ztp-clusterlogforwarder-yaml"]
+.Recommended ClusterLogForwarder.yaml
 [source,yaml]
 ----
 include::snippets/ztp_ClusterLogForwarder.yaml[]
 ----
 
-Set the `spec.outputs.url` field to the URL of the Kafka server where the logs are forwarded to.
+[NOTE]
+====
+Set the `spec.outputs.kafka.url` field to the URL of the Kafka server where the logs are forwarded to.
+====
+
+[id="ztp-clusterlogns-yaml"]
+.Recommended ClusterLogNS.yaml
+[source,yaml]
+----
+include::snippets/ztp_ClusterLogNS.yaml[]
+----
+
+[id="ztp-clusterlogopergroup-yaml"]
+.Recommended ClusterLogOperGroup.yaml
+[source,yaml]
+----
+include::snippets/ztp_ClusterLogOperGroup.yaml[]
+----
+
+[id="ztp-clusterlogserviceaccount-yaml"]
+.Recommended ClusterLogServiceAccount.yaml
+[source,yaml]
+----
+include::snippets/ztp_ClusterLogServiceAccount.yaml[]
+----
+
+[id="ztp-clusterlogserviceaccountauditbinding-yaml"]
+.Recommended ClusterLogServiceAccountAuditBinding.yaml
+[source,yaml]
+----
+include::snippets/ztp_ClusterLogServiceAccountAuditBinding.yaml[]
+----
+
+[id="ztp-clusterlogserviceaccountinfrastructurebinding-yaml"]
+.Recommended ClusterLogServiceAccountInfrastructureBinding.yaml
+[source,yaml]
+----
+include::snippets/ztp_ClusterLogServiceAccountInfrastructureBinding.yaml[]
+----
+
+[id="ztp-clusterlogsubscription-yaml"]
+.Recommended ClusterLogSubscription.yaml
+[source,yaml]
+----
+include::snippets/ztp_ClusterLogSubscription.yaml[]
+----

--- a/snippets/ztp_ClusterLogForwarder.yaml
+++ b/snippets/ztp_ClusterLogForwarder.yaml
@@ -1,32 +1,42 @@
-apiVersion: "logging.openshift.io/v1"
+apiVersion: "observability.openshift.io/v1"
 kind: ClusterLogForwarder
 metadata:
   name: instance
   namespace: openshift-logging
   annotations: {}
 spec:
-#  outputs: $outputs
-#  pipelines: $pipelines
-
-#apiVersion: "logging.openshift.io/v1"
+  # outputs: $outputs
+  # pipelines: $pipelines
+  serviceAccount:
+    name: log6collector
+#apiVersion: "observability.openshift.io/v1"
 #kind: ClusterLogForwarder
 #metadata:
 #  name: instance
 #  namespace: openshift-logging
-#spec:
-#  outputs:
-#    - type: "kafka"
-#      name: kafka-open
-#      url: tcp://10.46.55.190:9092/test
-#  pipelines:
-#  - inputRefs:
-#    - audit
-#    - infrastructure
-#    labels:
-#      label1: test1
-#      label2: test2
-#      label3: test3
-#      label4: test4
-#    name: all-to-default
-#    outputRefs: 
-#    - kafka-open  
+# spec:
+#   outputs:
+#   - type: "kafka"
+#     name: kafka-open
+#     # below url is an example
+#     kafka:
+#       url: tcp://10.46.55.190:9092/test
+#   filters:
+#   - name: test-labels
+#     type: openshiftLabels
+#     openshiftLabels:
+#       label1: test1
+#       label2: test2
+#       label3: test3
+#       label4: test4
+#   pipelines:
+#   - name: all-to-default
+#     inputRefs:
+#     - audit
+#     - infrastructure
+#     filterRefs:
+#     - test-labels
+#     outputRefs:
+#     - kafka-open
+#   serviceAccount:
+#     name: log6collector

--- a/snippets/ztp_ClusterLogServiceAccount.yaml
+++ b/snippets/ztp_ClusterLogServiceAccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: log6collector
+  namespace: openshift-logging
+  annotations: {}

--- a/snippets/ztp_ClusterLogServiceAccountAuditBinding.yaml
+++ b/snippets/ztp_ClusterLogServiceAccountAuditBinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logcollector-audit-logs-binding
+  annotations: {}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collect-audit-logs
+subjects:
+  - kind: ServiceAccount
+    name: log6collector
+    namespace: openshift-logging

--- a/snippets/ztp_ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/snippets/ztp_ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logcollector-infrastructure-logs-binding
+  annotations: {}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collect-infrastructure-logs
+subjects:
+  - kind: ServiceAccount
+    name: log6collector
+    namespace: openshift-logging

--- a/snippets/ztp_ClusterLogSubscription.yaml
+++ b/snippets/ztp_ClusterLogSubscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-logging
   annotations: {}
 spec:
-  channel: "stable"
+  channel: "stable-6.0"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Removing deprecated `ClusterLogging` CRs from RAN ZTP docs. 

Version(s):
enterprise-4.17+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2052

Link to docs preview:
https://82755--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-configuring-logging-locally-and-forwarding_sno-configure-for-vdu

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
