### PR TITLE
OCPBUGS-41915 lack of explanation regarding numaresources-operator for disconnected environments

### DIFF
--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -6,10 +6,9 @@
 [id="cnf-deploying-the-numa-aware-scheduler_{context}"]
 = Deploying the NUMA-aware secondary pod scheduler
 
-After you install the NUMA Resources Operator, do the following to deploy the NUMA-aware secondary pod scheduler:
+After you install the NUMA Resources Operator, follow this procedure to deploy the NUMA-aware secondary pod scheduler. 
 
 .Procedure
-
 . Create the `NUMAResourcesScheduler` custom resource that deploys the NUMA-aware custom pod scheduler:
 
 .. Save the following minimal required YAML in the `nro-scheduler.yaml` file:
@@ -21,8 +20,14 @@ kind: NUMAResourcesScheduler
 metadata:
   name: numaresourcesscheduler
 spec:
-  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}"
+  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}" <1>
 ----
++
+<1> In a disconnected environment, make sure to configure the resolution of this image by either:
+
+* Creating an `ImageTagMirrorSet` custom resource (CR). For more information, see "Configuring image registry repository mirroring" in the "Additional resources" section.
+
+* Setting the URL to the disconnected registry.
 
 .. Create the `NUMAResourcesScheduler` CR by running the following command:
 +

--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -37,6 +37,8 @@ include::modules/cnf-configuring-single-numa-policy.adoc[leveloffset=+2]
 
 .Additional resources
 
+* xref:../disconnected/updating/disconnected-update.adoc#images-configuration-registry-mirror-configuring_updating-disconnected-cluster[Configuring image registry repository mirroring]
+
 * xref:../scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-about-the-profile-creator-tool_cnf-low-latency-perf-profile[About the Performance Profile Creator]
 
 include::modules/cnf-sample-single-numa-policy-from-pp.adoc[leveloffset=+2]


### PR DESCRIPTION
[OCPBUGS-41915]: lack of explanation regarding numaresources-operator for disconnected environments

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17, 4.18, main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-41915
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://82756--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-deploying-the-numa-aware-scheduler_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
