### PR TITLE
OCPBUGS#41960: Removed Alibaba from the SDN supported tables

### DIFF
--- a/modules/nw-ovn-kubernetes-live-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration-about.adoc
@@ -36,16 +36,20 @@ The following table provides information about the supported platforms for the l
 |===
 | Platform              | Limited Live Migration
 
-| Bare metal hardware (IPI and UPI)             |&#10003;
-| Amazon Web Services (AWS) (IPI and UPI)       |&#10003;
-| Google Cloud Platform (GCP) (IPI and UPI)     |&#10003;
-| {ibm-cloud-name} (IPI and UPI)                |&#10003;
-| Microsoft Azure (IPI and UPI)                 |&#10003;
-| {rh-openstack-first} (IPI and UPI)            |&#10003;
-| VMware vSphere (IPI and UPI)                  |&#10003;
-| AliCloud (UPI)                                |&#10003;
-| Nutanix (IPI and UPI)                         |&#10003;
+| Bare-metal hardware   |&#10003;
+| {aws-first}           |&#10003;
+| {gcp-first}           |&#10003;
+| {ibm-cloud-name}      |&#10003;
+| {azure-first}         |&#10003;
+| {rh-openstack-first}  |&#10003;
+| {vmw-first}           |&#10003;
+| Nutanix               |&#10003;
 |===
+
+[NOTE]
+====
+Each listed platform supports installing an {product-title} cluster on installer-provisioned infrastructure and user-provisioned infrastructure.
+====
 
 [id="best-practices-live-migrating-ovn-kubernetes-network-provider_{context}"]
 == Best practices for limited live migration to the OVN-Kubernetes network plugin

--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -34,16 +34,20 @@ The following table provides information about the supported platforms for the o
 |===
 | Platform              | Offline Migration
 
-| Bare metal hardware (IPI and UPI)            |&#10003;
-| Amazon Web Services (AWS) (IPI and UPI)      |&#10003;
-| Google Cloud Platform (GCP) (IPI and UPI)    |&#10003;
-| {ibm-cloud-name} (IPI and UPI)               |&#10003;
-| Microsoft Azure (IPI and UPI)                |&#10003;
-| {rh-openstack-first} (IPI and UPI)           |&#10003;
-| VMware vSphere (IPI and UPI)                 |&#10003;
-| AliCloud (IPI and UPI)                       |&#10003;
-| Nutanix (IPI and UPI)                        |&#10003;
+| Bare-metal hardware   |&#10003;
+| {aws-first}           |&#10003;
+| {gcp-first}           |&#10003;
+| {ibm-cloud-name}      |&#10003;
+| {azure-first}         |&#10003;
+| {rh-openstack-first}  |&#10003;
+| {vmw-first}           |&#10003;
+| Nutanix               |&#10003;
 |===
+
+[NOTE]
+====
+Each listed platform supports installing an {product-title} cluster on installer-provisioned infrastructure and user-provisioned infrastructure.
+====
 
 [id="best-practices-migrating-ovn-kubernetes-network-provider_{context}"]
 == Best practices for offline migration to the OVN-Kubernetes network plugin


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OCPBUGS-41960](https://issues.redhat.com/browse/OCPBUGS-41960)

Link to docs preview:
* [Supported platforms when using the offline migration method](https://82759--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#supported-platforms-offline-migrating-ovn-kubernetes)
* [Supported platforms when using the limited live migration method
](https://82759--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#supported-platforms-live-migrating-ovn-kubernetes)

- [x] SME has approved this change.
- [x] QE has approved this change.
