### PR TITLE
OSDOCS#12186: Remove the mention of replicas:0 in the nodepool

### DIFF
--- a/modules/hcp-nodepool-hc.adoc
+++ b/modules/hcp-nodepool-hc.adoc
@@ -31,9 +31,9 @@ spec:
     type: Agent
   release:
     image: registry.<dns.base.domain.name>:5000/openshift/release-images:4.x.y-x86_64 \// <5>
-  replicas: 0
+  replicas: 2 // <6>
 status:
-  replicas: 0 // <6>
+  replicas: 2
 ----
 +
 <1> Replace `<hosted_cluster_name>` with your hosted cluster.
@@ -41,7 +41,7 @@ status:
 <3> The `autoRepair` field is set to `false` because the node will not be re-created if it is removed.
 <4> The `upgradeType` is set to `InPlace`, which indicates that the same bare metal node is reused during an upgrade.
 <5> All of the nodes included in this `NodePool` are based on the following {product-title} version: `4.x.y-x86_64`. Replace the `<dns.base.domain.name>` value with your DNS base domain name and the `4.x.y` value with the supported {product-title} version you want to use.
-<6> The `replicas` value is set to `0` so that you can scale them when needed. It is important to keep the `NodePool` replicas at 0 until all steps are completed.
+<6> You can set the `replicas` value to `2` to create two node pool replicas in your hosted cluster.
 
 . Create the `NodePool` object by entering the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12186
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://82760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.html#hcp-nodepool-hc_hcp-deploy-dc-bm
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE/SME review:
- [x] QE/SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
