### PR TITLE
CMP-2685: Added lifecycle support information for FIO and SPO

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1098,8 +1098,12 @@ Topics:
 - Name: File Integrity Operator
   Dir: file_integrity_operator
   Topics:
+  - Name: File Integrity Operator Overview
+    File: fio-overview
   - Name: File Integrity Operator release notes
     File: file-integrity-operator-release-notes
+  - Name: File Integrity Operator support
+    File: fio-support
   - Name: Installing the File Integrity Operator
     File: file-integrity-operator-installation
   - Name: Updating the File Integrity Operator
@@ -1119,6 +1123,8 @@ Topics:
     File: spo-overview
   - Name: Security Profiles Operator release notes
     File: spo-release-notes
+  - Name: Security Profiles Operator support
+    File: spo-support
   - Name: Understanding the Security Profiles Operator
     File: spo-understanding
   - Name: Enabling the Security Profiles Operator

--- a/security/file_integrity_operator/fio-overview.adoc
+++ b/security/file_integrity_operator/fio-overview.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="fio-overview"]
+= File Integrity Operator overview
+include::_attributes/common-attributes.adoc[]
+:context: fio-overview
+
+The File Integrity Operator continually runs file integrity checks on the cluster nodes. It deploys a DaemonSet that initializes and runs privileged link:https://aide.github.io/[Advanced Intrusion Detection Environment] (AIDE) containers on each node, providing a log of files that have been modified since the initial run of the DaemonSet pods.
+
+For the latest updates, see the xref:../../security/file_integrity_operator/file-integrity-operator-release-notes.adoc#file-integrity-operator-release-notes[File Integrity Operator release notes].
+
+xref:../../security/file_integrity_operator/file-integrity-operator-installation.adoc#installing-file-integrity-operator[Installing the File Integrity Operator]
+
+xref:../../security/file_integrity_operator/file-integrity-operator-updating.adoc#file-integrity-operator-updating[Updating the File Integrity Operator]
+
+xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[Understanding the File Integrity Operator]
+
+xref:../../security/file_integrity_operator/file-integrity-operator-configuring.adoc#configuring-file-integrity-operator[Configuring the Custom File Integrity Operator]
+
+xref:../../security/file_integrity_operator/file-integrity-operator-advanced-usage.adoc#file-integrity-operator-advanced-usage[Performing advanced Custom File Integrity Operator tasks]
+
+xref:../../security/file_integrity_operator/file-integrity-operator-troubleshooting.adoc#troubleshooting-file-integrity-operator[Troubleshooting the File Integrity Operator]

--- a/security/file_integrity_operator/fio-support.adoc
+++ b/security/file_integrity_operator/fio-support.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: ASSEMBLY
+//OpenShift File Integrity Operator support page
+[id="fio-support"]
+= File Integrity Operator support
+:context: fio-support
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+[id="fio-lifecycle_{context}"]
+== File Integrity Operator lifecycle
+
+The File Integrity Operator is a "Rolling Stream" Operator, meaning updates are available asynchronously of {product-title} releases. For more information, see link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] on the Red Hat Customer Portal.
+
+include::modules/support.adoc[leveloffset=+1]
+
+//If we ever add a must-gather for FIO:
+//include modules/fio-must-gather.adoc[leveloffset=+1]
+
+//[role="_additional-resources"]
+//[id="additional-resources_{context}"]
+//== Additional resources
+//
+//* xref:../../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[About the must-gather tool]

--- a/security/security_profiles_operator/spo-support.adoc
+++ b/security/security_profiles_operator/spo-support.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: ASSEMBLY
+//OpenShift Security Profiles Operator support page
+[id="spo-support"]
+= Security Profiles Operator support
+:context: spo-support
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+[id="spo-lifecycle_{context}"]
+== Security Profiles Operator lifecycle
+
+The Security Profiles Operator is a "Rolling Stream" Operator, meaning updates are available asynchronously of {product-title} releases. For more information, see link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] on the Red Hat Customer Portal.
+
+include::modules/support.adoc[leveloffset=+1]
+
+//If we ever add a must-gather for SPO:
+//include modules/spo-must-gather.adoc[leveloffset=+1]
+
+//[role="_additional-resources"]
+//[id="additional-resources_{context}"]
+//== Additional resources
+//
+//* xref:../../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[About the must-gather tool]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/CMP-2685

Link to docs preview:
[82762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/fio-overview.html](https://82762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/fio-overview.html)
[82762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/fio-support.html](https://82762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/fio-support.html)
[82762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-support.html](https://82762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-support.html)

Additional information:
No QE required, as this does not change the technical meaning of the docs. This implements [previously-approved infrastructure](https://github.com/openshift/openshift-docs/pull/80406) in the documentation for additional Operators. 