### PR TITLE
OCPBUGS-42031: Known issue for failing to revert bond br-ex mode

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2760,6 +2760,8 @@ The `IRQBALANCE_BANNED_CPULIST` variable and the `IRQBALANCE_BANNED_CPUS` variab
 
 * Each node group must only match one `MachineConfigPool` object. In some cases, the NUMA Resources Operator can allow a configuration where a node group matches more than one `MachineConfigPool` object. This issue could lead to unexpected behavior in resource management. (link:https://issues.redhat.com/browse/OCPBUGS-42523[*OCPBUGS-42523*])
 
+* When the bond mode in the `NetworkNodeConfigurationPolicy` is changed from `balance-rr` to `active-backup` on kernel bonds that are attached to the `br-ex` interface, the change might fail on arbitrary nodes. As a workaround, create a `NetworkNodeConfigurationPolicy` object without specifying the bond port configuration. (link:https://issues.redhat.com/browse/OCPBUGS-42031[*OCPBUGS-42031*])
+
 [id="ocp-storage-core-4-17-known-issues_{context}"]
 
 * If the controller pod terminates while cloning, or taking or restoring a volume snapshot, is in progress, the Microsoft Azure File clone or snapshot persistent volume claims (PVCs) remain in the Pending state. To resolve this issue, delete any affected clone or snapshot PVCs, and then recreate those PVCs. (link:https://issues.redhat.com/browse/OCPBUGS-35977[*OCPBUGS-35977*])


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-42031
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
https://82763--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-known-issues_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
