### PR TITLE
OSDOCS-11874-fix: Updated Migrating from the OpenShift SDN network pl…

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -23,9 +23,18 @@ While performing the migration, your cluster is unavailable and workloads might 
 * You can manually reboot each node.
 * You checked that your cluster is in a known good state without any errors.
 * You created a security group rule that allows User Datagram Protocol (UDP) packets on port `6081` for all nodes on all cloud platforms.
-* You set all timeouts for webhooks to `3` seconds or removed the webhooks.
+* You removed webhooks. Alternatively, you can set a timeout value for each webhook, which is detailed in the procedure. If you did not complete one of these tasks, your cluster might fail to schedule pods.
 
 .Procedure
+
+. If you did not remove webhooks, set the timeout value for each webhook to `3` seconds by creating a `ValidatingWebhookConfiguration` custom resource and then specify the timeout value for the `timeoutSeconds` parameter:
++
+[source,terminal]
+----
+oc patch ValidatingWebhookConfiguration <webhook_name> --type='json' \ <1>
+-p '[{"op": "replace", "path": "/webhooks/0/timeoutSeconds", "value": 3}]'
+----
+<1> Where `<webhook_name>` is the name of your webhook.
 
 . To backup the configuration for the cluster network, enter the following command:
 +

--- a/networking/openshift_sdn/rollback-to-ovn-kubernetes.adoc
+++ b/networking/openshift_sdn/rollback-to-ovn-kubernetes.adoc
@@ -13,3 +13,4 @@ include::snippets/sdn-deprecation-statement.adoc[]
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 
 include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-11874](https://issues.redhat.com/browse/OSDOCS-11874)

Link to docs preview:
* [Migrating to the OVN-Kubernetes network plugin by using the offline migration method](https://82768--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn)

- [x] SME has approved this change (Ramesh Sahoo/Rupesh Patel).
- [x] QE has approved this change (Weibin Liang/Zhanqi Zhao).

Add. resources:
* https://issues.redhat.com/browse/OCPBUGS-35840
