### PR TITLE
OSSM 3.0 OSSM-3944 Integrating Kiali with OTEL

### DIFF
--- a/kiali/ossm-kiali-assembly.adoc
+++ b/kiali/ossm-kiali-assembly.adoc
@@ -14,10 +14,16 @@ include::modules/ossm-install-kiali-operator.adoc[leveloffset=1]
 
 include::modules/ossm-config-openshift-monitoring-kiali.adoc[leveloffset=1]
 
+include::modules/ossm-integrating-kiali-otel.adoc[leveloffset=1]
+
+include::modules/ossm-config-otel-kiali.adoc[leveloffset=2]
+
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../metrics/ossm-metrics-assembly.adoc#ossm-config-openshift-monitoring-only_ossm-metrics-assembly[Configuring OpenShift Monitoring with Service Mesh]
+
+* xref:../traces/ossm-distr-tracing-assembly.html#ossm-config-otel_ossm-traces-assembly[Configuring {OTELName} with Service Mesh]
 
 // TP 1 content. Banner handled separately by different PR handled by Tim O'Keefe. Per Tim, banner should appear across all 3.0 content, nothing needs to be added to this file
 // Content may change, file names may change, directories may change, the order of directories may change, everything may change.

--- a/modules/ossm-config-otel-kiali.adoc
+++ b/modules/ossm-config-otel-kiali.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/kiali/ossm-kiali-assembly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-config-otel-kiali_{context}"]
+= Configuring {DTProductName} with {KialiProduct}
+
+After {KialiProduct} is integrated with {DTProductName}, you can view distributed traces in the Kiali console. Viewing these traces can provide insight into the communication between services within the service mesh, helping you understand how requests are flowing through your system and where potential issues might be.
+
+.Prerequisites
+
+* You installed {SMProductName}.
+
+* You configured {DTShortName} with {SMProductName}.
+
+.Procedure
+
+. Update the `Kiali` resource `spec` configuration for tracing:
++
+.Example `Kiali` resource `spec` configuration for tracing
+[source,yaml]
+----
+spec:
+  external_services:
+    grafana:
+      enabled: true # <1>
+      in_cluster_url: http://grafana-istio-system.apps-crc.testing/ # <2>
+      url: http://grafana-istio-system.apps-crc.testing/
+    tracing:
+      enabled: true
+      provider: tempo
+      use_grpc: false
+      in_cluster_url: http://tempo-sample-query-frontend.tempo:3200
+      url: https://tempo-sample-query-frontend-tempo.apps-crc.testing
+      tempo_config: # <3>
+        org_id: "1"
+        datasource_uid: a8d2ef1c-d31c-4de5-a90b-e7bc5252cd00
+----
+<1> Required so that you can see the *View in Tracing* link from the *Traces* tab.
+<2> If the Tempo resource is deployed with multiple tenants, then the `in_cluster_url` config should point to the gateway with the tenant name as part of the URL. For example: http://tempo-resource-gateway.tempo:8080/api/traces/v1/{tenantName}/tempo
+<3> Required so that you can see the *View in Tracing*  link from the *Traces* tab and redirect to the proper Tempo `datasource`.
+
+. Save the updated `spec` in 'kiali_cr.yaml`.
+
+. Run the following command to apply the configuration:
++
+[source, terminal]
+----
+oc patch -n istio-system kiali kiali --type merge -p "$(cat kiali_cr.yaml)"
+----
++
+Output:
++
+[source, terminal]
+----
+ kiali.kiali.io/kiali patched
+----
+
+.Verification
+
+. Run the following command to get the Kiali route:
++
+[source, terminal]
+----
+oc get route kiali ns istio-system
+----
+
+. Navigate to the Kiali UI.
+
+. Navigate to *Workload* → *Traces* tab to see traces in the Kiali UI.
+
+//Note for later: there are things in here, like Kiali UI, that may need attributes. Attributes will be updated prior to GA.
+//Note that "Kiali UI" is not the same as "Kiali Operator provided by Red Hat", and there currently is only 1 attribute related to Kiali, and it is for "Kiali Operator provided by Red Hat".

--- a/modules/ossm-integrating-kiali-otel.adoc
+++ b/modules/ossm-integrating-kiali-otel.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/kiali/ossm-kiali-assembly.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-integrating-kiali-otel_{context}"]
+= Integrating {DTProductName} with {KialiProduct}
+
+You can integrate {DTProductName} with {KialiProduct}, which enables the following features:
+
+* Display trace overlays and details on the graph.
+* Display scatterplot charts and in-depth trace/span information on detail pages.
+* Integrated span information in logs and metric charts.
+* Offer links to the external tracing UI.


### PR DESCRIPTION
**OSSM 3.0 TP1**

Kiali + OTEL was not required for TP 1 go live, but OSSM 3.0 is still in TP1 status so this applies to TP1.

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):
 
Technology Preview

OSSM 3.0 is moving to stand alone format is will not be cherry-picked back to OCP core branchs.

Issue:
https://issues.redhat.com/browse/OSSM-3944

Link to docs preview:

About the integration: https://82769--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/kiali/ossm-kiali-assembly#ossm-about-kiali-otel_ossm-kiali-assembly

Procedure: https://82769--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/kiali/ossm-kiali-assembly#ossm-config-otel-kiali_ossm-kiali-assembly

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
