### PR TITLE
OLS-1103: Change value of type parameter for rhoai configuration file

### DIFF
--- a/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
@@ -56,7 +56,7 @@ spec:
       models:
       - name: granite-8b-code-instruct-128k
       name: red_hat_openshift_ai
-      type: red_hat_openshift_ai_vllm
+      type: rohai_vllm 
       url: <url> <1>
   ols:
     defaultProvider: red_hat_openshift_ai

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
@@ -58,7 +58,7 @@ spec:
       models:
       - name: granite-8b-code-instruct-128k
       name: red_hat_openshift_ai
-      type: red_hat_openshift_ai_vllm
+      type: rohai_vllm
       url: <url> <1>
   ols:
     defaultProvider: red_hat_openshift_ai


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview


Issue: https://issues.redhat.com/browse/OLS-1103
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://82770--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-creating-lightspeed-custom-resource-file-using-web-console_ols-configuring-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
