### PR TITLE
OSDOCS-11777: Add to the "No CNI plugin" page to be more similar to our competing services pages

### DIFF
--- a/modules/rosa-hcp-sts-creating-a-cluster-cli-no-cni-plugin.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli-no-cni-plugin.adoc
@@ -58,6 +58,11 @@ $ rosa create cluster --hosted-cp --subnet-ids=$SUBNET_IDS --oidc-config-id=$OID
 $ rosa describe cluster --cluster=<cluster_name>
 ----
 +
+[IMPORTANT]
+====
+When you first log in to the cluster after it reaches `ready` status, the nodes will still be in the `not ready` state until you install your own CNI plugin. After CNI installation, the nodes will change to `ready`. 
+====
++
 The following `State` field changes are listed in the output as the cluster installation progresses:
 +
 * `pending (Preparing account)`
@@ -69,11 +74,6 @@ The following `State` field changes are listed in the output as the cluster inst
 ====
 If the installation fails or the `State` field does not change to `ready` after more than 10 minutes, check the installation troubleshooting documentation for details. For more information, see _Troubleshooting installations_. For steps to contact Red Hat Support for assistance, see _Getting support for Red Hat OpenShift Service on AWS_.
 ====
-+
-[IMPORTANT]
-====
-When you first log in to the cluster after it reaches `ready` status, the nodes will still be in the `not ready` state until you install your own CNI plugin. After CNI installation, the nodes will change to `ready`. 
-====
 
 . Track the progress of the cluster creation by watching the {product-title} installation program logs. To check the logs, run the following command:
 +
@@ -82,3 +82,7 @@ When you first log in to the cluster after it reaches `ready` status, the nodes 
 $ rosa logs install --cluster=<cluster_name> --watch <1>
 ----
 <1> Optional: To watch for new log messages as the installation progresses, use the `--watch` argument.
+
+[id="rosa-hcp-no-cni-expected-behavior_{context}"]
+== Expected behavior for clusters without a CNI plugin
+Although {hcp-title} cluster installation is complete, the cluster cannot operate without a CNI plugin. Because the nodes are not ready, the workloads cannot deploy. For example, the {product-title} cluster web console is not available, so you must use the {oc-first} to log in to the cluster. Additionally, other OpenShift components such as the HAProxy-based Ingress Controller, image registry, and prometheus-based monitoring stack are not running. This is expected behavior until you install a CNI provider.

--- a/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
+++ b/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
@@ -10,10 +10,14 @@ toc::[]
 You can use your own Container Network Interface (CNI) plugin when creating a {hcp-title-first} cluster.
 You can create a {hcp-title} cluster without a CNI and install your own CNI plugin after cluster creation.
 
-[NOTE]
+[IMPORTANT]
 ====
 For customers who choose to use their own CNI, the responsibility of CNI plugin support belongs to the customer in coordination with their chosen CNI vendor.
 ====
+
+The default plugin for {hcp-title} is the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin]. This plugin is the only Red Hat supported CNI plugin for {hcp-title}.  
+
+If you choose to use your own CNI for {hcp-title} clusters, it is strongly recommended that you obtain commercial support from the plugin vendor before creating your clusters. Red Hat support cannot assist with CNI-related issues such as pod to pod traffic for customers who choose to use their own CNI. Red Hat still provides support for all non-CNI issues. If you want CNI-related support from Red Hat, you must install the cluster with the default OVN-Kubernetes network plugin. For more information, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-responsibility-matrix[responsibility matrix].
 
 [id="rosa-hcp-no-cni-cluster-creation"]
 == Creating a {hcp-title} cluster without a CNI plugin


### PR DESCRIPTION
[OSDOCS-11777](https://issues.redhat.com//browse/OSDOCS-11777): Add to the "No CNI plugin" page to be more similar to our competing services pages

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17 +

Issue:
https://issues.redhat.com/browse/OSDOCS-11777

Link to docs preview:
https://82773--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-cluster-no-cni.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
