### PR TITLE
Minor edits as follow-up to WMCO hiding docs from 10.17

### DIFF
--- a/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
@@ -107,7 +107,7 @@ include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
 [NOTE]
 ====
-For more information on using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]

--- a/installing/installing_azure/ipi/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/ipi/installing-azure-network-customizations.adoc
@@ -49,7 +49,7 @@ include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
 [NOTE]
 ====
-For more information on using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
 
 [role="_additional-resources"]

--- a/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.adoc
@@ -53,7 +53,7 @@ include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
 [NOTE]
 ====
-For more information on using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
 
 

--- a/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -60,7 +60,7 @@ where:
 `manifests/` directory for your cluster.
 --
 
-. Open the `cluster-network-03-config.yml` file in an editor and configure OVN-Kubernetes with hybrid networking, such as in the following example:
+. Open the `cluster-network-03-config.yml` file in an editor and configure OVN-Kubernetes with hybrid networking, as in the following example:
 +
 --
 .Specify a hybrid networking configuration
@@ -79,7 +79,7 @@ spec:
           hostPrefix: 23
         hybridOverlayVXLANPort: 9898 <2>
 ----
-<1> Specify the CIDR configuration used for nodes on the additional overlay network. The `hybridClusterNetwork` CIDR cannot overlap with the `clusterNetwork` CIDR.
+<1> Specify the CIDR configuration used for nodes on the additional overlay network. The `hybridClusterNetwork` CIDR must not overlap with the `clusterNetwork` CIDR.
 <2> Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `4789` port. For more information on this requirement, see the Microsoft documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken].
 --
 +
@@ -97,7 +97,7 @@ ifdef::post-install[]
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
-* Log in to the cluster with a user with `cluster-admin` privileges.
+* Log in to the cluster as a user with `cluster-admin` privileges.
 * Ensure that the cluster uses the OVN-Kubernetes network plugin.
 
 .Procedure
@@ -129,7 +129,7 @@ $ oc patch networks.operator.openshift.io cluster --type=merge \
 --
 where:
 
-`cidr`:: Specify the CIDR configuration used for nodes on the additional overlay network. This CIDR cannot overlap with the cluster network CIDR.
+`cidr`:: Specify the CIDR configuration used for nodes on the additional overlay network. This CIDR must not overlap with the cluster network CIDR.
 `hostPrefix`:: Specifies the subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
 `hybridOverlayVXLANPort`:: Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `4789` port. For more information on this requirement, see the Microsoft documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken].
 


### PR DESCRIPTION
Minor style issue changes as suggested by @mramendi in his review of https://github.com/openshift/openshift-docs/pull/82725. 

Previews:
Installing AWS -> IPI -> Installing a cluster with network customization -> [Configuring hybrid networking with OVN-Kubernetes](https://82776--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-network-customizations#configuring-hybrid-ovnkubernetes_installing-aws-network-customizations) -- Various edits and updated NOTE at the end.  The _Configuring hybrid networking with OVN-Kubernetes_ module is used in all of these three assemblies. 
Installing Azure -> IPI -> Installing a cluster with network customization -> [Configuring hybrid networking with OVN-Kubernetes](https://82776--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-network-customizations#configuring-hybrid-ovnkubernetes_installing-azure-network-customizations) -- Updated NOTE at the end.
Installing Azure -> IPI -> Installing a cluster with network customization -> [Configuring hybrid networking with OVN-Kubernetes](https://82776--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations#configuring-hybrid-ovnkubernetes_installing-azure-stack-hub-network-customizations) -- Updated NOTE at the end.

No QE needed.


