### PR TITLE
Change UID/GID in Nodes 4.17 User Namespace Work

### DIFF
--- a/modules/nodes-pods-user-namespaces-configuring.adoc
+++ b/modules/nodes-pods-user-namespaces-configuring.adoc
@@ -73,8 +73,8 @@ metadata:
     openshift.io/display-name: ""
     openshift.io/requester: system:admin
     openshift.io/sa.scc.mcs: s0:c27,c24
-    openshift.io/sa.scc.supplemental-groups: 1024/10000 <1>
-    openshift.io/sa.scc.uid-range: 1024/10000 <2>
+    openshift.io/sa.scc.supplemental-groups: 1000/10000 <1>
+    openshift.io/sa.scc.uid-range: 1000/10000 <2>
 # ...
 name: userns
 # ...
@@ -84,7 +84,7 @@ name: userns
 +
 [NOTE]
 ====
-The range 1024/10000 means 10,000 values starting with ID 1024, so it specifies the range of IDs from 1024 to 11,023.
+The range 1000/10000 means 10,000 values starting with ID 1000, so it specifies the range of IDs from 1000 to 10,999.
 ====
 
 . Enable the use of Linux user namespaces by creating a pod configured to run with a `restricted` profile and with the `hostUsers` parameter set to `false`.
@@ -113,8 +113,8 @@ spec:
       runAsNonRoot: true <2>
       seccompProfile:
         type: RuntimeDefault
-      runAsUser: 1024 <3>
-      runAsGroup: 1024 <4>
+      runAsUser: 1000 <3>
+      runAsGroup: 1000 <4>
   hostUsers: false <5>
 
 # ...
@@ -158,7 +158,7 @@ sh-5.1$ id
 .Example output
 [source,terminal]
 ----
-uid=1024(1024) gid=1024(1024) groups=1024(1024)
+uid=1000(1000) gid=1000(1000) groups=1000(1000)
 ----
 
 .. Display the user ID being used in the container user namespace:
@@ -172,9 +172,9 @@ sh-5.1$ lsns -t user
 [source,terminal]
 ----
         NS TYPE  NPROCS PID USER COMMAND
-4026532447 user       3   1 1024 /usr/bin/coreutils --coreutils-prog-shebang=sleep /usr/bin/sleep 1000 <1>
+4026532447 user       3   1 1000 /usr/bin/coreutils --coreutils-prog-shebang=sleep /usr/bin/sleep 1000 <1>
 ----
-<1> The UID for the process is `1024`, the same as you set in the pod spec.
+<1> The UID for the process is `1000`, the same as you set in the pod spec.
 
 . Check the pod user ID being used on the node where the pod was created. The node is outside of the Linux user namespace. This user ID should be different from the UID being used in the container.
 


### PR DESCRIPTION
Follow up to Nodes 4.17 User Namespace Work to change the UID and GID values used in code examples. Requested by @haircommander. 

Preview: 
[Configuring Linux user namespace support](https://82777--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-user-namespaces.html#nodes-pods-user-namespaces-configuring_nodes-pods-user-namespaces) --  
Procedure step 1, call outs 1 and 2.
Procedure step 2, call outs 3 and 4.
Verification 2b and 2c.