### PR TITLE
OSDOCS-11737-backport

### DIFF
--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -11,7 +11,9 @@ The Kubernetes NMState Operator provides a Kubernetes API for performing state-d
 
 [IMPORTANT]
 ====
-Red Hat supports the Kubernetes NMState Operator in production environments on bare-metal, {ibm-power-name}, {ibm-z-name}, {ibm-linuxone-name}, VMware vSphere, and OpenStack installations.
+Red{nbsp}Hat supports the Kubernetes NMState Operator in production environments on bare-metal, {ibm-power-name}, {ibm-z-name}, {ibm-linuxone-name}, {vmw-first}, and {rh-openstack-first} installations.
+
+Red{nbsp}Hat support exists for using the Kubernetes NMState Operator on {azure-first} but in a limited capacity. Support is limited to configuring DNS servers on your system as a postinstallation task.
 ====
 
 Before you can use NMState with {product-title}, you must install the Kubernetes NMState Operator.


### PR DESCRIPTION
ALREADY merged to main. Forgot to cherry-pick. See https://github.com/openshift/openshift-docs/pull/81497 for approvals. 

Version(s):
4.17+

Issue:
[OSDOCS-11737](https://issues.redhat.com/browse/OSDOCS-11737)

Link to docs preview:
[About the Kubernetes NMState Operator](https://81497--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html)

- [x] SME has approved this change.
- [x] QE has approved this change.

