### PR TITLE
OSDOCS-12045: Updated the Network config. parameters doc to include OSP

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -182,16 +182,11 @@ endif::ibm-power-vs[]
 
 You can customize your installation configuration based on the requirements of your existing network infrastructure. For example, you can expand the IP address block for the cluster network or provide different IP address blocks than the defaults.
 
-// OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
-// But only for installer-provisioned
-// https://bugzilla.redhat.com/show_bug.cgi?id=2020416
-// Once BM UPI supports dual-stack, uncomment all the following conditionals and blocks
-
-ifndef::agent,bare,ibm-power,ibm-z,vsphere[]
+ifndef::agent,bare,ibm-power,ibm-z,vsphere,osp[]
 Only IPv4 addresses are supported.
-endif::agent,bare,ibm-power,ibm-z,vsphere[]
+endif::agent,bare,ibm-power,ibm-z,vsphere,osp[]
 
-ifdef::agent,bare,ibm-power,ibm-z,vsphere[]
+ifdef::agent,bare,ibm-power,ibm-z,vsphere,osp[]
 Consider the following information before you configure network parameters for your cluster:
 
 * If you use the {openshift-networking} OVN-Kubernetes network plugin, both IPv4 and IPv6 address families are supported.
@@ -209,7 +204,7 @@ endif::ibm-cloud[]
 ifdef::vsphere[]
 [NOTE]
 ====
-On VMware vSphere, dual-stack networking can specify either IPv4 or IPv6 as the primary address family.
+On {vmw-first}, dual-stack networking can specify either IPv4 or IPv6 as the primary address family.
 ====
 endif::vsphere[]
 
@@ -220,7 +215,7 @@ If you configure your cluster to use both IP address families, review the follow
 * Both IP families must have the default gateway.
 
 * You must specify IPv4 and IPv6 addresses in the same order for all network configuration parameters. For example, in the following configuration IPv4 addresses are listed before IPv6 addresses.
-
++
 [source,yaml]
 ----
 networking:
@@ -233,12 +228,14 @@ networking:
   - 172.30.0.0/16
   - fd00:172:16::/112
 ----
-endif::agent,bare,ibm-power,ibm-z,vsphere[]
+endif::agent,bare,ibm-power,ibm-z,vsphere,osp[]
 
+ifdef::osp[]
 [NOTE]
 ====
-Globalnet is not supported with {rh-storage-first} disaster recovery solutions. For regional disaster recovery scenarios, ensure that you use a nonoverlapping range of private IP addresses for the cluster and service networks in each cluster.
+Globalnet is not supported with {rh-storage-first} disaster recovery solutions. For regional disaster recovery scenarios, ensure that you use a non-overlapping range of private IP addresses for the cluster and service networks in each cluster.
 ====
+endif::osp[]
 
 .Network parameters
 [cols=".^2l,.^3a,.^3a",options="header"]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-12045](https://issues.redhat.com/browse/OSDOCS-12045)

Link to docs preview:
* [Network configuration parameters - OpenStack](https://82822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installation-config-parameters-openstack#installation-configuration-parameters-network_installation-config-parameters-openstack)
* [Network configuration parameters - vSphere](https://82822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-network_installation-config-parameters-vsphere)

- [x] SME has approved this change.
- [x] QE has approved this change (itbrown).

Add. resources:
* https://github.com/openshift/openshift-docs/pull/79422
* [GitLab example](https://gitlab.cee.redhat.com/itzikb/rfes/-/blob/master/ipv6-dualstack/install-config.yaml?ref_type=heads)

