### PR TITLE
[OCPBUGS-42690]Added $ before the start of the comment

### DIFF
--- a/modules/dr-hosted-cluster-within-aws-region-restore.adoc
+++ b/modules/dr-hosted-cluster-within-aws-region-restore.adoc
@@ -123,7 +123,7 @@ fi
 +
 [source,terminal]
 ----
-oc apply -f ${BACKUP_DIR}/namespaces/${HC_CLUSTER_NS}/np-*
+$ oc apply -f ${BACKUP_DIR}/namespaces/${HC_CLUSTER_NS}/np-*
 ----
 
 .Verification

--- a/modules/dr-hosted-cluster-within-aws-region-restore.adoc
+++ b/modules/dr-hosted-cluster-within-aws-region-restore.adoc
@@ -24,8 +24,8 @@ Ensure that the `kubeconfig` file of the destination management cluster is place
 [source,terminal]
 ----
 # Just in case
-export KUBECONFIG=${MGMT2_KUBECONFIG}
-BACKUP_DIR=${HC_CLUSTER_DIR}/backup
+$ export KUBECONFIG=${MGMT2_KUBECONFIG}
+$ BACKUP_DIR=${HC_CLUSTER_DIR}/backup
 
 # Namespace deletion in the destination Management cluster
 $ oc delete ns ${HC_CLUSTER_NS} || true


### PR DESCRIPTION
Added $ at the stating of the comment to make whole document in sequence.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14, 4.15, 4.15, 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-42690

Link to docs preview:
[Restoring a hosted cluster -- Step 7](https://82833--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-aws.html#dr-hosted-cluster-within-aws-region-restore_hcp-disaster-recovery-aws)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
