### PR TITLE
OSDOCS#11850: migrating disconnected OLM content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -127,6 +127,9 @@ Topics:
       File: installing-mirroring-disconnected
     - Name: Mirroring images for a disconnected installation using oc-mirror plugin v2
       File: about-installing-oc-mirror-v2
+- Name: Using OLM in disconnected environments
+  File: using-olm
+  Distros: openshift-origin,openshift-enterprise
 - Name: Updating a cluster in a disconnected environment
   Dir: updating
   Topics:
@@ -1890,7 +1893,7 @@ Topics:
   - Name: Managing custom catalogs
     File: olm-managing-custom-catalogs
     Distros: openshift-origin,openshift-enterprise
-  - Name: Using OLM on restricted networks
+  - Name: Using OLM in disconnected environments
     File: olm-restricted-networks
     Distros: openshift-origin,openshift-enterprise
   - Name: Catalog source pod scheduling

--- a/backup_and_restore/application_backup_and_restore/aws-sts/oadp-aws-sts.adoc
+++ b/backup_and_restore/application_backup_and_restore/aws-sts/oadp-aws-sts.adoc
@@ -12,7 +12,7 @@ include::snippets/oadp-mtc-operator.adoc[]
 
 You configure {aws-short} for Velero, create a default `Secret`, and then install the Data Protection Application. For more details, see xref:../../..//backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
 
-To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.
+To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
 
 You can install {oadp-short} on an AWS {sts-first} (AWS STS) cluster manually. Amazon {aws-short} provides {aws-short} STS as a web service that enables you to request temporary, limited-privilege credentials for users. You use STS to provide trusted users with temporary access to resources via API calls, your {aws-short} console, or the {aws-short} command line interface (CLI).
 

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -17,7 +17,7 @@ include::snippets/oadp-mtc-operator.adoc[]
 
 You configure AWS for Velero, create a default `Secret`, and then install the Data Protection Application. For more details, see xref:../../..//backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
 
-To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.
+To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
 
 
 //include::modules/oadp-installing-operator.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
@@ -15,7 +15,7 @@ include::snippets/oadp-mtc-operator.adoc[]
 
 You configure Azure for Velero, create a default `Secret`, and then install the Data Protection Application. For more details, see xref:../../..//backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
 
-To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.
+To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
 
 // include::modules/oadp-installing-operator.adoc[leveloffset=+1]
 include::modules/migration-configuring-azure.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
@@ -15,7 +15,7 @@ include::snippets/oadp-mtc-operator.adoc[]
 
 You configure GCP for Velero, create a default `Secret`, and then install the Data Protection Application. For more details, see xref:../../..//backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
 
-To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.
+To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
 
 //include::modules/oadp-installing-operator.adoc[leveloffset=+1]
 include::modules/migration-configuring-gcp.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
@@ -30,7 +30,7 @@ The following storage options are excluded:
 
 For more information, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic].
 ====
-To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.
+To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
 
 include::modules/install-and-configure-oadp-kubevirt.adoc[leveloffset=+1]
 
@@ -40,7 +40,7 @@ include::modules/install-and-configure-oadp-kubevirt.adoc[leveloffset=+1]
 * xref:../../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[{oadp-short} plugins]
 * xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[`Backup` custom resource (CR)]
 * xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#restoring-applications[`Restore` CR]
-* xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+* xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
@@ -22,7 +22,7 @@ include::snippets/technology-preview.adoc[]
 
 You create a `Secret` for the backup location and then you install the Data Protection Application. For more details, see xref:../../..//backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
 
-To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. For details, see xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. For details, see xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].
 
 //include::modules/oadp-installing-operator.adoc[leveloffset=+1]
 include::modules/migration-configuring-mcg.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -20,7 +20,7 @@ include::snippets/technology-preview.adoc[]
 
 You create a `Secret` for the backup location and then you install the Data Protection Application. For more details, see xref:../../..//backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
 
-To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. For details, see xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. For details, see xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].
 
 //include::modules/oadp-installing-operator.adoc[leveloffset=+1]
 include::modules/oadp-about-backup-snapshot-locations-secrets.adoc[leveloffset=+1]

--- a/disconnected/connected-to-disconnected.adoc
+++ b/disconnected/connected-to-disconnected.adoc
@@ -46,7 +46,7 @@ include::modules/connected-to-disconnected-mirror-images.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about mirroring Operator catalogs, see xref:../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog].
+* For more information about mirroring Operator catalogs, see xref:../disconnected/using-olm.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog].
 * For more information about the `oc adm catalog mirror` command, see the xref:../cli_reference/openshift_cli/administrator-cli-commands.adoc#oc-adm-catalog-mirror[OpenShift CLI administrator command reference].
 
 include::modules/connected-to-disconnected-config-registry.adoc[leveloffset=+1]

--- a/disconnected/mirroring/installing-mirroring-installation-images.adoc
+++ b/disconnected/mirroring/installing-mirroring-installation-images.adoc
@@ -85,7 +85,7 @@ include::modules/olm-mirroring-catalog.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 
 [id="olm-mirror-catalog-prerequisites_installing-mirroring-installation-images"]
 === Prerequisites

--- a/disconnected/updating/disconnected-update-osus.adoc
+++ b/disconnected/updating/disconnected-update-osus.adoc
@@ -73,7 +73,7 @@ To install the OpenShift Update Service, you must first install the OpenShift Up
 
 [NOTE]
 ====
-For clusters that are installed in disconnected environments, also known as disconnected clusters, Operator Lifecycle Manager by default cannot access the Red Hat-provided OperatorHub sources hosted on remote registries because those remote sources require full internet connectivity. For more information, see xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+For clusters that are installed in disconnected environments, also known as disconnected clusters, Operator Lifecycle Manager by default cannot access the Red Hat-provided OperatorHub sources hosted on remote registries because those remote sources require full internet connectivity. For more information, see xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].
 ====
 
 // Installing the OpenShift Update Service Operator by using the web console
@@ -134,7 +134,7 @@ The Cluster Version Operator (CVO) uses release image signatures to ensure that 
 [NOTE]
 ====
 If you have not recently installed or updated the OpenShift Update Service Operator, there might be a more recent version available.
-See xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for more information about how to update your OLM catalog in a disconnected environment.
+See xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for more information about how to update your OLM catalog in a disconnected environment.
 ====
 
 After you configure your cluster to use the installed OpenShift Update Service and local mirror registry, you can use any of the following update methods:

--- a/disconnected/updating/disconnected-update.adoc
+++ b/disconnected/updating/disconnected-update.adoc
@@ -61,6 +61,6 @@ include::modules/generating-icsp-object-scoped-to-a-registry.adoc[leveloffset=+1
 [role="_additional-resources"]
 == Additional resources
 
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 
 * xref:../../machine_configuration/index.adoc#machine-config-overview[Machine Config Overview]

--- a/disconnected/using-olm.adoc
+++ b/disconnected/using-olm.adoc
@@ -1,0 +1,79 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="olm-restricted-networks"]
+= Using Operator Lifecycle Manager in disconnected environments
+include::_attributes/common-attributes.adoc[]
+:context: olm-restricted-networks
+
+toc::[]
+
+For {product-title} clusters in disconnected environments, Operator Lifecycle Manager (OLM) by default cannot access the Red{nbsp}Hat-provided OperatorHub sources hosted on remote registries because those remote sources require full internet connectivity.
+
+However, as a cluster administrator you can still enable your cluster to use OLM in a disconnected environment if you have a workstation that has full internet access. The workstation, which requires full internet access to pull the remote OperatorHub content, is used to prepare local mirrors of the remote sources, and push the content to a mirror registry.
+
+The mirror registry can be located on a bastion host, which requires connectivity to both your workstation and the disconnected cluster, or a completely disconnected, or _airgapped_, host, which requires removable media to physically move the mirrored content to the disconnected environment.
+
+This guide describes the following process that is required to enable OLM in disconnected environments:
+
+* Disable the default remote OperatorHub sources for OLM.
+* Use a workstation with full internet access to create and push local mirrors of the OperatorHub content to a mirror registry.
+* Configure OLM to install and manage Operators from local sources on the mirror registry instead of the default remote sources.
+
+After enabling OLM in a disconnected environment, you can continue to use your unrestricted workstation to keep your local OperatorHub sources updated as newer versions of Operators are released.
+
+[IMPORTANT]
+====
+While OLM can manage Operators from local sources, the ability for a given Operator to run successfully in a disconnected environment still depends on the Operator itself meeting the following criteria:
+
+* List any related images, or other container images that the Operator might require to perform their functions, in the `relatedImages` parameter of its `ClusterServiceVersion` (CSV) object.
+* Reference all specified images by a digest (SHA) and not by a tag.
+
+You can search software on the link:https://catalog.redhat.com/software/search?p=1&deployed_as=Operator&type=Containerized%20application&badges_and_features=Disconnected[Red{nbsp}Hat Ecosystem Catalog] for a list of Red{nbsp}Hat Operators that support running in disconnected mode by filtering with the following selections:
+
+[horizontal]
+Type:: Containerized application
+Deployment method:: Operator
+Infrastructure features:: Disconnected
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red{nbsp}Hat-provided Operator catalogs]
+* xref:../operators/operator_sdk/osdk-generating-csvs.adoc#olm-enabling-operator-for-restricted-network_osdk-generating-csvs[Enabling your Operator for restricted network environments]
+
+[id="olm-restricted-network-prereqs"]
+== Prerequisites
+
+* You are logged in to your {product-title} cluster as a user with `cluster-admin` privileges.
+
+* If you are using OLM in a disconnected environment on {ibm-z-name}, you must have at least 12 GB allocated to the directory where you place your registry.
+
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+
+[id="olm-mirror-catalog_olm-restricted-networks"]
+== Mirroring an Operator catalog
+
+For instructions about mirroring Operator catalogs for use with disconnected clusters, see xref:../disconnected/mirroring/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters].
+
+[IMPORTANT]
+====
+As of {product-title} 4.11, the default Red{nbsp}Hat-provided Operator catalog releases in the file-based catalog format. The default Red{nbsp}Hat-provided Operator catalogs for {product-title} 4.6 through 4.10 released in the deprecated SQLite database format.
+
+The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
+
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format], xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs], and xref:../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+====
+
+include::modules/olm-creating-catalog-from-index.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries]
+* xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource-image-template_olm-understanding-olm[Image template for custom catalog sources]
+* xref:../openshift_images/managing_images/image-pull-policy.adoc#image-pull-policy[Image pull policy]
+
+[id="next-steps_olm-restricted-networks"]
+== Next steps
+
+* xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators]

--- a/edge_computing/ztp-preparing-the-hub-cluster.adoc
+++ b/edge_computing/ztp-preparing-the-hub-cluster.adoc
@@ -26,7 +26,7 @@ include::modules/ztp-acm-installing-disconnected-rhacm.adoc[leveloffset=+1]
 
 * xref:../edge_computing/cnf-talm-for-cluster-upgrades.adoc#installing-topology-aware-lifecycle-manager-using-cli_cnf-topology-aware-lifecycle-manager[Installing {cgu-operator}]
 
-* xref:../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog]
+* xref:../disconnected/using-olm.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog]
 
 include::modules/ztp-acm-adding-images-to-mirror-registry.adoc[leveloffset=+1]
 

--- a/extensions/catalogs/creating-catalogs.adoc
+++ b/extensions/catalogs/creating-catalogs.adoc
@@ -29,5 +29,5 @@ ifndef::openshift-dedicated,openshift-rosa[]
 
 * xref:../../operators/understanding/olm-packaging-format.adoc#olm-deprecations-schema_olm-packaging-format[Packaging format -> Schemas -> olm.deprecations schema]
 * xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#updating-mirror-registry-content[Mirroring images for a disconnected installation using the oc-mirror plugin -> Keeping your mirror registry content updated]
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-creating-catalog-from-index_olm-restricted-networks[Adding a catalog source to a cluster]
+* xref:../../disconnected/using-olm.adoc#olm-creating-catalog-from-index_olm-restricted-networks[Adding a catalog source to a cluster]
 endif::openshift-dedicated,openshift-rosa[]

--- a/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -109,6 +109,6 @@ include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffse
 * xref:../../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validate an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
@@ -180,7 +180,7 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validate an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * If necessary, see xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -246,7 +246,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -114,7 +114,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validate an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -150,7 +150,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Use Operator Lifecycle Manager in disconnected environments].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -71,5 +71,5 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
 * If you did not configure {rh-openstack} to accept application traffic over floating IP addresses, xref:../../installing/installing_openstack/installing-openstack-network-config.adoc#installation-osp-configuring-api-floating-ip_installing-openstack-network-config[configure {rh-openstack} access with floating IP addresses].

--- a/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
@@ -151,7 +151,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
-* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../disconnected/using-olm.adoc#olm-restricted-networks[use Operator Lifecycle Manager in disconnected environments].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 You can install the {mtc-full} ({mtc-short}) on {product-title} 3 and 4 in a restricted network environment by performing the following procedures:
 
-. Create a xref:../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[mirrored Operator catalog].
+. Create a xref:../disconnected/using-olm.adoc#olm-mirror-catalog_olm-restricted-networks[mirrored Operator catalog].
 +
 This process creates a `mapping.txt` file, which contains the mapping between the `registry.redhat.io` image and your mirror registry image. The `mapping.txt` file is required for installing the Operator on the source cluster.
 . Install the {mtc-full} Operator on the {product-title} {product-version} target cluster by using Operator Lifecycle Manager.

--- a/migration_toolkit_for_containers/installing-mtc-restricted.adoc
+++ b/migration_toolkit_for_containers/installing-mtc-restricted.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 You can install the {mtc-full} ({mtc-short}) on {product-title} 4 in a restricted network environment by performing the following procedures:
 
-. Create a xref:../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[mirrored Operator catalog].
+. Create a xref:../disconnected/using-olm.adoc#olm-mirror-catalog_olm-restricted-networks[mirrored Operator catalog].
 +
 This process creates a `mapping.txt` file, which contains the mapping between the `registry.redhat.io` image and your mirror registry image. The `mapping.txt` file is required for installing the _legacy_ {mtc-full} Operator on an {product-title} 4.2 to 4.5 source cluster.
 . Install the {mtc-full} Operator on the {product-title} {product-version} target cluster by using Operator Lifecycle Manager.

--- a/nodes/nodes/ecosystems/eco-node-health-check-operator.adoc
+++ b/nodes/nodes/ecosystems/eco-node-health-check-operator.adoc
@@ -30,4 +30,4 @@ To collect debugging information about the Node Health Check Operator, use the `
 [id="additional-resources-nhc-operator-installation"]
 == Additional resources
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Changing the update channel for an Operator]
-* xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+* xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].

--- a/nodes/nodes/ecosystems/eco-node-maintenance-operator.adoc
+++ b/nodes/nodes/ecosystems/eco-node-maintenance-operator.adoc
@@ -23,7 +23,7 @@ include::modules/eco-node-maintenance-operator-installation-web-console.adoc[lev
 
 include::modules/eco-node-maintenance-operator-installation-cli.adoc[leveloffset=+2]
 
-The Node Maintenance Operator is supported in a restricted network environment. For more information, see xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+The Node Maintenance Operator is supported in a restricted network environment. For more information, see xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].
 
 [id="setting-node-in-maintenance-mode"]
 == Setting a node to maintenance mode

--- a/nodes/nodes/ecosystems/eco-self-node-remediation-operator.adoc
+++ b/nodes/nodes/ecosystems/eco-self-node-remediation-operator.adoc
@@ -33,5 +33,5 @@ To collect debugging information about the Self Node Remediation Operator, use t
 
 [id="additional-resources-self-node-remediation-operator-installation"]
 == Additional resources
-* xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+* xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].
 * xref:../../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]

--- a/operators/admin/olm-cs-podsched.adoc
+++ b/operators/admin/olm-cs-podsched.adoc
@@ -34,7 +34,7 @@ include::modules/disabling-catalogsource-objects.adoc[leveloffset=+1]
 * xref:../../operators/understanding/olm-understanding-operatorhub.adoc#olm-operatorhub-arch-operatorhub_crd_olm-understanding-operatorhub[OperatorHub custom resource]
 
 ifndef::openshift-dedicated,openshift-rosa[]
-* xref:../../operators/admin/olm-restricted-networks.html#olm-restricted-networks-operatorhub_olm-restricted-networks[Disabling the default OperatorHub catalog sources]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks-operatorhub_olm-restricted-networks[Disabling the default OperatorHub catalog sources]
 endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-node-selector.adoc[leveloffset=+1]
@@ -53,7 +53,7 @@ include::modules/olm-priority-class-name.adoc[leveloffset=+1]
 
 include::modules/olm-tolerations.adoc[leveloffset=+1]
 
-// The following xref points to a topic that is not included in the OSD or 
+// The following xref points to a topic that is not included in the OSD or
 // ROSA docs.
 ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -64,7 +64,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 
 * xref:../../operators/understanding/olm-packaging-format.adoc#olm-deprecations-schema_olm-packaging-format[Packaging format -> Schemas -> olm.deprecations schema]
 * xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#updating-mirror-registry-content[Mirroring images for a disconnected installation using the oc-mirror plugin -> Keeping your mirror registry content updated]
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-creating-catalog-from-index_olm-restricted-networks[Adding a catalog source to a cluster]
+* xref:../../disconnected/using-olm.adoc#olm-creating-catalog-from-index_olm-restricted-networks[Adding a catalog source to a cluster]
 endif::openshift-dedicated,openshift-rosa[]
 
 [id="olm-managing-custom-catalogs-sqlite"]

--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -1,82 +1,23 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="olm-restricted-networks"]
-= Using Operator Lifecycle Manager on restricted networks
+= Using Operator Lifecycle Manager in disconnected environments
 include::_attributes/common-attributes.adoc[]
 :context: olm-restricted-networks
 
 toc::[]
 
-For {product-title} clusters that are installed on restricted networks, also known as _disconnected clusters_, Operator Lifecycle Manager (OLM) by default cannot access the Red{nbsp}Hat-provided OperatorHub sources hosted on remote registries because those remote sources require full internet connectivity.
+For {product-title} clusters in disconnected environments, Operator Lifecycle Manager (OLM) by default cannot access the Red{nbsp}Hat-provided OperatorHub sources hosted on remote registries because those remote sources require full internet connectivity.
 
-However, as a cluster administrator you can still enable your cluster to use OLM in a restricted network if you have a workstation that has full internet access. The workstation, which requires full internet access to pull the remote OperatorHub content, is used to prepare local mirrors of the remote sources, and push the content to a mirror registry.
+However, as a cluster administrator you can still enable your cluster to use OLM in a disconnected environment if you have a workstation that has full internet access. The workstation, which requires full internet access to pull the remote OperatorHub content, is used to prepare local mirrors of the remote sources, and push the content to a mirror registry.
 
 The mirror registry can be located on a bastion host, which requires connectivity to both your workstation and the disconnected cluster, or a completely disconnected, or _airgapped_, host, which requires removable media to physically move the mirrored content to the disconnected environment.
 
-This guide describes the following process that is required to enable OLM in restricted networks:
+This guide describes the following process that is required to enable OLM in disconnected environments:
 
 * Disable the default remote OperatorHub sources for OLM.
 * Use a workstation with full internet access to create and push local mirrors of the OperatorHub content to a mirror registry.
 * Configure OLM to install and manage Operators from local sources on the mirror registry instead of the default remote sources.
 
-After enabling OLM in a restricted network, you can continue to use your unrestricted workstation to keep your local OperatorHub sources updated as newer versions of Operators are released.
+After enabling OLM in a disconnected environment, you can continue to use your unrestricted workstation to keep your local OperatorHub sources updated as newer versions of Operators are released.
 
-[IMPORTANT]
-====
-While OLM can manage Operators from local sources, the ability for a given Operator to run successfully in a restricted network still depends on the Operator itself meeting the following criteria:
-
-* List any related images, or other container images that the Operator might require to perform their functions, in the `relatedImages` parameter of its `ClusterServiceVersion` (CSV) object.
-* Reference all specified images by a digest (SHA) and not by a tag.
-
-You can search software on the link:https://catalog.redhat.com/software/search?p=1&deployed_as=Operator&type=Containerized%20application&badges_and_features=Disconnected[Red{nbsp}Hat Ecosystem Catalog] for a list of Red{nbsp}Hat Operators that support running in disconnected mode by filtering with the following selections:
-
-[horizontal]
-Type:: Containerized application
-Deployment method:: Operator
-Infrastructure features:: Disconnected
-====
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red{nbsp}Hat-provided Operator catalogs]
-* xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#olm-enabling-operator-for-restricted-network_osdk-generating-csvs[Enabling your Operator for restricted network environments]
-
-[id="olm-restricted-network-prereqs"]
-== Prerequisites
-
-* Log in to your {product-title} cluster as a user with `cluster-admin` privileges.
-
-[NOTE]
-====
-If you are using OLM in a restricted network on {ibm-z-name}, you must have at least 12 GB allocated to the directory where you place your registry.
-====
-
-include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
-
-[id="olm-mirror-catalog_olm-restricted-networks"]
-== Mirroring an Operator catalog
-
-For instructions about mirroring Operator catalogs for use with disconnected clusters, see xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#olm-mirroring-catalog_installing-mirroring-installation-images[Installing -> Mirroring images for a disconnected installation].
-
-[IMPORTANT]
-====
-As of {product-title} 4.11, the default Red{nbsp}Hat-provided Operator catalog releases in the file-based catalog format. The default Red{nbsp}Hat-provided Operator catalogs for {product-title} 4.6 through 4.10 released in the deprecated SQLite database format.
-
-The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
-
-Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format], xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs], and xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
-====
-
-include::modules/olm-creating-catalog-from-index.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries]
-* xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource-image-template_olm-understanding-olm[Image template for custom catalog sources]
-* xref:../../openshift_images/managing_images/image-pull-policy.adoc#image-pull-policy[Image pull policy]
-
-[id="next-steps_olm-restricted-networks"]
-== Next steps
-
-* xref:../../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators]
+For more information, see xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] in the Disconnected environments section.

--- a/operators/admin/olm-upgrading-operators.adoc
+++ b/operators/admin/olm-upgrading-operators.adoc
@@ -29,5 +29,5 @@ ifndef::openshift-dedicated,openshift-rosa[]
 [id="additional-resources_olm-upgrading-operators"]
 == Additional resources
 
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 endif::openshift-dedicated,openshift-rosa[]

--- a/operators/index.adoc
+++ b/operators/index.adoc
@@ -64,7 +64,9 @@ endif::openshift-dedicated,openshift-rosa[]
 ** xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Delete installed Operators].
 ** xref:../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configure proxy support].
 ifndef::openshift-dedicated,openshift-rosa[]
-** xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Use Operator Lifecycle Manager on restricted networks].
+** xref:../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].
+
+// Not sure if the xref above should be changed in #82841 since this is the index page of the Operators section
 
 To know all about the cluster Operators that Red Hat provides, see xref:../operators/operator-reference.adoc#cluster-operators-ref[Cluster Operators reference].
 endif::openshift-dedicated,openshift-rosa[]

--- a/operators/understanding/olm-rh-catalogs.adoc
+++ b/operators/understanding/olm-rh-catalogs.adoc
@@ -33,7 +33,7 @@ include::modules/olm-about-catalogs.adoc[leveloffset=+1]
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs]
 * xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Packaging format]
 ifndef::openshift-dedicated,openshift-rosa[]
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-rh-catalogs.adoc[leveloffset=+1]

--- a/security/compliance_operator/co-management/compliance-operator-installation.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-installation.adoc
@@ -54,4 +54,4 @@ include::modules/compliance-operator-hcp-install.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* The Compliance Operator is supported in a restricted network environment. For more information, see xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+* The Compliance Operator is supported in a restricted network environment. For more information, see xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].

--- a/security/compliance_operator/co-management/compliance-operator-manage.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-manage.adoc
@@ -16,4 +16,4 @@ include::modules/compliance-update.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* The Compliance Operator is supported in a restricted network environment. For more information, see xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+* The Compliance Operator is supported in a restricted network environment. For more information, see xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].

--- a/security/file_integrity_operator/file-integrity-operator-installation.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-installation.adoc
@@ -15,4 +15,4 @@ include::modules/file-integrity-operator-installing-cli.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* The File Integrity Operator is supported in a restricted network environment. For more information, see xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+* The File Integrity Operator is supported in a restricted network environment. For more information, see xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].

--- a/serverless/install/preparing-serverless-install.adoc
+++ b/serverless/install/preparing-serverless-install.adoc
@@ -60,7 +60,7 @@ endif::[]
 [role="_additional-resources"]
 == Additional resources
 ifdef::openshift-enterprise[]
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 * xref:../../operators/understanding/olm-understanding-operatorhub.adoc#olm-operatorhub-overview[Understanding OperatorHub]
 * xref:../../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
 endif::[]

--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -49,7 +49,7 @@ endif::openshift-rosa,openshift-dedicated[]
 To install the {oadp-short} Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog.
 
 ifndef::openshift-rosa,openshift-dedicated[]
-See xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.
+See xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
 endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/install-and-configure-oadp-kubevirt.adoc[leveloffset=+1]
@@ -61,7 +61,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[{oadp-short} plugins]
 * xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[`Backup` custom resource (CR)]
 * xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#restoring-applications[`Restore` CR]
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]

--- a/virt/install/installing-virt.adoc
+++ b/virt/install/installing-virt.adoc
@@ -11,7 +11,7 @@ Install {VirtProductName} to add virtualization functionality to your {product-t
 ifndef::openshift-rosa,openshift-dedicated[]
 [IMPORTANT]
 ====
-If you install {VirtProductName} in a restricted environment with no internet connectivity, you must xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[configure Operator Lifecycle Manager (OLM) for restricted networks].
+If you install {VirtProductName} in a restricted environment with no internet connectivity, you must xref:../../disconnected/using-olm.adoc#olm-restricted-networks[configure Operator Lifecycle Manager for disconnected environments].
 
 If you have limited internet connectivity, you can xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in OLM] to access the OperatorHub.
 ====


### PR DESCRIPTION
[OSDOCS-11850](https://issues.redhat.com/browse/OSDOCS-11850)

Version(s):
4.17+

This PR moves the assembly for using OLM in a disconnected environment to a new section dedicated to disconnected environments.

QE review:
- [x] QE has approved this change.

Previews:

- NEW [Using OLM in disconnected environments](https://82841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/using-olm)
- STUB [Using OLM in disconnected environments](https://82841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks)