### PR TITLE
[OCPBUGS-42690]Added $ before the start of the comment in `Deleting a hosted cluster from your source management cluster` procedure 

### DIFF
--- a/modules/dr-hosted-cluster-within-aws-region-delete.adoc
+++ b/modules/dr-hosted-cluster-within-aws-region-delete.adoc
@@ -31,12 +31,12 @@ As a workaround, update the value of the `spec.persistentVolumeClaimRetentionPol
 [source,terminal]
 ----
 # Just in case
-export KUBECONFIG=${MGMT_KUBECONFIG}
+$ export KUBECONFIG=${MGMT_KUBECONFIG}
 
 # Scale down deployments
-oc scale deployment -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --replicas=0 --all
-oc scale statefulset.apps -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --replicas=0 --all
-sleep 15
+$ oc scale deployment -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --replicas=0 --all
+$ oc scale statefulset.apps -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --replicas=0 --all
+$ sleep 15
 ----
 
 . Delete the `NodePool` objects by entering these commands:
@@ -60,7 +60,7 @@ for m in $(oc get machines -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} -o name); do
     oc delete -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} ${m} || true
 done
 
-oc delete machineset -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --all || true
+$ oc delete machineset -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --all || true
 ----
 
 . Delete the cluster object by entering these commands:
@@ -68,9 +68,9 @@ oc delete machineset -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --all || true
 [source,terminal]
 ----
 # Cluster
-C_NAME=$(oc get cluster -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} -o name)
-oc patch -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} ${C_NAME} --type=json --patch='[ { "op":"remove", "path": "/metadata/finalizers" }]'
-oc delete cluster.cluster.x-k8s.io -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --all
+$ C_NAME=$(oc get cluster -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} -o name)
+$ oc patch -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} ${C_NAME} --type=json --patch='[ { "op":"remove", "path": "/metadata/finalizers" }]'
+$ oc delete cluster.cluster.x-k8s.io -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --all
 ----
 
 . Delete the AWS machines (Kubernetes objects) by entering these commands. Do not worry about deleting the real AWS machines. The cloud instances will not be affected.
@@ -90,9 +90,9 @@ done
 [source,terminal]
 ----
 # Delete HCP and ControlPlane HC NS
-oc patch -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} hostedcontrolplane.hypershift.openshift.io ${HC_CLUSTER_NAME} --type=json --patch='[ { "op":"remove", "path": "/metadata/finalizers" }]'
-oc delete hostedcontrolplane.hypershift.openshift.io -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --all
-oc delete ns ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} || true
+$ oc patch -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} hostedcontrolplane.hypershift.openshift.io ${HC_CLUSTER_NAME} --type=json --patch='[ { "op":"remove", "path": "/metadata/finalizers" }]'
+$ oc delete hostedcontrolplane.hypershift.openshift.io -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --all
+$ oc delete ns ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} || true
 ----
 
 . Delete the `HostedCluster` and HC namespace objects by entering these commands:
@@ -100,9 +100,9 @@ oc delete ns ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} || true
 [source,terminal]
 ----
 # Delete HC and HC Namespace
-oc -n ${HC_CLUSTER_NS} patch hostedclusters ${HC_CLUSTER_NAME} -p '{"metadata":{"finalizers":null}}' --type merge || true
-oc delete hc -n ${HC_CLUSTER_NS} ${HC_CLUSTER_NAME}  || true
-oc delete ns ${HC_CLUSTER_NS} || true
+$ oc -n ${HC_CLUSTER_NS} patch hostedclusters ${HC_CLUSTER_NAME} -p '{"metadata":{"finalizers":null}}' --type merge || true
+$ oc delete hc -n ${HC_CLUSTER_NS} ${HC_CLUSTER_NAME}  || true
+$ oc delete ns ${HC_CLUSTER_NS} || true
 ----
 
 .Verification
@@ -112,17 +112,17 @@ oc delete ns ${HC_CLUSTER_NS} || true
 [source,terminal]
 ----
 # Validations
-export KUBECONFIG=${MGMT2_KUBECONFIG}
+$ export KUBECONFIG=${MGMT2_KUBECONFIG}
 
-oc get hc -n ${HC_CLUSTER_NS}
-oc get np -n ${HC_CLUSTER_NS}
-oc get pod -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME}
-oc get machines -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME}
+$ oc get hc -n ${HC_CLUSTER_NS}
+$ oc get np -n ${HC_CLUSTER_NS}
+$ oc get pod -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME}
+$ oc get machines -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME}
 
 # Inside the HostedCluster
-export KUBECONFIG=${HC_KUBECONFIG}
-oc get clusterversion
-oc get nodes
+$ export KUBECONFIG=${HC_KUBECONFIG}
+$ oc get clusterversion
+$ oc get nodes
 ----
 
 .Next steps


### PR DESCRIPTION
[OCPBUGS-42690]Added $ before the start of the comment

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.17, 4.16, 4.15,4.14
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-42690

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://82857--ocpdocs-pr.netlify.app/
https://82857--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-aws.html
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
