### PR TITLE
OSDOCS-12052: Updated the network troubleshooting docs by adding info…

### DIFF
--- a/modules/virt-troubleshooting-incorrect-policy-config.adoc
+++ b/modules/virt-troubleshooting-incorrect-policy-config.adoc
@@ -6,16 +6,19 @@
 [id="virt-troubleshooting-incorrect-policy-config_{context}"]
 = Troubleshooting an incorrect node network configuration policy configuration
 
-You can apply changes to the node network configuration across your entire cluster by applying a node network configuration policy.
-If you apply an incorrect configuration, you can use the following example to troubleshoot and correct the failed node network policy.
+You can apply changes to the node network configuration across your entire cluster by applying a node network configuration policy. 
 
-In this example, a Linux bridge policy is applied to an example cluster that has three control plane nodes and three compute nodes.
-The policy fails to be applied because it references an incorrect interface.
-To find the error, investigate the available NMState resources. You can then update the policy with the correct configuration.
+If you applied an incorrect configuration, you can use the following example to troubleshoot and correct the failed node network policy. The example attempts to apply a Linux bridge policy to a cluster that has three control plane nodes and three compute nodes. The policy is not applied because the policy references the wrong interface. 
+
+To find an error, you need to investigate the available NMState resources. You can then update the policy with the correct configuration.
+
+.Prerequisites
+
+* You ensured that an `ens01` interface does not exist on your Linux system.
 
 .Procedure
 
-. Create a policy and apply it to your cluster. The following example creates a simple bridge on the `ens01` interface:
+. Create a policy on your cluster. The following example creates a simple bridge, `br1` that has `ens01` as its member:
 +
 [source,yaml]
 ----
@@ -39,7 +42,10 @@ spec:
               enabled: false
           port:
             - name: ens01
+# ...
 ----
+
+. Apply the policy to your network interface:
 +
 [source,terminal]
 ----
@@ -68,9 +74,9 @@ NAME                    STATUS
 ens01-bridge-testfail   FailedToConfigure
 ----
 +
-However, the policy status alone does not indicate if it failed on all nodes or a subset of nodes.
+The policy status alone does not indicate if it failed on all nodes or a subset of nodes.
 
-. List the node network configuration enactments to see if the policy was successful on any of the nodes. If the policy failed for only a subset of nodes, it suggests that the problem is with a specific node configuration. If the policy failed on all nodes, it suggests that the problem is with the policy.
+. List the node network configuration enactments to see if the policy was successful on any of the nodes. If the policy failed for only a subset of nodes, the output suggests that the problem is with a specific node configuration. If the policy failed on all nodes, the output suggests that the problem is with the policy.
 +
 [source,terminal]
 ----
@@ -91,102 +97,21 @@ compute-2.ens01-bridge-testfail              FailedToConfigure
 compute-3.ens01-bridge-testfail              FailedToConfigure
 ----
 
-. View one of the failed enactments and look at the traceback. The following command uses the output tool `jsonpath` to filter the output:
+. View one of the failed enactments. The following command uses the output tool `jsonpath` to filter the output:
 +
 [source,terminal]
 ----
 $ oc get nnce compute-1.ens01-bridge-testfail -o jsonpath='{.status.conditions[?(@.type=="Failing")].message}'
 ----
 +
-This command returns a large traceback that has been edited for brevity:
-+
 .Example output
 [source,terminal]
 ----
-error reconciling NodeNetworkConfigurationPolicy at desired state apply: , failed to execute nmstatectl set --no-commit --timeout 480: 'exit status 1' ''
-...
-libnmstate.error.NmstateVerificationError:
-desired
-=======
----
-name: br1
-type: linux-bridge
-state: up
-bridge:
-  options:
-    group-forward-mask: 0
-    mac-ageing-time: 300
-    multicast-snooping: true
-    stp:
-      enabled: false
-      forward-delay: 15
-      hello-time: 2
-      max-age: 20
-      priority: 32768
-  port:
-  - name: ens01
-description: Linux bridge with the wrong port
-ipv4:
-  address: []
-  auto-dns: true
-  auto-gateway: true
-  auto-routes: true
-  dhcp: true
-  enabled: true
-ipv6:
-  enabled: false
-mac-address: 01-23-45-67-89-AB
-mtu: 1500
-
-current
-=======
----
-name: br1
-type: linux-bridge
-state: up
-bridge:
-  options:
-    group-forward-mask: 0
-    mac-ageing-time: 300
-    multicast-snooping: true
-    stp:
-      enabled: false
-      forward-delay: 15
-      hello-time: 2
-      max-age: 20
-      priority: 32768
-  port: []
-description: Linux bridge with the wrong port
-ipv4:
-  address: []
-  auto-dns: true
-  auto-gateway: true
-  auto-routes: true
-  dhcp: true
-  enabled: true
-ipv6:
-  enabled: false
-mac-address: 01-23-45-67-89-AB
-mtu: 1500
-
-difference
-==========
---- desired
-+++ current
-@@ -13,8 +13,7 @@
-       hello-time: 2
-       max-age: 20
-       priority: 32768
--  port:
--  - name: ens01
-+  port: []
- description: Linux bridge with the wrong port
- ipv4:
-   address: []
-  line 651, in _assert_interfaces_equal\n    current_state.interfaces[ifname],\nlibnmstate.error.NmstateVerificationError:
+[2024-10-10T08:40:46Z INFO  nmstatectl] Nmstate version: 2.2.37
+NmstateError: InvalidArgument: Controller interface br1 is holding unknown port ens01
 ----
 +
-The `NmstateVerificationError` lists the `desired` policy configuration, the `current` configuration of the policy on the node, and the `difference` highlighting the parameters that do not match. In this example, the `port` is included in the `difference`, which suggests that the problem is the port configuration in the policy.
+The previous example shows the output from an `InvalidArgument` error that indicates that the `ens01` is an unknown port. For this example, you might need to change the port configuration in the policy configuration file.
 
 . To ensure that the policy is configured properly, view the network configuration for one or all of the nodes by requesting the `NodeNetworkState` object. The following command returns the network configuration for the `control-plane-1` node:
 +
@@ -236,5 +161,5 @@ $ oc get nncp
 NAME                    STATUS
 ens01-bridge-testfail   SuccessfullyConfigured
 ----
-
++
 The updated policy is successfully configured on all nodes in the cluster.


### PR DESCRIPTION
Version(s):
4.13+ (Traceback logs are OK for 4.12, but not 4.13+)

Issue:
[OSDOCS-12052](https://issues.redhat.com/browse/OSDOCS-12052)

Link to docs preview:
* [Troubleshooting an incorrect node network configuration policy configuration](https://82858--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.html#virt-troubleshooting-incorrect-policy-config_k8s-nmstate-troubleshooting-node-network)


- [x] SME has approved this change.
- [x] QE has approved this change.

