### PR TITLE
TRACING-4614: add some extra explanation about using the OpenTelemetry Collector metrics for troubleshooting

### DIFF
--- a/modules/otel-troubleshoot-metrics.adoc
+++ b/modules/otel-troubleshoot-metrics.adoc
@@ -6,14 +6,25 @@
 [id="exposing-metrics_{context}"]
 = Exposing the metrics
 
-The OpenTelemetry Collector exposes the metrics about the data volumes it has processed. The following metrics are for spans, although similar metrics are exposed for metrics and logs signals:
-
+The OpenTelemetry Collector exposes the metrics about the data volumes it has processed:
 `otelcol_receiver_accepted_spans`:: The number of spans successfully pushed into the pipeline.
 
 `otelcol_receiver_refused_spans`:: The number of spans that could not be pushed into the pipeline.
 `otelcol_exporter_sent_spans`:: The number of spans successfully sent to the destination.
-
 `otelcol_exporter_enqueue_failed_spans`:: The number of spans failed to be added to the sending queue.
+`otelcol_receiver_accepted_logs`:: The number of logs successfully pushed into the pipeline.
+`otelcol_receiver_refused_logs`:: The number of logs that could not be pushed into the pipeline.
+`otelcol_exporter_sent_logs`:: The number of logs successfully sent to the destination.
+`otelcol_exporter_enqueue_failed_logs`:: The number of logs failed to be added to the sending queue.
+`otelcol_receiver_accepted_metrics`:: The number of metrics successfully pushed into the pipeline.
+`otelcol_receiver_refused_metrics`:: The number of metrics that could not be pushed into the pipeline.
+`otelcol_exporter_sent_metrics`:: The number of metrics successfully sent to the destination.
+`otelcol_exporter_enqueue_failed_metrics`:: The number of metrics failed to be added to the sending queue.
+
+[TIP]
+====
+You can use those metrics to troubleshoot issues with your OpenTelemetry Collector. For example, if the `otelcol_receiver_refused_spans` metric has a high value, it indicates that the Collector is not able to process the incoming spans.
+====
 
 The Operator creates a `<cr_name>-collector-monitoring` telemetry service that you can use to scrape the metrics endpoint.
 
@@ -62,15 +73,8 @@ Depending on the deployment mode of the OpenTelemetry Collector, the internal me
 ====
 Alternatively, if you do not set the `enableMetrics` field to `true`, you can access the metrics endpoint at `+http://localhost:8888/metrics+`.
 ====
-
-. On the *Observe* page in the web console, enable *User Workload Monitoring* to visualize the scraped metrics.
 +
-[NOTE]
-====
-Not all processors expose the required metrics.
-====
-
-. In the web console, go to *Observe* -> *Dashboards* and select the *OpenTelemetry Collector* dashboard from the drop-down list to view it.
+. If you enabled link:../monitoring/enabling-monitoring-for-user-defined-projects.html[*User Workload Monitoring*], go to *Observe* -> *Dashboards* in the Web Console and select the *OpenTelemetry Collector* dashboard from the drop-down list to view it.
 +
 [TIP]
 ====


### PR DESCRIPTION
Version(s): 4.18, 4.17, 4.16, 4.15, 4.14, 4.13, 4.12

Issue: [TRACING-4614](https://issues.redhat.com//browse/TRACING-4614)

Link to docs preview: https://82867--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-troubleshooting.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Additional information: this can be added to the latest version of the documentation since it applies to the current RHOSDT version too.