### PR TITLE
OSDOCS-11694-RN Adding 2 missed Nutanix release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -543,6 +543,20 @@ With this update, the user-defined labels and tags for {gcp-first} is Generally 
 
 For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-user-defined-labels-and-tags_installing-gcp-customizations[Managing user-defined labels and tags for GCP].
 
+[id="ocp-4-17-installation-nutanix-gpus_{context}"]
+==== Installing a cluster on Nutanix with compute machines using GPUs
+
+With this update, you can install a cluster on Nutanix with compute machines that use GPUs for processing. You attach a GPU to compute nodes with the `compute.platform.nutanix.gpus` parameters in the `install-config.yaml` file.
+
+For more information, see xref:../installing/installing_nutanix/installation-config-parameters-nutanix.adoc#installation-configuration-parameters-nutanix[Installation configuration parameters for Nutanix].
+
+[id="ocp-4-17-installation-nutanix-disks_{context}"]
+==== Installing a cluster on Nutanix with compute nodes using multiple disks
+
+With this update, you can install a cluster on Nutanix with compute machines that have multiple disks attached to them. You attach multiple disks to compute nodes with the `compute.platform.nutanix.dataDisks` parameters in the `install-config.yaml` file.
+
+For more information, see xref:../installing/installing_nutanix/installation-config-parameters-nutanix.adoc#installation-configuration-parameters-nutanix[Installation configuration parameters for Nutanix].
+
 [id="ocp-4-17-installation-and-update-azure-spain_{context}"]
 ==== Installing a cluster on {azure-short} in the Central Spain region
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-11694
https://issues.redhat.com/browse/OSDOCS-11890

Link to docs preview:
https://82876--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-installation-nutanix-gpus_release-notes
https://82876--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-installation-nutanix-disks_release-notes

QE review:
- [X] QE has approved this change.

CM Acks:
- [x] DPM
- [x] PX
- [X] PM and Eng. via slack
- [x] CS