### PR TITLE
OCPBUGS#41971: Updated 4.16 RN for HyperShift/HCP note

### DIFF
--- a/installing/overview/cluster-capabilities.adoc
+++ b/installing/overview/cluster-capabilities.adoc
@@ -77,9 +77,6 @@ include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+2]
 // DeploymentConfig capability
 include::modules/deployment-config-capability.adoc[leveloffset=+2]
 
-// Ingress capability
-include::modules/ingress-operator.adoc[leveloffset=+2]
-
 // Insights capability
 include::modules/insights-operator.adoc[leveloffset=+2]
 

--- a/modules/ingress-operator.adoc
+++ b/modules/ingress-operator.adoc
@@ -1,29 +1,13 @@
 // Module included in the following assemblies:
 //
 // * operators/operator-reference.adoc
-// * installing/overview/cluster-capabilities.adoc
-
-ifeval::["{context}" == "cluster-capabilities"]
-:cluster-caps:
-endif::[]
-
-ifeval::["{context}" == "cluster-operators-ref"]
-:operator-ref:
-endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="ingress-operator_{context}"]
-ifdef::operator-ref[= Ingress Operator]
-ifdef::cluster-caps[= Ingress Capability]
+= Ingress Operator
 
 [discrete]
 == Purpose
-
-ifdef::cluster-caps[]
-
-The Ingress Operator provides the features for the `Ingress` capability.
-
-endif::cluster-caps[]
 
 The Ingress Operator configures and manages the {product-title} router.
 
@@ -77,11 +61,3 @@ $ oc get network/cluster -o jsonpath='{.status.clusterNetwork[*]}'
 ----
 map[cidr:10.128.0.0/14 hostPrefix:23]
 ----
-
-ifeval::["{context}" == "cluster-operators-ref"]
-:!operator-ref:
-endif::[]
-
-ifeval::["{context}" == "cluster-caps"]
-:!cluster-caps:
-endif::[]

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -100,16 +100,6 @@ featureGates:
 
 For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-optional_installation-config-parameters-gcp[Optional configuration parameters].
 
-[id="ocp-4-16-installation-and-update-ingress-capability_{context}"]
-==== Ingress capability
-
-Ingress capability is now a configurable cluster capability and is optional for Red{nbsp}Hat HyperShift. It is not configurable and is always enabled for standalone {product-title}.
-
-[WARNING]
-====
-Do not disable Ingress capability. An {product-title} cluster will not run with the Ingress capability disabled.
-====
-
 [id="ocp-4-16-installation-and-update-alibaba_{context}"]
 ==== Installation on Alibaba Cloud by using Assisted Installer (Technology Preview)
 
@@ -2167,8 +2157,6 @@ With this release, the issue has been fixed and upgrade times are reduced.
 
 * Previously, long cluster names were trimmed without warning the user. With this release, the installation program warns the user when trimming long cluster names. (link:https://issues.redhat.com/browse/OCPBUGS-33840[*OCPBUGS-33840*])
 
-* Previously, when installing a cluster, the Ingress capability was enabled even if it was disabled in `install-config.yaml` because it is required. With this release, the installation program fails if the Ingress capability is disabled in `install-config.yaml`. (link:https://issues.redhat.com/browse/OCPBUGS-33794[*OCPBUGS-33794*])
-
 * Previously, {product-title} did not perform quota checking for clusters installed in the `ca-west-1` an {aws-first} region. With this release, quotas are properly enforced in this region. (link:https://issues.redhat.com/browse/OCPBUGS-33649[*OCPBUGS-33649*])
 
 * Previously, the installation program could sometimes fail to detect that the {product-title} API is unavailable. An additional error was resolved by increasing the disk size of the bootstrap node in {azure-first} installations. With this release, the installation program correctly detects if the API is unavailable. (link:https://issues.redhat.com/browse/OCPBUGS-33610[*OCPBUGS-33610*])
@@ -3276,15 +3264,6 @@ In the following tables, features are marked with the following statuses:
 * Enabling LUKS encryption on a system using 512 emulation disks causes provisioning to fail and the system launches the emergency shell in the initramfs. This happens because of an alignment bug in `sfdisk` when growing a partition. As a workaround, you can use Ignition to perform the resizing instead. (link:https://issues.redhat.com/browse/OCPBUGS-35410[*OCPBUGS-35410*])
 
 * {product-title} version {product-version} disconnected installation fails on {ibm-power-name} Virtual Server. (link:https://issues.redhat.com/browse/OCPBUGS-36250[*OCPBUGS-36250*])
-
-* In {hcp} for {product-title}, if you disable the xref:../installing/overview/cluster-capabilities.adoc#ingress-operator_cluster-capabilities[Ingress capability], the Console Operator returns the following error message:
-+
-[source,text]
-----
-RouteHealthAvailable: failed to GET route.
-----
-+
-To avoid this error, do not disable the `Ingress` capability in an {product-title} managed cluster. (link:https://issues.redhat.com/browse/OCPBUGS-33788[*OCPBUGS-33788*])
 
 [id="ocp-telco-ran-4-16-known-issues_{context}"]
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OCPBUGS-41971](https://issues.redhat.com/browse/OCPBUGS-41971)

Link to docs preview:
* [Preview for removed release notes](https://82879--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-installation-and-update-alibaba_release-notes)
* [Cluster capabilities](https://82879--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities.html)
* [Cluster Operators reference](https://82879--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference.html)

