### PR TITLE
[enterprise-4.17] CNV#40187: RN - VM eviction strategies

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -63,6 +63,8 @@ This release adds new features and enhancements related to the following compone
 [id="virt-4-17-infrastructure"]
 === Infrastructure
 
+* Configuring xref:../../virt/nodes/virt-node-maintenance.adoc#eviction-strategies[VM eviction strategies] for an xref:../../virt/nodes/virt-node-maintenance.adoc#virt-configuring-cluster-eviction-strategy-cli_virt-node-maintenance[entire cluster] is now generally available.
+
 [id="virt-4-17-virtualization"]
 === Virtualization
 
@@ -120,9 +122,6 @@ Removed features are not supported in the current release.
 Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
-
-//CNV-28944 Release note: Preview Cluster level eviction strategy change
-* You can now configure a xref:../../virt/nodes/virt-node-maintenance.adoc#eviction-strategies[VM eviction strategy] for the xref:../../virt/nodes/virt-node-maintenance.adoc#virt-configuring-cluster-eviction-strategy-cli_virt-node-maintenance[entire cluster].
 
 //CNV-15028: Nested virt in virt hosts. This feature will remain in tech preview indefinitely.
 * You can now enable link:https://access.redhat.com/solutions/6692341[nested virtualization on {VirtProductName} hosts].


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/CNV-40187

Link to docs preview:
https://82880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-17-infrastructure

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Would like confirmation of placement for this RN
* This RN includes a [link to docs](https://docs.openshift.com/container-platform/4.16/virt/nodes/virt-node-maintenance.html#virt-configuring-cluster-eviction-strategy-cli_virt-node-maintenance) on how to do this, but has a TP disclaimer. I plan to remove this disclaimer, but I'll have to do that in another PR for the main branch.
