### PR TITLE
OSDOCS#12129: Add a backup step to the  'rotating certificate authority' procedure

### DIFF
--- a/modules/rotating-certificate-authority.adoc
+++ b/modules/rotating-certificate-authority.adoc
@@ -10,6 +10,13 @@ Rotate the `etcd` certificate before it expires.
 
 .Procedure
 
+. Make a backup copy of the current signer certificate by running the following command:
++
+[source,terminal]
+----
+$ oc get secret -n openshift-etcd etcd-signer -oyaml > signer_backup_secret.yaml
+----
+
 . Verify the remaining lifetime of the new signer certificate by running the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12129](https://issues.redhat.com/browse/OSDOCS-12129)

Link to docs preview:
[Rotating the etcd certificate](https://82881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/etcd-certificates.html#rotating-certificate-authority_cert-types-etcd-certificates) 

QE review:
- [ ] QE has approved this change.

Additional information:
This PR adds the backup copy of the signer certificate to the procedure for 4.16.
