### PR TITLE
OSDOCS-12118 changed the node count reference in the service definition

### DIFF
--- a/modules/rosa-sdpolicy-instance-types.adoc
+++ b/modules/rosa-sdpolicy-instance-types.adoc
@@ -13,20 +13,13 @@ endif::[]
 = Instance types
 
 ifdef::rosa-with-hcp[]
-All {hcp-title} clusters require a minimum of 2 worker nodes. All {hcp-title} clusters support a maximum of 500 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss.
-
-[NOTE]
-====
-Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 500 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
-====
-
+All {hcp-title} clusters require a minimum of 2 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss.
 endif::rosa-with-hcp[]
 ifndef::rosa-with-hcp[]
 Single availability zone clusters require a minimum of 3 control plane nodes, 2 infrastructure nodes, and 2 worker nodes deployed to a single availability zone.
 
 Multiple availability zone clusters require a minimum of 3 control plane nodes, 3 infrastructure nodes, and 3 worker nodes. Additional nodes must be purchased in multiples of three to maintain proper node distribution.
 
-All {product-title} clusters support a maximum of 180 worker nodes.
 
 Control plane and infrastructure nodes are deployed and managed by Red{nbsp}Hat. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss. There are at least 3 control plane nodes that handle etcd- and API-related workloads. There are at least 2 infrastructure nodes that handle metrics, routing, the web console, and other workloads. You must not run any workloads on the control and infrastructure nodes. Any workloads you intend to run must be deployed on worker nodes. See the Red{nbsp}Hat Operator support section below for more information about Red{nbsp}Hat workloads that must be deployed on worker nodes.
 endif::rosa-with-hcp[]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc
@@ -7,16 +7,13 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 {hcp-title} offers the following worker node instance types and sizes:
 
-[NOTE]
-====
-Currently, {hcp-title} supports a maximum of 500 worker nodes. Customers running {hcp-title} 4.14.x and 4.15.x clusters require a minimum z-stream version of 4.14.28 or 4.15.15 and greater to scale to 500 worker nodes. For earlier versions, the maximum is 90 worker nodes. 
-====
-
 include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+1]
 
 include::modules/rosa-sdpolicy-am-aws-compute-types-graviton.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+
+* xref:../../rosa_planning/rosa-hcp-limits-scalability.adoc#rosa-hcp-limits-scalability[{hcp-title} limits and scalability]
 
 * link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
@@ -27,8 +27,9 @@ include::modules/rosa-sdpolicy-instance-types.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-For a detailed listing of supported instance types, see xref:../rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-hcp-instance-types[{hcp-title} instance types].
+* xref:../rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-hcp-instance-types[{hcp-title} instance types]
 
+* xref:../../rosa_planning/rosa-hcp-limits-scalability.adoc#rosa-hcp-limits-scalability[{hcp-title} limits and scalability]
 
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]
 

--- a/rosa_architecture/rosa_policy_service_definition/rosa-instance-types.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-instance-types.adoc
@@ -13,4 +13,6 @@ include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
+
 * link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -27,7 +27,9 @@ include::modules/rosa-sdpolicy-instance-types.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-For a detailed listing of supported instance types, see xref:../rosa_policy_service_definition/rosa-instance-types.adoc#rosa-instance-types[{product-title} instance types].
+* xref:../rosa_policy_service_definition/rosa-instance-types.adoc#rosa-instance-types[{product-title} instance types]
+
+* xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 
 
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -25,7 +25,7 @@ toc::[]
 
 * **{hcp-title} multi-architecture cluster update.** {hcp-title-first} clusters created before 25 July, 2024 will migrate to a multi-architecture image on their next upgrade allowing you to use {AWS} Arm-based Graviton instance types for your workloads. For more information, see xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-upgrade-options_rosa-hcp-upgrading[Upgrading ROSA with HCP clusters].
 
-* **{hcp-title} cluster node limit update.** {hcp-title} clusters can now scale to 500 worker nodes. This is an increase from the previous limit of 250 nodes. For more information, see xref:../rosa_planning/rosa-hcp-limits-scalability.adoc#tested-cluster-maximums-hcp-sd_rosa-hcp-limits-scalability[ROSA with HCP limits and scalability].
+* **{hcp-title} cluster node limit update.** {hcp-title} clusters can now scale to 500 worker nodes. This is an increase from the previous limit of 250 nodes. The 250 node limit is an increase from the previous limit 90 nodes on 26 August, 2024. For more information, see xref:../rosa_planning/rosa-hcp-limits-scalability.adoc#tested-cluster-maximums-hcp-sd_rosa-hcp-limits-scalability[ROSA with HCP cluster maximums].
 
 * **IMDSv2 support in {hcp-title}.** You can now enforce the use of the IMDSv2 endpoint for default machine pool worker nodes on new {hcp-title} clusters and for new machine pools on existing clusters. For more information, see xref:../rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc#rosa-hcp-creating-a-cluster-quickly-terraform[Creating a default ROSA cluster using Terraform].
 


### PR DESCRIPTION
Removed mentions of node count where it was redundant and linked users to the L&S doc.
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12118

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

HCP Instance types:
https://82901--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.html

Classic Instance Types:
https://82901--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-instance-types.html

ROSA HCP Service def:
https://82901--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-instance-types_rosa-hcp-service-definition

ROSA classic Service def:
https://82901--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-instance-types_rosa-service-definition


Release note update:
https://82901--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes#rosa-q3-2024_rosa-whats-new


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
