### PR TITLE
OSDOCS-12214: Remove 10 character project name limit from OSD on GCP

### DIFF
--- a/modules/ccs-gcp-customer-procedure.adoc
+++ b/modules/ccs-gcp-customer-procedure.adoc
@@ -23,11 +23,6 @@ To use {product-title} in your GCP project, the following GCP organizational pol
 .Procedure
 
 . link:https://cloud.google.com/resource-manager/docs/creating-managing-projects[Create a Google Cloud project] to host the {product-title} cluster.
-+
-[NOTE]
-====
-The project name must be 10 characters or less.
-====
 
 . link:https://cloud.google.com/service-usage/docs/enable-disable#enabling[Enable] the following required APIs in the project that hosts your {product-title} cluster:
 +

--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -53,11 +53,6 @@ ifdef::osd-on-gcp[]
 * You have configured your GCP account for use with {product-title}.
 * You have configured the GCP account quotas and limits that are required to support the desired cluster size.
 * You have created a GCP project.
-+
-[NOTE]
-====
-The project name must be 10 characters or less.
-====
 * You have enabled the Google Cloud Resource Manager API in your GCP project. For more information about enabling APIs for your project, see link:https://cloud.google.com/endpoints/docs/openapi/enable-api[the Google Cloud documentation].
 * You have an IAM service account in GCP called `osd-ccs-admin` with the following roles attached:
   ** Compute Admin


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): `enterprise-4.17`+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12214
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://82928--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html
- https://82928--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-an-aws-cluster.html
- https://82928--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] ~~QE has approved this change.~~ QE approval not required for this change
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is an old holdover from OpenShift 4.3. We have verified via [OSD-25817](https://issues.redhat.com/browse/OSD-25817) that this is not actually enforced. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
