### PR TITLE
OCPBUGS-42711 Removing snippet from 4.15 branch

### DIFF
--- a/nodes/pods/run_once_duration_override/index.adoc
+++ b/nodes/pods/run_once_duration_override/index.adoc
@@ -8,8 +8,5 @@ toc::[]
 
 You can use the {run-once-operator} to specify a maximum time limit that run-once pods can be active for.
 
-:operator-name: The {run-once-operator}
-include::snippets/operator-not-available.adoc[]
-
 // About the {run-once-operator}
 include::modules/rodoo-about.adoc[leveloffset=+1]

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-install.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-install.adoc
@@ -8,13 +8,10 @@ toc::[]
 
 You can use the {run-once-operator} to specify a maximum time limit that run-once pods can be active for. By enabling the run-once duration override on a namespace, all future run-once pods created or updated in that namespace have their `activeDeadlineSeconds` field set to the value specified by the {run-once-operator}.
 
-:operator-name: The {run-once-operator}
-include::snippets/operator-not-available.adoc[]
-
-//[NOTE]
-//====
-//If both the run-once pod and the {run-once-operator} have their `activeDeadlineSeconds` value set, the lower of the two values is used.
-//====
+[NOTE]
+====
+If both the run-once pod and the {run-once-operator} have their `activeDeadlineSeconds` value set, the lower of the two values is used.
+====
 
 // Installing the {run-once-operator}
 include::modules/rodoo-install-operator.adoc[leveloffset=+1]

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can remove the {run-once-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
-:operator-name: The {run-once-operator}
-include::snippets/operator-not-available.adoc[]
-
 // Uninstalling the {run-once-operator}
 include::modules/rodoo-uninstall-operator.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-42711](https://issues.redhat.com/browse/OCPBUGS-42711)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://82939--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/index.html
https://82939--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-install.html
https://82939--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
