### PR TITLE
TELCODOCS-1994: Firmware search path is not automatically configured on OCP (KMM)

### DIFF
--- a/modules/kmm-example-module-cr.adoc
+++ b/modules/kmm-example-module-cr.adoc
@@ -74,7 +74,7 @@ spec:
 ----
 <1> Required.
 <2> Optional.
-<3> Optional: Copies `/firmware/*` into `/var/lib/firmware/` on the node.
+<3> Optional: Copies the contents of this path into the path specified in `worker.setFirmwareClassPath` (which is preset to `/var/lib/firmware`) of the `kmm-operator-manager-config` config map. This action occurs before `modprobe` is called to insert the kernel module.
 <4> Optional.
 <5> At least one kernel item is required.
 <6> For each node running a kernel matching the regular expression, KMM checks if you have included a tag or a digest. If you have not specified a tag or digest in the container image, then the validation webhook returns an error and does not apply the module.


### PR DESCRIPTION
D/S and RN Docs:[MGMT-18541] Firmware search path is not automatically configured on OCP (KMM)

Jira: https://issues.redhat.com/browse/TELCODOCS-1994

Version(s): openshift-4.17

Fix version: KMMO 2.2

Docs Preview: https://82941--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-example-cr_kernel-module-management-operator

Dev review: @ybettan
QE review: @lalon4 



