### PR TITLE
OSDOCS#10994: rewording cert-manager Operator prereq

### DIFF
--- a/modules/cert-manager-certificate-api-server.adoc
+++ b/modules/cert-manager-certificate-api-server.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * You have access to the cluster with `cluster-admin` privileges.
-* You have installed the {cert-manager-operator} 1.13.0 or later.
+* You have installed version 1.13.0 or later of the {cert-manager-operator}.
 
 .Procedure
 

--- a/modules/cert-manager-certificate-ingress.adoc
+++ b/modules/cert-manager-certificate-ingress.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * You have access to the cluster with `cluster-admin` privileges.
-* You have installed the {cert-manager-operator} 1.13.0 or later.
+* You have installed version 1.13.0 or later of the {cert-manager-operator}.
 
 .Procedure
 
@@ -57,7 +57,7 @@ $ oc create -f certificate.yaml
 .Verification
 
 * Verify that the certificate is created and ready to use by running the following command:
-+ 
++
 [source, terminal]
 ----
 $ oc get certificate -w -n openshift-ingress

--- a/modules/cert-manager-configure-cloud-credentials-aws-non-sts.adoc
+++ b/modules/cert-manager-configure-cloud-credentials-aws-non-sts.adoc
@@ -8,7 +8,7 @@
 
 .Prerequisites
 
-* You have installed the {cert-manager-operator} 1.11.1 or later.
+* You have installed version 1.11.1 or later of the {cert-manager-operator}.
 * You have configured the Cloud Credential Operator to operate in _mint_ or _passthrough_ mode.
 
 .Procedure

--- a/modules/cert-manager-configure-cloud-credentials-gcp-non-sts.adoc
+++ b/modules/cert-manager-configure-cloud-credentials-gcp-non-sts.adoc
@@ -8,7 +8,7 @@
 
 .Prerequisites
 
-* You have installed the {cert-manager-operator} 1.11.1 or later.
+* You have installed version 1.11.1 or later of the {cert-manager-operator}.
 * You have configured the Cloud Credential Operator to operate in _mint_ or _passthrough_ mode.
 
 .Procedure

--- a/modules/cert-manager-configure-cloud-credentials-gcp-sts.adoc
+++ b/modules/cert-manager-configure-cloud-credentials-gcp-sts.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * You extracted and prepared the `ccoctl` binary.
-* The {cert-manager-operator} 1.11.1 or later is installed.
+* You have installed version 1.11.1 or later of the {cert-manager-operator}.
 * You have configured an {product-title} cluster with GCP Workload Identity by using the Cloud Credential Operator in a manual mode.
 
 .Procedure

--- a/modules/cert-manager-configure-cpu-memory.adoc
+++ b/modules/cert-manager-configure-cpu-memory.adoc
@@ -11,7 +11,7 @@ After installing the {cert-manager-operator}, you can configure the CPU and memo
 .Prerequisites
 
 * You have access to the {product-title} cluster as a user with the `cluster-admin` role.
-* You have installed the {cert-manager-operator} 1.12.0 or later.
+* You have installed version 1.12.0 or later of the {cert-manager-operator}.
 
 .Procedure
 

--- a/modules/cert-manager-configuring-routes.adoc
+++ b/modules/cert-manager-configuring-routes.adoc
@@ -10,7 +10,7 @@ The following steps demonstrate the process of utilizing the {cert-manager-opera
 
 .Prerequisites
 
-* You have installed the {cert-manager-operator} 1.14.0 or later.
+* You have installed version 1.14.0 or later of the {cert-manager-operator}.
 * You have enabled the `RouteExternalCertificate` feature gate.
 * You have the `create` and `update` permissions on the `routes/custom-host` sub-resource.
 * You have a `Service` resource that you want to expose.
@@ -123,7 +123,7 @@ $ oc patch route <route_name> \ # <1>
 .Verification
 
 * Verify that the certificate is created and ready to use by running the following command:
-+ 
++
 [source, terminal]
 ----
 $ oc get certificate -n <namespace> <1>
@@ -132,7 +132,7 @@ $ oc get secret -n <namespace> <1>
 <1> Specify the namespace where both your secret and route reside.
 
 * Verify that the router is using the referenced external certificate by running the following command. The command should return with the status code `200 OK`.
-+ 
++
 [source, terminal]
 ----
 $ curl -IsS https://<hostname> <1>
@@ -140,7 +140,7 @@ $ curl -IsS https://<hostname> <1>
 <1> Specify the hostname of your route.
 
 * Verify the server certificate's `subject`, `subjectAltName` and `issuer` are all as expected from the curl verbose outputs by running the following command:
-+ 
++
 [source, terminal]
 ----
 $ curl -v https://<hostname> <1>

--- a/modules/cert-manager-enable-operand-log-level.adoc
+++ b/modules/cert-manager-enable-operand-log-level.adoc
@@ -11,7 +11,7 @@ You can set a log level for cert-manager to determine the verbosity of log messa
 .Prerequisites
 
 * You have access to the cluster with `cluster-admin` privileges.
-* You have installed the {cert-manager-operator} 1.11.1 or later.
+* You have installed version 1.11.1 or later of the {cert-manager-operator}.
 
 .Procedure
 

--- a/modules/cert-manager-enable-operator-log-level.adoc
+++ b/modules/cert-manager-enable-operator-log-level.adoc
@@ -11,7 +11,7 @@ You can set a log level for the {cert-manager-operator} to determine the verbosi
 .Prerequisites
 
 * You have access to the cluster with `cluster-admin` privileges.
-* You have installed the {cert-manager-operator} 1.11.1 or later.
+* You have installed version 1.11.1 or later of the {cert-manager-operator}.
 
 .Procedure
 

--- a/modules/cert-manager-override-flag-controller.adoc
+++ b/modules/cert-manager-override-flag-controller.adoc
@@ -16,7 +16,7 @@ If you uninstall the {cert-manager-operator} or delete certificate resources fro
 .Prerequisites
 
 * You have access to the {product-title} cluster as a user with the `cluster-admin` role.
-* You have installed the {cert-manager-operator} 1.12.0 or later.
+* You have installed version 1.12.0 or later of the {cert-manager-operator}.
 
 
 .Procedure


### PR DESCRIPTION
[OSDOCS-10994](https://issues.redhat.com/browse/OSDOCS-10994)

Version(s): 4.12+

This PR rephrases prereqs about version requirements for the "cert-manager Operator for Red Hat OpenShift". Previously a prereq such as "You have installed the cert-manager Operator for Red Hat OpenShift 1.13.0 or later" may have been interpreted as incorrectly referencing a 1.13.0 version of OCP, whereas the version is in reference to the Operator.

QE review: QE not required, this is just a grammar-level edit.

Previews:

- [Authenticating the cert-manager Operator for Red Hat OpenShift](https://82942--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-authenticate) (multiple references)
- [Configuring certificates with an issuer](https://82942--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-creating-certificate) (multiple references)
- [Customizing cert-manager by using the cert-manager Operator API fields](https://82942--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-customizing-api-fields) (multiple references)
- [Configuring log levels for cert-manager and the cert-manager Operator for Red Hat OpenShift](https://82942--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-log-levels) (multiple references)
- [Securing routes with the cert-manager Operator for Red Hat OpenShift](https://82942--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-securing-routes)
