### PR TITLE
OCPBUGS#38912: Add punctuation to a script for moving etcd to a different disk

### DIFF
--- a/modules/move-etcd-different-disk.adoc
+++ b/modules/move-etcd-different-disk.adoc
@@ -65,11 +65,11 @@ Note the device name of the new disk reported by the `lsblk` command.
 set -uo pipefail
 
 for device in <device_type_glob>; do # <1>
-/usr/sbin/blkid $device &> /dev/null
+/usr/sbin/blkid "${device}" &> /dev/null
  if [ $? == 2  ]; then
-    echo "secondary device found $device"
+    echo "secondary device found ${device}"
     echo "creating filesystem for etcd mount"
-    mkfs.xfs -L var-lib-etcd -f $device &> /dev/null
+    mkfs.xfs -L var-lib-etcd -f "${device}" &> /dev/null
     udevadm settle
     touch /etc/var-lib-etcd-mount
     exit


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-38912](https://issues.redhat.com/browse/OCPBUGS-38912)

Link to docs preview:
[Moving etcd to a different disk](https://82944--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html#move-etcd-different-disk_recommended-etcd-practices) (step 2)

QE review:
- [x] QE has approved this change.
