### PR TITLE
OSDOCS#12218: Add a net reqs table from ACM to OCP

### DIFF
--- a/modules/hcp-requirements-platform-version.adoc
+++ b/modules/hcp-requirements-platform-version.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="hcp-requirements-platform-version_{context}"]
-= Platform and version requirements for {hcp-capital}
+= Platform, version, and network requirements for {hcp}
 
 The following table indicates which {product-title} versions are supported for each platform. In the table, Hosting {product-title} version refers to the {product-title} version where the {mce-short} is enabled:
 
@@ -35,4 +35,33 @@ The following table indicates which {product-title} versions are supported for e
 |Non-bare metal agent machines
 |4.16
 |4.16 (only)
+|===
+
+
+When you use {hcp}, the `HypershiftDeployment` resource must have connectivity to the endpoints listed in the following table:
+
+.{hcp-capital} network requirements 
+[cols="3",options="header"]
+|===
+| Direction | Connection | Port (if specified)
+
+| Outbound
+| {product-title} control plane and worker nodes
+|
+
+| Outbound
+| For hosted clusters on {aws-first} only: Outbound connection to {aws-short} API and S3 API
+|
+
+| Outbound
+| For hosted clusters on Microsoft Azure cloud services only: Outbound connection to Azure API
+|
+
+| Outbound
+| {product-title} image repositories that store the ISO images of the coreOS and the image registry for {product-title} pods
+|
+
+| Outbound
+| Local API client of the klusterlet on the hosting cluster communicates with the API of the hosted cluster
+|
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12218
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://82947--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-requirements.html#hcp-requirements-platform-version_hcp-requirements --- Table 2: Network requirements
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
