### PR TITLE
PR for SRVCOM-3248: Update the Serverless 1.34 release notes

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,9 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-34-0.adoc[leveloffset=+1]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-33-2.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-33-0.adoc[leveloffset=+1]
 

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -11,25 +11,15 @@ Some features that were Generally Available (GA) or a Technology Preview (TP) in
 For the most recent list of major functionality deprecated and removed within {ServerlessProductName}, refer to the following table:
 
 .Deprecated and removed features tracker
-[cols="3,1,1,1,1,1,1,1",options="header"]
+[cols="3,1,1,1,1,1,1",options="header"]
 |====
-|Feature |1.27|1.28|1.29|1.30|1.31|1.32|1.33
-
-|Serving TLS for internal traffic
-|-
-|-
-|-
-|-
-|-
-|Removed
-|Removed
+|Feature |1.29|1.30|1.31|1.32|1.33|1.34
 
 |EventTypes `v1beta1` API
 |-
 |-
 |-
-|-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 
@@ -37,8 +27,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |-
 |-
 |-
-|-
-|-
+|Removed
 |Removed
 |Removed
 
@@ -46,22 +35,19 @@ For the most recent list of major functionality deprecated and removed within {S
 |-
 |-
 |-
-|-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 
 |`NamespacedKafka` annotation
 |-
-|-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
 
 |`enable-secret-informer-filtering` annotation
-|-
 |Deprecated
 |Deprecated
 |Deprecated
@@ -70,8 +56,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |Deprecated
 
 |Serving and Eventing `v1alpha1` API
-|Deprecated
-|Deprecated
+|Removed
 |Removed
 |Removed
 |Removed
@@ -85,10 +70,8 @@ For the most recent list of major functionality deprecated and removed within {S
 |Removed
 |Removed
 |Removed
-|Removed
 
 |`KafkaBinding` API
-|Removed
 |Removed
 |Removed
 |Removed

--- a/modules/serverless-rn-1-34-0.adoc
+++ b/modules/serverless-rn-1-34-0.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-34-0_{context}"]
+= Red Hat {ServerlessProductName} 1.34
+
+{ServerlessProductName} 1.34 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="new-features-1-34-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.14.
+* {ServerlessProductName} now uses Knative Eventing 1.14.
+* {ServerlessProductName} now uses Kourier 1.14.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.14.
+* {ServerlessProductName} now uses Knative for Apache Kafka 1.14.
+* The `kn func` CLI plugin now uses `func` 1.15.
+
+* {ServerlessLogicProductName} now supports multiple configuration for OpenAPI within the same namespace.
+
+* The management console for {ServerlessLogicProductName} is now available as a Technology Preview (TP) feature for streamlining the development process.
+
+* {ServerlessLogicProductName} 1.34 introduces a new feature that allows workflows to access different {ocp-product-title} clusters through configuration. This feature enables users to define REST calls within a workflow to seamlessly interact with multiple clusters.
+
+* In {ServerlessLogicProductName}, the Job Service liveness checks is now enhanced to limit the time required to retrieve the leader status. A new system property, `kogito.jobs-service.management.leader-check.expiration-in-seconds`, has been introduced, allowing you to configure the maximum time allowed for the leader status check.
+
+* Automatic `EventType` registration is an Eventing feature is now available as a Technology Preview (TP). It automatically creates `EventTypes` objects based on processed events on the broker ingress and in-memory channels, improving the experience of consuming and creating `EventTypes`.
+
+* Encryption Serving is now available as a Technology Preview (TP) feature.
+
+* Startup probes are now supported, helping to reduce cold start times for faster application startup and improved performance. These probes are particularly useful for containers with slow startup processes.
+
+* {ServerlessProductName} Serving transport encryption feature allows transporting data over secured and encrypted HTTPS connections using TLS. This is now available as a Technology Preview (TP) feature.
+
+* Go functions using S2I builder are now available as a Technology Preview (TP) feature for Linux and Mac developers, allowing them to implement and build Go functions on these platforms.
+
+* Multi-container support for Knative Serving allows you to use a single Knative service to deploy a multi-container pod. It also supports the `readiness` and `liveness` probe values for multiple containers.
+
+* Autoscaling for Knative Kafka triggers is now enhanced with KEDA (Kubernetes Event-Driven Autoscaling) as a Technology Preview (TP). Autoscaling using CMA/KEDA further enhances performance by optimizing resource allocation for Kafka triggers and `KafkaSource` objects, ensuring better scalability in event-driven workloads.
+
+* Knative Eventing now offers support for data in transit encryption (Eventing TLS) as a Technology Preview (TP) feature. You can configure Knative Eventing components to expose HTTPS addresses as well as add user-provided CA trust bundles to clients.
+
+[id="fixed-issues-1-34-0_{context}"]
+== Fixed issues
+
+* Previously, `KafkaSource` objects would incorrectly remain in the `Ready` status even when the `KafkaSource.spec.net.tls.key` failed to load. This issue has been resolved. An error is now reported when creating a Kafka `Broker`, `KafkaChannel`, `KafkaSource`, or `KafkaSink` object with unsupported TLS certificates in PKCS #1 (Public-Key Cryptography Standards #1) format, ensuring proper handling and notification of configuration issues.
+
+* The Eventing controller incorrectly requeued the wrong object type (`Namespace`), causing "resource not found" log errors. This issue is now resolved, and the controller now handles object requeuing, ensuring more accurate logging and resource management.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,40 +13,50 @@ The following table provides information about which {ServerlessProductName} fea
 .Generally Available and Technology Preview features tracker
 [cols="2,1,1,1",options="header"]
 |====
-|Feature |1.31|1.32|1.33
+|Feature |1.32|1.33|1.34
+
+|Eventing Transport encryption
+|-
+|-
+|TP
+
+|Serving Transport encryption
+|-
+|-
+|TP
 
 |OpenShift Serverless Logic
 |TP
-|TP
+|GA
 |GA
 
 |ARM64 support
 |-
-|-
+|TP
 |TP
 
 |Custom Metrics Autoscaler Operator (KEDA)
 |-
-|-
+|TP
 |TP
 
 |kn event plugin
-|-
+|TP
 |TP
 |TP
 
 |Pipelines-as-code
-|-
+|TP
 |TP
 |TP
 
 |`new-trigger-filters`
-|-
+|TP
 |TP
 |TP
 
 |Go function using S2I builder
-|-
+|TP
 |TP
 |TP
 
@@ -62,8 +72,8 @@ The following table provides information about which {ServerlessProductName} fea
 
 |Serverless Logic
 |TP
-|TP
-|TP
+|GA
+|GA
 
 |Overriding `liveness` and `readiness` in functions
 |GA


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.34`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3248

**Doc preview:** 

- [Serverless 1.34.0 release notes](https://82953--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-34-0_serverless-release-notes)

- [Generally Available and Technology Preview features table](https://82953--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes)

- [Deprecated and removed features table](https://82953--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-deprecated-removed-features_serverless-release-notes)