### PR TITLE
PR for SRVKE-1275: Document the Kafka Broker, Kafka Trigger, KafkaChannel, Kafka Subscription, KafkaSource, KafkaSink metrics content under the Knative Eventing metrics section.

### DIFF
--- a/modules/serverless-knative-kafka-broker-metrics.adoc
+++ b/modules/serverless-knative-kafka-broker-metrics.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-knative-kafka-broker-metrics_{context}"]
+= Knative Kafka broker metrics
+
+You can use the following metrics to debug and visualize the performance of Kafka broker.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count_1_total{job="kafka-broker-receiver-sm-service", namespace="knative-eventing"}`
+|Number of events received by a broker
+|Counter
+a|
+`name`:: broker name
+`namespace_name`:: broker namespace
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the broker
+`response_code_class`:: HTTP response code class returned by the broker: 2xx, 3xx, 4xx, 5xx
+|Dimensionless
+
+|`event_dispatch_latencies_ms_bucket{job="kafka-broker-receiver-sm-service", namespace="knative-eventing"}`
+|The time spent dispatching an event to a Kafka cluster
+|Histogram
+a|
+`name`:: broker name
+`namespace_name`:: broker namespace
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the broker
+`response_code_class`:: HTTP response code class returned by the broker: 2xx, 3xx, 4xx, 5xx
+|Milliseconds
+
+|`kafka_broker_controller_consumer_group_expected_replicas`
+|Number of expected replicas for a given Kafka consumer group resource
+|Gauge
+a|
+`consumer_name`:: resource name
+`namespace_name`:: resource namespace
+`consumer_kind`:: resource Kind, enum: `KafkaSource`, `Trigger`, `Subscription`
+
+[NOTE]
+====
+In this context, resources refer to user facing entities such as Kafka source, trigger, and subscription. Avoid using internal or generated names when using these resources.
+====
+
+|Dimensionless
+
+|`kafka_broker_controller_consumer_group_ready_replicas`
+|Number of ready replicas for a given Kafka consumer group resource
+|Gauge
+a|
+`consumer_name`:: resource name
+`namespace_name`:: resource namespace
+`consumer_kind`:: resource Kind, enum: `KafkaSource`, `Trigger`, `Subscription`
+
+[NOTE]
+====
+In this context, resources refer to user facing entities such as Kafka source, trigger, and subscription. Avoid using internal or generated names when using these resources.
+====
+
+|Dimensionless
+
+|===

--- a/modules/serverless-knative-kafka-channel-metrics.adoc
+++ b/modules/serverless-knative-kafka-channel-metrics.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-knative-kafka-channel-metrics_{context}"]
+= Knative Kafka channel metrics
+
+You can use the following metrics to debug and visualize the performance of Kafka channel.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count_1_total{job="kafka-channel-receiver-sm-service", namespace="knative-eventing"}`
+|Number of events received by a Kafka channel
+|Counter
+a|
+`name`:: Kafka channel name
+`namespace_name`:: Kafka channel namespace
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the Kafka channel
+`response_code_class`:: HTTP response code class returned by the Kafka channel: 2xx, 3xx, 4xx, 5xx
+|Dimensionless
+
+|`event_dispatch_latencies_ms_bucket{job="kafka-channel-receiver-sm-service", namespace="knative-eventing"}`
+|The time spent dispatching an event to a Kafka cluster
+|Histogram
+a|
+`name`:: Kafka channel name
+`namespace_name`:: Kafka channel namespace
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the Kafka channel
+`response_code_class`:: HTTP response code class returned by the Kafka channel: 2xx, 3xx, 4xx, 5xx
+|Milliseconds
+
+|===

--- a/modules/serverless-knative-kafka-sink-metrics.adoc
+++ b/modules/serverless-knative-kafka-sink-metrics.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-knative-kafka-sink-metrics_{context}"]
+= Knative Kafka sink metrics
+
+You can use the following metrics to debug and visualize the performance of Kafka sinks.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count_1_total{job="kafka-sink-receiver-sm-service", namespace="knative-eventing"}`
+|Number of events received by a broker
+|Counter
+a|
+`name`:: Kafka sink name
+`namespace_name`:: Kafka sink namespace
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the Kafka sink
+`response_code_class`:: HTTP response code class returned by the Kafka sink: 2xx, 3xx, 4xx, 5xx
+|Dimensionless
+
+|`event_dispatch_latencies_ms_bucket{job="kafka-sink-receiver-sm-service", namespace="knative-eventing"}`
+|The time spent dispatching an event to a Kafka cluster
+|Histogram
+a|
+`name`:: Kafka sink name
+`namespace_name`:: Kafka sink namespace
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the Kafka sink
+`response_code_class`:: HTTP response code class returned by the Kafka sink: 2xx, 3xx, 4xx, 5xx
+|Milliseconds
+
+|===

--- a/modules/serverless-knative-kafka-source-metrics.adoc
+++ b/modules/serverless-knative-kafka-source-metrics.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-knative-kafka-source-metrics_{context}"]
+= Knative Kafka source metrics
+
+You can use the following metrics to debug and visualize the performance of Kafka sources.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count_1_total{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
+|Number of events dispatched by a Kafka source
+|Counter
+a|
+`consumer_name`:: Kafka source name
+`namespace_name`:: Kafka source namespace
+`name`:: Kafka source name
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the Kafka source sink service
+`response_code_class`:: HTTP response code class returned by the Kafka source sink service: 2xx, 3xx, 4xx, 5xx
+|Dimensionless
+
+|`event_dispatch_latencies_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent dispatching an event to a sink
+|Histogram
+a|
+`consumer_name`:: Kafka source name
+`namespace_name`:: Kafka source namespace
+`name`:: Kafka source name
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the Kafka source sink service
+`response_code_class`:: HTTP response code class returned by the Kafka source sink service: 2xx, 3xx, 4xx, 5xx
+|Milliseconds
+
+|`event_processing_latencies_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent processing an event
+|Histogram
+a|
+`consumer_name`:: Kafka source name
+`namespace_name`:: Kafka source namespace
+`name`:: Kafka source name
+`event_type`:: event type
+|Milliseconds
+
+|`kafka_broker_controller_consumer_group_expected_replicas`
+|Number of expected replicas for a given Kafka consumer group resource
+|Gauge
+a|
+`consumer_name`:: resource name
+`namespace_name`:: resource namespace
+`consumer_kind`:: resource Kind, enum: `KafkaSource`, `Trigger`, `Subscription`
+
+[NOTE]
+====
+In this context, resources refer to user facing entities such as Kafka source,trigger, and subscription. Avoid using internal or generated names when using these resources.
+====
+
+|Dimensionless
+
+|`kafka_broker_controller_consumer_group_ready_replicas`
+|Number of ready replicas for a given Kafka consumer group resource
+|Gauge
+a|
+`consumer_name`:: resource name
+`namespace_name`:: resource namespace
+`consumer_kind`:: resource Kind, enum: `KafkaSource`, `Trigger`, `Subscription`
+
+[NOTE]
+====
+In this context, resources refer to user facing entities such as Kafka source,trigger, and subscription. Avoid using internal or generated names when using these resources.
+====
+
+|Dimensionless
+
+|===

--- a/modules/serverless-knative-kafka-subscription-metrics.adoc
+++ b/modules/serverless-knative-kafka-subscription-metrics.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-knative-kafka-subscription-metrics_{context}"]
+= Knative Kafka subscription metrics
+
+You can use the following metrics to debug and visualize the performance of subscriptions associated with the Kafka channel.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count_1_total{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
+|Number of events dispatched by a subscription to a subscriber
+|Counter
+a|
+`consumer_name`:: Subscription name
+`namespace_name`:: Subscription namespace
+`name`:: KafkaChannel name
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the `Subscription` subscriber service
+`response_code_class`:: HTTP response code class returned by the `Subscription` subscriber service: 2xx, 3xx, 4xx, 5xx
+|Dimensionless
+
+|`event_dispatch_latencies_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent dispatching an event to a subscriber
+|Histogram
+a|
+`consumer_name`:: Subscription name
+`namespace_name`:: Subscription namespace
+`name`:: KafkaChannel name
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the `Subscription` subscriber service
+`response_code_class`:: HTTP response code class returned by the `Subscription` subscriber service: 2xx, 3xx, 4xx, 5xx
+|Milliseconds
+
+|`event_processing_latencies_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent processing an event
+|Histogram
+a|
+`consumer_name`:: Subscription name
+`namespace_name`:: Subscription namespace
+`name`:: KafkaChannel name
+`event_type`:: event type
+|Dimensionless
+
+|===

--- a/modules/serverless-knative-kafka-trigger-metrics.adoc
+++ b/modules/serverless-knative-kafka-trigger-metrics.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-knative-kafka-trigger-metrics_{context}"]
+= Knative Kafka trigger metrics
+
+You can use the following metrics to debug and visualize the performance of Kafka triggers.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count_1_total{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
+|Number of events dispatched by a trigger to a subscriber
+|Counter
+a|
+`consumer_name`:: trigger name
+`namespace_name`:: trigger namespace
+`name`:: broker name
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the trigger subscriber service
+`response_code_class`:: HTTP response code class returned by the trigger subscriber service: 2xx, 3xx, 4xx, 5xx
+|Dimensionless
+
+|`event_dispatch_latencies_ms_bucket{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent dispatching an event to a subscriber
+|Histogram
+a|
+`consumer_name`:: trigger name
+`namespace_name`:: trigger namespace
+`name`:: broker name
+`event_type`:: event type
+`response_code`:: HTTP response code returned by the trigger subscriber service
+`response_code_class`:: HTTP response code class returned by the trigger subscriber service: 2xx, 3xx, 4xx, 5xx
+|Milliseconds
+
+|`event_processing_latencies_ms_bucket{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent processing and filtering an event
+|Histogram
+a|
+`consumer_name`:: trigger name
+`namespace_name`:: trigger namespace
+`name`:: broker name
+`event_type`:: event type
+|Milliseconds
+
+|===

--- a/observability/admin-metrics/serverless-admin-metrics-eventing.adoc
+++ b/observability/admin-metrics/serverless-admin-metrics-eventing.adoc
@@ -1,7 +1,7 @@
-:_content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
+:_mod-docs-content-type: ASSEMBLY
 [id="serverless-admin-metrics-eventing"]
 = Knative Eventing metrics
+include::_attributes/common-attributes.adoc[]
 :context: serverless-admin-metrics-eventing
 
 toc::[]
@@ -14,3 +14,10 @@ include::modules/serverless-broker-ingress-metrics.adoc[leveloffset=+1]
 include::modules/serverless-broker-filter-metrics.adoc[leveloffset=+1]
 include::modules/serverless-inmemory-dispatch-metrics.adoc[leveloffset=+1]
 include::modules/serverless-event-source-metrics.adoc[leveloffset=+1]
+
+include::modules/serverless-knative-kafka-broker-metrics.adoc[leveloffset=+1]
+include::modules/serverless-knative-kafka-trigger-metrics.adoc[leveloffset=+1]
+include::modules/serverless-knative-kafka-channel-metrics.adoc[leveloffset=+1]
+include::modules/serverless-knative-kafka-subscription-metrics.adoc[leveloffset=+1]
+include::modules/serverless-knative-kafka-source-metrics.adoc[leveloffset=+1]
+include::modules/serverless-knative-kafka-sink-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
**Affected versions:** 
- `serverless-docs-1.34`
- `serverless-docs-1.33`
- `serverless-docs-1.32`
- `serverless-docs-1.31`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVKE-1275

**Doc previews:**
- [Knative Kafka Broker metrics](https://82957--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/admin-metrics/serverless-admin-metrics-eventing.html#serverless-knative-kafka-broker-metrics_serverless-admin-metrics-eventing)
- [Knative Kafka Trigger metrics](https://82957--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/admin-metrics/serverless-admin-metrics-eventing.html#serverless-knative-kafka-trigger-metrics_serverless-admin-metrics-eventing)
- [Knative KafkaChannel metrics](https://82957--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/admin-metrics/serverless-admin-metrics-eventing.html#serverless-knative-kafka-channel-metrics_serverless-admin-metrics-eventing)
- [Knative Kafka Subscription metrics](https://82957--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/admin-metrics/serverless-admin-metrics-eventing.html#serverless-knative-kafka-subscription-metrics_serverless-admin-metrics-eventing)
- [Knative KafkaSource metrics](https://82957--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/admin-metrics/serverless-admin-metrics-eventing.html#serverless-knative-kafka-source-metrics_serverless-admin-metrics-eventing)
- [Knative KafkaSink metrics](https://82957--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/admin-metrics/serverless-admin-metrics-eventing.html#serverless-knative-kafka-sink-metrics_serverless-admin-metrics-eventing)