### PR TITLE
OSDOCS#12222: Update acm 2.10 links to 2.11 for enterprise-4.16

### DIFF
--- a/hosted_control_planes/hcp-getting-started.adoc
+++ b/hosted_control_planes/hcp-getting-started.adoc
@@ -13,43 +13,43 @@ You can view the procedures by selecting from one of the following providers:
 [id="hcp-getting-started-bm"]
 == Bare metal
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-sizing-guidance[Hosted control plane sizing guidance]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-cluster-workload-distributing[Distributing hosted cluster workloads]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#firewall-port-reqs-bare-metal[Bare metal firewall and port requirements]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#infrastructure-reqs-bare-metal[Bare metal infrastructure requirements]: Review the infrastructure requirements to create a hosted cluster on bare metal.
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-configure-bm[Configuring hosted control plane clusters on bare metal]:
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-sizing-guidance[Hosted control plane sizing guidance]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-cluster-workload-distributing[Distributing hosted cluster workloads]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#firewall-port-reqs-bare-metal[Bare metal firewall and port requirements]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#infrastructure-reqs-bare-metal[Bare metal infrastructure requirements]: Review the infrastructure requirements to create a hosted cluster on bare metal.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-configure-bm[Configuring hosted control plane clusters on bare metal]:
 ** Configure DNS
 ** Create a hosted cluster and verify cluster creation
 ** Scale the `NodePool` object for the hosted cluster
 ** Handle ingress traffic for the hosted cluster
 ** Enable node auto-scaling for the hosted cluster
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#configure-hosted-disconnected[Configuring {hcp} in a disconnected environment]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#configure-hosted-disconnected[Configuring {hcp} in a disconnected environment]
 
-* To destroy a hosted cluster on bare metal, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-bm[Destroying a hosted cluster on bare metal].
-* If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].
+* To destroy a hosted cluster on bare metal, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-bm[Destroying a hosted cluster on bare metal].
+* If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].
 
 [id="hcp-getting-started-virt"]
 == {VirtProductName}
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-sizing-guidance[Hosted control plane sizing guidance]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-cluster-workload-distributing[Distributing hosted cluster workloads]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on OpenShift Virtualization]: Create {product-title} clusters with worker nodes that are hosted by KubeVirt virtual machines.
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#configure-hosted-disconnected[Configuring {hcp} in a disconnected environment]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-sizing-guidance[Hosted control plane sizing guidance]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-cluster-workload-distributing[Distributing hosted cluster workloads]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on OpenShift Virtualization]: Create {product-title} clusters with worker nodes that are hosted by KubeVirt virtual machines.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#configure-hosted-disconnected[Configuring {hcp} in a disconnected environment]
 
-* To destroy a hosted cluster is on {VirtProductName}, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-kubevirt[Destroying a hosted cluster on OpenShift Virtualization].
-* If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].
+* To destroy a hosted cluster is on {VirtProductName}, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-kubevirt[Destroying a hosted cluster on OpenShift Virtualization].
+* If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].
 
 [id="hcp-getting-started-aws"]
 == {aws-first}
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosting-cluster-aws-infra-reqs[AWS infrastructure requirements]: Review the infrastructure requirements to create a hosted cluster on {aws-short}.
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring hosted control plane clusters on AWS]: The tasks to configure hosted control plane clusters on {aws-short} include creating the {aws-short} S3 OIDC secret, creating a routable public zone, enabling external DNS, enabling {aws-short} PrivateLink, and deploying a hosted cluster.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosting-cluster-aws-infra-reqs[AWS infrastructure requirements]: Review the infrastructure requirements to create a hosted cluster on {aws-short}.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring hosted control plane clusters on AWS]: The tasks to configure hosted control plane clusters on {aws-short} include creating the {aws-short} S3 OIDC secret, creating a routable public zone, enabling external DNS, enabling {aws-short} PrivateLink, and deploying a hosted cluster.
 * xref:../networking/hardware_networks/configuring-sriov-operator.adoc#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for {hcp}]: After you configure and deploy your hosting service cluster, you can create a subscription to the Single Root I/O Virtualization (SR-IOV) Operator on a hosted cluster. The SR-IOV pod runs on worker machines rather than the control plane.
 
-* To destroy a hosted cluster on AWS, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-aws[Destroying a hosted cluster on AWS].
-* If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].
+* To destroy a hosted cluster on AWS, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-aws[Destroying a hosted cluster on AWS].
+* If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].
 
 [id="hcp-getting-started-ibmz"]
 == {ibm-z-title}
@@ -57,8 +57,8 @@ You can view the procedures by selecting from one of the following providers:
 :FeatureName: {hcp-capital} on the {ibm-z-title} platform
 include::snippets/technology-preview.adoc[]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-ibmz[Configuring the hosting cluster on x86 bare metal for IBM Z compute nodes (Technology Preview)]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-ibmz[Configuring the hosting cluster on x86 bare metal for IBM Z compute nodes (Technology Preview)]
 
 [id="hcp-getting-started-ibmpower"]
 == {ibm-power-title}
@@ -66,8 +66,8 @@ include::snippets/technology-preview.adoc[]
 :FeatureName: {hcp-capital} on the {ibm-power-title} platform
 include::snippets/technology-preview.adoc[]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#config-hosted-service-ibmpower[Configuring the hosting cluster on a 64-bit x86 OpenShift Container Platform cluster to create {hcp} for IBM Power compute nodes (Technology Preview)]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#config-hosted-service-ibmpower[Configuring the hosting cluster on a 64-bit x86 OpenShift Container Platform cluster to create {hcp} for IBM Power compute nodes (Technology Preview)]
 
 [id="hcp-getting-started-non-bm-agent"]
 == Non bare metal agent machines
@@ -75,8 +75,8 @@ include::snippets/technology-preview.adoc[]
 :FeatureName: {hcp-capital} clusters using non bare metal agent machines
 include::snippets/technology-preview.adoc[]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-configure-agent-non-bm[Configuring hosted control plane clusters using non bare metal agent machines (Technology Preview)]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control plane command line interface]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-configure-agent-non-bm[Configuring hosted control plane clusters using non bare metal agent machines (Technology Preview)]
 
-* To destroy a hosted cluster on non bare metal agent machines, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-non-bm[Destroying a hosted cluster on non bare metal agent machines]
-* If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].
+* To destroy a hosted cluster on non bare metal agent machines, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-non-bm[Destroying a hosted cluster on non bare metal agent machines]
+* If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
This PR updates ACM doc links to redirect to ACM 2.11 for OCP 4.16.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12222
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://82958--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-getting-started.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
