### PR TITLE
OSDOCS-12223: Documented the 4.16.16 z-stream notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3356,6 +3356,44 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.16
+[id="ocp-4-16-16_{context}"]
+=== RHSA-2024:7599 - {product-title} {product-version}.16 bug fix and security update
+
+Issued: 09 October 2024
+
+{product-title} release {product-version}.16 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:7599[RHSA-2024:7599] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:7602[RHBA-2024:7602] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.16 --pullspecs
+----
+
+[id="ocp-4-16-16-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the `metal3-ironic-inspector` container in the `openshift-machine-api` namespace caused memory consumption issues for clusters. With this release, the memory consumption issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-42113[*OCPBUGS-42113*])
+
+* Previously, creating cron jobs to create pods for your cluster caused the component that fetches the pods to fail. Because of this issue, the *Topology* page on the {product-title} web console failed. With this release, a `3` second delay is configured for the component that fetches pods that are generated from the cron job so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-42015[*OCPBUGS-42015*])
+
+* Previously, because of an internal bug, the Node Tuning Operator incorrectly computed CPU masks for interrupt and network handling CPU affinity if a machine had more than 256 CPUs. This prevented proper CPU isolation on those machines and resulted in `systemd` unit failures. With this release, the Node Tuning Operator computes the masks correctly. (link:https://issues.redhat.com/browse/OCPBUGS-39377[*OCPBUGS-39377*])
+
+* Previously, when you used the Redfish Virtual Media to add an xFusion bare-metal node to your cluster, the node did not get added because of a node registration issue. The issue occurred because the hardware was not 100 percent compliant with Redfish. With this release, you can now add xFusion bare-metal nodes to your cluster.(link:https://issues.redhat.com/browse/OCPBUGS-38797[*OCPBUGS-38797*]) 
+
+* Previously, when you added IPv6 classless inter-domain routing (CIDR) addresses to the `no_proxy` variable, the Ironic API ignored the addresses. With this release, the Ironic API honors any IPv6 CIDR address added to the `no_proxy` variable. (link:https://issues.redhat.com/browse/OCPBUGS-37654[*OCPBUGS-37654*]) 
+
+* Previously, dynamic plugins using PatternFly 4 were referencing variables that are not available in {product-title} 4.15 and later. This was causing contrast issues for ACM in dark mode. With this update, older chart styles are now available to support PatternFly 4 charts used by dynamic plugins. (link:https://issues.redhat.com/browse/OCPBUGS-36816[*OCPBUGS-36816*])
+
+[id="ocp-4-16-16-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.16.15
 [id="ocp-4-16-15_{context}"]
 === RHSA-2024:7174 - {product-title} {product-version}.15 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12223](https://issues.redhat.com/browse/OSDOCS-12223)

Link to docs preview:
[4.16.6](https://82970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-16_release-notes)

Additional resources:
* Dropped https://issues.redhat.com/browse/OCPBUGS-42382 as per [this Slack thread](https://redhat-internal.slack.com/archives/C068JAU4Y0P/p1728288904989959).
* 

