### PR TITLE
OSDOCS-11945: adds 4.18 MicroShift relnotes build file to main

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -33,8 +33,8 @@ Name: Red Hat build of MicroShift release notes
 Dir: microshift_release_notes
 Distros: microshift
 Topics:
-- Name: Red Hat build of MicroShift 4.17 release notes
-  File: microshift-4-17-release-notes
+- Name: Red Hat build of MicroShift 4.18 release notes
+  File: microshift-4-18-release-notes
 ---
 Name: Getting ready to install MicroShift
 Dir: microshift_install_get_ready

--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-4-18-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/attributes-microshift.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+Release note changes should be added/edited in their own PR.
+
+This file is here to allow builds to work.

--- a/microshift_welcome/index.adoc
+++ b/microshift_welcome/index.adoc
@@ -21,7 +21,7 @@ To browse the {microshift-short} {product-version} documentation, use one of the
 To get started with {microshift-short}, use the following links:
 
 //text is in main assembly for the sake of cross references
-* xref:../microshift_release_notes/microshift-4-17-release-notes.adoc#microshift-4-17-release-notes[{product-title} release notes]
+* xref:../microshift_release_notes/microshift-4-18-release-notes.adoc#microshift-4-18-release-notes[{product-title} release notes]
 * xref:../microshift_install_rpm/microshift-install-rpm.adoc#microshift-install-rpm[Installing {product-title}]
 
 For related information, use the following links:


### PR DESCRIPTION
Version(s):
main only

Issue:
[OSDOCS-11945](https://issues.redhat.com/browse/OSDOCS-11945)

Link to docs preview:
N/A

QE review:
- N/A internal doc work

Additional information:
[4.18 release notes file in the enterprise-4.18 branch](https://github.com/openshift/openshift-docs/pull/82971)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
