### PR TITLE
OBSDOCS-1366: Add information about how to filter and keep metrics ba…

### DIFF
--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -36,7 +36,6 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 `openshift-user-workload-monitoring` namespace.
 endif::openshift-dedicated,openshift-rosa[]
-
 +
 [WARNING]
 ====
@@ -55,9 +54,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
 
-.. Add a `remoteWrite:` section under `data/config.yaml/prometheusK8s`.
-
-.. Add an endpoint URL and authentication credentials in this section:
+.. Add a `remoteWrite:` section under `data/config.yaml/prometheusK8s`, as shown in the following example:
 +
 [source,yaml]
 ----
@@ -70,10 +67,9 @@ data:
   config.yaml: |
     prometheusK8s:
       remoteWrite:
-      - url: "https://remote-write-endpoint.example.com" <1>
-        <endpoint_authentication_credentials> <2>
+      - url: "https://remote-write-endpoint.example.com" #<1>
+        <endpoint_authentication_credentials> #<2>
 ----
-+
 <1> The URL of the remote write endpoint.
 <2> The authentication method and credentials for the endpoint.
 Currently supported authentication methods are AWS Signature Version 4, authentication using HTTP in an `Authorization` request header, Basic authentication, OAuth 2.0, and TLS client.
@@ -94,14 +90,12 @@ data:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com"
         <endpoint_authentication_credentials>
-        <your_write_relabel_configs> <1>
+        writeRelabelConfigs:
+        - <your_write_relabel_configs> #<1>
 ----
-<1> The write relabel configuration settings.
+<1> Add configuration for metrics that you want to send to the remote endpoint.
 +
-For `<your_write_relabel_configs>` substitute a list of write relabel configurations for metrics that you want to send to the remote endpoint.
-+
-The following sample shows how to forward a single metric called `my_metric`:
-+
+.Example of forwarding a single metric called `my_metric`
 [source,yaml]
 ----
 apiVersion: v1
@@ -118,10 +112,26 @@ data:
         - sourceLabels: [__name__]
           regex: 'my_metric'
           action: keep
-
 ----
 +
-See the link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[Prometheus relabel_config documentation] for information about write relabel configuration options.
+.Example of forwarding metrics called `my_metric_1` and `my_metric_2` in `my_namespace` namespace
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      remoteWrite:
+      - url: "https://remote-write-endpoint.example.com"
+        writeRelabelConfigs:
+        - sourceLabels: [__name__,namespace]
+          regex: '(my_metric_1|my_metric_2);my_namespace'
+          action: keep 
+----
 
 ** *To configure remote write for the Prometheus instance that monitors user-defined projects*:
 endif::openshift-dedicated,openshift-rosa[]
@@ -132,9 +142,7 @@ endif::openshift-dedicated,openshift-rosa[]
 $ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
 ----
 
-.. Add a `remoteWrite:` section under `data/config.yaml/prometheus`.
-
-.. Add an endpoint URL and authentication credentials in this section:
+.. Add a `remoteWrite:` section under `data/config.yaml/prometheus`, as shown in the following example:
 +
 [source,yaml]
 ----
@@ -147,10 +155,9 @@ data:
   config.yaml: |
     prometheus:
       remoteWrite:
-      - url: "https://remote-write-endpoint.example.com" <1>
-        <endpoint_authentication_credentials> <2>
+      - url: "https://remote-write-endpoint.example.com" #<1>
+        <endpoint_authentication_credentials> #<2>
 ----
-+
 <1> The URL of the remote write endpoint.
 <2> The authentication method and credentials for the endpoint.
 Currently supported authentication methods are AWS Signature Version 4, authentication using HTTP an `Authorization` request header, basic authentication, OAuth 2.0, and TLS client.
@@ -171,14 +178,12 @@ data:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com"
         <endpoint_authentication_credentials>
-        <your_write_relabel_configs> <1>
+        writeRelabelConfigs:
+        - <your_write_relabel_configs> #<1>
 ----
-<1> The write relabel configuration settings.
+<1> Add configuration for metrics that you want to send to the remote endpoint.
 +
-For `<your_write_relabel_configs>` substitute a list of write relabel configurations for metrics that you want to send to the remote endpoint.
-+
-The following sample shows how to forward a single metric called `my_metric`:
-+
+.Example of forwarding a single metric called `my_metric`
 [source,yaml]
 ----
 apiVersion: v1
@@ -195,9 +200,25 @@ data:
         - sourceLabels: [__name__]
           regex: 'my_metric'
           action: keep
-
 ----
 +
-See the link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[Prometheus relabel_config documentation] for information about write relabel configuration options.
+.Example of forwarding metrics called `my_metric_1` and `my_metric_2` in `my_namespace` namespace
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      remoteWrite:
+      - url: "https://remote-write-endpoint.example.com"
+        writeRelabelConfigs:
+        - sourceLabels: [__name__,namespace]
+          regex: '(my_metric_1|my_metric_2);my_namespace'
+          action: keep 
+----
 
 . Save the file to apply the changes. The new configuration is applied automatically.


### PR DESCRIPTION
Version(s): 
* `enterprise-4.12` and later
* `monitoring-docs-restructure`

Issue: [OBSDOCS-1366](https://issues.redhat.com/browse/OBSDOCS-1366)

Link to docs preview: https://82994--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#configuring-remote-write-storage_configuring-the-monitoring-stack

QE review:
- [x] QE has approved this change.

**Additional information:**