### PR TITLE
[enterprise-4.14] Update oc edit command from the "Scaling down the data plane to zero" 

### DIFF
--- a/modules/scale-down-data-plane.adoc
+++ b/modules/scale-down-data-plane.adoc
@@ -33,7 +33,7 @@ $ oc get nodepool --namespace <HOSTED_CLUSTER_NAMESPACE>
 +
 [source,terminal]
 ----
-$ oc edit NodePool <nodepool> -o yaml --namespace <HOSTED_CLUSTER_NAMESPACE>
+$ oc edit nodepool <nodepool_name>  --namespace <hosted_cluster_namespace>
 ----
 +
 .Example output


### PR DESCRIPTION
Update oc edit command from the "Scaling down the data plane to zero" section  for branch enterprise-4.14

Created the change separately for the branch "enterprise-4.14" as we were facing some issues while merging the changes as a part of PR : https://github.com/openshift/openshift-docs/pull/82681 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
enterprise-4.14
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://83003--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting.html


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
