### PR TITLE
Osdocs 11356 - add a "/" to code block in step 5

### DIFF
--- a/modules/creating-machines-bare-metal.adoc
+++ b/modules/creating-machines-bare-metal.adoc
@@ -26,7 +26,4 @@ You can configure {op-system} during ISO and PXE installations by using the foll
 
 Whether to use an ISO or PXE install depends on your situation. A PXE install requires an available DHCP service and more preparation, but can make the installation process more automated. An ISO install is a more manual process and can be inconvenient if you are setting up more than a few machines.
 
-[NOTE]
-====
-As of {product-title} 4.6, the {op-system} ISO and other installation artifacts provide support for installation on disks with 4K sectors.
-====
+

--- a/modules/oc-mirror-procedure-delete-v2.adoc
+++ b/modules/oc-mirror-procedure-delete-v2.adoc
@@ -30,7 +30,7 @@ Where:
 +
 [source,terminal]
 ----
-$ oc mirror delete --v2 --delete-yaml-file <previously_mirrored_work_folder>/delete/delete-images.yaml docker:/ <remote_registry>
+$ oc mirror delete --v2 --delete-yaml-file <previously_mirrored_work_folder>/delete/delete-images.yaml docker://<remote_registry>
 ----
 Where:
 - `<previously_mirrored_work_folder>`: Specify your previously mirrored work folder.


### PR DESCRIPTION
Version(s):
16+

Issue:
https://issues.redhat.com/browse/OSDOCS-11356

Link to docs preview:
https://83009--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/about-installing-oc-mirror-v2.html
https://83009--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html
https://83009--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html
https://83009--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html
https://83009--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

