### PR TITLE
OSDOCS-12217: adds oc to prereqs embed for offline use

### DIFF
--- a/modules/microshift-embed-images-offline-use.adoc
+++ b/modules/microshift-embed-images-offline-use.adoc
@@ -12,6 +12,7 @@ To embed container images in devices at the edge that do not have any network co
 
 * You have root access to the host.
 * Application RPMs have been added to a blueprint.
+* You installed the {oc-first}.
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.16, 4.17, 4.18

Issue:
[OSDOCS-12217](https://issues.redhat.com/browse/OSDOCS-12217)

Link to docs preview:
[Embedding apps for offline use](https://83013--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-embed-apps-offline-use.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
