### PR TITLE
OSDOCS-12131: adds immutable setting note to configuration doc

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -110,7 +110,7 @@ Dir: microshift_configuring
 Distros: microshift
 Topics:
 - Name: Using the MicroShift configuration file
-  File: microshift-using-config-tools
+  File: microshift-using-config-yaml
 - Name: Configuring IPv6 networking
   File: microshift-nw-ipv6-config
 - Name: Cluster access with kubeconfig

--- a/microshift_configuring/microshift-using-config-yaml.adoc
+++ b/microshift_configuring/microshift-using-config-yaml.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="microshift-using-config-tools"]
+[id="microshift-using-config-yaml"]
 include::_attributes/attributes-microshift.adoc[]
 = Using the {microshift-short} configuration file
 :context: microshift-configuring
@@ -18,7 +18,7 @@ include::modules/microshift-nw-advertise-address.adoc[leveloffset=+2]
 
 include::modules/microshift-config-nodeport-limits.adoc[leveloffset=+2]
 
-[id="additional-resources_microshift-using-config-tools_{context}"]
+[id="additional-resources_microshift-using-config-yaml_{context}"]
 [role="_additional-resources"]
 == Additional resources
 

--- a/microshift_configuring/microshift_low_latency/microshift-low-latency.adoc
+++ b/microshift_configuring/microshift_low_latency/microshift-low-latency.adoc
@@ -23,7 +23,7 @@ include::modules/microshift-low-latency-config-yaml.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 //TODO * workload partitioning crossref here
-* xref:../../microshift_configuring/microshift-using-config-tools.adoc#microshift-config-yaml_microshift-configuring[Using a YAML configuration file]
+* xref:../../microshift_configuring/microshift-using-config-yaml.adoc#microshift-config-yaml_microshift-configuring[Using a YAML configuration file]
 * link:https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration[KubeletConfiguration reference] (Kubernetes upstream documentation)
 
 //RHEL TuneD

--- a/microshift_install_rpm/microshift-install-rpm.adoc
+++ b/microshift_install_rpm/microshift-install-rpm.adoc
@@ -21,7 +21,7 @@ include::modules/microshift-install-rpm-preparing.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * Download the link:https://console.redhat.com/openshift/install/pull-secret[pull secret] from the Red Hat Hybrid Cloud Console.
-* xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-using-config-tools[Configuring MicroShift].
+* xref:../microshift_configuring/microshift-using-config-yaml.adoc#microshift-using-config-yaml[Configuring MicroShift].
 * For more options on partition configuration, read link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_a_standard_rhel_9_installation/index#manual-partitioning_graphical-installation[Configuring Manual Partitioning].
 * For more information about resizing your existing LVs to free up capacity in your VGs, read link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/configuring_and_managing_logical_volumes/index#managing-lvm-volume-groups_configuring-and-managing-logical-volumes[Managing LVM Volume Groups].
 * For more information about creating VGs and PVs, read link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_logical_volumes/overview-of-logical-volume-management_configuring-and-managing-logical-volumes[Overview of logical volume management].

--- a/microshift_networking/microshift-cni.adoc
+++ b/microshift_networking/microshift-cni.adoc
@@ -68,7 +68,7 @@ include::modules/microshift-nw-topology.adoc[leveloffset=+1]
 [id="_additional-resources_microshift-cni_{context}"]
 == Additional resources
 
-* xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-config-yaml_microshift-configuring[Using a YAML configuration file]
+* xref:../microshift_configuring/microshift-using-config-yaml.adoc#microshift-config-yaml_microshift-configuring[Using a YAML configuration file]
 * xref:../microshift_networking/microshift-networking-settings.adoc#microshift-understanding-networking-settings[Understanding networking settings]
 * xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-cni-multus[About using multiple networks]
 * xref:../microshift_networking/microshift_network_policy/microshift-network-policy-index.adoc#microshift-network-policies[About network policies]

--- a/microshift_networking/microshift-nw-router.adoc
+++ b/microshift_networking/microshift-nw-router.adoc
@@ -24,7 +24,7 @@ include::modules/microshift-nw-router-config-ip-address.adoc[leveloffset=+2]
 [role="_additional-resources"]
 [id="additional-resources_microshift-understanding-and-configuring-router_{context}"]
 == Additional resources
-* xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-yaml-default_microshift-using-config-tools[Default settings] ({microshift-short})
+* xref:../microshift_configuring/microshift-using-config-yaml.adoc#microshift-yaml-default_microshift-using-config-yaml[Default settings] ({microshift-short})
 
 * xref:../microshift_networking/microshift_network_policy/microshift-network-policy-index.adoc#microshift-network-policies[About network policies]
 

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * microshift_configuring/microshift-using-config-tools.adoc
+// * microshift_configuring/microshift-using-config-yaml.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-yaml-default_{context}"]
@@ -86,7 +86,7 @@ storage:
 <16> A block of IP addresses from which pod IP addresses are allocated. IPv4 is the default. Dual-stack entries are supported. The first entry in this field is immutable after installation.
 <17> A block of virtual IP addresses for Kubernetes services. IP address pool for services. IPv4 is the default. Dual-stack entries are supported. The first entry in this field is immutable after installation.
 <18> The port range allowed for Kubernetes services of type `NodePort`. If not specified, the default range of 30000-32767 is used. Services without a `NodePort` specified are automatically allocated one from this range. This parameter can be updated after the cluster is installed.
-<19> The name of the node. The default value is the hostname. If non-empty, this string is used to identify the node instead of the hostname.
+<19> The name of the node. The default value is the hostname. If non-empty, this string is used to identify the node instead of the hostname. You cannot change this immutable setting after {microshift-short} starts for the first time.
 <20> The IPv4 address of the node. The default value is the IP address of the default route.
 <21> The IPv6 address for the node for dual-stack configurations. Cannot be configured in single stack for either IPv4 or IPv6. Default is empty or null.
 <22> Default value is empty. Valid values are "none" or "lvms". An empty value or null field defaults to LVMS deployment.

--- a/snippets/microshift-greenboot-status-snip.adoc
+++ b/snippets/microshift-greenboot-status-snip.adoc
@@ -1,6 +1,6 @@
 // Text snippet included in the following assemblies:
 //
-// * microshift_configuring/microshift-using-config-tools.adoc
+// * microshift_configuring/microshift-using-config-yaml.adoc
 //
 // Text snippet included in the following modules:
 //


### PR DESCRIPTION
Version(s):
4.17, 4.18

Issue:
[OSDOCS-12131](https://issues.redhat.com/browse/OSDOCS-12131)

Link to docs preview:
[Default values table, footnote #19](https://83015--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html)
[xref in additional resources](https://83015--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm/microshift-install-rpm.html#microshift-install-rpm-preparing_microshift-install-rpm)
[assembly-level xref](https://83015--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-nw-router.html#additional-resources_microshift-understanding-and-configuring-router_microshift-nw-router)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
See also https://github.com/openshift/openshift-docs/pull/83016

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
