### PR TITLE
OSDOCS-12131-416: adds immutable setting note to configuration doc

### DIFF
--- a/microshift_configuring/microshift-using-config-tools.adoc
+++ b/microshift_configuring/microshift-using-config-tools.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-using-config-tools"]
-= How configuration tools work
+= Using the {microshift-short} config.yaml
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-configuring
 

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -79,5 +79,5 @@ node:
 <15> A block of IP addresses from which pod IP addresses are allocated. This field is immutable after installation.
 <16> A block of virtual IP addresses for Kubernetes services. IP address pool for services. A single entry is supported. This field is immutable after installation.
 <17> The port range allowed for Kubernetes services of type `NodePort`. If not specified, the default range of 30000-32767 is used. Services without a `NodePort` specified are automatically allocated one from this range. This parameter can be updated after the cluster is installed.
-<18> The name of the node. The default value is the hostname. If non-empty, this string is used to identify the node instead of the hostname.
+<18> The name of the node. The default value is the hostname. If non-empty, this string is used to identify the node instead of the hostname. You cannot change this immutable setting after {microshift-short} starts for the first time.
 <19> The IP address of the node. The default value is the IP address of the default route.


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12131](https://issues.redhat.com/browse/OSDOCS-12131)

Link to docs preview:
[Using config tools, footnote #18](https://83016--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-tools.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
See also https://github.com/openshift/openshift-docs/pull/83015

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
