### PR TITLE
alphabetizes and labels modules in the cluster capabilities assembly (4.14)

### DIFF
--- a/installing/overview/cluster-capabilities.adoc
+++ b/installing/overview/cluster-capabilities.adoc
@@ -28,6 +28,7 @@ include::modules/explanation-of-capabilities.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../operators/operator-reference.adoc#cluster-operator-reference[Cluster Operators reference]
 
+// Bare-metal capability
 include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -39,14 +40,24 @@ include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 // Build capability
 include::modules/build-config-capability.adoc[leveloffset=+2]
 
+// Cluster Image Registry capability
+include::modules/cluster-image-registry-operator.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../registry/configuring-registry-operator.adoc#configuring-registry-operator[Image Registry Operator in {product-title}]
+
+// Cluster storage capability
 include::modules/cluster-storage-operator.adoc[leveloffset=+2]
 
+// Console capability
 include::modules/console-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../web_console/web-console-overview.adoc#web-console-overview[Web console overview]
 
+// CSI snapshot controller capability
 include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -56,12 +67,14 @@ include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+2]
 // DeploymentConfig capability
 include::modules/deployment-config-capability.adoc[leveloffset=+2]
 
+// Insights capability
 include::modules/insights-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
 
+// Machine API capability
 include::modules/machine-api-capability.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -71,29 +84,26 @@ include::modules/machine-api-capability.adoc[leveloffset=+2]
 * xref:../../operators/operator-reference.html#cluster-autoscaler-operator_cluster-operators-ref[Cluster Autoscaler Operator]
 * xref:../../operators/operator-reference.html#control-plane-machine-set-operator_cluster-operators-ref[Control Plane Machine Set Operator]
 
+// Marketplace capability
 include::modules/operator-marketplace.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs]
 
+// Node Tuning capability
 include::modules/node-tuning-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator]
 
+// OpenShift samples capability
 include::modules/cluster-samples-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configuring the Cluster Samples Operator]
-
-include::modules/cluster-image-registry-operator.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../registry/configuring-registry-operator.adoc#configuring-registry-operator[Image Registry Operator in {product-title}]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]


### PR DESCRIPTION
Version(s):
4.14

Issue:
N/A

Link to docs preview:
[Optional cluster capabilities in OpenShift Container Platform Branch Build](https://83024--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities.html#explanation_of_capabilities_cluster-capabilities)

QE review:
N/A

Additional information: