### PR TITLE
labels modules in the cluster capabilities assembly (4.12)

### DIFF
--- a/installing/overview/cluster-capabilities.adoc
+++ b/installing/overview/cluster-capabilities.adoc
@@ -28,6 +28,7 @@ include::modules/explanation-of-capabilities.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../operators/operator-reference.adoc#cluster-operator-reference[Cluster Operators reference]
 
+// Bare-metal capability
 include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -36,32 +37,38 @@ include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 * xref:../../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#preparing-to-install-on-bare-metal[Preparing for bare metal cluster installation]
 * xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
 
+// Cluster storage capability
 include::modules/cluster-storage-operator.adoc[leveloffset=+2]
 
+// Console capability
 include::modules/console-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../web_console/web-console-overview.adoc#web-console-overview[Web console overview]
 
+// CSI snapshot controller capability
 include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#persistent-storage-csi-snapshots[CSI volume snapshots]
 
+// Insights capability
 include::modules/insights-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
 
+// Marketplace capability
 include::modules/operator-marketplace.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs]
 
+// OpenShift samples capability
 include::modules/cluster-samples-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.12

Issue:
N/A

Link to docs preview:
[Optional cluster capabilities in OpenShift Container Platform Branch Build](https://83026--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities.html#explanation_of_capabilities_cluster-capabilities)

QE review:
N/A

Additional information: