### PR TITLE
Fixing unresolved attribute

### DIFF
--- a/modules/configuring-network-overrides-ibmz.adoc
+++ b/modules/configuring-network-overrides-ibmz.adoc
@@ -5,7 +5,7 @@
 [id="configuring-network-overrides-ibm_{context}"]
 = Configuring network overrides in {ibm-z-title}
 
-You can specify a static IP address on {ibm-z-title} machines that uses Logical Partition (LPAR) and z/VM. This is useful when the network devices do not have a static MAC address assigned to them. 
+You can specify a static IP address on {ibm-z-title} machines that uses Logical Partition (LPAR) and z/VM. This is useful when the network devices do not have a static MAC address assigned to them.
 
 .Procedure
 
@@ -25,17 +25,17 @@ This parameter allows the file to add the network settings to the CoreOS install
 rd.neednet=1 cio_ignore=all,!condev
 console=ttysclp0
 coreos.live.rootfs_url=<coreos_url> <1>
-ip=<ip>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> 
+ip=<ip>::<gateway>:<netmask>:<hostname>::none nameserver=<dns>
 rd.znet=qeth,<network_adaptor_range>,layer2=1
-rd.<disk_type>=<adapter> <2> 
+rd.<disk_type>=<adapter> <2>
 rd.zfcp=<adapter>,<wwpn>,<lun> random.trust_cpu=on <3>
-zfcp.allow_lun_scan=0 
+zfcp.allow_lun_scan=0
 ai.ip_cfg_override=1
-ignition.firstboot ignition.platform.id=metal 
+ignition.firstboot ignition.platform.id=metal
 random.trust_cpu=on
 ----
 <1> For the `coreos.live.rootfs_url` artifact, specify the matching `rootfs` artifact for the `kernel` and `initramfs` that you are booting. Only HTTP and HTTPS protocols are supported.
-<2> For installations on direct access storage devices (DASD) type disks, use `rd.` to specify the DASD where {rhel-first} is to be installed. For installations on Fibre Channel Protocol (FCP) disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {rhel} is to be installed.
+<2> For installations on direct access storage devices (DASD) type disks, use `rd.` to specify the DASD where {op-system-first} is to be installed. For installations on Fibre Channel Protocol (FCP) disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {rhel} is to be installed.
 <3> Specify values for `adapter`, `wwpn`, and `lun` as in the following example: `rd.zfcp=0.0.8002,0x500507630400d1e3,0x4000404600000000`.
 
 [NOTE]


### PR DESCRIPTION
Version(s): 4.17+

This PR fixes an unresolved attribute that was supposed to say "Red Hat Enterprise Linux CoreOS (RHCOS)", based on the [section directly below](https://docs.openshift.com/container-platform/4.17/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.html#installing-ocp-agent-ibm-z-zvm_prepare-pxe-assets-agent) where the example file was copied from.

QE review:
(not sure QE is required, but can request one if peer reviewers believes it needs QA)

Preview: [Configuring network overrides in IBM Z](https://83027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.html#configuring-network-overrides-ibm_prepare-pxe-assets-agent)