### PR TITLE
OSDOCS#12230: adding missing parameters for node procedure

### DIFF
--- a/modules/adding-node-iso-configs.adoc
+++ b/modules/adding-node-iso-configs.adoc
@@ -68,6 +68,17 @@ For more information, see "Root device hints" in the "Setting up the environment
 The configuration must match the Host Network Management API defined in the link:https://nmstate.io/[nmstate documentation].
 |A dictionary of host network configuration objects.
 
+|cpuArchitecture
+|Optional.
+Specifies the architecture of the nodes you are adding.
+This parameter allows you to override the default value from the cluster when required.
+|String.
+
+|sshKey
+|Optional.
+The file containing the SSH key to authenticate access to your cluster machines.
+|String.
+
 |====
 
 


### PR DESCRIPTION
[OSDOCS-12230](https://issues.redhat.com/browse/OSDOCS-12230)

Version(s): 4.17+

This PR adds two parameters that were not included in the config reference for the procedure about adding nodes to clusters.

QE review:
- [x] QE has approved this change.

Preview: [YAML file parameters](https://83029--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso.html#adding-node-iso-yaml-config_adding-node-iso)
