### PR TITLE
PLMCORE-10438: Clarifying that the referenced metrics are Prometheus

### DIFF
--- a/modules/nw-metallb-metrics.adoc
+++ b/modules/nw-metallb-metrics.adoc
@@ -5,7 +5,7 @@
 [id="nw-metallb-metrics_{context}"]
 = MetalLB metrics for BGP and BFD
 
-{product-title} captures the following metrics for MetalLB that relate to BGP peers and BFD profiles.
+{product-title} captures the following Prometheus metrics for MetalLB that relate to BGP peers and BFD profiles.
 
 .MetalLB BFD metrics
 [cols="30%,70%",options="header"]


### PR DESCRIPTION
https://issues.redhat.com/browse/PLMCORE-10438

Edit per discussion with @CFields651 in PX.

Preview build: https://83034--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-troubleshoot-support.html#nw-metallb-metrics_metallb-troubleshoot-support

No QE review needed.