### PR TITLE
OSDOCS-12225: Documenting the 4.12.67 z-stream RNs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4927,3 +4927,30 @@ $ oc adm release info 4.12.66 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.12.67
+[id="ocp-4-12-67"]
+=== RHSA-2024:7590 - {product-title} 4.12.67 bug fix and security update
+
+Issued: 09 October 2024
+
+{product-title} release 4.12.67, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:7590[RHSA-2024:7590] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:7592[RHBA-2024:7592] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.67 --pullspecs
+----
+
+[id="ocp-4-12-67-bug-fixes"]
+==== Bug fixes
+
+* Previously, when the Operator Lifecycle Manager (OLM) evaluated a potential upgrade, the Operator used the dynamic client list for all custom resource (CR) instances in the cluster. Clusters with a large number of CRs could experience timeouts from the `apiserver` and stranded upgrades. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-42161[*OCPBUGS-42161*])
+
+* Previously, the proxy service for the web console plugin handled non-200 response codes as error responses. This, in turn, caused browser caching issues. With this release, the proxy service is fixed so that it does not handle these responses as errors. (link:https://issues.redhat.com/browse/OCPBUGS-41600[*OCPBUGS-41600*])
+
+[id="ocp-4-12-67-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-12225](https://issues.redhat.com/browse/OSDOCS-12225)

Link to docs preview:
* https://83065--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-67

Additional information:
* https://errata.devel.redhat.com/advisory/139568
