### PR TITLE
[enterprise-4.12]PLMCORE-10438: Clarifying that the referenced metrics are Prometheus

### DIFF
--- a/modules/nw-metallb-metrics.adoc
+++ b/modules/nw-metallb-metrics.adoc
@@ -5,7 +5,7 @@
 [id="nw-metallb-metrics_{context}"]
 = MetalLB metrics for BGP and BFD
 
-{product-title} captures the following metrics that are related to MetalLB and BGP peers and BFD profiles:
+{product-title} captures the following Prometheus metrics for MetalLB that relate to BGP peers and BFD profiles.
 
 * `metallb_bfd_control_packet_input` counts the number of BFD control packets received from each BFD peer.
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/83034