### PR TITLE
OSDOCS-11766: adds 4.17.1 GA release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -6,18 +6,16 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-{product-title} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate single-node clusters in low-resource edge environments.
+{product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate single-node clusters in low-resource edge environments.
 
 {microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
-//TODO verify K8s version and another other relevant notes
 [id="microshift-4-17-about-this-release_{context}"]
 == About this release
-Version 4.17 of {product-title} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+Version 4.17 of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
 
-//TODO: Update OP system versions
 {microshift-short} {product-version} is supported on {op-system-base-full} 9.4.
 
 For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
@@ -27,22 +25,13 @@ For lifecycle information, see the link:https://access.redhat.com/product-life-c
 
 This release adds improvements related to the following components and concepts.
 
-//L3 major categories with features in each as L4s
 [id="microshift-4-17-rhel_{context}"]
 === {op-system-base-full}
 * {microshift-short} {product-version} runs on {op-system-base-full} 9.4.
 
 [id="microshift-4-17-updating_{context}"]
 === Updating
-Updating two minor versions in a single step is supported in 4.17. Updates for both single-version minor releases and patch releases are still supported.
-
-//TODO add new features and enhancements as needed, L4 [discrete] headings
-
-//[id="microshift-4-17-installation_{context}"]
-//=== Installation
-
-//[id="microshift-4-17-configuring_{context}"]
-//=== Configuring
+Updating two minor versions in a single step is not supported in 4.17. Updates for both single-version minor releases and patch releases are supported.
 
 [id="microshift-4-17-networking_{context}"]
 === Networking
@@ -73,53 +62,36 @@ You can now run a {microshift-short} cluster with low-latency response rates. Us
 ==== Support for workload partitioning
 With this release, workload partitioning is supported in {microshift-short}. See xref:../microshift_configuring/microshift_low_latency/microshift-workload-partitioning.adoc#microshift-workload-partitioning[Workload partitioning] for more information.
 
-//[id="microshift-4-17-support_{context}"]
-//=== Support
-
 [id="microshift-4-17-doc-enhancements_{context}"]
 === Documentation enhancements
-//Doc enhancements include additions for RFEs and other continuous improvement items that are substantial and are not tied to new features or bug fixes already listed here. These can also go under the relevant section as applicable.
 
 [id="microshift-4-17-data-cleanup_{context}"]
 ==== Data cleanup now documented
 With this release, the `microshift-cleanup-data` script is documented. See xref:../microshift_troubleshooting/microshift-cleanup-data.adoc#microshift-cleanup-data[Data cleanup] for more information.
 
-[id="microshift-4-17-tech-preview_{context}"]
-== Technology preview features
+[id="microshift-4-17-install-topics-reorg_{context}"]
+==== Installation topics are reorganized
+With this release, system requirements, installation types, and information about installing add-ons are reorganized into discrete topics so that they are easier to use.
 
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
+[id="microshift-4-17-tech-preview_{context}"]
+== Technology Preview feature
+
+One feature in this release is currently in Technology Preview. This experimental feature is not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for this feature:
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
 [id="microshift-4-17-rhel-image-mode_{context}"]
 === {op-system-base-full} image mode Technology Preview feature
-* You can now install {microshift-short} using a `bootc` container image. Image mode for {op-system} is a technology preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
+* You can now install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
 
 See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
-[id="microshift-4-17-bug-fixes_{context}"]
-== Bug fixes
+//[id="microshift-4-17-bug-fixes_{context}"]
+//== Bug fixes
 
-//[discrete]
-//[id="microshift-4-17-installation-bug-fixes"]
-//=== Installation
-
-//[discrete]
-//[id="microshift-4-17-networking-bug-fixes"]
-//=== Networking
-
-//[discrete]
-//[id="microshift-4-17-support-bug-fixes"]
-//=== Support
-
-//check status for next release+
 //[id="microshift-4-17-known-issues_{context}"]
 //== Known issues
-
-//[id="microshift-4-17-pods-writing-files-excess-memory-limits-crash_{context}"]
-//=== Pods crash when writing files that exceed memory limits
-//Because of an issue with {op-system-base}, when a pod tries to write files that are larger than configured memory limits to a persistent volume claim, the pod might crash with an out-of-memory error. The pod status shows `OOMKilled` when this occurs. Use the following workarounds to avoid this issue: link:https://access.redhat.com/solutions/7076169[Pods writing files larger than memory limit to PVCs tend to OOM frequently running on MicroShift](Red Hat Knowledgebase).
 
 [id="microshift-4-17-asynchronous-errata-updates_{context}"]
 == Asynchronous errata updates
@@ -135,12 +107,11 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
-//TODO verify info prior to merge
 [id="microshift-4-17-1-dp_{context}"]
-=== RHEA-2024:XXXX - {microshift-short} 4.17.1 bug fix and security update advisory
+=== RHBA-2024:7924 - {microshift-short} 4.17.1 Generally Available release advisory
 
-Issued: DD Month 2024
+Issued: 15 October 2024
 
-{product-title} release 4.17.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:XXXX[RHEA-2024:XXXX] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2024:XXXX[RHEA-2024:XXXX] advisory.
+{product-title} release 4.17.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:7924[RHBA-2024:7924] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:7922[RHSA-2024:7922] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11766](https://issues.redhat.com/browse/OSDOCS-11766)

Link to docs preview:
[4-17-1-dp_release-notes](https://83078--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-1-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
