### PR TITLE
Ocpbugs 25129: metallb should make sure that secondary nics are forwarding traffic

### DIFF
--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -1,0 +1,66 @@
+:_mod-docs-content-type: PROCEDURE
+[id="nw-metallb-configure-secondary-interface_{context}"]
+= Configuring MetalLB with secondary networks
+
+From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces. 
+[NOTE]
+====
+{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding. 
+====
+
+To enable IP forwarding for the secondary interface, you have two options: 
+
+* Enable IP forwarding for all interfaces.
+* Enable IP forwarding for a specific interface. 
++
+[NOTE]
+====
+Enabling IP forwarding for a specific interface provides more granular control, while enabling it for all interfaces applies a global setting.
+====
+
+.Procedure
+
+. Enable forwarding for a specific secondary interface, such as `bridge-net` by creating and applying a `MachineConfig` CR. 
+
+.. Create the `MachineConfig` CR to enable IP forwarding for the specified secondary interface named `bridge-net`.
+
+.. Save the following YAML in the `enable-ip-forward.yaml` file:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: <node_role> <1>
+  name: 81-enable-global-forwarding
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,`echo -e "net.ipv4.conf.bridge-net.forwarding = 1\nnet.ipv6.conf.bridge-net.forwarding = 1\nnet.ipv4.conf.bridge-net.rp_filter = 0\nnet.ipv6.conf.bridge-net.rp_filter = 0" | base64 -w0`
+           verification: {}
+        filesystem: root
+        mode: 644
+        path: /etc/sysctl.d/enable-global-forwarding.conf
+  osImageURL: ""
+----
++
+<1> Node role where you want to enable IP forwarding, for example, `worker`
+
+.. Apply the configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f enable-ip-forward.yaml
+----
+
+. Alternatively, you can enable IP forwarding globally by running the following command:
++
+[source,terminal]
+----
+$ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}
+----

--- a/networking/metallb/about-advertising-ipaddresspool.adoc
+++ b/networking/metallb/about-advertising-ipaddresspool.adoc
@@ -43,6 +43,9 @@ include::modules/nw-metallb-configure-l2-advertisement-label.adoc[leveloffset=+1
 // Configure MetalLB with a L2 advertisement using interface
 include::modules/nw-metallb-configure-l2-advertisement-interface.adoc[leveloffset=+1]
 
+// Configure MetalLB with a secondary interface
+include::modules/nw-metallb-configure-secondary-interface.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_about-advertiseipaddress"]
 == Additional resources


### PR DESCRIPTION
[OCPBUGS-25129: metallb should make sure that secondary nics are forwarding traffic

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):4.14, 4.15, 4.16, 4.17, 4.18 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-25129
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://83087--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/about-advertising-ipaddresspool.html#nw-metallb-configure-secondary-interface_about-advertising-ip-address-pool
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
