### PR TITLE
OSDOCS-12260 Adding RODOO 1.1.0 RNs to 4.16 branch

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -34,3 +34,17 @@ include::snippets/fips-snippet.adoc[]
 === Bug fixes
 
 * This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+[id="run-once-duration-override-operator-release-notes-1-1-0"]
+== Run Once Duration Override Operator 1.1.0
+
+Issued: 28 February 2024
+
+The following advisory is available for the {run-once-operator} 1.1.0:
+
+* link:https://access.redhat.com/errata/RHSA-2024:0269[RHSA-2024:0269]
+
+[id="run-once-duration-override-operator-1-1-0-bug-fixes"]
+=== Bug fixes
+
+* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-12260](https://issues.redhat.com/browse/OSDOCS-12260)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83088--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#run-once-duration-override-operator-release-notes-1-1-0
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
