### PR TITLE
Modified processor to processors in doc YAML

### DIFF
--- a/observability/otel/otel-collector/otel-collector-processors.adoc
+++ b/observability/otel/otel-collector/otel-collector-processors.adoc
@@ -68,7 +68,7 @@ The Memory Limiter Processor periodically checks the Collector's memory usage an
 ----
 # ...
   config: |
-    processor:
+    processors:
       memory_limiter:
         check_interval: 1s
         limit_mib: 4000
@@ -136,7 +136,7 @@ rules:
 ----
 # ...
   config: |
-    processor:
+    processors:
       resourcedetection:
         detectors: [openshift]
         override: true
@@ -229,7 +229,7 @@ include::snippets/technology-preview.adoc[]
 ----
 # ...
   config: |
-    processor:
+    processors:
       attributes:
       - key: cloud.availability_zone
         value: "zone-1"
@@ -259,7 +259,7 @@ include::snippets/technology-preview.adoc[]
 ----
 # ...
   config: |
-    processor:
+    processors:
       span:
         name:
           from_attributes: [<key1>, <key2>, ...] # <1>
@@ -276,7 +276,7 @@ You can use this processor to extract attributes from the span name.
 ----
 # ...
   config: |
-    processor:
+    processors:
       span/to_attributes:
         name:
           to_attributes:
@@ -293,7 +293,7 @@ You can have the span status modified.
 ----
 # ...
   config: |
-    processor:
+    processors:
       span/set_status:
         status:
           code: Error


### PR DESCRIPTION
The YAMLs provided in the documentation used the word "processor" instead of "processors".

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13, 4.14, 4.15, 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDA-972
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
