### PR TITLE
OLS-1117: OLS Release Notes for 0.2.0 Tech Preview release

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -30,7 +30,7 @@
 :ols-offical: Red Hat OpenShift Lightspeed
 :ols-long: OpenShift Lightspeed
 :ols-short: Lightspeed
-:ols-release: Developer Preview
+:ols-release: Technology Preview
 //LLM
 :openai: OpenAI
 :azure-openai: Microsoft Azure OpenAI

--- a/modules/ols-0-2-0-release-notes.adoc
+++ b/modules/ols-0-2-0-release-notes.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+// release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-2-0-release-notes_{context}"]
+= {ols-long} version 0.2.0
+
+{ols-offical} 0.2.0 is now available on {ocp-product-title} 4.15 or later.
+
+[id="ols-0-2-2-enhancements_{context}"]
+== Enhancements
+
+The following enhancements have been made with {ols-offical} 0.2.0:
+
+* This release introduces the {ols-offical} Operator as a Technology Preview release. Previously, the {ols-short} Operator was a Developer Preview release. 
+
+* Beginning in this release, the {ols-offical} Operator can be installed on an {ocp-product-title} cluster in a disconnected environment.
+
+* With this release, {rhelai} can be configured as the Large Language Model (LLM) provider.
+
+* This release adds the ability to attach a YAML file to a question you ask on the pages accessible from *Networking* in the {ocp-product-title} web console. Attaching a YAML file to a question can provide additional context, enabling {ols-long} to provide a more refined answer.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -8,6 +8,7 @@ toc::[]
 
 The release notes highlight what is new and what has changed with each {ols-offical} release.
 
+include::modules/ols-0-2-0-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-1-7-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-1-6-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-1-5-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OLS-1117

Link to docs preview:
https://83116--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
