### PR TITLE
OSSM-8133 [DOC] OSSM 3.0-TP2: Add link to Sail operator user documentation as "Additional Resource"

### DIFF
--- a/modules/ossm-customizing-istio-configuration.adoc
+++ b/modules/ossm-customizing-istio-configuration.adoc
@@ -12,7 +12,7 @@ The `values` field of the `Istio` custom resource definition, which was created 
 
 . Click *Operators* -> *Installed Operators*.
 . Click *Istio* in the *Provided APIs* column.
-. Click `Istio` instance, `istio-sample` by default, in the *Name* column.
+. Click the `Istio` instance, named `default`, in the *Name* column.
 . Click *YAML* to view the `Istio` configuration and make modifications.
 
 For a list of available configuration for the `values` field, refer to link:https://artifacthub.io/packages/search?org=istio&sort=relevance&page=1[Istio's artifacthub chart documentation].
@@ -22,3 +22,7 @@ For a list of available configuration for the `values` field, refer to link:http
 * link:https://artifacthub.io/packages/helm/istio-official/gateway?modal=values[Gateway parameters]
 * link:https://artifacthub.io/packages/helm/istio-official/cni?modal=values[CNI parameters]
 * link:https://artifacthub.io/packages/helm/istio-official/ztunnel?modal=values[ZTunnel parameters]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md[Service Mesh 3.0 Operator community documentation]


### PR DESCRIPTION
Change type: Doc update; Add link to Sail operator user documentation as "Additional Resource"

Doc JIRA: https://issues.redhat.com/browse/OSSM-8133

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

Doc Preview: https://83122--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#ossm-customizing-istio_ossm-accessing-bookinfo-application-using-gateway-API

**NOTE TO THE REVIEWER:** I have additionally fixed a small doc bug in the PR upon team's request, so you will find a small change other than the link.

SME Review: @luksa 
QE Review: @FilipB 
Peer Review: 