### PR TITLE
OSDOCS-11864: remove unneeded and confusing line from adding RHEL compute

### DIFF
--- a/modules/rhel-compute-overview.adoc
+++ b/modules/rhel-compute-overview.adoc
@@ -20,5 +20,3 @@ For installer-provisioned infrastructure clusters, you must manually add {op-sys
 
 * Swap memory is disabled on all {op-system-base} machines that you add to your {product-title} cluster. You cannot enable swap memory on these machines.
 ====
-
-You must add any {op-system-base} compute machines to the cluster after you initialize the control plane.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-11864](https://issues.redhat.com//browse/OSDOCS-11864)

Link to docs preview:
[About adding RHEL compute nodes to a cluster](https://83134--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-compute-overview_adding-rhel-compute)

QE review:
- [x] QE has approved this change.

Additional information: