### PR TITLE
OSDOCS-12010: adds 4.15.36 async relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -16,7 +16,6 @@ Version 4.15 of {product-title} includes new features and enhancements. {microsh
 
 You can deploy {microshift-short} clusters to either on-premise, cloud, or disconnected environments.
 
-// Double check OP system versions
 {microshift-short} {product-version} is supported on {op-system-ostree-first} and {op-system-base-full} 9.2 and 9.3.
 
 For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
@@ -468,5 +467,14 @@ For the latest images included with {microshift-short}, view the contents of the
 Issued: 2 October 2024
 
 The {product-title} release 4.15.35 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7181[RHBA-2024:7181] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7179[RHSA-2024:7179] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-36-dp_{context}"]
+=== RHBA-2024:7596 - {microshift-short} 4.15.36 bug fix and enhancement advisory
+
+Issued: 9 October 2024
+
+The {product-title} release 4.15.36 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7596[RHBA-2024:7596] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7594[RHSA-2024:7594] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12010](https://issues.redhat.com/browse/OSDOCS-12010)

Link to docs preview:
[4-15-36-dp_release-notes](https://83141--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-36-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
