### PR TITLE
TRACING-4620: add Network Observability Operator to the OTEL Troubleshoot

### DIFF
--- a/modules/otel-troubleshoot-network-traffic.adoc
+++ b/modules/otel-troubleshoot-network-traffic.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="debug-exporter-to-stdout_{context}"]
+= Troubleshoot your observability architecture using the Network Observability Operator
+
+You can use the Network Observability Operator to visualize the traffic between the different components from your observability architecture and debug possible issues.
+
+.Procedure
+
+- link:../network_observability/installing-operators.html[Install the Network Observability Operator]
++
+- In the OpenShift Console, go to **Observe** -> **Network Traffic** -> **Topology**.
++
+- Filter the workloads by **Namespace** to the namespace where your OpenTelemetry Collector is deployed.
++
+- Check for the network traffic flows in the graph to troubleshoot any issue.

--- a/observability/otel/otel-troubleshooting.adoc
+++ b/observability/otel/otel-troubleshooting.adoc
@@ -11,3 +11,4 @@ The OpenTelemetry Collector offers multiple ways to measure its health as well a
 include::modules/otel-troubleshoot-collector-logs.adoc[leveloffset=+1]
 include::modules/otel-troubleshoot-metrics.adoc[leveloffset=+1]
 include::modules/otel-troubleshoot-logging-exporter-stdout.adoc[leveloffset=+1]
+include::modules/otel-troubleshoot-network-traffic.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.18, 4.17, 4.16, 4.15, 4.14, 4.13, 4.12

Issue: [TRACING-4620](https://issues.redhat.com//browse/TRACING-4620)

Link to docs preview:

QE review:
- [ ] QE has approved this change.

Additional information: this can be added to the latest version of the documentation since it applies to the current RHOSDT version too.
