### PR TITLE
OCPBUGS-42826 - Fix xref typo in scalability_and_performance/optimization/optimizing-storage.adoc

### DIFF
--- a/scalability_and_performance/optimization/optimizing-storage.adoc
+++ b/scalability_and_performance/optimization/optimizing-storage.adoc
@@ -35,4 +35,4 @@ include::modules/optimizing-storage-azure.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="admission-plug-ins-additional-resources"]
 == Additional resources
-* xref :../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store]
+* xref:../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store]


### PR DESCRIPTION
Typo exists in 4.17 only. Not main or 4.18.

https://issues.redhat.com/browse/OCPBUGS-42826

Version(s):
enterprise-4.17

QE review:
- [x] QE review not required.