### PR TITLE
OSDOCS-12023: Remove ROSA OADP modules

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
@@ -4,6 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: oadp-rosa-backing-up-applications
 
+// OADP on ROSA is documented in rosa_backing_up_and_restoring_applications/backing-up-applications.adoc, which is published in the ROSA docs. All updates to this content should be made in that assembly.
+
 toc::[]
 
 You can use {oadp-first} with {product-rosa} (ROSA) clusters to back up and restore application data.
@@ -18,26 +20,4 @@ After you create your clusters, you can operate your clusters with the {product-
 
 For additional information about ROSA installation, see link:https://www.redhat.com/en/products/interactive-walkthrough/install-rosa[Installing Red Hat OpenShift Service on AWS (ROSA) interactive walkthrough].
 
-Before installing {oadp-first}, you must set up role and policy credentials for OADP so that it can use the {aws-full} API.
-
-This process is performed in the following two stages:
-
-. Prepare {aws-short} credentials
-. Install the OADP Operator and give it an IAM role
-
-include::modules/preparing-aws-credentials-for-oadp.adoc[leveloffset=+1]
-
-include::modules/installing-oadp-rosa-sts.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-from-operatorhub-using-web-console_olm-installing-operators-in-namespace[Installing from OperatorHub using the web console].
-* xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[Backing up applications]
-
-[id="oadp-rosa-backing-up-and-cleaning"]
-== Example: Backing up workload on OADP ROSA STS, with an optional cleanup
-
-include::modules/performing-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]
-
-include::modules/cleanup-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]
+For information about backing up applications in ROSA clusters, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/backing_up_and_restoring_applications/index[Backing up applications].


### PR DESCRIPTION
Version(s):
enterprise-4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12023

Link to docs preview:
https://83178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html

QE review:
- N/A