### PR TITLE
OBSDOCS-1361

### DIFF
--- a/modules/log6x-configuring-otlp-output.adoc
+++ b/modules/log6x-configuring-otlp-output.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-clf.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="log6x-configuring-otlp-output_{context}"]
+= Configuring OTLP output
+
+Cluster administrators can use the OpenTelemetry Protocol (OTLP) output to collect and forward logs to OTLP receivers. The OTLP output uses the specification defined by the https://opentelemetry.io/docs/specs/otlp/[OpenTelemetry Observability framework] to send data over HTTP with JSON encoding.
+
+:FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
+include::snippets/technology-preview.adoc[]
+
+.Procedure
+
+* Create or edit a `ClusterLogForwarder` custom resource (CR) to enable forwarding using OTLP by adding the following annotation:
++
+.Example `ClusterLogForwarder` CR
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  annotations:
+    observability.openshift.io/tech-preview-otlp-output: "enabled" # <1>
+  name: clf-otlp
+spec:
+  serviceAccount:
+    name: <service_account_name> 
+  outputs:
+  - name: otlp
+    type: otlp
+    otlp:
+      tuning:
+        compression: gzip 
+        deliveryMode: AtLeastOnce
+        maxRetryDuration: 20
+        maxWrite: 10M
+        minRetryDuration: 5
+      url: <otlp_url> # <2>
+  pipelines:
+  - inputRefs:
+    - application
+    - infrastructure
+    - audit
+    name: otlp-logs
+    outputRefs:
+    - otlp
+----
+<1> Use this annotation to enable the OpenTelemetry Protocol (OTLP) output, which is a Technology Preview feature.
+<2> This URL must be absolute and is a placeholder for the OTLP endpoint where logs are sent.
+
+[NOTE]
+====
+The OTLP output uses the OpenTelemetry data model, which is different from the ViaQ data model that is used by other output types. It adheres to the OTLP using https://opentelemetry.io/docs/specs/semconv/[OpenTelemetry Semantic Conventions] defined by the OpenTelemetry Observability framework.
+====

--- a/observability/logging/logging-6.0/log6x-clf.adoc
+++ b/observability/logging/logging-6.0/log6x-clf.adoc
@@ -88,6 +88,8 @@ syslog:: Forwards logs to an external syslog server.
 
 Each output type has its own configuration fields.
 
+include::modules/log6x-configuring-otlp-output.adoc[leveloffset=+1]
+
 === Pipelines
 
 Pipelines are configured in an array under `spec.pipelines`. Each pipeline must have a unique name and consists of:


### PR DESCRIPTION
[OBSDOCS-1361](https://issues.redhat.com/browse/OBSDOCS-1361): Document log collection of Open Telemetry Data Model TP
Aligned team: Observability - Logging
OCP version for cherry-picking: Not Applicable (for this branch)
JIRA issues: [OBSDOCS-1361](https://issues.redhat.com/browse/OBSDOCS-1361)
Preview pages: [Configuring OTLP output](https://83193--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-clf.html#log6x-configuring-otlp-output_logging-6x)
SME review **completed**: @jcantrill 
QE review **completed**:  @kabirbhartiRH
Peer review **completed**: @abhatt-rh