### PR TITLE
IBMZ updates for HCP 4.17

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2471,6 +2471,8 @@ Topics:
     File: hcp-deploy-dc-virt
   - Name: Deploying hosted control planes on bare metal in a disconnected environment
     File: hcp-deploy-dc-bm
+  - Name: Deploying hosted control planes on IBM Z in a disconnected environment
+    File: disconnected-install-ibmz-hcp
   - Name: Monitoring user workload in a disconnected environment
     File: hcp-dc-monitor
 - Name: Updating hosted control planes

--- a/hosted_control_planes/hcp-disconnected/disconnected-install-ibmz-hcp.adoc
+++ b/hosted_control_planes/hcp-disconnected/disconnected-install-ibmz-hcp.adoc
@@ -1,0 +1,37 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="disconnected-install-ibmz-hcp"]
+include::_attributes/common-attributes.adoc[]
+= Deploying {hcp} on {ibm-z-title} in a disconnected environment
+:context: disconnected-install-ibmz-hcp
+
+toc::[]
+
+{hcp-capital} deployments in disconnected environments function differently than in a standalone {product-title}.
+
+{hcp-capital} involves two distinct environments:
+
+* Control plane: Located in the management cluster, where the {hcp} pods are run and managed by the Control Plane Operator.
+* Data plane: Located in the workers of the hosted cluster, where the workload and a few other pods run, managed by the Hosted Cluster Config Operator.
+
+The `ImageContentSourcePolicy` (ICSP) custom resource for the data plane is managed through the `ImageContentSources` API in the hosted cluster manifest. 
+
+For the control plane, ICSP objects are managed in the management cluster. These objects are parsed by the HyperShift Operator and are shared as `registry-overrides` entries with the Control Plane Operator. These entries are injected into any one of the available  deployments in the {hcp} namespace as an argument.
+
+To work with disconnected registries in the {hcp}, you must first create the appropriate ICSP in the management cluster. Then, to deploy disconnected workloads in the data plane, you need to add the entries that you want into the `ImageContentSources` field in the hosted cluster manifest.
+
+.Prerequisites to deploy {hcp} on {ibm-z-title} in a disconnected environment
+
+* You set up the mirror registry. For more information, see "Creating a mirror registry with mirror registry for Red Hat OpenShift".   
+* You mirrored an image for a disconnected installation. For more information, see "Mirroring images for a disconnected installation using the oc-mirror plugin".
+
+include::modules/hcp-ibmz-adding-credentials-registry.adoc[leveloffset=+1]
+
+include::modules/hcp-ibmz-update-reg-ca.adoc[leveloffset=+1]
+
+include::modules/hcp-ibmz-adding-reg-ca-hostedcluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../disconnected/mirroring/installing-mirroring-creating-registry.adoc#mirror-registry-introduction_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift]
+
+* xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]

--- a/modules/destroy-hc-ibmz-cli.adoc
+++ b/modules/destroy-hc-ibmz-cli.adoc
@@ -17,6 +17,10 @@ To destroy a hosted cluster and its managed cluster on `x86` bare metal with {ib
 $ oc -n <hosted_cluster_namespace> scale nodepool <nodepool_name> --replicas 0
 ----
 +
+After the `NodePool` object is scaled to `0`, the compute nodes are detached from the hosted cluster. In {product-title} version 4.17, this function is applicable only for {ibm-z-title} with KVM. For z/VM and LPAR, you must delete the compute nodes manually.
++
+If you want to re-attach compute nodes to the cluster, you can scale up the `NodePool` object with the number of compute nodes that you want. For z/VM and LPAR to reuse the agents, you must re-create them by using the `Discovery` image.
++
 [IMPORTANT]
 ====
 If the compute nodes are not detached from the hosted cluster or are stuck in the `Notready` state, delete the compute nodes manually by running the following command:

--- a/modules/hcp-bm-autoscale.adoc
+++ b/modules/hcp-bm-autoscale.adoc
@@ -99,3 +99,10 @@ $ oc --kubeconfig ./hostedcluster-secrets -n <namespace> delete deployment <depl
 ----
 $ oc --kubeconfig ./hostedcluster-secrets get nodes
 ----
+
+[NOTE]
+====
+For {ibm-z-title} agents, compute nodes are detached from the cluster only for {ibm-z-title} with KVM agents. For z/VM and LPAR, you must delete the compute nodes manually.
+
+Agents can be reused only for {ibm-z-title} with KVM. For z/VM and LPAR, re-create the agents to use them as compute nodes.
+====

--- a/modules/hcp-ibmz-adding-credentials-registry.adoc
+++ b/modules/hcp-ibmz-adding-credentials-registry.adoc
@@ -1,0 +1,65 @@
+:_mod-docs-content-type: CONCEPT
+[id="hcp-ibmz-adding-credentials-registry_{context}"]
+= Adding credentials and the registry certificate authority to the management cluster
+
+To pull the mirror registry images from the management cluster, you must first add credentials and the certificate authority of the mirror registry to the management cluster. Use the following procedure:
+
+.Procedure
+
+. Create a `ConfigMap` with the certificate of the mirror registry by running the following command:
+
++
+[source,terminal]
+----
+$ oc apply -f registry-config.yaml
+----
++
+.Example registry-config.yaml file
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-config
+  namespace: openshift-config
+data:
+  <mirror_registry>: |
+    -----BEGIN CERTIFICATE-----
+    -----END CERTIFICATE-----
+----
+. Patch the `image.config.openshift.io` cluster-wide object to include the following entries:
+
++
+[source,yaml]
+----
+spec:
+  additionalTrustedCA:
+    - name: registry-config
+----
+. Update the management cluster pull secret to add the credentials of the mirror registry.
+..  Fetch the pull secret from the cluster in a JSON format by running the following command:
++
+[source,terminal]
+----
+$ oc get secret/pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > authfile
+----
+.. Edit the fetched secret JSON file to include a section with the credentials of the certificate authority: 
++
+[source,terminal]
+----
+  "auths": {
+    "<mirror_registry>": { // <1>
+      "auth": "<credentials>", // <2>
+      "email": "you@example.com"
+    }
+  },
+----
+<1> Provide the name of the mirror registry.
+<2> Provide the credentials for the mirror registry to allow fetch of images.
+
+.. Update the pull secret on the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=authfile
+----

--- a/modules/hcp-ibmz-adding-reg-ca-hostedcluster.adoc
+++ b/modules/hcp-ibmz-adding-reg-ca-hostedcluster.adoc
@@ -1,0 +1,48 @@
+:_mod-docs-content-type: CONCEPT
+[id="hcp-ibmz-adding-registry-ca-hostedcluster_{context}"]
+= Adding the registry certificate authority to the hosted cluster
+
+When you are deploying {hcp} on {ibm-z-title} in a disconnected environment, include the `additional-trust-bundle` and `image-content-sources` resources. Those resources allow the hosted cluster to inject the certificate authority into the data plane workers so that the images are pulled from the registry.
+
+. Create the `icsp.yaml` file with the `image-content-sources` information. 
++
+The `image-content-sources` information is available in the `ImageContentSourcePolicy` YAML file that is generated after you mirror the images by using `oc-mirror`.
++
+.Example ImageContentSourcePolicy file
+[source,terminal]
+----
+# cat icsp.yaml 
+- mirrors:
+  - <mirror_registry>/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - <mirror_registry>/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
+----
+
+. Create a hosted cluster and provide the `additional-trust-bundle` certificate to update the compute nodes with the certificates as in the following example:
++
+[source,terminal]
+----
+$ hcp create cluster agent \
+    --name=<hosted_cluster_name> \ // <1>
+    --pull-secret=<path_to_pull_secret> \ // <2>
+    --agent-namespace=<hosted_control_plane_namespace> \ // <3>
+    --base-domain=<basedomain> \ // <4>
+    --api-server-address=api.<hosted_cluster_name>.<basedomain> \
+    --etcd-storage-class=<etcd_storage_class> \ // <5>
+    --ssh-key  <path_to_ssh_public_key> \ // <6>
+    --namespace <hosted_cluster_namespace> \ // <7>
+    --control-plane-availability-policy SingleReplica \
+    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image> \ // <7>
+    --additional-trust-bundle <path for cert> \ // <8>
+    --image-content-sources icsp.yaml
+----
+<1> Replace `<hosted_cluster_name>` with the name of your hosted cluster.
+<2> Replace the path to your pull secret, for example, `/user/name/pullsecret`.
+<3> Replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, for example, `clusters-hosted`.
+<4> Replace the name with your base domain, for example, `example.com`.
+<5> Replace the etcd storage class name, for example, `lvm-storageclass`.
+<6> Replace the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
+<7> Replace with the supported {product-title} version that you want to use, for example, `4.17.0-multi`.
+<8> Replace the path to Certificate Authority of mirror registry.

--- a/modules/hcp-ibmz-lpar-agents.adoc
+++ b/modules/hcp-ibmz-lpar-agents.adoc
@@ -33,76 +33,32 @@ random.trust_cpu=on rd.luks.options=discard
 <3> For installations on DASD-type disks, use `rd.dasd` to specify the DASD where {op-system-first} is to be installed. For installations on FCP-type disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed.
 <4> Specify this parameter when you use an Open Systems Adapter (OSA) or HiperSockets.
 
-. Generate the `.ins` and `initrd.img.addrsize` files.
+. Download the `.ins` and `initrd.img.addrsize` files from the `InfraEnv` resource.
 +
-The `.ins` file includes installation data and is on the FTP server. You can access the file from the HMC system. The `.ins` file contains details such as mapping of the location of installation data on the disk or FTP server, the memory locations where the data is to be copied.
+By default, the URL for the `.ins` and `initrd.img.addrsize` files is not available in the `InfraEnv` resource. You must edit the URL to fetch those artifacts.
 +
-[NOTE]
-====
-In {product-title} 4.16, the `.ins` file and `initrd.img.addrsize` are not automatically generated as part of boot-artifacts from the installation program. You must manually generate these files.
-====
-
-.. Run the following commands to get the size of the `kernel` and `initrd`:
+.. Update the kernel URL endpoint to include `ins-file` by running the followign command:
 +
+[source,terminal]
+----
+$ curl -k -L -o generic.ins "< url for ins-file >"
+----
++
+.Example URL
 [source,yaml]
 ----
-KERNEL_IMG_PATH='./kernel.img'
-INITRD_IMG_PATH='./initrd.img'
-CMDLINE_PATH='./generic.prm'
-kernel_size=$(stat -c%s $KERNEL_IMG_PATH )
-initrd_size=$(stat -c%s $INITRD_IMG_PATH)
+https://…/boot-artifacts/ins-file?arch=s390x&version=4.17.0
 ----
-
-.. Round the `kernel` size up to the next MiB boundary. This value is the starting address of `initrd.img`.
 +
-[source,terminal]
-----
-offset=$(( (kernel_size + 1048575) / 1048576 * 1048576 ))
-----
-
-.. Create the kernel binary patch file that contains the `initrd` address and size by running the following commands:
+.. Update the `initrd` URL endpoint to include `s390x-initrd-addrsize`:
 +
-[source,terminal]
-----
-INITRD_IMG_NAME=$(echo $INITRD_IMG_PATH | rev | cut -d '/' -f 1 | rev)
-KERNEL_OFFSET=0x00000000
-KERNEL_CMDLINE_OFFSET=0x00010480
-INITRD_ADDR_SIZE_OFFSET=0x00010408
-OFFSET_HEX=$(printf '0x%08x\n' $offset)
-----
-
-.. Convert the address and size to binary format by running the following command:
-+
-[source,terminal]
-----
-$ printf "$(printf '%016x\n' $initrd_size)" | xxd -r -p > temp_size.bin
-----
-
-.. Merge the address and size binaries by running the following command:
-+
-[source,terminal]
-----
-$ cat temp_address.bin temp_size.bin > "$INITRD_IMG_NAME.addrsize"
-----
-
-.. Clean up temporary files by running the following command:
-+
-[source,terminal]
-----
-$ rm -rf temp_address.bin temp_size.bin
-----
-
-.. Create the `.ins` file. The file is based on the paths of the `kernel.img`, `initrd.img`, `initrd.img.addrsize`, and `cmdline` files and the memory locations where the data is to be copied.
-+
+.Example URL
 [source,yaml]
 ----
-$KERNEL_IMG_PATH $KERNEL_OFFSET
-$INITRD_IMG_PATH $OFFSET_HEX
-$INITRD_IMG_NAME.addrsize $INITRD_ADDR_SIZE_OFFSET
-$CMDLINE_PATH $KERNEL_CMDLINE_OFFSET
+https://…./s390x-initrd-addrsize?api_key=<api-key>&arch=s390x&version=4.17.0
 ----
 
-. Transfer the `initrd`, `kernel`, `generic.ins`, and `initrd.img.addrsize` parameter files to the file server. For more information about how to transfer the files with FTP and boot, see _Installing in an LPAR_.
+. Transfer the `initrd`, `kernel`, `generic.ins`, and `initrd.img.addrsize` parameter files to the file server. For more information about how to transfer the files with FTP and boot, see "Installing in an LPAR".
 
 . Start the machine.
 

--- a/modules/hcp-ibmz-update-reg-ca.adoc
+++ b/modules/hcp-ibmz-update-reg-ca.adoc
@@ -1,0 +1,63 @@
+:_mod-docs-content-type: CONCEPT
+[id="hcp-ibmz-update-registry-ca_{context}"]
+= Update the registry certificate authority in the AgentServiceConfig resource with the mirror registry
+
+When you use a mirror registry for images, agents need to trust the registry's certificate to securely pull images. You can add the certificate authority of the mirror registry to the `AgentServiceConfig` custom resource by creating a `ConfigMap`.
+
+.Prerequisites
+
+* You must have installed {mce}.
+
+.Procedure 
+
+. In the same namespace where you installed {mce-short}, create a `ConfigMap` resource with the mirror registry details. This `ConfigMap` resource ensures that you grant the hosted cluster workers the capability to retrieve images from the mirror registry.
++
+.Example ConfigMap file
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mirror-config
+  namespace: multicluster-engine
+  labels:
+    app: assisted-service
+data:
+  ca-bundle.crt: |
+    -----BEGIN CERTIFICATE-----
+    -----END CERTIFICATE-----
+  registries.conf: |
+
+    [[registry]]
+      location = "registry.stage.redhat.io"
+      insecure = false
+      blocked = false
+      mirror-by-digest-only = true
+      prefix = ""
+
+      [[registry.mirror]]
+        location = "<mirror_registry>"
+        insecure = false
+
+    [[registry]]
+      location = "registry.redhat.io/multicluster-engine"
+      insecure = false
+      blocked = false
+      mirror-by-digest-only = true
+      prefix = ""
+
+      [[registry.mirror]]
+        location = "<mirror_registry>/multicluster-engine" # <1>
+        insecure = false
+----
++
+<1> Where: `<mirror_registry>` is the name of the mirror registry.
+
+.  Patch the `AgentServiceConfig` resource to include the `ConfigMap` resource that you created. If the `AgentServiceConfig` resource is not present, create the `AgentServiceConfig` resource with the following content embedded into it:
++
+[source,terminal]
+----
+spec:
+  mirrorRegistryRef:
+    name: mirror-config
+----

--- a/modules/hosted-control-planes-version-support.adoc
+++ b/modules/hosted-control-planes-version-support.adoc
@@ -36,3 +36,5 @@ You can use the `hcp` CLI to create hosted clusters.
 You can use the `hypershift.openshift.io` API resources, such as, `HostedCluster` and `NodePool`, to create and manage {product-title} clusters at scale. A `HostedCluster` resource contains the control plane and common data plane configuration. When you create a `HostedCluster` resource, you have a fully functional control plane with no attached nodes. A `NodePool` resource is a scalable set of worker nodes that is attached to a `HostedCluster` resource.
 
 The API version policy generally aligns with the policy for link:https://kubernetes.io/docs/reference/using-api/#api-versioning[Kubernetes API versioning].
+
+Updates for {hcp} involve updating the hosted cluster and the node pools. For more information, see "Updates for hosted control planes".

--- a/modules/oc-mirror-image-set-config-examples.adoc
+++ b/modules/oc-mirror-image-set-config-examples.adoc
@@ -249,27 +249,6 @@ mirror:
 ----
 
 [discrete]
-[id="oc-mirror-image-set-examples-blocked-images_{context}"]
-== Use case: Including the `blockedImages` parameters
-
-The following `ImageSetConfiguration` file excludes the images that return `manifest unknown` errors.
-
-This example also shows how to use the `blockedImages` parameter in the `imageSetConfiguration` file to skip mirroring an image that fails to mirror due to an `manifest unknown` error.
-
-.Example `ImageSetConfiguration` file
-[source,yaml,subs=attributes+]
-----
-apiVersion: mirror.openshift.io/v2alpha1
-kind: ImageSetConfiguration
-mirror:
-  additionalImages:
-    - name: registry.redhat.io/ubi8/ubi:latest
-    - name: registry.redhat.io/ubi8/ubi:fake
-  blockedImages:
-    - name: registry.redhat.io/ubi8/ubi:fake
-----
-
-[discrete]
 [id="oc-mirror-image-set-examples-eus_{context}"]
 == Use case: Including the upgrade path for EUS releases
 
@@ -298,4 +277,33 @@ mirror:
       maxVersion: '4.14.16'
       shortestPath: true
       type: ocp
+----
+
+[discrete]
+[id="oc-mirror-image-set-examples-mce-images-catalog-ocp_{context}"]
+== Use case: Including the multi-arch {product-title} images and catalog for {mce-short}
+
+The following `ImageSetConfiguration` file includes {mce} and all {product-title} versions starting at a minimum version of `4.17.0` in the channel.  
+
+.Example `ImageSetConfiguration` file
+[source,yaml,subs=attributes+]
+----
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+storageConfig:
+  registry:
+    imageURL: agent.agent.example.com:5000/openshift/release/metadata:latest/openshift/release/metadata:latest
+mirror:
+  platform:
+    architectures:
+      - "multi"
+    channels:
+    - name: stable-4.17
+      minVersion: 4.17.0
+      maxVersion: 4.17.1
+      type: ocp
+  operators:
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.17
+      packages:
+        - name: multicluster-engine
 ----


### PR DESCRIPTION
Version(s):
4.17+

Issue: https://issues.redhat.com/browse/OSDOCS-12033 

Link to docs preview:
- Deploying hosted control planes on IBM Z in a disconnected environment: https://83206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/disconnected-install-ibmz-hcp (new section)
- Destroying a hosted cluster on IBM Z: https://83206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-destroy/hcp-destroy-ibmz.html (updated wording)
- Enabling node auto-scaling for the hosted cluster: https://83206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-bm.html#hcp-bm-autoscale_hcp-manage-bm (addition of note)
- Adding IBM Z LPAR as agents: https://83206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.html#hcp-ibmz-lpar-agents_hcp-deploy-ibmz (updated wording)
- Versioning for hosted control planes: https://83206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/#hosted-control-planes-version-support_hcp-overview (addition of last paragraph)
- Image set configuration example: https://83206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-disconnected.html#oc-mirror-image-set-examples_installing-mirroring-disconnected (adding example for MCE)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: QE review has been requested.
Boxnote inputs given by Vikas and Veera: https://ibm.ent.box.com/notes/1645718569598

