### PR TITLE
ROX-26514: Patch release 4.5.4 release notes

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -55,7 +55,7 @@ endif::[]
 :osp: Red{nbsp}Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.5.3
+:rhacs-version: 4.5.4
 :ocp-supported-version: 4.11
 :ocp-latest-version: 4.17
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS

--- a/release_notes/45-release-notes.adoc
+++ b/release_notes/45-release-notes.adoc
@@ -19,6 +19,7 @@ toc::[]
 |`4.5.1` | 14 August 2024
 |`4.5.2` | 16 September 2024
 |`4.5.3` | 1 October 2024
+|`4.5.4` | 16 October 2024
 
 |====
 
@@ -440,5 +441,17 @@ This release of {product-title-short} includes the following changes:
 This release of {product-title-short} fixes the following security vulnerability:
 
 * https://access.redhat.com/security/cve/CVE-2024-39249[CVE-2024-39249]: Fixed a Regular expression denial of service (ReDoS) vulnerability in the {product-title-short} main container.
+
+[id="about-release-454_{context}"]
+== About release 4.5.4
+
+*Release date*: 16 October 2024
+
+This release of {product-title-short} includes the following bug fixes:
+
+* Fixed incorrect timestamp data for the *First discovered* column on the *Workload CVE* single page when viewing affected images.
+* Fixed incorrect CVE counts when viewing an image in the *Vulnerability Management* window that contains CVEs with an unknown severity.
+* In runtime monitoring, process names and arguments could cause serialization problems when containing invalid UTF-8 characters. This resulted in error messages in the collector logs. Those characters are now filtered and replaced with a `?` when necessary.
+* Fixed a panic issue where the Central pod restarted on systems that were using Scanner V4. When this issue occurred, the logs displayed an "invalid memory address or nil pointer dereference" runtime error.
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):

4.5

[Issue
](https://issues.redhat.com/browse/ROX-26514)

[Link to docs preview
](https://83224--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/45-release-notes)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
