### PR TITLE
OBSDOCS-1338: Add missing prerequisite in Enabling the platform Alert…

### DIFF
--- a/modules/monitoring-deploying-a-sample-service.adoc
+++ b/modules/monitoring-deploying-a-sample-service.adoc
@@ -8,6 +8,10 @@
 
 To test monitoring of a service in a user-defined project, you can deploy a sample service.
 
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with administrative permissions for the namespace.
+
 .Procedure
 
 . Create a YAML file for the service configuration. In this example, it is called `prometheus-example-app.yaml`.

--- a/modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -11,6 +11,7 @@ You can allow users to create user-defined alert routing configurations that use
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
+* A cluster administrator has enabled monitoring for user-defined projects.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
@@ -33,8 +34,10 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
+    # ...
     alertmanagerMain:
-      enableUserAlertmanagerConfig: true <1>
+      enableUserAlertmanagerConfig: true # <1>
+    # ...
 ----
 <1> Set the `enableUserAlertmanagerConfig` value to `true` to allow users to create user-defined alert routing configurations that use the main platform instance of Alertmanager.
 +


### PR DESCRIPTION
Version(s): 
* `enterprise-4.12` and later
* `monitoring-docs-restructure`

Issue: [OBSDOCS-1338](https://issues.redhat.com/browse/OBSDOCS-1338)

Links to docs preview: 
* https://83233--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/enabling-alert-routing-for-user-defined-projects.html#enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing_enabling-alert-routing-for-user-defined-projects
* https://83233--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/managing-metrics.html#deploying-a-sample-service_managing-metrics

QE review:
- [x] QE has approved this change.

**Additional information:**