### PR TITLE
OSDOCS#11411: Adding multiarch scheduling section for ROSA and OSD

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1344,7 +1344,7 @@ Topics:
 #   File: nodes-scheduler-node-projects
 # - Name: Keeping your cluster balanced using the descheduler
 #   File: nodes-scheduler-descheduler
-# Cannot create namespace to install Desceduler Operator; revisit after Operator book converted
+# Cannot create namespace to install Descheduler Operator; revisit after Operator book converted
 #  - Name: Evicting pods using the descheduler
 #   File: nodes-descheduler
 # Cannot create namespace to install Secondary Scheduler Operator; revisit after Operator book converted
@@ -1360,6 +1360,8 @@ Topics:
 #     File: nodes-secondary-scheduler-configuring
 #   - Name: Uninstalling the Secondary Scheduler Operator
 #     File: nodes-secondary-scheduler-uninstalling
+  - Name: Scheduling workloads on clusters with multi-architecture compute machines
+    File: multi-architecture-compute-scheduling
 - Name: Using Jobs and DaemonSets
   Dir: jobs
   Topics:

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1281,6 +1281,9 @@ Topics:
 #      File: nodes-secondary-scheduler-configuring
 #    - Name: Uninstalling the Secondary Scheduler Operator
 #      File: nodes-secondary-scheduler-uninstalling
+# TODO OSDOCS-11411: The following file needs to be included in the HCP migration
+#  - Name: Scheduling workloads on clusters with multi-architecture compute machines
+#    File: multi-architecture-compute-scheduling
 # - Name: Using Jobs and DaemonSets
 #   Dir: jobs
 #   Topics:

--- a/modules/multi-architecture-scheduling-examples.adoc
+++ b/modules/multi-architecture-scheduling-examples.adoc
@@ -4,10 +4,11 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="multi-architecture-scheduling-examples_{context}"]
-
 = Sample multi-architecture node workload deployments
 
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 Before you schedule workloads on a cluster with compute nodes of different architectures, consider the following use cases:
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 Using node affinity to schedule workloads on a node:: You can allow a workload to be scheduled on only a set of nodes with architectures supported by its images, you can set the `spec.affinity.nodeAffinity` field in your pod's template specification.
 +
@@ -35,6 +36,8 @@ spec:
 ----
 <1> Specify the supported architectures. Valid values include `amd64`,`arm64`, or both values.
 
+//Omitting taint and toleration based examples from ROSA docs
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 Tainting every node for a specific architecture:: You can taint a node to avoid workloads that are not compatible with its architecture to be scheduled on that node. In the case where your cluster is using a `MachineSet` object, you can add parameters to the `.spec.template.spec.taints` field to avoid workloads being scheduled on nodes with non-supported architectures.
 
 * Before you can taint a node, you must scale down the `MachineSet` object or remove available machines. You can scale down the machine set by using one of following commands:
@@ -137,3 +140,4 @@ spec:
         operator: "Equal"
         effect: "NoSchedule"
 ----
+endif::openshift-rosa,openshift-rosa-hcp[]

--- a/nodes/scheduling/multi-architecture-compute-scheduling.adoc
+++ b/nodes/scheduling/multi-architecture-compute-scheduling.adoc
@@ -1,0 +1,1 @@
+../../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc
@@ -1,4 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
+// NOTE: This file is the target of the following symbolic link:
+// - nodes/scheduling/multi-architecture-compute-scheduling.adoc
+//For non-ROSA builds
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 :context: multi-architecture-compute-managing
 [id="multi-architecture-compute-managing"]
 = Managing a cluster with multi-architecture compute machines
@@ -8,26 +12,48 @@ toc::[]
 
 == Scheduling workloads on clusters with multi-architecture compute machines
 
+endif::openshift-rosa,openshift-rosa-hcp[]
+
+//For ROSA builds
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+:context: multi-architecture-compute-scheduling
+[id="multi-architecture-compute-scheduling"]
+= Scheduling workloads on clusters with multi-architecture compute machines
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+[IMPORTANT]
+====
+Multi-architecture compute machines are supported only for {product-title} with {hcp}.
+====
+endif::openshift-rosa,openshift-rosa-hcp[]
+
 Deploying a workload on a cluster with compute nodes of different architectures requires attention and monitoring of your cluster. There might be further actions you need to take in order to successfully place pods in the nodes of your cluster.
 
-You can use the Multiarch Tuning Operator to enable architecture-aware scheduling of workloads on clusters with multi-architecture compute machines. The Multiarch Tuning Operator implements additional scheduler predicates in the pods specifications based on the architectures that the pods can support at creation time. For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]. 
+//Omitted from ROSA builds until operator is fully supported
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+You can use the Multiarch Tuning Operator to enable architecture-aware scheduling of workloads on clusters with multi-architecture compute machines. The Multiarch Tuning Operator implements additional scheduler predicates in the pods specifications based on the architectures that the pods can support at creation time. For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
 
-For more information on node affinity, scheduling, taints and tolerations, see the following documentation:
+For more information on controlling workload placement, see the following documentation:
 
-ifndef::openshift-dedicated,openshift-rosa[]
+//Omitted from ROSA builds as customers cannot use these methods to set taints and tolerations
 * xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
-endif::openshift-dedicated,openshift-rosa[]
-
 * xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity[Controlling pod placement on nodes using node affinity]
-
 * xref:../../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/multi-architecture-scheduling-examples.adoc[leveloffset=+2]
 
+//Not included in ROSA builds
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 .Additional resources
-
 * xref:../../machine_management/modifying-machineset.adoc#machineset-modifying_modifying-machineset[Modifying a compute machine set]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
+//Omitted until fully tested with ROSA 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 include::modules/multi-architecture-enabling-64k-pages.adoc[leveloffset=+1]
 
 include::modules/multi-architecture-import-imagestreams.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.16 only - this update needs to be available before ROSA docs split will be complete; changes for 4.17 and beyond will be handled elsewhere

Issue:
https://issues.redhat.com/browse/OSDOCS-11411

Link to docs preview:
- Post-install doc in OCP, contains all sections: https://83236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.html
- Nodes doc in ROSA, contains only node affinity based options as taints and tolerations cannot be controlled the same way in ROSA: https://83236--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/scheduling/multi-architecture-compute-scheduling.html

QE review:
- [x] QE has approved this change.