### PR TITLE
OCPBUGS#42950: Fixed the 4.14.38 URL syntax

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3350,6 +3350,7 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 // 4.14.38
+[id="ocp-4-14-38_{context}"]
 === RHSA-2024:7184 - {product-title} 4.14.38 bug fix and security update
 
 Issued: 3 October 2024


### PR DESCRIPTION
Fixes a URL issue because of a missing ID tag.

Version(s):
4.14

Issue:
[OCPBUGS-42950](https://issues.redhat.com/browse/OCPBUGS-42950)

Link to docs preview:
* https://83237--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-38_release-notes
