### PR TITLE
OSDOCS#12284: HCP: Update OADP backup, restore, and disaster recovery

### DIFF
--- a/modules/hcp-dr-oadp-backup-cp-workload.adoc
+++ b/modules/hcp-dr-oadp-backup-cp-workload.adoc
@@ -12,15 +12,6 @@ To monitor and observe the backup process, see "Observing the backup and restore
 
 .Procedure
 
-. Scale down the `NodePool` replicas to `0` by running the following command:
-+
-[source,terminal]
-----
-$ oc --kubeconfig <management_cluster_kubeconfig_file> \
-  scale nodepool -n <hosted_cluster_namespace> \
-  <node_pool_name> --replicas 0
-----
-
 . Pause the reconciliation of the `HostedCluster` resource by running the following command:
 +
 [source,terminal]
@@ -37,6 +28,33 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
 $ oc --kubeconfig <management_cluster_kubeconfig_file> \
   patch nodepool -n <hosted_cluster_namespace> <node_pool_name> \
   --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "true"}]'
+----
+
+. Pause the reconciliation of the `AgentCluster` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  annotate agentcluster -n <hosted_control_plane_namespace>  \
+  cluster.x-k8s.io/paused=true --all'
+----
+
+. Pause the reconciliation of the `AgentMachine` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  annotate agentmachine -n <hosted_control_plane_namespace>  \
+  cluster.x-k8s.io/paused=true --all'
+----
+
+. Annotate the `HostedCluster` resource to prevent the deletion of the hosted control plane namespace by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  annotate hostedcluster -n <hosted_cluster_namespace> <hosted_cluster_name> \
+  hypershift.openshift.io/skip-delete-hosted-controlplane-namespace=true
 ----
 
 . Create a YAML file that defines the `Backup` CR:

--- a/modules/hcp-dr-oadp-restore.adoc
+++ b/modules/hcp-dr-oadp-restore.adoc
@@ -104,6 +104,36 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
   --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "false"}]'
 ----
 
+. Start the reconciliation of the Agent provider resources that you paused during backing up of the control plane workload:
+
+.. Start the reconciliation of the `AgentCluster` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  annotate agentcluster -n <hosted_control_plane_namespace>  \
+  cluster.x-k8s.io/paused- --overwrite=true --all
+----
+
+.. Start the reconciliation of the `AgentMachine` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  annotate agentmachine -n <hosted_control_plane_namespace>  \
+  cluster.x-k8s.io/paused- --overwrite=true --all
+----
+
+. Remove the `hypershift.openshift.io/skip-delete-hosted-controlplane-namespace-` annotation in the `HostedCluster` resource to avoid manually deleting the hosted control plane namespace by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  annotate hostedcluster -n <hosted_cluster_namespace> <hosted_cluster_name> \
+  hypershift.openshift.io/skip-delete-hosted-controlplane-namespace- \
+  --overwrite=true --all
+----
+
 . Scale the `NodePool` resource to the desired number of replicas by running the following command:
 +
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12284
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- [Backing up the control plane workload](https://83238--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.html#hcp-dr-oadp-backup-cp-workload_hcp-disaster-recovery-oadp)
- [Restoring a hosted cluster by using OADP](https://83238--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.html#hcp-dr-oadp-restore_hcp-disaster-recovery-oadp)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
