### PR TITLE
bugfix: ibm-power filename consistency

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1736,7 +1736,7 @@ Topics:
   - Name: GCP Filestore CSI Driver Operator
     File: persistent-storage-csi-google-cloud-file
   - Name: IBM Cloud Block Storage (VPC) CSI Driver Operator
-    File: persistent-storage-csi-ibm-vpc-block
+    File: persistent-storage-csi-ibm-cloud-vpc-block
   - Name: IBM Power Virtual Server Block Storage CSI Driver Operator
     File: persistent-storage-csi-ibm-powervs-block
   - Name: OpenStack Cinder CSI Driver Operator
@@ -2459,7 +2459,7 @@ Topics:
   - Name: Deploying hosted control planes on IBM Z
     File: hcp-deploy-ibmz
   - Name: Deploying hosted control planes on IBM Power
-    File: hcp-deploy-ibmpower
+    File: hcp-deploy-ibm-power
 - Name: Managing hosted control planes
   Dir: hcp-manage
   Topics:
@@ -2472,7 +2472,7 @@ Topics:
   - Name: Managing hosted control planes on non-bare metal agent machines
     File: hcp-manage-non-bm
   - Name: Managing hosted control planes on IBM Power
-    File: hcp-manage-ibmpower
+    File: hcp-manage-ibm-power
 - Name: Deploying hosted control planes in a disconnected environment
   Dir: hcp-disconnected
   Topics:
@@ -2525,7 +2525,7 @@ Topics:
   - Name: Destroying a hosted cluster on IBM Z
     File: hcp-destroy-ibmz
   - Name: Destroying a hosted cluster on IBM Power
-    File: hcp-destroy-ibmpower
+    File: hcp-destroy-ibm-power
   - Name: Destroying a hosted cluster on non-bare metal agent machines
     File: hcp-destroy-non-bm
 - Name: Manually importing a hosted cluster

--- a/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
@@ -29,7 +29,7 @@ OpenShift API for Data Protection (OADP) is platform neutral. The information th
 
 include::modules/oadp-ibm-power-test-support.adoc[leveloffset=+2]
 include::modules/oadp-ibm-z-test-support.adoc[leveloffset=+2]
-include::modules/oadp-ibm-p-and-z-known-issues.adoc[leveloffset=+3]
+include::modules/oadp-ibm-power-and-z-known-issues.adoc[leveloffset=+3]
 
 include::modules/oadp-fips.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="hcp-deploy-ibmpower"]
+[id="hcp-deploy-ibm-power"]
 include::_attributes/common-attributes.adoc[]
 = Deploying {hcp} on {ibm-power-title}
-:context: hcp-deploy-ibmpower
+:context: hcp-deploy-ibm-power
 
 toc::[]
 
@@ -21,7 +21,7 @@ Each {ibm-power-title} host must be started with a Discovery Image that the cent
 
 When you create a hosted cluster with the Agent platform, HyperShift installs the Agent Cluster API provider in the hosted control plane namespace.
 
-include::modules/hcp-ibmpower-prereqs.adoc[leveloffset=+1]
+include::modules/hcp-ibm-power-prereqs.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -32,8 +32,8 @@ include::modules/hcp-ibmpower-prereqs.adoc[leveloffset=+1]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
 
-include::modules/hcp-ibmpower-infra-reqs.adoc[leveloffset=+1]
+include::modules/hcp-ibm-power-infra-reqs.adoc[leveloffset=+1]
 
-include::modules/hcp-ibmpower-dns.adoc[leveloffset=+1]
+include::modules/hcp-ibm-power-dns.adoc[leveloffset=+1]
 
 include::modules/hcp-bm-hc.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-destroy/hcp-destroy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-destroy/hcp-destroy-ibm-power.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="hcp-destroy-ibmpower"]
+[id="hcp-destroy-ibm-power"]
 include::_attributes/common-attributes.adoc[]
 = Destroying a hosted cluster on {ibm-power-title}
-:context: hcp-destroy-ibmpower
+:context: hcp-destroy-ibm-power
 
 toc::[]
 
 You can destroy a hosted cluster on {ibm-power-title} by using the command-line interface (CLI).
 
-include::modules/destroy-hc-ibmpower-cli.adoc[leveloffset=+1]
+include::modules/destroy-hc-ibm-power-cli.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-manage/hcp-manage-ibm-power.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-ibm-power.adoc
@@ -1,18 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="hcp-manage-ibmpower"]
+[id="hcp-manage-ibm-power"]
 include::_attributes/common-attributes.adoc[]
 = Managing {hcp} on {ibm-power-title}
-:context: hcp-manage-ibmpower
+:context: hcp-manage-ibm-power
 
 toc::[]
 
 After you deploy {hcp} on {ibm-power-title}, you can manage a hosted cluster by completing the following tasks.
 
-include::modules/hcp-ibmpower-infraenv.adoc[leveloffset=+1]
+include::modules/hcp-ibm-power-infraenv.adoc[leveloffset=+1]
 
-include::modules/hcp-ibmpower-add-agents.adoc[leveloffset=+1]
+include::modules/hcp-ibm-power-add-agents.adoc[leveloffset=+1]
 
-include::modules/hcp-ibmpower-scale-np.adoc[leveloffset=+1]
+include::modules/hcp-ibm-power-scale-np.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/destroy-hc-ibm-power-cli.adoc
+++ b/modules/destroy-hc-ibm-power-cli.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * hosted_control_planes/hcp-destroy/hcp-destroy-ibmpower.adoc
+// * hosted_control_planes/hcp-destroy/hcp-destroy-ibm-power.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="destroy-hc-ibmpower-cli_{context}"]
+[id="destroy-hc-ibm-power-cli_{context}"]
 = Destroying a hosted cluster on {ibm-power-title} by using the CLI
 
 To destroy a hosted cluster on {ibm-power-title}, you can use the hcp command-line interface (CLI).

--- a/modules/hcp-bm-hc.adoc
+++ b/modules/hcp-bm-hc.adoc
@@ -2,7 +2,7 @@
 //
 // * hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
 // * hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
-// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-bm-hc_{context}"]

--- a/modules/hcp-ibm-power-add-agents.adoc
+++ b/modules/hcp-ibm-power-add-agents.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * hosted_control_planes/hcp-manage/hcp-manage-ibmpower.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-ibm-power.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="hcp-ibmpower-add-agents_{context}"]
+[id="hcp-ibm-power-add-agents_{context}"]
 = Adding {ibm-power-title} agents to the InfraEnv resource
 
 You can add agents by manually configuring the machine to start with the live ISO.

--- a/modules/hcp-ibm-power-dns.adoc
+++ b/modules/hcp-ibm-power-dns.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="hcp-ibmpower-dns_{context}"]
+[id="hcp-ibm-power-dns_{context}"]
 = DNS configuration for {hcp} on {ibm-power-title}
 
 The API server for the hosted cluster is exposed. A DNS entry must exist for the `api.<hosted_cluster_name>.<basedomain>` entry that points to the destination where the API server is reachable.

--- a/modules/hcp-ibm-power-infra-reqs.adoc
+++ b/modules/hcp-ibm-power-infra-reqs.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="hcp-ibmpower-infra-reqs_{context}"]
+[id="hcp-ibm-power-infra-reqs_{context}"]
 = {ibm-power-title} infrastructure requirements
 
 The Agent platform does not create any infrastructure, but requires the following resources for infrastructure:

--- a/modules/hcp-ibm-power-infraenv.adoc
+++ b/modules/hcp-ibm-power-infraenv.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * hosted_control_planes/hcp-manage/hcp-manage-ibmpower.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-ibm-power.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="hcp-ibmpower-infraenv_{context}"]
+[id="hcp-ibm-power-infraenv_{context}"]
 = Creating an InfraEnv resource for {hcp} on {ibm-power-title}
 
 An `InfraEnv` is a environment where hosts that are starting the live ISO can join as agents. In this case, the agents are created in the same namespace as your hosted control plane.

--- a/modules/hcp-ibm-power-prereqs.adoc
+++ b/modules/hcp-ibm-power-prereqs.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * hosted_control_planes/hcp-deploy/hcp-deploy-ibmpower.adoc
+// * hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="hcp-ibmpower-prereqs_{context}"]
+[id="hcp-ibm-power-prereqs_{context}"]
 = Prerequisites to configure {hcp} on {ibm-power-title}
 
 * The {mce} version 2.7 and later installed on an {product-title} cluster. The {mce-short} is automatically installed when you install {rh-rhacm-first}. You can also install the {mce-short} without {rh-rhacm} as an Operator from the {product-title} OperatorHub.

--- a/modules/hcp-ibm-power-scale-np.adoc
+++ b/modules/hcp-ibm-power-scale-np.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * hosted_control_planes/hcp-manage/hcp-manage-ibmpower.adoc
+// * hosted_control_planes/hcp-manage/hcp-manage-ibm-power.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="hcp-ibmpower-scale-np_{context}"]
+[id="hcp-ibm-power-scale-np_{context}"]
 = Scaling the NodePool object for a hosted cluster on {ibm-power-title}
 
 The `NodePool` object is created when you create a hosted cluster. By scaling the `NodePool` object, you can add more compute nodes to {hcp}.

--- a/modules/oadp-ibm-power-and-z-known-issues.adoc
+++ b/modules/oadp-ibm-power-and-z-known-issues.adoc
@@ -3,7 +3,7 @@
 // * backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="oadp-ibm-p-and-z-known-issues_{context}"]
+[id="oadp-ibm-power-and-z-known-issues_{context}"]
 = Known issue of OADP using {ibm-power-name} and {ibm-z-name} platforms
 
 * Currently, there are backup method restrictions for {sno-caps} clusters deployed on {ibm-power-name} and {ibm-z-name} platforms. Only NFS storage is currently compatible with {sno-caps} clusters on these platforms. In addition, only the File System Backup (FSB) methods such as Kopia and Restic are supported for backup and restore operations. There is currently no workaround for this issue.

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -62,7 +62,7 @@ ifndef::openshift-rosa[]
 endif::openshift-rosa[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 - {ibm-power-server-title} Block
-- {ibm-name} VPC Block
+- {ibm-cloud-name} VPC Block
 endif::openshift-enterprise,openshift-webscale,openshift-origin[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-aro[]
 - HostPath
@@ -165,7 +165,7 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 //|GlusterFS  | ✅ |✅ | ✅ | ✅
 |HostPath  | ✅ |✅ |   |   
 |{ibm-power-server-title}  Disk | ✅ |✅  | ✅ |  ✅
-|{ibm-name} VPC Disk | ✅ |✅ |  |  
+|{ibm-cloud-name} VPC Disk | ✅ |✅ |  |  
 |iSCSI  | ✅ | ✅ |✅ |  ✅ ^[3]^
 |Local volume | ✅ |✅ |  |  
 endif::[]

--- a/storage/container_storage_interface/persistent-storage-csi-ibm-cloud-vpc-block.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ibm-cloud-vpc-block.adoc
@@ -1,7 +1,8 @@
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
-[id="persistent-storage-csi-ibm-vpc-block"]
-= {ibm-title} VPC Block CSI Driver Operator
-:context: persistent-storage-csi-ibm-vpc-block
+[id="persistent-storage-csi-ibm-cloud-vpc-block"]
+= {ibm-cloud-title} VPC Block CSI Driver Operator
+:context: persistent-storage-csi-ibm-cloud-vpc-block
 
 toc::[]
 
@@ -11,11 +12,11 @@ toc::[]
 
 Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
 
-To create CSI-provisioned PVs that mount to {ibm-name} VPC Block storage assets, {product-title} installs the {ibm-name} VPC Block CSI Driver Operator and the {ibm-name} VPC Block CSI driver by default in the `openshift-cluster-csi-drivers` namespace.
+To create CSI-provisioned PVs that mount to {ibm-cloud-name} VPC Block storage assets, {product-title} installs the {ibm-cloud-name} VPC Block CSI Driver Operator and the {ibm-cloud-name} VPC Block CSI driver by default in the `openshift-cluster-csi-drivers` namespace.
 
-* The _{ibm-name} VPC Block CSI Driver Operator_ provides three storage classes named `ibmc-vpc-block-10iops-tier` (default), `ibmc-vpc-block-5iops-tier`, and `ibmc-vpc-block-custom` for different tiers that you can use to create persistent volume claims (PVCs). The {ibm-name} VPC Block CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on demand, eliminating the need for cluster administrators to pre-provision storage. You can disable this default storage class if desired (see xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]).
+* The _{ibm-cloud-name} VPC Block CSI Driver Operator_ provides three storage classes named `ibmc-vpc-block-10iops-tier` (default), `ibmc-vpc-block-5iops-tier`, and `ibmc-vpc-block-custom` for different tiers that you can use to create persistent volume claims (PVCs). The {ibm-cloud-name} VPC Block CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on demand, eliminating the need for cluster administrators to pre-provision storage. You can disable this default storage class if desired (see xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]).
 
-* The _{ibm-name} VPC Block CSI driver_ enables you to create and mount {ibm-name} VPC Block PVs.
+* The _{ibm-cloud-name} VPC Block CSI driver_ enables you to create and mount {ibm-cloud-name} VPC Block PVs.
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 

--- a/storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc
@@ -35,7 +35,7 @@ Managing the default storage classes is supported by the following Container Sto
 
 * xref:../../storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc#persistent-storage-csi-gcp-pd[Google Cloud Platform (GCP) Persistent Disk (PD)]
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-ibm-vpc-block.adoc#persistent-storage-csi-ibm-vpc-block[{ibm-name} VPC Block]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-ibm-cloud-vpc-block.adoc#persistent-storage-csi-ibm-cloud-vpc-block[{ibm-cloud-name} VPC Block]
 
 * xref:../../storage/container_storage_interface/persistent-storage-csi-cinder.adoc#persistent-storage-csi-cinder[OpenStack Cinder]
 


### PR DESCRIPTION
Provide consistency of `ibm-*` naming in accordance with IBM Infrastructure top-line business unit structure and product lines. This PR solves IBM Power filename consistency, a separate PR to be raised for all files prefixed `ibmz-*` instead of `ibm-z-*` by assigned owner (messaged internally)

- IBM Infrastructure  _(top-line unit, others are IBM Consulting, IBM Software, IBM Research)_
    - IBM Cloud
    - IBM Power
    - IBM Z
    - IBM Storage


Version(s):
4.17+, do not cherry pick (and apply to prior versions) due to significant merge conflicts where content has changed between releases

Issue:
- None (GH or Jira), this is community author contribution

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Related to subdirectory re-structure and filename for IBM Cloud in PR #82684

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
