### PR TITLE
[OSDOCS-11292]: Remove OpenShift Virtualization (OCP-Virt) from the OSD docs

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1426,274 +1426,274 @@ Topics:
   Topics:
   - Name: Serverless overview
     File: about-serverless
----
-Name: Virtualization
-Dir: virt
-Distros: openshift-dedicated
-Topics:
-- Name: About
-  Dir: about_virt
-  Topics:
-  - Name: About OpenShift Virtualization
-    File: about-virt
-    Distros: openshift-dedicated
-  - Name: About OKD Virtualization
-    File: about-virt
-    Distros: openshift-origin
-  - Name: Security policies
-    File: virt-security-policies
-  - Name: Architecture
-    File: virt-architecture
-    Distros: openshift-dedicated
-#- Name: Release notes
-#  Dir: release_notes
-#  Topics:
-#  - Name: OpenShift Virtualization release notes
-#    File: virt-release-notes-placeholder
-#    Distros: openshift-rosa
-- Name: Getting started
-  Dir: getting_started
-  Topics:
-  - Name: Getting started with OpenShift Virtualization
-    File: virt-getting-started
-    Distros: openshift-dedicated
-  - Name: Getting started with OKD Virtualization
-    File: virt-getting-started
-    Distros: openshift-origin
-  - Name: virtctl and libguestfs
-    File: virt-using-the-cli-tools
-    Distros: openshift-dedicated
-- Name: Installing
-  Dir: install
-  Topics:
-  - Name: Preparing your cluster
-    File: preparing-cluster-for-virt
-  - Name: Installing OpenShift Virtualization
-    File: installing-virt
-  - Name: Uninstalling OpenShift Virtualization
-    File: uninstalling-virt
-- Name: Post-installation configuration
-  Dir: post_installation_configuration
-  Topics:
-  - Name: Post-installation configuration
-    File: virt-post-install-config
-  - Name: Node placement rules
-    File: virt-node-placement-virt-components
-  - Name: Network configuration
-    File: virt-post-install-network-config
-  - Name: Storage configuration
-    File: virt-post-install-storage-config
-- Name: Updating
-  Dir: updating
-  Topics:
-  - Name: Updating OpenShift Virtualization
-    File: upgrading-virt
-    Distros: openshift-dedicated
-- Name: Virtual machines
-  Dir: virtual_machines
-  Topics:
-  - Name: Creating VMs from Red Hat images
-    Dir: creating_vms_rh
-    Topics:
-    - Name: Creating VMs from Red Hat images overview
-      File: virt-creating-vms-from-rh-images-overview
-    - Name: Creating VMs from templates
-      File: virt-creating-vms-from-templates
-    - Name: Creating VMs from instance types
-      File: virt-creating-vms-from-instance-types
-    - Name: Creating VMs from the CLI
-      File: virt-creating-vms-from-cli
-  - Name: Creating VMs from custom images
-    Dir: creating_vms_custom
-    Topics:
-    - Name: Creating VMs from custom images overview
-      File: virt-creating-vms-from-custom-images-overview
-    - Name: Creating VMs by using container disks
-      File: virt-creating-vms-from-container-disks
-    - Name: Creating VMs by importing images from web pages
-      File: virt-creating-vms-from-web-images
-    - Name: Creating VMs by uploading images
-      File: virt-creating-vms-uploading-images
-    - Name: Creating VMs by cloning PVCs
-      File: virt-creating-vms-by-cloning-pvcs
-    - Name: Installing the QEMU guest agent and VirtIO drivers
-      File: virt-installing-qemu-guest-agent
-  - Name: Connecting to VM consoles
-    File: virt-accessing-vm-consoles
-  - Name: Configuring SSH access to VMs
-    File: virt-accessing-vm-ssh
-  - Name: Editing virtual machines
-    File: virt-edit-vms
-  - Name: Editing boot order
-    File: virt-edit-boot-order
-  - Name: Deleting virtual machines
-    File: virt-delete-vms
-  - Name: Exporting virtual machines
-    File: virt-exporting-vms
-  - Name: Managing virtual machine instances
-    File: virt-manage-vmis
-  - Name: Controlling virtual machine states
-    File: virt-controlling-vm-states
-  - Name: Using virtual Trusted Platform Module devices
-    File: virt-using-vtpm-devices
-  - Name: Managing virtual machines with OpenShift Pipelines
-    File: virt-managing-vms-openshift-pipelines
-  - Name: Advanced virtual machine management
-    Dir: advanced_vm_management
-    Topics:
-#Advanced virtual machine configuration
-    - Name: Working with resource quotas for virtual machines
-      File: virt-working-with-resource-quotas-for-vms
-    - Name: Specifying nodes for virtual machines
-      File: virt-specifying-nodes-for-vms
-    - Name: Configuring certificate rotation
-      File: virt-configuring-certificate-rotation
-    - Name: Configuring the default CPU model
-      File: virt-configuring-default-cpu-model
-    - Name: UEFI mode for virtual machines
-      File: virt-uefi-mode-for-vms
-    - Name: Configuring PXE booting for virtual machines
-      File: virt-configuring-pxe-booting
-# Huge pGES  not supported in OSD
-#    - Name: Using huge pages with virtual machines
-#      File: virt-using-huge-pages-with-vms
-# CPU Manager not supported in OSD
-#    - Name: Enabling dedicated resources for a virtual machine
-#      File: virt-dedicated-resources-vm
-    - Name: Scheduling virtual machines
-      File: virt-schedule-vms
-# Cannot create required machine config in OSD as required
-#    - Name: Configuring PCI passthrough
-#      File: virt-configuring-pci-passthrough
-# Cannot create required machine config in OSD as required
-#    - Name: Configuring virtual GPUs
-#      File: virt-configuring-virtual-gpus
-# Feature is TP, thus not supported in ROSA
-#    - Name: Enabling descheduler evictions on virtual machines
-#      File: virt-enabling-descheduler-evictions
-    - Name: About high availability for virtual machines
-      File: virt-high-availability-for-vms
-# invalid: spec.tuningPolicy: Unsupported value: "highBurst"
-#    - Name: Control plane tuning
-#      File: virt-vm-control-plane-tuning
-  - Name: VM disks
-    Dir: virtual_disks
-    Topics:
-    - Name: Hot-plugging VM disks
-      File: virt-hot-plugging-virtual-disks
-    - Name: Expanding VM disks
-      File: virt-expanding-vm-disks
-- Name: Networking
-  Dir: vm_networking
-  Topics:
-  - Name: Networking configuration overview
-    File: virt-networking-overview
-  - Name: Connecting a VM to the default pod network
-    File: virt-connecting-vm-to-default-pod-network
-  - Name: Exposing a VM by using a service
-    File: virt-exposing-vm-with-service
-# Not supported in ROSA/OSD
-#  - Name: Connecting a VM to a Linux bridge network
-#    File: virt-connecting-vm-to-linux-bridge
-#  - Name: Connecting a VM to an SR-IOV network
-#    File: virt-connecting-vm-to-sriov
-#  - Name: Using DPDK with SR-IOV
-#    File: virt-using-dpdk-with-sriov
-  - Name: Connecting a VM to an OVN-Kubernetes secondary network
-    File: virt-connecting-vm-to-ovn-secondary-network
-# Tecp preview not supported ROSA/OSD
-#  - Name: Hot plugging secondary network interfaces
-#    File: virt-hot-plugging-network-interfaces
-  - Name: Connecting a VM to a service mesh
-    File: virt-connecting-vm-to-service-mesh
-  - Name: Configuring a dedicated network for live migration
-    File: virt-dedicated-network-live-migration
-  - Name: Configuring and viewing IP addresses
-    File: virt-configuring-viewing-ips-for-vms
-# Tech Preview features not supported in ROSA/OSD
-#  - Name: Accessing a VM by using the cluster FQDN
-#    File: virt-accessing-vm-secondary-network-fqdn
-  - Name: Managing MAC address pools for network interfaces
-    File: virt-using-mac-address-pool-for-vms
-- Name: Storage
-  Dir: storage
-  Topics:
-  - Name: Storage configuration overview
-    File: virt-storage-config-overview
-  - Name: Configuring storage profiles
-    File: virt-configuring-storage-profile
-  - Name: Managing automatic boot source updates
-    File: virt-automatic-bootsource-updates
-  - Name: Reserving PVC space for file system overhead
-    File: virt-reserving-pvc-space-fs-overhead
-  - Name: Configuring local storage by using HPP
-    File: virt-configuring-local-storage-with-hpp
-  - Name: Enabling user permissions to clone data volumes across namespaces
-    File: virt-enabling-user-permissions-to-clone-datavolumes
-  - Name: Configuring CDI to override CPU and memory quotas
-    File: virt-configuring-cdi-for-namespace-resourcequota
-  - Name: Preparing CDI scratch space
-    File: virt-preparing-cdi-scratch-space
-  - Name: Using preallocation for data volumes
-    File: virt-using-preallocation-for-datavolumes
-  - Name: Managing data volume annotations
-    File: virt-managing-data-volume-annotations
-# Virtual machine live migration
-- Name: Live migration
-  Dir: live_migration
-  Topics:
-  - Name: About live migration
-    File: virt-about-live-migration
-  - Name: Configuring live migration
-    File: virt-configuring-live-migration
-  - Name: Initiating and canceling live migration
-    File: virt-initiating-live-migration
-# Node maintenance mode
-- Name: Nodes
-  Dir: nodes
-  Topics:
-  - Name: Node maintenance
-    File: virt-node-maintenance
-  - Name: Managing node labeling for obsolete CPU models
-    File: virt-managing-node-labeling-obsolete-cpu-models
-  - Name: Preventing node reconciliation
-    File: virt-preventing-node-reconciliation
-# Hiding in ROSA/OSD as user cannot cordon and drain nodes
-#  - Name: Deleting a failed node to trigger VM failover
-#    File: virt-triggering-vm-failover-resolving-failed-node
-- Name: Monitoring
-  Dir: monitoring
-  Topics:
-  - Name: Monitoring overview
-    File: virt-monitoring-overview
-# Hiding in ROSA/OSD as TP not supported
-#  - Name: Cluster checkup framework
-#    File: virt-running-cluster-checkups
-  - Name: Prometheus queries for virtual resources
-    File: virt-prometheus-queries
-  - Name: Virtual machine custom metrics
-    File: virt-exposing-custom-metrics-for-vms
-  - Name: Virtual machine health checks
-    File: virt-monitoring-vm-health
-  - Name: Runbooks
-    File: virt-runbooks
-- Name: Support
-  Dir: support
-  Topics:
-  - Name: Support overview
-    File: virt-support-overview
-  - Name: Collecting data for Red Hat Support
-    File: virt-collecting-virt-data
-    Distros: openshift-dedicated
-  - Name: Troubleshooting
-    File: virt-troubleshooting
-- Name: Backup and restore
-  Dir: backup_restore
-  Topics:
-  - Name: Backup and restore by using VM snapshots
-    File: virt-backup-restore-snapshots
-  - Name: Backing up and restoring virtual machines
-    File: virt-backup-restore-overview
-#  - Name: Collecting OKD Virtualization data for community report
-#    File: virt-collecting-virt-data
-#    Distros: openshift-origin
+# ---
+# Name: Virtualization
+# Dir: virt
+# Distros: openshift-dedicated
+# Topics:
+# - Name: About
+#   Dir: about_virt
+#   Topics:
+#   - Name: About OpenShift Virtualization
+#     File: about-virt
+#     Distros: openshift-dedicated
+#   - Name: About OKD Virtualization
+#     File: about-virt
+#     Distros: openshift-origin
+#   - Name: Security policies
+#     File: virt-security-policies
+#   - Name: Architecture
+#     File: virt-architecture
+#     Distros: openshift-dedicated
+# #- Name: Release notes
+# #  Dir: release_notes
+# #  Topics:
+# #  - Name: OpenShift Virtualization release notes
+# #    File: virt-release-notes-placeholder
+# #    Distros: openshift-rosa
+# - Name: Getting started
+#   Dir: getting_started
+#   Topics:
+#   - Name: Getting started with OpenShift Virtualization
+#     File: virt-getting-started
+#     Distros: openshift-dedicated
+#   - Name: Getting started with OKD Virtualization
+#     File: virt-getting-started
+#     Distros: openshift-origin
+#   - Name: virtctl and libguestfs
+#     File: virt-using-the-cli-tools
+#     Distros: openshift-dedicated
+# - Name: Installing
+#   Dir: install
+#   Topics:
+#   - Name: Preparing your cluster
+#     File: preparing-cluster-for-virt
+#   - Name: Installing OpenShift Virtualization
+#     File: installing-virt
+#   - Name: Uninstalling OpenShift Virtualization
+#     File: uninstalling-virt
+# - Name: Post-installation configuration
+#   Dir: post_installation_configuration
+#   Topics:
+#   - Name: Post-installation configuration
+#     File: virt-post-install-config
+#   - Name: Node placement rules
+#     File: virt-node-placement-virt-components
+#   - Name: Network configuration
+#     File: virt-post-install-network-config
+#   - Name: Storage configuration
+#     File: virt-post-install-storage-config
+# - Name: Updating
+#   Dir: updating
+#   Topics:
+#   - Name: Updating OpenShift Virtualization
+#     File: upgrading-virt
+#     Distros: openshift-dedicated
+# - Name: Virtual machines
+#   Dir: virtual_machines
+#   Topics:
+#   - Name: Creating VMs from Red Hat images
+#     Dir: creating_vms_rh
+#     Topics:
+#     - Name: Creating VMs from Red Hat images overview
+#       File: virt-creating-vms-from-rh-images-overview
+#     - Name: Creating VMs from templates
+#       File: virt-creating-vms-from-templates
+#     - Name: Creating VMs from instance types
+#       File: virt-creating-vms-from-instance-types
+#     - Name: Creating VMs from the CLI
+#       File: virt-creating-vms-from-cli
+#   - Name: Creating VMs from custom images
+#     Dir: creating_vms_custom
+#     Topics:
+#     - Name: Creating VMs from custom images overview
+#       File: virt-creating-vms-from-custom-images-overview
+#     - Name: Creating VMs by using container disks
+#       File: virt-creating-vms-from-container-disks
+#     - Name: Creating VMs by importing images from web pages
+#       File: virt-creating-vms-from-web-images
+#     - Name: Creating VMs by uploading images
+#       File: virt-creating-vms-uploading-images
+#     - Name: Creating VMs by cloning PVCs
+#       File: virt-creating-vms-by-cloning-pvcs
+#     - Name: Installing the QEMU guest agent and VirtIO drivers
+#       File: virt-installing-qemu-guest-agent
+#   - Name: Connecting to VM consoles
+#     File: virt-accessing-vm-consoles
+#   - Name: Configuring SSH access to VMs
+#     File: virt-accessing-vm-ssh
+#   - Name: Editing virtual machines
+#     File: virt-edit-vms
+#   - Name: Editing boot order
+#     File: virt-edit-boot-order
+#   - Name: Deleting virtual machines
+#     File: virt-delete-vms
+#   - Name: Exporting virtual machines
+#     File: virt-exporting-vms
+#   - Name: Managing virtual machine instances
+#     File: virt-manage-vmis
+#   - Name: Controlling virtual machine states
+#     File: virt-controlling-vm-states
+#   - Name: Using virtual Trusted Platform Module devices
+#     File: virt-using-vtpm-devices
+#   - Name: Managing virtual machines with OpenShift Pipelines
+#     File: virt-managing-vms-openshift-pipelines
+#   - Name: Advanced virtual machine management
+#     Dir: advanced_vm_management
+#     Topics:
+# #Advanced virtual machine configuration
+#     - Name: Working with resource quotas for virtual machines
+#       File: virt-working-with-resource-quotas-for-vms
+#     - Name: Specifying nodes for virtual machines
+#       File: virt-specifying-nodes-for-vms
+#     - Name: Configuring certificate rotation
+#       File: virt-configuring-certificate-rotation
+#     - Name: Configuring the default CPU model
+#       File: virt-configuring-default-cpu-model
+#     - Name: UEFI mode for virtual machines
+#       File: virt-uefi-mode-for-vms
+#     - Name: Configuring PXE booting for virtual machines
+#       File: virt-configuring-pxe-booting
+# # Huge pGES  not supported in OSD
+# #    - Name: Using huge pages with virtual machines
+# #      File: virt-using-huge-pages-with-vms
+# # CPU Manager not supported in OSD
+# #    - Name: Enabling dedicated resources for a virtual machine
+# #      File: virt-dedicated-resources-vm
+#     - Name: Scheduling virtual machines
+#       File: virt-schedule-vms
+# # Cannot create required machine config in OSD as required
+# #    - Name: Configuring PCI passthrough
+# #      File: virt-configuring-pci-passthrough
+# # Cannot create required machine config in OSD as required
+# #    - Name: Configuring virtual GPUs
+# #      File: virt-configuring-virtual-gpus
+# # Feature is TP, thus not supported in ROSA
+# #    - Name: Enabling descheduler evictions on virtual machines
+# #      File: virt-enabling-descheduler-evictions
+#     - Name: About high availability for virtual machines
+#       File: virt-high-availability-for-vms
+# # invalid: spec.tuningPolicy: Unsupported value: "highBurst"
+# #    - Name: Control plane tuning
+# #      File: virt-vm-control-plane-tuning
+#   - Name: VM disks
+#     Dir: virtual_disks
+#     Topics:
+#     - Name: Hot-plugging VM disks
+#       File: virt-hot-plugging-virtual-disks
+#     - Name: Expanding VM disks
+#       File: virt-expanding-vm-disks
+# - Name: Networking
+#   Dir: vm_networking
+#   Topics:
+#   - Name: Networking configuration overview
+#     File: virt-networking-overview
+#   - Name: Connecting a VM to the default pod network
+#     File: virt-connecting-vm-to-default-pod-network
+#   - Name: Exposing a VM by using a service
+#     File: virt-exposing-vm-with-service
+# # Not supported in ROSA/OSD
+# #  - Name: Connecting a VM to a Linux bridge network
+# #    File: virt-connecting-vm-to-linux-bridge
+# #  - Name: Connecting a VM to an SR-IOV network
+# #    File: virt-connecting-vm-to-sriov
+# #  - Name: Using DPDK with SR-IOV
+# #    File: virt-using-dpdk-with-sriov
+#   - Name: Connecting a VM to an OVN-Kubernetes secondary network
+#     File: virt-connecting-vm-to-ovn-secondary-network
+# # Tecp preview not supported ROSA/OSD
+# #  - Name: Hot plugging secondary network interfaces
+# #    File: virt-hot-plugging-network-interfaces
+#   - Name: Connecting a VM to a service mesh
+#     File: virt-connecting-vm-to-service-mesh
+#   - Name: Configuring a dedicated network for live migration
+#     File: virt-dedicated-network-live-migration
+#   - Name: Configuring and viewing IP addresses
+#     File: virt-configuring-viewing-ips-for-vms
+# # Tech Preview features not supported in ROSA/OSD
+# #  - Name: Accessing a VM by using the cluster FQDN
+# #    File: virt-accessing-vm-secondary-network-fqdn
+#   - Name: Managing MAC address pools for network interfaces
+#     File: virt-using-mac-address-pool-for-vms
+# - Name: Storage
+#   Dir: storage
+#   Topics:
+#   - Name: Storage configuration overview
+#     File: virt-storage-config-overview
+#   - Name: Configuring storage profiles
+#     File: virt-configuring-storage-profile
+#   - Name: Managing automatic boot source updates
+#     File: virt-automatic-bootsource-updates
+#   - Name: Reserving PVC space for file system overhead
+#     File: virt-reserving-pvc-space-fs-overhead
+#   - Name: Configuring local storage by using HPP
+#     File: virt-configuring-local-storage-with-hpp
+#   - Name: Enabling user permissions to clone data volumes across namespaces
+#     File: virt-enabling-user-permissions-to-clone-datavolumes
+#   - Name: Configuring CDI to override CPU and memory quotas
+#     File: virt-configuring-cdi-for-namespace-resourcequota
+#   - Name: Preparing CDI scratch space
+#     File: virt-preparing-cdi-scratch-space
+#   - Name: Using preallocation for data volumes
+#     File: virt-using-preallocation-for-datavolumes
+#   - Name: Managing data volume annotations
+#     File: virt-managing-data-volume-annotations
+# # Virtual machine live migration
+# - Name: Live migration
+#   Dir: live_migration
+#   Topics:
+#   - Name: About live migration
+#     File: virt-about-live-migration
+#   - Name: Configuring live migration
+#     File: virt-configuring-live-migration
+#   - Name: Initiating and canceling live migration
+#     File: virt-initiating-live-migration
+# # Node maintenance mode
+# - Name: Nodes
+#   Dir: nodes
+#   Topics:
+#   - Name: Node maintenance
+#     File: virt-node-maintenance
+#   - Name: Managing node labeling for obsolete CPU models
+#     File: virt-managing-node-labeling-obsolete-cpu-models
+#   - Name: Preventing node reconciliation
+#     File: virt-preventing-node-reconciliation
+# # Hiding in ROSA/OSD as user cannot cordon and drain nodes
+# #  - Name: Deleting a failed node to trigger VM failover
+# #    File: virt-triggering-vm-failover-resolving-failed-node
+# - Name: Monitoring
+#   Dir: monitoring
+#   Topics:
+#   - Name: Monitoring overview
+#     File: virt-monitoring-overview
+# # Hiding in ROSA/OSD as TP not supported
+# #  - Name: Cluster checkup framework
+# #    File: virt-running-cluster-checkups
+#   - Name: Prometheus queries for virtual resources
+#     File: virt-prometheus-queries
+#   - Name: Virtual machine custom metrics
+#     File: virt-exposing-custom-metrics-for-vms
+#   - Name: Virtual machine health checks
+#     File: virt-monitoring-vm-health
+#   - Name: Runbooks
+#     File: virt-runbooks
+# - Name: Support
+#   Dir: support
+#   Topics:
+#   - Name: Support overview
+#     File: virt-support-overview
+#   - Name: Collecting data for Red Hat Support
+#     File: virt-collecting-virt-data
+#     Distros: openshift-dedicated
+#   - Name: Troubleshooting
+#     File: virt-troubleshooting
+# - Name: Backup and restore
+#   Dir: backup_restore
+#   Topics:
+#   - Name: Backup and restore by using VM snapshots
+#     File: virt-backup-restore-snapshots
+#   - Name: Backing up and restoring virtual machines
+#     File: virt-backup-restore-overview
+# #  - Name: Collecting OKD Virtualization data for community report
+# #    File: virt-collecting-virt-data
+# #    Distros: openshift-origin


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.17+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-12292
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://83241--ocpdocs-pr.netlify.app/openshift-dedicated/latest/welcome/
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
