### PR TITLE
RHDEVDOCS-6197: Content creation for cluster-scoped installation

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -129,6 +129,8 @@ Topics:
   File: configuring_traffic_management_and_metric_plugins_in_argo_rollouts
 - Name: Enabling high availability support for Argo Rollouts
   File: enabling-ha-support-for-argo-rollouts
+- Name: Using a cluster-scoped Argo Rollouts instance to manage resources
+  File: using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources
 ---
 Name: Security
 Dir: securing_openshift_gitops

--- a/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.adoc
+++ b/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="using-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources"]
+= Using a cluster-scoped Argo Rollouts instance to manage rollout resources
+context: using-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources
+
+toc::[]
+
+By default, Argo Rollouts supports the cluster-scoped mode of installation for Argo Rollouts custom resources (CRs). This mode of installation uses the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable to specify a list of namespaces that can be used to manage the rollout resources.
+
+To manage Argo Rollouts resources, after you install the {gitops-title} Operator on the cluster, you can create and configure a `RolloutManager` custom resource (CR) instance in the namespace of your choice. You can then update the existing `Subscription` object for the {gitops-title} Operator and add user-defined namespaces to the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `spec` section of the Argo CD instance.
+
+[id="prerequisites_{context}"]
+== Prerequisites
+* You have logged in to the {OCP} cluster as an administrator.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
+* You have created a `RolloutManager` custom resource.
+
+// Configuring a cluster-scoped Argo Rollouts instance to manage rollout resources 
+include::modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc#gitops-creating-rolloutmanager-custom-resource_using-argo-rollouts-for-progressive-deployment-delivery[Creating RolloutManager custom resources]

--- a/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
+++ b/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources_{context}"]
+= Configuring a cluster-scoped Argo Rollouts instance to manage rollout resources
+
+To configure a cluster-scoped Argo Rollouts instance for managing rollout resources, add the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `Subscription` resource. This variable contains a list of user-defined namespaces which can be configured for a cluster-scoped Argo Rollouts installation. If the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable is empty, you can create cluster-scoped Argo Rollouts installation in the `openshift-gitops` namespace.
+
+[NOTE]
+====
+You can only create a cluster-scoped Argo Rollouts instance if the `NAMESPACE_SCOPED_ARGO_ROLLOUTS` variable is set to `false`. By default, if the `NAMESPACE_SCOPED_ARGO_ROLLOUTS` variable is not defined, it is set to `false`.
+====
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, navigate to *Operators* → *Installed Operators* → *{gitops-title}* → *Subscription*.
+
+. Click the *Actions* list and then click *Edit Subscription*.
+
+. On the *openshift-gitops-operator* Subscription details page, under the *YAML* tab, edit the `Subscription` YAML file by adding the namespace of the Argo CD instance to the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `spec` section:
++
+.Example configuring the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+spec:
+  config:
+   env: 
+    - name: NAMESPACE_SCOPED_ARGO_ROLLOUTS
+      value: 'false' #<1>
+    - name: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES
+      value: <list_of_namespaces_in_the_cluster-scoped_Argo_CD_instances> #<2>
+ ...
+----
+<1> Specify this value to enable or disable the cluster-scoped installation. If the value is set to `'false'`, it means that the you have enabled cluster-scoped installation. If it is set to `'true'`, it means that you have enabled namespace-scoped installation. If the value is empty, it is set to `false`.
+<2> Specifies a comma-separated list of namespaces that can host a cluster-scoped Argo Rollouts instance, for example `test-123-cluster-scoped,test-456-cluster-scoped`.
+
+. Click *Save* and *Reload*.

--- a/modules/gitops-creating-rolloutmanager-custom-resource.adoc
+++ b/modules/gitops-creating-rolloutmanager-custom-resource.adoc
@@ -33,8 +33,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: RolloutManager
 metadata:
   name: argo-rollout
-  labels:
-    example: basic
+  namespace: openshift-gitops
 spec: {}
 ----
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6197

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Using a cluster-scoped rollouts instance to manage rollouts resources](https://83242--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: jparsai@redhat.com
Peer review: @bscott-rh 
QE review: @varshab1210 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
