### PR TITLE
structure: sequence as generic then vendor specific cloud and onprem

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -169,6 +169,87 @@ Topics:
   - Name: Support for FIPS cryptography
     File: installing-fips
     Distros: openshift-enterprise,openshift-online
+- Name: Installing on any platform
+  Dir: installing_platform_agnostic
+  Distros: openshift-origin,openshift-enterprise
+  Topics:
+  - Name: Installing a cluster on any platform
+    File: installing-platform-agnostic
+- Name: Installing on-premise with the Assisted Installer
+  Dir: installing_on_prem_assisted
+  Distros: openshift-enterprise
+  Topics:
+  - Name: Installing an on-premise cluster using the Assisted Installer
+    File: installing-on-prem-assisted
+- Name: Installing on-premise with the Agent-based Installer
+  Dir: installing_with_agent_based_installer
+  Distros: openshift-enterprise
+  Topics:
+  - Name: Preparing to install with Agent-based Installer
+    File: preparing-to-install-with-agent-based-installer
+  - Name: Understanding disconnected installation mirroring
+    File: understanding-disconnected-installation-mirroring
+  - Name: Installing a cluster with Agent-based Installer
+    File: installing-with-agent-based-installer
+  - Name: Preparing PXE assets for OCP
+    File: prepare-pxe-assets-agent
+  - Name: Preparing an Agent-based installed cluster for the multicluster engine for Kubernetes
+    File: preparing-an-agent-based-installed-cluster-for-mce
+  - Name: Installation configuration parameters for the Agent-based Installer
+    File: installation-config-parameters-agent
+- Name: Installing on a single node
+  Dir: installing_sno
+  Distros: openshift-enterprise,openshift-origin
+  Topics:
+  - Name: Preparing to install OpenShift on a single node
+    File: install-sno-preparing-to-install-sno
+  - Name: Installing OpenShift on a single node
+    File: install-sno-installing-sno
+- Name: Installing on bare metal with the UPI Installer
+  Dir: installing_bare_metal
+  Distros: openshift-origin,openshift-enterprise
+  Topics:
+  - Name: Preparing to install on bare metal
+    File: preparing-to-install-on-bare-metal
+  - Name: Installing a user-provisioned cluster on bare metal
+    File: installing-bare-metal
+  - Name: Installing a user-provisioned bare metal cluster with network customizations
+    File: installing-bare-metal-network-customizations
+  - Name: Installing a user-provisioned bare metal cluster on a restricted network
+    File: installing-restricted-networks-bare-metal
+  - Name: Scaling a user-provisioned installation with the bare metal operator
+    File: scaling-a-user-provisioned-cluster-with-the-bare-metal-operator
+  - Name: Installation configuration parameters for bare metal
+    File: installation-config-parameters-bare-metal
+- Name: Installing on bare metal with the IPI Installer
+  Dir: installing_bare_metal_ipi
+  Distros: openshift-origin,openshift-enterprise
+  Topics:
+  - Name: Overview
+    File: ipi-install-overview
+  - Name: Prerequisites
+    File: ipi-install-prerequisites
+  - Name: Setting up the environment for an OpenShift installation
+    File: ipi-install-installation-workflow
+  - Name: Installing a cluster
+    File: ipi-install-installing-a-cluster
+  - Name: Troubleshooting the installation
+    File: ipi-install-troubleshooting
+  - Name: Postinstallation configuration
+    File: ipi-install-post-installation-configuration
+  - Name: Expanding the cluster
+    File: ipi-install-expanding-the-cluster
+- Name: Installation configuration
+  Dir: install_config
+  Distros: openshift-origin,openshift-enterprise
+  Topics:
+  - Name: Customizing nodes
+    File: installing-customizing
+  - Name: Configuring your firewall
+    File: configuring-firewall
+  - Name: Enabling Linux control group version 1 (cgroup v1)
+    File: enabling-cgroup-v1
+    Distros: openshift-enterprise
 - Name: Installing on Alibaba Cloud
   Distros: openshift-origin,openshift-enterprise
   Dir: installing_alibaba
@@ -282,36 +363,6 @@ Topics:
     File: uninstalling-cluster-azure
   - Name: Installation configuration parameters for Azure
     File: installation-config-parameters-azure
-- Name: Installing on Azure Stack Hub
-  Dir: installing_azure_stack_hub
-  Distros: openshift-origin,openshift-enterprise
-  Topics:
-  - Name: Installation methods
-    File: preparing-to-install-on-azure-stack-hub
-  - Name: Configuring an Azure Stack Hub account
-    File: installing-azure-stack-hub-account
-  - Name: Installer-provisioned infrastructure
-    Dir: ipi
-    Distros: openshift-origin,openshift-enterprise
-    Topics:
-    - Name: Preparing to install a cluster
-      File: ipi-ash-preparing-to-install
-    - Name: Installing a cluster
-      File: installing-azure-stack-hub-default
-    - Name: Installing a cluster with network customizations
-      File: installing-azure-stack-hub-network-customizations
-  - Name: User-provisioned infrastructure
-    Dir: upi
-    Distros: openshift-origin,openshift-enterprise
-    Topics:
-    - Name: Preparing to install a cluster
-      File: upi-ash-preparing-to-install
-    - Name: Installing a cluster using ARM templates
-      File: installing-azure-stack-hub-user-infra
-  - Name: Installation configuration parameters
-    File: installation-config-parameters-ash
-  - Name: Uninstalling a cluster
-    File: uninstalling-cluster-azure-stack-hub
 - Name: Installing on GCP
   Dir: installing_gcp
   Distros: openshift-origin,openshift-enterprise
@@ -374,89 +425,29 @@ Topics:
     File: installation-config-parameters-ibm-cloud-vpc
   - Name: Uninstalling a cluster on IBM Cloud
     File: uninstalling-cluster-ibm-cloud
-- Name: Installing on Nutanix
-  Dir: installing_nutanix
-  Distros: openshift-origin,openshift-enterprise
-  Topics:
-  - Name: Preparing to install on Nutanix
-    File: preparing-to-install-on-nutanix
-  - Name: Fault tolerant deployments
-    File: nutanix-failure-domains
-  - Name: Installing a cluster on Nutanix
-    File: installing-nutanix-installer-provisioned
-  - Name: Installing a cluster on Nutanix in a restricted network
-    File: installing-restricted-networks-nutanix-installer-provisioned
-  - Name: Installing a three-node cluster on Nutanix
-    File: installing-nutanix-three-node
-  - Name: Uninstalling a cluster on Nutanix
-    File: uninstalling-cluster-nutanix
-  - Name: Installation configuration parameters for Nutanix
-    File: installation-config-parameters-nutanix
-- Name: Installing on-premise with Assisted Installer
-  Dir: installing_on_prem_assisted
+- Name: Installing on IBM Power Virtual Server with IBM Cloud
+  Dir: installing_ibm_powervs
   Distros: openshift-enterprise
   Topics:
-  - Name: Installing an on-premise cluster using the Assisted Installer
-    File: installing-on-prem-assisted
-- Name: Installing an on-premise cluster with the Agent-based Installer
-  Dir: installing_with_agent_based_installer
-  Distros: openshift-enterprise
-  Topics:
-  - Name: Preparing to install with Agent-based Installer
-    File: preparing-to-install-with-agent-based-installer
-  - Name: Understanding disconnected installation mirroring
-    File: understanding-disconnected-installation-mirroring
-  - Name: Installing a cluster with Agent-based Installer
-    File: installing-with-agent-based-installer
-  - Name: Preparing PXE assets for OCP
-    File: prepare-pxe-assets-agent
-  - Name: Preparing an Agent-based installed cluster for the multicluster engine for Kubernetes
-    File: preparing-an-agent-based-installed-cluster-for-mce
-  - Name: Installation configuration parameters for the Agent-based Installer
-    File: installation-config-parameters-agent
-- Name: Installing on a single node
-  Dir: installing_sno
-  Distros: openshift-enterprise,openshift-origin
-  Topics:
-  - Name: Preparing to install OpenShift on a single node
-    File: install-sno-preparing-to-install-sno
-  - Name: Installing OpenShift on a single node
-    File: install-sno-installing-sno
-- Name: Installing on bare metal
-  Dir: installing_bare_metal
-  Distros: openshift-origin,openshift-enterprise
-  Topics:
-  - Name: Preparing to install on bare metal
-    File: preparing-to-install-on-bare-metal
-  - Name: Installing a user-provisioned cluster on bare metal
-    File: installing-bare-metal
-  - Name: Installing a user-provisioned bare metal cluster with network customizations
-    File: installing-bare-metal-network-customizations
-  - Name: Installing a user-provisioned bare metal cluster on a restricted network
-    File: installing-restricted-networks-bare-metal
-  - Name: Scaling a user-provisioned installation with the bare metal operator
-    File: scaling-a-user-provisioned-cluster-with-the-bare-metal-operator
-  - Name: Installation configuration parameters for bare metal
-    File: installation-config-parameters-bare-metal
-- Name: Deploying installer-provisioned clusters on bare metal
-  Dir: installing_bare_metal_ipi
-  Distros: openshift-origin,openshift-enterprise
-  Topics:
-  - Name: Overview
-    File: ipi-install-overview
-  - Name: Prerequisites
-    File: ipi-install-prerequisites
-  - Name: Setting up the environment for an OpenShift installation
-    File: ipi-install-installation-workflow
-  - Name: Installing a cluster
-    File: ipi-install-installing-a-cluster
-  - Name: Troubleshooting the installation
-    File: ipi-install-troubleshooting
-  - Name: Postinstallation configuration
-    File: ipi-install-post-installation-configuration
-  - Name: Expanding the cluster
-    File: ipi-install-expanding-the-cluster
-- Name: Installing IBM Cloud Bare Metal (Classic)
+  - Name: Preparing to install on IBM Power Virtual Server
+    File: preparing-to-install-on-ibm-power-vs
+  - Name: Configuring an IBM Cloud account
+    File: installing-ibm-cloud-account-power-vs
+  - Name: Creating an IBM Power Virtual Server workspace
+    File: creating-ibm-power-vs-workspace
+  - Name: Installing a cluster on IBM Power Virtual Server with customizations
+    File: installing-ibm-power-vs-customizations
+  - Name: Installing a cluster on IBM Power Virtual Server into an existing VPC
+    File: installing-ibm-powervs-vpc
+  - Name: Installing a private cluster on IBM Power Virtual Server
+    File: installing-ibm-power-vs-private-cluster
+  - Name: Installing a cluster on IBM Power Virtual Server in a restricted network
+    File: installing-restricted-networks-ibm-power-vs
+  - Name: Uninstalling a cluster on IBM Power Virtual Server
+    File: uninstalling-cluster-ibm-power-vs
+  - Name: Installation configuration parameters for IBM Power Virtual Server
+    File: installation-config-parameters-ibm-power-vs
+- Name: Installing on IBM Cloud (Classic)
   Dir: installing_ibm_cloud_classic
   Distros: openshift-origin,openshift-enterprise
   Topics:
@@ -464,6 +455,56 @@ Topics:
     File: install-ibm-cloud-prerequisites
   - Name: Installation workflow
     File: install-ibm-cloud-installation-workflow
+- Name: Installing on OCI
+  Dir: installing_oci
+  Distros: openshift-origin,openshift-enterprise
+  Topics:
+  - Name: Installing a cluster on Oracle Cloud Infrastructure by using the Assisted Installer
+    File: installing-oci-assisted-installer
+  - Name: Installing a cluster on Oracle Cloud Infrastructure by using the Agent-based Installer
+    File: installing-oci-agent-based-installer
+- Name: Installing on Azure Stack Hub
+  Dir: installing_azure_stack_hub
+  Distros: openshift-origin,openshift-enterprise
+  Topics:
+  - Name: Installation methods
+    File: preparing-to-install-on-azure-stack-hub
+  - Name: Configuring an Azure Stack Hub account
+    File: installing-azure-stack-hub-account
+  - Name: Installer-provisioned infrastructure
+    Dir: ipi
+    Distros: openshift-origin,openshift-enterprise
+    Topics:
+    - Name: Preparing to install a cluster
+      File: ipi-ash-preparing-to-install
+    - Name: Installing a cluster
+      File: installing-azure-stack-hub-default
+    - Name: Installing a cluster with network customizations
+      File: installing-azure-stack-hub-network-customizations
+  - Name: User-provisioned infrastructure
+    Dir: upi
+    Distros: openshift-origin,openshift-enterprise
+    Topics:
+    - Name: Preparing to install a cluster
+      File: upi-ash-preparing-to-install
+    - Name: Installing a cluster using ARM templates
+      File: installing-azure-stack-hub-user-infra
+  - Name: Installation configuration parameters
+    File: installation-config-parameters-ash
+  - Name: Uninstalling a cluster
+    File: uninstalling-cluster-azure-stack-hub
+- Name: Installing on IBM Power
+  Dir: installing_ibm_power
+  Distros: openshift-enterprise
+  Topics:
+  - Name: Preparing to install on IBM Power
+    File: preparing-to-install-on-ibm-power
+  - Name: Installing a cluster on IBM Power
+    File: installing-ibm-power
+  - Name: Restricted network IBM Power installation
+    File: installing-restricted-networks-ibm-power
+  - Name: Installation configuration parameters for IBM Power
+    File: installation-config-parameters-ibm-power
 - Name: Installing on IBM Z and IBM LinuxONE
   Dir: installing_ibm_z
   Distros: openshift-enterprise
@@ -486,40 +527,24 @@ Topics:
     File: installation-config-parameters-ibm-z
   - Name: Configuring additional devices in an IBM Z or IBM LinuxONE environment
     File: ibmz-post-install
-- Name: Installing on IBM Power
-  Dir: installing_ibm_power
-  Distros: openshift-enterprise
+- Name: Installing on Nutanix
+  Dir: installing_nutanix
+  Distros: openshift-origin,openshift-enterprise
   Topics:
-  - Name: Preparing to install on IBM Power
-    File: preparing-to-install-on-ibm-power
-  - Name: Installing a cluster on IBM Power
-    File: installing-ibm-power
-  - Name: Restricted network IBM Power installation
-    File: installing-restricted-networks-ibm-power
-  - Name: Installation configuration parameters for IBM Power
-    File: installation-config-parameters-ibm-power
-- Name: Installing on IBM Power Virtual Server
-  Dir: installing_ibm_powervs
-  Distros: openshift-enterprise
-  Topics:
-  - Name: Preparing to install on IBM Power Virtual Server
-    File: preparing-to-install-on-ibm-power-vs
-  - Name: Configuring an IBM Cloud account
-    File: installing-ibm-cloud-account-power-vs
-  - Name: Creating an IBM Power Virtual Server workspace
-    File: creating-ibm-power-vs-workspace
-  - Name: Installing a cluster on IBM Power Virtual Server with customizations
-    File: installing-ibm-power-vs-customizations
-  - Name: Installing a cluster on IBM Power Virtual Server into an existing VPC
-    File: installing-ibm-powervs-vpc
-  - Name: Installing a private cluster on IBM Power Virtual Server
-    File: installing-ibm-power-vs-private-cluster
-  - Name: Installing a cluster on IBM Power Virtual Server in a restricted network
-    File: installing-restricted-networks-ibm-power-vs
-  - Name: Uninstalling a cluster on IBM Power Virtual Server
-    File: uninstalling-cluster-ibm-power-vs
-  - Name: Installation configuration parameters for IBM Power Virtual Server
-    File: installation-config-parameters-ibm-power-vs
+  - Name: Preparing to install on Nutanix
+    File: preparing-to-install-on-nutanix
+  - Name: Fault tolerant deployments
+    File: nutanix-failure-domains
+  - Name: Installing a cluster on Nutanix
+    File: installing-nutanix-installer-provisioned
+  - Name: Installing a cluster on Nutanix in a restricted network
+    File: installing-restricted-networks-nutanix-installer-provisioned
+  - Name: Installing a three-node cluster on Nutanix
+    File: installing-nutanix-three-node
+  - Name: Uninstalling a cluster on Nutanix
+    File: uninstalling-cluster-nutanix
+  - Name: Installation configuration parameters for Nutanix
+    File: installation-config-parameters-nutanix
 - Name: Installing on OpenStack
   Dir: installing_openstack
   Distros: openshift-origin,openshift-enterprise
@@ -552,15 +577,7 @@ Topics:
     File: uninstalling-openstack-user
   - Name: Installation configuration parameters for OpenStack
     File: installation-config-parameters-openstack
-- Name: Installing on OCI
-  Dir: installing_oci
-  Distros: openshift-origin,openshift-enterprise
-  Topics:
-  - Name: Installing a cluster on Oracle Cloud Infrastructure by using the Assisted Installer
-    File: installing-oci-assisted-installer
-  - Name: Installing a cluster on Oracle Cloud Infrastructure by using the Agent-based Installer
-    File: installing-oci-agent-based-installer
-- Name: Installing on vSphere
+- Name: Installing on VMware vSphere
   Dir: installing_vsphere
   Distros: openshift-origin,openshift-enterprise
   Topics:
@@ -616,23 +633,6 @@ Topics:
     File: vsphere-post-installation-encryption
   - Name: Configuring the vSphere connection settings after an installation
     File: installing-vsphere-post-installation-configuration
-- Name: Installing on any platform
-  Dir: installing_platform_agnostic
-  Distros: openshift-origin,openshift-enterprise
-  Topics:
-  - Name: Installing a cluster on any platform
-    File: installing-platform-agnostic
-- Name: Installation configuration
-  Dir: install_config
-  Distros: openshift-origin,openshift-enterprise
-  Topics:
-  - Name: Customizing nodes
-    File: installing-customizing
-  - Name: Configuring your firewall
-    File: configuring-firewall
-  - Name: Enabling Linux control group version 1 (cgroup v1)
-    File: enabling-cgroup-v1
-    Distros: openshift-enterprise
 - Name: Validation and troubleshooting
   Dir: validation_and_troubleshooting
   Topics:


### PR DESCRIPTION
Address GH Issue #81621 for inconsistent documentation navigation structure. The commit is nonintrusive and does not alter the structure of any topic object.

Version(s):
4.17, do not cherry pick as this file is likely to have changed between each version

Issue:
- None (GH or Jira), this is community author contribution

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- n/a

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->



#### The structure from this PR will reflect:

```yaml
# generic
- Name: Installation overview
- Name: Installing on any platform
- Name: Installing on-premise with the Assisted Installer
- Name: Installing on-premise with the Agent-based Installer
- Name: Installing on a single node
- Name: Installing on bare metal with the UPI Installer
- Name: Installing on bare metal with the IPI Installer
- Name: Installation configuration
# vendor-specific, type Cloud IaaS
- Name: Installing on Alibaba Cloud
- Name: Installing on AWS
- Name: Installing on Azure
- Name: Installing on GCP
- Name: Installing on IBM Cloud
- Name: Installing on IBM Power Virtual Server
- Name: Installing on IBM Cloud (Classic)
- Name: Installing on OCI
# vendor-specific, type On-Premise 
- Name: Installing on Azure Stack Hub
- Name: Installing on IBM Power
- Name: Installing on IBM Z and IBM LinuxONE
- Name: Installing on Nutanix
- Name: Installing on OpenStack
- Name: Installing on VMware vSphere
- Name: Validation and troubleshooting
```


#### The following renames occured for fixing bad descriptions

```
Installing on bare metal
>>>
Installing on bare metal with the UPI Installer
```

```
Deploying installer-provisioned clusters on bare metal
>>>
Installing on bare metal with the IPI Installer
```

#### The following renames occured for consistency

```
Installing on-premise with Assisted Installer
>>>
Installing on-premise with the Assisted Installer
```

```
Installing an on-premise cluster with the Agent-based Installer
>>>
Installing on-premise with the Agent-based Installer
```

```
Installing IBM Cloud Bare Metal (Classic)
>>>
Installing on IBM Cloud (Classic)
```

```
Installing on vSphere
>>>
Installing on VMware vSphere
```