### PR TITLE
Update list of all supported wapiVersions in External DNS Operator Documentation

### DIFF
--- a/modules/nw-control-dns-records-public-hosted-zone-infoblox.adoc
+++ b/modules/nw-control-dns-records-public-hosted-zone-infoblox.adoc
@@ -53,20 +53,21 @@ spec:
         name: infoblox-credentials
       gridHost: ${INFOBLOX_GRID_PUBLIC_IP}
       wapiPort: 443
-      wapiVersion: "2.3.1"
+      wapiVersion: "2.3.1" <3>
   domains:
   - filterType: Include
     matchType: Exact
     name: test.example.com
   source:
-    type: OpenShiftRoute <3>
+    type: OpenShiftRoute <4>
     openshiftRouteOptions:
-      routerName: default <4>
+      routerName: default <5>
 ----
 <1> Specifies the External DNS name.
 <2> Defines the provider type.
-<3> You can define options for the source of DNS records.
-<4> If the source type is `OpenShiftRoute`, you can pass the OpenShift Ingress Controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
+<3> Currently supported wapiVersions : 2.3.1, 2.4, 2.5, 2.6, 2.6.1, 2.7, 2.7.1, 2.7.2, 2.7.3, 2.8, 2.9, 2.9.1. Unless explicitly stated in the release notes, previously available WAPI versions are intended to remain accessible and operative with later versions.
+<4> You can define options for the source of DNS records.
+<5> If the source type is `OpenShiftRoute`, you can pass the OpenShift Ingress Controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
 
 . Create the `ExternalDNS` resource on Infoblox by running the following command:
 +

--- a/modules/nw-control-dns-records-public-hosted-zone-infoblox.adoc
+++ b/modules/nw-control-dns-records-public-hosted-zone-infoblox.adoc
@@ -65,7 +65,7 @@ spec:
 ----
 <1> Specifies the External DNS name.
 <2> Defines the provider type.
-<3> Currently supported wapiVersions : 2.3.1, 2.4, 2.5, 2.6, 2.6.1, 2.7, 2.7.1, 2.7.2, 2.7.3, 2.8, 2.9, 2.9.1. Unless explicitly stated in the release notes, previously available WAPI versions are intended to remain accessible and operative with later versions.
+<3> The currently supported WAPI versions are 2.3.1, 2.4, 2.5, 2.6, 2.6.1, 2.7, 2.7.1, 2.7.2, 2.7.3, 2.8, 2.9, and 2.9.1. Unless explicitly stated in the release notes, previously available WAPI versions are intended to remain accessible and operative with later versions.
 <4> You can define options for the source of DNS records.
 <5> If the source type is `OpenShiftRoute`, you can pass the OpenShift Ingress Controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
 


### PR DESCRIPTION
Update list of all supported wapiVersions in external dns operator documentations

https://issues.redhat.com/browse/OSDOCS-12220

Version(s):

4.16+

Issue:

https://issues.redhat.com/browse/OSDOCS-12220

Link to docs preview:

https://83270--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-creating-dns-records-on-infoblox.html 

QE review:
- [ ] QE has approved this change.

Additional information:

Currently in External DNS operator documentation, the wapiVersion present is "2.3.1" which is quite old as there are multiple new versions updated after that.

- Here are the list of currently supported wapiVersions: 2.3.1, 2.4, 2.5, 2.6, 2.6.1, 2.7, 2.7.1, 2.7.2, 2.7.3, 2.8, 2.9, 2.9.1.
- Unless explicitly stated in the release notes, previously available WAPI versions are intended to remain accessible and operative with later versions.

Also, we raised a test PR[1] with the latest wapiVersion "2.9.1" as the default version for tests, and it passed all the e2e tests. So, "2.9.1" seems to be working fine with our Infoblox instance.

So, we need to update the list of all supported wapiVersions in our product documentation[2] to avoid the confusion :
[1] [openshift/external-dns-operator#229](https://github.com/openshift/external-dns-operator/pull/229)
[2] https://docs.openshift.com/container-platform/4.16/networking/external_dns_operator/nw-creating-dns-records-on-infoblox.html