### PR TITLE
TELCODOCS-1994: Firmware search path is not automatically configured on OCP (KMM) RELEASE NOTES

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1024,10 +1024,15 @@ For information about using the {secrets-store-operator} to mount secrets from G
 [id="ocp-4-17-network-observability-1-6-2-known-issue_{context}"]
 ==== Known issue
 The 1.6.2 version of the Network Observability Operator fixes a compatibility issue with console plugins that would have prevented Network Observability from being installed on {product-title} 4.17 clusters. By upgrading to version 1.6.2 of the Network Observability Operator, this compatibility issue is resolved, and Network Observability can be installed as expected. (link:https://issues.redhat.com/browse/NETOBSERV-1737[*NETOBSERV-1737*])
+////
 
 [id="ocp-4-17-scalability-and-performance_{context}"]
 === Scalability and performance
-////
+
+[id="ocp-4-17-kmmo_{context}"]
+==== Kernel Module Management Operator
+
+In this release, the firmware search path has been updated to copy the contents of the specified path into the path specified in `worker.setFirmwareClassPath` (default: `/var/lib/firmware`). For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-example-cr_kernel-module-management-operator[Example Module CR].
 
 [id="ocp-4-17-etcd-4-5-nodes_{context}"]
 ==== Node scaling for etcd


### PR DESCRIPTION
D/S and RN Docs:[MGMT-18541] Firmware search path is not automatically configured on OCP (KMM) Release Note

Jira: https://issues.redhat.com/browse/TELCODOCS-1994

Applies to OCP version : 4.17

Fix version: KMMO 2.2

Docs Preview: https://83272--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-kmmo_release-notes

Dev review: @ybettan
QE review: @ggordaniRed 

