### PR TITLE
OSDOCS-12116: clarify user-replaceable values for procedure

### DIFF
--- a/modules/microshift-viewing-audit-logs.adoc
+++ b/modules/microshift-viewing-audit-logs.adoc
@@ -21,25 +21,28 @@ You can identify pod security admission violations on a workload by viewing the 
 ----
 $ <node_name>=$(oc get node -ojsonpath='{.items[0].metadata.name}')
 ----
+//output example?
+
 . To view the audit logs, run the following command:
 +
 [source,terminal]
 ----
-$ oc adm node-logs <node_name> --path=kube-apiserver/
+$ oc adm node-logs <node_name> --path=kube-apiserver/ <1>
 ----
+<1> Replace _<node_name>_ with the name of the node retrieved from the previous step.
 +
 .Example output
 [source,terminal]
 ----
-rhel-92.lab.local audit-2023-08-18T18-25-41.663.log
-rhel-92.lab.local audit-2023-08-19T11-21-29.225.log
-rhel-92.lab.local audit-2023-08-20T04-16-09.622.log
-rhel-92.lab.local audit-2023-08-20T21-11-41.163.log
-rhel-92.lab.local audit-2023-08-21T14-06-10.402.log
-rhel-92.lab.local audit-2023-08-22T06-35-10.392.log
-rhel-92.lab.local audit-2023-08-22T23-26-27.667.log
-rhel-92.lab.local audit-2023-08-23T16-52-15.456.log
-rhel-92.lab.local audit-2023-08-24T07-31-55.238.log
+rhel-94.lab.local audit-2024-10-18T18-25-41.663.log
+rhel-94.lab.local audit-2024-10-19T11-21-29.225.log
+rhel-94.lab.local audit-2024-10-20T04-16-09.622.log
+rhel-94.lab.local audit-2024-10-20T21-11-41.163.log
+rhel-94.lab.local audit-2024-10-21T14-06-10.402.log
+rhel-94.lab.local audit-2024-10-22T06-35-10.392.log
+rhel-94.lab.local audit-2024-10-22T23-26-27.667.log
+rhel-94.lab.local audit-2024-10-23T16-52-15.456.log
+rhel-94.lab.local audit-2024-10-24T07-31-55.238.log
 ----
 
 . To parse the affected audit logs, enter the following command:
@@ -48,5 +51,6 @@ rhel-92.lab.local audit-2023-08-24T07-31-55.238.log
 ----
 $ oc adm node-logs <node_name> --path=kube-apiserver/audit.log \
   | jq -r 'select((.annotations["pod-security.kubernetes.io/audit-violations"] != null) and (.objectRef.resource=="pods")) | .objectRef.namespace + " " + .objectRef.name + " " + .objectRef.resource' \
-  | sort | uniq -c
+  | sort | uniq -c <1>
 ----
+<1> Replace _<node_name>_ with the name of the node retrieved from the previous step.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-12116](https://issues.redhat.com/browse/OSDOCS-12116)

Link to docs preview:
[microshift_troubleshooting/microshift-audit-logs](https://83281--ocpdocs-pr.netlify.app/microshift/latest/microshift_troubleshooting/microshift-audit-logs.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
