### PR TITLE
OSDOCS-12154: Modularizing multiple pods on same node with RWO access

### DIFF
--- a/microshift_storage/understanding-persistent-storage-microshift.adoc
+++ b/microshift_storage/understanding-persistent-storage-microshift.adoc
@@ -29,6 +29,10 @@ include::modules/microshift-pv-rwo-access-mode-permission.adoc[leveloffset=+1]
 
 include::modules/microshift-checking-pods-mismatch.adoc[leveloffset=+1]
 
+include::modules/microshift-updating-pods-mismatch.adoc[leveloffset=+1]
+
+include::modules/microshift-verifying-pods-mismatch.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_file_systems/mounting-file-systems_managing-file-systems#common-mount-options_mounting-file-systems[Common mount options]

--- a/modules/microshift-checking-pods-mismatch.adoc
+++ b/modules/microshift-checking-pods-mismatch.adoc
@@ -6,13 +6,13 @@
 [id="microshift-checking-pods-mismatch_{context}"]
 = Checking the pods for mismatch
 
-Check if the pods have a mismatch. Update the SELinux context if a mismatch is found by using the following procedure.
+Check if the pods have a mismatch by using the following procedure.
 
 [IMPORTANT]
 ====
-* Replace `_<pod_name_A>_` with the name of the first pod in the following procedure.
-* Replace `_<pod_name_B>_` with the name of the second pod in the following procedure.
-* Replace `_<PVC_mountpoint>_` with the mount point within the pods.
+* Replace `_<pod_name_a>_` with the name of the first pod in the following procedure.
+* Replace `_<pod_name_b>_` with the name of the second pod in the following procedure.
+* Replace `_<pvc_mountpoint>_` with the mount point within the pods.
 ====
 
 .Procedure
@@ -22,9 +22,9 @@ Check if the pods have a mismatch. Update the SELinux context if a mismatch is f
 [source,terminal]
 [subs="+quotes"]
 ----
-$ oc get pods -n _<pod_name_A>_ -ojsonpath='{.spec.containers[*].volumeMounts[*].mountPath}' <1>
+$ oc get pods -n _<pod_name_a>_ -ojsonpath='{.spec.containers[*].volumeMounts[*].mountPath}' <1>
 ----
-<1> Replace `_<pod_name_A>_` with the name of the first pod.
+<1> Replace `_<pod_name_a>_` with the name of the first pod.
 +
 .Example output
 [source,terminal]
@@ -36,9 +36,9 @@ $ oc get pods -n _<pod_name_A>_ -ojsonpath='{.spec.containers[*].volumeMounts[*]
 [source,terminal]
 [subs="+quotes"]
 ----
-$ oc get pods -n _<pod_name_B>_ -ojsonpath='{.spec.containers[*].volumeMounts[*].mountPath}' <1>
+$ oc get pods -n _<pod_name_b>_ -ojsonpath='{.spec.containers[*].volumeMounts[*].mountPath}' <1>
 ----
-<1> Replace `_<pod_name_B>_` with the name of the second pod.
+<1> Replace `_<pod_name_b>_` with the name of the second pod.
 +
 .Example output
 [source,terminal]
@@ -50,9 +50,9 @@ $ oc get pods -n _<pod_name_B>_ -ojsonpath='{.spec.containers[*].volumeMounts[*]
 [source,terminal]
 [subs="+quotes"]
 ----
-$ oc rsh _<pod_name_A>_ ls -lZah _<PVC_mountpoint>_ <1>
+$ oc rsh _<pod_name_a>_ ls -lZah _<pvc_mountpoint>_ <1>
 ----
-<1> Replace `_<pod_name_A>_` with the name of the first pod and replace `_<PVC_mountpoint>_` with the mount point within the first pod.
+<1> Replace `_<pod_name_a>_` with the name of the first pod and replace `_<pvc_mountpoint>_` with the mount point within the first pod.
 +
 .Example output
 [source,terminal]
@@ -67,9 +67,9 @@ dr-xr-xr-x.   1 root root system_u:object_r:container_file_t:s0:c398,c806   40 F
 [source,terminal]
 [subs="+quotes"]
 ----
-$ oc rsh _<pod_name_B>_ ls -lZah _<PVC_mountpoint>_ <1>
+$ oc rsh _<pod_name_b>_ ls -lZah _<pvc_mountpoint>_ <1>
 ----
-<1> Replace `_<pod_name_B>_` with the name of the second pod and replace `_<PVC_mountpoint>_` with the mount point within the second pod.
+<1> Replace `_<pod_name_b>_` with the name of the second pod and replace `_<pvc_mountpoint>_` with the mount point within the second pod.
 +
 .Example output
 [source,terminal]
@@ -80,82 +80,3 @@ dr-xr-xr-x.   1 root root system_u:object_r:container_file_t:s0:c15,c25   40 Feb
 [...]
 ----
 . Compare both the outputs to check if there is a mismatch of SELinux context.
-. When there is a mismatch of the SELinux content, create a new SCC and assign it to both PODs. To create a SCC see link: https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html#security-context-constraints-creating_configuring-internal-oauth[Creating security context constraints].
-. Update the SELinuxContext as shown in the following example:
-+
-.Example output
-[source,terminal]
-----
- [...]
- securityContext:privileged
-      seLinuxOptions:MustRunAs
-        level: "s0:cXX,cYY"
-  [...]
-----
-
-.Verification
-
-. Verify that the same SCC is assigned to the first pod by running the following command:
-+
-[source,terminal]
-[subs="+quotes"]
-----
-$ oc describe pod _<pod_name_A>_ |grep -i scc <1>
-----
-<1> Replace `_<pod_name_A>_` with the name of the first pod.
-+
-.Example output
-[source,terminal]
-----
-openshift.io/scc: restricted
-----
-. Verify that the same SCC is assigned to first second pod by running the following command:
-+
-[source,terminal]
-[subs="+quotes"]
-----
-$ oc describe pod _<pod_name_B>_ |grep -i scc <1>
-----
-<1> Replace `_<pod_name_B>_` with the name of the second pod.
-+
-.Example output
-[source,terminal]
-----
-openshift.io/scc: restricted
-----
-. Verify that the same SELinux label is applied to first pod by running the following command:
-+
-[source,terminal]
-[subs="+quotes"]
-----
-$ oc exec _<pod_name_A>_ -- ls -laZ _<PVC_mountpoint>_ <1>
-----
-<1> Replace `_<pod_name_A>_` with the name of the first pod and replace `_<PVC_mountpoint>_` with the mount point within the first pod.
-+
-.Example output
-[source,terminal]
-----
-total 4
-drwxrwsrwx. 2 root       1000670000 system_u:object_r:container_file_t:s0:c10,c26 19 Aug 29 18:17 .
-dr-xr-xr-x. 1 root       root       system_u:object_r:container_file_t:s0:c10,c26 61 Aug 29 18:16 ..
--rw-rw-rw-. 1 1000670000 1000670000 system_u:object_r:container_file_t:s0:c10,c26 29 Aug 29 18:17 test1
-[...]
-----
-. Verify that the same SELinux label is applied to second pod by running the following command:
-+
-[source,terminal]
-[subs="+quotes"]
-----
-$ oc exec _<pod_name_B>_ -- ls -laZ _<PVC_mountpoint>_ <1>
-----
-<1> Replace `_<pod_name_B>_` with the name of the second pod and replace `_<PVC_mountpoint>_` with the mount point within the second pod.
-+
-.Example output
-[source,terminal]
-----
-total 4
-drwxrwsrwx. 2 root       1000670000 system_u:object_r:container_file_t:s0:c10,c26 19 Aug 29 18:17 .
-dr-xr-xr-x. 1 root       root       system_u:object_r:container_file_t:s0:c10,c26 61 Aug 29 18:16 ..
--rw-rw-rw-. 1 1000670000 1000670000 system_u:object_r:container_file_t:s0:c10,c26 29 Aug 29 18:17 test1
-[...]
-----

--- a/modules/microshift-updating-pods-mismatch.adoc
+++ b/modules/microshift-updating-pods-mismatch.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/understanding-persistent-storage-microshift.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-updating-pods-mismatch_{context}"]
+= Updating the pods which have mismatch
+
+Update the SELinux context of the pods if a mismatch is found by using the following procedure.
+
+.Procedure
+
+. When there is a mismatch of the SELinux content, create a new security context constraint (SCC) and assign it to both pods. To create a SCC, see link:https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html#security-context-constraints-creating_configuring-internal-oauth[Creating security context constraints].
+. Update the SELinux context as shown in the following example:
++
+.Example output
+[source,terminal]
+----
+ [...]
+ securityContext:privileged
+      seLinuxOptions:MustRunAs
+        level: "s0:cXX,cYY"
+  [...]
+----

--- a/modules/microshift-verifying-pods-mismatch.adoc
+++ b/modules/microshift-verifying-pods-mismatch.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * microshift_storage/understanding-persistent-storage-microshift.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-verifying-pods-mismatch_{context}"]
+= Verifying pods after resolving a mismatch
+
+Verify the security context constraint (SCC) and the SELinux label of both the pods by using the following verification steps.
+
+.Verification
+
+. Verify that the same SCC is assigned to the first pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc describe pod _<pod_name_a>_ |grep -i scc <1>
+----
+<1> Replace `_<pod_name_a>_` with the name of the first pod.
++
+.Example output
+[source,terminal]
+----
+openshift.io/scc: restricted
+----
+. Verify that the same SCC is assigned to first second pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc describe pod _<pod_name_b>_ |grep -i scc <1>
+----
+<1> Replace `_<pod_name_b>_` with the name of the second pod.
++
+.Example output
+[source,terminal]
+----
+openshift.io/scc: restricted
+----
+. Verify that the same SELinux label is applied to first pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc exec _<pod_name_a>_ -- ls -laZ _<pvc_mountpoint>_ <1>
+----
+<1> Replace `_<pod_name_a>_` with the name of the first pod and replace `_<pvc_mountpoint>_` with the mount point within the first pod.
++
+.Example output
+[source,terminal]
+----
+total 4
+drwxrwsrwx. 2 root       1000670000 system_u:object_r:container_file_t:s0:c10,c26 19 Aug 29 18:17 .
+dr-xr-xr-x. 1 root       root       system_u:object_r:container_file_t:s0:c10,c26 61 Aug 29 18:16 ..
+-rw-rw-rw-. 1 1000670000 1000670000 system_u:object_r:container_file_t:s0:c10,c26 29 Aug 29 18:17 test1
+[...]
+----
+. Verify that the same SELinux label is applied to second pod by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ oc exec _<pod_name_b>_ -- ls -laZ _<pvc_mountpoint>_ <1>
+----
+<1> Replace `_<pod_name_b>_` with the name of the second pod and replace `_<pvc_mountpoint>_` with the mount point within the second pod.
++
+.Example output
+[source,terminal]
+----
+total 4
+drwxrwsrwx. 2 root       1000670000 system_u:object_r:container_file_t:s0:c10,c26 19 Aug 29 18:17 .
+dr-xr-xr-x. 1 root       root       system_u:object_r:container_file_t:s0:c10,c26 61 Aug 29 18:16 ..
+-rw-rw-rw-. 1 1000670000 1000670000 system_u:object_r:container_file_t:s0:c10,c26 29 Aug 29 18:17 test1
+[...]
+----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-12154](https://issues.redhat.com/browse/OSDOCS-12154)

Link to docs preview:
[Checking the pods for mismatch](https://83288--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html#microshift-checking-pods-mismatch_understanding-persistent-storage-microshift)
[Updating the pods which have mismatch](https://83288--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html#microshift-updating-pods-mismatch_understanding-persistent-storage-microshift)
[verification of the pods](https://83288--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html#microshift-verifying-pods-mismatch_understanding-persistent-storage-microshift)

QE review:
- NA as only structural changes are made and modularization is done. 
Technical content is not modified.

Additional information:
Related PR is https://github.com/openshift/openshift-docs/pull/81957