### PR TITLE
CNV#34780: wasp for swap/memory overcommitment RN

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -68,6 +68,14 @@ This release adds new features and enhancements related to the following compone
 [id="virt-4-17-virtualization"]
 === Virtualization
 
+//CNV-34780 GA: Safe memory overcommitment using WASP
+* You can now increase VM workload density on nodes by overcommitting memory (RAM) with the `wasp-agent`. The wasp agent assigns swap resources to worker nodes and manages pod evictions when nodes are at risk.
++
+[NOTE]
+====
+Overcommitting memory on a highly utilized system can decrease workload performance.
+====
+
 //CNV-30590 NEW GA Host-side USB passthrough
 * As a cluster administrator, you can xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring-usb-host-passthrough.adoc#virt-configuring-usb-host-passthrough[expose USB devices in a cluster], making them available for virtual machine (VM) owners to assign to VMs. You expose a USB device by first enabling host passthrough and then configuring the VM to access the USB device.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17 only (RN)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-34780](https://issues.redhat.com//browse/CNV-34780)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-17-virtualization
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: ~Since we don't currently have this documented downstream, I'm wondering if we should link to https://github.com/openshift-virtualization/wasp-agent/blob/main/docs/configuration.md (would need support and PM approval to include a github link). @stu-gott @djfjeff - thoughts?~ (talked to Stu)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
