### PR TITLE
OBSDOCS-1348: Add support exception statement in Logging docs for COO due to its Logging UI Plugin

### DIFF
--- a/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
@@ -6,9 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The {coo-full}
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
+[IMPORTANT]
+====
+Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for the logging UI plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the logging UI plugin is ready for GA.
+====
 
 The logging UI plugin surfaces logging data in the {product-title} web console on the *Observe* -> *Logs* page. 
 You can specify filters, queries, time ranges and refresh rates, with the results displayed as a list of collapsed logs, which can then be expanded to show more detailed information for each log.

--- a/observability/logging/cluster-logging-support.adoc
+++ b/observability/logging/cluster-logging-support.adoc
@@ -19,7 +19,7 @@ include::snippets/logging-compatibility-snip.adoc[]
 * A guaranteed log sink
 * Secure storage - audit logs are not stored by default
 
-[id="cluster-logging-support-CRDs"]
+[id="cluster-logging-support-CRDs_{context}"]
 == Supported API custom resource definitions
 
 LokiStack development is ongoing. Not all APIs are currently supported.
@@ -51,7 +51,12 @@ LokiStack development is ongoing. Not all APIs are currently supported.
 include::modules/cluster-logging-maintenance-support-list.adoc[leveloffset=+1]
 include::modules/unmanaged-operators.adoc[leveloffset=+1]
 
-[id="cluster-logging-support-must-gather"]
+[id="support-exception-for-coo-logging-ui-plugin_{context}"]
+== Support exception for the Logging UI Plugin
+
+Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its Logging UI Plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
+
+[id="cluster-logging-support-must-gather_{context}"]
 == Collecting logging data for Red Hat Support
 
 When opening a support case, it is helpful to provide debugging information about your cluster to Red{nbsp}Hat Support.

--- a/observability/logging/logging-6.0/log6x-release-notes.adoc
+++ b/observability/logging/logging-6.0/log6x-release-notes.adoc
@@ -39,7 +39,11 @@ In order to continue to use Elasticsearch and Kibana managed by the elasticsearc
 
 * This feature introduces a new architecture for {logging} {for} by shifting component responsibilities to their relevant Operators, such as for storage, visualization, and collection. It introduces the `ClusterLogForwarder.observability.openshift.io` API for log collection and forwarding. Support for the `ClusterLogging.logging.openshift.io` and `ClusterLogForwarder.logging.openshift.io` APIs, along with the Red Hat managed Elastic stack (Elasticsearch and Kibana), is removed. Users are encouraged to migrate to the Red Hat `LokiStack` for log storage. Existing managed Elasticsearch deployments can be used for a limited time. Automated migration for log collection is not provided, so administrators need to create a new ClusterLogForwarder.observability.openshift.io specification to replace their previous custom resources. Refer to the official product documentation for more details. (link:https://issues.redhat.com/browse/LOG-3493[LOG-3493])
 
-* With this release, the responsibility for deploying the {logging} view plugin shifts from the {clo} to the {coo-first}. For new log storage installations that need visualization, the {coo-full} and the associated UIPlugin resource must be deployed. Refer to the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator Overview] product documentation for more details. (link:https://issues.redhat.com/browse/LOG-5461[LOG-5461])
+* With this release, the responsibility for deploying the {logging} view plugin shifts from the {clo} to the {coo-first}. For new log storage installations that need visualization, the {coo-full} and the associated `UIPlugin` resource must be deployed. For more information, see xref:log6x-visual.adoc#log6x-visual[Visualization for logging]. (link:https://issues.redhat.com/browse/LOG-5461[LOG-5461])
++
+--
+include::snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc[]
+--
 
 * This enhancement sets default requests and limits for Vector collector deployments' memory and CPU usage based on Vector documentation recommendations. (link:https://issues.redhat.com/browse/LOG-4745[LOG-4745])
 

--- a/observability/logging/logging-6.0/log6x-visual.adoc
+++ b/observability/logging/logging-6.0/log6x-visual.adoc
@@ -6,4 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Visualization for logging is provided by installing the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator].
+Visualization for logging is provided by deploying the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator], which requires Operator installation.
+
+include::snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc[]

--- a/snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc
+++ b/snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc
@@ -1,0 +1,10 @@
+// Text snippet included in the following assembly:
+//
+// * observability/logging/logging-6.0/log6x-visual.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14, 4.15, 4.16, 4.17, 4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1348

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- https://83306--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-release-notes.html#log6x-release-notes-6-0-0-enhancements
![image](https://github.com/user-attachments/assets/57d646b4-5a8b-40ba-b0ec-7cf1350eccd5)

- https://83306--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/cluster-logging-support.html#support-exception-for-coo-logging-ui-plugin
(Note that I was getting CI/CD errors when attempting to link to the COO's Logging UI Plugin page from this page. I was troubleshooting the whole afternoon and evening yesterday, I tried everything I could, but the current disposition of the files appears to make it impossible to link due to absence of the COO pages and Logging 6.0 from the OSD/ROSA docs. So I recommend publishing it without the link on this one page if this content is urgent.)
![image](https://github.com/user-attachments/assets/4f8251f1-cee8-4630-a45f-c4f3729d6ef5)

- https://83306--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-visual.html
![image](https://github.com/user-attachments/assets/dca45626-9e70-41fc-a69e-e1d206d64c48)

- https://83306--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.html
![image](https://github.com/user-attachments/assets/1967adb6-63df-4d13-8d6c-5cf823f2b5b7)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
