### PR TITLE
CNV-40005: RN Application-aware resource quota

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -79,6 +79,10 @@ Overcommitting memory on a highly utilized system can decrease workload performa
 //CNV-30590 NEW GA Host-side USB passthrough
 * As a cluster administrator, you can xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring-usb-host-passthrough.adoc#virt-configuring-usb-host-passthrough[expose USB devices in a cluster], making them available for virtual machine (VM) owners to assign to VMs. You expose a USB device by first enabling host passthrough and then configuring the VM to access the USB device.
 
+//CNV-40005 Application-aware resource quota
+* You can now use the Application-Aware Quota (AAQ) Operator to customize and manage resource quotas for individual components in an {product-title} cluster. The AAQ Operator provides the `ApplicationAwareResourceQuota` and `ApplicationAwareClusterResourceQuota` custom resource definitions (CRDs) that can be used to allocate resources without interfering with cluster-level activities such as upgrades and node maintenance.
+
+
 [id="virt-4-17-networking"]
 === Networking
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-40005](https://issues.redhat.com//browse/CNV-40005)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83307--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-17-virtualization
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The documentation for this feature is still in progress; adding release note first to make it in time for GA next week
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
