### PR TITLE
OCPBUGS#37423: Added .cloudflarestorage.com to allow list

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -265,47 +265,48 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must includ
 |===
 |URL | Port | Function
 
-|`mirror.openshift.com`
-|443
-|Required to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
-
-|`storage.googleapis.com/openshift-release`
-|443
-|A source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
-
 |`*.apps.<cluster_name>.<base_domain>`
 |443
 |Required to access the default cluster routes unless you set an ingress wildcard during installation.
 
-|`quayio-production-s3.s3.amazonaws.com`
+|`*.cloudflarestorage.com`
 |443
-|Required to access Quay image content in AWS.
+|Required to access mirrored installation content and images that were redirected from `mirror.openshift.com`.
 
 |`api.openshift.com`
 |443
 |Required both for your cluster token and to check if updates are available for the cluster.
 
-|`rhcos.mirror.openshift.com`
-|443
-|Required to download {op-system-first} images.
-
 |`console.redhat.com`
 |443
 |Required for your cluster token.
+
+|`mirror.openshift.com`
+|443
+|Required to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
+
+|`quayio-production-s3.s3.amazonaws.com`
+|443
+|Required to access Quay image content in AWS.
 
 // |`registry.access.redhat.com`
 // |443
 // |Required for `odo` CLI.
 
+|`rhcos.mirror.openshift.com`
+|443
+|Required to download {op-system-first} images.
+
 |`sso.redhat.com`
 |443
 |The `https://console.redhat.com` site uses authentication from `sso.redhat.com`
 
+|`storage.googleapis.com/openshift-release`
+|443
+|A source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
 |===
-Operators require route access to perform health checks. Specifically, the
-authentication and web console Operators connect to two routes to verify that
-the routes work. If you are the cluster administrator and do not want to allow
-`*.apps.<cluster_name>.<base_domain>`, then allow these routes:
++
+Operators require route access to perform health checks. Specifically, the authentication and web console Operators connect to two routes to verify that the routes work. If you are the cluster administrator and do not want to allow `*.apps.<cluster_name>.<base_domain>`, then allow these routes:
 +
 * `oauth-openshift.apps.<cluster_name>.<base_domain>`
 * `console-openshift-console.apps.<cluster_name>.<base_domain>`, or the hostname


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-37423](https://issues.redhat.com/browse/OCPBUGS-37423)

Link to docs preview:
* [Configuring your firewall](https://83321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html)
* [Configuring your firewall for OpenShift Container Platform](https://83321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer.html#configuring-firewall_installing-oci-agent-based-installer)

- [x] SME has approved this change (asked Installer team).
- [x] QE has approved this change (Gaoyun Pei).


Additional information:
* https://access.redhat.com/solutions/7081361
