### PR TITLE
OADP-3472 Added warning for windows vm backup fail

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
@@ -43,6 +43,7 @@ include::modules/install-and-configure-oadp-kubevirt.adoc[leveloffset=+1]
 * xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
+include::snippets/oadp-windows-vm-backup-fails.adoc[]
 include::modules/oadp-configuring-client-burst-qps.adoc[leveloffset=+1]
 include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]
 include::modules/oadp-incremental-backup-support.adoc[leveloffset=+1]

--- a/snippets/oadp-windows-vm-backup-fails.adoc
+++ b/snippets/oadp-windows-vm-backup-fails.adoc
@@ -1,0 +1,10 @@
+
+//This snippet appears in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+
+:_mod-docs-content-type: SNIPPET
+[WARNING]
+====
+If you run a backup of a Microsoft Windows virtual machine (VM) immediately after the VM reboots, the backup might fail with a `PartiallyFailed` error. This is because, immediately after a VM boots, the Microsoft Windows Volume Shadow Copy Service (VSS) and Guest Agent (GA) service are not ready. The VSS and GA service being unready causes the backup to fail. In such a case, retry the backup a few minutes after the VM boots.
+====


### PR DESCRIPTION
## Jira 

* [OADP-3472](https://issues.redhat.com/browse/OADP-3472)

Added warning in OADP virt doc section regarding windows vm backup fail

##  Version

* OCP 4.13 → OCP 4.18

## Preview

Look for the **warning** at the end of the virt dpa.

* [Virt DPA](https://83327--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.html#oadp-installing-dpa-1-3_installing-oadp-kubevirt)

## QE Review

* [x] QE has approved this change.

