### PR TITLE
SRVCOM-3223 Adds 1.34 to _page_openshift.html.erb

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -235,6 +235,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.34">1.34</option>
               <option value="1.33">1.33</option>
               <option value="1.32">1.32</option>
               <option value="1.31">1.31</option>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: [SRVCOM-3223](https://issues.redhat.com//browse/SRVCOM-3223) adjusts page openshift

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[SRVCOM-3223](https://issues.redhat.com/browse/SRVCOM-3223)

Link to docs preview:
N/A

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
