### PR TITLE
bugfix: descriptive titles accuracy

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -392,13 +392,13 @@ Topics:
     File: uninstalling-cluster-nutanix
   - Name: Installation configuration parameters for Nutanix
     File: installation-config-parameters-nutanix
-- Name: Installing on-premise with Assisted Installer
+- Name: Installing on-premise with the Assisted Installer
   Dir: installing_on_prem_assisted
   Distros: openshift-enterprise
   Topics:
-  - Name: Installing an on-premise cluster using the Assisted Installer
+  - Name: Installing on-premise with the Assisted Installer
     File: installing-on-prem-assisted
-- Name: Installing an on-premise cluster with the Agent-based Installer
+- Name: Installing on-premise with the Agent-based Installer
   Dir: installing_with_agent_based_installer
   Distros: openshift-enterprise
   Topics:
@@ -438,7 +438,7 @@ Topics:
     File: scaling-a-user-provisioned-cluster-with-the-bare-metal-operator
   - Name: Installation configuration parameters for bare metal
     File: installation-config-parameters-bare-metal
-- Name: Deploying installer-provisioned clusters on bare metal
+- Name: Installing on bare metal
   Dir: installing_bare_metal_ipi
   Distros: openshift-origin,openshift-enterprise
   Topics:

--- a/installing/overview/cluster-capabilities.adoc
+++ b/installing/overview/cluster-capabilities.adoc
@@ -32,7 +32,7 @@ include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Deploying installer-provisioned clusters on bare metal]
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Installing on bare metal as installer-provisioned infrastructure cluster]
 * xref:../../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#preparing-to-install-on-bare-metal[Preparing for bare metal cluster installation]
 * xref:../../installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc#bmo-config-using-bare-metal-operator_ipi-install-post-installation-configuration[Configuration using the Bare Metal Operator]
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2071,7 +2071,7 @@ Use the `bootMACAddress` configuration setting to enable Ironic to identify the 
 |The URL for communicating with the host's BMC controller.
 The address configuration setting specifies the protocol.
 For example, `redfish+http://10.10.10.1:8000/redfish/v1/Systems/1234` enables Redfish.
-For more information, see "BMC addressing" in the "Deploying installer-provisioned clusters on bare metal" section.
+For more information, see "BMC addressing" in the "Installing on bare metal as installer-provisioned infrastructure cluster" section.
 |URL.
 
 |platform:

--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -104,7 +104,7 @@ To define a DNS configuration for a network interface, you must initially specif
 ====
 You cannot use `br-ex` bridge, an OVNKubernetes-managed Open vSwitch bridge, as the interface when configuring DNS resolvers unless you manually configured a customized `br-ex` bridge.
 
-For more information, see "Creating a manifest object that includes a customized br-ex bridge" in the _Deploying installer-provisioned clusters on bare metal_ document or the _Installing a user-provisioned cluster on bare metal_ document.
+For more information, see "Creating a manifest object that includes a customized br-ex bridge" in the _Installing on bare metal as installer-provisioned infrastructure cluster_ document or the _Installing a user-provisioned cluster on bare metal_ document.
 ====
 
 The following example shows a default situation that stores DNS values globally:


### PR DESCRIPTION
Address GH Issue #81621 for documentation titles with unclear descriptions. The commit is nonintrusive and does not alter the structure of any topic object; split commit from rejected PR #83244.

Version(s):
4.17+, do not cherry pick as this file is likely to have changed between each version

Issue:
- None (GH or Jira), this is community author contribution

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- n/a

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->


#### The following renames occured for fixing bad descriptions

```
Installing on bare metal
>>>
Installing on bare metal with the UPI Installer
```

```
Deploying installer-provisioned clusters on bare metal
>>>
Installing on bare metal with the IPI Installer
```

#### The following renames occured for consistency

```
Installing on-premise with Assisted Installer
>>>
Installing on-premise with the Assisted Installer
```

```
Installing an on-premise cluster with the Agent-based Installer
>>>
Installing on-premise with the Agent-based Installer
```
