### PR TITLE
bugfix: vendor titles accuracy

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -456,13 +456,13 @@ Topics:
     File: ipi-install-post-installation-configuration
   - Name: Expanding the cluster
     File: ipi-install-expanding-the-cluster
-- Name: Installing IBM Cloud Bare Metal (Classic)
+- Name: Installing on IBM Cloud (Classic)
   Dir: installing_ibm_cloud_classic
   Distros: openshift-origin,openshift-enterprise
   Topics:
-  - Name: Prerequisites
+  - Name: Prerequisites for IBM Cloud (Classic)
     File: install-ibm-cloud-prerequisites
-  - Name: Installation workflow
+  - Name: Installation workflow for IBM Cloud Bare Metal (Classic)
     File: install-ibm-cloud-installation-workflow
 - Name: Installing on IBM Z and IBM LinuxONE
   Dir: installing_ibm_z
@@ -560,7 +560,7 @@ Topics:
     File: installing-oci-assisted-installer
   - Name: Installing a cluster on Oracle Cloud Infrastructure by using the Agent-based Installer
     File: installing-oci-agent-based-installer
-- Name: Installing on vSphere
+- Name: Installing on VMware vSphere
   Dir: installing_vsphere
   Distros: openshift-origin,openshift-enterprise
   Topics:


### PR DESCRIPTION
Address GH Issue #81621 for infrastructure platform vendor-specific names in documentation titles were inconsistent with vendor. The commit is nonintrusive and does not alter the structure of any topic object; split commit from rejected PR #83244.

Version(s):
4.17+, do not cherry pick as this file is likely to have changed between each version

Issue:
- None (GH or Jira), this is community author contribution

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- n/a

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->


#### The following renames occured for consistency

```
Installing IBM Cloud Bare Metal (Classic)
>>>
Installing on IBM Cloud (Classic)
```

```
Installing on vSphere
>>>
Installing on VMware vSphere
```