### PR TITLE
OCPBUGS#43042: Added line back to installation-user-infra-generate-k8…

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -193,9 +193,9 @@ ifndef::user-infra-vpc[]
 the Kubernetes manifest files that define the worker machines:
 endif::user-infra-vpc[]
 endif::gcp[]
-ifdef::azure,ash,user-infra-vpc[]
+ifdef::aws,azure,ash,user-infra-vpc[]
 . Remove the Kubernetes manifest files that define the worker machines:
-endif::azure,ash,user-infra-vpc[]
+endif::aws,azure,ash,user-infra-vpc[]
 ifdef::aws,azure,ash,gcp[]
 +
 [source,terminal]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-43042](https://issues.redhat.com/browse/OCPBUGS-43042)

Link to docs preview:
[Creating the Kubernetes manifest and Ignition config files](https://83352--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws#installation-user-infra-generate-k8s-manifest-ignition_installing-restricted-networks-aws)

Additional resources:
* https://redhat-internal.slack.com/archives/C68TNFWA2/p1726704724151759
