### PR TITLE
OSDOCS-12015: updated RHDE pages for 4.18 MicroShift

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -14,6 +14,6 @@
 :op-system-version-major: 9
 :microshift-first: Red Hat build of MicroShift
 :microshift: MicroShift
-:microshift-version: 4.17
+:microshift-version: 4.18
 :ansible: Red Hat Ansible Automation Platform
 :ansible-version: 2.4

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -36,32 +36,31 @@ The latest release notes for each product that is part of {product-title} are av
 
 {op-system-first} and {microshift} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift} from 4.14 to 4.16 requires a {op-system} update. Supported configurations of {product-title} use verified releases for each together as listed in the following table:
 
-[cols="4",%autowidth]
+[%header,cols="3",cols="1,1,2"]
 |===
-^|*{op-system-ostree} Version(s)*
-^|*{microshift} Version*
-^|*{microshift} Release Status*
-^|*Supported {microshift} Version&#8594;{microshift} Version Updates*
+^|*{op-system-base} Version(s)*
+^|*{microshift-short} Version*
+^|*Supported {microshift-short} Version{nbsp}&#8594;{nbsp}Version Updates*
+
+^|9.4
+^|4.18
+^|4.18.0{nbsp}&#8594;{nbsp}4.18.z
 
 ^|9.4
 ^|4.17
-^|Generally Available
-^|4.17.1&#8594;4.17.z
+^|4.17.1{nbsp}&#8594;{nbsp}4.17.z, 4.17{nbsp}&#8594;{nbsp}4.18
 
 ^|9.4
 ^|4.16
-^|Generally Available
-^|4.16.0&#8594;4.16.z, 4.16&#8594;4.17
+^|4.16.0{nbsp}&#8594;{nbsp}4.16.z, 4.16{nbsp}&#8594;{nbsp}4.17, 4.16{nbsp}&#8594;{nbsp}4.18
 
 ^|9.2, 9.3
 ^|4.15
-^|Generally Available
-^|4.15.0&#8594;4.15.z, 4.15&#8594;4.16
+^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16 on {op-system} 9.4
 
 ^|9.2, 9.3
 ^|4.14
-^|Generally Available
-^|4.14.0&#8594;4.14.z, 4.14&#8594;4.15, 4.14&#8594;4.16
+^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15, 4.14{nbsp}&#8594;{nbsp}4.16 on {op-system} 9.4
 |===
 
 [id="device-edge-compatibility-ansible_{context}"]


### PR DESCRIPTION
Version(s):
MicroShift 4.18, RHDE 4

Issue:
[OSDOCS-12015](https://issues.redhat.com/browse/OSDOCS-12015)

Link to docs preview:
[RHDE overview](https://83356--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
OK to merge, but NOT to sync and publish until 4.18 is released.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
