### PR TITLE
OSDOCS-12310: updates RHDE attributes file for MicroShift 4.17

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -10,11 +10,10 @@
 :op-system: RHEL
 :op-system-ostree-first: Red Hat Enterprise Linux (RHEL) for Edge
 :op-system-ostree: RHEL for Edge
-:op-system-version: 9.2
+:op-system-version: 9.4
 :op-system-version-major: 9
 :microshift-first: Red Hat build of MicroShift
 :microshift: MicroShift
-//removing short form of MicroShift pending approval of use
-:microshift-version: 4.16
+:microshift-version: 4.17
 :ansible: Red Hat Ansible Automation Platform
 :ansible-version: 2.4


### PR DESCRIPTION
Version(s):
rhde-docs-main, no picks

Issue:
[OSDOCS-12310](https://issues.redhat.com/browse/OSDOCS-12310)

Link to docs preview:
N/A internal docs work
[General page; note that 4.17 MicroShift docs are not published yet](https://83357--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

QE review:
- N/A internal docs work

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
