### PR TITLE
OSDOCS-11688: adds drop-in config MicroShift

### DIFF
--- a/microshift_configuring/microshift-using-config-yaml.adoc
+++ b/microshift_configuring/microshift-using-config-yaml.adoc
@@ -18,6 +18,8 @@ include::modules/microshift-config-yaml-custom.adoc[leveloffset=+1]
 
 include::modules/microshift-config-parameters-table.adoc[leveloffset=+2]
 
+include::modules/microshift-config-snippets.adoc[leveloffset=+2]
+
 include::modules/microshift-nw-advertise-address.adoc[leveloffset=+2]
 
 include::modules/microshift-config-nodeport-limits.adoc[leveloffset=+2]

--- a/modules/microshift-config-snippets.adoc
+++ b/modules/microshift-config-snippets.adoc
@@ -1,0 +1,162 @@
+// Module included in the following assemblies:
+//
+// * microshift_configuring/microshift-using-config-yaml.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-config-snippets_{context}"]
+= Using configuration snippets
+
+If you want to configure one or two settings, such as adding subject alternative names (SANs), you can use the  `/etc/microshift/config.d/` configuration directory to drop in configuration snippet YAML files. You must restart {microshift-short} for new configurations to apply.
+
+To return to previous values, you can delete a configuration snippet and restart {microshift-short}.
+
+[id="microshift-how-config-snippets-work_{context}"]
+== How configuration snippets work
+
+At runtime, the YAML files inside `/etc/microshift/config.d` are merged into the existing {microshift-short} configuration, whether that configuration is a result of default values or a user-created `config.yaml` file. You do not need to create a `config.yaml` file to use a configuration snippet.
+
+Files in the snippet directory are sorted in lexicographical order and run sequentially. You can use numerical prefixes for snippets so that each is read in the order you want. The last-read file takes precedence when there is more than one YAML for the same parameter.
+
+[IMPORTANT]
+====
+Configuration snippets take precedence over both default values and a customized `config.yaml` configuration file.
+====
+
+[id="microshift-example-list-config-snippets_{context}"]
+== Example list configuration snippets
+
+Lists, or arrays, are not merged, they are overwritten. For example, you can replace a SAN or list of SANs by creating an additional snippet for the same field that is read after the first:
+
+.{microshift-short} configuration directory contents
+* `/etc/microshift/config.yaml.default` or `/etc/microshift/config.yaml`
+
+.Example {microshift-short} configuration snippet directory contents
+* `/etc/microshift/config.d/10-san.yaml`
+* `/etc/microshift/config.d/20-san.yaml`
++
+.Example `10-san.yaml` snippet
+[source,yaml]
+----
+apiServer:
+  subjectAltNames:
+    - host1
+    - host2
+----
++
+.Example `20-san.yaml` snippet
+[source,yaml]
+----
+apiServer:
+  subjectAltNames:
+    - hostZ
+----
++
+.Example configuration result
+[source,yaml]
+----
+apiServer:
+  subjectAltNames:
+    - hostZ
+----
+
+If you want to add a value to an existing list, you can add it to an existing snippet. For example, to add `hostZ` to an existing list of SANs, edit the snippet you have instead of creating a new one:
+
+.Example `10-san.yaml` snippet
+[source,yaml]
+----
+apiServer:
+  subjectAltNames:
+    - host1
+    - host2
+    - hostZ
+----
+
+.Example configuration result
+[source,yaml]
+----
+apiServer:
+  subjectAltNames:
+    - host1
+    - host2
+    - hostZ
+----
+
+[id="microshift-example-object-config-snippets_{context}"]
+== Example object configuration snippets
+
+Objects are merged together.
+
+.Example `10-advertiseAddress.yaml` snippet
+[source,yaml]
+----
+apiServer:
+  advertiseAddress: "microshift-example"
+----
+
+.Example `20-audit-log.yaml` snippet
+[source,yaml]
+----
+apiServer:
+  auditLog:
+    maxFileAge: 12
+----
+
+.Example configuration result
+[source,yaml]
+----
+apiServer:
+  advertiseAddress: "microshift-example"
+  auditLog:
+    maxFileAge: 12
+----
+
+[id="microshift-example-mixed-config-snippets_{context}"]
+== Example mixed configuration snippets
+
+In this example, the values of both `advertiseAddress` and `auditLog.maxFileAge` fields are merged into the configuration, but only the `c.com` and `d.com` `subjectAltNames` values are retained because the numbering in the filename indicates that they are higher priority.
+
+.Example `10-advertiseAddress.yaml` snippet
+[source,yaml]
+----
+apiServer:
+  advertiseAddress: "microshift-example"
+----
+
+.Example `20-audit-log.yaml` snippet
+[source,yaml]
+----
+apiServer:
+  auditLog:
+    maxFileAge: 12
+----
+
+.Example `30-SAN.yaml` snippet
+[source,yaml]
+----
+apiServer:
+  subjectAltNames:
+    - a.com
+    - b.com
+----
+
+.Example `40-SAN.yaml` snippet
+[source,yaml]
+----
+apiServer:
+  subjectAltNames:
+    - c.com
+    - d.com
+----
+
+.Example configuration result
+[source,yaml]
+----
+apiServer:
+  advertiseAddress: "microshift-example"
+  auditLog:
+    maxFileAge: 12
+  subjectAltNames:
+    - c.com
+    - d.com
+----
+


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-12309](https://issues.redhat.com/browse/OSDOCS-12309)

Link to docs preview:
[Using configuration snippets](https://83366--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-config-snippets_microshift-configuring)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
