### PR TITLE
[OCPBUGS-42978]: Updating etcd node scaling terminology

### DIFF
--- a/modules/etcd-node-scaling.adoc
+++ b/modules/etcd-node-scaling.adoc
@@ -6,11 +6,11 @@
 [id="etcd-node-scaling_{context}"]
 = Node scaling for etcd
 
-In general, clusters must have 3 control plane nodes. However, if your cluster is installed on a bare metal platform, you can scale a cluster up to 5 nodes as a post-installation task. For example, to scale from 3 to 4 nodes after installation, you can add a host and install it as a control plane node. Then, the etcd Operator scales accordingly to account for the additional node.
+In general, clusters must have 3 control plane nodes. However, if your cluster is installed on a bare metal platform, you can scale a cluster up to 5 control plane nodes as a postinstallation task. For example, to scale from 3 to 4 control plane nodes after installation, you can add a host and install it as a control plane node. Then, the etcd Operator scales accordingly to account for the additional control plane node.
 
-Scaling to 4-node or 5-node clusters is available only on bare metal platforms.
+Scaling a cluster to 4 or 5 control plane nodes is available only on bare metal platforms.
 
-For more information about how to scale from 3 to 4 nodes by using the Assisted Installer, see "Adding hosts with the API" and "Installing a primary control plane node on a healthy cluster".
+For more information about how to scale control plane nodes by using the Assisted Installer, see "Adding hosts with the API" and "Installing a primary control plane node on a healthy cluster".
 
 The following table shows failure tolerance for clusters of different sizes:
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-42978
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83368--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html#etcd-node-scaling_recommended-etcd-practices
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
