### PR TITLE
OLS-1145: Document attaching a YAML file from the Networking page

### DIFF
--- a/modules/ols-attaching-a-resource-object-to-your-query.adoc
+++ b/modules/ols-attaching-a-resource-object-to-your-query.adoc
@@ -24,6 +24,8 @@ You can attach the following resources:
 * `CronJob`, `DaemonSet`, `Deployment`, `Job`, `Pod`, `ReplicaSet` and `StatefulSet` from *Workloads* in the {ocp-product-title} web console.
 
 * `Alert` from *Observe* in the {ocp-product-title} web console.
+
+* `Services`, `Routes`, `Ingresses`, and `NetworkPolicies` from *Networking* in the {ocp-product-title} web console.
 ====
 
 . Enter a question.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OLS-1145
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://83371--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/operate/ols-using-openshift-lightspeed.html#ols-attaching-a-resource-object-to-your-query_ols-using-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
