### PR TITLE
OSDOCS-11695 adding Nutanix FVN to docs

### DIFF
--- a/modules/installation-nutanix-installer-infra-reqs.adoc
+++ b/modules/installation-nutanix-installer-infra-reqs.adoc
@@ -115,6 +115,8 @@ You must use either AHV IP Address Management (IPAM) or Dynamic Host Configurati
 * IP addresses
 * DNS records
 
+Nutanix Flow Virtual Networking is supported for new cluster installations. To use this feature, enable Flow Virtual Networking on your AHV cluster before installing. For more information, see link:https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Flow-Virtual-Networking-Guide-vpc_2024_1:ear-flow-nw-overview-pc.html[Flow Virtual Networking overview].
+
 [NOTE]
 ====
 It is recommended that each {product-title} node in the cluster have access to a Network Time Protocol (NTP) server that is discoverable via DHCP. Installation is possible without an NTP server. However, an NTP server prevents errors typically associated with asynchronous server clocks.


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-11695

Link to docs preview:
https://83373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/preparing-to-install-on-nutanix.html#installation-nutanix-installer-infra-requirements-networking_preparing-to-install-on-nutanix

Change management approvals:
- [X] QE 
- [X] PM
- [x] DPM
- [x] CS
- [x] Eng