### PR TITLE
[RHACS] [Docs] [4.5 and later versions] ROX-26541: Adding the dnsport option information

### DIFF
--- a/modules/roxctl-netpol-generate.adoc
+++ b/modules/roxctl-netpol-generate.adoc
@@ -21,6 +21,9 @@ $ roxctl netpol generate <folder_path> [flags] <1>
 |===
 |Option |Description
 
+|`--dnsport uint16` 
+|Specify the DNS port that you want to use in the egress rules of synthesized network policies. The default value is `53`.
+
 |`--fail`
 |Fail on the first encountered error. The default value is `false`.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.5+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-26541
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://83378--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/command-reference/roxctl-netpol.html#roxctl-netpol-generate_roxctl-netpol:~:text=%2D%2Ddnsport%20uint16,is%2053.

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Merge into `rhacs-docs-main` and cherry-pick to:
    - `rhacs-docs-4.5`
    - `rhacs-docs-4.6` 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
