### PR TITLE
OSDOCS-12298: Documented the 4.17.1 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2799,13 +2799,6 @@ As a temporary workaround, the image registry should not be configured as privat
 
 [id="ocp-telco-core-4-17-known-issues_{context}"]
 
-* When the `globallyDisableIrqLoadBalancing` field is set to `true` in the `PerformanceProfile` object, the isolated CPUs are listed in the `IRQBALANCE_BANNED_CPULIST` variable instead of the `IRQBALANCE_BANNED_CPUS` variable. However, changing the value of the `globallyDisableIrqLoadBalancing` field from `true` to `false` does not update the `IRQBALANCE_BANNED_CPULIST` variable correctly. As a result, the number of CPUs available for load rebalancing does not increase, as the isolated CPUs remain in the `IRQBALANCE_BANNED_CPULIST` variable. (link:https://issues.redhat.com/browse/OCPBUGS-42323[*OCPBUGS-42323*])
-+
-[NOTE]
-====
-The `IRQBALANCE_BANNED_CPULIST` variable and the `IRQBALANCE_BANNED_CPUS` variable are stored in the `/etc/sysconfig/irqbalance` file.
-====
-
 * Each node group must only match one `MachineConfigPool` object. In some cases, the NUMA Resources Operator can allow a configuration where a node group matches more than one `MachineConfigPool` object. This issue could lead to unexpected behavior in resource management. (link:https://issues.redhat.com/browse/OCPBUGS-42523[*OCPBUGS-42523*])
 
 * When the bond mode in the `NetworkNodeConfigurationPolicy` is changed from `balance-rr` to `active-backup` on kernel bonds that are attached to the `br-ex` interface, the change might fail on arbitrary nodes. As a workaround, create a `NetworkNodeConfigurationPolicy` object without specifying the bond port configuration. (link:https://issues.redhat.com/browse/OCPBUGS-42031[*OCPBUGS-42031*])
@@ -2837,6 +2830,104 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.1
+[id="ocp-4-17-1-ga_{context}"]
+=== RHSA-2024:7922 - {product-title} {product-version}.0 image release, bug fix, and security update advisory
+
+Issued: 16 October 2024
+
+{product-title} release {product-version}.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:7922[RHSA-2024:7922] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7925[RHSA-2024:7925] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.1 --pullspecs
+----
+
+[id="ocp-4-17-1-enhancements_{context}"]
+==== Enhancements
+
+* The Operator SDK now correctly scaffolds the Dockerfile for `ansible-operator`. Additionally, the Operator SDK can now use `-rhel9` container images. (link:https://issues.redhat.com/browse/OCPBUGS-42853[*OCPBUGS-42853*])
+
+* The Operator SDK now correctly scaffolds the Dockerfile for `helm-operator`. Additionally, the Operator SDK can now use `-rhel9` container images. (link:https://issues.redhat.com/browse/OCPBUGS-42786[*OCPBUGS-42786*])
+
+* When you install the {ols-official}, which is a Developer Preview feature only, the checkbox for enabling in-cluster monitoring is now enabled by default. (link:https://issues.redhat.com/browse/OCPBUGS-42380[*OCPBUGS-42380*])
+
+* The installation program now uses a newer version of the `cluster-api-provider-ibmcloud` provider that includes Transit Gateway fixes. (link:https://issues.redhat.com/browse/OCPBUGS-42483[*OCPBUGS-42483*])
+
+* The migrating CNS volumes feature, which is a Developer Preview feature only, includes the following enhancements:
++
+** The feature now checks for the vCenter version before moving CNS volumes to {vmw-first}. (link:https://issues.redhat.com/browse/OCPBUGS-42006[*OCPBUGS-42006*])
+** The feature keeps migrating CNS volumes even if some volumes do not exist, so that the migration operation does not exit when no volume exists. (link:https://issues.redhat.com/browse/OCPBUGS-42008[*OCPBUGS-42008*])
+
+* The vSphere CSI Driver Operator can now delete all resources for a vSphere CSI driver that was removed from a cluster. (link:https://issues.redhat.com/browse/OCPBUGS-42007[*OCPBUGS-42007*])
+
+[id="ocp-4-17-1-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the Single-Root I/O Virtualization (SR-IOV) Operator did not expire the acquired lease during the Operator's shutdown operation. This impacted a new instance of the Operator, because the new instance had to wait for the lease to expire before the new instance was operational. With this release, an update to the Operator shutdown logic ensures that the Operator expires the lease when the Operator is shutting down. (link:https://issues.redhat.com/browse/OCPBUGS-37668[*OCPBUGS-37668*])
+
+* Previously, when you configured the image registry to use an {azure-first} storage account that was located in a resource group other than the cluster's resource group, the Image Registry Operator would become degraded. This occurred because of a validation error. With this release, an update to the Operator allows for authentication only by using a storage account key. Validation of other authentication requirements is not required. (link:https://issues.redhat.com/browse/OCPBUGS-42812[*OCPBUGS-42812*])
+
+* Previously, if availability zones were not in a specific order in the `install-config.yaml` configuration file, the installation program would wrongly sort the zones before saving the control plane machine set manifests. When the program created the machines, additional control plane virtual machines were created to reconcile the machines into each zone. This caused a resource-constraint issue. With this release, the installation program no longer sorts availability zones so that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-42699[*OCPBUGS-42699*])
+
+* Previously, the Red{nbsp}Hat {product-title} web console did not require the `Creator` field as a mandatory field. API changes specified an empty value for this field, but a user profile could still create silent alerts. With this release, the API marks the `Creator` field as a mandatory field for a user profile. (link:https://issues.redhat.com/browse/OCPBUGS-42606[*OCPBUGS-42606*])
+
+* Previously, during root certification rotation, the Ingress Operator and DNS Operator failed to start. With this release, an update to the kubeconfigs for the Ingress Operator and DNS Operator ensure that annotations set the conditions for managing the public key infrastructure (PKI). This update ensures that both Operators can start as expected during root certification rotation. (link:https://issues.redhat.com/browse/OCPBUGS-42261[*OCPBUGS-42261*])
+
+* Previously, during root certification rotation, the `metrics-server` pod in the data plane failed to start correctly. This happened because of a certificate issue. With this release, the `hostedClusterConfigOperator` resource sends the correct certificate to the data plane so that the `metrics-server` pod starts as expected. (link:https://issues.redhat.com/browse/OCPBUGS-42098[*OCPBUGS-42098*])
+
+* Previously, the installation program attempted to create a private zone for a cluster that needed to be installed on a {gcp-full} shared virtual private network (VPC). This caused the installation of the cluster to fail. With this release, a fix skips the creation of the private zone so that this cluster installation issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-42142[*OCPBUGS-42142*])
+
+* Previously, when the installation program installed a cluster on a {gcp-full} VPC, role bindings for the control plane service account were not removed by the program. With this release, a fix removes the role bindings so that your cluster no longer includes these artifacts. (link:https://issues.redhat.com/browse/OCPBUGS-42116[*OCPBUGS-42116*])
+
+* Previously, if you enabled on-cluster layering for your cluster and you attempted to configure kernel arguments in the machine configuration, machine config pools (MCPs) and nodes entered a degraded state. This happened because of a configuration mismatch. With this release, a check for kernel arguments for a cluster with OCL-enabled ensures that the arguments are configured and applied to nodes in the cluster. This update prevents any mismatch that previously occurred between the machine configuration and the node configuration. (link:https://issues.redhat.com/browse/OCPBUGS-42081[*OCPBUGS-42081*])
+
+* Previously, creating cron jobs to create pods for your cluster caused the component that fetches the pods to fail. Because of this issue, the *Topology* page on the {product-title} web console failed. With this release, a `3` second delay is configured for the component that fetches pods that are generated from the cron job so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-41685[*OCPBUGS-41685*])
+
+* Previously, when you deployed an {product-title} cluster that listed a `TechPreviewNoUpgrade` feature gate in its configured on {rh-openstack}, the `cluster-capi-operator` pod crashed. This occurred because the Cluster CAPI Operator expected a different API version than the one that was served. With this release, an update to the Cluster CAPI Operator ensures that the Operator uses the correct version of the API so that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-41576[*OCPBUGS-41576*])
+
+* Previously, using DNF to install additional packages on your customized {op-system-first} builds caused builds to fail because packages could not be located. With this release, the Subscription Manager adds the correct packages to {op-system} so that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-41376[*OCPBUGS-41376*])
+
+* Previosuly, bonds that were configured in `active-backup` mode would have EFI System Partition (ESP) offload active even if underlying links did not support ESP offload. This caused IPsec associations to fail. With this release, ESP offload is disabled for bonds so that IPsec associations pass. (link:https://issues.redhat.com/browse/OCPBUGS-41255[*OCPBUGS-41255*])
+
+* Previosuly, resources for a new user account were not removed when the account was deleted. This caused unnecessary information in config maps, roles, and role-bindings. With this release, an `ownerRef` tag is added to these resources, so that when you delete a user account the resources are also deleted from all cluster resources. (link:https://issues.redhat.com/browse/OCPBUGS-39601[*OCPBUGS-39601*])
+
+* Previosuly, a coding issue caused the Ansible script on {op-system} user-provisioned installation infrastructure to fail. This occurred when IPv6 was enabled for a three-node cluster. With this release, support exists for installing a three-node cluster with IPv6 enabled on {op-system}. (link:https://issues.redhat.com/browse/OCPBUGS-39409[*OCPBUGS-39409*])
+
+* Previously, the order of an Ansible Playbook was modified to run before the `metadata.json` file was created, which caused issues with older versions of Ansible. With this release, the playbook is more tolerant of missing files and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-39286[*OCPBUGS-39286*])
+
+* Previously, when the Node Tuning Operator (NTO) was configured to use `PerformanceProfiles`, NTO would create an `ocp-tuned-one-shot systemd` service. The `systemd` service would run before kubelet and blocked execution. The `systemd` service invokes Podman which uses an NTO image, but when the NTO image was not present Podman still tried to fetch the image and it would fail. With this release, support is added for cluster-wide proxy environment variables defined in `/etc/mco/proxy.env`. Now, Podman pulls NTO images in environments which need to use proxies for out-of-cluster connections. (link:https://issues.redhat.com/browse/OCPBUGS-39124[*OCPBUGS-39124*])
+
+* Previously, the resource type filter for the *Events* page on the {product-title} web console wrongly reported the number of resources when you selected more than three resources. With this release, the filter now reports the correct number of resources based on your resource selection. (link:https://issues.redhat.com/browse/OCPBUGS-39091[*OCPBUGS-39091*])
+
+* Previously, Ironic inspection failed if special or invalid characters existed in the serial number of a block device. This occurred because the `lsblk` command failed to escape the characters. With this release, the command now escapes the characters so this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-39013[*OCPBUGS-39013*])
+
+* Previously, when you used the Redfish Virtual Media to add an xFusion bare-metal node to your cluster, the node did not get added because of a node registration issue. The issue occurred because the hardware was not 100% compliant with Redfish. With this release, you can now add xFusion bare-metal nodes to your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-38784[*OCPBUGS-38784*])
+
+* Previously, on the *Developer* perspective on the {product-title} web console, when you navigated to *Observe* > *Metrics*, two *Metrics* tabs existed. With this release, the duplicate tab is removed and now exists in the `openshift-monitoring/monitoring-plugin` application that serves the *Metrics* tabs on the web console. (link:https://issues.redhat.com/browse/OCPBUGS-38462[*OCPBUGS-38462*])
+
+* Previously, the `manila-csi-driver` and node registrar pods had missing healthchecks because of a configuration issue. With this release, the health checks are now added to both of these resources. (link:https://issues.redhat.com/browse/OCPBUGS-38457[*OCPBUGS-38457*]) 
+
+* Previously, updating the `additionalTrustBundle` parameter in a {hcp} cluster configuration did not get applied to compute nodes. With this release, a fix ensures that updates to the `additionalTrustBundle` parameter automatically apply to compute nodes that exist in your {hcp} cluster. (link:https://issues.redhat.com/browse/OCPBUGS-36680[*OCPBUGS-36680*])
+
+* Previously, with oc-mirror plugin v2 (Technology Preview), images that referenced both `tag` and `digest` references were not supported. During the disk-to-mirror process for fully disconnected environments, the images were skipped and this caused build issues for the archive file. With this release, oc-mirror plugin v2 now supports an image that includes both of these references. An image is now pulled from the `digest` reference and keeps the `tag` reference for information purposes,  while an appropriate warning message is displayed in the console output. (link:https://issues.redhat.com/browse/OCPBUGS-42421[*OCPBUGS-42421*])
+
+* Previously, the Cluster API used an unsupported tag template for a virtual network installation when compared with the default non-cluster-API-provisioned installation. This caused the Image Registry Operator to enter a degraded state when configured with `networkAccess: Internal`. With this release, the Image Registry Operator now supports both tag templates so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-42394[*OCPBUGS-42394*])
+
+* Previously, the Cloud Controller Manager (CCM) liveness probe used on {ibm-cloud-title} cluster installations could not use loopback and this caused the probe to continuously restart. With this release, the probe can use loopback so that this issue not longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-41941[*OCPBUGS-41941*])
+
+* Previously, when the `globallyDisableIrqLoadBalancing` field was set to `true` in the `PerformanceProfile` object, the isolated CPUs were listed in the `IRQBALANCE_BANNED_CPULIST` variable instead of the `IRQBALANCE_BANNED_CPUS` variable. These variables are stored in `/etc/sysconfig/irqbalance`. Changing the value of the `globallyDisableIrqLoadBalancing` field from `true` to `false` did not update the `IRQBALANCE_BANNED_CPULIST` variable correctly. As a result, the number of CPUs available for load rebalancing did not increase because the isolated CPUs remained in the `IRQBALANCE_BANNED_CPULIST` variable. With this release, a fix ensures that isolated CPUs are now listed in the `IRQBALANCE_BANNED_CPUS` variable, so that the number of CPUs available for load rebalancing increase as expected. (link:https://issues.redhat.com/browse/OCPBUGS-42323[*OCPBUGS-42323*])
+
+// OCPBUGS-39121 is a known issue? Martin K to confirm.
+
+[id="ocp-4-17-1-updating_{context}"]
+==== Updating
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //Update with relevant advisory information
 [id="ocp-4-17-0-ga_{context}"]
 === RHSA-2024:3718 - {product-title} {product-version}.0 image release, bug fix, and security update advisory
@@ -2853,6 +2944,18 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.17.0 --pullspecs
 ----
+
+[id="ocp-4-17-0-known-issues_{context}"]
+==== Known issues
+
+* When the `globallyDisableIrqLoadBalancing` field is set to `true` in the `PerformanceProfile` object, the isolated CPUs are listed in the `IRQBALANCE_BANNED_CPULIST` variable instead of the `IRQBALANCE_BANNED_CPUS` variable. However, changing the value of the `globallyDisableIrqLoadBalancing` field from `true` to `false` does not update the `IRQBALANCE_BANNED_CPULIST` variable correctly. As a result, the number of CPUs available for load rebalancing does not increase, as the isolated CPUs remain in the `IRQBALANCE_BANNED_CPULIST` variable. 
++
+[NOTE]
+====
+The `IRQBALANCE_BANNED_CPULIST` variable and the `IRQBALANCE_BANNED_CPUS` variable are stored in the `/etc/sysconfig/irqbalance` file.
+====
++
+(link:https://issues.redhat.com/browse/OCPBUGS-42323[*OCPBUGS-42323*])
 
 [id="ocp-4-17-0-updating_{context}"]
 ==== Updating


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12298](https://issues.redhat.com/browse/OSDOCS-12298)

Link to docs preview:
* [4.17.1](https://83379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-1-ga_release-notes)
