### PR TITLE
bugfix: chapter title consistency

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installing-a-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installing-a-cluster.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ipi-install-installing-a-cluster"]
-= Installing a cluster
+= Installing a installer-provisioned cluster on bare metal
 include::_attributes/common-attributes.adoc[]
 :context: ipi-install-installing-a-cluster
 


### PR DESCRIPTION
Chapter titles are inconsistent between bare metal UPI and IPI documentation. Amend IPI title to `Installing a installer-provisioned cluster on bare metal`

- [BM UPI - Chapter 2. Installing a user-provisioned cluster on bare metal](https://docs.redhat.com/en/documentation/openshift_container_platform_installation/4.17/html/installing_on_bare_metal/installing-bare-metal)
- [BM IPI - Chapter 4. Installing a cluster](https://docs.redhat.com/en/documentation/openshift_container_platform_installation/4.17/html/deploying_installer-provisioned_clusters_on_bare_metal/ipi-install-installing-a-cluster)

Version(s):
4.17, do not cherry pick as this file is likely to have changed between each version

Issue:
- None (GH or Jira), this is community author contribution

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- n/a

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
