### PR TITLE
[OCPBUGS#43093] Fix SPO xref

### DIFF
--- a/security/security_profiles_operator/spo-overview.adoc
+++ b/security/security_profiles_operator/spo-overview.adoc
@@ -14,6 +14,6 @@ You can create xref:../../security/security_profiles_operator/spo-seccomp.adoc#s
 
 Use xref:../../security/security_profiles_operator/spo-advanced.adoc#spo-advanced[Advanced Security Profile Operator tasks] to enable the log enricher, configure webhooks and metrics, or restrict profiles to a single namespace.
 
-xref:../../security/security_profiles_operator/spo-troubleshooting.adoc#[Troubleshoot the Security Profiles Operator] as needed, or engage link:https://access.redhat.com/support/[Red Hat support].
+xref:../../security/security_profiles_operator/spo-troubleshooting.adoc#spo-inspecting-seccomp-profiles_spo-troubleshooting[Troubleshoot the Security Profiles Operator] as needed, or engage link:https://access.redhat.com/support/[Red Hat support].
 
 You can xref:../../security/security_profiles_operator/spo-uninstalling.adoc#spo-uninstalling[Uninstall the Security Profiles Operator] by removing the profiles before removing the Operator.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-43093](https://issues.redhat.com/browse/OCPBUGS-43093)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83384--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-overview.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] ~QE has approved this change.~ No QE needed for fixing an adoc error.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: I think that adding the anchor ID should fix this on d.rh.c. No error apparent on d.o.c.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
