### PR TITLE
bugfix: inconsistent install methods content cross-vendor

### DIFF
--- a/installing/installing_ibm_cloud/preparing-to-install-on-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud/preparing-to-install-on-ibm-cloud.adoc
@@ -1,36 +1,17 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="preparing-to-install-on-ibm-cloud"]
-= Preparing to install on {ibm-cloud-title}
+= Installation methods
+include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-cloud
 
 toc::[]
-
-The installation workflows documented in this section are for {ibm-cloud-name} infrastructure environments. {ibm-cloud-name} classic is not supported at this time. For more information about the difference between classic and VPC infrastructures, see the {ibm-name} link:https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[documentation].
-
-[id="prerequisites_preparing-to-install-on-ibm-cloud"]
-== Prerequisites
-
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-
-[id="requirements-for-installing-ocp-on-ibm-cloud"]
-== Requirements for installing {product-title} on {ibm-cloud-title}
-
-Before installing {product-title} on {ibm-cloud-name}, you must create a service account and configure an {ibm-cloud-name} account. See xref:../../installing/installing_ibm_cloud/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an {ibm-cloud-name} account] for details about creating an account, enabling API services, configuring DNS, {ibm-cloud-name} account limits, and supported {ibm-cloud-name} regions.
-
-You must manually manage your cloud credentials when installing a cluster to {ibm-cloud-name}. Do this by configuring the Cloud Credential Operator (CCO) for manual mode before you install the cluster. For more information, see xref:../../installing/installing_ibm_cloud/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for {ibm-cloud-name}].
-
-[id="choosing-a-method-to-install-ocp-on-ibm-cloud"]
-== Choosing a method to install {product-title} on {ibm-cloud-title}
 
 You can install {product-title} on {ibm-cloud-name} using installer-provisioned infrastructure. This process involves using an installation program to provision the underlying infrastructure for your cluster. Installing {product-title} on {ibm-cloud-name} using user-provisioned infrastructure is not supported at this time.
 
 See xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process] for more information about installer-provisioned installation processes.
 
 [id="choosing-an-method-to-install-ocp-on-ibm-cloud-installer-provisioned"]
-=== Installing a cluster on installer-provisioned infrastructure
+== Installing a cluster on installer-provisioned infrastructure
 
 You can install a cluster on {ibm-cloud-name} infrastructure that is provisioned by the {product-title} installation program by using one of the following methods:
 

--- a/installing/installing_ibm_power/preparing-to-install-on-ibm-power.adoc
+++ b/installing/installing_ibm_power/preparing-to-install-on-ibm-power.adoc
@@ -1,19 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="preparing-to-install-on-ibm-power"]
-= Preparing to install on {ibm-power-title}
+= Installation methods
+include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-power
 
 toc::[]
-
-[id="preparing-to-install-on-ibm-power-prerequisites"]
-== Prerequisites
-
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-
-[id="choosing-an-method-to-install-ocp-on-ibm-power"]
-== Choosing a method to install {product-title} on {ibm-power-title}
 
 You can install a cluster on {ibm-power-name} infrastructure that you provision, by using one of the following methods:
 

--- a/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
@@ -1,36 +1,17 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="preparing-to-install-on-ibm-power-vs"]
-= Preparing to install on {ibm-power-server-title}
+= Installation methods
+include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-power-vs
 
 toc::[]
-
-The installation workflows documented in this section are for {ibm-power-server-name} infrastructure environments.
-
-[id="prerequisites_preparing-to-install-on-ibm-power-vs"]
-== Prerequisites
-
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-
-[id="requirements-for-installing-ocp-on-ibm-power-vs"]
-== Requirements for installing {product-title} on {ibm-power-server-title}
-
-Before installing {product-title} on {ibm-power-server-name} you must create a service account and configure an {ibm-cloud-name} account. See xref:../../installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs.adoc#installing-ibm-cloud-account-power-vs[Configuring an {ibm-cloud-name} account] for details about creating an account, configuring DNS and supported {ibm-power-server-name} regions.
-
-You must manually manage your cloud credentials when installing a cluster to {ibm-power-server-name}. Do this by configuring the Cloud Credential Operator (CCO) for manual mode before you install the cluster.
-
-[id="choosing-a-method-to-install-ocp-on-ibm-power-vs"]
-== Choosing a method to install {product-title} on {ibm-power-server-title}
 
 You can install {product-title} on {ibm-power-server-name} using installer-provisioned infrastructure. This process involves using an installation program to provision the underlying infrastructure for your cluster. Installing {product-title} on {ibm-power-server-name} using user-provisioned infrastructure is not supported at this time.
 
 See xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process] for more information about installer-provisioned installation processes.
 
 [id="choosing-an-method-to-install-ocp-on-power-vs-installer-provisioned"]
-=== Installing a cluster on installer-provisioned infrastructure
+== Installing a cluster on installer-provisioned infrastructure
 
 You can install a cluster on {ibm-power-server-name} infrastructure that is provisioned by the {product-title} installation program by using one of the following methods:
 

--- a/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
+++ b/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
@@ -1,27 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="preparing-to-install-on-ibm-z"]
-= Preparing to install on {ibm-z-title} and {ibm-linuxone-title}
+= Installation methods
+include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-z
 
 toc::[]
-
-[id="preparing-to-install-on-ibm-z-prerequisites"]
-== Prerequisites
-
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* Before you begin the installation process, you must clean the installation directory. This ensures that the required installation files are created and updated during the installation process.
-* You provisioned xref:../../storage/persistent_storage/persistent-storage-ocs.adoc#persistent-storage-ocs[persistent storage using {rh-storage}] or other supported storage protocols for your cluster. To deploy a private image registry, you must set up persistent storage with `ReadWriteMany` access.
-* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
-
-[NOTE]
-====
-While this document refers only to {ibm-z-name}, all information in it also applies to {ibm-linuxone-name}.
-====
-
-[id="choosing-an-method-to-install-ocp-on-ibm-z"]
-== Choosing a method to install {product-title} on {ibm-z-title} or {ibm-linuxone-title}
 
 The {product-title} installation program offers the following methods for deploying a cluster on {ibm-z-name}:
 
@@ -76,7 +59,7 @@ The {product-title} installation program offers the following methods for deploy
 
 For more information about the installation process, see the xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process].
 
-=== User-provisioned infrastructure installation of {product-title} on {ibm-z-title}
+== User-provisioned infrastructure installation of {product-title} on {ibm-z-title}
 
 User-provisioned infrastructure requires the user to provision all resources required by {product-title}.
 


### PR DESCRIPTION
Installation Methods page is inconsistent across infrastructure platform vendors. This uses the new structure found in AWS and MS Azure content, removing the duplicated prerequisite content found at the start of each `/installing/installing_<<platform>>/installing_*.adoc` file.

The change cannot be immediately applied to the following, as the file also contains other preparation content / the content file structure is too different:
- `installing/installing_nutanix/preparing-to-install-on-nutanix.adoc`
- `installing/installing_openstack/preparing-to-install-on-openstack.adoc`
- `installing/installing_sno/install-sno-preparing-to-install-sno.adoc`

Version(s):
4.17, do not cherry pick as this file is likely to have changed between each version

Issue:
- None (GH or Jira), this is community author contribution

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- n/a

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
