### PR TITLE
bugfix: standardise and dedupe chapter titles

### DIFF
--- a/installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc
+++ b/installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ipi-aws-preparing-to-install"]
-= Preparing to install a cluster on AWS
+= Preparing to install a cluster on AWS with IPI
 include::_attributes/common-attributes.adoc[]
 :context: ipi-aws-preparing-to-install
 

--- a/installing/installing_aws/upi/upi-aws-preparing-to-install.adoc
+++ b/installing/installing_aws/upi/upi-aws-preparing-to-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="upi-aws-preparing-to-install"]
-= Preparing to install a cluster on AWS
+= Preparing to install a cluster on AWS with UPI
 include::_attributes/common-attributes.adoc[]
 :context: upi-aws-preparing-to-install
 

--- a/installing/installing_azure/ipi/installing-azure-preparing-ipi.adoc
+++ b/installing/installing_azure/ipi/installing-azure-preparing-ipi.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-azure-preparing-ipi"]
-= Preparing to install a cluster on Azure
+= Preparing to install a cluster on Azure with IPI
 include::_attributes/common-attributes.adoc[]
 :context: installing-azure-preparing-ipi
 

--- a/installing/installing_azure/upi/installing-azure-preparing-upi.adoc
+++ b/installing/installing_azure/upi/installing-azure-preparing-upi.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-azure-preparing-upi"]
-= Preparing to install a cluster on Azure
+= Preparing to install a cluster on Azure with UPI
 include::_attributes/common-attributes.adoc[]
 :context: installing-azure-preparing-upi
 

--- a/installing/installing_azure_stack_hub/ipi/ipi-ash-preparing-to-install.adoc
+++ b/installing/installing_azure_stack_hub/ipi/ipi-ash-preparing-to-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ash-preparing-to-install-ipi"]
-= Preparing to install a cluster on Azure Stack Hub
+= Preparing to install a cluster on Azure Stack Hub with IPI
 include::_attributes/common-attributes.adoc[]
 :context: ash-preparing-to-install-ipi
 

--- a/installing/installing_azure_stack_hub/upi/upi-ash-preparing-to-install.adoc
+++ b/installing/installing_azure_stack_hub/upi/upi-ash-preparing-to-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="upi-ash-preparing-to-install"]
-= Preparing to install a cluster on Azure Stack Hub
+= Preparing to install a cluster on Azure Stack Hub with UPI
 include::_attributes/common-attributes.adoc[]
 :context: upi-ash-preparing-to-install
 

--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-installer-provisioned-vsphere"]
-= Installing a cluster on vSphere in a restricted network
+= Installing a cluster on vSphere in a restricted network with IPI
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-installer-provisioned-vsphere
 

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-vsphere-installer-provisioned-customizations"]
-= Installing a cluster on vSphere with customizations
+= Installing a cluster on vSphere with IPI and customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere-installer-provisioned-customizations
 :platform: vSphere

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-vsphere-installer-provisioned-network-customizations"]
-= Installing a cluster on vSphere with network customizations
+= Installing a cluster on vSphere with IPI and network customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere-installer-provisioned-network-customizations
 

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-vsphere-installer-provisioned"]
-= Installing a cluster on vSphere
+= Installing a cluster on vSphere with IPI
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere-installer-provisioned
 

--- a/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
+++ b/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ipi-vsphere-installation-reqs"]
-= vSphere installation requirements
+= vSphere installation requirements with IPI
 include::_attributes/common-attributes.adoc[]
 :context: ipi-vsphere-installation-reqs
 

--- a/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
+++ b/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ipi-vsphere-preparing-to-install"]
-= Preparing to install a cluster using installer-provisioned infrastructure
+= Preparing to install a cluster with IPI
 include::_attributes/common-attributes.adoc[]
 :context: ipi-vsphere-preparing-to-install
 

--- a/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-vsphere"]
-= Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure
+= Installing a cluster on vSphere in a restricted network with UPI
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-vsphere
 

--- a/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-vsphere-network-customizations"]
-= Installing a cluster on vSphere with network customizations
+= Installing a cluster on vSphere with UPI and network customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere-network-customizations
 

--- a/installing/installing_vsphere/upi/installing-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-vsphere"]
-= Installing a cluster on vSphere with user-provisioned infrastructure
+= Installing a cluster on vSphere with UPI
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere
 :platform: vSphere

--- a/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
+++ b/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="upi-vsphere-installation-reqs"]
-= vSphere installation requirements for user-provisioned infrastructure
+= vSphere installation requirements with UPI
 include::_attributes/common-attributes.adoc[]
 :context: upi-vsphere-installation-reqs
 

--- a/installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
+++ b/installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="upi-vsphere-preparing-to-install"]
-= Preparing to install a cluster using user-provisioned infrastructure
+= Preparing to install a cluster with UPI
 include::_attributes/common-attributes.adoc[]
 :context: upi-vsphere-preparing-to-install
 


### PR DESCRIPTION
Where the new style has a chapter break to differentiate between IPI and UPI, some chapter titles are identical which will cause difficulties with SEO and end-user usage (finding the page, and not ignoring the page as a duplicate when there is different content on the page). In addition, VMware vSphere chapter titles do this inconsistently and with the long name even though the chapter menu uses the full name - so rebaseline to `with IPI` and `with UPI` across all vendor content.

Version(s):
4.17, do not cherry pick as this file is likely to have changed between each version

Issue:
- None (GH or Jira), this is community author contribution

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- n/a

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
