### PR TITLE
OBSDOCS-1402 Release notes for COO 0.4.1

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -27,6 +27,34 @@ The following table provides information about which features are available depe
 | 0.3.0+        | 4.16+              | ✔            | ✔                     | ✔         | ✔ 
 |===
 
+[id="cluster-observability-operator-release-notes-0-4-1_{context}"]
+== {coo-full} 0.4.1
+
+The following advisory is available for {coo-full} 0.4.1:
+
+* link:https://access.redhat.com/errata/RHSA-2024:8040[RHEA-2024:8040 {coo-full} 0.4.1]
+
+[id="cluster-observability-operator-0-4-1-new-features-enhancements_{context}"]
+=== New features and enhancements
+
+* You can now configure WebTLS for Prometheus and Alertmanager.
+
+[id="cluster-observability-operator-0-4-1-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-6104[CVE-2024-6104]
+* link:https://access.redhat.com/security/cve/CVE-2024-24786[CVE-2024-24786]
+
+[id="cluster-observability-operator-0-4-1-bug-fixes_{context}"]
+=== Bug fixes
+
+* Previously, when you deleted the dashboard UI plugin, the `consoles.operator.openshift.io` resource still contained `console-dashboards-plugin`. This release resolves the issue. (link:https://issues.redhat.com/browse/COO-152[*COO-152*])
+
+* Previously, the web console did not display the correct icon for Red Hat {coo-short}  . This release resolves the issue. (link:https://issues.redhat.com/browse/COO-353[*COO-353*])
+
+* Previously, when you installed the {coo-short} from the web console, the support section contained an invalid link. This release resolves the issue. (link:https://issues.redhat.com/browse/COO-354[*COO-354*])
+
+* Previously, the cluster service version (CSV) for {coo-short} linked to an unofficial version of the documentation. This release resolves the issue. (link:https://issues.redhat.com/browse/COO-356[*COO-356*])
 
 [id="cluster-observability-operator-release-notes-0-4-0_{context}"]
 == {coo-full} 0.4.0


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-1402](https://issues.redhat.com//browse/OBSDOCS-1402)

Link to docs preview:
https://83388--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Errata link will be updated before merge/publication