### PR TITLE
OSDOCS-12299: 4.16.17 z-stream RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3328,6 +3328,43 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.17
+[id="ocp-4-16-17_{context}"]
+=== RHSA-2024:7944 - {product-title} {product-version}.17 bug fix and security update
+
+Issued: 16 October 2024
+
+{product-title} release {product-version}.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:7944[RHSA-2024:7944] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:7947[RHBA-2024:7947] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.17 --pullspecs
+----
+
+[id="ocp-4-16-17-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the Ingress and DNS Operators failed to start correctly because of rotating root certificates. With this release, the Ingress and DNS Operator kubeconfigs are conditionally managed by using the annotation that defines when the PKI requires management, and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-42431[*OCPBUGS-42431*])
+
+* Previously on Red{nbsp}Hat OpenShift Service on AWS (ROSA) with hosted control planes (HCP), a cluster that used mirroring release images might result in existing node pools to use the hosted cluster's operating system version instead of the `NodePool` version. With this release, a fix ensures that node pools use their own versions. (link:https://issues.redhat.com/browse/OCPBUGS-42342[*OCPBUGS-42342*])
+
+* Previously, a coding issue caused the Ansible script on {op-system} user-provisioned installation infrastructure to fail. This occurred when IPv6 was enabled for a three-node cluster. With this release, support exists for installing a three-node cluster with IPv6 enabled on {op-system}. (link:https://issues.redhat.com/browse/OCPBUGS-41334[*OCPBUGS-41334*])
+
+* Previously, bonds that were configured in `active-backup` mode would have IPsec Encapsulating Security Payload (ESP) offload active even if underlying links did not support ESP offload. This caused IPsec associations to fail. With this release, ESP offload is disabled for bonds so that IPsec associations pass. (link:https://issues.redhat.com/browse/OCPBUGS-41256[*OCPBUGS-41256*])
+
+* Previously, Ironic inspection failed if special or invalid characters existed in the serial number of a block device. This occurred because the `lsblk` command failed to escape the characters. With this release, the command escapes the characters so this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-39017[*OCPBUGS-39017*])
+
+* Previously, the `manila-csi-driver` and node registrar pods had missing health checks because of a configuration issue. With this release, the health checks are added to each resource. (link:https://issues.redhat.com/browse/OCPBUGS-38458[*OCPBUGS-38458*])
+
+[id="ocp-4-16-17-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.16.16
 [id="ocp-4-16-16_{context}"]
 === RHSA-2024:7599 - {product-title} {product-version}.16 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12299](https://issues.redhat.com/browse/OSDOCS-12299)

Link to docs preview: https://83400--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html

QE review:
N/A

Additional information:
Errata URL's will return 404 until go-live (10/16)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
