### PR TITLE
ROX:26400: Update RHACS to use VEX

### DIFF
--- a/architecture/acs-architecture.adoc
+++ b/architecture/acs-architecture.adoc
@@ -15,6 +15,8 @@ include::modules/acs-architecture-overview.adoc[leveloffset=+1]
 
 include::modules/acs-central-services-overview.adoc[leveloffset=+1]
 
+include::modules/con-vuln-sources.adoc[leveloffset=+2]
+
 include::modules/acs-secured-cluster-services-overview.adoc[leveloffset=+1]
 
 include::modules/acs-architecture-external-components.adoc[leveloffset=+1]

--- a/cloud_service/acscs-architecture.adoc
+++ b/cloud_service/acscs-architecture.adoc
@@ -12,6 +12,8 @@ include::modules/acscs-architecture-overview.adoc[leveloffset=+1]
 
 include::modules/acscs-central-overview.adoc[leveloffset=+1]
 
+include::modules/con-vuln-sources.adoc[leveloffset=+2]
+
 include::modules/acs-secured-cluster-services-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/configuration/enable-offline-mode.adoc
+++ b/configuration/enable-offline-mode.adoc
@@ -18,8 +18,7 @@ To deploy and operate {product-title} in offline mode:
 
 . Download {product-title-short} images and install them in your clusters. If you are using {ocp}, you can use link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/understanding-operators#operator-lifecycle-manager-olm[{olm-first}] and OperatorHub to download images to a workstation that is connected to the internet. The workstation then pushes images to a mirror registry that is also connected to your secured cluster. For other platforms, you can use a program such as Skopeo or Docker to pull the images from the remote registry and push them to your own private registry, as described in xref:../configuration/enable-offline-mode.adoc#download-images-for-offline-use[Downloading images for offline use].
 . Enable offline mode during installation.
-. (Optional) Routinely update Scanner’s vulnerability list by uploading a new definitions file.
-. (Optional) When required, add support for runtime collection on more kernel versions by uploading new kernel support packages.
+. Update Scanner’s vulnerability list by uploading a new definitions file at least once per day.
 
 [IMPORTANT]
 ====

--- a/modules/acs-central-services-overview.adoc
+++ b/modules/acs-central-services-overview.adoc
@@ -21,37 +21,4 @@ You can use the same Central instance to secure multiple {ocp} or Kubernetes clu
 * *Scanner-DB*: This database contains data for the StackRox Scanner.
 
 {product-title-short} scanners analyze each image layer to determine the base operating system and identify programming language packages and packages that were installed by the operating system package manager. They match the findings against known vulnerabilities from various vulnerability sources. In addition, the StackRox Scanner identifies vulnerabilities in the node's operating system and platform. These capabilities are planned for Scanner V4 in a future release.
-
-[id="vulnerability-sources_{context}"]
-== Vulnerability sources
-
-{product-title-short} uses the following vulnerability sources:
-
-* link:https://secdb.alpinelinux.org/[Alpine Security Database]
-* Data tracked in link:https://alas.aws.amazon.com/index.html[Amazon Linux Security Center]
-* link:https://security-tracker.debian.org/tracker/data/json[Debian Security Tracker]
-* link:https://linux.oracle.com/security/oval[Oracle OVAL]
-* link:https://packages.vmware.com/photon/photon_oval_definitions/[Photon OVAL]
-* link:https://access.redhat.com/security/data/oval/v2/[Red{nbsp}Hat OVAL]
-* link:https://access.redhat.com/security/data/metrics/cvemap.xml[Red{nbsp}Hat CVE Map]: This is used for images which appear in the link:https://catalog.redhat.com/software/containers/explore[Red{nbsp}Hat Container Catalog].
-* link:https://support.novell.com/security/oval/[SUSE OVAL]
-* link:https://security-metadata.canonical.com/oval/[Ubuntu OVAL]
-* link:https://osv.dev/[OSV]: This is used for language-related vulnerabilities, such as Go, Java, Node.js (JavaScript), Python, and Ruby. This source might provide GitHub Security Advisory (GHSA) IDs rather than CVE numbers for vulnerabilities.
-+
-[NOTE]
-====
-The {product-title-short} Scanner V4 also uses the OSV database available at link:https://osv.dev/[OSV.dev] under link:https://github.com/google/osv.dev/blob/master/LICENSE[this license].
-====
-* link:https://nvd.nist.gov/vuln/search[NVD]: This is used for various purposes such as filling in information gaps when vendors do not provide information. For example, Alpine does not provide a description, CVSS score, severity, or published date.
-+
-[NOTE]
-====
-This product uses the NVD API but is not endorsed or certified by the NVD.
-====
-* link:https://github.com/stackrox/stackrox/blob/master/scanner/updater/manual/vulns.go[StackRox]: The upstream StackRox project maintains a set of vulnerabilities that might not be discovered due to data formatting from other sources or absence of data.
-
-The Scanner V4 Indexer uses the following files to index Red{nbsp}Hat containers:
-
-* link:https://www.redhat.com/security/data/metrics/repository-to-cpe.json[repository-to-cpe.json]: Maps RPM repositories to their related CPEs, which is required for matching vulnerabilities for RHEL-based images.
-* link:https://access.redhat.com/security/data/metrics/container-name-repos-map.json[container-name-repos-map.json]: This matches container names to the repositories to which they are shipped.
-
+//moved vulnerability source info to its own module - con-vuln-sources.adoc

--- a/modules/acscs-central-overview.adoc
+++ b/modules/acscs-central-overview.adoc
@@ -16,37 +16,4 @@ It handles API interactions and user interface ({product-title-short} Portal) ac
 * *Scanner-DB*: This database contains data for the StackRox Scanner.
 
 {product-title-short} scanners analyze each image layer to determine the base operating system and identify programming language packages and packages that were installed by the operating system package manager. They match the findings against known vulnerabilities from various vulnerability sources. In addition, the StackRox Scanner identifies vulnerabilities in the node's operating system and platform. These capabilities are planned for Scanner V4 in a future release.
-
-[id="vulnerability-sources_{context}"]
-== Vulnerability sources
-
-{product-title-short} uses the following vulnerability sources:
-
-* link:https://secdb.alpinelinux.org/[Alpine Security Database]
-* Data tracked in link:https://alas.aws.amazon.com/index.html[Amazon Linux Security Center]
-* link:https://security-tracker.debian.org/tracker/data/json[Debian Security Tracker]
-* link:https://linux.oracle.com/security/oval[Oracle OVAL]
-* link:https://packages.vmware.com/photon/photon_oval_definitions/[Photon OVAL]
-* link:https://access.redhat.com/security/data/oval/v2/[Red{nbsp}Hat OVAL]
-* link:https://access.redhat.com/security/data/metrics/cvemap.xml[Red{nbsp}Hat CVE Map]: This is used for images which appear in the link:https://catalog.redhat.com/software/containers/explore[Red{nbsp}Hat Container Catalog].
-* link:https://support.novell.com/security/oval/[SUSE OVAL]
-* link:https://security-metadata.canonical.com/oval/[Ubuntu OVAL]
-* link:https://osv.dev/[OSV]: This is used for language-related vulnerabilities, such as Go, Java, Node.js (JavaScript), Python, and Ruby. This source might provide GitHub Security Advisory (GHSA) IDs rather than CVE numbers for vulnerabilities.
-+
-[NOTE]
-====
-The {product-title-short} Scanner V4 also uses the OSV database available at link:https://osv.dev/[OSV.dev] under link:https://github.com/google/osv.dev/blob/master/LICENSE[this license].
-====
-* link:https://nvd.nist.gov/vuln/search[NVD]: This is used for various purposes such as filling in information gaps when vendors do not provide information. For example, Alpine does not provide a description, CVSS score, severity, or published date.
-+
-[NOTE]
-====
-This product uses the NVD API but is not endorsed or certified by the NVD.
-====
-* link:https://github.com/stackrox/stackrox/blob/master/scanner/updater/manual/vulns.go[StackRox]: The upstream StackRox project maintains a set of vulnerabilities that might not be discovered due to data formatting from other sources or absence of data.
-
-The Scanner V4 Indexer uses the following files to index Red{nbsp}Hat containers:
-
-* link:https://www.redhat.com/security/data/metrics/repository-to-cpe.json[repository-to-cpe.json]: Maps RPM repositories to their related CPEs, which is required for matching vulnerabilities for RHEL-based images.
-* link:https://access.redhat.com/security/data/metrics/container-name-repos-map.json[container-name-repos-map.json]: This matches container names to the repositories to which they are shipped.
-
+//moved vulnerability source info to its own module - con-vuln-sources.adoc

--- a/modules/con-vuln-sources.adoc
+++ b/modules/con-vuln-sources.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * architecture/acs-architecture.adoc
+// * cloud_service/acscs-architecture.adoc
+:_mod-docs-content-type: CONCEPT
+[id="con-vuln-sources_{context}"]
+= Vulnerability data sources
+
+Sources for vulnerabilities depend on the scanner that is used in your system. {product-title-short} contains two scanners: StackRox Scanner and Scanner V4. StackRox Scanner is the default scanner and is deprecated beginning with release 4.6. Scanner V4 was introduced in release 4.4 and is the recommended image scanner.
+
+[id="stackrox-scanner-vuln-sources"]
+== StackRox Scanner sources
+
+StackRox Scanner uses the following vulnerability sources:
+
+* link:https://access.redhat.com/security/data/oval/v2/[Red{nbsp}Hat OVAL] v2
+* link:https://secdb.alpinelinux.org/[Alpine Security Database]
+* Data tracked in link:https://alas.aws.amazon.com/index.html[Amazon Linux Security Center]
+* link:https://security-tracker.debian.org/tracker/data/json[Debian Security Tracker]
+* link:https://git.launchpad.net/ubuntu-cve-tracker/[Ubuntu CVE Tracker]
+* link:https://nvd.nist.gov/[NVD]: This is used for various purposes such as filling in information gaps when vendors do not provide information. For example, Alpine does not provide a description, CVSS score, severity, or published date.
++
+[NOTE]
+====
+This product uses the NVD API but is not endorsed or certified by the NVD.
+====
+* link:https://github.com/stackrox/scanner/blob/master/ext/vulnsrc/manual/manual.go and link:https://github.com/stackrox/scanner/blob/master/pkg/vulnloader/nvdloader/manual.go: The upstream StackRox project maintains a set of vulnerabilities that might not be discovered due to data formatting from other sources or absence of data.
+* link:https://security.access.redhat.com/data/metrics/repository-to-cpe.json[repository-to-cpe.json]: Maps RPM repositories to their related CPEs, which is required for matching vulnerabilities for RHEL-based images.
+
+[id="scanner-v4-vuln-sources"]
+== Scanner V4 sources
+
+Scanner V4 uses the following vulnerability sources:
+
+link:https://security.access.redhat.com/data/csaf/v2/vex/[Red{nbsp}Hat VEX]:: Used with release 4.6 and later. This source provides vulnerability data in link:https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#45-profile-5-vex[Vulnerability Exploitability eXchange(VEX)] format. {product-title-short} takes advantage of VEX benefits to significantly decrease the time needed for the initial loading of vulnerability data, and the space needed to store vulnerability data.
++
+{product-title-short} might list a different number of vulnerabilities when you are scanning with a {product-title-short} version that uses OVAL, such as {product-title-short} version 4.5, and a version that uses VEX, such as version 4.6. For example, {product-title-short} no longer displays vulnerabilities with a status of "under investigation," while these vulnerabilities were included with previous versions that used OVAL data.
++
+For more information about Red Hat security data, including information about the use of OVAL, Common Security Advisory Framework Version 2.0 (CSAF), and VEX, see link:https://www.redhat.com/en/blog/future-red-hat-security-data[The future of Red Hat security data].
+https://access.redhat.com/security/data/metrics/cvemap.xml[Red{nbsp}Hat CVE Map]:: This is used in addition with VEX data for images which appear in the link:https://catalog.redhat.com/software/containers/explore[Red{nbsp}Hat Container Catalog].
+link:https://osv.dev/[OSV]:: This is used for language-related vulnerabilities, such as Go, Java, JavaScript, Python, and Ruby. This source might provide
+vulnerability IDs other than CVE IDs for vulnerabilities, such as a GitHub Security Advisory (GHSA) ID.
++
+[NOTE]
+====
+{product-title-short} uses the OSV database available at link:https://osv.dev/[OSV.dev] under link:https://github.com/google/osv.dev/blob/master/LICENSE[Apache License 2.0].
+====
+link:https://nvd.nist.gov/[NVD]:: This is used for various purposes such as filling in information gaps when vendors do not provide information. For example, Alpine does not provide a description, CVSS score, severity, or published date.
++
+[NOTE]
+====
+This product uses the NVD API but is not endorsed or certified by the NVD.
+====
+Additional vulnerability sources::
+* link:https://secdb.alpinelinux.org/[Alpine Security Database]
+* Data tracked in link:https://alas.aws.amazon.com/index.html[Amazon Linux Security Center]
+* link:https://security-tracker.debian.org/tracker/data/json[Debian Security Tracker]
+* link:https://linux.oracle.com/security/oval[Oracle OVAL]
+* link:https://packages.vmware.com/photon/photon_oval_definitions/[Photon OVAL]
+* link:https://support.novell.com/security/oval/[SUSE OVAL]
+* link:https://security-metadata.canonical.com/oval/[Ubuntu OVAL]
+* link:https://github.com/stackrox/stackrox/blob/master/scanner/updater/manual/vulns.go[StackRox]: The upstream StackRox project maintains a set of vulnerabilities that might not be discovered due to data formatting from other sources or absence of data.
+
+Scanner V4 Indexer sources:: Scanner V4 indexer uses the following files to index Red{nbsp}Hat containers:
+
+* link:https://security.access.redhat.com/data/metrics/repository-to-cpe.json[repository-to-cpe.json]: Maps RPM repositories to their related CPEs, which is required for matching vulnerabilities for RHEL-based images.
+* link:https://security.access.redhat.com/data/metrics/container-name-repos-map.json[container-name-repos-map.json]: This matches container names to their respective repositories.
+

--- a/modules/consolidated-scanner.adoc
+++ b/modules/consolidated-scanner.adoc
@@ -8,4 +8,9 @@
 [role="_abstract"]
 {product-title-short} provides its own scanner, or you can configure an integration to use {product-title-short} with another vulnerability scanner.
 
-Beginning with version 4.4, Scanner V4, built on link:https://github.com/quay/claircore[ClairCore], provides scanning for language and operating system-specific image components. For version 4.4, {product-title-short} also uses the StackRox Scanner to provide some scanning functionality until that functionality is implemented in a future release.
+Beginning with version 4.4, Scanner V4, built on link:https://github.com/quay/claircore[ClairCore], provides scanning for language and operating system-specific image components. Currently, {product-title-short} also uses the StackRox Scanner. To continue receiving full scanning support with the latest features, usage of both scanners is required.
+
+[NOTE]
+====
+Beginning with release 4.6, due to changes in vulnerability sources used, Scanner V4 only considers vulnerabilities affecting Red{nbsp}Hat products dated back to 2014. Previously, when reading Red Hat's OVAL data, the vulnerabilities dated back to before 2000.
+====

--- a/modules/rhcos-match-vulnerability.adoc
+++ b/modules/rhcos-match-vulnerability.adoc
@@ -3,10 +3,12 @@
 // * operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
 :_mod-docs-content-type: CONCEPT
 [id="rhcos-match-vulnerability_{context}"]
-= Vulnerability matching
+= Vulnerability matching on RHCOS nodes
 
 [role="_abstract"]
-Central services, which include Central and Scanner, perform vulnerability matching. Scanner uses Red{nbsp}Hat's Open Vulnerability and Assessment Language (OVAL) v2 security data streams to match vulnerabilities on {op-system-first} software components.
+Central services, which include Central and Scanner, perform vulnerability matching. Node scanning is performed using the following scanners:
 
-Unlike the earlier versions, {product-title-short} 4.0 no longer uses the Kubernetes node metadata to find the kernel and container runtime versions. Instead, it uses the installed {op-system} RPMs to assess that information.
-//changes made in https://github.com/openshift/openshift-docs/pull/83406 for 4.6
+* StackRox Scanner: This is the default scanner. StackRox Scanner uses Red{nbsp}Hat's Open Vulnerability and Assessment Language (OVAL) v2 security data streams to match vulnerabilities on {op-system-first} software components.
+* Scanner V4: Scanner V4 is available for node scanning as a Technology Preview feature. Scanner V4 must be explicitly enabled. See the documentation in "Additional resources" for more information.
+
+When scanning {op-system} nodes, {product-title-short} releases after 4.0 no longer use the Kubernetes node metadata to find the kernel and container runtime versions. Instead, {product-title-short} uses the installed {op-system} RPMs to assess that information.

--- a/operating/examine-images-for-vulnerabilities.adoc
+++ b/operating/examine-images-for-vulnerabilities.adoc
@@ -13,7 +13,7 @@ The scanners in {product-title-short} analyze each image layer to find packages 
 
 [NOTE]
 ====
-The {product-title-short} Scanner V4 uses the OSV database available at link:https://osv.dev/[OSV.dev] under link:https://github.com/google/osv.dev/blob/master/LICENSE[this license].
+The {product-title-short} Scanner V4 uses the OSV database available at link:https://osv.dev/[OSV.dev] under link:https://github.com/google/osv.dev/blob/master/LICENSE[Apache License 2.0].
 ====
 
 {product-title-short} contains two scanners: the StackRox Scanner and Scanner V4.

--- a/operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
+++ b/operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
@@ -34,6 +34,13 @@ include::modules/rhcos-analyse-detect.adoc[leveloffset=+1]
 
 include::modules/rhcos-match-vulnerability.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_ocp/install-central-config-options-ocp.adoc#scannerv4-settings_install-central-config-options-ocp[Scanner V4 settings for installing {product-title-short} for {ocp} by using the Operator]
+* xref:../../installing/installing_ocp/install-central-ocp.adoc#central-services-public-configuration-file-scannerv4_install-central-ocp[Scanner V4 settings for installing {product-title-short} for {ocp} by using Helm]
+* xref:../../installing/installing_other/install-central-other.adoc#central-services-public-configuration-file-scannerv4_install-central-other[Scanner V4 settings for installing {product-title-short} for Kubernetes by using Helm]
+
 include::modules/rhcos-environment-variables.adoc[leveloffset=+1]
 
 include::modules/identify-vulnerabilities-in-nodes.adoc[leveloffset=+1]


### PR DESCRIPTION
**PLEASE READ "ADDITIONAL INFORMATION"**

Version(s):
4.6+

[Issue](https://issues.redhat.com/browse/ROX-26400)

Links to docs previews:

[83406--ocpdocs-pr.netlify.app/openshift-acs/latest/architecture/acs-architecture.html](https://83406--ocpdocs-pr.netlify.app/openshift-acs/latest/architecture/acs-architecture.html)
[83406--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/acscs-architecture.html](https://83406--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/acscs-architecture.html)
[83406--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-vulnerabilities/scan-rhcos-node-host.html](https://83406--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-vulnerabilities/scan-rhcos-node-host.html)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

* Moved vulnerability sources into its own module.
* See https://github.com/openshift/openshift-docs/pull/84256 for other Scanner V4 changes.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
