### PR TITLE
fix: fix kubevirt-tekton-tasks documentation

### DIFF
--- a/modules/virt-running-ssp-pipeline-cli.adoc
+++ b/modules/virt-running-ssp-pipeline-cli.adoc
@@ -10,87 +10,49 @@ Use a `PipelineRun` resource to run the example pipelines. A `PipelineRun` objec
 
 .Procedure
 
-. To run the Windows 10 installer pipeline, create the following `PipelineRun` manifest:
+. To run the Windows 11 installer pipeline, create the following `PipelineRun` manifest:
 +
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  generateName: windows10-installer-run-
+  generateName: windows11-installer-run-
   labels:
-    pipelinerun: windows10-installer-run
+    pipelinerun: windows11-installer-run
 spec:
-  params:
-  - name: winImageDownloadURL
-    value: <link_to_windows_10_iso> <1>
-  pipelineRef:
-    name: windows10-installer
-  taskRunSpecs:
-    - pipelineTaskName: copy-template
-      serviceAccountName: copy-template-task
-    - pipelineTaskName: modify-vm-template
-      serviceAccountName: modify-vm-template-task
-    - pipelineTaskName: create-vm-from-template
-      serviceAccountName: create-vm-from-template-task
-    - pipelineTaskName: wait-for-vmi-status
-      serviceAccountName: wait-for-vmi-status-task
-    - pipelineTaskName: create-base-dv
-      serviceAccountName: modify-data-object-task
-    - pipelineTaskName: cleanup-vm
-      serviceAccountName: cleanup-vm-task
-  status: {}
+    params:
+    -   name: winImageDownloadURL
+        value: ${WIN_IMAGE_DOWNLOAD_URL} <1>
+    -   name: acceptEula
+        value: false <2>
+    pipelineRef:
+        params:
+        -   name: catalog
+            value: redhat-pipelines
+        -   name: type
+            value: artifact
+        -   name: kind
+            value: pipeline
+        -   name: name
+            value: windows-efi-installer
+        -   name: version
+            value: 
+        resolver: hub
+    taskRunSpecs:
+    -   pipelineTaskName: modify-windows-iso-file
+        podTemplate:
+            securityContext:
+                fsGroup: 107
+                runAsUser: 107
+
 ----
-<1> Specify the URL for the Windows 10 64-bit ISO file. The product language must be English (United States).
+<1> Specify the URL for the Windows 11 64-bit ISO file. The product language must be English (United States).
+<2> Example PipelineRuns have special parameter acceptEula. By setting this parameter, you are agreeing to the applicable Microsoft end user license agreement(s) for each deployment or installation for the Microsoft product(s). In case you set it to false, the Pipeline will exit in first task.
 
 . Apply the `PipelineRun` manifest:
 +
 [source,terminal]
 ----
-$ oc apply -f windows10-installer-run.yaml
-----
-
-. To run the Windows 10 customize pipeline, create the following `PipelineRun` manifest:
-+
-[source,yaml]
-----
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  generateName: windows10-customize-run-
-  labels:
-    pipelinerun: windows10-customize-run
-spec:
-  params:
-    - name: allowReplaceGoldenTemplate
-      value: true
-    - name: allowReplaceCustomizationTemplate
-      value: true
-  pipelineRef:
-    name: windows10-customize
-  taskRunSpecs:
-    - pipelineTaskName: copy-template-customize
-      serviceAccountName: copy-template-task
-    - pipelineTaskName: modify-vm-template-customize
-      serviceAccountName: modify-vm-template-task
-    - pipelineTaskName: create-vm-from-template
-      serviceAccountName: create-vm-from-template-task
-    - pipelineTaskName: wait-for-vmi-status
-      serviceAccountName: wait-for-vmi-status-task
-    - pipelineTaskName: create-base-dv
-      serviceAccountName: modify-data-object-task
-    - pipelineTaskName: cleanup-vm
-      serviceAccountName: cleanup-vm-task
-    - pipelineTaskName: copy-template-golden
-      serviceAccountName: copy-template-task
-    - pipelineTaskName: modify-vm-template-golden
-      serviceAccountName: modify-vm-template-task
-status: {}
-----
-
-. Apply the `PipelineRun` manifest:
-+
-[source,terminal]
-----
-$ oc apply -f windows10-customize-run.yaml
+$ oc apply -f windows11-installer-run.yaml
 ----

--- a/modules/virt-supported-ssp-tasks.adoc
+++ b/modules/virt-supported-ssp-tasks.adoc
@@ -4,11 +4,11 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="virt-supported-ssp-tasks_{context}"]
-= Virtual machine tasks supported by the SSP Operator
+= Supported Virtual machine tasks
 
-The following table shows the tasks that are included as part of the SSP Operator.
+The following table shows the tasks that are supported.
 
-.Virtual machine tasks supported by the SSP Operator
+.Supported Virtual machine tasks
 [cols="1,1",options="header"]
 |===
 | Task | Description

--- a/virt/virtual_machines/virt-managing-vms-openshift-pipelines.adoc
+++ b/virt/virtual_machines/virt-managing-vms-openshift-pipelines.adoc
@@ -8,11 +8,15 @@ toc::[]
 
 link:https://docs.openshift.com/pipelines/latest/about/understanding-openshift-pipelines.html[{pipelines-title}] is a Kubernetes-native CI/CD framework that allows developers to design and run each step of the CI/CD pipeline in its own container.
 
-The Scheduling, Scale, and Performance (SSP) Operator integrates {VirtProductName} with {pipelines-shortname}. The SSP Operator includes tasks and example pipelines that allow you to:
+The {pipelines-shortname} tasks and example pipeline allow you to:
 
-* Create and manage virtual machines (VMs), persistent volume claims (PVCs), and data volumes
+* Create and manage virtual machines (VMs), persistent volume claims (PVCs), data volumes and data sources
 * Run commands in VMs
 * Manipulate disk images with `libguestfs` tools
+
+The tasks are located in https://artifacthub.io/packages/search?repo=redhat-tekton-tasks&sort=relevance&page=1[tasks catalog].
+
+Example Windows pipeline is located in https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer[pipelines catalog].
 
 [id="prerequisites_virt-managing-vms-openshift-pipelines"]
 == Prerequisites


### PR DESCRIPTION
Version(s):
4.16, 4.17, main

Issue:
the kubevirt tekton tasks are no longer deployed by ssp operator. This commit changes the documentation to reflect current state of deployment

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
/cc @sash
