### PR TITLE
OBSDOCS-1408: Make an example separation for Moving monitoring compon…

### DIFF
--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -3,36 +3,66 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="moving-monitoring-components-to-different-nodes_{context}"]
-= Moving monitoring components to different nodes
 
-ifndef::openshift-dedicated,openshift-rosa[]
-To specify the nodes in your cluster on which monitoring stack components will run, configure the `nodeSelector` constraint in the component's `ConfigMap` object to match labels assigned to the nodes.
+// The final solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+
+// tag::CPM[]
+[id="moving-monitoring-components-to-different-nodes-cpm_{context}"]
+= Moving monitoring components to different nodes for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="moving-monitoring-components-to-different-nodes-uwm_{context}"]
+= Moving monitoring components to different nodes for monitoring for user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples.
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+// end::UWM[]
+
+// tag::CPM[]
+To specify the nodes in your cluster on which monitoring stack components will run, configure the `nodeSelector` constraint for the components in the `cluster-monitoring-config` config map to match labels assigned to the nodes.
 
 [NOTE]
 ====
 You cannot add a node selector constraint directly to an existing scheduled pod.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+// end::CPM[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
-You can move any of the components that monitor workloads for user-defined projects to specific worker nodes. It is not permitted to move components to control plane or infrastructure nodes.
-endif::openshift-dedicated,openshift-rosa[]
+// tag::UWM[]
+You can move any of the components that monitor workloads for user-defined projects to specific worker nodes. 
+
+[WARNING]
+====
+It is not permitted to move components to control plane or infrastructure nodes.
+====
+// end::UWM[]
 
 .Prerequisites
+
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+* You have installed the OpenShift CLI (`oc`).
+// end::CPM[]
+
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` `ConfigMap` object.
-* *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 * You have installed the OpenShift CLI (`oc`).
+// end::UWM[]
 
 .Procedure
 
@@ -40,75 +70,38 @@ endif::openshift-dedicated,openshift-rosa[]
 +
 [source,terminal]
 ----
-$ oc label nodes <node-name> <node-label>
+$ oc label nodes <node_name> <node_label> <1>
 ----
-. Edit the `ConfigMap` object:
-ifndef::openshift-dedicated,openshift-rosa[]
-** *To move a component that monitors core {product-title} projects*:
+<1> Replace `<node_name>` with the name of the node where you want to add the label. 
+Replace `<node_label>` with the name of the wanted label.
 
-.. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` `ConfigMap` object in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-.. Specify the node labels for the `nodeSelector` constraint for the component under `data/config.yaml`:
+. Specify the node labels for the `nodeSelector` constraint for the component under `data/config.yaml`:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    <component>: <1>
+    # ...
+    <component>: #<1>
       nodeSelector:
-        <node-label-1> <2>
-        <node-label-2> <3>
-        <...>
+        <node_label_1> #<2>
+        <node_label_2> #<3>
+    # ...
 ----
 <1> Substitute `<component>` with the appropriate monitoring stack component name.
-<2> Substitute `<node-label-1>` with the label you added to the node.
-<3> Optional: Specify additional labels.
-If you specify additional labels, the pods for the component are only scheduled on the nodes that contain all of the specified labels.
-+
-[NOTE]
-====
-If monitoring components remain in a `Pending` state after configuring the `nodeSelector` constraint, check the pod events for errors relating to taints and tolerations.
-====
-
-** *To move a component that monitors user-defined projects*:
-endif::openshift-dedicated,openshift-rosa[]
-
-.. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-
-.. Specify the node labels for the `nodeSelector` constraint for the component under `data/config.yaml`:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    <component>: <1>
-      nodeSelector:
-        <node-label-1> <2>
-        <node-label-2> <3>
-        <...>
-----
-<1> Substitute `<component>` with the appropriate monitoring stack component name.
-<2> Substitute `<node-label-1>` with the label you added to the node.
+<2> Substitute `<node_label_1>` with the label you added to the node.
 <3> Optional: Specify additional labels.
 If you specify additional labels, the pods for the component are only scheduled on the nodes that contain all of the specified labels.
 +

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -119,8 +119,16 @@ endif::openshift-dedicated,openshift-rosa[]
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#using-pod-topology-spread-constraints-for-monitoring_configuring-the-monitoring-stack[Using pod topology spread constraints for monitoring]
 * link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[Kubernetes documentation about node selectors]
 
-include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc[leveloffset=+2]
+// This following ifndef causes the first procedure NOT to show up in ROSA/OSD builds, only in the OCP build
+// The final solution WILL NOT need those ifdef statements
+// The module should only include core platform monitoring
+ifndef::openshift-dedicated,openshift-rosa[]
+include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc[leveloffset=+2,tags=**;CPM;!UWM]
+endif::openshift-dedicated,openshift-rosa[]
 
+// The following module shows in all builds.
+// The module should only include monitoring for user-defined projects
+include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s): no CP

Issue: [OBSDOCS-1408](https://issues.redhat.com/browse/OBSDOCS-1408)

Link to docs preview: 

* OCP: 
  * Core platform monitoring: https://83431--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#moving-monitoring-components-to-different-nodes-cpm_configuring-the-monitoring-stack
  * User workload monitoring: https://83431--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#moving-monitoring-components-to-different-nodes-uwm_configuring-the-monitoring-stack

* ROSA/OSD: https://83431--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/monitoring/configuring-the-monitoring-stack.html#moving-monitoring-components-to-different-nodes-uwm_configuring-the-monitoring-stack

QE review:
- [x] QE has approved this change.

**Additional information:**
This is the first example split of core platform monitoring and user workload monitoring procedures. The issue is getting merged to only `monitoring-docs-restructure`, not to `main`, therefore this change will not be visible in the documentation.

The tagging is implemented so that once this is moved to two different assemblies, we will still only have one module to maintain. This will ensure content reuse instead of duplication. It also prevents creation of multiple new modules with basically identical content.

This issue also asks for changes in ID, however, in the final product, the two procedures will be in a different assembly, therefore two IDs will not be needed (context parameter will take care of it)