### PR TITLE
OSDOCS-12239-main: Created the release notes template for 4.18 on main

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -52,8 +52,8 @@ Name: Release notes
 Dir: release_notes
 Distros: openshift-enterprise
 Topics:
-- Name: OpenShift Container Platform 4.15 release notes
-  File: ocp-4-15-release-notes
+- Name: OpenShift Container Platform 4.18 release notes
+  File: ocp-4-18-release-notes
 ---
 Name: Getting started
 Dir: getting_started

--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -9,7 +9,7 @@ toc::[]
 {product-title} {product-version} introduces architectural changes and enhancements. The procedures that you used to manage your {product-title} 3 cluster might not apply to {product-title} 4.
 
 ifndef::openshift-origin[]
-For information about configuring your {product-title} 4 cluster, review the appropriate sections of the {product-title} documentation. For information about new features and other notable technical changes, review the xref:../release_notes/ocp-4-15-release-notes.adoc#ocp-4-15-release-notes[OpenShift Container Platform 4.15 release notes].
+For information about configuring your {product-title} 4 cluster, review the appropriate sections of the {product-title} documentation. For information about new features and other notable technical changes, review the xref:../release_notes/ocp-4-18-release-notes.adoc#ocp-4-18-release-notes[{product-title} 4.18 release notes].
 endif::[]
 
 It is not possible to upgrade your existing {product-title} 3 cluster to {product-title} 4. You must start with a new {product-title} 4 installation. Tools are available to assist in migrating your control plane settings and application workloads.

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ocp-4-18-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/common-attributes.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch that they are relevant for.
+
+Release note changes should be added or edited in their own PR.
+
+This file is here to allow builds to work.

--- a/rosa_architecture/index.adoc
+++ b/rosa_architecture/index.adoc
@@ -59,7 +59,7 @@ Start with xref:../architecture/architecture.adoc#architecture-overview-architec
 xref:../security/container_security/security-understanding.adoc#understanding-security[Security and compliance].
 ifdef::openshift-enterprise,openshift-webscale[]
 Next, view the
-xref:../release_notes/ocp-4-15-release-notes.adoc#ocp-4-15-release-notes[release notes].
+xref:../release_notes/ocp-4-18-release-notes.adoc#ocp-4-18-release-notes[release notes].
 endif::[]
 
 ifdef::openshift-online,openshift-aro[]


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12239](https://issues.redhat.com/browse/OSDOCS-12239)

Link to docs preview:
* [RN 4.18 doc](https://83432--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html)
* [Differences between OpenShift Container Platform 3 and 4](https://83432--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/planning-migration-3-4.html)

