### PR TITLE
OBSDOCS-1333: Enhance API command with 'Instant Query' endpoint of th…

### DIFF
--- a/modules/accessing-metrics-outside-cluster.adoc
+++ b/modules/accessing-metrics-outside-cluster.adoc
@@ -84,5 +84,7 @@ The output shows the status for each application pod that Prometheus is scraping
 +
 [NOTE]
 ====
-The formatted example output uses a filtering tool, such as `jq`, to provide the formatted indented JSON. See the link:https://stedolan.github.io/jq/manual/[jq Manual] for more information about using `jq`.
+* The formatted example output uses a filtering tool, such as `jq`, to provide the formatted indented JSON. See the link:https://stedolan.github.io/jq/manual/[jq Manual] (jq documentation) for more information about using `jq`.
+
+* The command requests an instant query endpoint of the Thanos Querier service, which evaluates selectors at one point in time.
 ====


### PR DESCRIPTION
Version(s): 
* `enterprise-4.12` and later
* $${\color{red}PLEASE  \space ALSO \space MERGE \space INTO \space THIS \space BRANCH}$$: `monitoring-docs-restructure`

Issue: [OBSDOCS-1333](https://issues.redhat.com/browse/OBSDOCS-1333)

Link to docs preview: https://83440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-third-party-monitoring-apis.html#accessing-metrics-from-outside-cluster_accessing-monitoring-apis-by-using-the-cli

QE review:
- [x] QE has approved this change.

**Additional information:**