### PR TITLE
OSDOCS-12330: move include so attribute resolves MicroShift

### DIFF
--- a/microshift_configuring/microshift-using-config-tools.adoc
+++ b/microshift_configuring/microshift-using-config-tools.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes-microshift.adoc[]
 [id="microshift-using-config-tools"]
 = Using the {microshift-short} config.yaml
-include::_attributes/attributes-microshift.adoc[]
 :context: microshift-configuring
 
 toc::[]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12330](https://issues.redhat.com/browse/OSDOCS-12330)

Link to docs preview:
https://83442--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-tools.html

QE review:
- N/A internal docs change

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
