### PR TITLE
OCPBUGS#41971-17: Removed Ingress capability docs

### DIFF
--- a/installing/overview/cluster-capabilities.adoc
+++ b/installing/overview/cluster-capabilities.adoc
@@ -77,9 +77,6 @@ include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+2]
 // DeploymentConfig capability
 include::modules/deployment-config-capability.adoc[leveloffset=+2]
 
-// Ingress capability
-include::modules/ingress-operator.adoc[leveloffset=+2]
-
 // Insights capability
 include::modules/insights-operator.adoc[leveloffset=+2]
 

--- a/modules/ingress-operator.adoc
+++ b/modules/ingress-operator.adoc
@@ -1,29 +1,13 @@
 // Module included in the following assemblies:
 //
 // * operators/operator-reference.adoc
-// * installing/overview/cluster-capabilities.adoc
-
-ifeval::["{context}" == "cluster-capabilities"]
-:cluster-caps:
-endif::[]
-
-ifeval::["{context}" == "cluster-operators-ref"]
-:operator-ref:
-endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="ingress-operator_{context}"]
-ifdef::operator-ref[= Ingress Operator]
-ifdef::cluster-caps[= Ingress Capability]
+= Ingress Operator
 
 [discrete]
 == Purpose
-
-ifdef::cluster-caps[]
-
-The Ingress Operator provides the features for the `Ingress` capability.
-
-endif::cluster-caps[]
 
 The Ingress Operator configures and manages the {product-title} router.
 
@@ -77,11 +61,3 @@ $ oc get network/cluster -o jsonpath='{.status.clusterNetwork[*]}'
 ----
 map[cidr:10.128.0.0/14 hostPrefix:23]
 ----
-
-ifeval::["{context}" == "cluster-operators-ref"]
-:!operator-ref:
-endif::[]
-
-ifeval::["{context}" == "cluster-caps"]
-:!cluster-caps:
-endif::[]

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1834,8 +1834,6 @@ link:https://issues.redhat.com/browse/OCPBUGS-39428[(*OCPBUGS-39428*)]
 
 * Previously, text areas were not resizable. With this update, you are now able to resize text areas. (link:https://issues.redhat.com/browse/OCPBUGS-34200[*OCPBUGS-34200*])
 
-* Previously, the Console Operator was not able to tolerate the absence of the ingress capability. With this update, the Console Operator configuration API has been enhanced with the possibility to add alternative ingress for the environments where the ingress cluster capability is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-33787[*OCPBUGS-33787*])
-
 * Previously, the *Debug container* link was not displayed for pods with a `Completed` status. With this change, the link now appears. (link:https://issues.redhat.com/browse/OCPBUGS-33631[*OCPBUGS-33631*])
 
 * Previously, the {product-title} web console did not show `filesystem` metrics on the *Nodes list* page due to incorrect Prometheus query. With this update, `filesystem` metrics are correctly displayed. (link:https://issues.redhat.com/browse/OCPBUGS-33136[*OCPBUGS-33136*])


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OCPBUGS-41971](https://issues.redhat.com/browse/OCPBUGS-41971)

Link to docs preview:
*[4.17 RN DOC](https://83446--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html)
* [Cluster capabilities](https://83446--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities.html)
* [Cluster Operators reference](https://83446--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference.html)

