### PR TITLE
Removing wasp-agent RN from TP section (it's GA)

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -158,9 +158,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //CNV-15028: Nested virt in virt hosts. This feature will remain in tech preview indefinitely.
 * You can now enable link:https://access.redhat.com/solutions/6692341[nested virtualization on {VirtProductName} hosts].
 
-//CNV-22314: Safe memory overcommitment using `wasp-agent`
-* Cluster admins can now use the `wasp-agent` tool to xref:../../virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc#virt-configuring-higher-vm-workload-density[configure a higher VM workload density] in their clusters by overcommitting the amount of memory, in RAM, and assigning swap resources to VM workloads.
-
 [id="virt-4-17-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17 only, no cherrypick (RN)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: related to [CNV-34780](https://issues.redhat.com//browse/CNV-34780)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: removed note from this section: https://83455--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-16-technology-preview_virt-4-17-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: I don't think this needs QE approval because the [related PR](https://github.com/openshift/openshift-docs/pull/83289) that added it as a GA feature was already approved by QE.
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The RN for GA (tracked by [CNV-34780](https://issues.redhat.com//browse/CNV-34780)) was merged last week (PR: https://github.com/openshift/openshift-docs/pull/83289)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
