### PR TITLE
OSDOCS#11844: adding install page for disconnected section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -113,7 +113,7 @@ Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Converting a connected cluster to a disconnected cluster
   File: connected-to-disconnected
-- Name: Mirroring in disconnected enviroments
+- Name: Mirroring in disconnected environments
   Dir: mirroring
   Distros: openshift-origin,openshift-enterprise
   Topics:
@@ -127,6 +127,8 @@ Topics:
       File: installing-mirroring-disconnected
     - Name: Mirroring images for a disconnected installation using oc-mirror plugin v2
       File: about-installing-oc-mirror-v2
+- Name: Installing a cluster in a disconnected environment
+  File: installing
 - Name: Using OLM in disconnected environments
   File: using-olm
   Distros: openshift-origin,openshift-enterprise

--- a/disconnected/installing.adoc
+++ b/disconnected/installing.adoc
@@ -1,0 +1,115 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-disconnected-environments"]
+= Installing a cluster in a disconnected environment
+include::_attributes/common-attributes.adoc[]
+:context: installing-disconnected-environments
+
+toc::[]
+
+You can install an {product-title} cluster in a disconnected environment, choosing the installation method and infrastructure that best suits your requirements.
+This includes installing {product-title} on either on-premise hardware or on a cloud hosting service such as Amazon Web Services (AWS).
+
+The following sections outline all of the supported methods for installing a cluster in a disconnected environment.
+
+[NOTE]
+====
+In order to learn about other requirements for installing a cluster using a particular method, be sure to review other content in the procedure's respective section of the documentation.
+
+For example, if you plan to install a cluster on {aws-short} with installer-provisioned infrastructure, see xref:../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account] and xref:../installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc#ipi-aws-preparing-to-install[Preparing to install a cluster on {aws-short}]
+====
+// Not sure if the sentence above should be a note or just plain text.
+
+ifndef::openshift-origin[]
+[id="installing-agent_{context}"]
+== Installing a cluster with the Agent-based Installer
+
+To learn more about installing a cluster in a disconnected environment with the Agent-based installer, see the following procedure:
+
+* xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer]
+endif::openshift-origin[]
+
+[id="installing-aws_{context}"]
+== Installing a cluster on {aws-full}
+
+To learn more about installing a cluster on {aws-first} in a disconnected environment, see the following procedures:
+
+* Installer-provisioned infrastructure: xref:../installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[Installing a cluster on {aws-short} in a restricted network]
+
+* User-provisioned infrastructure: xref:../installing/installing_aws/upi/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[Installing a cluster on {aws-short} in a restricted network with user-provisioned infrastructure]
+
+[id="installing-azure_{context}"]
+== Installing a cluster on {azure-full}
+
+To learn more about installing a cluster on {azure-first} in a disconnected environment, see the following procedures:
+
+* Installer-provisioned infrastructure: xref:../installing/installing_azure/ipi/installing-restricted-networks-azure-installer-provisioned.adoc#installing-restricted-networks-azure-installer-provisioned[Installing a cluster on {azure-short} in a restricted network]
+
+* User-provisioned infrastructure: xref:../installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned.adoc#installing-restricted-networks-azure-user-provisioned[Installing a cluster on {azure-short} in a restricted network with user-provisioned infrastructure]
+
+[id="installing-gcp_{context}"]
+== Installing a cluster on {gcp-full}
+
+To learn more about installing a cluster on {gcp-first} in a disconnected environment, see the following procedures:
+
+* Installer-provisioned infrastructure: xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[Installing a cluster on {gcp-short} in a restricted network]
+
+* User-provisioned infrastructure: xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[Installing a cluster on {gcp-short} in a restricted network with user-provisioned infrastructure]
+
+ifndef::openshift-origin[]
+[id="installing-ibm-cloud_{context}"]
+== Installing a cluster on {ibm-cloud-title}
+
+To learn more about installing a cluster on {ibm-cloud-name} in a disconnected environment, see the following procedure:
+
+* xref:../installing/installing_ibm_cloud/installing-ibm-cloud-restricted.adoc#installing-ibm-cloud-restricted[Installing a cluster on {ibm-cloud-title} in a restricted network]
+endif::openshift-origin[]
+
+[id="installing-nutanix_{context}"]
+== Installing a cluster on Nutanix
+
+To learn more about installing a cluster on Nutanix in a disconnected environment, see the following procedure:
+
+* xref:../installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc#installing-restricted-networks-nutanix-installer-provisioned[Installing a cluster on Nutanix in a restricted network]
+
+[id="installing-baremetal_{context}"]
+== Installing a bare-metal cluster
+
+To learn more about installing a bare-metal cluster in a disconnected environment, see the following procedure:
+
+* xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[Installing a user-provisioned bare metal cluster on a restricted network]
+
+ifndef::openshift-origin[]
+[id="installing-ibm-z_{context}"]
+== Installing a cluster on {ibm-z-name} or {ibm-linuxone-name}
+
+To learn more about installing a cluster on {ibm-z-name} or {ibm-linuxone-name} in a disconnected environment, see the following procedures:
+
+* xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[Installing a cluster with z/VM on {ibm-z-title} and {ibm-linuxone-title} in a restricted network]
+
+* xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[Installing a cluster with {op-system-base} KVM on {ibm-z-title} and {ibm-linuxone-title} in a restricted network]
+
+* xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-lpar.adoc#installing-restricted-networks-ibm-z-lpar[Installing a cluster in an LPAR on {ibm-z-title} and {ibm-linuxone-title} in a restricted network]
+
+[id="installing-ibm-power_{context}"]
+== Installing a cluster on {ibm-power-title}
+
+To learn more about installing a cluster on {ibm-power-title} in a disconnected environment, see the following procedure:
+
+* xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[Installing a cluster on {ibm-power-title} in a restricted network]
+endif::openshift-origin[]
+
+[id="installing-ibm-openstack_{context}"]
+== Installing a cluster on OpenStack
+
+To learn more about installing a cluster on {rh-openstack-first} in a disconnected environment, see the following procedure:
+
+* xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[Installing a cluster on OpenStack in a restricted network]
+
+[id="installing-vsphere_{context}"]
+== Installing a cluster on {vmw-short}
+
+To learn more about installing a cluster on {vmw-first} in a disconnected environment, see the following procedures:
+
+* Installer-provisioned infrastructure: xref:../installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[Installing a cluster on {vmw-short} in a restricted network]
+
+* User-provisioned infrastructure: xref:../installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[Installing a cluster on {vmw-short} in a restricted network with user-provisioned infrastructure]


### PR DESCRIPTION
[OSDOCS-11844](https://issues.redhat.com/browse/OSDOCS-11844)

Version(s): 4.17+

This PR adds a page to the disconnected environments section that points users to all of the various disconnected install procedures.

QE review:
IMO QE is not required due to the fact that this assembly is doing nothing other than linking to existing procedures that they can use to install a disconnected cluster.

Preview: [Installing a cluster in a disconnected environment](https://83459--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing)
