### PR TITLE
Network Observability 1.7 regenerate flows format doc

### DIFF
--- a/modules/network-observability-flows-format.adoc
+++ b/modules/network-observability-flows-format.adoc
@@ -9,140 +9,162 @@ The "Filter ID" column shows which related name to use when defining Quick Filte
 
 The "Loki label" column is useful when querying Loki directly: label fields need to be selected using link:https://grafana.com/docs/loki/latest/logql/log_queries/#log-stream-selector[stream selectors].
 
-The "Cardinality" column gives information about the implied metric cardinality if this field was to be used as a Prometheus label with the `FlowMetric` API. For more information, see the "FlowMetric API reference". 
+The "Cardinality" column contains information about the implied metric cardinality if this field was to be used as a Prometheus label with the `FlowMetrics` API. For more information, see the `FlowMetrics` documentation for more information on using this API.
 
-[cols="1,1,3,1,1,1",options="header"]
+
+[cols="1,1,3,1,1,1,1",options="header"]
 |===
-| Name | Type | Description | Filter ID | Loki label | Cardinality
+| Name | Type | Description | Filter ID | Loki label | Cardinality | OpenTelemetry
 | `Bytes`
 | number
 | Number of bytes
 | n/a
 | no
 | avoid
+| bytes
 | `DnsErrno`
 | number
 | Error number returned from DNS tracker ebpf hook function
 | `dns_errno`
 | no
 | fine
+| dns.errno
 | `DnsFlags`
 | number
 | DNS flags for DNS record
 | n/a
 | no
 | fine
+| dns.flags
 | `DnsFlagsResponseCode`
 | string
 | Parsed DNS header RCODEs name
 | `dns_flag_response_code`
 | no
 | fine
+| dns.responsecode
 | `DnsId`
 | number
 | DNS record id
 | `dns_id`
 | no
 | avoid
+| dns.id
 | `DnsLatencyMs`
 | number
 | Time between a DNS request and response, in milliseconds
 | `dns_latency`
 | no
 | avoid
+| dns.latency
 | `Dscp`
 | number
 | Differentiated Services Code Point (DSCP) value
 | `dscp`
 | no
 | fine
+| dscp
 | `DstAddr`
 | string
 | Destination IP address (ipv4 or ipv6)
 | `dst_address`
 | no
 | avoid
+| destination.address
 | `DstK8S_HostIP`
 | string
 | Destination node IP
 | `dst_host_address`
 | no
 | fine
+| destination.k8s.host.address
 | `DstK8S_HostName`
 | string
 | Destination node name
 | `dst_host_name`
 | no
 | fine
+| destination.k8s.host.name
 | `DstK8S_Name`
 | string
 | Name of the destination Kubernetes object, such as Pod name, Service name or Node name.
 | `dst_name`
 | no
 | careful
+| destination.k8s.name
 | `DstK8S_Namespace`
 | string
 | Destination namespace
 | `dst_namespace`
 | yes
 | fine
+| destination.k8s.namespace.name
 | `DstK8S_OwnerName`
 | string
 | Name of the destination owner, such as Deployment name, StatefulSet name, etc.
 | `dst_owner_name`
 | yes
 | fine
+| destination.k8s.owner.name
 | `DstK8S_OwnerType`
 | string
 | Kind of the destination owner, such as Deployment, StatefulSet, etc.
 | `dst_kind`
 | no
 | fine
+| destination.k8s.owner.kind
 | `DstK8S_Type`
 | string
 | Kind of the destination Kubernetes object, such as Pod, Service or Node.
 | `dst_kind`
 | yes
 | fine
+| destination.k8s.kind
 | `DstK8S_Zone`
 | string
 | Destination availability zone
 | `dst_zone`
 | yes
 | fine
+| destination.zone
 | `DstMac`
 | string
 | Destination MAC address
 | `dst_mac`
 | no
 | avoid
+| destination.mac
 | `DstPort`
 | number
 | Destination port
 | `dst_port`
 | no
 | careful
+| destination.port
 | `DstSubnetLabel`
 | string
 | Destination subnet label
 | `dst_subnet_label`
 | no
 | fine
+| n/a
 | `Duplicate`
 | boolean
 | Indicates if this flow was also captured from another interface on the same host
 | n/a
-| yes
+| no
 | fine
+| n/a
 | `Flags`
 | number
 | Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags to represent the following per-packet combinations: +
 - SYN+ACK (0x100) +
 - FIN+ACK (0x200) +
 - RST+ACK (0x400)
-| n/a
+| `tcp_flags`
 | no
 | fine
+| tcp.flags
 | `FlowDirection`
 | number
 | Flow interpreted direction from the node observation point. Can be one of: +
@@ -152,18 +174,21 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `node_direction`
 | yes
 | fine
+| host.direction
 | `IcmpCode`
 | number
 | ICMP code
 | `icmp_code`
 | no
 | fine
+| icmp.code
 | `IcmpType`
 | number
 | ICMP type
 | `icmp_type`
 | no
 | fine
+| icmp.type
 | `IfDirections`
 | number
 | Flow directions from the network interface observation point. Can be one of: +
@@ -172,172 +197,208 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `ifdirections`
 | no
 | fine
+| interface.directions
 | `Interfaces`
 | string
 | Network interfaces
 | `interfaces`
 | no
 | careful
+| interface.names
 | `K8S_ClusterName`
 | string
 | Cluster name or identifier
 | `cluster_name`
 | yes
 | fine
+| k8s.cluster.name
 | `K8S_FlowLayer`
 | string
 | Flow layer: 'app' or 'infra'
 | `flow_layer`
-| no
+| yes
 | fine
+| k8s.layer
+| `NetworkEvents`
+| string
+| Network events flow monitoring
+| `network_events`
+| no
+| avoid
+| n/a
 | `Packets`
 | number
 | Number of packets
 | n/a
 | no
 | avoid
+| packets
 | `PktDropBytes`
 | number
 | Number of bytes dropped by the kernel
 | n/a
 | no
 | avoid
+| drops.bytes
 | `PktDropLatestDropCause`
 | string
 | Latest drop cause
 | `pkt_drop_cause`
 | no
 | fine
+| drops.latestcause
 | `PktDropLatestFlags`
 | number
 | TCP flags on last dropped packet
 | n/a
 | no
 | fine
+| drops.latestflags
 | `PktDropLatestState`
 | string
 | TCP state on last dropped packet
 | `pkt_drop_state`
 | no
 | fine
+| drops.lateststate
 | `PktDropPackets`
 | number
 | Number of packets dropped by the kernel
 | n/a
 | no
 | avoid
+| drops.packets
 | `Proto`
 | number
 | L4 protocol
 | `protocol`
 | no
 | fine
+| protocol
 | `SrcAddr`
 | string
 | Source IP address (ipv4 or ipv6)
 | `src_address`
 | no
 | avoid
+| source.address
 | `SrcK8S_HostIP`
 | string
 | Source node IP
 | `src_host_address`
 | no
 | fine
+| source.k8s.host.address
 | `SrcK8S_HostName`
 | string
 | Source node name
 | `src_host_name`
 | no
 | fine
+| source.k8s.host.name
 | `SrcK8S_Name`
 | string
 | Name of the source Kubernetes object, such as Pod name, Service name or Node name.
 | `src_name`
 | no
 | careful
+| source.k8s.name
 | `SrcK8S_Namespace`
 | string
 | Source namespace
 | `src_namespace`
 | yes
 | fine
+| source.k8s.namespace.name
 | `SrcK8S_OwnerName`
 | string
 | Name of the source owner, such as Deployment name, StatefulSet name, etc.
 | `src_owner_name`
 | yes
 | fine
+| source.k8s.owner.name
 | `SrcK8S_OwnerType`
 | string
 | Kind of the source owner, such as Deployment, StatefulSet, etc.
 | `src_kind`
 | no
 | fine
+| source.k8s.owner.kind
 | `SrcK8S_Type`
 | string
 | Kind of the source Kubernetes object, such as Pod, Service or Node.
 | `src_kind`
 | yes
 | fine
+| source.k8s.kind
 | `SrcK8S_Zone`
 | string
 | Source availability zone
 | `src_zone`
 | yes
 | fine
+| source.zone
 | `SrcMac`
 | string
 | Source MAC address
 | `src_mac`
 | no
 | avoid
+| source.mac
 | `SrcPort`
 | number
 | Source port
 | `src_port`
 | no
 | careful
+| source.port
 | `SrcSubnetLabel`
 | string
 | Source subnet label
 | `src_subnet_label`
 | no
 | fine
+| n/a
 | `TimeFlowEndMs`
 | number
 | End timestamp of this flow, in milliseconds
 | n/a
 | no
 | avoid
+| timeflowend
 | `TimeFlowRttNs`
 | number
 | TCP Smoothed Round Trip Time (SRTT), in nanoseconds
 | `time_flow_rtt`
 | no
 | avoid
+| tcp.rtt
 | `TimeFlowStartMs`
 | number
 | Start timestamp of this flow, in milliseconds
 | n/a
 | no
 | avoid
+| timeflowstart
 | `TimeReceived`
 | number
 | Timestamp when this flow was received and processed by the flow collector, in seconds
 | n/a
 | no
 | avoid
+| timereceived
 | `_HashId`
 | string
 | In conversation tracking, the conversation identifier
 | `id`
 | no
 | avoid
+| n/a
 | `_RecordType`
 | string
 | Type of record: 'flowLog' for regular flow logs, or 'newConnection', 'heartbeat', 'endConnection' for conversation tracking
 | `type`
 | yes
 | fine
+| n/a
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
https://issues.redhat.com/browse/OSDOCS-11084
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Merge only to `no-1.7`. On GA 10/21/24, Sara will open a branch to integrate `no-1.7` with `main`, and that branch will go to 4.12+.

NOTE to reviewers: The Vale warnings are n/a here because the text its calling out are formatting values, not regular text in a paragraph or step. 
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
