### PR TITLE
CNV#32740: adding guided tour info to getting started page

### DIFF
--- a/virt/getting_started/virt-getting-started.adoc
+++ b/virt/getting_started/virt-getting-started.adoc
@@ -13,6 +13,34 @@ You can explore the features and functionalities of {VirtProductName} by install
 Cluster configuration procedures require `cluster-admin` privileges.
 ====
 
+// Hiding in ROSA/OSD for now - unsure if supported
+ifndef::openshift-rosa,openshift-dedicated[]
+[id="tours-quick-starts_{context}"]
+== Tours and quick starts
+
+You can start exploring {VirtProductName} by taking tours in the {product-title} web console.
+
+[discrete]
+[id="virt-intro-tour_{context}"]
+=== Getting started tour
+
+This short guided tour introduces several key aspects of using {VirtProductName}. There are two ways to start the tour:
+
+* On the *Welcome to {VirtProductName}* dialog, click *Start Tour*.
+* Go to *Virtualization* -> *Overview* -> *Settings* -> *User* -> *Getting started resources* and click *Guided tour*.
+
+[discrete]
+[id="virt-quick-starts_{context}"]
+=== Quick starts
+
+Quick start tours are available for several {VirtProductName} features. To access quick starts, complete the following steps:
+
+. Click the *Help* icon *?* in the menu bar on the header of the {product-title} web console.
+. Select *Quick Starts*. 
+
+You can filter the available tours by entering the keyword `virtualization` in the *Filter* field.
+endif::openshift-rosa,openshift-dedicated[]
+
 [id="planning-and-installing-virt_{context}"]
 == Planning and installing {VirtProductName}
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-32740](https://issues.redhat.com//browse/CNV-32740) 
Note: I think most of the features added in this release were too advanced for a "Getting started" page, but I wanted to propose including this guided tour information (from the RNs) due to its introductory nature.
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83466--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-getting-started.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This doesn't really conform to modular docs requirements, but this is  not something I foresee as being reused elsewhere in the docs, so I think it might ok to leave as-is.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
