### PR TITLE
OCPBUGS-38689: Add section for xpn deletion permissions

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -25,6 +25,13 @@ Ensure that the host project applies one of the following configurations to the 
 * `roles/compute.securityAdmin`
 ====
 
+.Required permissions for deleting firewalls in the host project
+[%collapsible]
+====
+* `compute.firewalls.delete`
+* `compute.networks.updatePolicy`
+====
+
 .Required minimal permissions
 [%collapsible]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
OCPBUGS-38689: Add section for xpn deletion permissions

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18, 4.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-38689

Link to docs preview:
https://83469--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#minimum-required-permissions-ipi-gcp-xpn_installing-gcp-account

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

The docs leave out the permissions for deleting firewalls in a gcp xpn install. The section is added to include the 3 permissions to do so.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
