### PR TITLE
OCPBUGS#28655: Removing core API group from example

### DIFF
--- a/modules/ldap-auto-syncing.adoc
+++ b/modules/ldap-auto-syncing.adoc
@@ -59,7 +59,6 @@ metadata:
   name: ldap-group-syncer
 rules:
   - apiGroups:
-      - ''
       - user.openshift.io
     resources:
       - groups


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-28655

Link to docs preview:
https://83470--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/ldap-syncing.html#ldap-auto-syncing_ldap-syncing-groups

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
