### PR TITLE
OCPBUGS-43331: update release note for 4.15.18

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -3505,11 +3505,20 @@ $ oc adm release info 4.15.18 --pullspecs
 The following enhancements are included in this z-stream release:
 
 [id="ocp-4-15-18-unservable-future-versions-status-condition"]
-===== Introducing the UnservableFutureVersions status condition for SHA1 routes
+===== Blocking upgrades for SHA1 serving certificates on routes and Ingress Controllers
 
-* {product-title} {product-version} does not support SHA1 certificates on routes. Consequently, upgrades from 4.15 to {product-version} causes routes with SHA1 certificates to be rejected.
+* {product-title} {product-version} supports SHA1 certificates on routes, but sets `Upgradeable=False`. Consequently, upgrades from 4.15 to 4.16 cause routes and Ingress Controllers with SHA1 certificates to be rejected.
 +
-This update introduces a new `UnservableInFutureVersions` status condition to routes that contain a SHA1 certificate. Additionally, it adds an `admin-gate` to block upgrades if this new status is present on any route. As a result, if cluster administrators have routes that use SHA1 certificates in {product-title} 4.15, they must either upgrade these certificates to a support algorithm or provide an `admin-ack` for the created `admin-gate`. This `admin-ack` allows administrators to proceed with the upgrade without resolving the SHA1 certificate issues, even though the routes will be rejected. (link:https://issues.redhat.com/browse/OCPBUGS-28928[*OCPBUGS-28928*]).
+Only serving certificates are affected. For routes, this is the certificate specified in `spec.tls.certificate`. For Ingress Controllers, this is the serving certificate in the secret specified in `spec.defaultCertificate`. CA certificates using SHA1 are not impacted. However, due to link:https://issues.redhat.com/browse/OCPBUGS-42480[*OCPBUGS-42480*], some Ingress Controllers were incorrectly blocking upgrades if the serving certificate was not using SHA1, but the CA certificate was. To resolve this, upgrade to version 4.15.37 to receive this bug fix.
++
+Additionally, this update introduces a new `UnservableInFutureVersions` status condition to routes that contain a SHA1 certificate. It also adds an `admin-gate` to block upgrades if this new status is present on any route. As a result, if cluster administrators have routes that use SHA1 certificates in {product-title} 4.15, they must either upgrade these certificates to a supported algorithm or provide an `admin-ack` for the created `admin-gate`. This `admin-ack` allows administrators to proceed with the upgrade without resolving the SHA1 certificate issues, even though the routes will be rejected. The full `admin-ack` command is:
++
+[source,terminal]
+----
+$ oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.15-route-config-not-supported-in-4.16":"true"}}' --type=merge
+----
++
+(link:https://issues.redhat.com/browse/OCPBUGS-28928[*OCPBUGS-28928*]).
 
 [id="ocp-4-15-18-password-colon-character"]
 ===== Allowing pull secret passwords to contain a colon character


### PR DESCRIPTION
Version(s):
4.15.18 

Issue:
[OCPBUGS-43331](https://issues.redhat.com/browse/OCPBUGS-43331)

Link to docs preview:
https://83474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-18-unservable-future-versions-status-condition

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
