### PR TITLE
OSDOCS12296 Improve VPA Operator performance tuning section with baseline recommendations

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-configuring.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-configuring.adoc
@@ -8,6 +8,8 @@
 
 You can use the Vertical Pod Autoscaler Operator (VPA) by creating a VPA custom resource (CR). The CR indicates which pods it should analyze and determines the actions the VPA should take with those pods.
 
+You can use the VPA to scale built-in resources such as deployments or stateful sets, and custom resources that manage pods. For more information on using the VPA with custom resources, see "Using the Vertical Pod Autoscaler Operator with Custom Resources."
+
 .Prerequisites
 
 * The workload object that you want to autoscale must exist.

--- a/modules/nodes-pods-vertical-autoscaler-custom-resource.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-custom-resource.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-vertical-autoscaler.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nodes-pods-vertical-autoscaler-custom-resource_{context}"]
+= Example custom resources for the Vertical Pod Autoscaler
+
+The Vertical Pod Autoscaler Operator (VPA) can update not only built-in resources such as deployments or stateful sets, but also custom resources that manage pods.
+
+In order to use the VPA with a custom resource, when you create the the `CustomResourceDefinition` (CRD) object, you must configure the `labelSelectorPath` field in the `/scale` subresource. The `/scale` subresource creates a `Scale` object. The `labelSelectorPath` field defines the JSON path inside the custom resource that corresponds to `Status.Selector` in the `Scale` object and in the custom resource. The following is an example of a `CustomResourceDefinition` and a `CustomResource` that fulfills these requirements, along with a `VerticalPodAutoscaler` definition that targets the custom resource. The following example shows the `/scale` subresource contract. 
+
+[NOTE]
+====
+This example does not result in the VPA scaling pods because there is no controller for the custom resource that allows it to own any pods. As such, you must write a controller in a language supported by Kubernetes to manage the reconciliation and state management between the custom resource and your pods. The example illustrates the configuration for the VPA to understand the custom resource as scalable.
+====
+
+.Example custom CRD, CR
+[source,yaml]
+----
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: scalablepods.testing.openshift.io
+spec:
+  group: testing.openshift.io
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              replicas:
+                type: integer
+                minimum: 0
+              selector:
+                type: string
+          status:
+            type: object
+            properties:
+              replicas:
+                type: integer
+    subresources:
+      status: {}
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+        labelSelectorPath: .spec.selector <1>
+  scope: Namespaced
+  names:
+    plural: scalablepods
+    singular: scalablepod
+    kind: ScalablePod
+    shortNames:
+    - spod
+----
+<1> Specifies the JSON path that corresponds to `status.selector` field of the custom resource object.
+
+.Example custom CR 
+[source,yaml]
+----
+apiVersion: testing.openshift.io/v1
+kind: ScalablePod
+metadata:
+  name: scalable-cr
+  namespace: default
+spec:
+  selector: "app=scalable-cr" <1>
+  replicas: 1
+----
+<1> Specify the label type to apply to managed pods. This is the field referenced by the `labelSelectorPath` in the custom resource definition object.
+
+.Example VPA object
+[source,yaml]
+----
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: scalable-cr
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: testing.openshift.io/v1
+    kind: ScalablePod
+    name: scalable-cr
+  updatePolicy:
+    updateMode: "Auto"
+----

--- a/modules/nodes-pods-vertical-autoscaler-tuning.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-tuning.adoc
@@ -20,7 +20,167 @@ You can perform the following tunings on the VPA components by editing the `Vert
 
 * To configure the VPA Operator to monitor only workloads that are being managed by a VPA CR, set the `memory-saver` parameter to `true` for the recommender component.
 
-The following example VPA controller CR sets the VPA API QPS and burts rates, configures the component pod resource requests, and sets `memory-saver` to `true` for the recommender:
+For guidelines on the resources and rate limits that you could set for each VPA component, the following tables provide recommended baseline values, depending on the size of your cluster and other factors. 
+
+[IMPORTANT]
+====
+These recommended values were derived from internal Red{nbsp}Hat testing on clusters that are not necessarily representative of real-world clusters. You should test these values in a non-production cluster before configuring a production cluster.
+====
+
+.Requests by containers in the cluster
+[cols="1,1,1,1,1,1,1,1,1,5,5"]
+|===
+| Component 2+| 1-500 containers 2+| 500-1000 containers 2+| 1000-2000 containers 2+| 2000-4000 containers 2+| 4000+ containers
+
+| 
+| *CPU*
+| *Memory*
+| *CPU*
+| *Memory*
+| *CPU*
+| *Memory*
+| *CPU*
+| *Memory*
+| *CPU*
+| *Memory*
+
+s| Admission 
+| 25m 
+| 50Mi
+| 25m 
+| 75Mi 
+| 40m 
+| 150Mi 
+| 75m 
+| 260Mi 
+| (0.03c)/2 + 10 ^[1]^
+| (0.1c)/2 + 50 ^[1]^
+
+s| Recommender
+| 25m
+| 100Mi
+| 50m
+| 160Mi
+| 75m
+| 275Mi
+| 120m
+| 420Mi
+| (0.05c)/2 + 50 ^[1]^
+| (0.15c)/2 + 120 ^[1]^
+
+s| Updater
+| 25m
+| 100Mi
+| 50m
+| 220Mi
+| 80m
+| 350Mi
+| 150m
+| 500Mi
+| (0.07c)/2 + 20 ^[1]^
+| (0.15c)/2 + 200 ^[1]^
+
+|===
+[.small]
+. `c` is the number of containers in the cluster.
+
+[NOTE]
+====
+It is recommended that you set the memory limit on your containers to at least double the recommended requests in the table. However, because CPU is a compressible resource, setting CPU limits for containers can throttle the VPA. As such, it is recommended that you do not set a CPU limit on your containers.
+====
+
+.Rate limits by VPAs in the cluster
+[cols="1,3,2,3,2,3,2,3,2"]
+|===
+| Component 2+| 1 - 150 VPAs 2+| 151 - 500 VPAs 2+| 501-2000 VPAs 2+| 2001-4000 VPAs
+
+| 
+| *QPS Limit* ^[1]^
+| *Burst* ^[2]^
+| *QPS Limit*
+| *Burst*
+| *QPS Limit*
+| *Burst*
+| *QPS Limit*
+| *Burst*
+
+s| Recommender
+| 5
+| 10
+| 30
+| 60
+| 60
+| 120
+| 120
+| 240
+
+s| Updater
+| 5
+| 10
+| 30
+| 60
+| 60
+| 120
+| 120
+| 240
+
+|===
+[.small]
+. QPS specifies the queries per second (QPS) limit when making requests to Kubernetes API server. The default for the updater and recommender pods is `5.0`. 
+. Burst specifies the burst limit when making requests to Kubernetes API server. The default for the updater and recommender pods is `10.0`.
+
+[NOTE]
+====
+If you have more than 4000 VPAs in your cluster, it is recommended that you start performance tuning with the values in the table and slowly increase the values until you achieve the desired recommender and updater latency and performance. You should adjust these values slowly because increased QPS and Burst could affect the cluster health and slow down the Kubernetes API server if too many API requests are being sent to the API server from the VPA components.
+====
+
+////
+Hiding these two NOTEs as not supported. These and the the above should be sub-bullets for "If you have more than 4000 VPAs in your cluster, note the following recommendations:".
+** It is recommended that you increase the recommender and updater interval, which is how often the VPA fetches pod metrics. However, with the longer intervals, the Operator takes longer to recommend and restart pods. The example `VerticalPodAutoscalerController` CR that follows includes the parameters to increase the intervals.
+** If you increase the `recommender-interval` value, it is recommended that you also increase the `checkpoints-timeout` value, which configures the timeout for writing VPA checkpoints after the start of the recommender interval. It is recommended that you set the timeout to the same value `recommender-interval` so that the recommender pod has time to write checkpoints before the next interval. The example `VerticalPodAutoscalerController` CR that follows includes the parameters to increase the timeout.
+////
+
+////
+Hiding as autoscaling custom resources not supported
+.Admission Rate limits (by custom resource pod creation surge)
+[options="header"]
+|===
+| Component 2+| 1-25 CR pod creation surge ^[1]^ 2+| 26-50 CR pod creation surge 2+| 50+ CR pod creation surge
+
+| 
+| *QPS Limit* ^[2]^
+| *Burst* ^[3]^
+| *QPS Limit*
+| *Burst*
+| *QPS Limit*
+| *Burst*
+
+s| Admission
+| 25
+| 50
+| 50
+| 100
+| Pod Surge / 2
+| Pod Surge
+
+|===
+[.small]
+. _Pod creation surge_ refers to the maximum number of pods that you expect to be created in a single second at any given time.
+. QPS specifies the queries per second (QPS) limit when making requests to Kubernetes API server. The default is `5.0`. 
+. Burst specifies the burst limit when making requests to Kubernetes API server. The default is `10.0`.
+
+[NOTE]
+====
+The admission pod can get throttled if you are using the VPA on custom resources.
+====
+////
+
+The following example VPA controller CR is for a cluster with 1000 to 2000 containers and a pod creation surge of 26 to 50. The CR sets the following values: 
+
+* The container memory and CPU requests for all three VPA components
+* The container memory limit for all three VPA components
+* The QPS and burst rates for all three VPA components
+* The `memory-saver` parameter to `true` for the VPA recommender component
 
 .Example `VerticalPodAutoscalerController` CR
 [source,yaml]
@@ -35,31 +195,37 @@ spec:
     admission: <1>
       container:
         args: <2>
-          - '--kube-api-qps=30.0'
-          - '--kube-api-burst=40.0'
+          - '--kube-api-qps=50.0'
+          - '--kube-api-burst=100.0'
         resources:
           requests: <3>
             cpu: 40m
-            memory: 40Mi
+            memory: 150Mi
+          limits:
+            memory: 300Mi            
     recommender: <4>
       container:
         args:
-          - '--kube-api-qps=20.0'
-          - '--kube-api-burst=60.0'
+          - '--kube-api-qps=60.0'
+          - '--kube-api-burst=120.0'
           - '--memory-saver=true' <5>
         resources:
           requests:
-            cpu: 60m
-            memory: 60Mi
+            cpu: 75m
+            memory: 275Mi
+          limits:
+            memory: 550Mi
     updater: <6>
       container:
         args:
-          - '--kube-api-qps=20.0'
-          - '--kube-api-burst=80.0'
+          - '--kube-api-qps=60.0'
+          - '--kube-api-burst=120.0'
         resources:
           requests:
             cpu: 80m
-            memory: 80Mi
+            memory: 350M
+          limits:
+            memory: 700Mi
   minReplicas: 2
   podMinCPUMillicores: 25
   podMinMemoryMb: 250
@@ -73,10 +239,20 @@ spec:
 * `kube-api-qps`: Specifies the queries per second (QPS) limit when making requests to Kubernetes API server. The default is `5.0`.
 * `kube-api-burst`: Specifies the burst limit when making requests to Kubernetes API server. The default is `10.0`.
 --
-<3> Specifies the CPU and memory requests for the VPA admission controller pod.
+<3> Specifies the resource requests and limits for the VPA admission controller pod.
 <4> Specifies the tuning parameters for the VPA recommender.
 <5> Specifies that the VPA Operator monitors only workloads with a VPA CR. The default is `false`.
 <6> Specifies the tuning parameters for the VPA updater.
+
+////
+Hiding these three callouts as not supported
+<5> Specifies how often the VPA should collect the container metrics for the recommender pod. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`. The default is one minute.
+<6> Specifies the timeout for writing VPA checkpoints after the start of the recommender interval. If you increase the `recommender-interval` value, it is recommended setting this value to the same value. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`. The default is one minute.
+<9> Specifies how often the VPA should collect the container metrics for the updater pod. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`. The default is one minute. 
+          - '--recommender-interval=2m' <5>
+          - '--checkpoints-timeout=' <6>
+          - '--updater-interval=30m0s' <9>
+////
 
 You can verify that the settings were applied to each VPA component pod.
 
@@ -95,13 +271,13 @@ spec:
     - --logtostderr
     - --v=1
     - --min-replicas=2
-    - --kube-api-qps=20.0
-    - --kube-api-burst=80.0
+    - --kube-api-qps=60.0
+    - --kube-api-burst=120.0
 # ...
     resources:
       requests:
         cpu: 80m
-        memory: 80Mi
+        memory: 350M
 # ...
 ----
 
@@ -123,13 +299,13 @@ spec:
     - --tls-private-key=/data/tls-certs/tls.key
     - --client-ca-file=/data/tls-ca-certs/service-ca.crt
     - --webhook-timeout-seconds=10
-    - --kube-api-qps=30.0
-    - --kube-api-burst=40.0
+    - --kube-api-qps=50.0
+    - --kube-api-burst=100.0
 # ...
     resources:
       requests:
         cpu: 40m
-        memory: 40Mi
+        memory: 150Mi
 # ...
 ----
 
@@ -150,13 +326,13 @@ spec:
     - --recommendation-margin-fraction=0.15
     - --pod-recommendation-min-cpu-millicores=25
     - --pod-recommendation-min-memory-mb=250
-    - --kube-api-qps=20.0
-    - --kube-api-burst=60.0
+    - --kube-api-qps=60.0
+    - --kube-api-burst=120.0
     - --memory-saver=true
 # ...
     resources:
       requests:
-        cpu: 60m
-        memory: 60Mi
+        cpu: 75m
+        memory: 275Mi
 # ...
 ----

--- a/nodes/pods/nodes-pods-vertical-autoscaler.adoc
+++ b/nodes/pods/nodes-pods-vertical-autoscaler.adoc
@@ -8,7 +8,17 @@ toc::[]
 
 
 
-The {product-title} Vertical Pod Autoscaler Operator (VPA) automatically reviews the historic and current CPU and memory resources for containers in pods and can update the resource limits and requests based on the usage values it learns. The VPA uses individual custom resources (CR) to update all of the pods associated with a workload object, such as a `Deployment`, `DeploymentConfig`, `StatefulSet`, `Job`, `DaemonSet`, `ReplicaSet`, or `ReplicationController`, in a project.
+The {product-title} Vertical Pod Autoscaler Operator (VPA) automatically reviews the historic and current CPU and memory resources for containers in pods and can update the resource limits and requests based on the usage values it learns. The VPA uses individual custom resources (CR) to update all of the pods in a project that are associated with any built-in workload objects, including the following object types: 
+
+* `Deployment`
+* `DeploymentConfig`
+* `StatefulSet`
+* `Job`
+* `DaemonSet`
+* `ReplicaSet`
+* `ReplicationController`
+
+The VPA can also update certain custom resource object that manage pods, as described in xref:../../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vertical-autoscaler-custom-resource_nodes-pods-vertical-autoscaler[Using the Vertical Pod Autoscaler Operator with Custom Resources].
 
 The VPA helps you to understand the optimal CPU and memory usage for your pods and can automatically maintain pod resources through the pod lifecycle.
 
@@ -35,5 +45,7 @@ include::modules/nodes-pods-vertical-autoscaler-tuning.adoc[leveloffset=+2]
 include::modules/nodes-pods-vertical-autoscaler-custom.adoc[leveloffset=+2]
 
 include::modules/nodes-pods-vertical-autoscaler-configuring.adoc[leveloffset=+1]
+
+include::modules/nodes-pods-vertical-autoscaler-custom-resource.adoc[leveloffset=+2]
 
 include::modules/nodes-pods-vertical-autoscaler-uninstall.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-12296

QE Jira for testing the autoscaling of a CR: https://issues.redhat.com/browse/PODAUTO-249

**PEER REVIEW** There are multiple places that I commented-out, as we decided that some aspects of the dev work is not fully complete. Feel free to skip the peer review of those sections at this time. 

[Automatically adjust pod resource levels with the vertical pod autoscaler](https://83475--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html) -- Added second paragraph with link.
[Using the Vertical Pod Autoscaler Operator on a Custom Resource](https://83475--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-custom-resource_nodes-pods-vertical-autoscaler) -- New module.
[Performance tuning the VPA Operator](https://83475--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-tuning_nodes-pods-vertical-autoscaler) -- New text and tables from _If you are not sure about the initial resources and Kubernetes API rate limits_ to _The following example VPA controller CR_...

Change management:
- [x] Gaurav Singh
- [x] Eric Rich
- [x] Xiaoli Tan
- [x] Matt Werner
- [x] Russell Teague