### PR TITLE
OSDOCS-12300: 4.13.52 z-stream RN

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4400,6 +4400,36 @@ $ oc adm release info 4.13.51 --pullspecs
 
 * Previously, Open vSwitch (OVS) could function by using older configurations after a cluster upgrade operations. These older configurations might have caused issues for networking components that interact with OVS. With this release, OVS is restarted after an upgrade operation so that OVS is forced to receive the latest configurations. (link:https://issues.redhat.com/browse/OCPBUGS-41723[*OCPBUGS-41723*])
 
+
 [id="ocp-4-13-51-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.13.52
+[id="ocp-4-13-52"]
+=== RHSA-2024:7939 - {product-title} 4.13.52 bug fix and security updates
+
+Issued: 16 October 2024
+
+{product-title} release 4.13.52, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:7939[RHSA-2024:7939] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7941[RHSA-2024:7941] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.52 --pullspecs
+----
+
+[id="ocp-4-13-52-bug-fixes"]
+==== Bug fixes
+
+* Previously, a group ID was not added to the `/etc/group` in the container when the `spec.securityContext.runAsGroup` attribute was set in the pod resource. With this release, this issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-41247[*OCPBUGS-41247*])
+
+* Previously, enabling FIPS for a cluster causes SR-IOV device plugin pods to fail. With this release, SR-IOV device plugin pods have FIPS enabled so that when you enable FIPS for the cluster, the pods do not fail. (link:https://issues.redhat.com/browse/OCPBUGS-23018[*OCPBUGS-23018*])
+
+[id="ocp-4-13-52-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-12300](https://issues.redhat.com/browse/OSDOCS-12300)

Link to docs preview:
[4.13.52](https://83478--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-52)

QE review:
- N/A

Additional information:
- Errata URLs will return 404 until go-live (10/16)
- The merge request for this PR for today is due to this [information](https://docs.google.com/document/d/1i8X-YzyrJMFA5504d0uX2wyIcgthq2J8K3NIHIHMzno/edit#bookmark=kix.k7evyj1yp2m8). Each advisory can also be checked, if needed.