### PR TITLE
Update the admonition for the supported backup storage providers

### DIFF
--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -21,13 +21,12 @@ The following AWS S3 compatible object storage providers are fully supported by 
 * Ceph RADOS Gateway (Ceph Object Gateway)
 * Red Hat Container Storage
 * {odf-full}
+* Google Cloud Platform (GCP)
+* Microsoft Azure
 
 [NOTE]
 ====
-The following compatible object storage providers are supported and have their own Velero object store plugins:
-
-* Google Cloud Platform (GCP)
-* Microsoft Azure
+Google Cloud Platform (GCP) and Microsoft Azure have their own Velero object store plugins.
 ====
 
 [id="oadp-s3-compatible-backup-storage-providers-unsupported"]


### PR DESCRIPTION
Version(s):
OCP 4.13 → OCP 4.17

Issue:
[OADP-4012](https://issues.redhat.com/browse/OADP-4012)

Link to docs preview:
https://83479--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-s3-compatible-backup-storage-providers-supported

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

