### PR TITLE
OCPBUGS#43325: Updated the Networking requirement vSphere doc to corr…

### DIFF
--- a/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
+++ b/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
@@ -25,11 +25,13 @@ For a cluster that contains user-provisioned infrastructure, you must deploy all
 
 This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
 
+// vCenter requirements
 include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere_creating-machineset-vsphere[Creating a compute machine set on vSphere]
+* xref: ../installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc#installation-network-user-infra_upi-vsphere-installation-reqs[Networking requirements for user-provisioned infrastructure]
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -801,25 +801,26 @@ Available resources vary between clusters. The number of possible clusters withi
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-networking_{context}"]
 == Networking requirements
-Use Dynamic Host Configuration Protocol (DHCP) for the network and ensure that the DHCP server is configured to provide persistent IP addresses to the cluster machines.
+
+You can use Dynamic Host Configuration Protocol (DHCP) for the network and configure the DHCP server to set persistent IP addresses to machines in your cluster. In the DHCP lease, you must configure the DHCP to use the default gateway.
 
 [NOTE]
 ====
 You do not need to use the DHCP for the network if you want to provision nodes with static IP addresses.
 ====
 
-Configure the default gateway to use the DHCP server. All nodes must be in the same VLAN. You cannot scale the cluster using a second VLAN as a Day 2 operation.
-
-You must use the Dynamic Host Configuration Protocol (DHCP) for the network and ensure that the DHCP server is configured to provide persistent IP addresses to the cluster machines. In the DHCP lease, you must configure the DHCP to use the default gateway. All nodes must be in the same VLAN. You cannot scale the cluster using a second VLAN as a Day 2 operation.
+ifdef::upi[]
+If you specify nodes or groups of nodes on different VLANs for a cluster that you want to install on user-provisioned infrastructure, you must ensure that machines in your cluster meet the requirements outlined in the "Network connectivity requirements" section of the _Networking requirements for user-provisioned infrastructure_ document.
+endif::upi[]
 
 If you are installing to a restricted environment, the VM in your restricted network must have access to vCenter so that it can provision and manage nodes, persistent volume claims (PVCs), and other resources.
 
-Additionally, you must create the following networking resources before you install the {product-title} cluster:
-
 [NOTE]
 ====
-It is recommended that each {product-title} node in the cluster must have access to a Network Time Protocol (NTP) server that is discoverable via DHCP. Installation is possible without an NTP server. However, asynchronous server clocks will cause errors, which NTP server prevents.
+Ensure that each {product-title} node in the cluster has access to a Network Time Protocol (NTP) server that is discoverable by DHCP. Installation is possible without an NTP server. However, asynchronous server clocks can cause errors, which the NTP server prevents.
 ====
+
+Additionally, you must create the following networking resources before you install the {product-title} cluster:
 
 ifndef::upi[]
 [discrete]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-43325](https://issues.redhat.com/browse/OCPBUGS-43325)

Link to docs preview:
* [Networking requirements IPI - VLAN statement excluded](https://83510--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html#vsphere-csi-driver-reqs_ipi-vsphere-installation-reqs)
* [Networking requirements UPI - VLAN statement included](https://83510--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html#installation-vsphere-installer-infra-requirements_upi-vsphere-installation-reqs)

- [x] SME has approved this change (Simone Massimo Zucchi).
- [x] QE has approved this change (Wenxin Wei).


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
