### PR TITLE
Add release note for VolumeDetachTimeout configuration on ROSA with HCP

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 [id="rosa-q4-2024_{context}"]
 === Q4 2024
 
+* **`VolumeDetachTimeout` configuration applied to machine pools for {hcp-title}.** ROSA is applying a `VolumeDetachTimeout` configuration of 5 minutes to all machine pools. This prevents issues with node deletion when volumes fail to detach. This only applies to {hcp-title}.
+
 * **Configure machine pool disk volume for {hcp-title} clusters.** You can now configure the disk volume size for machine pools in {hcp-title} clusters. The default disk size is 300 GiB, and you can configure it from a minimum of 75 GiB to a maximum of 16,384 GiB. For more information, see xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#configuring-machine-pool-disk-volume_rosa-managing-worker-nodes[Configuring machine pool disk volume].
 
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12338

Link to docs preview:
https://83517--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html#rosa-q4-2024_rosa-whats-new

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
