### PR TITLE
OSDOCS-12340:updating the links in storage section

### DIFF
--- a/modules/microshift-control-permissions-security-context-constraints.adoc
+++ b/modules/microshift-control-permissions-security-context-constraints.adoc
@@ -8,7 +8,7 @@
 
 You can use security context constraints (SCCs) to control permissions for the pods in your cluster. These permissions determine the actions that a pod can perform and what resources it can access. You can use SCCs to define a set of conditions that a pod must run with to be accepted into the system.
 
-For more information see link:https://docs.openshift.com/container-platform/4.16/authentication/managing-security-context-constraints.html[Managing security context constraints].
+For more information see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/authentication_and_authorization/managing-pod-security-policies[Managing security context constraints].
 
 [IMPORTANT]
 ====

--- a/modules/microshift-updating-pods-mismatch.adoc
+++ b/modules/microshift-updating-pods-mismatch.adoc
@@ -10,7 +10,7 @@ Update the SELinux context of the pods if a mismatch is found by using the follo
 
 .Procedure
 
-. When there is a mismatch of the SELinux content, create a new security context constraint (SCC) and assign it to both pods. To create a SCC, see link:https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html#security-context-constraints-creating_configuring-internal-oauth[Creating security context constraints].
+. When there is a mismatch of the SELinux content, create a new security context constraint (SCC) and assign it to both pods. To create a SCC, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/authentication_and_authorization/managing-pod-security-policies#security-context-constraints-creating_configuring-internal-oauth[Creating security context constraints].
 . Update the SELinux context as shown in the following example:
 +
 .Example output


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-12340](https://issues.redhat.com/browse/OSDOCS-12340)

Link to docs preview:
[Control permissions with security context constraints](https://83567--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html#microshift-control-permissions-security-context-constraints_understanding-persistent-storage-microshift)
[Updating the pods which have mismatch](https://83567--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html#microshift-updating-pods-mismatch_understanding-persistent-storage-microshift)

QE review:
- NA as only links are modified. Technical content is not modified.
