### PR TITLE
[enterprise-4.16] OCPBUGS#43358: Fix OSDK upgrade details in 4.16

### DIFF
--- a/modules/osdk-updating-128-to-131.adoc
+++ b/modules/osdk-updating-128-to-131.adoc
@@ -40,39 +40,41 @@ The following procedure updates an existing {type}-based Operator project for co
 
 .Procedure
 
-ifdef::golang,hybrid,java[]
-* Edit your Operator project's makefile to update the Operator SDK version to {osdk_ver}, as shown in the following example:
+. Edit your Operator project's Makefile to update the Operator SDK version to `v{osdk_ver}-ocp`, as shown in the following example:
 +
-.Example makefile
+.Example Makefile
 [source,make,subs="attributes+"]
 ----
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v{osdk_ver} <1>
+OPERATOR_SDK_VERSION ?= v{osdk_ver}-ocp
 ----
-<1> Change the version from `{osdk_ver_n1}` to `{osdk_ver}`.
-endif::[]
+
+. Find the `ose-kube-rbac-proxy` pull spec in the following files, and update the image tag to `v{product-version}`:
++
+--
+* `config/default/manager_auth_proxy_patch.yaml`
+* `bundle/manifests/memcached-operator.clusterserviceversion.yaml`
+--
++
+.Example `ose-kube-rbac-proxy` pull spec with `v{product-version}` image tag
+[source,yaml,subs="attributes+"]
+----
+# ...
+      containers:
+      - name: kube-rbac-proxy
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v{product-version}
+# ...
+----
 
 ifdef::helm[]
-. Edit your Operator's Dockerfile to update the Helm Operator version to {osdk_ver}, as shown in the following example:
+. Edit your Operator's Dockerfile to update the Helm Operator version to `v{product-version}`, as shown in the following example:
 +
 .Example Dockerfile
 [source,docker,subs="attributes+"]
 ----
-FROM quay.io/operator-framework/helm-operator:v{osdk_ver} <1>
+FROM registry.redhat.io/openshift4/ose-helm-operator:v{product-version}
 ----
-<1> Update the Helm Operator version from `{osdk_ver_n1}` to `{osdk_ver}`
-
-. Edit your Operator project's makefile to update the Operator SDK to {osdk_ver}, as shown in the following example:
-+
-.Example makefile
-[source,make,subs="attributes+"]
-----
-# Set the Operator SDK version to use. By default, what is installed on the system is used.
-# This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v{osdk_ver} <1>
-----
-<1> Change the version from `{osdk_ver_n1}` to `{osdk_ver}`.
 
 . If you use a custom service account for deployment, define the following role to require a watch operation on your secrets resource, as shown in the following example:
 +
@@ -106,12 +108,12 @@ ifdef::ansible[]
 
 . Make the following changes to your Operator's Dockerfile:
 
-.. Replace the `ansible-operator-2.11-preview` base image with the `ansible-operator` base image and update the version to {osdk_ver}, as shown in the following example:
+.. Replace the `ansible-operator-2.11-preview` base image with the Ansible Operator base image and update the version to `v{product-version}`, as shown in the following example:
 +
 .Example Dockerfile
 [source,docker,subs="attributes+"]
 ----
-FROM quay.io/operator-framework/ansible-operator:v{osdk_ver}
+FROM registry.redhat.io/openshift4/ose-ansible-operator:v{product-version}
 ----
 
 .. The update to Ansible 2.15.0 in version 1.30.0 of the Ansible Operator removed the following preinstalled Python modules:
@@ -124,18 +126,7 @@ FROM quay.io/operator-framework/ansible-operator:v{osdk_ver}
 * `oauthlib`
 --
 +
-If your Operator depends on one of these removed Python modules, update your Dockerfile to install the required modules using the `pip install` command.
-
-. Edit your Operator project's makefile to update the Operator SDK version to {osdk_ver}, as shown in the following example:
-+
-.Example makefile
-[source,make,subs="attributes+"]
-----
-# Set the Operator SDK version to use. By default, what is installed on the system is used.
-# This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v{osdk_ver} <1>
-----
-<1> Change the version from `{osdk_ver_n1}` to `{osdk_ver}`.
+If your Operator depends on one of these removed Python modules, update your Dockerfile to install the required modules by running the `pip install` command.
 
 . Update your `requirements.yaml` and `requirements.go` files to remove the `community.kubernetes` collection and update the `operator_sdk.util` collection to version `0.5.0`, as shown in the following example:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-43358

4.16

* Changes pull spec references from the upstream image to the downstream image (i.e., `quay.io` images -> `registry.redhat.io` images)
* Add back the `ose-kube-rbac-proxy` image step 
* Add `-ocp` suffix to `OPERATOR_SDK_VERSION` value

Preview:

* [Ansible](https://83581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-updating-projects.html#osdk-upgrading-projects_osdk-ansible-updating-projects)
* [Helm](https://83581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-updating-projects.html)