### PR TITLE
[enterprise-4.17] OCPBUGS#43395: Add ose-kube-rbac-proxy-rhel9 step to OSDK upgrade 4.17

### DIFF
--- a/modules/osdk-updating-131-to-1361.adoc
+++ b/modules/osdk-updating-131-to-1361.adoc
@@ -42,16 +42,33 @@ The following procedure updates an existing {type}-based Operator project for co
 
 // The following few steps should be retained/updated for each new migration procedure, as they're just bumping the OSDK version for each language type.
 
-. Edit your Operator project's Makefile to update the Operator SDK version to {osdk_ver}, as shown in the following example:
+. Edit your Operator project's Makefile to update the Operator SDK version to `v{osdk_ver}-ocp`, as shown in the following example:
 +
 .Example Makefile
 [source,make,subs="attributes+"]
 ----
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v{osdk_ver} <1>
+OPERATOR_SDK_VERSION ?= v{osdk_ver}-ocp
 ----
-<1> Change the version from `{osdk_ver_n1}` to `{osdk_ver}`.
+
+. Find the `ose-kube-rbac-proxy` pull spec in the following files, and update the image tag to `v{product-version}`:
++
+--
+* `config/default/manager_auth_proxy_patch.yaml`
+* `bundle/manifests/memcached-operator.clusterserviceversion.yaml`
+--
++
+.Example `ose-kube-rbac-proxy` pull spec with `v{product-version}` image tag
+[source,yaml,subs="attributes+"]
+----
+# ...
+      containers:
+      - name: kube-rbac-proxy
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v{product-version}
+# ...
+----
+
 ifdef::helm[]
 . Edit your Operator's Dockerfile to update the `ose-helm-rhel9-operator` image tag to `{product-version}`, as shown in the following example:
 +
@@ -116,16 +133,6 @@ sigs.k8s.io/controller-runtime v0.17.3
 ----
 $ go mod tidy
 ----
-
-ifdef::golang,hybrid[]
-.. Projects are now scaffolded with `kube-rbac-proxy` version `0.16.0`. Modify the version of `kube-rbac-proxy` in the scaffolded `config/default/manager_auth_proxy_patch.yaml` file by making the following changes:
-+
-[source,diff]
-----
-- gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
-+ gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
-----
-endif::[]
 
 ifdef::golang[]
 .. You can now generate a file that contains all the resources built with Kustomize, which are necessary to install this project without its dependencies. Update your Makefile by making the following changes:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-43395

4.17

* Add `ose-kube-rbac-proxy-rhel9` image step
* Add `-ocp` suffix to `OPERATOR_SDK_VERSION` value

NOTE: `{product-version}` will render as `4.17` on the `enterprise-4.17` branch when it is merged and published. It will show as `Branch Build` only during PR preview stage.

Preview: https://83587--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-updating-projects#osdk-upgrading-projects_osdk-golang-updating-projects 