### PR TITLE
[enterprise-4.17] OSDOCS#12352: Update OSDK 4.17 Ansible migration to use ose-ansible-rhel9-operator

### DIFF
--- a/modules/osdk-updating-131-to-1361.adoc
+++ b/modules/osdk-updating-131-to-1361.adoc
@@ -62,12 +62,12 @@ FROM registry.redhat.io/openshift4/ose-helm-rhel9-operator:v{product-version}
 ----
 endif::[]
 ifdef::ansible[]
-. Edit your Operator's Dockerfile to update the `ose-ansible-operator` image tag to `{product-version}`, as shown in the following example:
+. Edit your Operator's Dockerfile to update the `ose-ansible-rhel9-operator` image tag to `{product-version}`, as shown in the following example:
 +
 .Example Dockerfile
 [source,docker,subs="attributes+"]
 ----
-FROM registry.redhat.io/openshift4/ose-ansible-operator:v{product-version}
+FROM registry.redhat.io/openshift4/ose-ansible-rhel9-operator:v{product-version}
 ----
 endif::[]
 ifdef::golang,hybrid[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-12352

4.17

NOTE: `{product-version}` will render as `4.17` on the `enterprise-4.17` branch when it is merged and published. It will show as `Branch Build` only during PR preview stage.


Preview: https://83588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-updating-projects#osdk-upgrading-projects_osdk-ansible-updating-projects