### PR TITLE
OSDOCS-12297:Added WIF as auth type in create cluster on GCP workflow.

### DIFF
--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -101,10 +101,17 @@ ifdef::osd-on-aws[]
 endif::osd-on-aws[]
 ifdef::osd-on-gcp[]
 . Select *Run on Google Cloud Platform*.
+. Select either *Service account* or *Workload Identity Federation* as the Authentication type.
++
+[NOTE]
+====
+For more information about authentication types, click the question icon located next to *Authentication type*.
+====
++
 endif::osd-on-gcp[]
 
-. After selecting your cloud provider, review and complete the listed *Prerequisites*. Select the checkbox to acknowledge that you have read and completed all of the prerequisites.
-
+. Review and complete the listed *Prerequisites*.
+. Select the checkbox to acknowledge that you have read and completed all of the prerequisites.
 ifdef::osd-on-aws[]
 . Provide your AWS account details:
 .. Enter your *AWS account ID*.
@@ -122,7 +129,19 @@ Some AWS SCPs can cause the installation to fail, even if you have the required 
 ====
 endif::osd-on-aws[]
 ifdef::osd-on-gcp[]
-. Provide your GCP service account private key in JSON format. You can either click *Browse* to locate and attach a JSON file or add the details in the *Service account JSON* field.
+. If you selected *Service account* as the Authentication type, provide your GCP service account private key in JSON format. You can either click *Browse* to locate and attach a JSON file or add the details in the *Service account JSON* field.
+. If you selected *Workload Identity Federation* as the Authentication type, you will first need to create a new WIF configuration.
+Open a terminal window and run the following `ocm` CLI command.
++
+[source,terminal]
+----
+$ ocm gcp create wif-config --name <wif_name> \ <1>
+  --project <gcp_project_id> <2>
+----
+<1> Replace `<wif_name>` with the name of your WIF configuration.
+<2> Replace `<gcp_project_id>` with the ID of the {GCP} project where the WIF configuration will be implemented.
+
+. Select a configured WIF configuration from the *WIF configuration* drop-down list. If you want to select the WIF configuration you created in the last step, click *Refresh* first.
 endif::osd-on-gcp[]
 
 . Click *Next* to validate your cloud provider account and go to the *Cluster details* page.
@@ -133,6 +152,14 @@ endif::osd-on-gcp[]
 +
 To customize the subdomain, select the *Create customize domain prefix* checkbox, and enter your domain prefix name in the *Domain prefix* field. The domain prefix cannot be longer than 15 characters, must be unique within your organization, and cannot be changed after cluster creation.
 .. Select a cluster version from the *Version* drop-down menu.
+ifdef::osd-on-gcp[]
++
+[NOTE]
+====
+Workload Identity Federation (WIF) is only supported on {product-title} version 4.17 and later.
+====
++
+endif::osd-on-gcp[]
 .. Select a cloud provider region from the *Region* drop-down menu.
 .. Select a *Single zone* or *Multi-zone* configuration.
 +
@@ -218,7 +245,14 @@ For more information regarding IMDS, see link:https://docs.aws.amazon.com/AWSEC2
 endif::osd-on-aws[]
 
 . Optional: Expand *Edit node labels* to add labels to your nodes. Click *Add label* to add more node labels and select *Next*.
-
+ifdef::osd-on-gcp[]
++
+[IMPORTANT]
+====
+This step refers to labels within Kubernetes, not Google Cloud. For more information regarding Kubernetes labels, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[Labels and Selectors].
+====
++
+endif::osd-on-gcp[]
 . On the *Network configuration* page, select *Public* or *Private* to use either public or private API endpoints and application routes for your cluster.
 +
 [IMPORTANT]

--- a/modules/osd-create-cluster-gcp-account.adoc
+++ b/modules/osd-create-cluster-gcp-account.adoc
@@ -19,22 +19,42 @@ When creating an {product-title} (OSD) cluster on Google Cloud through the OpenS
 .. From the drop-down menu, select *Google Cloud Marketplace*.
 .. Select the *Customer Cloud Subscription* infrastructure type.
 .. Click *Next*.
-. On the *Cloud provider* page, read the provided prerequisites and the Google terms and conditions. Add your service account key.
-.. Click the *Review Google Terms and Agreements* link.
-.. To continue creating the cluster, click the checkbox indicating that you agree to the Google terms and agreements.
-.. Add your service account key.
+. On the *Cloud provider* page, select *Run on Google Cloud Platform*.
+. Select either *Service account* or *Workload Identity Federation* as the Authentication type.
 +
 [NOTE]
 ====
-For more information about service account keys, click the information icon located next to *Service account key*.
+For more information about authentication types, click the question icon located next to *Authentication type*.
 ====
-.. Click *Next* to validate your cloud provider account and go to the *Cluster details* page.
++
+. Review and complete the listed *Prerequisites*.
+. Select the checkbox to acknowledge that you have read and completed all of the prerequisites.
+. If you selected *Service account* as the Authentication type, provide your GCP service account private key in JSON format. You can either click *Browse* to locate and attach a JSON file or add the details in the *Service account JSON* field.
+. If you selected *Workload Identity Federation* as the Authentication type, you will first need to create a new WIF configuration.
+Open a terminal window and run the following `ocm` CLI command.
++
+[source,terminal]
+----
+$ ocm gcp create wif-config --name <wif_name> \ <1>
+  --project <gcp_project_id> <2>
+----
+<1> Replace `<wif_name>` with the name of your WIF configuration.
+<2> Replace `<gcp_project_id>` with the ID of the {GCP} project where the WIF configuration will be implemented.
++
+. Select a configured WIF configuration from the *WIF configuration* drop-down list. If you want to select the WIF configuration you created in the last step, click *Refresh* first.
+. Click *Next* to validate your cloud provider account and go to the *Cluster details* page.
 . On the *Cluster details* page, provide a name for your cluster and specify the cluster details:
 .. Add a *Cluster name*.
 .. Optional: Cluster creation generates a domain prefix as a subdomain for your provisioned cluster on `openshiftapps.com`. If the cluster name is less than or equal to 15 characters, that name is used for the domain prefix. If the cluster name is longer than 15 characters, the domain prefix is randomly generated as a 15-character string.
 +
 To customize the subdomain, select the *Create custom domain prefix* checkbox, and enter your domain prefix name in the *Domain prefix* field. The domain prefix cannot be longer than 15 characters, must be unique within your organization, and cannot be changed after cluster creation.
 .. Select a cluster version from the *Version* drop-down menu.
++
+[NOTE]
+====
+Workload Identity Federation (WIF) is only supported on {product-title} version 4.17 and later.
+====
++
 .. Select a cloud provider region from the *Region* drop-down menu.
 .. Select a *Single zone* or *Multi-zone* configuration.
 +
@@ -79,7 +99,7 @@ By enabling etcd encryption for the key values in etcd, you incur a performance 
 +
 . Click *Next*.
 
-. On the *Machine pool* page, select a *Compute node instance type* and a *Compute node count*. The number and types of nodes that are available depend on your {product-title} subscription. If you are using multiple availability zones, the compute node count is per zone.
+. On the *Dafault machine pool* page, select a *Compute node instance type* and a *Compute node count*. The number and types of nodes that are available depend on your {product-title} subscription. If you are using multiple availability zones, the compute node count is per zone.
 +
 [NOTE]
 ====
@@ -87,7 +107,12 @@ After your cluster is created, you can change the number of compute nodes, but y
 ====
 
 . Optional: Expand *Add node labels* to add labels to your nodes. Click *Add additional label* to add more node labels.
-
++
+[IMPORTANT]
+====
+This step refers to labels within Kubernetes, not Google Cloud. For more information regarding Kubernetes labels, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[Labels and Selectors].
+====
++
 . Click *Next*.
 
 . In the *Cluster privacy* dialog, select *Public* or *Private* to use either public or private API endpoints and application routes for your cluster.

--- a/modules/osd-create-cluster-rhm-gcp-account.adoc
+++ b/modules/osd-create-cluster-rhm-gcp-account.adoc
@@ -19,15 +19,29 @@ OSD pricing is consumption-based and customers are billed directly through their
 .. Select the *On-Demand* subscription type.
 .. From the drop-down menu, select *Red Hat Marketplace*.
 .. Click *Next*.
-. On the *Cloud provider* page:
-.. Select *Google Cloud* as your cloud provider.
-.. Click the checkbox indicating that you have read and completed all the prerequisites necessary to continue creating your cluster.
-.. Add your service account key.
+. On the *Cloud provider* page, select *Run on Google Cloud Platform*.
+. Select either *Service account* or *Workload Identity Federation* as the Authentication type.
 +
 [NOTE]
 ====
-For more information about service account keys, click the information icon located next to *Service account key*.
+For more information about authentication types, click the question icon located next to *Authentication type*.
 ====
++
+. Review and complete the listed *Prerequisites*.
+. Select the checkbox to acknowledge that you have read and completed all of the prerequisites.
+. If you selected *Service account* as the Authentication type, provide your GCP service account private key in JSON format. You can either click *Browse* to locate and attach a JSON file or add the details in the *Service account JSON* field.
+. If you selected *Workload Identity Federation* as the Authentication type, you will first need to create a new WIF configuration.
+Open a terminal window and run the following `ocm` CLI command.
++
+[source,terminal]
+----
+$ ocm gcp create wif-config --name <wif_name> \ <1>
+  --project <gcp_project_id> <2>
+----
+<1> Replace `<wif_name>` with the name of your WIF configuration.
+<2> Replace `<gcp_project_id>` with the ID of the {GCP} project where the WIF configuration will be implemented.
++
+. Select a configured WIF configuration from the *WIF configuration* drop-down list. If you want to select the WIF configuration you created in the last step, click *Refresh* first.
 .. Click *Next* to validate your cloud provider account and go to the *Cluster details* page.
 . On the *Cluster details* page, provide a name for your cluster and specify the cluster details:
 .. Add a *Cluster name*.
@@ -35,6 +49,12 @@ For more information about service account keys, click the information icon loca
 +
 To customize the subdomain, select the *Create custom domain prefix* checkbox, and enter your domain prefix name in the *Domain prefix* field. The domain prefix cannot be longer than 15 characters, must be unique within your organization, and cannot be changed after cluster creation.
 .. Select a cluster version from the *Version* drop-down menu.
++
+[NOTE]
+====
+Workload Identity Federation (WIF) is only supported on {product-title} version 4.17 and later.
+====
++
 .. Select a cloud provider region from the *Region* drop-down menu.
 .. Select a *Single zone* or *Multi-zone* configuration.
 +
@@ -79,7 +99,7 @@ By enabling etcd encryption for the key values in etcd, you incur a performance 
 +
 . Click *Next*.
 
-. On the *Machine pool* page, select a *Compute node instance type* and a *Compute node count*. The number and types of nodes that are available depend on your {product-title} subscription. If you are using multiple availability zones, the compute node count is per zone.
+. On the *Default machine pool* page, select a *Compute node instance type* and a *Compute node count*. The number and types of nodes that are available depend on your {product-title} subscription. If you are using multiple availability zones, the compute node count is per zone.
 +
 [NOTE]
 ====
@@ -87,7 +107,12 @@ After your cluster is created, you can change the number of compute nodes, but y
 ====
 
 . Optional: Expand *Add node labels* to add labels to your nodes. Click *Add additional label* to add more node labels.
-
++
+[IMPORTANT]
+====
+This step refers to labels within Kubernetes, not Google Cloud. For more information regarding Kubernetes labels, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[Labels and Selectors].
+====
++
 . Click *Next*.
 
 . In the *Cluster privacy* dialog, select *Public* or *Private* to use either public or private API endpoints and application routes for your cluster.


### PR DESCRIPTION
This PR adds information about WIF as an authentication type for GCP with CCS clusters. It also refreshes some other parts of the docs so that they are up to date with the current UI design.

Version(s):
4.17+

Issue:
[OSDOCS-12297](https://issues.redhat.com/browse/OSDOCS-12297)

Link to docs preview:
- [Creating a cluster on GCP with Red Hat Marketplace](https://83595--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-cluster-rhm-gcp-account_osd-creating-a-cluster-on-gcp)
- [Creating a cluster on GCP with CCS](https://83595--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp)
- [Creating a cluster on GCP with Google Cloud Marketplace](https://83595--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-cluster-gcp-account_osd-creating-a-cluster-on-gcp)
- [Creating a cluster on AWS with CCS](https://83595--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-an-aws-cluster#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change. 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
