### PR TITLE
Fix formatting problem on docs.rh due to bad ids

### DIFF
--- a/modules/coo-logging-ui-plugin-install.adoc
+++ b/modules/coo-logging-ui-plugin-install.adoc
@@ -10,7 +10,7 @@
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You have logged in to the {product-title} web console.
 * You have installed the {coo-full}.
-* You have a `LokiStack` instance in you cluster.
+* You have a `LokiStack` instance in your cluster.
 
 
 .Procedure

--- a/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.adoc
@@ -12,7 +12,7 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 You can use the {coo-first} to install and manage UI plugins to enhance the observability capabilities of the {product-title} web console.
 The plugins extend the default functionality, providing new UI features for monitoring, troubleshooting, distributed tracing, and cluster logging.
 
-["dashboards_{context}"]
+[id="dashboards_{context}"]
 == Dashboards
 
 The dashboard UI plugin supports enhanced dashboards in the {product-title} web console at *Observe* -> *Dashboards*.
@@ -21,7 +21,7 @@ This results in a unified observability experience across different data sources
 
 For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/dashboard-ui-plugin.adoc#dashboard-ui-plugin[dashboard UI plugin] page.
 
-["troubleshooting_{context}"]
+[id="troubleshooting_{context}"]
 == Troubleshooting
 
 The troubleshooting panel UI plugin for {product-title} version 4.16+ provides observability signal correlation, powered by the open source Korrel8r project.
@@ -32,7 +32,7 @@ The output of Korrel8r is displayed as an interactive node graph. When you click
 
 For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin.adoc#troubleshooting-ui-plugin[troubleshooting UI plugin] page.
 
-["distributed-tracing_{context}"]
+[id="distributed-tracing_{context}"]
 == Distributed tracing
 
 The distributed tracing UI plugin adds tracing-related features to the web console on the *Observe* -> *Traces* page.
@@ -42,7 +42,7 @@ You can select a supported `TempoStack` or `TempoMonolithic` multi-tenant instan
 For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc#distributed-tracing-ui-plugin[distributed tracing UI plugin] page.
 
 
-["cluster-logging_{context}"]
+[id="cluster-logging_{context}"]
 == Cluster logging
 
 The logging UI plugin surfaces logging data in the web console on the  *Observe* -> *Logs* page. 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-1421](https://issues.redhat.com//browse/OBSDOCS-1421)

Link to docs preview:
https://83600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.html

QE review:
Not required

Additional information:
This PR is mainly to fix a problem on docs.redhat, where the misformed ids cause a formatting problem - this does not happen on docs.openshift, so the preview is irrelevant 
