### PR TITLE
TELCODOCS-2065 -  PTP events API v1 is deprecated release - note update

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -831,7 +831,8 @@ For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k
 
 A new PTP fast events O-RAN Release 3 compliant REST API version 2 is available.
 Now, you can develop PTP event consumer applications that receive host hardware PTP events directly from the PTP Operator-managed pod.
-The PTP fast events REST API v1 will be deprecated in a future release.
+
+The PTP events REST API v1 and PTP events consumer application sidecar is deprecated.
 
 [NOTE]
 ====
@@ -1396,6 +1397,10 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Removed
 
+|PTP events REST API v1 and PTP events consumer application sidecar
+|General Availability
+|General Availability
+|Deprecated
 |====
 
 
@@ -2910,7 +2915,7 @@ $ oc adm release info 4.17.1 --pullspecs
 
 * Previously, on the *Developer* perspective on the {product-title} web console, when you navigated to *Observe* > *Metrics*, two *Metrics* tabs existed. With this release, the duplicate tab is removed and now exists in the `openshift-monitoring/monitoring-plugin` application that serves the *Metrics* tabs on the web console. (link:https://issues.redhat.com/browse/OCPBUGS-38462[*OCPBUGS-38462*])
 
-* Previously, the `manila-csi-driver` and node registrar pods had missing healthchecks because of a configuration issue. With this release, the health checks are now added to both of these resources. (link:https://issues.redhat.com/browse/OCPBUGS-38457[*OCPBUGS-38457*]) 
+* Previously, the `manila-csi-driver` and node registrar pods had missing healthchecks because of a configuration issue. With this release, the health checks are now added to both of these resources. (link:https://issues.redhat.com/browse/OCPBUGS-38457[*OCPBUGS-38457*])
 
 * Previously, updating the `additionalTrustBundle` parameter in a {hcp} cluster configuration did not get applied to compute nodes. With this release, a fix ensures that updates to the `additionalTrustBundle` parameter automatically apply to compute nodes that exist in your {hcp} cluster. (link:https://issues.redhat.com/browse/OCPBUGS-36680[*OCPBUGS-36680*])
 
@@ -2948,7 +2953,7 @@ $ oc adm release info 4.17.0 --pullspecs
 [id="ocp-4-17-0-known-issues_{context}"]
 ==== Known issues
 
-* When the `globallyDisableIrqLoadBalancing` field is set to `true` in the `PerformanceProfile` object, the isolated CPUs are listed in the `IRQBALANCE_BANNED_CPULIST` variable instead of the `IRQBALANCE_BANNED_CPUS` variable. However, changing the value of the `globallyDisableIrqLoadBalancing` field from `true` to `false` does not update the `IRQBALANCE_BANNED_CPULIST` variable correctly. As a result, the number of CPUs available for load rebalancing does not increase, as the isolated CPUs remain in the `IRQBALANCE_BANNED_CPULIST` variable. 
+* When the `globallyDisableIrqLoadBalancing` field is set to `true` in the `PerformanceProfile` object, the isolated CPUs are listed in the `IRQBALANCE_BANNED_CPULIST` variable instead of the `IRQBALANCE_BANNED_CPUS` variable. However, changing the value of the `globallyDisableIrqLoadBalancing` field from `true` to `false` does not update the `IRQBALANCE_BANNED_CPULIST` variable correctly. As a result, the number of CPUs available for load rebalancing does not increase, as the isolated CPUs remain in the `IRQBALANCE_BANNED_CPULIST` variable.
 +
 [NOTE]
 ====


### PR DESCRIPTION
ORAN PTP events REST API v1 is deprecated in 4.17

Related: https://github.com/openshift/openshift-docs/pull/83611

Version(s):
enterprise-4.17

Issue:
https://issues.redhat.com/browse/TELCODOCS-2065

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
