### PR TITLE
DOCS-1319 - docs.openshift.com is going away banner

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -59,20 +59,21 @@
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
     <ol class="breadcrumb hide-for-print">
-      <% if (!["openshift-webscale", "openshift-dpu", "openshift-lightspeed", "openshift-service-mesh", "openshift-origin"].include?(distro_key) 
-        || (unsupported_versions.include?(version) ||
-            unsupported_versions_acs.include?(version) ||
-            unsupported_versions_pipelines.include?(version) ||
-            unsupported_versions_serverless.include?(version) ||
-            unsupported_versions_builds.include?(version) ||
-            unsupported_versions_gitops.include?(version) ||
-            unsupported_versions_origin.include?(version)
-            )
-        )
+      <% 
+        unsupported = (unsupported_versions.include?(version) ||
+                      unsupported_versions_acs.include?(version) ||
+                      unsupported_versions_builds.include?(version) ||
+                      unsupported_versions_gitops.include?(version) ||
+                      unsupported_versions_origin.include?(version)
+                      unsupported_versions_pipelines.include?(version) ||
+                      unsupported_versions_serverless.include?(version)
+                      );
+
+        if (!["openshift-webscale", "openshift-dpu", "openshift-lightspeed", "openshift-service-mesh", "openshift-origin"].include?(distro_key) || unsupported)
       %>
       <span>
         <div class="alert alert-info" role="primary" id="support-info">
-          <strong>Soon, all Red Hat OpenShift documentation will only be available on <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>, the official location of all Red Hat product documentation.</strong> Get familiar with the updated experience today!
+          <strong>OpenShift docs are moving and will soon only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>, the home of all Red Hat product documentation. Explore the <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">new docs experience</a> today.</strong>
         </div>
       </span>
       <% end %>


### PR DESCRIPTION
Issue:
https://issues.redhat.com/browse/DOCS-1319

Link to docs preview:
https://83634--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/

