### PR TITLE
OCPBUGS#23204: clarifying agent wwn parameter

### DIFF
--- a/modules/agent-install-ipi-install-root-device-hints.adoc
+++ b/modules/agent-install-ipi-install-root-device-hints.adoc
@@ -10,6 +10,7 @@ The `rootDeviceHints` parameter enables the installer to provision the {op-syste
 
 .Subfields
 
+[cols="1,3"]
 |===
 | Subfield | Description
 
@@ -26,6 +27,7 @@ The `rootDeviceHints` parameter enables the installer to provision the {op-syste
 | `minSizeGigabytes` | An integer representing the minimum size of the device in gigabytes.
 
 | `wwn` | A string containing the unique storage identifier. The hint must match the actual value exactly.
+If you use the `udevadm` command to retrieve the `wwn` value, and the command outputs a value for `ID_WWN_WITH_EXTENSION`, then you must use this value to specify the `wwn` subfield.
 
 | `rotational` | A boolean indicating whether the device should be a rotating disk (true) or not (false).
 


### PR DESCRIPTION
[OCPBUGS-23204](https://issues.redhat.com/browse/OCPBUGS-23204)

Version(s): 4.12+

This PR adds a clarification about which value you must use for the `wwn` subfield of the `rootDeviceHint` parameter.

QE review:
- [x] QE has approved this change.

Preview: [About root device hints](https://83637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#root-device-hints_preparing-to-install-with-agent-based-installer)