### PR TITLE
fixing missing additional resources in Agent PXE doc

### DIFF
--- a/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
+++ b/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
@@ -45,6 +45,7 @@ include::modules/configuring-network-overrides-ibmz.adoc[leveloffset=+2]
 include::modules/installing-ocp-agent-ibm-z-zvm.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+.Additional resources
 
 * xref:../../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[Installing a cluster with z/VM on {ibm-z-title} and {ibm-linuxone-title}]
 


### PR DESCRIPTION
Version(s): 4.16+

This PR simply adds a missing additional resources title in the Agent docs

QE review: N/A

Preview: [Adding IBM Z agents with z/VM](https://83645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.html#installing-ocp-agent-ibm-z-zvm_prepare-pxe-assets-agent)