### PR TITLE
[OCPBUGS-41344] Update minor version of RHEL 8 for worker node

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy OpenShift clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.6-8.9 as well as on {op-system-first} 4.12.
+{product-title} {product-version} is supported on {op-system-base-full} 8.6 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version} 4.12.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
CONFIRMED WITH DPM THAT NO QE IS NEEDED.

Jira: 
[OCPBUGS-41344](https://issues.redhat.com/browse/OCPBUGS-41344)

Version(s):
OpenShift Version: 4.12

Issue:
Updated the RHEL8 versions for worker nodes in release notes for RHOCP4.12 

Link to docs preview:
[About this release](https://83652--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-about-this-release)

- [x] SME has approved this change (Scott Dodson).

