### PR TITLE
logging-about section, bad indent in CLF YAML file

### DIFF
--- a/observability/logging/logging-6.0/log6x-about.adoc
+++ b/observability/logging/logging-6.0/log6x-about.adoc
@@ -148,9 +148,9 @@ spec:
       target:
         name: logging-loki
         namespace: openshift-logging
-    authentication:
-      token:
-        from: serviceAccount
+      authentication:
+        token:
+          from: serviceAccount
     tls:
       ca:
         key: service-ca.crt


### PR DESCRIPTION
[OSDOCS#1426]: Logging quick-start, fix bad indent in CLF YAML file

Version(s): OCP 4.16-4.17, logging 6.0.0

Issue: https://issues.redhat.com/browse/OBSDOCS-1426