### PR TITLE
[OCPBUGS-41344] Update minor version of RHEL 8 for worker node

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.6, 8.7, and 8.8 as well as on {op-system-first} 4.14.
+{product-title} {product-version} is supported on {op-system-base-full} 8.6 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported  on {op-system-first} {product-version}.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
NO QE NEEDED. CONFIRMED WITH DPM.

Jira: 
https://issues.redhat.com/browse/OCPBUGS-41344

Version(s):
OpenShift Version: 4.14

Issue:
Updated the RHEL8 versions for worker nodes in release notes for RHOCP4.14 

Link to docs preview:
[About this release](https://83659--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-about-this-release)

- [x] SME has approved this change (Scott Dodson).

