### PR TITLE
OSDOCS-12308: adds drop-in config release note

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -17,7 +17,6 @@ Version {product-version} of {microshift-short} includes new features and enhanc
 
 You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
 
-//TODO: Update OP system versions
 {microshift-short} {product-version} is supported on {op-system-base-full} 9.4.
 
 For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
@@ -28,24 +27,28 @@ For lifecycle information, see the link:https://access.redhat.com/product-life-c
 This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s
-[id="microshift-4-18-rhel_{context}"]
-=== {op-system-base-full}
-* {microshift-short} {product-version} runs on {op-system-base-full} 9.4.
+//[id="microshift-4-18-rhel_{context}"]
+//=== {op-system-base-full}
+//Image mode for RHEL here if GA; otherwise leave in TP
 
 [id="microshift-4-18-updating_{context}"]
 === Updating
-Updating two minor versions in a single step is supported in 4.18. Updates for both single-version minor releases and patch releases are still supported.
+Updating two minor EUS versions in a single step is supported in 4.18. Updates for both single-version minor releases and patch releases are also supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
 
 //TODO add new features and enhancements as needed, L4 [discrete] headings
 
 //[id="microshift-4-18-installation_{context}"]
 //=== Installation
 
-//[id="microshift-4-18-configuring_{context}"]
-//=== Configuring
+[id="microshift-4-18-configuring_{context}"]
+=== Configuring
 
-[id="microshift-4-18-networking_{context}"]
-=== Networking
+[id="microshift-4-18-drop-in-config_{context}"]
+==== Drop-in configuration snippets now available
+With this release, make configuring your {microshift-short} instances easier by using drop-in configuration snippets. See xref:../microshift_configuring/microshift-using-config-yaml.adoc#microshift-config-snippets_microshift-configuring[Using configuration snippets] for details.
+
+//[id="microshift-4-18-networking_{context}"]
+//=== Networking
 
 //[id="microshift-4-18-ingress-controller_{context}"]
 //==== Ingress controller for the router included


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12308](https://issues.redhat.com/browse/OSDOCS-12308)

Link to docs preview:
[drop-in config release note](https://83660--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Feature work, https://github.com/openshift/openshift-docs/pull/83366

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
