### PR TITLE
Adds the z-stream version in which the limited live migration proc is…

### DIFF
--- a/modules/nw-ovn-kubernetes-live-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration-about.adoc
@@ -5,7 +5,13 @@
 [id="nw-ovn-kubernetes-live-migration-about_{context}"]
 = Limited live migration to the OVN-Kubernetes network plugin overview
 
-The limited live migration method is the process in which the OpenShift SDN network plugin and its network configurations, connections, and associated resources, are migrated to the OVN-Kubernetes network plugin without service interruption. It is available for {product-title}.
+The limited live migration method is the process in which the OpenShift SDN network plugin and its network configurations, connections, and associated resources, are migrated to the OVN-Kubernetes network plugin without service interruption. For {product-title} 4.15, it is available for versions 4.15.31 and later.
+
+[IMPORTANT]
+====
+Before you migrate your {product-title} cluster to use the OVN-Kubernetes network plugin, update your cluster to the latest z-stream release so that all the latest bug fixes apply to your cluster.
+====
+
 // Azure Red Hat OpenShift deployment types will needed added in .z stream.
 It is not available for hosted control plane deployment types. This migration method is valuable for deployment types that require constant service availability and offers the following benefits:
 
@@ -30,16 +36,25 @@ The following table provides information about the supported platforms for the l
 |===
 | Platform              | Limited Live Migration
 
-| Bare metal hardware (IPI and UPI)             |&#10003;
-| Amazon Web Services (AWS) (IPI and UPI)       |&#10003;
-| Google Cloud Platform (GCP) (IPI and UPI)     |&#10003;
-| {ibm-cloud-name} (IPI and UPI)                |&#10003;
-| Microsoft Azure (IPI and UPI)                 |&#10003;
-| {rh-openstack-first} (IPI and UPI)            |&#10003;
-| VMware vSphere (IPI and UPI)                  |&#10003;
-| AliCloud (UPI)                                |&#10003;
-| Nutanix (IPI and UPI)                         |&#10003;
+| Bare-metal hardware   |&#10003;
+| {aws-first}           |&#10003;
+| {gcp-first}           |&#10003;
+| {ibm-cloud-name}      |&#10003;
+| {azure-first}         |&#10003;
+| {rh-openstack-first}  |&#10003;
+| {vmw-first}           |&#10003;
+| Nutanix               |&#10003;
 |===
+
+[NOTE]
+====
+Each listed platform supports installing an {product-title} cluster on installer-provisioned infrastructure and user-provisioned infrastructure.
+====
+
+[id="best-practices-live-migrating-ovn-kubernetes-network-provider_{context}"]
+== Best practices for limited live migration to the OVN-Kubernetes network plugin
+
+For a list of best practices when migrating to the OVN-Kubernetes network plugin with the limited live migration method, see link:https://access.redhat.com/solutions/7057169[Limited Live Migration from OpenShift SDN to OVN-Kubernetes].
 
 [id="considerations-live-migrating-ovn-kubernetes-network-provider_{context}"]
 == Considerations for limited live migration to the OVN-Kubernetes network plugin


### PR DESCRIPTION
PR is a size medium because it copies the 4.16 module from https://raw.githubusercontent.com/openshift/openshift-docs/refs/heads/enterprise-4.16/modules/nw-ovn-kubernetes-live-migration-about.adoc. The 4.16 module had changes in it that were missed during the manual cherry pick from https://github.com/openshift/openshift-docs/pull/81120. This is a whole confusing thing, so PM me if you have questions.

This PR only adds the following line, as far as net new content goes: 

For {product-title} version 4.15, it is available for versions 4.15.31 and later.

The rest of the changes were already peer reviewed several times. It's just pulling that content from 4.16 into 4.15. 

Version(s):
4.15

Issue:
https://github.com/openshift/openshift-docs/pull/83666

Link to docs preview:
https://83666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-live-migration-about_migrate-from-openshift-sdn

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
