### PR TITLE
ROX-26652: update scanner OS support

### DIFF
--- a/modules/scanning-images.adoc
+++ b/modules/scanning-images.adoc
@@ -68,45 +68,6 @@ IMPORTANT: If you are using a Red{nbsp}Hat link:https://catalog.redhat.com/softw
 
 |===
 
-[id="supported-package-formats_{context}"]
-== Supported package formats
-
-Scanner can check for vulnerabilities in images that use the following package formats:
-
-* apt
-* apk
-* dpkg
-* rpm
-
-[id="supported-programming-languages_{context}"]
-== Supported programming languages
-
-Scanner can check for vulnerabilities in dependencies for the following programming languages:
-
-* Go (Scanner V4 only)
-** Binaries: The standard library version used to build the binary is analyzed. If the binaries are built with module support (go.mod), then the dependencies are also analyzed.
-* Java
-** JAR
-** WAR
-** EAR
-* JavaScript
-** Node.js
-** npm package.json
-* Python
-** egg and wheel formats
-* Ruby
-** gem
-
-[id="supported-runtimes-frameworks_{context}"]
-== Supported runtimes and frameworks
-
-Beginning from {product-title} 3.0.50 (Scanner version 2.5.0), the StackRox Scanner identifies vulnerabilities in the following developer platforms:
-
-* .NET Core
-* ASP.NET Core
-
-These are not supported by Scanner V4.
-
 [id="supported-operating-systems_{context}"]
 == Supported operating systems
 
@@ -114,6 +75,7 @@ The supported platforms listed in this section are the distributions in which Sc
 
 Scanner identifies vulnerabilities in images that contain the following Linux distributions. For more information about the vulnerability databases used, see "Vulnerability sources" in "{product-title-short} Architecture".
 
+[cols="1,3",options="header"]
 |===
 | Distribution | Version
 
@@ -127,7 +89,10 @@ Scanner identifies vulnerabilities in images that contain the following Linux di
 | `centos:6`^[1]^, `centos:7`^[1]^, `centos:8`^[1]^
 
 | link:https://www.debian.org/releases/[Debian]
-| `debian:10`, `debian:11`, `debian:12`, `debian:unstable`^[1]^, `distroless`
+| `debian:11`, `debian:12`, `debian:unstable`^[1]^, link:https://github.com/GoogleContainerTools/distroless[`Distroless`]
+
+The following vulnerability sources are not updated by the vendor:
+`debian:8`^[1]^, `debian:9`^[1]^, `debian:10`^[1]^
 
 | link:https://www.oracle.com/linux/[Oracle Linux]
 | `ol:5`^[2]^, `ol:6`^[2]^, `ol:7`^[2]^, `ol:8`^[2]^, `ol:9`^[2]^
@@ -142,10 +107,10 @@ Scanner identifies vulnerabilities in images that contain the following Linux di
 | `sles:11`^[2]^, `sles:12`^[2]^, `sles:15`^[2]^, `opensuse-leap:15.0`^[2]^, `opensuse-leap:15.1`^[2]^
 
 | link:http://releases.ubuntu.com/[Ubuntu]
-| `ubuntu:14.04`, `ubuntu:16.04`, `ubuntu:18.04`, `ubuntu:20.04`,`ubuntu:22.04`, `ubuntu:23.10`, `ubuntu:24.04`
+| `ubuntu:14.04`, `ubuntu:16.04`, `ubuntu:18.04`, `ubuntu:20.04`, `ubuntu:22.04`, `ubuntu:24.04`, `ubuntu:24.10`
 
 The following vulnerability sources are not updated by the vendor:
-`ubuntu:12.04`, `ubuntu:12.10`, `ubuntu:13.04`, `ubuntu:14.10`, `ubuntu:15.04`, `ubuntu::15.10`, `ubuntu::16.10`, `ubuntu:17.04`, `ubuntu:17.10`, `ubuntu:18.10`, `ubuntu:19.04`, `ubuntu:19.10`, `ubuntu:20.10`, `ubuntu:21.04`, `ubuntu:21.10`, `ubuntu:22.10`, `ubuntu:23.04`, `debian:8`^[1]^, `debian:9`^[1]^, `debian:10`^[1]^
+`ubuntu:12.04`^[1]^, `ubuntu:12.10`^[1]^, `ubuntu:13.04`^[1]^, `ubuntu:14.10`^[1]^, `ubuntu:15.04`^[1]^, `ubuntu::15.10`^[1]^, `ubuntu::16.10`^[1]^, `ubuntu:17.04`^[1]^, `ubuntu:17.10`^[1]^, `ubuntu:18.10`^[1]^, `ubuntu:19.04`^[1]^, `ubuntu:19.10`^[1]^, `ubuntu:20.10`^[1]^, `ubuntu:21.04`^[1]^, `ubuntu:21.10`^[1]^, `ubuntu:22.10`^[1]^, `ubuntu:23.04`^[1]^, `ubuntu:23.10`^[1]^
 |===
 . Only supported in the StackRox Scanner.
 . Only supported in Scanner V4.
@@ -153,6 +118,61 @@ The following vulnerability sources are not updated by the vendor:
 
 [NOTE]
 ====
-* Scanner does not support the Fedora operating system because Fedora does not maintain a vulnerability database.
+Scanner does not support the Fedora operating system because Fedora does not maintain a vulnerability database.
 However, Scanner still detects language-specific vulnerabilities in Fedora-based images.
 ====
+
+[id="supported-package-formats_{context}"]
+== Supported package formats
+
+Scanner can check for vulnerabilities in images that use the following package formats:
+
+[cols="2",options="header"]
+|===
+| Package format | Package managers
+
+| apk
+| apk
+
+| dpkg
+| apt, dpkg
+
+| rpm
+| dnf, microdnf, rpm, yum
+|===
+
+[id="supported-programming-languages_{context}"]
+== Supported programming languages
+
+Scanner can check for vulnerabilities in dependencies for the following programming languages:
+
+[cols="1,3",options="header"]
+|===
+| Programming language | Package format
+
+| Go^[1]^
+| Binaries: The standard library version used to build the binary is analyzed. If the binaries are built with module support (go.mod), then the dependencies are also analyzed.
+
+| Java
+| JAR, WAR, EAR, JPI, HPI
+
+| JavaScript
+| package.json
+
+| Python
+| egg, wheel
+
+| Ruby
+| gem
+|===
+. Only supported in Scanner V4.
+
+[id="supported-runtimes-frameworks_{context}"]
+== Supported runtimes and frameworks
+
+Beginning from {product-title} 3.0.50 (Scanner version 2.5.0), the StackRox Scanner identifies vulnerabilities in the following developer platforms:
+
+* .NET Core
+* ASP.NET Core
+
+These are not supported by Scanner V4.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

* 4.6

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

* https://issues.redhat.com/browse/ROX-26652
* https://issues.redhat.com/browse/ROX-26470

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://83675--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

I decided to move the OS support to the top, as that tends to be the first thing people would look for. I also made a super minor change to the JavaScript line to remove Node.js (not needed). I also added the related package managers next to the package formats, so it'll be clearer for those who are not familiar with the formats and only the managers

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
