### PR TITLE
OBSDOCS-881 Typo in logging docs

### DIFF
--- a/modules/logging-5.6-api-ref.adoc
+++ b/modules/logging-5.6-api-ref.adoc
@@ -353,7 +353,7 @@ https://docs.fluentd.org/configuration/buffer-section#retries-parameters
 |chunkLimitSize|string|  *(optional)* ChunkLimitSize represents the maximum size of each chunk. Events will be
 |flushInterval|string|  *(optional)* FlushInterval represents the time duration to wait between two consecutive flush
 |flushMode|string|  *(optional)* FlushMode represents the mode of the flushing thread to write chunks. The mode
-|flushThreadCount|int|  *(optional)* FlushThreadCount reprents the number of threads used by the fluentd buffer
+|flushThreadCount|int|  *(optional)* FlushThreadCount represents the number of threads used by the fluentd buffer
 |overflowAction|string|  *(optional)* OverflowAction represents the action for the fluentd buffer plugin to
 |retryMaxInterval|string|  *(optional)* RetryMaxInterval represents the maximum time interval for exponential backoff
 |retryTimeout|string|  *(optional)* RetryTimeout represents the maximum time interval to attempt retries before giving up


### PR DESCRIPTION
Change type: Doc update; Typo in Logging docs
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-881

Fix Version: 4.12, 4.13, 4.14, 4.15, 4.16

Doc Preview: https://83676--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/api_reference/logging-5-6-reference.html#type-24

QE Review: @anpingli 
Peer Review: