### PR TITLE
small-fix-4.17.1

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2827,7 +2827,7 @@ For any {product-title} release, always review the instructions on xref:../updat
 
 // 4.17.1
 [id="ocp-4-17-1-ga_{context}"]
-=== RHSA-2024:7922 - {product-title} {product-version}.0 image release, bug fix, and security update advisory
+=== RHSA-2024:7922 - {product-title} {product-version}.1 image release, bug fix, and security update advisory
 
 Issued: 16 October 2024
 


### PR DESCRIPTION
Fix a small typo in heading of 4.17.1 z-stream notes.

Version(s):
4.17

Link to docs preview:
* https://83677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-1-ga_release-notes
