### PR TITLE
[enterprise-4.12] OCPBUGS-43101 Configure how to set SR-IOV in systemd mode relevant fo…

### DIFF
--- a/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
+++ b/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
@@ -6,12 +6,11 @@
 [id="configuring-machine-config-pool_{context}"]
 = Configuring a machine config pool for hardware offloading
 
-To enable hardware offloading, you must first create a dedicated machine config pool and configure it to work with the SR-IOV Network Operator.
+To enable hardware offloading, you now create a dedicated machine config pool and configure it to work with the SR-IOV Network Operator.
 
 .Prerequisites
 
-* You installed the OpenShift CLI (`oc`).
-* You have access to the cluster as a user with the `cluster-admin` role.
+. SR-IOV Network Operator installed and set into `systemd` mode.
 
 .Procedure
 

--- a/modules/nw-sriov-hwol-configuring-systemd-mode.adoc
+++ b/modules/nw-sriov-hwol-configuring-systemd-mode.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-hardware-offloading.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-sriov-hwol-configuring-systemd-mode_{context}"]
+= Setting the SR-IOV Network Operator into systemd mode
+
+To support hardware offloading, you must first set the SR-IOV Network Operator into `systemd` mode.
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user that has the `cluster-admin` role.
+
+.Procedure
+
+. Create a `SriovOperatorConfig` custom resource (CR) to deploy all the SR-IOV Operator components:
+
+.. Create a file named `sriovOperatorConfig.yaml` that contains the following YAML:
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default <1>
+  namespace: openshift-sriov-network-operator
+spec:
+  enableInjector: true
+  enableOperatorWebhook: true
+  configurationMode: "systemd" <2>
+  logLevel: 2
+----
++
+<1> The only valid name for the `SriovOperatorConfig` resource is `default` and it must be in the namespace where the Operator is deployed.
+<2> Setting the SR-IOV Network Operator into `systemd` mode is only relevant for Open vSwitch hardware offloading. 
+
+.. Create the resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f sriovOperatorConfig.yaml
+----

--- a/modules/proc-switching-bf2-nic.adoc
+++ b/modules/proc-switching-bf2-nic.adoc
@@ -93,3 +93,5 @@ spec:
 <1> Optional: The PCI address of a specific card can optionally be specified, for example `ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic 0000:5e:00.0 || echo done'`. By default, the first device is selected. If there is more than one device, you must specify which PCI address to be used. The PCI address must be the same on all nodes that are switching Bluefield-2 from DPU mode to NIC mode.
 
 . Wait for the worker nodes to restart. After restarting, the Bluefield-2 network device on the worker nodes is switched into NIC mode.
+
+. Optional: You might need to restart the host hardware because most recent Bluefield-2 firmware releases require a hardware restart to switch into NIC mode. 

--- a/networking/hardware_networks/configuring-hardware-offloading.adoc
+++ b/networking/hardware_networks/configuring-hardware-offloading.adoc
@@ -25,6 +25,9 @@ include::modules/nw-sriov-hwol-supported-devices.adoc[leveloffset=+1]
 * In your xref:../../networking/cluster-network-operator.adoc#gatewayConfig-object_cluster-network-operator[OVN-Kubernetes network plugin configuration], the `gatewayConfig.routingViaHost` field is set to `false`.
 
 //Configure a machine config pool for hardware offloading
+include::modules/nw-sriov-hwol-configuring-systemd-mode.adoc[leveloffset=+1]
+
+//Configure a machine config pool for hardware offloading
 include::modules/nw-sriov-hwol-configuring-machine-config-pool.adoc[leveloffset=+1]
 
 //Configuring the SR-IOV network node policy


### PR DESCRIPTION
[OCPBUGS-43101]: Configure how to set SR-IOV in systemd mode relevant for configuring hardware offloading

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12,
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue :https://issues.redhat.com/browse/OCPBUGS-43101
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

- https://83685--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-hardware-offloading.html
- https://83685--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/switching-bf2-nic-dpu.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:  Already merged (4.13 >) and this is cherry pick from c819fcef4c04d3aadc1625de52b94c343f69af9a  xref: [https://github.com/openshift/openshift-docs/pull/83516].  
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->