### PR TITLE
OCPBUGS-37423-revert: Reverted the .cloudflarestorage.com update

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -269,10 +269,6 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must includ
 |443
 |Required to access the default cluster routes unless you set an ingress wildcard during installation.
 
-|`*.cloudflarestorage.com`
-|443
-|Required to access mirrored installation content and images that were redirected from `mirror.openshift.com`.
-
 |`api.openshift.com`
 |443
 |Required both for your cluster token and to check if updates are available for the cluster.


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-10623 validates that the .cloudflarestorage.com` is no longer valid. Reverting the change.

Version(s):
4.12+

Issue:
[OCPBUGS-37423](https://issues.redhat.com/browse/OCPBUGS-37423)

Link to docs preview:
* [Configuring your firewall](https://83690--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html)
* [Configuring your firewall for OpenShift Container Platform](https://83690--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer.html#configuring-firewall_installing-oci-agent-based-installer)

- [x] SME has approved this change (asked Installer team).
- [x] QE has approved this change (Gaoyun Pei).

