### PR TITLE
OADP-1986: OADP doc for ROSA needs uninstallation steps

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
@@ -23,3 +23,5 @@ The OADP Operator installs link:https://{velero-domain}/docs/v{velero-version}/[
 . Click *Operators* -> *Installed Operators* to verify the installation.
 
 include::modules/velero-oadp-version-relationship.adoc[leveloffset=+1]
+
+include::snippets/operator-additional-resources.adoc[]

--- a/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
@@ -3,6 +3,7 @@
 = Backing up applications on ROSA clusters using OADP
 include::_attributes/common-attributes.adoc[]
 :context: oadp-rosa-backing-up-applications
+:oadp-rosa-backing-up-applications:
 
 toc::[]
 
@@ -41,3 +42,7 @@ include::modules/installing-oadp-rosa-sts.adoc[leveloffset=+1]
 include::modules/performing-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]
 
 include::modules/cleanup-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]
+
+include::snippets/operator-additional-resources.adoc[]
+
+:oadp-rosa-backing-up-applications!:

--- a/snippets/operator-additional-resources.adoc
+++ b/snippets/operator-additional-resources.adoc
@@ -1,0 +1,20 @@
+// Snippets included in the following assemblies and modules:
+//
+// * /backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+// * /backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+* xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-adding-operators-to-a-cluster[Updating installed Operators]
+* xref:../../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]
+* xref:../../../operators/admin/olm-troubleshooting-operator-issues.adoc#olm-troubleshooting-operator-issues[Troubleshooting Operator issues]
+// docs not in OCP enterprise so using links
+
+ifdef::oadp-rosa-backing-up-applications[]
+* link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-deleting-access-cluster.html[Deleting access to a ROSA cluster]
+* link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-deleting-cluster.html[Deleting a ROSA cluster]
+endif::[]


### PR DESCRIPTION
### JIRA

* [OADP-1986](https://issues.redhat.com/browse/OADP-1986)

As this ticket asks for documentation that exists elsewhere in OCP docs, I think it would be ok to link to those pieces of documentation. I have added the relevant links to *Additional resources*:

| Additional resources |
| ------------------------------ |
| ![image](https://github.com/user-attachments/assets/0a26434d-6320-4e89-b1e0-eac7292f91c0) |

I have created a snippet with an IFDEF statement to include the relevant ROSA links only in the OADP ROSA docs. This way I can use this snippet in two locations as suggested by Amos.

### VERSION

* OCP 4.12 and later

### Link to docs preview:

* [Backing up applications on ROSA clusters using OADP](https://83694--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html#cleanup-a-backup-oadp-rosa-sts_oadp-rosa-backing-up-applications)
* [Installing the OADP Operator ](https://83694--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
