### PR TITLE
OLS-1167: Document that OLS does not have update path for existing installa…

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -39,6 +39,8 @@
 :azure-official: Microsoft Azure
 :entra-id: Microsoft Entra ID
 :azure-studio: Microsoft Azure OpenAI Studio
+//Operator Lifecycle Manager
+:olm: Operator Lifecycle Manager
 //service mesh v3
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh

--- a/modules/ols-0-2-0-release-notes.adoc
+++ b/modules/ols-0-2-0-release-notes.adoc
@@ -14,6 +14,8 @@ The following enhancements have been made with {ols-offical} 0.2.0:
 
 * This release introduces the {ols-offical} Operator as a Technology Preview release. Previously, the {ols-short} Operator was a Developer Preview release. 
 
+* Existing Developer Preview installations of {ols-offical} version 0.1.6 and earlier that use the preview {olm} (OLM) channel must switch the update channel to *alpha* and then install the 0.2.0 Technology Preview version.
+
 * Beginning in this release, the {ols-offical} Operator can be installed on an {ocp-product-title} cluster in a disconnected environment.
 
 * With this release, {rhelai} can be configured as the Large Language Model (LLM) provider.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-1167
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83721--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
