### PR TITLE
GH 81452: MCO Fix Configuring updated boot images

### DIFF
--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -23,7 +23,7 @@ include::snippets/technology-preview.adoc[]
 $ oc edit MachineConfiguration cluster
 ----
 
-.. Optional: Configure the boot image update feature for all the machine sets:
+* Optional: Configure the boot image update feature for all the machine sets:
 +
 [source,yaml]
 ----
@@ -44,7 +44,7 @@ spec:
 <1> Activates the boot image update feature.
 <2> Specifies that all the machine sets in the cluster are to be updated.
 
-.. Optional: Configure the boot image update feature for specific machine sets:
+* Optional: Configure the boot image update feature for specific machine sets:
 +
 [source,yaml]
 ----
@@ -61,10 +61,10 @@ spec:
       apiGroup: machine.openshift.io
       selection:
         mode: Partial
-          partial:
-            machineResourceSelector:
-              matchLabels:
-                update-boot-image: "true" <2>
+        partial:
+          machineResourceSelector:
+            matchLabels:
+              update-boot-image: "true" <2>
 ----
 <1> Activates the boot image update feature.
 <2> Specifies that any machine set with this label is to be updated.
@@ -84,7 +84,7 @@ $ oc label machineset.machine ci-ln-hmy310k-72292-5f87z-worker-a update-boot-ima
 +
 [source,terminal]
 ----
-$ oc get machine configuration <machineset_name> -n openshift-machine-api -o yaml
+$ oc get machineconfiguration cluster -n openshift-machine-api -o yaml
 ----
 +
 .Example machine set with the boot image reference


### PR DESCRIPTION
I noticed a couple of issues with a new module, detailed in https://github.com/openshift/openshift-docs/issues/81452

Preview: [Configuring updated boot images](https://83732--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-configuring_machine-configs-configure) -- Made the substeps in Step 1 into bullets, as you wouldn't do both. Fixed the formatting in Step 1b code block. Fixed the command in Verification Step 1. 