### PR TITLE
OSDOCS-12151: adds 4.14.39 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -630,3 +630,12 @@ Issued: 3 October 2024
 {product-title} release 4.14.38 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:7186[RHBA-2024:7186] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7184[RHSA-2024:7184] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-39-dp_{context}"]
+=== RHBA-2024:8237 - {microshift-short} 4.14.39 bug fix and security update advisory
+
+Issued: 23 October 2024
+
+{product-title} release 4.14.39 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:8237[RHBA-2024:8237] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8235[RHSA-2024:8235] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-12151](https://issues.redhat.com/browse/OSDOCS-12151)

Link to docs preview:
[4.1.4.39 async release notes](https://83742--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-39-dp_release-notes)

QE review:
* N/A stock text, no other changes