### PR TITLE
Clean out single-line xrefs that are commented in build_for_portal

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -41,6 +41,7 @@ INCLUDE_RE = re.compile("include::(.*?)\[(.*?)\]", re.M)
 IFDEF_RE = re.compile(r"^if(n?)def::(.*?)\[\]", re.M)
 ENDIF_RE = re.compile(r"^endif::(.*?)\[\]\r?\n", re.M)
 COMMENT_CONTENT_RE = re.compile(r"^^////$.*?^////$", re.M | re.DOTALL)
+COMMENTED_XREF_RE = re.compile(r"^//.*xref:.*$")
 TAG_CONTENT_RE = re.compile(
     r"//\s+tag::(.*?)\[\].*?// end::(.*?)\[\]", re.M | re.DOTALL
 )
@@ -655,6 +656,9 @@ def scrub_file(info, book_src_dir, src_file, tag=None, cwd=None):
         # Ignore any leading blank lines, before any meaningful content is found
         if line.strip() == "" and not content_found:
             continue
+
+        # Replace lines containing commented xrefs
+        line = COMMENTED_XREF_RE.sub("// Removed commented line that contains an xref", line)
 
         # Check if the line should be included in the output
         if include_line(line):


### PR DESCRIPTION
build_for_portal should not fail on single line xrefs that are commented out. 