### PR TITLE
OCPBUGS-43325-fix-link

### DIFF
--- a/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
+++ b/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
@@ -31,7 +31,6 @@ include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloff
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere_creating-machineset-vsphere[Creating a compute machine set on vSphere]
-* xref: ../installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc#installation-network-user-infra_upi-vsphere-installation-reqs[Networking requirements for user-provisioned infrastructure]
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.18 to 4.15

Issue:
[OCPBUGS-43325](https://issues.redhat.com/browse/OCPBUGS-43325)

Link to docs preview:
* [Networking requirements IPI - VLAN statement excluded](https://83793--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html#vsphere-csi-driver-reqs_ipi-vsphere-installation-reqs)
* [Networking requirements UPI - VLAN statement included](https://83793--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html#installation-vsphere-installer-infra-requirements_upi-vsphere-installation-reqs)
