### PR TITLE
OBSDOCS-1359_New and OBSDOCS-817 (partially covered)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2893,6 +2893,10 @@ Topics:
       File: log6x-clf
     - Name: Configuring LokiStack storage
       File: log6x-loki
+    - Name: Configuring LokiStack for OTLP
+      File: log6x-configuring-lokistack-otlp
+    - Name: OpenTelemetry data model
+      File: log6x-opentelemetry-data-model
     - Name: Visualization for logging
       File: log6x-visual
     # - Name: API reference 6.0

--- a/modules/log6x-configuring-lokistack-otlp-data-ingestion.adoc
+++ b/modules/log6x-configuring-lokistack-otlp-data-ingestion.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-configuring-lokistack-otlp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="log6x-configuring-lokistack-otlp-data-ingestion_{context}"]
+= Configuring LokiStack for OTLP data ingestion
+
+:FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
+include::snippets/technology-preview.adoc[]
+
+To configure a `LokiStack` custom resource (CR) for OTLP ingestion, follow these steps:
+
+.Prerequisites
+
+* Ensure that your Loki setup supports structured metadata, introduced in schema version 13 to enable OTLP log ingestion.
+
+.Procedure
+
+. Set the schema version:
++
+** When creating a new `LokiStack` CR, set `version: v13` in the storage schema configuration.
++
+[NOTE]
+====
+For existing configurations, add a new schema version entry `version: v13` to activate it in the future. For more information on updating schema versions, see link:https://grafana.com/docs/loki/latest/configure/storage/#upgrading-schemas[Upgrading Schemas] (Grafana documentation).
+====
+
+. Configure the storage schema as follows:
++
+.Example configure storage schema
+[source,yaml]
+----
+# ...
+spec:
+  storage:
+    schemas:
+    - version: v13
+      effectiveDate: 2024-10-25
+----
++
+After the `effectiveDate` passes, the new schema configuration activates, preparing your `LokiStack` to store structured metadata.

--- a/modules/log6x-quickstart-opentelemetry.adoc
+++ b/modules/log6x-quickstart-opentelemetry.adoc
@@ -1,0 +1,158 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-about.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="quick-start-opentelemetry_{context}"]
+= Quick start with OpenTelemetry
+
+:FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
+include::snippets/technology-preview.adoc[]
+
+To configure OTLP ingestion and enable the OpenTelemetry data model, follow these steps:
+
+.Prerequisites
+* Cluster administrator permissions
+
+.Procedure
+
+. Install the {clo}, {loki-op}, and {coo-first} from OperatorHub.
+
+. Create a `LokiStack` custom resource (CR) in the `openshift-logging` namespace:
++
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  managementState: Managed
+  size: 1x.extra-small
+  storage:
+    schemas:
+    - effectiveDate: '2024-10-01'
+      version: v13
+    secret:
+      name: logging-loki-s3
+      type: s3
+  storageClassName: gp3-csi
+  tenants:
+    mode: openshift-logging
+----
++
+[NOTE]
+====
+Ensure that the `logging-loki-s3` secret is created beforehand. The contents of this secret vary depending on the object storage in use. For more information, see "Secrets and TLS Configuration".
+====
+
+. Create a service account for the collector:
++
+[source,terminal]
+----
+$ oc create sa collector -n openshift-logging
+----
+
+. Allow the collector's service account to write data to the `LokiStack` CR:
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector
+----
++
+[NOTE]
+====
+The `ClusterRole` resource is created automatically during the Cluster Logging Operator installation and does not need to be created manually.
+====
+
+. Allow the collector's service account to collect logs:
++
+[source,terminal]
+----
+$ oc project openshift-logging
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector
+----
++
+[NOTE]
+====
+The example binds the collector to all three roles (application, infrastructure, and audit). By default, only application and infrastructure logs are collected. To collect audit logs, update your `ClusterLogForwarder` configuration to include them. Assign roles based on the specific log types required for your environment.
+====
+
+. Create a `UIPlugin` CR to enable the *Log* section in the *Observe* tab:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: logging
+spec:
+  type: Logging
+  logging:
+    lokiStack:
+      name: logging-loki
+----
+
+. Create a `ClusterLogForwarder` CR to configure log forwarding:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: collector
+  namespace: openshift-logging
+  annotations:
+    observability.openshift.io/tech-preview-otlp-output: "enabled" # <1>
+spec:
+  serviceAccount:
+    name: collector
+  outputs:
+  - name: loki-otlp
+    type: lokiStack # <2>
+    lokiStack:
+      target:
+        name: logging-loki
+        namespace: openshift-logging
+      dataModel: Otel # <3>
+      authentication:
+        token:
+          from: serviceAccount
+    tls:
+      ca:
+        key: service-ca.crt
+        configMapName: openshift-service-ca.crt
+  pipelines:
+  - name: my-pipeline
+    inputRefs:
+    - application
+    - infrastructure
+    outputRefs:
+    - loki-otlp
+----
+<1> Use the annotation to enable the `Otel` data model, which is a Technology Preview feature.
+<2> Define the output type as `lokiStack`.
+<3> Specifies the OpenTelemetry data model.
++
+[NOTE]
+====
+You cannot use `lokiStack.labelKeys` when `dataModel` is `Otel`. To achieve similar functionality when `dataModel` is `Otel`, refer to "Configuring LokiStack for OTLP data ingestion".
+====
+
+.Verification
+* Verify that OTLP is functioning correctly by going to *Observe* -> *OpenShift Logging* -> *LokiStack* -> *Writes* in the OpenShift web console, and checking *Distributor - Structured Metadata*.

--- a/modules/log6x-quickstart-viaq.adoc
+++ b/modules/log6x-quickstart-viaq.adoc
@@ -1,0 +1,149 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-about.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="quick-start-viaq_{context}"]
+= Quick start with ViaQ
+
+To use the default ViaQ data model, follow these steps:  
+
+.Prerequisites
+* Cluster administrator permissions
+
+.Procedure
+
+. Install the {clo}, {loki-op}, and {coo-first} from OperatorHub.
+
+. Create a `LokiStack` custom resource (CR) in the `openshift-logging` namespace:
++
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  managementState: Managed
+  size: 1x.extra-small
+  storage:
+    schemas:
+    - effectiveDate: '2024-10-01'
+      version: v13
+    secret:
+      name: logging-loki-s3
+      type: s3
+  storageClassName: gp3-csi
+  tenants:
+    mode: openshift-logging
+----
++
+[NOTE]
+====
+Ensure that the `logging-loki-s3` secret is created beforehand. The contents of this secret vary depending on the object storage in use. For more information, see Secrets and TLS Configuration.
+====
+
+. Create a service account for the collector:
++
+[source,terminal]
+----
+$ oc create sa collector -n openshift-logging
+----
+
+. Allow the collector's service account to write data to the `LokiStack` CR:
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector
+----
++
+[NOTE]
+====
+The `ClusterRole` resource is created automatically during the Cluster Logging Operator installation and does not need to be created manually.
+====
+
+. Allow the collector's service account to collect logs:
++
+[source,terminal]
+----
+$ oc project openshift-logging
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector
+----
++
+[NOTE]
+====
+The example binds the collector to all three roles (application, infrastructure, and audit), but by default, only application and infrastructure logs are collected. To collect audit logs, update your `ClusterLogForwarder` configuration to include them. Assign roles based on the specific log types required for your environment.
+====
+
+. Create a `UIPlugin` CR to enable the *Log* section in the *Observe* tab:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: logging
+spec:
+  type: Logging
+  logging:
+    lokiStack:
+      name: logging-loki
+----
+
+. Create a `ClusterLogForwarder` CR to configure log forwarding:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: collector
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: collector
+  outputs:
+  - name: default-lokistack
+    type: lokiStack
+    lokiStack:
+      authentication:
+        token:
+          from: serviceAccount
+      target:
+        name: logging-loki
+        namespace: openshift-logging
+    tls:
+      ca:
+        key: service-ca.crt
+        configMapName: openshift-service-ca.crt
+  pipelines:
+  - name: default-logstore
+    inputRefs:
+    - application
+    - infrastructure
+    outputRefs:
+    - default-lokistack
+----
++
+[NOTE]
+====
+The `dataModel` field is optional and left unset (`dataModel: ""`) by default. This allows the Cluster Logging Operator (CLO) to automatically select a data model. Currently, the CLO defaults to the ViaQ model when the field is unset, but this will change in future releases. Specifying `dataModel: ViaQ` ensures the configuration remains compatible if the default changes.
+====
+
+.Verification
+* Verify that logs are visible in the *Log* section of the *Observe* tab in the OpenShift web console.

--- a/observability/logging/logging-6.0/log6x-about.adoc
+++ b/observability/logging/logging-6.0/log6x-about.adoc
@@ -34,134 +34,32 @@ The Cluster Logging Operator manages the deployment and configuration of the col
 == Validation
 Logging includes extensive validation rules and default values to ensure a smooth and error-free configuration experience. The `ClusterLogForwarder` resource enforces validation checks on required fields, dependencies between fields, and the format of input values. Default values are provided for certain fields, reducing the need for explicit configuration in common scenarios.
 
-=== Quick Start
+[id="quick-start_{context}"]
+== Quick start
 
-.Prerequisites
-* Cluster administrator permissions
+OpenShift Logging supports two data models:
 
-.Procedure
+* ViaQ (General Availability)
+* OpenTelemetry (Technology Preview)
 
-. Install the `OpenShift Logging` and `Loki` Operators from OperatorHub.
+You can select either of these data models based on your requirement by configuring the `lokiStack.dataModel` field in the `ClusterLogForwarder`. ViaQ is the default data model when forwarding logs to LokiStack. For more information on OpenTelemetry, see xref:../../../observability/logging/logging-6.0/log6x-opentelemetry-data-model.adoc#log6x-opentelemetry-data-model[OpenTelemetry data model].
 
-. Create a `LokiStack` custom resource (CR) in the `openshift-logging` namespace:
-+
-[source,yaml]
-----
-apiVersion: loki.grafana.com/v1
-kind: LokiStack
-metadata:
-  name: logging-loki
-  namespace: openshift-logging
-spec:
-  managementState: Managed
-  size: 1x.extra-small
-  storage:
-    schemas:
-    - effectiveDate: '2022-06-01'
-      version: v13
-    secret:
-      name: logging-loki-s3
-      type: s3
-    storageClassName: gp3-csi
-  tenants:
-    mode: openshift-logging
-----
+[NOTE]
+====
+In future releases of OpenShift Logging, the default data model will change from ViaQ to OpenTelemetry.
+====
 
-. Create a service account for the collector:
-+
-[source,shell]
-----
-$ oc create sa collector -n openshift-logging
-----
+include::modules/log6x-quickstart-viaq.adoc[leveloffset=+2]
 
-. Create a `ClusterRole` for the collector:
-+
-[source,yaml]
-----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: logging-collector-logs-writer
-rules:
-- apiGroups:
-  - loki.grafana.com
-  resourceNames:
-  - logs
-  resources:
-  - application
-  - audit
-  - infrastructure
-  verbs:
-  - create
-----
+[discrete]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../observability/logging/logging-6.0/log6x-upgrading-to-6.adoc#secrets-and-tls-configuration[Secrets and TLS Configuration]
 
-. Bind the `ClusterRole` to the service account:
-+
-[source,shell]
-----
-$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector
-----
+include::modules/log6x-quickstart-opentelemetry.adoc[leveloffset=+2]
 
-. Install the Cluster Observability Operator.
-
-. Create a `UIPlugin` to enable the Log section in the Observe tab:
-+
-[source,yaml]
-----
-apiVersion: observability.openshift.io/v1alpha1
-kind: UIPlugin
-metadata:
-  name: logging
-spec:
-  type: Logging
-  logging:
-    lokiStack:
-      name: logging-loki
-----
-
-. Add additional roles to the collector service account:
-+
-[source,shell]
-----
-$ oc project openshift-logging
-$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector
-$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector
-$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector
-----
-
-. Create a `ClusterLogForwarder` CR to configure log forwarding:
-+
-[source,yaml]
-----
-apiVersion: observability.openshift.io/v1
-kind: ClusterLogForwarder
-metadata:
-  name: collector
-  namespace: openshift-logging
-spec:
-  serviceAccount:
-    name: collector
-  outputs:
-  - name: default-lokistack
-    type: lokiStack
-    lokiStack:
-      target:
-        name: logging-loki
-        namespace: openshift-logging
-    authentication:
-      token:
-        from: serviceAccount
-    tls:
-      ca:
-        key: service-ca.crt
-        configMapName: openshift-service-ca.crt
-  pipelines:
-  - name: default-logstore
-    inputRefs:
-    - application
-    - infrastructure
-    outputRefs:
-    - default-lokistack
-----
-
-. Verify that logs are visible in the Log section of the Observe tab in the OpenShift web console.
+[discrete]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../observability/logging/logging-6.0/log6x-upgrading-to-6.adoc#secrets-and-tls-configuration[Secrets and TLS Configuration]
+* xref:../../../observability/logging/logging-6.0/log6x-configuring-lokistack-otlp.adoc#log6x-configuring-lokistack-otlp-data-ingestion_log6x-configuring-lokistack-otlp[Configuring LokiStack for OTLP data ingestion]

--- a/observability/logging/logging-6.0/log6x-configuring-lokistack-otlp.adoc
+++ b/observability/logging/logging-6.0/log6x-configuring-lokistack-otlp.adoc
@@ -1,0 +1,150 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="log6x-configuring-lokistack-otlp"]
+= OTLP data ingestion in Loki
+include::_attributes/common-attributes.adoc[]
+:context: log6x-configuring-lokistack-otlp
+
+toc::[]
+
+Loki 3.0 introduces an API endpoint using the OpenTelemetry Protocol (OTLP), providing a new way to ingest log entries into Loki. This endpoint complements the standard Push API, which is available in Loki from its initial release. Because OTLP is a standardized format not specifically designed for Loki, it requires additional configuration on Loki's side to map OpenTelemetry's data format to Loki's data model. OTLP lacks concepts such as _stream labels_ or _structured metadata_. Instead, OTLP provides metadata about log entries as *attributes*, grouped into three categories:
+
+* Resource
+* Scope
+* Log
+
+This allows metadata to be set for multiple entries simultaneously or individually as needed.
+
+include::modules/log6x-configuring-lokistack-otlp-data-ingestion.adoc[leveloffset=+1]
+
+[id="attribute-mapping_{context}"]
+== Attribute mapping
+
+When the {loki-op} is set to `openshift-logging` mode, it automatically applies a default set of xref:../../../observability/logging/logging-6.0/log6x-opentelemetry-data-model.adoc#attributes_log6x-opentelemetry-data-model[attribute mappings]. These mappings align specific OTLP attributes with Loki's stream labels and structured metadata.
+
+For typical setups, these default mappings should be sufficient. However, you might need to customize attribute mapping in the following cases:
+
+* Using a custom Collector: If your setup includes a custom collector that generates additional attributes, consider customizing the mapping to ensure these attributes are retained in Loki.
+* Adjusting attribute detail levels: If the default attribute set is more detailed than necessary, you can reduce it to essential attributes only. This can avoid excessive data storage and streamline the {logging} process.
+
+For more infomation on configuring custom attribute mappings, see xref:../../../observability/logging/logging-6.0/log6x-configuring-lokistack-otlp.adoc#custom-attribute-mapping-for-openshift_log6x-configuring-lokistack-otlp[Custom attribute mapping for OpenShift].
+
+[NOTE]
+====
+Attributes that are not mapped to either stream labels or structured metadata are not stored in Loki.
+====
+
+[id="custom-attribute-mapping-for-openshift_{context}"]
+=== Custom attribute mapping for OpenShift
+
+When using the {loki-op} in `openshift-logging` mode, attribute mapping follow OpenShift defaults, but custom mappings can be configured to adjust these. Custom mappings allow further configurations to meet specific needs. 
+
+In `openshift-logging` mode, custom attribute mappings can be configured globally for all tenants or for individual tenants as needed. When custom mappings are defined, they are appended to the OpenShift defaults. If default recommended labels are not required, they can be disabled in the tenant configuration. For more information, see xref:../../../observability/logging/logging-6.0/log6x-configuring-lokistack-otlp.adoc#customizing-openshift-defaults_log6x-configuring-lokistack-otlp[Customizing OpenShift defaults].
+
+[NOTE]
+====
+A major difference between the {loki-op} and Loki itself lies in inheritance handling. Loki only copies `default_resource_attributes_as_index_labels` to tenants by default, while the {loki-op} applies the entire global configuration to each tenant in `openshift-logging` mode.
+====
+
+Within `LokiStack`, attribute mapping configuration is managed through the `limits` setting:
+
+[source,yaml]
+----
+# ...
+spec:
+  limits:
+    global:
+      otlp: {} # <1> 
+    tenants:
+      application:
+        otlp: {} # <2> 
+----
+<1> Global OTLP attribute configuration.
+<2> OTLP attribute configuration for the `application` tenant within `openshift-logging` mode.
+
+[NOTE]
+====
+Both global and per-tenant OTLP configurations can map attributes to stream labels or structured metadata. At least one stream label is required to save a log entry to Loki storage, so ensure this configuration meets that requirement.
+====
+
+Stream labels derive only from resource-level attributes, which the `LokiStack` resource structure reflects:
+
+[source,yaml]
+----
+spec:
+  limits:
+    global:
+      otlp:
+        streamLabels:
+          resourceAttributes:
+          - name: "k8s.namespace.name"
+          - name: "k8s.pod.name"
+          - name: "k8s.container.name"
+----
+
+Structured metadata, in contrast, can be generated from resource, scope or log-level attributes:
+
+[source,yaml]
+----
+# ...
+spec:
+  limits:
+    global:
+      otlp:
+        streamLabels:
+          # ...
+        structuredMetadata:
+          resourceAttributes:
+          - name: "process.command_line"
+          - name: "k8s\\.pod\\.labels\\..+"
+            regex: true
+          scopeAttributes:
+          - name: "service.name"
+          logAttributes:
+          - name: "http.route"
+----
+
+[TIP]
+====
+Use regular expressions by setting `regex: true` for attributes names when mapping similar attributes in Loki. 
+====
+
+[IMPORTANT]
+====
+Avoid using regular expressions for stream labels, as this can increase data volume.
+====
+
+[id="customizing-openshift-defaults_{context}"]
+=== Customizing OpenShift defaults
+
+In `openshift-logging` mode, certain attributes are required and cannot be removed from the configuration due to their role in OpenShift functions. Other attributes, labeled *recommended*, might be disabled if performance is impacted. For a complete attribute list, see xref:../../../observability/logging/logging-6.0/log6x-opentelemetry-data-model.adoc#attributes_log6x-opentelemetry-data-model[OpenShift default attributes].
+
+When using the `openshift-logging` mode without custom attributes, you can achieve immediate compatibility with OpenShift tools. If additional attributes are needed as stream labels or structured metadata, use custom configuration. Custom configurations can merge with default configurations.
+
+[id="removing-recommended-attributes_{context}"]
+=== Removing recommended attributes
+
+To reduce default attributes in `openshift-logging` mode, disable recommended attributes:
+
+[source,yaml]
+----
+# ...
+spec:
+  tenants:
+    mode: openshift-logging
+    openshift:
+      otlp:
+        disableRecommendedAttributes: true # <1>
+----
+<1> Set `disableRecommendedAttributes: true` to remove recommended attributes, which limits default attributes to the *required attributes*.
+
+[NOTE]
+====
+This option is beneficial if the default attributes causes performance or storage issues. This setting might negatively impact query performance, as it removes default stream labels. You should pair this option with a custom attribute configuration to retain attributes essential for queries.
+====
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://grafana.com/docs/loki/latest/get-started/labels/[Loki labels]
+* link:https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/[Structured metadata]
+* link:https://opentelemetry.io/docs/specs/otel/common/#attribute[OpenTelemetry attribute]

--- a/observability/logging/logging-6.0/log6x-loki.adoc
+++ b/observability/logging/logging-6.0/log6x-loki.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[leveloffset=+1]
 [id="log6x-loki"]
 = Storing logs with LokiStack
-include::_attributes/common-attributes.adoc[leveloffset=+1]
 :context: logging-6x
 
 toc::[]

--- a/observability/logging/logging-6.0/log6x-opentelemetry-data-model.adoc
+++ b/observability/logging/logging-6.0/log6x-opentelemetry-data-model.adoc
@@ -1,0 +1,383 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="log6x-opentelemetry-data-model"]
+= OpenTelemetry data model
+include::_attributes/common-attributes.adoc[]
+:context: log6x-opentelemetry-data-model
+
+toc::[]
+
+This document outlines the protocol and semantic conventions {for} Logging's OpenTelemetry support with {logging-uc} 6.1.
+
+:FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
+include::snippets/technology-preview.adoc[]
+
+[id="forwarding-and-ingestion-protocol_{context}"]
+== Forwarding and ingestion protocol
+
+Red Hat OpenShift {logging-uc} collects and forwards logs to OpenTelemetry endpoints using link:https://opentelemetry.io/docs/specs/otlp/[OTLP Specification]. OTLP encodes, transports, and delivers telemetry data. You can also deploy Loki storage, which provides an OTLP endpont to ingest log streams. This document defines the semantic conventions for the logs collected from various OpenShift cluster sources.
+
+[id="semantic-conventions_{context}"]
+== Semantic conventions
+
+The log collector in this solution gathers the following log streams:
+
+* Container logs
+* Cluster node journal logs
+* Cluster node auditd logs
+* Kubernetes and OpenShift API server logs
+* OpenShift Virtual Network (OVN) logs
+
+You can forward these streams according to the sementatic conventions defined by OpenTelemetry semantic attributes. The semantic conventions in OpenTelemetry define a resource as an immutable representation of the entity producing telemetry, identified by attributes. For example, a process running in a container includes attributes such as `container_name`, `cluster_id`, `pod_name`, `namespace`, and possibly `deployment` or `app_name`. These attributes are grouped under the resource object, which helps reduce repetition and optimizes log transmission as telemetry data.
+
+In addition to resource attributes, logs might also contain scope attributes specific to instrumentation libraries and log attributes specific to each log entry. These attributes provide greater detail about each log entry and enhance filtering capabilities when querying logs in storage.
+
+The following sections define the attributes that are generally forwarded.
+
+[id="log-entry-structure_{context}"]
+=== Log entry structure
+
+All log streams include the following link:https://opentelemetry.io/docs/specs/otel/logs/data-model/#log-and-event-record-definition[log data] fields:
+
+The *Applicable Sources* column indicates which log sources each field applies to:
+
+* `all`: This field is present in all logs.
+* `container`: This field is present in Kubernetes container logs, both application and infrastructure.
+* `audit`: This field is present in Kubernetes, OpenShift API, and OVN logs.
+* `auditd`: This field is present in node auditd logs.
+* `journal`: This field is present in node journal logs.
+
+[cols="1,1,1", options="header"]
+|===
+|Name |Applicable Sources |Comment
+
+|`body`
+|all
+|
+
+|`observedTimeUnixNano`
+|all
+|
+
+|`timeUnixNano`
+|all
+|
+
+|`severityText`
+|container, journal
+|
+
+|`attributes`
+|all
+|(Optional) Present when forwarding stream specific attributes
+|===
+
+[id="attributes_{context}"]
+=== Attributes
+
+Log entries include a set of resource, scope, and log attributes based on their source, as described in the following table.
+
+The *Location* column specifies the type of attribute:
+
+* `resource`: Indicates a resource attribute
+* `scope`: Indicates a scope attribute
+* `log`: Indicates a log attribute
+
+The *Storage* column indicates whether the attribute is stored in a LokiStack using the default `openshift-logging` mode and specifies where the attribute is stored:
+
+* `stream label`: 
+** Enables efficient filtering and querying based on specific labels.
+** Can be labeled as `required` if the {loki-op} enforces this attribute in the configuration.
+* `structured metadata`: 
+** Allows for detailed filtering and storage of key-value pairs.
+** Enables users to use direct labels for streamlined queries without requiring JSON parsing.
+
+With OTLP, users can filter queries directly by labels rather than using JSON parsing, improving the speed and efficiency of queries.
+
+[cols="1,1,1,1,1", options="header"]
+|===
+|Name |Location |Applicable Sources |Storage (LokiStack) |Comment
+
+|`log_source`
+|resource
+|all
+|required stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `openshift.log.source`
+
+|`log_type`
+|resource
+|all
+|required stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `openshift.log.type`
+
+|`kubernetes.container_name`
+|resource
+|container
+|stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `k8s.container.name`
+
+|`kubernetes.host`
+|resource
+|all
+|stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `k8s.node.name`
+
+|`kubernetes.namespace_name`
+|resource
+|container
+|required stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `k8s.namespace.name`
+
+|`kubernetes.pod_name`
+|resource
+|container
+|stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `k8s.pod.name`
+
+|`openshift.cluster_id`
+|resource
+|all
+|
+|*(DEPRECATED)* Compatibility attribute, contains same information as `openshift.cluster.uid`
+
+|`level`
+|log
+|container, journal
+|
+|*(DEPRECATED)* Compatibility attribute, contains same information as `severityText`
+
+|`openshift.cluster.uid`
+|resource
+|all
+|required stream label
+|
+
+|`openshift.log.source`
+|resource
+|all
+|required stream label
+|
+
+|`openshift.log.type`
+|resource
+|all
+|required stream label
+|
+
+|`openshift.labels.*`
+|resource
+|all
+|structured metadata
+|
+
+|`k8s.node.name`
+|resource
+|all
+|stream label
+|
+
+|`k8s.namespace.name`
+|resource
+|container
+|required stream label
+|
+
+|`k8s.container.name`
+|resource
+|container
+|stream label
+|
+
+|`k8s.pod.labels.*`
+|resource
+|container
+|structured metadata
+|
+
+|`k8s.pod.name`
+|resource
+|container
+|stream label
+|
+
+|`k8s.pod.uid`
+|resource
+|container
+|structured metadata
+|
+
+|`k8s.cronjob.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`k8s.daemonset.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`k8s.deployment.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`k8s.job.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`k8s.replicaset.name`
+|resource
+|container
+|structured metadata
+|Conditionally forwarded based on creator of pod
+
+|`k8s.statefulset.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`log.iostream`
+|log
+|container
+|structured metadata
+|
+
+|`k8s.audit.event.level`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.stage`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.user_agent`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.request.uri`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.response.code`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.annotation.*`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.resource`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.name`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.namespace`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.api_group`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.api_version`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.user.username`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.user.groups`
+|log
+|audit
+|structured metadata
+|
+
+|`process.executable.name`
+|resource
+|journal
+|structured metadata
+|
+
+|`process.executable.path`
+|resource
+|journal
+|structured metadata
+|
+
+|`process.command_line`
+|resource
+|journal
+|structured metadata
+|
+
+|`process.pid`
+|resource
+|journal
+|structured metadata
+|
+
+|`service.name`
+|resource
+|journal
+|stream label
+|
+
+|`systemd.t.*`
+|log
+|journal
+|structured metadata
+|
+
+|`systemd.u.*`
+|log
+|journal
+|structured metadata
+|
+|===
+
+[NOTE]
+====
+Attributes marked as *Compatibility attribute* support minimal backward compatibility with the ViaQ data model. These attributes are deprecated and function as a compatibility layer to ensure continued UI functionality. These attributes will remain supported until the Logging UI fully supports the OpenTelemetry counterparts in future releases.
+====
+
+Loki changes the attribute names when persisting them to storage. The names will be lowercased, and all characters in the set: (`.`,`/`,`-`) will be replaced by underscores (`_`). For example, `k8s.namespace.name` will become `k8s_namespace_name`.
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://opentelemetry.io/docs/specs/semconv/[Semantic Conventions]
+* link:https://opentelemetry.io/docs/specs/otel/logs/data-model/[Logs Data Model]
+* link:https://opentelemetry.io/docs/specs/semconv/general/logs/[General Logs Attributes]


### PR DESCRIPTION
[OBSDOCS-1359](https://issues.redhat.com/browse/OBSDOCS-1359) and [OBSDOCS-817](https://issues.redhat.com/browse/OBSDOCS-817): Document support for OTLP-ingestion and OTEL Semantic Conventions **and** Document efficient OTEL Support for Loki
Aligned team: Observability - Logging
OCP version for cherry-picking: Not Applicable (for this branch)
JIRA issues: [OBSDOCS-1359](https://issues.redhat.com/browse/OBSDOCS-1359) and [OBSDOCS-817](https://issues.redhat.com/browse/OBSDOCS-817)
Preview pages: [Quick Start](https://83850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-about.html#quick-start), [Configuring LokiStack for OTLP](https://83850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-configuring-lokistack-otlp.html), [OpenTelemetry data model](https://83850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-opentelemetry-data-model.html)
SME review **completed**: @xperimental and @jcantrill
QE review **completed**:  @anpingli 
Peer review **completed**: @adellape

**Note:** [OBSDOCS-817](https://issues.redhat.com//browse/OBSDOCS-817) is partially covered as part of this PR. As discussed with Logging team, we will cover remaining pieces of [OBSDOCS-817](https://issues.redhat.com//browse/OBSDOCS-817) as part of separate Jira [OBSDOCS-1477](https://issues.redhat.com/browse/OBSDOCS-1477).