### PR TITLE
OSDOCS#10737: Changed note for clarity reg IPI parameter

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2703,7 +2703,7 @@ ifdef::vsphere[]
 |Virtual IP (VIP) addresses that you configured for control plane API access.
 [NOTE]
 ====
-This parameter applies only to installer-provisioned infrastructure.
+This parameter applies only to installer-provisioned infrastructure without an external load balancer configured. You must not specify this parameter in user-provisioned infrastructure.
 ====
 |Multiple IP addresses
 
@@ -2838,7 +2838,7 @@ ifdef::vsphere[]
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
 [NOTE]
 ====
-This parameter applies only to installer-provisioned infrastructure.
+This parameter applies only to installer-provisioned infrastructure without an external load balancer configured. You must not specify this parameter in user-provisioned infrastructure.
 ====
 |Multiple IP addresses
 endif::vsphere[]


### PR DESCRIPTION
Version(s): 4.12+

Issue: https://issues.redhat.com/browse/OSDOCS-10737
 
Link to docs preview: https://83853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere

QE review:
- [x] QE has approved this change.