### PR TITLE
Separate UWM and core platform monitoring (part 1)

### DIFF
--- a/modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc
+++ b/modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc
@@ -3,22 +3,40 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="about-specifying-limits-and-requests-for-monitoring-components_{context}"]
-= About specifying limits and requests for monitoring components
 
-You can configure resource limits and request settings for core platform monitoring components and for the components that monitor user-defined projects, including the following components:
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+// tag::CPM[]
+[id="about-specifying-limits-and-requests-for-monitoring-components-cpm_{context}"]
+= About specifying limits and requests for core monitoring components
+// end::CPM[]
 
-* Alertmanager (for core platform monitoring and for user-defined projects)
+// tag::UWM[]
+[id="about-specifying-limits-and-requests-for-monitoring-components-uwm_{context}"]
+= About specifying limits and requests for monitoring components for user-defined projects
+// end::UWM[]
+
+// tag::CPM[]
+You can configure resource limits and requests for the following core platform monitoring components:
+
+* Alertmanager
 * kube-state-metrics
 * monitoring-plugin
 * node-exporter
 * openshift-state-metrics
-* Prometheus (for core platform monitoring and for user-defined projects)
+* Prometheus
 * Metrics Server
 * Prometheus Operator and its admission webhook service
 * Telemeter Client
 * Thanos Querier
+// end::CPM[]
+
+// tag::UWM[]
+You can configure resource limits and requests for the following components that monitor user-defined projects:
+
+* Alertmanager
+* Prometheus
 * Thanos Ruler
+// end::UWM[]
 
 By defining resource limits, you limit a container's resource usage, which prevents the container from exceeding the specified maximum values for CPU and memory resources.
 

--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -3,54 +3,75 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="assigning-tolerations-to-monitoring-components_{context}"]
-= Assigning tolerations to monitoring components
 
-ifndef::openshift-dedicated,openshift-rosa[]
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+// tag::CPM[]
+[id="assigning-tolerations-to-monitoring-components-cpm_{context}"]
+= Assigning tolerations to monitoring components for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="assigning-tolerations-to-monitoring-components-uwm_{context}"]
+= Assigning tolerations to monitoring components for monitoring for user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples.
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:component: alertmanagerMain
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:component: thanosRuler
+// end::UWM[]
+
+// tag::CPM[]
 You can assign tolerations to any of the monitoring stack components to enable moving them to tainted nodes.
-endif::openshift-dedicated,openshift-rosa[]
+// end::CPM[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+// tag::UWM[]
 You can assign tolerations to the components that monitor user-defined projects, to enable moving them to tainted worker nodes. Scheduling is not permitted on control plane or infrastructure nodes.
-endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 
 .Prerequisites
 
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+// end::CPM[]
+
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` `ConfigMap` object.
-* *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists in the `openshift-user-workload-monitoring` namespace. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-. Edit the `ConfigMap` object:
-ifndef::openshift-dedicated,openshift-rosa[]
-** *To assign tolerations to a component that monitors core {product-title} projects*:
-.. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-.. Specify `tolerations` for the component:
+. Specify `tolerations` for the component:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
     <component>:
@@ -60,64 +81,18 @@ data:
 +
 Substitute `<component>` and `<toleration_specification>` accordingly.
 +
-For example, `oc adm taint nodes node1 key1=value1:NoSchedule` adds a taint to `node1` with the key `key1` and the value `value1`. This prevents monitoring components from deploying pods on `node1` unless a toleration is configured for that taint. The following example configures the `alertmanagerMain` component to tolerate the example taint:
+For example, `oc adm taint nodes node1 key1=value1:NoSchedule` adds a taint to `node1` with the key `key1` and the value `value1`. This prevents monitoring components from deploying pods on `node1` unless a toleration is configured for that taint. The following example configures the `{component}` component to tolerate the example taint:
 +
-[source,yaml,subs=quotes]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    alertmanagerMain:
-      tolerations:
-      - key: "key1"
-        operator: "Equal"
-        value: "value1"
-        effect: "NoSchedule"
-----
-
-** *To assign tolerations to a component that monitors user-defined projects*:
-endif::openshift-dedicated,openshift-rosa[]
-.. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-
-.. Specify `tolerations` for the component:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    <component>:
-      tolerations:
-        <toleration_specification>
-----
-+
-Substitute `<component>` and `<toleration_specification>` accordingly.
-+
-For example, `oc adm taint nodes node1 key1=value1:NoSchedule` adds a taint to `node1` with the key `key1` and the value `value1`. This prevents monitoring components from deploying pods on `node1` unless a toleration is configured for that taint. The following example configures the `thanosRuler` component to tolerate the example taint:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    thanosRuler:
+    {component}:
       tolerations:
       - key: "key1"
         operator: "Equal"
@@ -126,3 +101,8 @@ data:
 ----
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
+
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!component:

--- a/modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc
+++ b/modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc
@@ -3,52 +3,77 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="specifying-limits-and-resource-requests-for-monitoring-components_{context}"]
-= Specifying limits and requests for monitoring components
 
-To configure CPU and memory resources, specify values for resource limits and requests in the appropriate `ConfigMap` object for the namespace in which the monitoring component is located:
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+// tag::CPM[]
+[id="specifying-limits-and-resource-requests-for-monitoring-components-cpm_{context}"]
+= Specifying limits and requests for core monitoring components
+// end::CPM[]
 
-* The `cluster-monitoring-config` config map in the `openshift-monitoring` namespace for core platform monitoring
-* The `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace for components that monitor user-defined projects
+// tag::UWM[]
+[id="specifying-limits-and-resource-requests-for-monitoring-components-uwm_{context}"]
+= Specifying limits and requests for monitoring components for user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples.
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:alertmanager: alertmanagerMain
+:prometheus: prometheusK8s
+:thanos: thanosQuerier
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:alertmanager: alertmanager
+:prometheus: prometheus
+:thanos: thanosRuler
+// end::UWM[]
+
+To configure CPU and memory resources, specify values for resource limits and requests in the `{configmap-name}` `ConfigMap` object in the `{namespace-name}` namespace.
 
 .Prerequisites
 
-* *If you are configuring core platform monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created a `ConfigMap` object named `cluster-monitoring-config`.
-* *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `ConfigMap` object named `cluster-monitoring-config`.
+// end::CPM[]
+
+// tag::UWM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+// end::UWM[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-. To configure core platform monitoring components, edit the `cluster-monitoring-config` config map object in the `openshift-monitoring` namespace:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-. Add values to define resource limits and requests for each core platform monitoring component you want to configure.
+. Add values to define resource limits and requests for each component you want to configure.
 +
 [IMPORTANT]
 ====
-Make sure that the value set for a limit is always higher than the value set for a request.
+Ensure that the value set for a limit is always higher than the value set for a request.
 Otherwise, an error will occur, and the container will not run.
 ====
 +
-.Example
+.Example of setting resource limits and requests
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    alertmanagerMain:
+    {alertmanager}:
       resources:
         limits:
           cpu: 500m
@@ -56,7 +81,7 @@ data:
         requests:
           cpu: 200m
           memory: 500Mi
-    prometheusK8s:
+    {prometheus}:
       resources:
         limits:
           cpu: 500m
@@ -64,6 +89,15 @@ data:
         requests:
           cpu: 200m
           memory: 500Mi
+    {thanos}:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 1Gi
+        requests:
+          cpu: 200m
+          memory: 500Mi
+# tag::CPM[]
     prometheusOperator:
       resources:
         limits:
@@ -104,14 +138,6 @@ data:
         requests:
           cpu: 200m
           memory: 500Mi
-    thanosQuerier:
-      resources:
-        limits:
-          cpu: 500m
-          memory: 1Gi
-        requests:
-          cpu: 200m
-          memory: 500Mi
     nodeExporter:
       resources:
         limits:
@@ -136,10 +162,18 @@ data:
         requests:
           cpu: 20m
           memory: 50Mi
+# end::CPM[]
 ----
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits[Kubernetes requests and limits documentation]
+* link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits[Kubernetes requests and limits documentation] (Kubernetes documentation)
+
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!alertmanager:
+:!prometheus:
+:!thanos:

--- a/observability/monitoring/common-monitoring-configuration-scenarios.adoc
+++ b/observability/monitoring/common-monitoring-configuration-scenarios.adoc
@@ -47,7 +47,7 @@ Be sure to xref:../../observability/monitoring/configuring-the-monitoring-stack.
 ====
 +
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[Assign monitoring cluster roles] to any non-administrator users that need to access certain monitoring features.
-* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#assigning-tolerations-to-monitoring-components_configuring-the-monitoring-stack[Assign tolerations] to monitoring stack components so that administrators can move them to tainted nodes.
+* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#assigning-tolerations-to-monitoring-components-cpm_configuring-the-monitoring-stack[Assign tolerations] to monitoring stack components so that administrators can move them to tainted nodes.
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#setting-the-body-size-limit-for-metrics-scraping_configuring-the-monitoring-stack[Set the body size limit] for metrics collection to help avoid situations in which Prometheus consumes excessive amounts of memory when scraped targets return a response that contains a large amount of data.
 * xref:../../observability/monitoring/managing-alerts.adoc#managing-core-platform-alerting-rules_managing-alerts[Modify or create alerting rules] for your cluster.
 These rules specify the conditions that trigger alerts, such as high CPU or memory usage, network latency, and so forth.

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -144,7 +144,10 @@ endif::openshift-dedicated,openshift-rosa[]
 * See the link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[Kubernetes documentation] for details on the `nodeSelector` constraint
 
 // Assigning tolerations to monitoring components
-include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[leveloffset=+1]
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[leveloffset=+1,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
 [role="_additional-resources"]
 .Additional resources
@@ -175,9 +178,15 @@ You can ensure that the containers that run monitoring components have enough CP
 
 You can configure these limits and requests for core platform monitoring components in the `openshift-monitoring` namespace and for the components that monitor user-defined projects in the `openshift-user-workload-monitoring` namespace.
 
-include::modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2]
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
-include::modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2]
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
 // Configuring persistent storage
 include::modules/monitoring-configuring-persistent-storage.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): No version for CP

Issue: [OBSDOCS-1432](https://issues.redhat.com/browse/OBSDOCS-1432)

Link to docs preview: 
* CPM tolerations: [link](https://83854--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#assigning-tolerations-to-monitoring-components-cpm_configuring-the-monitoring-stack)
* UWM tolerations: [link](https://83854--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#assigning-tolerations-to-monitoring-components-uwm_configuring-the-monitoring-stack)
* CPM limits: 
  * [link 1](https://83854--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#about-specifying-limits-and-requests-for-monitoring-components-cpm_configuring-the-monitoring-stack)
  * [link 2](https://83854--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#specifying-limits-and-resource-requests-for-monitoring-components-cpm_configuring-the-monitoring-stack)
* UWM limits:
  * [link 1](https://83854--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#about-specifying-limits-and-requests-for-monitoring-components-uwm_configuring-the-monitoring-stack)
  * [link 2](https://83854--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#specifying-limits-and-resource-requests-for-monitoring-components-uwm_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

**Additional information:**
This is the part 1 split of core platform monitoring (CPM) and user workload monitoring (UWM) procedures. The issue is getting merged to only `monitoring-docs-restructure`, not to `main`, therefore this change will not be visible in the documentation.

The tagging is implemented so that once this is moved to two different assemblies, we will still only have one module to maintain. This will ensure content reuse instead of duplication. It also prevents creation of multiple new modules with basically identical content.

This issue also asks for changes in ID, however, in the final product, the two procedures will be in a different assembly, therefore two IDs will not be needed (context parameter will take care of it)

You can see https://github.com/openshift/openshift-docs/pull/83431 for reference.