### PR TITLE
OSDOCS-12182: Adding deleting manifests in microshift release notes

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -56,8 +56,12 @@ Updating two minor versions in a single step is supported in 4.18. Updates for b
 //[id="microshift-4-18-storage_{context}"]
 //==== tbd storage feature here
 
-//[id="microshift-4-18-running-apps_{context}"]
-//=== Running applications
+[id="microshift-4-18-running-apps_{context}"]
+=== Running applications
+
+[id="microshift-4-18-deleting-resource-manifest_{context}"]
+==== Deleting or updating Kustomize manifest resources now documented
+With this release, you can delete or upgrade the Kustomize manifest resources. For more information, see xref:../microshift_running_apps/microshift-deleting-resource-manifests.adoc#microshift-deleting-resource-manifests[Deleting or updating Kustomize manifest resources].
 
 //[id="microshift-4-18-run-apps_{context}"]
 //====  tbd run apps feature here


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-12182](https://issues.redhat.com/browse/OSDOCS-12182)

Link to docs preview:
[Deleting resource manifests now documented](https://83855--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-running-apps_release-notes)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
