### PR TITLE
doc: Correct deprecated AuthProvider resource reference to the replacing Access one

### DIFF
--- a/modules/configure-ocp-oauth-identity-provider.adoc
+++ b/modules/configure-ocp-oauth-identity-provider.adoc
@@ -9,7 +9,7 @@
 To integrate the built-in {ocp} OAuth server as an identity provider for {product-title-short}, use the instructions in this section.
 
 .Prerequisites
-* You must have the `AuthProvider` permission to configure identity providers in {product-title-short}.
+* You must have the `Access` permission to configure identity providers in {product-title-short}.
 * You must have already configured users and groups in {ocp} OAuth server through an identity provider. For information about the identity provider requirements, see link:https://docs.openshift.com/container-platform/4.9/authentication/understanding-identity-provider.html[Understanding identity provider configuration].
 
 [NOTE]

--- a/modules/create-a-custom-permission-set.adoc
+++ b/modules/create-a-custom-permission-set.adoc
@@ -9,7 +9,7 @@
 You can create new permission sets from the *Access Control* view.
 
 .Prerequisites
-* You must have the *Admin* role, or a role with the permission set with read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete permission sets.
+* You must have the *Admin* role, or read and write permissions for the `Access` resource to create, modify, and delete permission sets.
 
 .Procedure
 . In the {product-title-short} portal, go to *Platform Configuration* -> *Access Control*.

--- a/modules/create-a-custom-role-3630.adoc
+++ b/modules/create-a-custom-role-3630.adoc
@@ -9,7 +9,7 @@
 You can create new roles from the *Access Control* view.
 
 .Prerequisites
-* You must have the *Admin* role, or a role with the permission set with read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete custom roles.
+* You must have the *Admin* role, or read and write permissions for the `Access` resource to create, modify, and delete custom roles.
 * You must create a permissions set and an access scope for the custom role before creating the role.
 
 .Procedure

--- a/modules/create-a-custom-role.adoc
+++ b/modules/create-a-custom-role.adoc
@@ -9,7 +9,7 @@
 You can create new roles from the *Access Control* view.
 
 .Prerequisites
-* You must have the *Admin* role, or read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete custom roles.
+* You must have the *Admin* role, or read and write permissions for the `Access` resource to create, modify, and delete custom roles.
 
 .Procedure
 . In the {product-title-short} portal, go to *Platform Configuration* -> *Access control*.

--- a/modules/delete-a-custom-role.adoc
+++ b/modules/delete-a-custom-role.adoc
@@ -9,7 +9,7 @@
 From the *Access Control* view, you can delete the custom roles that you have created.
 
 .Prerequisites
-* You must have the *Admin* role, or read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete custom roles.
+* You must have the *Admin* role, or read and write permissions for the `Access` resource to create, modify, and delete custom roles.
 
 .Procedure
 . In the {product-title-short} portal, go to *Platform Configuration* -> *Access control*.

--- a/modules/manage-access-for-specific-users-or-groups.adoc
+++ b/modules/manage-access-for-specific-users-or-groups.adoc
@@ -24,7 +24,7 @@ For example:
 ====
 
 .Prerequisites
-* You must have the *Admin* role, or read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete custom roles.
+* You must have the *Admin* role, or read and write permissions for the `Access` resource to create, modify, and delete custom roles.
 
 .Procedure
 . In the {product-title-short} portal, go to *Platform Configuration* -> *Access control*.

--- a/modules/modify-a-custom-role.adoc
+++ b/modules/modify-a-custom-role.adoc
@@ -9,7 +9,7 @@
 From the *Access Control* view, you can modify permissions for the custom roles that you have created.
 
 .Prerequisites
-* You must have the *Admin* role, or read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete custom roles.
+* You must have the *Admin* role, or read and write permissions for the `Access` resource to create, modify, and delete custom roles.
 
 .Procedure
 . In the {product-title-short} portal, go to *Platform Configuration* -> *Access control*.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
References to a deprecated and removed resource are still present in the RHACS documentation. This PR aims at correcting the references and point them at the appropriate resource.

Version(s):
4.5+

Issue: ***n/a***
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Links to docs previews:

[83856--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/configuring-identity-providers/configure-ocp-oauth.html](https://83856--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/configuring-identity-providers/configure-ocp-oauth.html)
[83856--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/manage-role-based-access-control-3630.html](https://83856--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/manage-role-based-access-control-3630.html)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
