### PR TITLE
OCPBUGS-31846: Replaced imageContentSources with imageDigestSources

### DIFF
--- a/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -13,7 +13,7 @@ In {product-title} version {product-version}, you can install a cluster on Amazo
 
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
@@ -30,7 +30,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry on your mirror host] and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_azure/ipi/installing-restricted-networks-azure-installer-provisioned.adoc
+++ b/installing/installing_azure/ipi/installing-restricted-networks-azure-installer-provisioned.adoc
@@ -16,7 +16,7 @@ You can install an {product-title} cluster by using mirrored installation releas
 [id="prerequisites_installing-restricted-networks-azure-installer-provisioned"]
 == Prerequisites
 
-* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned.adoc
+++ b/installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned.adoc
@@ -20,7 +20,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You xref:../../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[configured an Azure account] to host the cluster and determined the tested and validated region to deploy the cluster to.
-* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -19,7 +19,7 @@ You can install an {product-title} cluster by using mirrored installation releas
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster.
-* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -25,7 +25,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -19,7 +19,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry for installation in a restricted network] and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry for installation in a restricted network] and obtained the `imageDigestSources` data for your version of {product-title}.
 * Before you begin the installation process, you must move or remove any existing installation files. This ensures that the required installation files are created and updated during the installation process.
 +
 [IMPORTANT]

--- a/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
@@ -14,7 +14,7 @@ In {product-title} {product-version}, you can install a cluster on {ibm-cloud-na
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You xref:../../installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs.adoc#installing-ibm-cloud-account-power-vs[configured an {ibm-cloud-name} account] to host the cluster.
-* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -25,7 +25,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageDigestSources` data for your version of {product-title}.
 * You must move or remove any existing installation files, before you begin the installation process. This ensures that the required installation files are created and updated during the installation process.
 +
 [IMPORTANT]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-lpar.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-lpar.adoc
@@ -24,7 +24,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry for installation in a restricted network] and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry for installation in a restricted network] and obtained the `imageDigestSources` data for your version of {product-title}.
 * Before you begin the installation process, you must move or remove any existing installation files. This ensures that the required installation files are created and updated during the installation process.
 +
 [IMPORTANT]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -25,7 +25,7 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry for installation in a restricted network] and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry for installation in a restricted network] and obtained the `imageDigestSources` data for your version of {product-title}.
 * Before you begin the installation process, you must move or remove any existing installation files. This ensures that the required installation files are created and updated during the installation process.
 +
 [IMPORTANT]

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -14,7 +14,7 @@ In {product-title} {product-version}, you can install a cluster on
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You verified that {product-title} {product-version} is compatible with your {rh-openstack} version by using the xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters] section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
@@ -20,7 +20,7 @@ include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
+* You xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtain the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -18,7 +18,7 @@ include::snippets/technology-preview.adoc[]
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
@@ -24,7 +24,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageDigestSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====

--- a/modules/agent-install-about-mirroring-for-disconnected-registry.adoc
+++ b/modules/agent-install-about-mirroring-for-disconnected-registry.adoc
@@ -17,7 +17,7 @@ The following example shows the output of the `oc adm release mirror` command.
 
 [source,terminal]
 ----
-$ oc adm release mirror
+$ oc adm release mirror --print-mirror-instructions=idms
 ----
 
 .Example output
@@ -27,7 +27,7 @@ $ oc adm release mirror
 To use the new mirrored repository to install, add the following
 section to the install-config.yaml:
 
-imageContentSources:
+imageDigestSources:
 
 mirrors:
 virthost.ostest.test.metalkube.org:5000/localimages/local-release-image

--- a/modules/agent-install-configuring-for-disconnected-registry.adoc
+++ b/modules/agent-install-configuring-for-disconnected-registry.adoc
@@ -17,9 +17,9 @@ You must use the output of either the `oc adm release mirror` command or the oc-
 
 . If you used the `oc adm release mirror` command to mirror your release images:
 
-* Copy the text in the `imageContentSources` section of the command output.
+* Copy the text in the `imageDigestSources` section of the command output.
 
-. Paste the copied text into the `imageContentSources` field of the `install-config.yaml` file.
+. Paste the copied text into the `imageDigestSources` field of the `install-config.yaml` file.
 
 . Add the certificate file used for the mirror registry to the `additionalTrustBundle` field of the yaml file.
 +

--- a/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
@@ -12,12 +12,12 @@ You must mirror both the platform image and Operator images that you want to upd
 
 * For platform updates, you must perform the following steps:
 +
-. Mirror the desired {product-title} image repository. Ensure that the desired platform image is mirrored by following the "Mirroring the {product-title} image repository" procedure linked in the Additional resources. Save the contents of the `imageContentSources` section in the `imageContentSources.yaml` file:
+. Mirror the desired {product-title} image repository. Ensure that the desired platform image is mirrored by following the "Mirroring the {product-title} image repository" procedure linked in the Additional resources. Save the contents of the `imageDigestSources` section in the `imageDigestSources.yaml` file:
 +
 .Example output
 [source,yaml]
 ----
-imageContentSources:
+imageDigestSources:
  - mirrors:
    - mirror-ocp-registry.ibmcloud.io.cpak:5000/openshift-release-dev/openshift4
    source: quay.io/openshift-release-dev/ocp-release

--- a/modules/hcp-hc-objects.adoc
+++ b/modules/hcp-hc-objects.adoc
@@ -116,7 +116,7 @@ spec:
   additionalTrustBundle:
     name: "user-ca-bundle"
   olmCatalogPlacement: guest
-  imageContentSources: <3>
+  imageDigestSources: <3>
   - source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
     mirrors:
     - registry.<dns.base.domain.name>:5000/openshift/release <4>
@@ -186,7 +186,7 @@ status:
 +
 <1> Replace `<hosted_cluster_name>` with your hosted cluster.
 <2> Replace `<hosted_cluster_namespace>` with the name of your hosted cluster namespace.
-<3> The `imageContentSources` section contains mirror references for user workloads within the hosted cluster.
+<3> The `imageDigestSources` section contains mirror references for user workloads within the hosted cluster.
 <4> Replace `<dns.base.domain.name>` with the DNS base domain name.
 <5> Replace `4.x.y` with the supported {product-title} version you want to use.
 

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -280,7 +280,7 @@ additionalTrustBundle: | <16>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <17>
+imageDigestSources: <17>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -293,7 +293,7 @@ additionalTrustBundle: | <15>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <16>
+imageDigestSources: <16>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -414,7 +414,7 @@ port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
 <16> Provide the contents of the certificate file that you used for your mirror registry.
-<17> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<17> Provide the `imageDigestSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 <14> For `<local_registry>`, specify the registry domain name, and optionally the
@@ -422,7 +422,7 @@ port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
 <15> Provide the contents of the certificate file that you used for your mirror registry.
-<16> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<16> Provide the `imageDigestSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]
 

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -177,7 +177,7 @@ additionalTrustBundle: | <18>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <19>
+imageDigestSources: <19>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -316,7 +316,7 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 ifdef::restricted[]
 <18> Provide the contents of the certificate file that you used for your mirror registry.
-<19> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<19> Provide the `imageDigestSources` section from the output of the command to mirror the repository.
 <20> How to publish the user-facing endpoints of your cluster. When using Azure Firewall to restrict Internet access, set `publish` to `Internal` to deploy a private cluster. The user-facing endpoints then cannot be accessed from the internet. The default value is `External`.
 endif::restricted[]
 ifdef::private[]

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -139,7 +139,7 @@ additionalTrustBundle: | <15>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <16>
+imageDigestSources: <16>
 - mirrors:
 ifdef::ibm-z,ibm-z-kvm[]
   - <local_repository>/ocp4/openshift4
@@ -161,7 +161,7 @@ additionalTrustBundle: | <14>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <15>
+imageDigestSources: <15>
 - mirrors:
 ifdef::ibm-z,ibm-z-kvm[]
   - <local_repository>/ocp4/openshift4
@@ -288,17 +288,17 @@ ifdef::ibm-z,ibm-z-kvm[]
 <15> Add the `additionalTrustBundle` parameter and value. The value must be the contents of the certificate file that you used for your mirror registry. The certificate file can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
 endif::ibm-z,ibm-z-kvm[]
 ifndef::openshift-origin[]
-<16> Provide the `imageContentSources` section according to the output of the command that you used to mirror the repository.
+<16> Provide the `imageDigestSources` section according to the output of the command that you used to mirror the repository.
 +
 [IMPORTANT]
 ====
-* When using the `oc adm release mirror` command, use the output from the `imageContentSources` section.
+* When using the `oc adm release mirror` command, use the output from the `imageDigestSources` section.
 * When using `oc mirror` command, use the `repositoryDigestMirrors` section of the `ImageContentSourcePolicy` file that results from running the command.
 * `ImageContentSourcePolicy` is deprecated. For more information see _Configuring image registry repository mirroring_.
 ====
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<15> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<15> Provide the `imageDigestSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -655,16 +655,16 @@ If you are using Azure File storage, you cannot enable FIPS mode.
 ====
 |`false` or `true`
 endif::openshift-origin,ibm-power-vs[]
-|imageContentSources:
+|imageDigestSources:
 |Sources and repositories for the release-image content.
 |Array of objects. Includes a `source` and, optionally, `mirrors`, as described in the following rows of this table.
 
-|imageContentSources:
+|imageDigestSources:
   source:
-|Required if you use `imageContentSources`. Specify the repository that users refer to, for example, in image pull specifications.
+|Required if you use `imageDigestSources`. Specify the repository that users refer to, for example, in image pull specifications.
 |String
 
-|imageContentSources:
+|imageDigestSources:
   mirrors:
 |Specify one or more repositories that may also contain the same images.
 |Array of strings

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -167,7 +167,7 @@ additionalTrustBundle: | <16>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <17>
+imageDigestSources: <17>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -180,7 +180,7 @@ additionalTrustBundle: | <15>
   -----BEGIN CERTIFICATE-----
   <MY_TRUSTED_CA_CERT>
   -----END CERTIFICATE-----
-imageContentSources: <16>
+imageDigestSources: <16>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -274,11 +274,11 @@ endif::private[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
 <16> Provide the contents of the certificate file that you used for your mirror registry.
-<17> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<17> Provide the `imageDigestSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 <15> Provide the contents of the certificate file that you used for your mirror registry.
-<16> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<16> Provide the `imageDigestSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]
 

--- a/modules/installation-generate-aws-user-infra-install-config.adoc
+++ b/modules/installation-generate-aws-user-infra-install-config.adoc
@@ -110,7 +110,7 @@ additionalTrustBundle: |
 +
 [source,yaml]
 ----
-imageContentSources:
+imageDigestSources:
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -119,7 +119,7 @@ imageContentSources:
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 ----
 +
-Use the `imageContentSources` section from the output of the command to mirror the repository or the values that you used when you mirrored the content from the media that you brought into your restricted network.
+Use the `imageDigestSources` section from the output of the command to mirror the repository or the values that you used when you mirrored the content from the media that you brought into your restricted network.
 
 .. Optional: Set the publishing strategy to `Internal`:
 +

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -364,7 +364,7 @@ additionalTrustBundle: | <17>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <18>
+imageDigestSources: <18>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -377,7 +377,7 @@ additionalTrustBundle: | <16>
   -----BEGIN CERTIFICATE-----
   <MY_TRUSTED_CA_CERT>
   -----END CERTIFICATE-----
-imageContentSources: <17>
+imageDigestSources: <17>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release

--- a/modules/installation-ibm-power-vs-config-yaml.adoc
+++ b/modules/installation-ibm-power-vs-config-yaml.adoc
@@ -334,7 +334,7 @@ additionalTrustBundle: | <14>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <15>
+imageDigestSources: <15>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -366,7 +366,7 @@ When simultaneous multithreading (SMT), or hyperthreading is not enabled, one vC
 <12> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, registry.example.com or registry.example.com:5000. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
 <13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 <14> Provide the contents of the certificate file that you used for your mirror registry.
-<15> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<15> Provide the `imageDigestSources` section from the output of the command to mirror the repository.
 +
 [NOTE]
 ====

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -104,7 +104,7 @@ endif::ibm-cloud-restricted[]
 * You have obtained the {product-title} installation program and the pull secret for your
 cluster.
 ifdef::restricted,restricted-upi[]
-* Obtain the `imageContentSources` section from the output of the command to
+* Obtain the `imageDigestSources` section from the output of the command to
 mirror the repository.
 * Obtain the contents of the certificate for your mirror registry.
 endif::restricted,restricted-upi[]
@@ -179,7 +179,7 @@ For `platform.ibmcloud.vpcName`, specify the name for the existing {ibm-cloud-ti
 +
 [source,yaml]
 ----
-imageContentSources:
+imageDigestSources:
 - mirrors:
   - <mirror_host_name>:5000/<repo_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -248,7 +248,7 @@ ifdef::restricted,restricted-upi[]
 `docker.io`, you must provide the contents of the certificate for your mirror
 repository in the `additionalTrustBundle` section. In most cases, you must
 provide the certificate for your mirror.
-** You must include the `imageContentSources` section from the output of the command to
+** You must include the `imageDigestSources` section from the output of the command to
 mirror the repository.
 
 +

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -201,7 +201,7 @@ endif::nutanix[]
 ifdef::restricted[]
 For a restricted network installation, these files are on your mirror host.
 ifndef::nutanix,ibm-cloud[]
-* You have the `imageContentSources` values that were generated during mirror registry creation.
+* You have the `imageDigestSources` values that were generated during mirror registry creation.
 endif::nutanix,ibm-cloud[]
 ifdef::nutanix+restricted[]
 * You have the `imageContentSourcePolicy.yaml` file that was created when you mirrored your registry.
@@ -534,7 +534,7 @@ endif::ibm-cloud+restricted[]
 +
 [source,yaml]
 ----
-imageContentSources:
+imageDigestSources:
 - mirrors:
   - <mirror_host_name>:5000/<repo_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -544,7 +544,7 @@ imageContentSources:
 ----
 +
 ifndef::nutanix,ibm-cloud[]
-For these values, use the `imageContentSources` that you recorded during mirror registry creation.
+For these values, use the `imageDigestSources` that you recorded during mirror registry creation.
 endif::nutanix,ibm-cloud[]
 ifdef::nutanix,ibm-cloud[]
 For these values, use the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -93,7 +93,7 @@ additionalTrustBundle: | <13>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <14>
+imageDigestSources: <14>
 - mirrors:
   - <mirror_host_name>:<mirror_port>/<repo_name>/release
   source: <source_image_1>
@@ -129,7 +129,7 @@ port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
 <13> Provide the contents of the certificate file that you used for your mirror registry.
-<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<14> Provide the `imageDigestSources` section from the output of the command to mirror the repository.
 endif::restricted[]
 
 [NOTE]

--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -139,10 +139,10 @@ ifndef::openshift-rosa,openshift-dedicated[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
-     --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE} \
-     --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
-     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE} --dry-run
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON} \ 
+     --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE} \ 
+     --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \ 
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE} --dry-run --print-mirror-instructions=idms
 ----
 endif::[]
 ifndef::openshift-origin[]
@@ -155,8 +155,8 @@ $ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
 ----
 endif::[]
 
-... Record the entire `imageContentSources` section from the output of the previous
-command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageContentSources` section to the `install-config.yaml` file during installation.
+... Record the entire `imageDigestSources` section from the output of the previous
+command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageDigestSources` section to the `install-config.yaml` file during installation.
 ... Mirror the images to a directory on the removable media:
 +
 ifdef::openshift-origin[]
@@ -209,10 +209,10 @@ $ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
 endif::[]
 +
 This command pulls the release information as a digest, and its output includes
-the `imageContentSources` data that you require when you install your cluster.
+the `imageDigestSources` data that you require when you install your cluster.
 
-... Record the entire `imageContentSources` section from the output of the previous
-command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageContentSources` section to the `install-config.yaml` file during installation.
+... Record the entire `imageDigestSources` section from the output of the previous
+command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageDigestSources` section to the `install-config.yaml` file during installation.
 +
 [NOTE]
 ====
@@ -277,10 +277,10 @@ $ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
 ----
 +
 This command pulls the release information as a digest, and its output includes
-the `imageContentSources` data that you require when you install your cluster.
+the `imageDigestSources` data that you require when you install your cluster.
 
-.. Record the entire `imageContentSources` section from the output of the previous
-command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageContentSources` section to the `install-config.yaml` file during installation.
+.. Record the entire `imageDigestSources` section from the output of the previous
+command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageDigestSources` section to the `install-config.yaml` file during installation.
 +
 [NOTE]
 ====

--- a/modules/installation-nutanix-config-yaml.adoc
+++ b/modules/installation-nutanix-config-yaml.adoc
@@ -224,7 +224,7 @@ additionalTrustBundle: | <12>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <13>
+imageDigestSourcess: <13>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -237,7 +237,7 @@ additionalTrustBundle: | <11>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <12>
+imageDigestSources: <12>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release

--- a/modules/installation-osp-restricted-config-yaml.adoc
+++ b/modules/installation-osp-restricted-config-yaml.adoc
@@ -59,7 +59,7 @@ additionalTrustBundle: |
 
   -----END CERTIFICATE-----
 
-imageContentSources:
+imageDigestSources:
 - mirrors:
   - <mirror_registry>/<repo_name>/release
   source: quay.io/openshift-release-dev/ocp-release

--- a/modules/installation-performing-disconnected-mirror-without-registry.adoc
+++ b/modules/installation-performing-disconnected-mirror-without-registry.adoc
@@ -11,7 +11,7 @@ If a production mirror registry is not available, you can configure a simple mir
 
 . Determine the IP of your host within the restricted network as `<private_ip>`.
 
-. On a local host, copy the required `imageContentSources` and `ImageContentSourcePolicy`:
+. On a local host, copy the required `imageDigestSources` and `ImageContentSourcePolicy`:
 .. Make the mirror directory and change to it:
 +
 ----

--- a/modules/installation-performing-disconnected-mirror.adoc
+++ b/modules/installation-performing-disconnected-mirror.adoc
@@ -18,7 +18,7 @@ procedure.
 $ oc adm release mirror <product_version> --to <mirror_repository> --dry-run
 ----
 
-. On a local host, copy the required `imageContentSources` and `ImageContentSourcePolicy`:
+. On a local host, copy the required `imageDigestSources` and `ImageContentSourcePolicy`:
 .. Make the mirror directory and change to it:
 +
 ----

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -95,7 +95,7 @@ additionalTrustBundle: | <17>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <18>
+imageDigestSources: <18>
 - mirrors:
   - <mirror_host_name>:<mirror_port>/<repo_name>/release
   source: <source_image_1>
@@ -108,7 +108,7 @@ additionalTrustBundle: | <16>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <17>
+imageDigestSources: <17>
 - mirrors:
   - <mirror_host_name>:<mirror_port>/<repo_name>/release
   source: <source_image_1>
@@ -209,13 +209,13 @@ ifdef::restricted[]
 ifndef::openshift-origin[]
 <17> Provide the contents of the certificate file that you used for your mirror
 registry.
-<18> Provide the `imageContentSources` section from the output of the command to
+<18> Provide the `imageDigestSources` section from the output of the command to
 mirror the repository.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 <16> Provide the contents of the certificate file that you used for your mirror
 registry.
-<17> Provide the `imageContentSources` section from the output of the command to
+<17> Provide the `imageDigestSources` section from the output of the command to
 mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]

--- a/modules/ipi-install-mirroring-for-disconnected-registry.adoc
+++ b/modules/ipi-install-mirroring-for-disconnected-registry.adoc
@@ -145,8 +145,8 @@ $ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
 ----
 endif::[]
 
-... Record the entire `imageContentSources` section from the output of the previous
-command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageContentSources` section to the `install-config.yaml` file during installation.
+... Record the entire `imageDigestSources` section from the output of the previous
+command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageDigestSources` section to the `install-config.yaml` file during installation.
 ... Mirror the images to a directory on the removable media:
 +
 ifdef::openshift-origin[]
@@ -194,10 +194,10 @@ $ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
 endif::[]
 +
 This command pulls the release information as a digest, and its output includes
-the `imageContentSources` data that you require when you install your cluster.
+the `imageDigestSources` data that you require when you install your cluster.
 
-... Record the entire `imageContentSources` section from the output of the previous
-command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageContentSources` section to the `install-config.yaml` file during installation.
+... Record the entire `imageDigestSources` section from the output of the previous
+command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageDigestSources` section to the `install-config.yaml` file during installation.
 +
 [NOTE]
 ====

--- a/modules/ipi-install-troubleshooting-install-config.adoc
+++ b/modules/ipi-install-troubleshooting-install-config.adoc
@@ -7,7 +7,7 @@
 
 = Troubleshooting `install-config.yaml`
 
-The `install-config.yaml` configuration file represents all of the nodes that are part of the {product-title} cluster. The file contains the necessary options consisting of but not limited to `apiVersion`, `baseDomain`, `imageContentSources` and virtual IP addresses. If errors occur early in the deployment of the {product-title} cluster, the errors are likely in the `install-config.yaml` configuration file.
+The `install-config.yaml` configuration file represents all of the nodes that are part of the {product-title} cluster. The file contains the necessary options consisting of but not limited to `apiVersion`, `baseDomain`, `imageDigestSources` and virtual IP addresses. If errors occur early in the deployment of the {product-title} cluster, the errors are likely in the `install-config.yaml` configuration file.
 
 .Procedure
 

--- a/modules/ipi-modify-a-disconnected-registry-config-yaml.adoc
+++ b/modules/ipi-modify-a-disconnected-registry-config-yaml.adoc
@@ -36,7 +36,7 @@ The value must be the contents of the certificate file that you used for your mi
 +
 [source,yaml]
 ----
-imageContentSources:
+imageDigestSourcess:
 - mirrors:
   - <mirror_host_name>:5000/<repo_name>/release
   source: quay.example.com/openshift-release-dev/ocp-release
@@ -45,6 +45,6 @@ imageContentSources:
   source: registry.example.com/ocp/release
 ----
 +
-For these values, use the `imageContentSources` that you recorded during mirror registry creation.
+For these values, use the `imageDigestSources` that you recorded during mirror registry creation.
 
 . Make any other modifications to the `install-config.yaml` file that you require. You can find more information about the available parameters in the *Installation configuration parameters* section.

--- a/modules/ipi-modify-install-config-for-a-disconnected-registry.adoc
+++ b/modules/ipi-modify-install-config-for-a-disconnected-registry.adoc
@@ -30,7 +30,7 @@ $ sed -e 's/^/  /' /opt/registry/certs/domain.crt >> install-config.yaml
 +
 [source,terminal]
 ----
-$ echo "imageContentSources:" >> install-config.yaml
+$ echo "imageDigestSources:" >> install-config.yaml
 ----
 +
 [source,terminal]

--- a/modules/preparing-an-initial-cluster-deployment-for-mce-disconnected.adoc
+++ b/modules/preparing-an-initial-cluster-deployment-for-mce-disconnected.adoc
@@ -70,11 +70,11 @@ $ oc mirror --dest-skip-tls --config ocp-mce-imageset.yaml docker://<your-local-
 
 . Update the registry and certificate in the `install-config.yaml` file:
 +
-.Example `imageContentSources.yaml`
+.Example `imageDigestSources.yaml`
 
 [source,yaml]
 ----
-  imageContentSources:
+  imageDigestSources:
     - source: "quay.io/openshift-release-dev/ocp-release"
       mirrors:
         - "<your-local-registry-dns-name>:<your-local-registry-port>/openshift/release-images"

--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -51,8 +51,8 @@ data:
 ----
 <1> The `ConfigMap` namespace must be set to `multicluster-engine`.
 <2> The mirror registry’s certificate that is used when creating the mirror registry.
-<3> The configuration file for the mirror registry. The mirror registry configuration adds mirror information to the `/etc/containers/registries.conf` file in the discovery image. The mirror information is stored in the `imageContentSources` section of the `install-config.yaml` file when the information is passed to the installation program. The Assisted Service pod that runs on the hub cluster fetches the container images from the configured mirror registry.
-<4> The URL of the mirror registry. You must use the URL from the `imageContentSources` section by running the `oc adm release mirror` command when you configure the mirror registry. For more information, see the _Mirroring the OpenShift Container Platform image repository_ section.
+<3> The configuration file for the mirror registry. The mirror registry configuration adds mirror information to the `/etc/containers/registries.conf` file in the discovery image. The mirror information is stored in the `imageDigestSources` section of the `install-config.yaml` file when the information is passed to the installation program. The Assisted Service pod that runs on the hub cluster fetches the container images from the configured mirror registry.
+<4> The URL of the mirror registry. You must use the URL from the `imageDigestSources` section by running the `oc adm release mirror` command when you configure the mirror registry. For more information, see the _Mirroring the OpenShift Container Platform image repository_ section.
 <5> The registries defined in the `registries.conf` file must be scoped by repository, not by registry. In this example, both the `quay.io/example-repository` and the `mirror1.registry.corp.com:5000/example-repository` repositories are scoped by the `example-repository` repository.
 +
 This updates `mirrorRegistryRef` in the `AgentServiceConfig` custom resource, as shown below:

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-platform-update.adoc
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-platform-update.adoc
@@ -62,5 +62,5 @@ policies:
 ----
 <1> Shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image pre-caching.
 <2> `ImageSignature.yaml` contains the image signature of the required release image. The image signature is used to verify the image before applying the platform update.
-<3> Shows the mirror repository that contains the required {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
+<3> Shows the mirror repository that contains the required {product-title} image. Get the mirrors from the `imageDigestSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
 

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-platform-update.adoc
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-platform-update.adoc
@@ -44,5 +44,5 @@ spec:
 ----
 <1> The `ConfigMap` CR contains the signature of the desired release image to update to.
 <2> Shows the image signature of the desired {product-title} release. Get the signature from the `checksum-${OCP_RELEASE_NUMBER}.yaml` file you saved when following the procedures in the "Setting up the environment" section.
-<3> Shows the mirror repository that contains the desired {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
+<3> Shows the mirror repository that contains the desired {product-title} image. Get the mirrors from the `imageDigestSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
 <4> Shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image pre-caching.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-31846](https://issues.redhat.com/browse/OCPBUGS-31846)

Link to docs preview:
* Too many files impacted. See the list [artifacts/updated_preview_urls.txt](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_openshift-docs/83857/pull-ci-openshift-openshift-docs-main-validate-asciidoc/1848306774558380032/artifacts/validate-asciidoc/openshift-docs-preview-comment-pages/artifacts/updated_preview_urls.txt)

- [ ] SME has approved this change.
- [ ] QE has approved this change.

Add. resources:
* [Disconnected doc proposal](https://docs.google.com/document/d/17jV_D-uMW8secOyShYZ9pvaMzigZmGgsoxQz276XqNE/edit?tab=t.0#heading=h.w8wbakuuo8mj)
* The [ImageContentSourcePolicy (ICSP) object](https://docs.openshift.com/container-platform/4.13/release_notes/ocp-4-13-release-notes.html#ocp-4-13-icsp_release-notes) was replaced by ImageDigestMirrorSet (IDMS) in 4.13. Not the same thing as [ImageContentSources](https://github.com/openshift/installer/blob/master/pkg/types/installconfig.go) and ImageDigestSource. 
* oc-mirror v1 still uses the ICSP object. oc-mirror v2 in 4.18 will be GA and will use IDMS.
* In the context of oc-mirror, a user must copy images from the ICSP object and apply them to the ImageDigestSource section of the install-config.yaml file (ensure as disconnected docs reflect this).