### PR TITLE
OSDOCS#11933: About gathering information about the workloads in your multi-architecture cluster

### DIFF
--- a/modules/multi-arch-gather-info-about-workloads.adoc
+++ b/modules/multi-arch-gather-info-about-workloads.adoc
@@ -1,0 +1,31 @@
+//Module included in the following assemblies
+//
+// *post_installation_configuration/multiarch-tuning-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="multi-architecture-gather-info-about-workloads_{context}"]
+= Multiarch Tuning Operator pod labels and architecture support overview
+
+After installing the Multiarch Tuning Operator, you can verify the multi-architecture support for workloads in your cluster. You can identify and manage pods based on their architecture compatibility by using the pod labels. These labels are automatically set on the newly created pods to provide insights into their architecture support.
+
+The following table describes the labels that the Multiarch Tuning Operator adds when you create a pod:
+
+.Pod labels that the Multiarch Tuning Operator adds when you create a pod
+[%autowidth,options="header"]
+|====
+
+|Label |Description
+
+|`multiarch.openshift.io/multi-arch: ""` |The pod supports multiple architectures.
+|`multiarch.openshift.io/single-arch: ""` |The pod supports only a single architecture.
+|`multiarch.openshift.io/arm64: ""` |The pod supports the `arm64` architecture.
+|`multiarch.openshift.io/amd64: ""` |The pod supports the `amd64` architecture.
+|`multiarch.openshift.io/ppc64le: ""` |The pod supports the `ppc64le` architecture.
+|`multiarch.openshift.io/s390x: ""` |The pod supports the `s390x` architecture.
+|`multirach.openshift.io/node-affinity: set` |The Operator has set the node affinity requirement for the architecture.
+|`multirach.openshift.io/node-affinity: not-set` |The Operator did not set the node affinity requirement. For example, when the pod already has a node affinity for the architecture, the Multiarch Tuning Operator adds this label to the pod.
+|`multiarch.openshift.io/scheduling-gate: gated` |The pod is gated.
+|`multiarch.openshift.io/scheduling-gate: removed` |The pod gate has been removed.
+|`multiarch.openshift.io/inspection-error: ""` |An error has occurred while building the node affinity requirements.
+
+|====

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc
@@ -42,6 +42,9 @@ include::modules/multi-arch-installing-using-cli.adoc[leveloffset=+1]
 
 include::modules/multi-arch-installing-using-web-console.adoc[leveloffset=+1]
 
+//Multiarch Tuning Operator pod labels and architecture support overview
+include::modules/multi-arch-gather-info-about-workloads.adoc[leveloffset=+1]
+
 //Creating the pod placement config object
 include::modules/multi-arch-creating-podplacment-config.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-11933](https://issues.redhat.com/browse/OSDOCS-11933)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Gathering information about the workloads in your multi-architecture cluster](https://83859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html#multi-architecture-gather-info-about-workloads_multiarch-tuning-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


Note to Peer reviewer: The title is not apt for a concept module because it starts with a gerund. I'd appreciate any alternative suggestions for the title. 
