### PR TITLE
OCPBUGS-38352-fix

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -30,7 +30,7 @@
 
 |IPv4/IPv6 dual-stack|Not Supported|Supported ^[4]^
 
-|IPv6/IPv4 dual-stack|Not supported|Supported ^[4]^
+|IPv6/IPv4 dual-stack|Not supported|Supported ^[5]^
 
 |Kubernetes network policy|Supported|Supported
 
@@ -49,5 +49,7 @@
 
 3. IPv6 single-stack networking on a bare-metal platform.
 
-4. IPv4/IPv6 or IPv6/IPv4 dual-stack networking on bare-metal, {vmw-full} (installer-provisioned infrastructure installations only), {ibm-power-name}, {ibm-z-name}, and {rh-openstack} platforms.
+4. IPv4/IPv6 dual-stack networking on bare-metal, {vmw-full} (installer-provisioned infrastructure installations only), {ibm-power-name}, {ibm-z-name}, and {rh-openstack} platforms.
+
+5. IPv6/IPv4 dual-stack networking on bare-metal, {vmw-full} (installer-provisioned infrastructure installations only), and {ibm-power-name} platforms.
 --


### PR DESCRIPTION
Version(s):
4.15 and 4.16

Issue:
[OCPBUGS-38352](https://issues.redhat.com/browse/OCPBUGS-38352)

Link to docs preview:
[Supported network plugin feature matrix - OVNK](https://83860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-matrix_about-ovn-kubernetess)

- [x] SME has approved this change.
- [x] QE has approved this change.

