### PR TITLE
OSDOCS-12006: adds 4.16.18 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -298,12 +298,20 @@ Issued: 8 October 2024
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
 
-
 [id="microshift-4-16-17-dp_{context}"]
 === RHBA-2024:7946 - {microshift-short} 4.16.17 bug fix and enhancement advisory
 
 Issued: 16 October 2024
 
 {product-title} release 4.16.17 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7946[RHBA-2024:7946] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7944[RHSA-2024:7944] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-18-dp_{context}"]
+=== RHBA-2024:8262 - {microshift-short} 4.16.18 bug fix and enhancement advisory
+
+Issued: 24 October 2024
+
+{product-title} release 4.16.18 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8262[RHBA-2024:8262] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8260[RHSA-2024:8260] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12006](https://issues.redhat.com/browse/OSDOCS-12006)

Link to docs preview:
[microshift-4-16-18-dp_release-notes](https://83861--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-18-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
