### PR TITLE
Remove TP prereq for node disruption policy

### DIFF
--- a/modules/machine-config-node-disruption-config.adoc
+++ b/modules/machine-config-node-disruption-config.adoc
@@ -12,15 +12,6 @@ You can control how your nodes respond to changes in the files in the `/var` or 
 
 include::snippets/machine-config-node-disruption-actions.adoc[]
 
-.Prerequisites
-
-* You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates".
-+
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster prevents minor version updates. The `TechPreviewNoUpgrade` feature set cannot be disabled. Do not enable this feature set on production clusters.
-====
-
 .Procedure
 
 . Edit the `machineconfigurations.operator.openshift.io` object to define the node disruption policy:


### PR DESCRIPTION
Based on [private Slack conversation](https://redhat-internal.slack.com/archives/D05B159J6BD/p1729301677412819), removed the TP prereq as the [feature went GA in 4.17](https://docs.openshift.com/container-platform/4.17/release_notes/ocp-4-17-release-notes.html#ocp-4-17-machine-config-operator-node-disrupt-ga_release-notes).

[Configuring node restart behaviors upon machine config changes](https://83864--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-node-disruption.html#machine-config-node-disruption-config_machine-configs-configure) -- Removed Prerequisites section.

No QE needed.