### PR TITLE
Relax jq guidance in contrib guide

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1559,7 +1559,7 @@ Do not use `[...]`, `<snip>`, or any other variant.
 
 [[jq-commands]]
 ==== Commands with jq
-Do not use `jq` in commands (unless it is truly required), because this requires users to install the `jq` tool. Oftentimes, the same or similar result can be accomplished using `jsonpath` for `oc` commands.
+For commands that use `oc`, you can generally use `jsonpath` instead of redirecting a command output to `jq`.
 
 For example, this command that uses `jq`:
 
@@ -1572,6 +1572,15 @@ can be updated to use `jsonpath` instead:
 ----
 $ oc get clusterversion -o jsonpath='{.items[0].spec}{"\n"}'
 ----
+
+Where a command or procedure requires the user to manipulate JSON and the same result cannot be achieved with existing `oc` and `jsonpath` functionality, you can use `jq` in the procedure.
+If a command or procedure includes `jq`, add installing `jq` as a prerequisite for the procedure.
+
+[NOTE]
+====
+Requiring `jq` can add a maintenance burden for users especially where the user is operating in a secure or restricted environment.
+Only use `jq` in your procedures when there is no alternative.
+====
 
 === YAML formatting for Kubernetes and OpenShift API objects
 The following formatting guidelines apply to YAML manifests, but do not apply to the installation configuration YAML specified by `install-config.yaml`.


### PR DESCRIPTION
Relax jq guidance in the openshift-docs contribution guide. Since RHEL 8, `jq` is ~included in~  installable from the standard compliment of packages.
https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/

Version(s):
enterprise-4.17+

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
