### PR TITLE
CNV-49892: 4.14-specific changes to NetworkAttachmentDefinition YAML

### DIFF
--- a/modules/virt-creating-linux-bridge-nad-cli.adoc
+++ b/modules/virt-creating-linux-bridge-nad-cli.adoc
@@ -32,15 +32,16 @@ metadata:
   annotations:
     k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/bridge-interface <2>
 spec:
-  config: '{
-    "cniVersion": "0.3.1",
-    "name": "bridge-network", <3>
-    "type": "bridge", <4>
-    "bridge": "bridge-interface", <5>
-    "macspoofchk": false, <6>
-    "vlan": 100, <7>
-    "preserveDefaultVlan": false <8>
-  }'
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "bridge-network", <3>
+      "type": "bridge", <4>
+      "bridge": "bridge-interface", <5>
+      "macspoofchk": false, <6>
+      "vlan": 100, <7>
+      "preserveDefaultVlan": false <8>
+    }
 ----
 <1> The name for the `NetworkAttachmentDefinition` object.
 <2> Optional: Annotation key-value pair for node selection, where `bridge-interface` must match the name of a bridge configured on some nodes. If you add this annotation to your network attachment definition, your virtual machine instances will only run on the nodes that have the `bridge-interface` bridge connected.

--- a/modules/virt-pxe-booting-with-mac-address.adoc
+++ b/modules/virt-pxe-booting-with-mac-address.adoc
@@ -28,30 +28,26 @@ endif::openshift-rosa,openshift-dedicated[]
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: pxe-net-conf
+  name: pxe-net-conf # <1>
 spec:
-  config: '{
-    "cniVersion": "0.3.1",
-    "name": "pxe-net-conf",
-    "plugins": [
-      {
-        "type": "bridge",
-        "bridge": "br1",
-        "vlan": 1 <1>
-      },
-      {
-        "type": "cnv-tuning" <2>
-      }
-    ]
-  }'
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "pxe-net-conf", <2>
+      "type": "bridge", <3>
+      "bridge": "bridge-interface", <4>
+      "macspoofchk": false, <5>
+      "vlan": 100, <6>
+      "preserveDefaultVlan": false <7>
+    }
 ----
-<1> Optional: The VLAN tag.
-<2> The `cnv-tuning` plugin provides support for custom MAC addresses.
-+
-[NOTE]
-====
-The virtual machine instance will be attached to the bridge `br1` through an access port with the requested VLAN.
-====
+<1> The name for the `NetworkAttachmentDefinition` object.
+<2> The name for the configuration. It is recommended to match the configuration name to the `name` value of the network attachment definition.
+<3> The actual name of the Container Network Interface (CNI) plugin that provides the network for this network attachment definition. This example uses a Linux bridge CNI plugin. You can also use an OVN-Kubernetes localnet or an SR-IOV CNI plugin.
+<4> The name of the Linux bridge configured on the node.
+<5> Optional: A flag to enable the MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute allows only a single MAC address to exit the pod, which provides security against a MAC spoofing attack.
+<6> Optional: The VLAN tag. No additional VLAN configuration is required on the node network configuration policy.
+<7> Optional: Indicates whether the VM connects to the bridge through the default VLAN. The default value is `true`.
 
 . Create the network attachment definition by using the file you created in the previous step:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-49892](https://issues.redhat.com//browse/CNV-49892)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83885--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge.html#virt-creating-linux-bridge-nad-cli_virt-connecting-vm-to-linux-bridge
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
