### PR TITLE
OCPBUGS#38352-13-12: Updated the OVNK and SDN support matrix table

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -11,52 +11,35 @@
 .Default CNI network plugin feature comparison
 [cols="50%,25%,25%",options="header"]
 |===
-ifeval::["{context}" == "about-ovn-kubernetes"]
-|Feature|OVN-Kubernetes|OpenShift SDN
 
-|Egress IPs|Supported|Supported
-
-|Egress firewall ^[1]^|Supported|Supported
-
-|Egress router|Supported ^[2]^|Supported
-
-|Hybrid networking|Supported|Not supported
-
-|IPsec encryption for intra-cluster communication|Supported|Not supported
-
-|IPv6|Supported ^[3]^ ^[4]^|Not supported
-
-|Kubernetes network policy|Supported|Supported
-
-|Kubernetes network policy logs|Supported|Not supported
-
-|Hardware offloading|Supported|Not supported
-
-|Multicast|Supported|Supported
-endif::[]
-ifeval::["{context}" == "about-openshift-sdn"]
 |Feature|OpenShift SDN|OVN-Kubernetes
 
 |Egress IPs|Supported|Supported
 
-|Egress firewall ^[1]^|Supported|Supported
+|Egress firewall|Supported|Supported ^[1]^
 
 |Egress router|Supported|Supported ^[2]^
 
 |Hybrid networking|Not supported|Supported
 
-|IPsec encryption|Not supported|Supported
+|IPsec encryption for intra-cluster communication|Not supported|Supported
 
-|IPv6|Not supported|Supported ^[3]^ ^[4]^
+|IPv4 single-stack|Supported|Supported
+
+|IPv6 single-stack|Not supported|Supported ^[3]^
+
+|IPv4/IPv6 dual-stack|Not Supported|Supported ^[4]^
+
+|IPv6/IPv4 dual-stack|Not supported|Supported ^[5]^
 
 |Kubernetes network policy|Supported|Supported
 
 |Kubernetes network policy logs|Not supported|Supported
 
+|Hardware offloading|Not supported|Supported
+
 |Multicast|Supported|Supported
 
-|Hardware offloading|Not supported|Supported
-endif::[]
 |===
 [.small]
 --
@@ -64,7 +47,9 @@ endif::[]
 
 2. Egress router for OVN-Kubernetes supports only redirect mode.
 
-3. IPv6 is supported only on bare metal, {ibmpowerProductName}, and {ibmzProductName} clusters.
+3. IPv6 single-stack networking on a bare-metal platform.
 
-4. IPv6 single stack does not support xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState] and is not supported on {ibmpowerProductName} and {ibmzProductName} clusters.
+4. IPv4/IPv6 dual-stack networking on bare-metal, {vmw-full} (installer-provisioned infrastructure installations only), {ibm-power-name}, and {ibm-z-name} platforms. On {vmw-full}, dual-stack networking limitations exist. 
+
+5. IPv6/IPv4 dual-stack networking on bare-metal and {ibm-power-name} platforms.
 --

--- a/networking/openshift_sdn/about-openshift-sdn.adoc
+++ b/networking/openshift_sdn/about-openshift-sdn.adoc
@@ -21,5 +21,10 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/nw-openshift-sdn-modes.adoc[leveloffset=+1]
 endif::[]
 
-// flipped table for OpenShift SDN
+// Supported network plugin feature matrix
 include::modules/nw-ovn-kubernetes-matrix.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about dual-stack networking limitations on {vmw-full}, see xref:../../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#modifying-install-config-for-dual-stack-network_installing-vsphere-installer-provisioned-network-customizations[Optional: Deploying with dual-stack networking].

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -45,7 +45,14 @@ The OVN controller programs the Open vSwitch daemon on the nodes to support the 
 
 include::modules/nw-ovn-kubernetes-features.adoc[leveloffset=+1]
 
+// Supported network plugin feature matrix
 include::modules/nw-ovn-kubernetes-matrix.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about dual-stack networking limitations on {vmw-full}, see xref:../../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#modifying-install-config-for-dual-stack-network_installing-vsphere-installer-provisioned-network-customizations[Optional: Deploying with dual-stack networking].
+
 // This is a moving target; what is included isn't valid for 4.6
 //include::modules/nw-ovn-kubernetes-metrics.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.13

IBMZ: IPv4/IPv6 dual-stack networking support only and not IPv6/IPv4.

Issue:
[OCPBUGS-38352](https://issues.redhat.com/browse/OCPBUGS-38352)

Link to docs preview:
* [Supported network plugin feature matrix-SDN doc
](https://83886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/about-openshift-sdn.html)
* [Supported network plugin feature matrix-OVNK doc
](https://83886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html)
* [RHCOS: Deploying the dual-stack cluster](https://83886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#install-osp-deploy-dualstack_installing-openstack-installer-custom)

- [x] SME has approved this change (IBM Z: Alexander Klein/Dominik Werle , IBM POWER: Paul Bastide).
- [x] QE has approved this change.
