### PR TITLE
OCPBUGS#34724: Removed incorrect vSphere link and replaced step

### DIFF
--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -21,6 +21,11 @@ in the VMware documentation prior to the next step.
 Once converted from a template, do not power on the virtual machine.
 ====
 
-. Update the VM in the vSphere client. Follow link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-60768C2F-72E1-42E0-8A17-CA76849F2950.html[Upgrade the Compatibility of a Virtual Machine Manually] in the VMware documentation for more information.
-. Convert the VM in the vSphere client from a VM to template. Follow link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.hostclient.doc/GUID-846238E4-A1E3-4A28-B230-33BDD1D57454.html[Convert a Virtual Machine to a Template in the vSphere Client] in the VMware documentation for more information.
+. Update the virtual machine (VM) in the {vmw-full} client. Complete the steps outlined in link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-60768C2F-72E1-42E0-8A17-CA76849F2950.html[Upgrade the Compatibility of a Virtual Machine Manually] ({vmw-full} documentation).
+. Convert the VM in the {vmw-short} client to a template by right-clicking on the VM and then selecting **Template -> Convert to Template**.  
++
+[IMPORTANT]
+====
+The steps for converting a VM to a template might change in future {vmw-short} documentation versions.
+====
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-34724](https://issues.redhat.com/browse/OCPBUGS-34724)

Link to docs preview:
https://83887--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
