### PR TITLE
[enterprise-4.17] OCPBUGS#43395: Clarify ose-kube-rbac-proxy-rhel9 pull spec details

### DIFF
--- a/modules/osdk-updating-131-to-1361.adoc
+++ b/modules/osdk-updating-131-to-1361.adoc
@@ -52,14 +52,18 @@ The following procedure updates an existing {type}-based Operator project for co
 OPERATOR_SDK_VERSION ?= v{osdk_ver}-ocp
 ----
 
-. Find the `ose-kube-rbac-proxy` pull spec in the following files, and update the image tag to `v{product-version}`:
+. Update the `kube-rbac-proxy` container to use the {op-system-base-full} 9-based image:
+
+.. Find the entry for the `kube-rbac-proxy` container in the following files:
 +
 --
 * `config/default/manager_auth_proxy_patch.yaml`
-* `bundle/manifests/memcached-operator.clusterserviceversion.yaml`
+* `bundle/manifests/<operator_name>.clusterserviceversion.yaml` for your Operator project, for example `memcached-operator.clusterserviceversion.yaml` from the tutorials
 --
+
+.. Update the image name in the pull spec from `ose-kube-rbac-proxy` to `ose-kube-rbac-proxy-rhel9`, and update the tag to `v{product-version}`:
 +
-.Example `ose-kube-rbac-proxy` pull spec with `v{product-version}` image tag
+.Example `ose-kube-rbac-proxy-rhel9` pull spec with `v{product-version}` image tag
 [source,yaml,subs="attributes+"]
 ----
 # ...


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-43395

4.17

Follow-up to https://github.com/openshift/openshift-docs/pull/83587 for clarity.

* Splits the single step into substeps (felt there was too much info jammed into one step previously)
* More specific about the image name change / switch to RHEL 9
* User might not have a literal `memcached-operator.clusterserviceversion.yaml` file unless they ran the tutorials, so clarify that they should look at whatever their project's file is called

Preview: https://83888--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-updating-projects#osdk-upgrading-projects_osdk-golang-updating-projects (step 2)

NOTE: `{product-version}` will render as `4.17` on the `enterprise-4.17` branch when it is merged and published. It will show as `Branch Build` only during PR preview stage.