### PR TITLE
Adds small note to address bug when creating service accounts

### DIFF
--- a/modules/builds-secrets-restrictions.adoc
+++ b/modules/builds-secrets-restrictions.adoc
@@ -10,7 +10,12 @@ To use a secret, a pod needs to reference the secret. A secret can be used with 
 * As files in a volume mounted on one or more of its containers.
 * By kubelet when pulling images for the pod.
 
-Volume type secrets write data into the container as a file using the volume mechanism. `imagePullSecrets` use service accounts for the automatic injection of the secret into all pods in a namespaces.
+Volume type secrets write data into the container as a file using the volume mechanism. `imagePullSecrets` use service accounts for the automatic injection of the secret into all pods in a namespaces. 
+
+[NOTE]
+====
+When creating secrets to image pull information using `imagePullSecrets` object, you cannot use the `{serviceaccount-name}-dockercfg` pattern. When this pattern is used, the `openshift-controller-manager` does not create a token or pull secret for that service account.
+====
 
 When a template contains a secret definition, the only way for the template to use the provided secret is to ensure that the secret volume sources are validated and that the specified object reference actually points to an object of type `Secret`. Therefore, a secret needs to be created before any pods that depend on it. The most effective way to ensure this is to have it get injected automatically through the use of a service account.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Link to docs preview:
https://83900--ocpdocs-pr.netlify.app/openshift-rosa/latest/cicd/builds/creating-build-inputs.html#builds-secrets-restrictions_creating-build-inputs

Issue
https://issues.redhat.com/browse/OCPBUGS-32691

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
