### PR TITLE
OSDOCS-12394: GCP machineset single svc acct limit

### DIFF
--- a/modules/cpmso-yaml-provider-spec-gcp.adoc
+++ b/modules/cpmso-yaml-provider-spec-gcp.adoc
@@ -67,7 +67,7 @@ spec:
               subnetwork: <cluster_id>-master-subnet
             projectID: <project_name> <4>
             region: <region> <5>
-            serviceAccounts:
+            serviceAccounts: <6>
             - email: <cluster_id>-m@<project_name>.iam.gserviceaccount.com
               scopes:
               - https://www.googleapis.com/auth/cloud-platform
@@ -77,8 +77,8 @@ spec:
             targetPools:
             - <cluster_id>-api
             userDataSecret:
-              name: master-user-data <6>
-            zone: "" <7>
+              name: master-user-data <7>
+            zone: "" <8>
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the path to the image that was used to create the disk.
@@ -93,5 +93,6 @@ To use a GCP Marketplace image, specify the offer to use:
 <3> Specifies the cloud provider platform type. Do not change this value.
 <4> Specifies the name of the GCP project that you use for your cluster.
 <5> Specifies the GCP region for the cluster.
-<6> Specifies the control plane user data secret. Do not change this value.
-<7> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.
+<6> Specifies a single service account. Multiple service accounts are not supported. 
+<7> Specifies the control plane user data secret. Do not change this value.
+<8> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -106,7 +106,7 @@ endif::infra[]
             subnetwork: <infrastructure_id>-worker-subnet
           projectID: <project_name> <5>
           region: us-central1
-          serviceAccounts:
+          serviceAccounts: <6>
           - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
@@ -116,7 +116,7 @@ endif::infra[]
             name: worker-user-data
           zone: us-central1-a
 ifdef::infra[]
-      taints: <6>
+      taints: <7>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -139,8 +139,9 @@ To use a GCP Marketplace image, specify the offer to use:
 --
 <4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
 <5> For `<project_name>`, specify the name of the GCP project that you use for your cluster.
+<6> Specifies a single service account. Multiple service accounts are not supported.
 ifdef::infra[]
-<6> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<7> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-12394](https://issues.redhat.com//browse/OSDOCS-12394)

Link to docs preview:
- [Sample YAML for a compute machine set custom resource on GCP](https://83906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-yaml-gcp_creating-machineset-gcp) regular compute
- [Sample YAML for a compute machine set custom resource on GCP](https://83906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-gcp_creating-infrastructure-machinesets) infra
- [Sample GCP provider specification](https://83906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp#cpmso-yaml-provider-spec-gcp_cpmso-config-options-gcp) control plane

QE review:
- [x] QE has approved this change.

Additional information: