### PR TITLE
OSDOCS#11840: about disconnected env page

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -111,6 +111,8 @@ Name: Disconnected environments
 Dir: disconnected
 Distros: openshift-enterprise,openshift-origin
 Topics:
+- Name: About disconnected environments
+  File: about
 - Name: Converting a connected cluster to a disconnected cluster
   File: connected-to-disconnected
 - Name: Mirroring in disconnected environments

--- a/disconnected/about.adoc
+++ b/disconnected/about.adoc
@@ -1,0 +1,61 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="about-disconnected-environments"]
+= About disconnected environments
+include::_attributes/common-attributes.adoc[]
+:context: about-disconnected-environments
+
+toc::[]
+
+A disconnected environment is an environment that does not have full access to the internet.
+
+{product-title} is designed to perform many automatic functions that depend on an internet connection, such as retrieving release images from a registry or retrieving update paths and recommendations for the cluster.
+Without a direct internet connection, you must perform additional setup and configuration for your cluster to maintain full functionality in the disconnected environment.
+
+[id="glossary-disconnected_{context}"]
+== Glossary of disconnected environment terms
+
+Although it is used throughout the {product-title} documentation, _disconnected environment_ is a broad term that can refer to environments with various levels of internet connectivity.
+Other terms are sometimes used to refer to a specific level of internet connectivity, and these environments might require additional unique configurations.
+
+The following table describes the different terms used to refer to environments without a full internet connection:
+
+.Disconnected environment terms
+[cols=".^2,.^4",options="header"]
+|====
+|Term |Description
+
+|Air-gapped network
+|An environment or network that is completely isolated from an external network.
+
+This isolation depends on a physical separation, or an "air gap", between machines on the internal network and any other part of an external network.
+Air-gapped environments are often used in industries with strict security or regulatory requirements.
+
+|Disconnected environment
+|An environment or network that has some level of isolation from an external network.
+
+This isolation could be enabled by physical or logical separation between machines on the internal network and an external network.
+Regardless of the level of isolation from the external network, a cluster in a disconnected environment does not have access to public services hosted by Red{nbsp}Hat and requires additional setup to maintain full cluster functionality.
+
+|Restricted Network
+|An environment or network with limited connection to an external network.
+
+A physical connection may exist between machines on the internal network and an external network, but network traffic is limited by additional configurations, such as with firewalls and proxies.
+|====
+
+[id="preferred-methods_{context}"]
+== Preferred methods for working with disconnected environments
+
+// Not sure about the heading above, I'm trying to find some phrasing that basically says "You should probably use these things if you don't have a strong reason to go with other options".
+
+You can choose between multiple options for most aspects of managing a cluster in a disconnected environment.
+For example, when mirroring images you can choose between using the oc-mirror {oc-first} plugin or using the `oc adm` command.
+
+However, some options provide a simpler and more convenient user experience for disconnected environments, and are the preferred method over their alternatives.
+
+Unless your organizational needs require you to choose another option, use the following methods for mirroring images, installing your cluster, and updating your cluster:
+
+* Mirror your images using the xref:../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[oc-mirror plugin].
+
+* Install your cluster using the xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Agent-based Installer].
+
+* Update your cluster using a xref:../disconnected/updating/disconnected-update-osus.adoc#updating-disconnected-cluster-osus[local OpenShift Update Service instance].


### PR DESCRIPTION
[OSDOCS-11840](https://issues.redhat.com/browse/OSDOCS-11840)

Version(s): 4.17+

This PR adds an index page to the section for disconnected environments

QE review:
- [x] QE has approved this change.

Preview: [About disconnected environments](https://83907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/about)
