### PR TITLE
NO-JIRA: Remove cluster-admin prerequisite for creating bound service account token

### DIFF
--- a/modules/bound-sa-tokens-configuring-externally.adoc
+++ b/modules/bound-sa-tokens-configuring-externally.adoc
@@ -8,12 +8,6 @@
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
-* You have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-* You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
 * You have created a service account. This procedure assumes that the service account is named `build-robot`.
 
 .Procedure


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
NO-JIRA

Link to docs preview:
Prow CI generated the docs preview:
https://83909--ocpdocs-pr.netlify.app/openshift-dedicated/latest/authentication/bound-service-account-tokens.html
https://83909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/bound-service-account-tokens.html
https://83909--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/bound-service-account-tokens.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
While reviewing `AUTH-522`, found the issue. Did not remember which earliest version applies. Then double tested in 4.11, normal user can create bound service account token, indeed needs not cluster-admin; confirmed via [release note in k8s 1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md?plain=1#L2656) ; 4.11 is on k8s 1.24.
```
$ oc get clusterversion
NAME      VERSION                              AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.11.0-0.nightly-2024-03-18-165432   True        False         143m    Cluster version is 4.11.0-0.nightly-2024-03-18-165432

$ oc login -u testuser-20 
...
Login successful.

You don't have any projects. You can try to create a new project, by running
...

$ oc new-project tmp-test
Now using project "tmp-test" on server "...".
...

$ oc create sa build-robot
serviceaccount/build-robot created
$ oc create token build-robot
eyJhbGciOiJSUzI1NiIsImtpZCI6ImdOOGUyRFhBbmk4M0dfMk...
```

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

@bergerhoffer help review/merge, thanks!
