### PR TITLE
OSDOCS#11934: Multiarch Tuning Operator release notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -685,6 +685,8 @@ Topics:
     File: multi-architecture-compute-managing
   - Name: Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator
     File: multiarch-tuning-operator
+  - Name: Multiarch Tuning Operator release notes
+    File: multi-arch-tuning-operator-release-notes
 - Name: Cluster tasks
   File: cluster-tasks
 - Name: Node tasks

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="multi-arch-tuning-operator-release-notes"]
+= Multiarch Tuning Operator release notes
+include::_attributes/common-attributes.adoc[]
+:context: multi-arch-tuning-operator-release-notes
+
+toc::[]
+
+The Multiarch Tuning Operator optimizes workload management within multi-architecture clusters and in single-architecture clusters transitioning to multi-architecture environments.
+
+These release notes track the development of the Multiarch Tuning Operator.
+
+For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
+
+
+[id="multi-arch-tuning-operator-release-notes-1.0.0_{context}"]
+== Release notes for the Multiarch Tuning Operator 1.0.0
+
+Issued: 30 October 2024
+
+[id="multi-arch-tuning-operator-1.0.0-new-features-and-enhancements_{context}"]
+=== New features and enhancements
+
+* With this release, the Multiarch Tuning Operator supports custom network scenarios and cluster-wide custom registries configurations.
+* With this release, you can identify pods based on their architecture compatibility by using the pod labels that the Multiarch Tuning Operator adds to newly created pods.
+* With this release, you can monitor the behavior of the Multiarch Tuning Operator by using the metrics and alerts that are registered in the Cluster Monitoring Operator.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-11934](https://issues.redhat.com/browse/OSDOCS-11934)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Multiarch Tuning Operator release notes](https://83911--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
