### PR TITLE
[OCPBUGS-41344] Update minor version of RHEL 8 for worker node

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.8-8.10, and on {op-system-first} 9.4.
+{product-title} {product-version} is supported on {op-system-base-full} 8.8 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported on {op-system-first} {product-version}.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines. {op-system-base} machines are deprecated in {product-title} 4.16 and will be removed in a future release.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Jira:  
[OCPBUGS-41344](https://issues.redhat.com/browse/OCPBUGS-41344)
[OCPBUGS-44422](https://issues.redhat.com/browse/OCPBUGS-44422)

Version(s):
OpenShift version: 4.18

Issue: 
[OCPBUGS-41344](https://issues.redhat.com/browse/OCPBUGS-41344):Updated the RHEL8 versions for worker nodes in release notes for RHOCP 4.18

[OCPBUGS-44422](https://issues.redhat.com/browse/OCPBUGS-44422): Wrong RHCOS version mentioned in the release notes on RHOCP 

Link to docs preview:
[About this release](https://83914--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html)

- [ ] SME has approved this change.
- [ ] QE has approved this change.



