### PR TITLE
OSDOCS-12396: fixes compatibility table layout

### DIFF
--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -9,7 +9,7 @@
 
 {op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
 
-[cols="3","20%,20%,60%",options="header"]
+[%header,cols="3",cols="1,1,2"]
 |===
 ^|*{op-system-base} Version(s)*
 ^|*{microshift-short} Version*
@@ -17,7 +17,7 @@
 
 ^|9.4
 ^|4.18
-^|4.18.1{nbsp}&#8594;{nbsp}4.18.z
+^|4.18.0{nbsp}&#8594;{nbsp}4.18.z
 
 ^|9.4
 ^|4.17
@@ -29,9 +29,9 @@
 
 ^|9.2, 9.3
 ^|4.15
-^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16 ({op-system-base} 9.4)
+^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
 
 ^|9.2, 9.3
 ^|4.14
-^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15, 4.14{nbsp}&#8594;{nbsp}4.16 ({op-system-base} 9.4)
+^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15, 4.14{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
 |===


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-12396](https://issues.redhat.com/browse/OSDOCS-12396)

Link to docs preview:
https://83921--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready.html
https://83921--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options.html

QE review:
- N/A formatting only

See also https://github.com/openshift/openshift-docs/pull/83932. 
