### PR TITLE
[SRVCOM-3354] Correct inline pass-through to +++

### DIFF
--- a/modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc
+++ b/modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc
@@ -34,9 +34,9 @@ spec:
       brokers.topic.template: <template> <2>
       channels.topic.template: <template> <3>
 ----
-<1> The template for generating the consumer group ID used by your triggers. Use a valid Go `text/template` value. Defaults to `{% raw %}"knative-trigger-{{ .Namespace }}-{{ .Name }}"{% endraw %}`.
-<2> The template for generating Kafka topic names used by your brokers. Use a valid Go `text/template` value. Defaults to `{% raw %}"knative-broker-{{ .Namespace }}-{{ .Name }}"{% endraw %}`.
-<3> The template for generating Kafka topic names used by your channels. Use a valid Go `text/template` value. Defaults to `{% raw %}"messaging-kafka.{{ .Namespace }}.{{ .Name }}"{% endraw %}`.
+<1> The template for generating the consumer group ID used by your triggers. Use a valid Go `text/template` value. Defaults to `+++"knative-trigger-{{ .Namespace }}-{{ .Name }}"+++`.
+<2> The template for generating Kafka topic names used by your brokers. Use a valid Go `text/template` value. Defaults to `+++"knative-broker-{{ .Namespace }}-{{ .Name }}"+++`.
+<3> The template for generating Kafka topic names used by your channels. Use a valid Go `text/template` value. Defaults to `+++"messaging-kafka.{{ .Namespace }}.{{ .Name }}"+++`.
 +
 .Example template configuration
 [source,yaml]


### PR DESCRIPTION
Version(s):
serverless-docs-1.32+

Issue:
https://issues.redhat.com/browse/SRVCOM-3354

Link to docs preview:
https://83922--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/tuning/overriding-config-eventing.html

QE review:
- [x] QE has approved this change.
