### PR TITLE
OSDOCS-12399: Documented the 4.16.18 z-stream notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3325,6 +3325,50 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.18
+[id="ocp-4-16-18_{context}"]
+=== RHSA-2024:8260 - {product-title} {product-version}.18 bug fix and security update
+
+Issued: 24 October 2024
+
+{product-title} release {product-version}.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:8260[RHSA-2024:8260] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8263[RHSA-2024:8263] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.18 --pullspecs
+----
+
+[id="ocp-4-16-18-enhancements_{context}"]
+==== Enhancements
+
+* The SR-IOV Network Operator supports Intel NetSec Accelerator Cards and Marvell Octeon 10 DPUs. (link:https://issues.redhat.com/browse/OCPBUGS-43452[*OCPBUGS-43452*])
+
+[id="ocp-4-16-18-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the Single-Root I/O Virtualization (SR-IOV) Operator did not expire the acquired lease during the Operator's shutdown operation. This impacted a new instance of the Operator, because the new instance had to wait for the lease to expire before the new instance was operational. With this release, an update to the Operator shutdown logic ensures that the Operator expires the lease when the Operator is shutting down. (link:https://issues.redhat.com/browse/OCPBUGS-37669[*OCPBUGS-37669*])
+
+* Previously, an interface created inside a new pod would remain inactive and the Gratuitous Address Resolution Protocol (GARP) notification would be generated. The notification did not reach the cluster and this prevented ARP tables of other pods inside the cluster from updating the MAC address of the new pod. This situation caused cluster traffic to stall until ARP table entries expired. With this release, a GARP notification is now sent after the interface inside a pod is active so that the GARP notification reaches the cluster. As a result, surrounding pods can identify the new pod earlier than they could with the previous behavior. (link:https://issues.redhat.com/browse/OCPBUGS-36735[*OCPBUGS-36735*])
+
+* Previously, a machine controller failed to save the {vmw-full} task ID of an instance template clone operation. This caused the machine to go into the `Provisioning` state and to power off. With this release, the {vmw-full} machine controller can detect and recover from this state. (link:https://issues.redhat.com/browse/OCPBUGS-43433[*OCPBUGS-43433*])
+
+* Previously, when you attempted to use the `oc import-image` command to import an image in a {hcp} cluster, the command failed because of access issues with a private image registry. With this release, an update to `openshift-apiserver` pods in a {hcp} cluster resolves names that use the data plane so that the `oc import-image` command now works as expected with private image registries. (link:https://issues.redhat.com/browse/OCPBUGS-43308[*OCPBUGS-43308*])
+
+* Previously, when you used the `must-gather` tool, a Multus Container Network Interface (CNI) log file, `multus.log`, was stored in a node's file system. This situation caused the tool to generate unnecessary debug pods in a node. With this release, the Multus CNI no longer creates a `multus.log` file, and instead uses a CNI plugin pattern to inspect any logs for Multus DaemonSet pods in the `openshift-multus` namespace. (link:https://issues.redhat.com/browse/OCPBUGS-33959[*OCPBUGS-33959*])
+
+* Previously, when you configured the image registry to use an {azure-first} storage account that was located in a resource group other than the cluster's resource group, the Image Registry Operator would become degraded. This occurred because of a validation error. With this release, an update to the Operator allows for authentication only by using a storage account key. Validation of other authentication requirements is not required. (link:https://issues.redhat.com/browse/OCPBUGS-42933[*OCPBUGS-42933*])
+
+* Previously, during root certification rotation, the `metrics-server` pod in the data plane failed to start correctly. This happened because of a certificate issue. With this release, the `hostedClusterConfigOperator` resource sends the correct certificate to the data plane so that the `metrics-server` pod starts as expected. (link:https://issues.redhat.com/browse/OCPBUGS-42432[*OCPBUGS-42432*])
+
+[id="ocp-4-16-18-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.16.17
 [id="ocp-4-16-17_{context}"]
 === RHSA-2024:7944 - {product-title} {product-version}.17 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12399](https://issues.redhat.com/browse/OSDOCS-12399)

Link to docs preview:

[4.16.18](https://83931--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-18_release-notes)

