### PR TITLE
OSDOCS-12396-417: fixed compat table render 4.17 MicroShift

### DIFF
--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -9,30 +9,25 @@
 
 {op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
 
-[cols="4",cols="~,~,~,20h"]
+[%header,cols="3",cols="1,1,2"]
 |===
 ^|*{op-system-base} Version(s)*
 ^|*{microshift-short} Version*
-^|*{microshift-short} Release Status*
 ^|*Supported {microshift-short} Version{nbsp}&#8594;{nbsp}Version Updates*
 
 ^|9.4
 ^|4.17
-^|Generally Available
 ^|4.17.1{nbsp}&#8594;{nbsp}4.17.z
 
-^|9.4
-^|4.16
-^|Generally Available
+^.^|9.4
+^.^|4.16
 ^|4.16.0{nbsp}&#8594;{nbsp}4.16.z, 4.16{nbsp}&#8594;{nbsp}4.17
 
-^|9.2, 9.3
-^|4.15
-^|Generally Available
-^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16
+^.^|9.2, 9.3
+^.^|4.15
+^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16 on RHEL 9.4
 
-^|9.2, 9.3
-^|4.14
-^|Generally Available
-^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15, 4.14{nbsp}&#8594;{nbsp}4.16
+^.^|9.2, 9.3
+^.^|4.14
+^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15 or 4.14{nbsp}&#8594;{nbsp}4.16 on RHEL 9.4
 |===


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12396](https://issues.redhat.com/browse/OSDOCS-12396)

Link to docs preview:
https://83932--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready.html
https://83932--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options.html

QE review:
- N/A format updates only

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
