### PR TITLE
OBSDOCS-1387: Logging Z-Stream Release Notes - 5.8.14

### DIFF
--- a/modules/logging-release-notes-5-8-14.adoc
+++ b/modules/logging-release-notes-5-8-14.adoc
@@ -1,0 +1,41 @@
+// module included in logging-5-8-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="cluster-logging-release-notes-5-8-14_{context}"]
+= Logging 5.8.14
+This release includes link:https://access.redhat.com/errata/RHSA-2024:8317[OpenShift Logging Bug Fix Release 5.8.14] and link:https://access.redhat.com/errata/RHBA-2024:8316[OpenShift Logging Bug Fix Release 5.8.14].
+
+[id="openshift-logging-5-8-14-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, it was possible to set the `.containerLimit.maxRecordsPerSecond` parameter in the `ClusterLogForwarder` custom resource to `0`, which could lead to an exception during Vector's startup. With this update, the configuration is validated before being applied, and any invalid values (less than or equal to zero) are rejected. (link:https://issues.redhat.com/browse/LOG-4671[LOG-4671])
+
+* Before this update, the Loki Operator did not automatically add the default `namespace` label to all its alerting rules, which caused Alertmanager instance for user-defined projects to skip routing such alerts. With this update, all alerting and recording rules have the `namespace` label and Alertmanager now routes these alerts correctly. (link:https://issues.redhat.com/browse/LOG-6182[LOG-6182])
+
+* Before this update, the LokiStack ruler component view was not properly initialized, which caused the invalid field error when the ruler component was disabled. With this update, the issue is resolved by the component view being initialized with an empty value. (link:https://issues.redhat.com/browse/LOG-6184[LOG-6184])
+
+[id="openshift-logging-5-8-14-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-37920[CVE-2023-37920]
+* link:https://access.redhat.com/security/cve/CVE-2024-2398[CVE-2024-2398]
+* link:https://access.redhat.com/security/cve/CVE-2024-4032[CVE-2024-4032]
+* link:https://access.redhat.com/security/cve/CVE-2024-6232[CVE-2024-6232]
+* link:https://access.redhat.com/security/cve/CVE-2024-6345[CVE-2024-6345]
+* link:https://access.redhat.com/security/cve/CVE-2024-6923[CVE-2024-6923]
+* link:https://access.redhat.com/security/cve/CVE-2024-30203[CVE-2024-30203]
+* link:https://access.redhat.com/security/cve/CVE-2024-30205[CVE-2024-30205]
+* link:https://access.redhat.com/security/cve/CVE-2024-39331[CVE-2024-39331]
+* link:https://access.redhat.com/security/cve/CVE-2024-45490[CVE-2024-45490]
+* link:https://access.redhat.com/security/cve/CVE-2024-45491[CVE-2024-45491]
+* link:https://access.redhat.com/security/cve/CVE-2024-45492[CVE-2024-45492]
+* link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+* link:https://access.redhat.com/security/cve/CVE-2024-24791[CVE-2024-24791]
+* link:https://access.redhat.com/security/cve/CVE-2024-34155[CVE-2024-34155]
+* link:https://access.redhat.com/security/cve/CVE-2024-34156[CVE-2024-34156]
+* link:https://access.redhat.com/security/cve/CVE-2024-34158[CVE-2024-34158]
+* link:https://access.redhat.com/security/cve/CVE-2024-34397[CVE-2024-34397]
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#moderate[Severity ratings].
+====

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-14.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-13.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-12.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions for cherry-picking: `enterprise-4.12`, `enterprise-4.13`, `enterprise-4.14`
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1387
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83934--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html#cluster-logging-release-notes-5-8-14_logging-5-8-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
