### PR TITLE
OCPBUGS#43078: RE-added statement about pods and conversion to dual-s…

### DIFF
--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -2,7 +2,12 @@
 [id="nw-dual-stack-convert_{context}"]
 = Converting to a dual-stack cluster network
 
-As a cluster administrator, you can convert your single-stack cluster network to a dual-stack cluster network. After converting to a dual-stack network, new and existing pods have dual-stack networking enabled.
+As a cluster administrator, you can convert your single-stack cluster network to a dual-stack cluster network. 
+
+[IMPORTANT]
+====
+After converting your cluster to use dual-stack networking, you must re-create any existing pods for them to receive IPv6 addresses, because only new pods are assigned IPv6 addresses.
+====
 
 Converting a single-stack cluster network to a dual-stack cluster network consists of creating patches and applying them to the cluster's network and infrastructure. You can convert to a dual-stack cluster network for a cluster that runs on installer-provisioned infrastructure.
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-43078](https://issues.redhat.com/browse/OCPBUGS-43078)

Link to docs preview:
[Converting to a dual-stack cluster network](https://83941--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html)

- [x] SME has approved this change
- [x] QE has approved this change.

