### PR TITLE
OCPBUGS#38906: Fix missing step in etcd disk migration procedure

### DIFF
--- a/modules/move-etcd-different-disk.adoc
+++ b/modules/move-etcd-different-disk.adoc
@@ -57,7 +57,7 @@ $ oc debug node/<node_name>
 +
 Note the device name of the new disk reported by the `lsblk` command.
 
-. Decode and replace the device name in the script according to your environment.
+. Create the following script and name it `etcd-find-secondary-device.sh`:
 +
 [source,bash]
 ----
@@ -79,6 +79,14 @@ echo "Couldn't find secondary block device!" >&2
 exit 77
 ----
 <1> Replace `<device_type_glob>` with a shell glob for your block device type. For SCSI or SATA drives, use `/dev/sd*`; for virtual drives, use `/dev/vd*`; for NVMe drives, use `/dev/nvme*[0-9]\*n*`.
+
+. Create a base64-encoded string from the `etcd-find-secondary-device.sh` script and note its contents:
++
+[source,terminal]
+----
+$ base64 -w0 etcd-find-secondary-device.sh
+----
+
 . Create a `MachineConfig` YAML file named `etcd-mc.yml` with contents such as the following:
 +
 [source,yaml]
@@ -98,7 +106,7 @@ spec:
         - path: /etc/find-secondary-device
           mode: 0755
           contents:
-            source: data:text/plain;charset=utf-8;base64,<encoded_etc_find_secondary_device_script> # <1>
+            source: data:text/plain;charset=utf-8;base64,<encoded_etcd_find_secondary_device_script> # <1>
     systemd:
       units:
         - name: find-secondary-device.service
@@ -172,7 +180,7 @@ spec:
             [Install]
             WantedBy=multi-user.target graphical.target
 ----
-<1> Use the encoded string that you previously created and replace it with the encoded script that you noted.
+<1> Replace `<encoded_etcd_find_secondary_device_script>` with the encoded script contents that you noted.
 
 .Verification steps
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-38906](https://issues.redhat.com/browse/OCPBUGS-38906)

Link to docs preview:
[Moving etcd to a different disk](https://83949--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html#move-etcd-different-disk_recommended-etcd-practices)

QE review:
- [x] QE has approved this change.

Additional information:
N/A