### PR TITLE
OSDOCS-7651: Removing MCO info (4.16+)

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -57,22 +57,6 @@ include::modules/arch-olm-operators.adoc[leveloffset=+2]
 * For more details on running add-on Operators in {product-title}, see the _Operators_ guide sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager (OLM)] and xref:../operators/understanding/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[OperatorHub].
 * For more details on the Operator SDK, see xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operators].
 
-// This module does not apply to OSD/ROSA
-ifndef::openshift-dedicated,openshift-rosa[]
-include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]
-endif::openshift-dedicated,openshift-rosa[]
-
-// These additional resources do not apply to OSD/ROSA
-ifndef::openshift-dedicated,openshift-rosa[]
-[role="_additional-resources"]
-.Additional resources
-* For more information about detecting configuration drift, see xref:../machine_configuration/index.adoc#machine-config-drift-detection_machine-config-overview[Understanding configuration drift detection].
-
-* For information about preventing the control plane machines from rebooting after the Machine Config Operator makes changes to the machine configuration, see xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling Machine Config Operator from automatically rebooting].
-
-* xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Understanding node restart behaviors after machine config changes]
-endif::openshift-dedicated,openshift-rosa[]
-
 include::modules/etcd-overview.adoc[leveloffset=+1]
 
 // These modules only apply to ROSA/OSD

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * architecture/control-plane.adoc
+// * machine_configuration/machine-config-index.adoc
 :_mod-docs-content-type: CONCEPT
 [id="about-machine-config-operator_{context}"]
 = About the Machine Config Operator


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-7651

Link to docs preview:
https://83951--ocpdocs-pr.netlify.app/openshift-dedicated/latest/architecture/control-plane.html
https://83951--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/control-plane.html
https://83951--ocpdocs-pr.netlify.app/openshift-rosa/latest/architecture/control-plane.html

QE review:
- [x] SME approval

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
