### PR TITLE
OSDOCS-12362: 4.14.39 z-stream RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3384,6 +3384,54 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+// 4.14.39
+[id="ocp-4-14-39_{context}"]
+=== RHSA-2024:8235 - {product-title} 4.14.39 bug fix and security update
+
+Issued: 23 October 2024
+
+{product-title} release 4.14.39, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:8235[RHSA-2024:8235] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8238[RHSA-2024:8238] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.39 --pullspecs
+----
+
+[id="ocp-4-14-39-enhancements"]
+==== Enhancements
+
+The following enhancement is included in this z-stream release:
+
+[id="ocp-4-14-39-enhancements-IO-Prometheus-metric_{context}"]
+===== Using the Insights Operator to collect data from a Prometheus metric
+
+* The Insights Operator (IO) now collects data from the `haproxy_exporter_server_threshold` metric of Prometheus. (link:https://issues.redhat.com/browse/OCPBUGS-41918[*OCPBUGS-41918*])
+
+[id="ocp-4-14-39-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, if a connection on port 9637 for Windows nodes was refused, the Kubelet Service Monitor threw a `target down` alert because CRI-O does not run on Windows nodes. With this release, Windows nodes are excluded from the Kubelet Service Monitor. (link:https://issues.redhat.com/browse/OCPBUGS-42603[*OCPBUGS-42603*])
+
+* Previously, when the Node Tuning Operator (NTO) was configured using the `PerformanceProfiles` specification, it created an `ocp-tuned-one-shot systemd` service which ran prior to kubelet and blocked NTO execution. This prevented Podman from fetching the image. With this release, support for cluster-wide proxy environment variables defined in `/etc/mco/proxy.env` is available. This allows Podman to pull NTO images into environments that need to use the http(s) proxy for out-of-cluster connections. (https://issues.redhat.com/browse/OCPBUGS-42567[*OCPBUGS-42567*])
+
+* Previously, a group ID was not added to the `/etc/group` within the container when the `spec.securityContext.runAsGroup` attribute was set in the `Pod` resource. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-41246[*OCPBUGS-41246*])
+
+* Previously, the inspection process failed if special or invalid characters were present in the serial number of a block device and could not escape the `lsblk` command. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-39019[*OCPBUGS-39019*])
+
+* Previously, after installing the Pipelines Operator, users could still create the Deployment before the Pipeline template became available. With this update, the *Create* button on the *Import from Git* page is disabled if a pipeline template is unavailable for the selected resource. (link:https://issues.redhat.com/browse/OCPBUGS-37353[*OCPBUGS-37353*])
+
+* Previously, a node registration issue prevented you from using Redfish Virtual Media to add an xFusion bare metal node to your cluster. The issue occurred because the hardware was not fully compliant with Redfish. With this release, you can add xFusion bare-metal nodes to your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-32266[*OCPBUGS-32266*])
+
+[id="ocp-4-14-39-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.38
 [id="ocp-4-14-38_{context}"]
 === RHSA-2024:7184 - {product-title} 4.14.38 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-12362](https://issues.redhat.com/browse/OSDOCS-12362)

Link to docs preview:
https://83959--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-39_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (10/23)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
