### PR TITLE
[enterprise-4.13] OSDOCS-12394: GCP machineset single svc acct limit

### DIFF
--- a/modules/cpmso-yaml-provider-spec-gcp.adoc
+++ b/modules/cpmso-yaml-provider-spec-gcp.adoc
@@ -33,42 +33,52 @@ $ oc -n openshift-machine-api \
 .Sample GCP `providerSpec` values
 [source,yaml]
 ----
-providerSpec:
-  value:
-    apiVersion: machine.openshift.io/v1beta1
-    canIPForward: false
-    credentialsSecret:
-      name: gcp-cloud-credentials <1>
-    deletionProtection: false
-    disks:
-    - autoDelete: true
-      boot: true
-      image: <path_to_image> <2>
-      labels: null
-      sizeGb: 200
-      type: pd-ssd
-    kind: GCPMachineProviderSpec <3>
-    machineType: e2-standard-4
-    metadata:
-      creationTimestamp: null
-    metadataServiceOptions: {}
-    networkInterfaces:
-    - network: <cluster_id>-network
-      subnetwork: <cluster_id>-master-subnet
-    projectID: <project_name> <4>
-    region: <region> <5>
-    serviceAccounts:
-    - email: <cluster_id>-m@<project_name>.iam.gserviceaccount.com
-      scopes:
-      - https://www.googleapis.com/auth/cloud-platform
-    shieldedInstanceConfig: {}
-    tags:
-    - <cluster_id>-master
-    targetPools:
-    - <cluster_id>-api
-    userDataSecret:
-      name: master-user-data <6>
-    zone: "" <7>
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+      spec:
+        providerSpec:
+          value:
+            apiVersion: machine.openshift.io/v1beta1
+            canIPForward: false
+            credentialsSecret:
+              name: gcp-cloud-credentials <1>
+            deletionProtection: false
+            disks:
+            - autoDelete: true
+              boot: true
+              image: <path_to_image> <2>
+              labels: null
+              sizeGb: 200
+              type: pd-ssd
+            kind: GCPMachineProviderSpec <3>
+            machineType: e2-standard-4
+            metadata:
+              creationTimestamp: null
+            metadataServiceOptions: {}
+            networkInterfaces:
+            - network: <cluster_id>-network
+              subnetwork: <cluster_id>-master-subnet
+            projectID: <project_name> <4>
+            region: <region> <5>
+            serviceAccounts: <6>
+            - email: <cluster_id>-m@<project_name>.iam.gserviceaccount.com
+              scopes:
+              - https://www.googleapis.com/auth/cloud-platform
+            shieldedInstanceConfig: {}
+            tags:
+            - <cluster_id>-master
+            targetPools:
+            - <cluster_id>-api
+            userDataSecret:
+              name: master-user-data <7>
+            zone: "" <8>
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the path to the image that was used to create the disk.
@@ -83,5 +93,6 @@ To use a GCP Marketplace image, specify the offer to use:
 <3> Specifies the cloud provider platform type. Do not change this value.
 <4> Specifies the name of the GCP project that you use for your cluster.
 <5> Specifies the GCP region for the cluster.
-<6> Specifies the control plane user data secret. Do not change this value.
-<7> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.
+<6> Specifies a single service account. Multiple service accounts are not supported. 
+<7> Specifies the control plane user data secret. Do not change this value.
+<8> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -106,7 +106,7 @@ endif::infra[]
             subnetwork: <infrastructure_id>-worker-subnet
           projectID: <project_name> <5>
           region: us-central1
-          serviceAccounts:
+          serviceAccounts: <6>
           - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
@@ -116,7 +116,7 @@ endif::infra[]
             name: worker-user-data
           zone: us-central1-a
 ifdef::infra[]
-      taints: <6>
+      taints: <7>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -139,8 +139,9 @@ To use a GCP Marketplace image, specify the offer to use:
 --
 <4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
 <5> For `<project_name>`, specify the name of the GCP project that you use for your cluster.
+<6> Specifies a single service account. Multiple service accounts are not supported.
 ifdef::infra[]
-<6> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<7> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Cherrypicked from https://github.com/openshift/openshift-docs/commit/b0c70cd5736af0b4d64c0e71cd81e0487c930932 xref: https://github.com/openshift/openshift-docs/pull/83906