### PR TITLE
[enterprise-4.12] OSDOCS-12394: GCP machineset single svc acct limit

### DIFF
--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -84,7 +84,7 @@ endif::infra[]
             subnetwork: <infrastructure_id>-worker-subnet
           projectID: <project_name> <5>
           region: us-central1
-          serviceAccounts:
+          serviceAccounts: <6>
           - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
@@ -94,7 +94,7 @@ endif::infra[]
             name: worker-user-data
           zone: us-central1-a
 ifdef::infra[]
-      taints: <6>
+      taints: <7>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -129,8 +129,9 @@ To use a GCP Marketplace image, specify the offer to use:
 --
 <4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
 <5> For `<project_name>`, specify the name of the GCP project that you use for your cluster.
+<6> Specifies a single service account. Multiple service accounts are not supported.
 ifdef::infra[]
-<6> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<7> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Cherrypicked from https://github.com/openshift/openshift-docs/commit/b0c70cd5736af0b4d64c0e71cd81e0487c930932 xref: https://github.com/openshift/openshift-docs/pull/83906