### PR TITLE
[OCPBUGS-37638]: Add troubleshooting docs for HCP on bare metal

### DIFF
--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -48,6 +48,18 @@ include::modules/hcp-ts-non-bm.adoc[leveloffset=+2]
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management]
 
+[id="hcp-ts-bm"]
+== Troubleshooting hosted clusters on bare metal
+
+The following information applies to troubleshooting {hcp-short} on bare metal.
+
+include::modules/hcp-ts-bm-nodes-not-added.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/clusters/index#on-prem-creating-your-cluster-with-the-cli-pull-secret[Add the pull secret to the namespace]
+
 include::modules/hosted-restart-hcp-components.adoc[leveloffset=+1]
 include::modules/hosted-control-planes-pause-reconciliation.adoc[leveloffset=+1]
 include::modules/scale-down-data-plane.adoc[leveloffset=+1]

--- a/modules/hcp-ts-bm-nodes-not-added.adoc
+++ b/modules/hcp-ts-bm-nodes-not-added.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-ts-bm-nodes-not-added_{context}"]
+= Nodes fail to be added to {hcp} on bare metal
+
+When you scale up a {hcp} cluster with nodes that were provisioned by using Assisted Installer, the host fails to pull the ignition with a URL that contains port 22642. That URL is invalid for {hcp} and indicates that an issue exists with the cluster.
+
+.Procedure
+
+. To determine the issue, review the assisted-service logs:
++
+[source,terminal]
+----
+$ oc logs -n multicluster-engine <assisted_service_pod_name> <1>
+----
++
+<1> Specify the Assisted Service pod name.
+
+. In the logs, find errors that resemble these examples:
++
+[source,terminal]
+----
+error="failed to get pull secret for update: invalid pull secret data in secret pull-secret"
+----
++
+[source,terminal]
+----
+pull secret must contain auth for \"registry.redhat.io\"
+----
+
+. To fix this issue, see "Add the pull secret to the namespace" in the {mce} documentation.
++
+[NOTE]
+====
+To use {hcp}, you must have {mce-short} installed, either as a standalone operator or as part of {rh-rhacm-title}. Because the operator has a close association with {rh-rhacm-title}, the documentation for the operator is published within that product's documentation. Even if you do not use {rh-rhacm-title}, the parts of its documentation that cover {mce-short} are relevant to {hcp}.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-37638
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83968--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting.html#hcp-ts-bm-nodes-not-added_hcp-troubleshooting
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
