### PR TITLE
OCBPUGS-41822 updated nw-ovn-ipsec-north-south-enable document under …

### DIFF
--- a/modules/nw-ovn-ipsec-north-south-enable.adoc
+++ b/modules/nw-ovn-ipsec-north-south-enable.adoc
@@ -179,7 +179,7 @@ done
 [source,terminal]
 ----
 $ for role in master worker; do
-  butane 99-ipsec-${role}-endpoint-config.bu -o ./99-ipsec-$role-endpoint-config.yaml
+  butane -d . 99-ipsec-${role}-endpoint-config.bu -o ./99-ipsec-$role-endpoint-config.yaml
 done
 ----
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-41822

Link to docs preview:
https://83969--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

