### PR TITLE
OLS-1190: Update official attribute for OLS doc

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -24,10 +24,8 @@
 :ossm: OpenShift Service Mesh
 //Kubernetes
 :k8s: Kubernetes
-//Lightspeed - Delete this entry and replace usage with official
-:ols-full: Red Hat OpenShift Lightspeed
 //Lightspeed
-:ols-offical: Red Hat OpenShift Lightspeed
+:ols-official: Red Hat OpenShift Lightspeed
 :ols-long: OpenShift Lightspeed
 :ols-short: Lightspeed
 :ols-release: Technology Preview

--- a/install/ols-installing-openshift-lightspeed.adoc
+++ b/install/ols-installing-openshift-lightspeed.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The installation process for {ols-full} consists of two main tasks: configuring the Large Language Model (LLM) provider and installing the {ols-short} Operator.
+The installation process for {ols-official} consists of two main tasks: configuring the Large Language Model (LLM) provider and installing the {ols-short} Operator.
 
 include::modules/ols-large-language-model-configuration-overview.adoc[leveloffset=+1]
 include::modules/ols-installing-operator.adoc[leveloffset=+1]

--- a/modules/ols-0-1-5-release-notes.adoc
+++ b/modules/ols-0-1-5-release-notes.adoc
@@ -7,12 +7,12 @@
 
 Issued: 12 September 2024
 
-{ols-offical} 0.1.5 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.1.5 is now available on {ocp-product-title} 4.15 or later.
 
 [id="ols-0-1-5-enhancements_{context}"]
 == Enhancements
 
-The following enhancements have been made with {ols-offical} 0.1.5:
+The following enhancements have been made with {ols-official} 0.1.5:
 
 * This release introduces support for Large Language Model (LLM) authentication using {azure-official} with {entra-id}.
 

--- a/modules/ols-0-1-6-release-notes.adoc
+++ b/modules/ols-0-1-6-release-notes.adoc
@@ -5,12 +5,12 @@
 [id="ols-0-1-6-release-notes_{context}"]
 = {ols-long} version 0.1.6
 
-{ols-offical} 0.1.6 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.1.6 is now available on {ocp-product-title} 4.15 or later.
 
 [id="ols-0-1-6-enhancements_{context}"]
 == Enhancements
 
-The following enhancements have been made with {ols-offical} 0.1.6:
+The following enhancements have been made with {ols-official} 0.1.6:
 
 * When installing the {ols-long} Operator, the *Enable Operator recommended cluster monitoring on this Namespace* check box is now selected by default on the Operator Installation User Interface. The installer applies the `openshift-lightspeed openshift.io/cluster-monitoring=true` label to the `openshift-lightspeed` namespace. Applying this label allows cluster monitoring metrics to be obtained from the Service. To disable metric collection by the cluster monitoring stack, remove the label from the `openshift-lightspeed` namespace.
 

--- a/modules/ols-0-1-7-release-notes.adoc
+++ b/modules/ols-0-1-7-release-notes.adoc
@@ -5,11 +5,11 @@
 [id="ols-0-1-7-release-notes_{context}"]
 = {ols-long} version 0.1.7
 
-{ols-offical} 0.1.7 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.1.7 is now available on {ocp-product-title} 4.15 or later.
 
 [id="ols-0-1-7-enhancements_{context}"]
 == Enhancements
 
-The following enhancements have been made with {ols-offical} 0.1.7:
+The following enhancements have been made with {ols-official} 0.1.7:
 
 * The `OLSConfig` Custom Resource (CR) has new fields for configuring an additional Certificate Autority (CA) to authenticate the connection with the Large Language Model (LLM) provider. {ols-long} Administrators can add certificates for additional CAs into a configuration map and refer to it by name in the `OLSConfig` CR.

--- a/modules/ols-0-2-0-release-notes.adoc
+++ b/modules/ols-0-2-0-release-notes.adoc
@@ -5,18 +5,18 @@
 [id="ols-0-2-0-release-notes_{context}"]
 = {ols-long} version 0.2.0
 
-{ols-offical} 0.2.0 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.2.0 is now available on {ocp-product-title} 4.15 or later.
 
 [id="ols-0-2-2-enhancements_{context}"]
 == Enhancements
 
-The following enhancements have been made with {ols-offical} 0.2.0:
+The following enhancements have been made with {ols-official} 0.2.0:
 
-* This release introduces the {ols-offical} Operator as a Technology Preview release. Previously, the {ols-short} Operator was a Developer Preview release. 
+* This release introduces the {ols-official} Operator as a Technology Preview release. Previously, the {ols-short} Operator was a Developer Preview release. 
 
-* Existing Developer Preview installations of {ols-offical} version 0.1.6 and earlier that use the preview {olm} (OLM) channel must switch the update channel to *alpha* and then install the 0.2.0 Technology Preview version.
+* Existing Developer Preview installations of {ols-official} version 0.1.6 and earlier that use the preview {olm} (OLM) channel must switch the update channel to *alpha* and then install the 0.2.0 Technology Preview version.
 
-* Beginning in this release, the {ols-offical} Operator can be installed on an {ocp-product-title} cluster in a disconnected environment.
+* Beginning in this release, the {ols-official} Operator can be installed on an {ocp-product-title} cluster in a disconnected environment.
 
 * With this release, {rhelai} can be configured as the Large Language Model (LLM) provider.
 

--- a/modules/ols-about-azure-openai.adoc
+++ b/modules/ols-about-azure-openai.adoc
@@ -5,4 +5,4 @@
 [id="ols-about-azure-openai_{context}"]
 = About Azure OpenAI 
 
-To use {azure-official} with {ols-full}, you must have access to {azure-openai}.
+To use {azure-official} with {ols-official}, you must have access to {azure-openai}.

--- a/modules/ols-about-data-use.adoc
+++ b/modules/ols-about-data-use.adoc
@@ -3,7 +3,7 @@
 = About data use
 :context: ols-about-data-use
 
-{ols-full} is a virtual assistant you interact with using natural language. Using the {ols-long} interface, you send chat messages that {ols-long} transforms and sends to the Large Language Model (LLM) provider you have configured for your environment. These messages can contain information about your cluster, cluster resources, or other aspects of your environment.
+{ols-official} is a virtual assistant you interact with using natural language. Using the {ols-long} interface, you send chat messages that {ols-long} transforms and sends to the Large Language Model (LLM) provider you have configured for your environment. These messages can contain information about your cluster, cluster resources, or other aspects of your environment.
 
 The {ols-long} {ols-release} release has limited capabilities to filter or redact the information you provide to the LLM. Do not enter information into the {ols-long} interface that you do not want to send to the LLM provider.
 

--- a/modules/ols-about-openai.adoc
+++ b/modules/ols-about-openai.adoc
@@ -3,4 +3,4 @@
 = About OpenAI 
 :context: ols-about-openai
 
-To use {openai} with {ols-full}, you will need access to the {openai} link:https://openai.com/api/[API platform].
+To use {openai} with {ols-official}, you will need access to the {openai} link:https://openai.com/api/[API platform].

--- a/modules/ols-about-watsonx.adoc
+++ b/modules/ols-about-watsonx.adoc
@@ -5,4 +5,4 @@
 [id="ols-about-watsonx_{context}"]
 = About WatsonX
 
-To use {watsonx} with {ols-full}, you will need an account with link:https://www.ibm.com/products/watsonx-ai[IBM Cloud's WatsonX].
+To use {watsonx} with {ols-official}, you will need an account with link:https://www.ibm.com/products/watsonx-ai[IBM Cloud's WatsonX].

--- a/modules/ols-asking-about-cluster-state.adoc
+++ b/modules/ols-asking-about-cluster-state.adoc
@@ -19,7 +19,7 @@ This procedure shows how to attach an object to a {ols-long} query, and how to p
 
 . Click to *Workloads* -> *DaemonSets*.
 
-. Click the {ols-offical} icon in the lower-right corner of the screen.
+. Click the {ols-official} icon in the lower-right corner of the screen.
 
 . Click the Plus button in the OpenShift Lightspeed user interface. 
 

--- a/modules/ols-asking-general-information.adoc
+++ b/modules/ols-asking-general-information.adoc
@@ -9,7 +9,7 @@ This procedure shows how to ask {ols-long} a general question about the {ocp-pro
 
 .Procedure
 
-. Click the {ols-offical} icon in the lower-right corner of the screen.
+. Click the {ols-official} icon in the lower-right corner of the screen.
 
 . Enter the following question into the *Send message* field:
 +

--- a/modules/ols-asking-related-questions.adoc
+++ b/modules/ols-asking-related-questions.adoc
@@ -6,7 +6,7 @@ This procedure shows how to ask {ols-long} a series of related questions in orde
 
 .Procedure
 
-. Click the {ols-offical} icon in the lower-right corner of the screen.
+. Click the {ols-official} icon in the lower-right corner of the screen.
 
 . Enter the following question into the *Send message* field:
 +

--- a/modules/ols-attaching-a-resource-object-to-your-query.adoc
+++ b/modules/ols-attaching-a-resource-object-to-your-query.adoc
@@ -11,9 +11,9 @@ This procedure explains how to attach a resource object to provide additional co
 
 . Navigate to a supported resource in the {ocp-product-title} web console. For example, click *Workloads* -> *Pods* and then click the name of a pod.
 
-. Click the {ols-offical} icon in the lower-right corner of the screen.
+. Click the {ols-official} icon in the lower-right corner of the screen.
 
-. Click the plus icon in the {ols-offical} user interface to attach a resource object.
+. Click the plus icon in the {ols-official} user interface to attach a resource object.
 
 . Select the resource object to attach to the question.
 +

--- a/modules/ols-initiating-chat-using-actions-list.adoc
+++ b/modules/ols-initiating-chat-using-actions-list.adoc
@@ -13,7 +13,7 @@ This procedure explains how to use the *Actions* dropdown list to ask {ols-long}
 
 . Click the *Actions* dropdown list and select *Ask OpenShift Lightspeed*.
 +
-This presents the {ols-offical} user interface.
+This presents the {ols-official} user interface.
 
 . Enter a question.
 

--- a/modules/ols-initiating-chat-using-chat-window.adoc
+++ b/modules/ols-initiating-chat-using-chat-window.adoc
@@ -5,13 +5,13 @@
 [id="ols-initiating-chat-using-chat-window_{context}"]
 = Using the chat window to ask a question 
 
-This procedure explains how to use the {ols-offical} icon to ask a question using natural language.
+This procedure explains how to use the {ols-official} icon to ask a question using natural language.
 
 .Procedure
  
-. Click the {ols-offical} icon in the lower-right corner of the screen.
+. Click the {ols-official} icon in the lower-right corner of the screen.
 +
-This action presents the {ols-offical} user interface.
+This action presents the {ols-official} user interface.
 
 . Enter a question.
 

--- a/modules/ols-initiating-chat-using-node-options-icon.adoc
+++ b/modules/ols-initiating-chat-using-node-options-icon.adoc
@@ -13,7 +13,7 @@ This procedure explains how to use the *Node options* to ask {ols-long} a questi
 
 . Click the *Node options* icon in the row for a pod and select *Ask OpenShift Lightspeed*.
 +
-This action presents the {ols-offical} natural language interface.
+This action presents the {ols-official} natural language interface.
 
 . Enter a question.
 

--- a/modules/ols-openshift-lightspeed-overview.adoc
+++ b/modules/ols-openshift-lightspeed-overview.adoc
@@ -3,7 +3,7 @@
 = OpenShift Lightspeed Overview 
 :context: ols-openshift-lightspeed-overview
 
-{ols-full} is a generative AI-powered virtual assistant for {ocp-product-title}. Lightspeed functionality uses a natural-language interface in the {ocp-short-name} web console.
+{ols-official} is a generative AI-powered virtual assistant for {ocp-product-title}. Lightspeed functionality uses a natural-language interface in the {ocp-short-name} web console.
 
 This early access program exists so that customers can provide feedback on the user experience, features and capabilities, issues encountered, and any other aspects of the product so that Lightspeed can become more aligned with your needs when it is released and made generally available.
 

--- a/modules/ols-providing-feedback-for-conversation.adoc
+++ b/modules/ols-providing-feedback-for-conversation.adoc
@@ -13,7 +13,7 @@
 
 .Procedure
 
-. Click the {ols-offical} icon in the lower-right corner of the screen.
+. Click the {ols-official} icon in the lower-right corner of the screen.
 
 . Enter a question into the *Send message* field:
 

--- a/modules/ols-starting-a-new-chat.adoc
+++ b/modules/ols-starting-a-new-chat.adoc
@@ -11,7 +11,7 @@ This procedure explains how to clear the chat history and start a new conversati
 
 .Procedure
 
-. In the {ols-offical} natural language interface, click *New chat*. 
+. In the {ols-official} natural language interface, click *New chat*. 
 +
 This action clears the history of your previous conversation. 
 

--- a/modules/ols-using-lightspeed-to-troubleshoot-alerts.adoc
+++ b/modules/ols-using-lightspeed-to-troubleshoot-alerts.adoc
@@ -17,9 +17,9 @@ This procedure shows how to use {ols-long} to troubleshoot alerts.
 
 . Copy the title and text of the warning.
 
-. Click the {ols-offical} icon in the lower-right corner of the screen.
+. Click the {ols-official} icon in the lower-right corner of the screen.
 
-. In the {ols-offical} user interface, enter the following text:
+. In the {ols-official} user interface, enter the following text:
 +
 What should I do about this alert?
 

--- a/operate/ols-using-openshift-lightspeed.adoc
+++ b/operate/ols-using-openshift-lightspeed.adoc
@@ -6,9 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-There are different ways you can access the {ols-long} user interface.
+There are different ways you can access the {ols-official} user interface.
 
-* Clicking the {ols-long} chat window floating icon in the lower-right of the screen
+* Clicking the {ols-official} chat window floating icon in the lower-right of the screen
 * Using the *Actions* dropdown list on specific resources in the {ocp-product-title} web console
 * Using the *Node options* icon from a list of resources in the {ocp-product-title} web console
 

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The release notes highlight what is new and what has changed with each {ols-offical} release.
+The release notes highlight what is new and what has changed with each {ols-official} release.
 
 include::modules/ols-0-2-0-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-1-7-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue:
https://issues.redhat.com/browse/OLS-1190

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
