### PR TITLE
OSDOCS-12411 RODOO 1.1.2 release notes on 4.16 branch

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="run-once-duration-override-release-notes"]
-= Run Once Duration Override Operator release notes
+= {run-once-operator} release notes
 include::_attributes/common-attributes.adoc[]
 :context: run-once-duration-override-release-notes
 
@@ -14,12 +14,28 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
+[id="run-once-duration-override-operator-release-notes-1-1-2"]
+== {run-once-operator} 1.1.2
+
+Issued: 31 October 2024
+
+The following advisory is available for the {run-once-operator} 1.1.2:
+
+* link:https://access.redhat.com/errata/RHSA-2024:8337[RHSA-2024:8337]
+
+[id="run-once-duration-override-operator-1-1-2-bug-fixes"]
+=== Bug fixes
+
+* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
 [id="run-once-duration-override-operator-release-notes-1-1-1"]
-== Run Once Duration Override Operator 1.1.1
+== {run-once-operator} 1.1.1
 
 Issued: 1 July 2024
 
-The following advisory is available for the {run-once-operator} 1.1.1: link:https://access.redhat.com/errata/RHSA-2024:1616[RHSA-2024:1616]
+The following advisory is available for the {run-once-operator} 1.1.1:
+
+* link:https://access.redhat.com/errata/RHSA-2024:1616[RHSA-2024:1616]
 
 [id="RODOO-operator-1-1-1-new-features-and-enhancements"]
 === New features and enhancements


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-12411](https://issues.redhat.com/browse/OSDOCS-12411)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://83973--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#run-once-duration-override-operator-release-notes-1-1-2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Errata link will not work until October 31.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
