### PR TITLE
Removed redundant metadata field in example

### DIFF
--- a/modules/deployments-ab-testing-lb.adoc
+++ b/modules/deployments-ab-testing-lb.adoc
@@ -79,7 +79,6 @@ $ oc edit route <route_name>
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-metadata:
   name: route-alternate-service
   annotations:
     haproxy.router.openshift.io/balance: roundrobin


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]:
Removed redundant metadata field in example

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Should be back ported to all supported 4.x versions

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
