### PR TITLE
OBSDOCS:1438:  Separate UWM and core platform monitoring (part 3)

### DIFF
--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -3,25 +3,48 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="configuring-remote-write-storage_{context}"]
-= Configuring remote write storage
+
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+// tag::CPM[]
+[id="configuring-remote-write-storage-cpm_{context}"]
+= Configuring remote write storage for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="configuring-remote-write-storage-uwm_{context}"]
+= Configuring remote write storage for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:component: prometheusK8s
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:component: prometheus
+// end::UWM[]
 
 You can configure remote write storage to enable Prometheus to send ingested metrics to remote systems for long-term storage. Doing so has no impact on how or for how long Prometheus stores metrics.
 
 .Prerequisites
 
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+// end::CPM[]
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are configuring core {product-title} monitoring components:*
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` `ConfigMap` object.
-* *If you are configuring components that monitor user-defined projects:*
-** You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 * You have installed the OpenShift CLI (`oc`).
 * You have set up a remote write compatible endpoint (such as Thanos) and know the endpoint URL. See the link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Prometheus remote endpoints and storage documentation] for information about endpoints that are compatible with the remote write feature.
 +
@@ -29,13 +52,7 @@ endif::openshift-dedicated,openshift-rosa[]
 ====
 Red{nbsp}Hat only provides information for configuring remote write senders and does not offer guidance on configuring receiver endpoints. Customers are responsible for setting up their own endpoints that are remote-write compatible. Issues with endpoint receiver configurations are not included in Red{nbsp}Hat production support.
 ====
-* You have set up authentication credentials in a `Secret` object for the remote write endpoint. You must create the secret in the
-ifndef::openshift-dedicated,openshift-rosa[]
-same namespace as the Prometheus object for which you configure remote write: the `openshift-monitoring` namespace for default platform monitoring or the `openshift-user-workload-monitoring` namespace for user workload monitoring.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-`openshift-user-workload-monitoring` namespace.
-endif::openshift-dedicated,openshift-rosa[]
+* You have set up authentication credentials in a `Secret` object for the remote write endpoint. You must create the secret in the `{namespace-name}` namespace.
 +
 [WARNING]
 ====
@@ -44,49 +61,46 @@ To reduce security risks, use HTTPS and authentication to send metrics to an end
 
 .Procedure
 
-. Edit the `ConfigMap` object:
-ifndef::openshift-dedicated,openshift-rosa[]
-** *To configure remote write for the Prometheus instance that monitors core {product-title} projects*:
-.. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-.. Add a `remoteWrite:` section under `data/config.yaml/prometheusK8s`, as shown in the following example:
+. Add a `remoteWrite:` section under `data/config.yaml/{component}`, as shown in the following example:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
+    {component}:
       remoteWrite:
-      - url: "https://remote-write-endpoint.example.com" #<1>
-        <endpoint_authentication_credentials> #<2>
+      - url: "https://remote-write-endpoint.example.com" # <1>
+        <endpoint_authentication_credentials> # <2>
 ----
 <1> The URL of the remote write endpoint.
 <2> The authentication method and credentials for the endpoint.
 Currently supported authentication methods are AWS Signature Version 4, authentication using HTTP in an `Authorization` request header, Basic authentication, OAuth 2.0, and TLS client.
 See _Supported remote write authentication settings_ for sample configurations of supported authentication methods.
 
-.. Add write relabel configuration values after the authentication credentials:
+. Add write relabel configuration values after the authentication credentials:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
+    {component}:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com"
         <endpoint_authentication_credentials>
@@ -96,16 +110,16 @@ data:
 <1> Add configuration for metrics that you want to send to the remote endpoint.
 +
 .Example of forwarding a single metric called `my_metric`
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
+    {component}:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com"
         writeRelabelConfigs:
@@ -115,104 +129,16 @@ data:
 ----
 +
 .Example of forwarding metrics called `my_metric_1` and `my_metric_2` in `my_namespace` namespace
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
-      remoteWrite:
-      - url: "https://remote-write-endpoint.example.com"
-        writeRelabelConfigs:
-        - sourceLabels: [__name__,namespace]
-          regex: '(my_metric_1|my_metric_2);my_namespace'
-          action: keep 
-----
-
-** *To configure remote write for the Prometheus instance that monitors user-defined projects*:
-endif::openshift-dedicated,openshift-rosa[]
-.. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-
-.. Add a `remoteWrite:` section under `data/config.yaml/prometheus`, as shown in the following example:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    prometheus:
-      remoteWrite:
-      - url: "https://remote-write-endpoint.example.com" #<1>
-        <endpoint_authentication_credentials> #<2>
-----
-<1> The URL of the remote write endpoint.
-<2> The authentication method and credentials for the endpoint.
-Currently supported authentication methods are AWS Signature Version 4, authentication using HTTP an `Authorization` request header, basic authentication, OAuth 2.0, and TLS client.
-See _Supported remote write authentication settings_ below for sample configurations of supported authentication methods.
-
-.. Add write relabel configuration values after the authentication credentials:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    prometheus:
-      remoteWrite:
-      - url: "https://remote-write-endpoint.example.com"
-        <endpoint_authentication_credentials>
-        writeRelabelConfigs:
-        - <your_write_relabel_configs> #<1>
-----
-<1> Add configuration for metrics that you want to send to the remote endpoint.
-+
-.Example of forwarding a single metric called `my_metric`
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    prometheus:
-      remoteWrite:
-      - url: "https://remote-write-endpoint.example.com"
-        writeRelabelConfigs:
-        - sourceLabels: [__name__]
-          regex: 'my_metric'
-          action: keep
-----
-+
-.Example of forwarding metrics called `my_metric_1` and `my_metric_2` in `my_namespace` namespace
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    prometheus:
+    {component}:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com"
         writeRelabelConfigs:
@@ -222,3 +148,8 @@ data:
 ----
 
 . Save the file to apply the changes. The new configuration is applied automatically.
+
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!component:

--- a/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
+++ b/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
@@ -3,98 +3,111 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="creating-cluster-id-labels-for-metrics_{context}"]
-= Creating cluster ID labels for metrics
+
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+// tag::CPM[]
+[id="creating-cluster-id-labels-for-metrics-cpm_{context}"]
+= Creating cluster ID labels for metrics for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="creating-cluster-id-labels-for-metrics-uwm_{context}"]
+= Creating cluster ID labels for metrics for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:component: prometheusK8s
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:component: prometheus
+// end::UWM[]
+
+You can create cluster ID labels for metrics by adding the `write_relabel` settings for remote write storage in the `{configmap-name}` config map in the `{namespace-name}` namespace.
 
 ifndef::openshift-dedicated,openshift-rosa[]
-You can create cluster ID labels for metrics for default platform monitoring and for user workload monitoring.
-
-For default platform monitoring, you add cluster ID labels for metrics in the `write_relabel` settings for remote write storage in the `cluster-monitoring-config` config map in the `openshift-monitoring` namespace.
-
-For user workload monitoring, you edit the settings in the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
-
+// tag::UWM[]
 [NOTE]
 ====
 When Prometheus scrapes user workload targets that expose a `namespace` label, the system stores this label as `exported_namespace`. 
 This behavior ensures that the final namespace label value is equal to the namespace of the target pod.
 You cannot override this default configuration by setting the value of the `honorLabels` field to `true` for `PodMonitor` or `ServiceMonitor` objects.
 ====
-
-endif::openshift-dedicated,openshift-rosa[]
-
-ifdef::openshift-dedicated,openshift-rosa[]
-You can create cluster ID labels for metrics by editing the settings in the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
+// end::UWM[]
 endif::openshift-dedicated,openshift-rosa[]
 
 .Prerequisites
 
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+// end::CPM[]
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are configuring default platform monitoring components:*
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` `ConfigMap` object.
-* *If you are configuring components that monitor user-defined projects:*
-** You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` ConfigMap object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 * You have installed the OpenShift CLI (`oc`).
 * You have configured remote write storage.
 
 .Procedure
 
-. Edit the `ConfigMap` object:
-ifndef::openshift-dedicated,openshift-rosa[]
-** *To create cluster ID labels for core {product-title} metrics:*
-.. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-.. In the `writeRelabelConfigs:` section under `data/config.yaml/prometheusK8s/remoteWrite`, add cluster ID relabel configuration values:
+. In the `writeRelabelConfigs:` section under `data/config.yaml/{component}/remoteWrite`, add cluster ID relabel configuration values:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
+    {component}:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com"
         <endpoint_authentication_credentials>
-        writeRelabelConfigs: <1>
-          - <relabel_config> <2>
+        writeRelabelConfigs: # <1>
+          - <relabel_config> # <2>
 ----
 <1> Add a list of write relabel configurations for metrics that you want to send to the remote endpoint.
 <2> Substitute the label configuration for the metrics sent to the remote write endpoint.
 +
-The following sample shows how to forward a metric with the cluster ID label `cluster_id` in default platform monitoring:
+The following sample shows how to forward a metric with the cluster ID label `cluster_id`:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
+    {component}:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com"
         writeRelabelConfigs:
         - sourceLabels:
-          - __tmp_openshift_cluster_id__ <1>
-          targetLabel: cluster_id <2>
-          action: replace <3>
+          - __tmp_openshift_cluster_id__ # <1>
+          targetLabel: cluster_id # <2>
+          action: replace # <3>
 ----
 <1> The system initially applies a temporary cluster ID source label named `+++__tmp_openshift_cluster_id__+++`. This temporary label gets replaced by the cluster ID label name that you specify.
 <2> Specify the name of the cluster ID label for metrics sent to remote write storage.
@@ -103,58 +116,9 @@ For the label name, do not use `+++__tmp_openshift_cluster_id__+++`. The final r
 <3> The `replace` write relabel action replaces the temporary label with the target label for outgoing metrics.
 This action is the default and is applied if no action is specified.
 
-** *To create cluster ID labels for user-defined project metrics:*
-endif::openshift-dedicated,openshift-rosa[]
-.. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-
-.. In the `writeRelabelConfigs:` section under `data/config.yaml/prometheus/remoteWrite`, add cluster ID relabel configuration values:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    prometheus:
-      remoteWrite:
-      - url: "https://remote-write-endpoint.example.com"
-        <endpoint_authentication_credentials>
-        writeRelabelConfigs: <1>
-          - <relabel_config> <2>
-----
-<1> Add a list of write relabel configurations for metrics that you want to send to the remote endpoint.
-<2> Substitute the label configuration for the metrics sent to the remote write endpoint.
-+
-The following sample shows how to forward a metric with the cluster ID label `cluster_id` in user-workload monitoring:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    prometheus:
-      remoteWrite:
-      - url: "https://remote-write-endpoint.example.com"
-        writeRelabelConfigs:
-        - sourceLabels:
-          - __tmp_openshift_cluster_id__ <1>
-          targetLabel: cluster_id <2>
-          action: replace <3>
-----
-<1> The system initially applies a temporary cluster ID source label named `+++__tmp_openshift_cluster_id__+++`. This temporary label gets replaced by the cluster ID label name that you specify.
-<2> Specify the name of the cluster ID label for metrics sent to remote write storage. If you use a label name that already exists for a metric, that value is overwritten with the name of this cluster ID label. For the label name, do not use `+++__tmp_openshift_cluster_id__+++`. The final relabeling step removes labels that use this name.
-<3> The `replace` write relabel action replaces the temporary label with the target label for outgoing metrics. This action is the default and is applied if no action is specified.
-
 . Save the file to apply the changes. The new configuration is applied automatically.
+
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!component:

--- a/modules/monitoring-example-remote-write-authentication-settings.adoc
+++ b/modules/monitoring-example-remote-write-authentication-settings.adoc
@@ -3,32 +3,47 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="example-remote-write-authentication-settings_{context}"]
-= Example remote write authentication settings
 
-// Set attributes to distinguish between cluster monitoring examples and user workload monitoring examples.
-ifndef::openshift-dedicated,openshift-rosa[]
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+// tag::CPM[]
+[id="example-remote-write-authentication-settings-cpm_{context}"]
+= Example remote write authentication settings for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="example-remote-write-authentication-settings-uwm_{context}"]
+= Example remote write authentication settings for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+// tag::CPM[]
 :configmap-name: cluster-monitoring-config
 :namespace-name: openshift-monitoring
-:prometheus-instance: prometheusK8s
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+:component: prometheusK8s
+// end::CPM[]
+// tag::UWM[]
 :configmap-name: user-workload-monitoring-config
 :namespace-name: openshift-user-workload-monitoring
-:prometheus-instance: prometheus
-endif::openshift-dedicated,openshift-rosa[]
+:component: prometheus
+// end::UWM[]
 
 The following samples show different authentication settings you can use to connect to a remote write endpoint. Each sample also shows how to configure a corresponding `Secret` object that contains authentication credentials and other relevant settings. Each sample configures authentication for use with
-ifndef::openshift-dedicated,openshift-rosa[]
+// tag::CPM[]
 default platform monitoring
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-monitoring user-defined projects
-endif::openshift-dedicated,openshift-rosa[]
+// end::CPM[]
+// tag::UWM[]
+monitoring for user-defined projects
+// end::UWM[]
 in the `{namespace-name}` namespace.
 
-[id="remote-write-sample-yaml-aws-sigv4_{context}"]
-== Sample YAML for AWS Signature Version 4 authentication
+// tag::CPM[]
+[id="remote-write-sample-yaml-aws-sigv4-cmp_{context}"]
+== Sample YAML for AWS Signature Version 4 authentication for core platform monitoring
+// end::CPM[]
+// tag::UWM[]
+[id="remote-write-sample-yaml-aws-sigv4-uwm_{context}"]
+== Sample YAML for AWS Signature Version 4 authentication for monitoring of user-defined projects
+// end::UWM[]
 
 The following shows the settings for a `sigv4` secret named `sigv4-credentials` in the `{namespace-name}` namespace.
 
@@ -58,7 +73,7 @@ metadata:
   namespace: {namespace-name}
 data:
   config.yaml: |
-    {prometheus-instance}:
+    {component}:
       remoteWrite:
       - url: "https://authorization.example.com/api/write"
         sigv4:
@@ -79,8 +94,14 @@ data:
 <5> The name of the AWS profile that is being used to authenticate.
 <6> The unique identifier for the Amazon Resource Name (ARN) assigned to your role.
 
-[id="remote-write-sample-yaml-basic-auth_{context}"]
-== Sample YAML for Basic authentication
+// tag::CPM[]
+[id="remote-write-sample-yaml-basic-auth-cmp_{context}"]
+== Sample YAML for Basic authentication for core platform monitoring
+// end::CPM[]
+// tag::UWM[]
+[id="remote-write-sample-yaml-basic-auth-uwm_{context}"]
+== Sample YAML for Basic authentication for monitoring of user-defined projects
+// end::UWM[]
 
 The following shows sample Basic authentication settings for a `Secret` object named `rw-basic-auth` in the `{namespace-name}` namespace:
 
@@ -111,7 +132,7 @@ metadata:
   namespace: {namespace-name}
 data:
   config.yaml: |
-    {prometheus-instance}:
+    {component}:
       remoteWrite:
       - url: "https://basicauth.example.com/api/write"
         basicAuth:
@@ -126,8 +147,14 @@ data:
 <2> The key that contains the username  in the specified `Secret` object.
 <3> The key that contains the password in the specified `Secret` object.
 
-[id="remote-write-sample-yaml-bearer-token_{context}"]
-== Sample YAML for authentication with a bearer token using a `Secret` Object
+// tag::CPM[]
+[id="remote-write-sample-yaml-bearer-token-cmp_{context}"]
+== Sample YAML for authentication with a bearer token using a `Secret` Object for core platform monitoring
+// end::CPM[]
+// tag::UWM[]
+[id="remote-write-sample-yaml-bearer-token-uwm_{context}"]
+== Sample YAML for authentication with a bearer token using a `Secret` Object for monitoring of user-defined projects
+// end::UWM[]
 
 The following shows bearer token settings for a `Secret` object named `rw-bearer-auth` in the `{namespace-name}` namespace:
 
@@ -156,7 +183,7 @@ metadata:
 data:
   config.yaml: |
     enableUserWorkload: true
-    {prometheus-instance}:
+    {component}:
       remoteWrite:
       - url: "https://authorization.example.com/api/write"
         authorization:
@@ -169,8 +196,14 @@ data:
 <2> The name of the `Secret` object that contains the authentication credentials.
 <3> The key that contains the authentication token in the specified `Secret` object.
 
-[id="remote-write-sample-yaml-oauth-20_{context}"]
-== Sample YAML for OAuth 2.0 authentication
+// tag::CPM[]
+[id="remote-write-sample-yaml-oauth-20-cmp_{context}"]
+== Sample YAML for OAuth 2.0 authentication for core platform monitoring
+// end::CPM[]
+// tag::UWM[]
+[id="remote-write-sample-yaml-oauth-20-uwm_{context}"]
+== Sample YAML for OAuth 2.0 authentication for monitoring of user-defined projects
+// end::UWM[]
 
 The following shows sample OAuth 2.0 settings for a `Secret` object named `oauth2-credentials` in the `{namespace-name}` namespace:
 
@@ -200,7 +233,7 @@ metadata:
   namespace: {namespace-name}
 data:
   config.yaml: |
-    {prometheus-instance}:
+    {component}:
       remoteWrite:
       - url: "https://test.example.com/api/write"
         oauth2:
@@ -225,8 +258,14 @@ data:
 <4> The OAuth 2.0 scopes for the authorization request. These scopes limit what data the tokens can access.
 <5> The OAuth 2.0 authorization request parameters required for the authorization server.
 
-[id="remote-write-sample-yaml-tls_{context}"]
-== Sample YAML for TLS client authentication
+// tag::CPM[]
+[id="remote-write-sample-yaml-tls-cmp_{context}"]
+== Sample YAML for TLS client authentication for core platform monitoring
+// end::CPM[]
+// tag::UWM[]
+[id="remote-write-sample-yaml-tls-uwm_{context}"]
+== Sample YAML for TLS client authentication for monitoring of user-defined projects
+// end::UWM[]
 
 The following shows sample TLS client settings for a `tls` `Secret` object named `mtls-bundle` in the `{namespace-name}` namespace.
 
@@ -258,7 +297,7 @@ metadata:
   namespace: {namespace-name}
 data:
   config.yaml: |
-    {prometheus-instance}:
+    {component}:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com"
         tlsConfig:
@@ -280,5 +319,6 @@ data:
 <4> The key in the specified `Secret` object that contains the client key secret.
 
 // Unset the source code block attributes just to be safe.
+:!configmap-name:
 :!namespace-name:
-:!prometheus-instance:
+:!component:

--- a/modules/monitoring-example-remote-write-queue-configuration.adoc
+++ b/modules/monitoring-example-remote-write-queue-configuration.adoc
@@ -3,28 +3,37 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="example-remote-write-queue-configuration_{context}"]
-= Example remote write queue configuration
 
-// Set attributes to distinguish between cluster monitoring examples and user workload monitoring examples.
-ifndef::openshift-dedicated,openshift-rosa[]
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+// tag::CPM[]
+[id="example-remote-write-queue-configuration-cpm_{context}"]
+= Example remote write queue configuration for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="example-remote-write-queue-configuration-uwm_{context}"]
+= Example remote write queue configuration for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+// tag::CPM[]
 :configmap-name: cluster-monitoring-config
 :namespace-name: openshift-monitoring
-:prometheus-instance: prometheusK8s
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+:component: prometheusK8s
+// end::CPM[]
+// tag::UWM[]
 :configmap-name: user-workload-monitoring-config
 :namespace-name: openshift-user-workload-monitoring
-:prometheus-instance: prometheus
-endif::openshift-dedicated,openshift-rosa[]
+:component: prometheus
+// end::UWM[]
 
 You can use the `queueConfig` object for remote write to tune the remote write queue parameters. The following example shows the queue parameters with their default values for 
-ifndef::openshift-dedicated,openshift-rosa[]
+// tag::CPM[]
 default platform monitoring
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+// end::CPM[]
+// tag::UWM[]
 monitoring for user-defined projects
-endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 in the `{namespace-name}` namespace.
 
 .Example configuration of remote write parameters with default values
@@ -37,7 +46,7 @@ metadata:
   namespace: {namespace-name}
 data:
   config.yaml: |
-    {prometheus-instance}:
+    {component}:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com" 
         <endpoint_authentication_credentials>
@@ -63,6 +72,7 @@ data:
 <9> The samples that are older than the `sampleAgeLimit` limit are dropped from the queue. If the value is undefined or set to `0s`, the parameter is ignored.
 
 // Unset the source code block attributes just to be safe.
+:!configmap-name:
 :!namespace-name:
-:!prometheus-instance:
+:!component:
 

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 
-// The final solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
 
 // tag::CPM[]
 [id="moving-monitoring-components-to-different-nodes-cpm_{context}"]

--- a/observability/monitoring/accessing-third-party-monitoring-apis.adoc
+++ b/observability/monitoring/accessing-third-party-monitoring-apis.adoc
@@ -44,6 +44,6 @@ include::modules/monitoring-resources-reference-for-the-cluster-monitoring-opera
 ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 endif::openshift-dedicated,openshift-rosa[]
-* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-remote-write-storage_configuring-the-monitoring-stack[Configuring remote write storage]
+* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-remote-write-storage-cpm_configuring-the-monitoring-stack[Configuring remote write storage]
 * xref:../../observability/monitoring/managing-metrics.adoc#managing-metrics[Managing metrics]
 * xref:../../observability/monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]

--- a/observability/monitoring/common-monitoring-configuration-scenarios.adoc
+++ b/observability/monitoring/common-monitoring-configuration-scenarios.adoc
@@ -39,7 +39,7 @@ Specify the metrics data retention parameters for Prometheus and Thanos Ruler.
 * By default, in a newly installed {product-title} system, the monitoring `ClusterOperator` resource reports a `PrometheusDataPersistenceNotConfigured` status message to remind you that storage is not configured.
 ====
 +
-* For longer term data retention, xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-remote-write-storage_configuring-the-monitoring-stack[configure the remote write feature] to enable Prometheus to send ingested metrics to remote systems for storage.
+* For longer term data retention, xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-remote-write-storage-cpm_configuring-the-monitoring-stack[configure the remote write feature] to enable Prometheus to send ingested metrics to remote systems for storage.
 +
 [IMPORTANT]
 ====

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -209,10 +209,26 @@ ifdef::openshift-dedicated,openshift-rosa[]
 endif::openshift-dedicated,openshift-rosa[]
 
 // Configuring remote write storage for Prometheus
-include::modules/monitoring-configuring-remote-write-storage.adoc[leveloffset=+1]
+
+// Configuring remote write storage
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-configuring-remote-write-storage.adoc[leveloffset=+1,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-configuring-remote-write-storage.adoc[leveloffset=+1,tags=**;!CPM;UWM]
+
 include::modules/monitoring-supported-remote-write-authentication-settings.adoc[leveloffset=+2]
-include::modules/monitoring-example-remote-write-authentication-settings.adoc[leveloffset=+2]
-include::modules/monitoring-example-remote-write-queue-configuration.adoc[leveloffset=+2]
+
+// Example remote write authentication settings
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-example-remote-write-authentication-settings.adoc[leveloffset=+2,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-example-remote-write-authentication-settings.adoc[leveloffset=+2,tags=**;!CPM;UWM]
+
+// Example remote write queue configuration
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-example-remote-write-queue-configuration.adoc[leveloffset=+2,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-example-remote-write-queue-configuration.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
 [role="_additional-resources"]
 .Additional resources
@@ -228,12 +244,17 @@ endif::openshift-dedicated,openshift-rosa[]
 
 // Configuring labels for outgoing metrics
 include::modules/monitoring-adding-cluster-id-labels-to-metrics.adoc[leveloffset=+1]
-include::modules/monitoring-creating-cluster-id-labels-for-metrics.adoc[leveloffset=+2]
+
+// Creating cluster ID labels for metrics
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-creating-cluster-id-labels-for-metrics.adoc[leveloffset=+2,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-creating-cluster-id-labels-for-metrics.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-remote-write-storage_configuring-the-monitoring-stack[Configuring remote write storage]
+* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-remote-write-storage-cpm_configuring-the-monitoring-stack[Configuring remote write storage]
 ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../support/gathering-cluster-data.adoc#support-get-cluster-id_gathering-cluster-data[Obtaining your cluster ID]
 endif::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
Version(s): No version for CP

Issue: [OBSDOCS-1438](https://issues.redhat.com/browse/OBSDOCS-1438)

Link to docs preview (OCP):
**You can ignore the rendering of the ROSA/OSD distributions, those will be correctly separated later.**
**Title of the chapters is also temporary to make it easy for reviewers to identify which is which**
* [Configuring remote write storage for core platform monitoring
](https://84002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack#configuring-remote-write-storage-cpm_configuring-the-monitoring-stack)
* [Configuring remote write storage for monitoring of user-defined projects](https://84002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack#configuring-remote-write-storage-uwm_configuring-the-monitoring-stack)
* [Example remote write authentication settings for core platform monitoring](https://84002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack#example-remote-write-authentication-settings-cpm_configuring-the-monitoring-stack)
* [Example remote write authentication settings for monitoring of user-defined projects](https://84002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack#example-remote-write-authentication-settings-uwm_configuring-the-monitoring-stack)
* [Example remote write queue configuration for core platform monitoring](https://84002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack#example-remote-write-queue-configuration-cpm_configuring-the-monitoring-stack)
* [Example remote write queue configuration for monitoring of user-defined projects](https://84002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack#example-remote-write-queue-configuration-uwm_configuring-the-monitoring-stack)
* [Creating cluster ID labels for metrics for core platform monitoring](https://84002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack#creating-cluster-id-labels-for-metrics-cpm_configuring-the-monitoring-stack)
* [Creating cluster ID labels for metrics for monitoring of user-defined projects](https://84002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack#creating-cluster-id-labels-for-metrics-uwm_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

**Additional information:**
This is the part 3 split of core platform monitoring (CPM) and user workload monitoring (UWM) procedures. The issue is getting merged to only `monitoring-docs-restructure`, not to `main`, therefore this change will not be visible in the documentation.

The tagging is implemented so that once this is moved to two different assemblies, we will still only have one module to maintain. This will ensure content reuse instead of duplication. It also prevents creation of multiple new modules with basically identical content.

This issue also asks for changes in ID, however, in the final product, the two procedures will be in a different assembly, therefore two IDs will not be needed (context parameter will take care of it)

You can see https://github.com/openshift/openshift-docs/pull/83431 for reference.