### PR TITLE
OCPBUGS 43310 RN Documentation deficiency for ipForwarding: Global - moving Known issue as really new feature

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -863,7 +863,14 @@ Support for the Broadcom BCM57504 network interface controller is now available 
 [id="ocp-4-14-networking-ovn-kubernetes-secondary-network"]
 ==== OVN-Kubernetes is available as a secondary network
 
-With this release, the {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. As a secondary network, OVN-Kubernetes supports both layer 2 switched and localnet switched topology networks.For more information about OVN-Kubernetes as a secondary network, see xref:../networking/multiple_networks/configuring-additional-network.adoc#configuration-ovnk-additional-networks_configuring-additional-network[Configuration for an OVN-Kubernetes additional network].
+With this release, the {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. As a secondary network, OVN-Kubernetes supports both layer 2 switched and localnet switched topology networks. For more information about OVN-Kubernetes as a secondary network, see xref:../networking/multiple_networks/configuring-additional-network.adoc#configuration-ovnk-additional-networks_configuring-additional-network[Configuration for an OVN-Kubernetes additional network].
+
+[id="ocp-4-14-global-ip-forwarding-network-disabled"]
+==== Global IP forwarding is disabled on OVN-Kubernetes based cluster deployments
+
+Starting with this release, global IP address forwarding is disabled on OVN-Kubernetes based cluster deployments to prevent undesirable effects for cluster administrators with nodes acting as routers. OVN-Kubernetes now enables and restricts forwarding on a per-managed interface basis.
+
+You can control IP forwarding for all traffic on OVN-Kubernetes managed interfaces by using the `gatewayConfig.ipForwarding` specification in the `Network` resource. Specify `Restricted` to forward all traffic related to OVN-Kubernetes only. Specify `Global` to allow forwarding of all IP traffic. For new installations, the default is `Restricted`. Clusters upgraded to 4.14 are not affected by this change; the IP forwarding behavior remains unchanged and continues to be globally enabled. For more information about enabling IP forwarding globally, see xref:../networking/cluster-network-operator.adoc#nw-cno-enable-ip-forwarding_cluster-network-operator[Enabling IP forwarding globally].
 
 [id="ocp-4-14-admin-network-policy"]
 ==== Admin Network Policy (Technology Preview)
@@ -3048,10 +3055,6 @@ To revert all nodes in the cluster to the cgroups v2 configuration, you must edi
 * AWS `M4` and `C4` instances might fail to boot properly in clusters installed using {product-title} {product-version}. There is no current workaround. (link:https://issues.redhat.com/browse/OCPBUGS-17154[*OCPBUGS-17154*])
 
 * There is a known issue in this release which prevents installing a cluster on Alibaba Cloud by using installer-provisioned infrastructure. Installing a cluster on Alibaba Cloud is a Technology Preview feature in this release. (link:https://issues.redhat.com/browse/OCPBUGS-20552[*OCPBUGS-20552*])
-
-* From {product-title} {product-version} onwards, global IP address forwarding is disabled on OVN-Kubernetes based cluster deployments to prevent undesirable effects for cluster administrators with nodes acting as routers. OVN-Kubernetes now enables and restricts forwarding on a per-managed interface basis.
-+
-You can control IP forwarding for all traffic on OVN-Kubernetes managed interfaces by using the `gatewayConfig.ipForwarding` specification in the `Network` resource. Specify `Restricted` to forward all traffic related to OVN-Kubernetes only. Specify `Global` to allow forwarding of all IP traffic. For new installations, the default is `Restricted`. For upgrades to {product-version}, the default is `Global`. (link:https://issues.redhat.com/browse/OCPBUGS-3176[*OCPBUGS-3176*]) (link:https://issues.redhat.com/browse/OCPBUGS-16051[*OCPBUGS-16051*])
 
 * For clusters that have root volume availability zones and are running on {rh-openstack} that you upgrade to {product-version}, you must converge control plane machines onto one server group before you can enable control plane machine sets. To make the required change, follow the instructions in the link:https://access.redhat.com/solutions/7013893[knowledge base article]. (link:https://issues.redhat.com/browse/OCPBUGS-13300[*OCPBUGS-13300*])
 


### PR DESCRIPTION
[OCPBUGS-43310]: Documentation deficiency for ipForwarding: Global

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14 RN
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-43310
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://84003--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-global-ip-forwarding-network-disabled
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Moving this up to new feature as I don't believe it is correctly placed and has lead to some bugs being raised as not called out as enhancement really. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
