### PR TITLE
OSSM-8185 Document installing OSSM 3 on a cluster with OSSM 2 (without interfering with the OSSM 2)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -21,6 +21,8 @@ Distros: openshift-service-mesh
 Topics:
 - Name: Installing OpenShift Service Mesh
   File: ossm-installing-openshift-service-mesh
+- Name: Running Service Mesh 2.6 in the same cluster as Service Mesh 3
+  File: ossm-running-v2-same-cluster-as-v3-assembly
 ---
 Name: Updating
 Dir: update

--- a/install/ossm-running-v2-same-cluster-as-v3-assembly.adoc
+++ b/install/ossm-running-v2-same-cluster-as-v3-assembly.adoc
@@ -1,0 +1,23 @@
+:_content-type: ASSEMBLY
+[id="ossm-running-v2-same-cluster-as-v3_{context}"]
+= Running {SMProduct} 2.6 in the same cluster as {SMProduct} 3
+include::_attributes/common-attributes.adoc[]
+:context: ossm-running-v2-same-cluster-as-v3-assembly
+
+toc::[]
+
+If you are moving from {SMProductName} v2.6, you can run {SMProduct} v2.6 side-by-side with {SMProduct} v3.0, in one cluster, without them interfering with each other.
+
+include::modules/ossm-running-v2-v3-multitenant-deployment-model.adoc[leveloffset=+1]
+include::modules/ossm-running-v2-v3-cluster-wide-deployment-model.adoc[leveloffset=+1]
+
+//For TP1 only OSSM 2.6 has been tested and verified to be able to run in same cluster as OSSM 3.0. For GA, it might other versions of 2.x. As of 10/31/2024, that is unknown, so 2.6 is specifically called out for now but the id says v2 in the event it applies to other versions of 2.x.
+
+[role="_additional-resources"]
+[id="additional-resources-running-v2-same-cluster-as-v3"]
+== Additional resources
+
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-installing-operator_ossm-about-deployment-and-update-strategies[Installing {SMProduct} Operator]
+* link:https://docs.openshift.com/container-platform/4.17/service_mesh/v2x/upgrading-ossm.html[Upgrading Service Mesh 2.x]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/service_mesh/service-mesh-2-x#ossm-deployment-models[Service Mesh 2.x deployment models]
+* link:https://istio.io/latest/docs/setup/install/multiple-controlplanes/[Install Multiple Istio Control Planes in a Single Cluster]

--- a/modules/ossm-running-v2-v3-cluster-wide-deployment-model.adoc
+++ b/modules/ossm-running-v2-v3-cluster-wide-deployment-model.adoc
@@ -1,0 +1,153 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/install/ossm-v2-v3-side-by-side-assembly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-running-v2-v3-cluster-wide-deployment-model_{context}"]
+= Running {SMProductName} 2.6 and {SMProductName} 3 using cluster-wide deployment model
+//TP1 content influx. Title, etc may change.
+//No IA as of 10/23/2024 so this content is likely to move.
+
+If you are moving from {SMProductName} 2.6 in a cluster-wide deployment model, you can run {SMProduct} 2.6 side-by-side with {SMProduct} 3.0, in one cluster, without them interfering with each other.
+
+In {SMProduct} 2.6, you can check your deployment model from the `ServiceMeshControlPlane` under `spec.mode`:
+
+.Example `ServiceMeshControlPlane` yaml
+[source, yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+spec:
+  mode: ClusterWide
+----
+
+To prevent conflicts with {SMProduct} 3.0 when using the {SMProduct} 2.6 cluster-wide deployment model, you need to configure the `ServiceMeshControlPlane` resource to restrict namespaces to only those belonging to (SMProduct) 2.6.
+
+//NOTES: 10/23/2024
+
+//DO NOT USE VERSION NUMBER ATTRIBUTE. It is set for 3.0, will likely change, and it is unclear if later versions would impact this procedure for moving from 2.6.
+//Only moving from 2.6 has been tested and verified by QE.
+//Cluster-wide requires changes to OSSM 2.6 ServiceMeshControlPlane before installing OSSM 3.0
+
+.Prerequisites
+
+* You are running {ocp-product-title} 4.14 or later.
+* You are running {SMProduct} 2.6.
++
+[IMPORTANT]
+====
+If you are not running {SMProduct} 2.6, you must upgrade to 2.6 before following this procedure. To upgrade to {SMProduct} version to 2.6, see: link:https://docs.openshift.com/container-platform/4.17/service_mesh/v2x/upgrading-ossm.html[Upgrading Service Mesh 2.x]
+====
+
+.Procedure
+
+. Configure `discoverySelectors`, and set the `ENABLE_ENHANCED_RESOURCE_SCOPING` environment variable on the pilot container to `true` in your {SMProduct} 2.6 `ServiceMeshControlPlane` custom resource (CR):
++
+.Example `ServiceMeshControlPlane` CR
+[source, yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+  namespace: istio-system
+spec:
+  version: v2.6
+  mode: ClusterWide
+  meshConfig:
+    discoverySelectors:
+      - matchExpressions:
+        - key: maistra.io/member-of
+          operator: Exists
+  runtime:
+    components:
+      pilot:
+        container:
+          env:
+            ENABLE_ENHANCED_RESOURCE_SCOPING: 'true'
+----
+
+. Install the {SMProduct} 3 Operator.
+
+. Create an `IstioCNI` resource in the `istio-cni` namespace.
+
+. Create an `Istio` resource in a different namespace than the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6. In this example, `istio-system3` is being used:
++
+.Example `Istio` resource with `istio-system3`
+[source, yaml]
+----
+kind: Istio
+apiVersion: sailoperator.io/v1alpha1
+metadata:
+  name: ossm3 # <1>
+spec:
+  namespace: istio-system3 # <2>
+  values:
+    meshConfig:
+      discoverySelectors: # <3>
+        - matchExpressions:
+          - key: maistra.io/member-of
+            operator: DoesNotExist
+  updateStrategy:
+    type: InPlace
+  version: v1.23.0
+----
+<1> Do not use `default` as the name.
+<2> Must be different from the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6.
+<3> To ignore {SMProduct} 2.6 namespaces, configure the `discoverySelectors` section as shown. All other namespaces will be part of the {SMProduct} 3.0 mesh.
++
+
+//. install `Red Hat OpenShift Service Mesh 3` operator
+//. create `IstioCNI` resource in `istio-cni` namespace
+//. create following `Istio` resource in `istio-system3` (must be a different namespace than a namespace running OSSM 2). Make sure to use discovery selectors which are ignoring OSSM 2 namespaces and NOT to use `default` name for `Istio` resource. You can optionally restrict discovered namespaces even more. Configuration shown in the example only ignores OSSM 2 namespaces but all other namespaces will be part of OSSM 3 mesh.
+
+. Deploy your workloads and label the namespaces with `istio.io/rev=ossm3` label by running the following command:
++
+[source, terminal]
+----
+$ oc label namespace <namespace-name> istio.io/rev=ossm3
+----
++
+[NOTE]
+====
+If you have changed `spec.memberSelectors` in `ServiceMeshMemberRoll` in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6., then use the `istio-injection=enabled` label for your {SMProduct} 3.0 workload namespaces.
+====
+
+. Confirm the application workloads are managed by their respective control planes by running the following command:
++
+[source,terminal]
+----
+$ istioctl ps -i istio-system
+----
++
+.Sample output `istio-system`
+[source, terminal]
+----
+$ istioctl ps -i istio-system
+NAME                                          CLUSTER        CDS        LDS        EDS        RDS        ECDS         ISTIOD                                          VERSION
+details-v1-7f46897b-88x4l.bookinfo            Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+mongodb-v1-6cf7dc9885-7nlmq.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+mysqldb-v1-7c4c44b9b4-22b57.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+productpage-v1-6f9c6589cb-l6rvg.bookinfo      Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+ratings-v1-559b64556-f6b4l.bookinfo           Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+ratings-v2-8ddc4d65c-bztrg.bookinfo           Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+ratings-v2-mysql-cbc957476-m5j7w.bookinfo     Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+reviews-v1-847fb7c54d-7dwt7.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+reviews-v2-5c7ff5b77b-5bpc4.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+reviews-v3-5c5d764c9b-mk8vn.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+----
++
+.Sample output `istio-system3`
+[source,terminal]
+----
+$ istioctl ps -i istio-system3
+NAME                                          CLUSTER        CDS                LDS                EDS                RDS                ECDS        ISTIOD                            VERSION
+details-v1-57f6466bdc-5krth.bookinfo2         Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+productpage-v1-5b84ccdddf-f8d9t.bookinfo2     Kubernetes     SYNCED (2m39s)     SYNCED (2m39s)     SYNCED (2m34s)     SYNCED (2m39s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+ratings-v1-fb764cb99-kx2dr.bookinfo2          Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+reviews-v1-8bd5549cf-xqqmd.bookinfo2          Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+reviews-v2-7f7cc8bf5c-5rvln.bookinfo2         Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+reviews-v3-84f674b88c-ftcqg.bookinfo2         Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+----

--- a/modules/ossm-running-v2-v3-multitenant-deployment-model.adoc
+++ b/modules/ossm-running-v2-v3-multitenant-deployment-model.adoc
@@ -1,0 +1,120 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/install/ossm-v2-v3-side-by-side-assembly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-running-v2-v3-multitenant-deployment-model_{context}"]
+= Running {SMProduct} 2.6 and {SMProduct} 3 using multi-tenant deployment model
+//TP1 content influx. Title, etc may change.
+//No IA as of 10/23/2024 so this content is likely to move.
+
+If you are moving from {SMProductName} 2.6 from the default multi-tenant deployment model, you can run {SMProduct} 2.6 side-by-side with {SMProduct} 3.0, in one cluster, without them interfering with each other.
+
+In {SMProduct} 2.6, you can check your deployment model from the `ServiceMeshControlPlane` under `spec.mode`:
+
+.Example `ServiceMeshControlPlane` yaml
+[source, yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+spec:
+  mode: MultiTenant
+----
+
+//NOTES: 10/23/2024
+
+//DO NOT USE VERSION NUMBER ATTRIBUTE. It is set for 3.0, will likely change, and it is unclear if later versions would impact this procedure for moving from 2.6.
+//Only moving from 2.6 has been tested and verified by QE.
+//Mulitenant has no changes to OSSM 2.6, separate module.
+
+.Prerequisites
+
+* You are running {ocp-product-title} 4.14 or later.
+* You are running {SMProduct} 2.6.
++
+[IMPORTANT]
+====
+If you are not running {SMProduct} 2.6, you must upgrade to 2.6 before following this procedure. To upgrade to {SMProduct} version to 2.6, see: link:https://docs.openshift.com/container-platform/4.17/service_mesh/v2x/upgrading-ossm.html[Upgrading Service Mesh 2.x]
+====
+
+.Procedure
+
+. Install the {SMProduct} 3 Operator.
+
+. Create an `IstioCNI` resource in the `istio-cni` namespace.
+
+. Create an `Istio` resource in a different namespace than the `namespace` used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6. In this example, `istio-system3` is being used:
++
+.Example `Istio` resource with `istio-system3`
+[source, yaml]
+----
+kind: Istio
+piVersion: sailoperator.io/v1alpha1
+metadata:
+  name: ossm3 # <1>
+spec:
+  namespace: istio-system3 # <2>
+  values:
+    meshConfig:
+      discoverySelectors: # <3>
+        - matchExpressions:
+          - key: maistra.io/member-of
+            operator: DoesNotExist
+  updateStrategy:
+    type: InPlace
+  version: v1.23.0
+----
+<1> Do not use `default` as the name.
+<2> Must be different from the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6.
+<3> To ignore {SMProduct} 2.6 namespaces, configure the `discoverySelectors` section as shown. All other namespaces will be part of the {SMProduct} 3.0 mesh.
+
+. Deploy your workloads and label the namespaces with `istio.io/rev=ossm3` label by running the following command:
++
+[source, terminal]
+----
+$ oc label namespace <namespace-name> istio.io/rev=<revision-name>
+----
++
+[NOTE]
+====
+If you have changed `spec.memberSelectors` in `ServiceMeshMemberRoll` in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6., then use the `istio-injection=enabled` label for your {SMProduct} 3.0 workload namespaces.
+====
+
+. Confirm the application workloads are managed by their respective control planes by running the following command:
++
+[source,terminal]
+----
+$ istioctl ps -i istio-system
+----
++
+.Sample output `istio-system`
+[source, terminal]
+----
+$ istioctl ps -i istio-system
+NAME                                          CLUSTER        CDS        LDS        EDS        RDS        ECDS         ISTIOD                                          VERSION
+details-v1-7f46897b-88x4l.bookinfo            Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+mongodb-v1-6cf7dc9885-7nlmq.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+mysqldb-v1-7c4c44b9b4-22b57.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+productpage-v1-6f9c6589cb-l6rvg.bookinfo      Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+ratings-v1-559b64556-f6b4l.bookinfo           Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+ratings-v2-8ddc4d65c-bztrg.bookinfo           Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+ratings-v2-mysql-cbc957476-m5j7w.bookinfo     Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+reviews-v1-847fb7c54d-7dwt7.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+reviews-v2-5c7ff5b77b-5bpc4.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+reviews-v3-5c5d764c9b-mk8vn.bookinfo          Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-install-istio-system-bd58bdcd5-2htkf     1.20.8
+----
++
+.Sample output `istio-system3`
+[source,terminal]
+----
+$ istioctl ps -i istio-system3
+NAME                                          CLUSTER        CDS                LDS                EDS                RDS                ECDS        ISTIOD                            VERSION
+details-v1-57f6466bdc-5krth.bookinfo2         Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+productpage-v1-5b84ccdddf-f8d9t.bookinfo2     Kubernetes     SYNCED (2m39s)     SYNCED (2m39s)     SYNCED (2m34s)     SYNCED (2m39s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+ratings-v1-fb764cb99-kx2dr.bookinfo2          Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+reviews-v1-8bd5549cf-xqqmd.bookinfo2          Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+reviews-v2-7f7cc8bf5c-5rvln.bookinfo2         Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+reviews-v3-84f674b88c-ftcqg.bookinfo2         Kubernetes     SYNCED (2m40s)     SYNCED (2m40s)     SYNCED (2m34s)     SYNCED (2m40s)     IGNORED     istiod-ossm3-5b46b6b8cb-gbjx6     1.23.0
+----


### PR DESCRIPTION
**OSSM 3.0 TP1**

Document installing OSSM 3 on a cluster with OSSM 2 (without interfering with the OSSM 2)

Content was not required for TP1. OSSM 3.0 is still in TP1 so this content applies.

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters

Version(s):

Technology Preview

Issue:
https://issues.redhat.com/browse/OSSM-8185

Link to docs preview:
https://84004--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-running-v2-same-cluster-as-v3-assembly.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Engineering PR: https://github.com/openshift-service-mesh/sail-operator/pull/143 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
