### PR TITLE
Removing TP notice from NetObserv CLI docs

### DIFF
--- a/observability/network_observability/netobserv_cli/netobserv-cli-install.adoc
+++ b/observability/network_observability/netobserv_cli/netobserv-cli-install.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 The Network Observability CLI (`oc netobserv`) is deployed separately from the Network Observability Operator. The CLI is available as an {oc-first} plugin. It provides a lightweight way to quickly debug and troubleshoot with network observability.
 
-:FeatureName: Network Observability CLI (`oc netobserv`)
-include::snippets/technology-preview.adoc[]
-
 include::modules/network-observability-netobserv-cli-about.adoc[leveloffset=+1]
 include::modules/network-observability-netobserv-cli-install.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://84005--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-install.html
QE review:
- The CLI is GA, as a fact, I just forgot to remove this. No QE needed. See https://access.redhat.com/errata/RHEA-2024:8264 "Network Observability CLI General Availability."
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
