### PR TITLE
OBSDOCS-1440: Separate UWM and core platform monitoring (part 4)

### DIFF
--- a/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
+++ b/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
@@ -2,64 +2,77 @@
 //
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
-:_mod-docs-content-type: PROCEDURE
-[id="monitoring-adding-a-secret-to-the-alertmanager-configuration_{context}"]
-= Adding a secret to the Alertmanager configuration
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
 
-ifndef::openshift-dedicated,openshift-rosa[]
-You can add secrets to the Alertmanager configuration for core platform monitoring components by editing the `cluster-monitoring-config` config map in the `openshift-monitoring` project.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-You can add secrets to the Alertmanager configuration for user-defined projects by editing the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` project.
-endif::openshift-dedicated,openshift-rosa[]
+// tag::CPM[]
+[id="monitoring-adding-a-secret-to-the-alertmanager-configuration-cpm_{context}"]
+= Adding a secret to the Alertmanager configuration for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="monitoring-adding-a-secret-to-the-alertmanager-configuration-uwm_{context}"]
+= Adding a secret to the Alertmanager configuration for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:component: alertmanagerMain
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:component: alertmanager
+// end::UWM[]
+
+You can add secrets to the Alertmanager configuration by editing the `{configmap-name}` config map in the `{namespace-name}` project.
 
 After you add a secret to the config map, the secret is mounted as a volume at `/etc/alertmanager/secrets/<secret_name>` within the `alertmanager` container for the Alertmanager pods.
 
 .Prerequisites
 
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` config map.
+// end::CPM[]
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are configuring core {product-title} monitoring components in the `openshift-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` config map.
-** You have created the secret to be configured in Alertmanager in the `openshift-monitoring` project.
-* *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the secret to be configured in Alertmanager in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-* You have created the secret to be configured in Alertmanager in the `openshift-user-workload-monitoring` project.
 endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
+* You have created the secret to be configured in Alertmanager in the `{namespace-name}` project.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-. Edit the `ConfigMap` object.
-ifndef::openshift-dedicated,openshift-rosa[]
-** *To add a secret configuration to Alertmanager for core platform monitoring*:
-.. Edit the `cluster-monitoring-config` config map in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-.. Add a `secrets:` section under `data/config.yaml/alertmanagerMain` with the following configuration:
+. Add a `secrets:` section under `data/config.yaml/{component}` with the following configuration:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    alertmanagerMain:
-      secrets: <1>
-      - <secret_name_1> <2>
+    {component}:
+      secrets: # <1>
+      - <secret_name_1> # <2>
       - <secret_name_2>
 ----
 <1> This section contains the secrets to be mounted into Alertmanager. The secrets must be located within the same namespace as the Alertmanager object.
@@ -67,67 +80,25 @@ data:
 +
 The following sample config map settings configure Alertmanager to use two `Secret` objects named `test-secret-basic-auth` and `test-secret-api-token`:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    alertmanagerMain:
+    {component}:
       secrets:
       - test-secret-basic-auth
       - test-secret-api-token
 ----
 
-** *To add a secret configuration to Alertmanager for user-defined project monitoring*:
-endif::openshift-dedicated,openshift-rosa[]
-
-.. Edit the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-
-.. Add a `secrets:` section under `data/config.yaml/alertmanager/secrets` with the following configuration:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    alertmanager:
-      secrets: <1>
-      - <secret_name_1> <2>
-      - <secret_name_2>
-----
-<1> This section contains the secrets to be mounted into Alertmanager. The secrets must be located within the same namespace as the Alertmanager object.
-<2> The name of the `Secret` object that contains authentication credentials for the receiver. If you add multiple secrets, place each one on a new line.
-+
-The following sample config map settings configure Alertmanager to use two `Secret` objects named `test-secret` and `test-secret-api-token`:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    alertmanager:
-      enabled: true
-      secrets:
-      - test-secret
-      - test-api-receiver-token
-----
-
 . Save the file to apply the changes. The new configuration is applied automatically.
+
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!component:
 

--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -3,56 +3,77 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="attaching-additional-labels-to-your-time-series-and-alerts_{context}"]
-= Attaching additional labels to your time series and alerts
+
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+
+// tag::CPM[]
+[id="attaching-additional-labels-to-your-time-series-and-alerts-cpm_{context}"]
+= Attaching additional labels to your time series and alerts for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="attaching-additional-labels-to-your-time-series-and-alerts-uwm_{context}"]
+= Attaching additional labels to your time series and alerts for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:component: prometheusK8s
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:component: prometheus
+// end::UWM[]
 
 You can attach custom labels to all time series and alerts leaving Prometheus by using the external labels feature of Prometheus.
 
 .Prerequisites
 
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+// end::CPM[]
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` `ConfigMap` object.
-* *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-. Edit the `ConfigMap` object:
-ifndef::openshift-dedicated,openshift-rosa[]
-** *To attach custom labels to all time series and alerts leaving the Prometheus instance that monitors core {product-title} projects*:
-.. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-.. Define a map of labels you want to add for every metric under `data/config.yaml`:
+. Define labels you want to add for every metric under `data/config.yaml`:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
+    {component}:
       externalLabels:
         <key>: <value> # <1>
 ----
-+
-<1> Substitute `<key>: <value>` with a map of key-value pairs where `<key>` is a unique name for the new label and `<value>` is its value.
+<1> Substitute `<key>: <value>` with key-value pairs where `<key>` is a unique name for the new label and `<value>` is its value.
 +
 [WARNING]
 ====
@@ -60,80 +81,34 @@ data:
 
 * Do not use `cluster` or `managed_cluster` as key names. Using them can cause issues where you are unable to see data in the developer dashboards.
 ====
-+
-For example, to add metadata about the region and environment to all time series and alerts, use the following example:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
-data:
-  config.yaml: |
-    prometheusK8s:
-      externalLabels:
-        region: eu
-        environment: prod
-----
-
-.. Save the file to apply the changes. The new configuration is applied automatically.
-
-** *To attach custom labels to all time series and alerts leaving the Prometheus instance that monitors user-defined projects*:
-endif::openshift-dedicated,openshift-rosa[]
-.. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-
-.. Define a map of labels you want to add for every metric under `data/config.yaml`:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    prometheus:
-      externalLabels:
-        <key>: <value> # <1>
-----
-+
-<1> Substitute `<key>: <value>` with a map of key-value pairs where `<key>` is a unique name for the new label and `<value>` is its value.
-+
-[WARNING]
-====
-* Do not use `prometheus` or `prometheus_replica` as key names, because they are reserved and will be overwritten.
-
-* Do not use `cluster` or `managed_cluster` as key names. Using them can cause issues where you are unable to see data in the developer dashboards.
-====
+// tag::UWM[]
 +
 [NOTE]
 ====
 In the `openshift-user-workload-monitoring` project, Prometheus handles metrics and Thanos Ruler handles alerting and recording rules. Setting `externalLabels` for `prometheus` in the `user-workload-monitoring-config` `ConfigMap` object will only configure external labels for metrics and not for any rules.
 ====
+// end::UWM[]
 +
-For example, to add metadata about the region and environment to all time series and alerts related to user-defined projects, use the following example:
+For example, to add metadata about the region and environment to all time series and alerts, use the following example:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheus:
+    {component}:
       externalLabels:
         region: eu
         environment: prod
 ----
 
-.. Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
+. Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
+
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!component:

--- a/modules/monitoring-configuring-external-alertmanagers.adoc
+++ b/modules/monitoring-configuring-external-alertmanagers.adoc
@@ -3,144 +3,116 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="monitoring-configuring-external-alertmanagers_{context}"]
-= Configuring external Alertmanager instances
+
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+
+// tag::CPM[]
+[id="monitoring-configuring-external-alertmanagers-cpm_{context}"]
+= Configuring external Alertmanager instances for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="monitoring-configuring-external-alertmanagers-uwm_{context}"]
+= Configuring external Alertmanager instances for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:component: prometheusK8s
+:component-name: Prometheus
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:component: thanosRuler
+:component-name: Thanos Ruler
+// end::UWM[]
 
 The {product-title} monitoring stack includes a local Alertmanager instance that routes alerts from Prometheus.
-ifndef::openshift-dedicated,openshift-rosa[]
-You can add external Alertmanager instances to route alerts for core {product-title} projects or user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+
+// tag::CPM[]
+You can add external Alertmanager instances to route alerts for core {product-title} projects.
+// end::CPM[]
+// tag::UWM[]
 You can add external Alertmanager instances to route alerts for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 
 If you add the same external Alertmanager configuration for multiple clusters and disable the local instance for each cluster, you can then manage alert routing for multiple clusters by using a single external Alertmanager instance.
 
 .Prerequisites
 
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+// end::CPM[]
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are configuring core {product-title} monitoring components in the `openshift-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` config map.
-* *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-. Edit the `ConfigMap` object.
-ifndef::openshift-dedicated,openshift-rosa[]
-** *To configure additional Alertmanagers for routing alerts from core {product-title} projects*:
-.. Edit the `cluster-monitoring-config` config map in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-.. Add an `additionalAlertmanagerConfigs:` section under `data/config.yaml/prometheusK8s`.
-
-.. Add the configuration details for additional Alertmanagers in this section:
+. Add an `additionalAlertmanagerConfigs` section with configuration details under 
+// tag::CPM[]
+`data/config.yaml/prometheusK8s`:
+// end::CPM[]
+// tag::UWM[]
+`data/config.yaml/<component>`:
+// end::UWM[]
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
+# tag::CPM[]
     prometheusK8s:
+# end::CPM[]
+# tag::UWM[]
+    <component>: # <2>
+# end::UWM[]
       additionalAlertmanagerConfigs:
-      - <alertmanager_specification>
+      - <alertmanager_specification> # <1>
 ----
-+
-For `<alertmanager_specification>`, substitute authentication and other configuration details for additional Alertmanager instances.
+<1> Substitute `<alertmanager_specification>` with authentication and other configuration details for additional Alertmanager instances.
 Currently supported authentication methods are bearer token (`bearerToken`) and client TLS (`tlsConfig`).
-The following sample config map configures an additional Alertmanager using a bearer token with client TLS authentication:
+// tag::UWM[]
+<2> Substitute `<component>` for one of two supported external Alertmanager components: `prometheus` or `thanosRuler`.
+// end::UWM[]
 +
-[source,yaml]
+The following sample config map configures an additional Alertmanager for {component-name} by using a bearer token with client TLS authentication:
++
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
-      additionalAlertmanagerConfigs:
-      - scheme: https
-        pathPrefix: /
-        timeout: "30s"
-        apiVersion: v1
-        bearerToken:
-          name: alertmanager-bearer-token
-          key: token
-        tlsConfig:
-          key:
-            name: alertmanager-tls
-            key: tls.key
-          cert:
-            name: alertmanager-tls
-            key: tls.crt
-          ca:
-            name: alertmanager-tls
-            key: tls.ca
-        staticConfigs:
-        - external-alertmanager1-remote.com
-        - external-alertmanager1-remote2.com
-----
-
-** *To configure additional Alertmanager instances for routing alerts from user-defined projects*:
-endif::openshift-dedicated,openshift-rosa[]
-
-.. Edit the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-
-.. Add a `<component>/additionalAlertmanagerConfigs:` section under `data/config.yaml/`.
-
-.. Add the configuration details for additional Alertmanagers in this section:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    <component>:
-      additionalAlertmanagerConfigs:
-      - <alertmanager_specification>
-----
-+
-For `<component>`, substitute one of two supported external Alertmanager components: `prometheus` or `thanosRuler`.
-+
-For `<alertmanager_specification>`, substitute authentication and other configuration details for additional Alertmanager instances. Currently supported authentication methods are bearer token (`bearerToken`) and client TLS (`tlsConfig`). The following sample config map configures an additional Alertmanager using Thanos Ruler with a bearer token and client TLS authentication:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    thanosRuler:
+    {component}:
       additionalAlertmanagerConfigs:
       - scheme: https
         pathPrefix: /
@@ -165,3 +137,9 @@ data:
 ----
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
+
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!component:
+:!component-name:

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 
-// The final solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
+// The ultimate solution DOES NOT NEED separate IDs, it is just needed for now so that the tests will not break
 
 // tag::CPM[]
 [id="moving-monitoring-components-to-different-nodes-cpm_{context}"]

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -270,15 +270,26 @@ include::modules/monitoring-creating-scrape-sample-alerts.adoc[leveloffset=+2]
 * See xref:../../observability/monitoring/troubleshooting-monitoring-issues.adoc#determining-why-prometheus-is-consuming-disk-space_troubleshooting-monitoring-issues[Determining why Prometheus is consuming a lot of disk space] for steps to query which metrics have the highest number of scrape samples.
 endif::openshift-dedicated,openshift-rosa[]
 
-//Configuring external alertmanagers
-include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=1]
+//Configuring external Alertmanager instances
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=1,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=1,tags=**;!CPM;UWM]
 
 //Configuring secrets for Alertmanager
 include::modules/monitoring-configuring-secrets-for-alertmanager.adoc[leveloffset=1]
-include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc[leveloffset=2]
+
+// Adding a secret to the Alertmanager configuration
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc[leveloffset=2,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc[leveloffset=2,tags=**;!CPM;UWM]
 
 //Attaching additional labels to your time series and alerts
-include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1]
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s): No version for CP

Issue: [OBSDOCS-1440](https://issues.redhat.com/browse/OBSDOCS-1440)

Link to docs preview (OCP)
**You can ignore the rendering of the ROSA/OSD distributions, those will be correctly separated later.**
**Title of the chapters is also temporary to make it easy for reviewers to identify which is which**
* [Configuring external Alertmanager instances for core platform monitoring](https://84023--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#monitoring-configuring-external-alertmanagers-cpm_configuring-the-monitoring-stack)
* [Configuring external Alertmanager instances for monitoring of user-defined projects](https://84023--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#monitoring-configuring-external-alertmanagers-uwm_configuring-the-monitoring-stack)
* [Adding a secret to the Alertmanager configuration for core platform monitoring](https://84023--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#monitoring-adding-a-secret-to-the-alertmanager-configuration-cpm_configuring-the-monitoring-stack)
* [Adding a secret to the Alertmanager configuration for monitoring of user-defined projects](https://84023--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#monitoring-adding-a-secret-to-the-alertmanager-configuration-uwm_configuring-the-monitoring-stack)
* [Attaching additional labels to your time series and alerts for core platform monitoring](https://84023--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#attaching-additional-labels-to-your-time-series-and-alerts-cpm_configuring-the-monitoring-stack)
* [Attaching additional labels to your time series and alerts for monitoring of user-defined projects](https://84023--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#attaching-additional-labels-to-your-time-series-and-alerts-uwm_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

**Additional information:**
This is the part 4 split of core platform monitoring (CPM) and user workload monitoring (UWM) procedures. The issue is getting merged to only `monitoring-docs-restructure`, not to `main`, therefore this change will not be visible in the documentation.

The tagging is implemented so that once this is moved to two different assemblies, we will still only have one module to maintain. This will ensure content reuse instead of duplication. It also prevents creation of multiple new modules with basically identical content.

This issue also asks for changes in ID, however, in the final product, the two procedures will be in a different assembly, therefore two IDs will not be needed (context parameter will take care of it)

You can see https://github.com/openshift/openshift-docs/pull/83431 for reference.