### PR TITLE
Telcodocs 2087: Document how to Enabling IP forwarding globally

### DIFF
--- a/modules/nw-cno-enable-ip-forwarding.adoc
+++ b/modules/nw-cno-enable-ip-forwarding.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * networking/cluster-network-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-cno-enable-ip-forwarding_{context}"]
+= Enabling IP forwarding globally
+
+From {product-title} 4.14 onward, global IP address forwarding is disabled on OVN-Kubernetes based cluster deployments to prevent undesirable effects for cluster administrators with nodes acting as routers. However, in some cases where an administrator expects traffic to be forwarded a new configuration parameter `ipForwarding` is available to allow forwarding of all IP traffic.
+
+To re-enable IP forwarding for all traffic on OVN-Kubernetes managed interfaces set the `gatewayConfig.ipForwarding` specification in the Cluster Network Operator to `Global` following this procedure:
+
+.Procedure
+
+. Backup the existing network configuration by running the following command: 
++
+[source,terminal]
+----
+$ oc get network.operator cluster -o yaml > network-config-backup.yaml
+----
+
+. Run the following command to modify the existing network configuration: 
++
+[source,terminal]
+----
+$ oc edit network.operator cluster
+----
+
+.. Add or update the following block under `spec` as illustrated in the following example:
++
+[source,yaml]
+----
+spec:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  serviceNetwork:
+  - 172.30.0.0/16
+  networkType: OVNKubernetes
+  clusterNetworkMTU: 8900
+  defaultNetwork:
+    ovnKubernetesConfig:
+      gatewayConfig:
+        ipForwarding: Global
+----
+
+.. Save and close the file. 
+
+. After applying the changes, the OpenShift Cluster Network Operator (CNO) applies the update across the cluster. You can monitor the progress by using the following command:
++
+[source,terminal]
+----
+$ oc get clusteroperators network
+
+----
++
+The status should eventually report as `Available`, `Progressing=False`, and `Degraded=False`.
+
+. Alternatively, you can enable IP forwarding globally by running the following command:
++
+[source,terminal]
+----
+$ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}
+----
++
+[NOTE]
+====
+The other valid option for this parameter is `Restricted` in case you want to revert this change. `Restricted` is the default and with that setting global IP address forwarding is disabled. 
+====
+

--- a/networking/cluster-network-operator.adoc
+++ b/networking/cluster-network-operator.adoc
@@ -14,6 +14,8 @@ include::modules/nw-cno-view.adoc[leveloffset=+1]
 
 include::modules/nw-cno-status.adoc[leveloffset=+1]
 
+include::modules/nw-cno-enable-ip-forwarding.adoc[leveloffset=+1]
+
 include::modules/nw-cno-logs.adoc[leveloffset=+1]
 
 include::modules/nw-operator-cr.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-2087]: Document how to Enabling IP forwarding globally

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.15, 4.16, 4.17, 4.18 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2087
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://84041--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/cluster-network-operator.html#nw-cno-enable-ip-forwarding_cluster-network-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
