### PR TITLE
OSSM-8297 Remove attribute from OSSM 3.x rel notes for Pantheon

### DIFF
--- a/ossm-release-notes/ossm-release-notes-assembly.adoc
+++ b/ossm-release-notes/ossm-release-notes-assembly.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="ossm-release-notes-assembly"]
-= {SMProductName} 3.x release notes
+= OpenShift Service Mesh 3.x release notes
 include::_attributes/common-attributes.adoc[]
 :context: ossm-release-notes-assembly
 


### PR DESCRIPTION
**OSSM 3.0 TP1**

Required for Pantheon setup

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):
 
Technology Preview

OSSM 3.0 is moving to stand alone format is will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8297

Link to docs preview:
https://84070--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-assembly.html

QE review:
QE is not needed for this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
