### PR TITLE
OBSDOCS-1389 - 5.9.8 Logging RNs

### DIFF
--- a/modules/logging-release-notes-5-9-8.adoc
+++ b/modules/logging-release-notes-5-9-8.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+// observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="cluster-logging-release-notes-5-9-8_{context}"]
+= Logging 5.9.8
+This release includes link:https://access.redhat.com/errata/RHSA-2024:8315[OpenShift Logging Bug Fix Release 5.9.8].
+
+// 4.13, 4.14, 4.15, 4.16
+
+[id="openshift-logging-5-9-8-bug-fixes_{context}"]
+== Bug fixes
+// no-rn * (link:https://issues.redhat.com/browse/LOG-6169[LOG-6169])
+// no-rn * (link:https://issues.redhat.com/browse/LOG-6159[LOG-6159])
+* Before this update, the Loki Operator failed to add the default `namespace` label to all `AlertingRule` resources, which caused the User-Workload-Monitoring Alertmanager to skip routing these alerts. This update adds the rule namespace as a label to all alerting and recording rules, resolving the issue and restoring proper alert routing in Alertmanager.
+(link:https://issues.redhat.com/browse/LOG-6181[LOG-6181])
+
+* Before this update, the LokiStack ruler component view did not initialize properly, causing an invalid field error when the ruler component was disabled. This update ensures that the component view initializes with an empty value, resolving the issue.
+(link:https://issues.redhat.com/browse/LOG-6183[LOG-6183])
+
+* Before this update, an LF character in the `vector.toml` file under the ES authentication configuration caused the collector pods to crash. This update removes the newline characters from the username and password fields, resolving the issue.
+(link:https://issues.redhat.com/browse/LOG-6206[LOG-6206])
+
+* Before this update, it was possible to set the `.containerLimit.maxRecordsPerSecond` parameter in the `ClusterLogForwarder` custom resource to `0`, which could lead to an exception during Vector's startup. With this update, the configuration is validated before being applied, and any invalid values (less than or equal to zero) are rejected. (link:https://issues.redhat.com/browse/LOG-6214[LOG-6214])
+
+
+[id="openshift-logging-5-9-8-CVEs_{context}"]
+== CVEs
+* (link:https://access.redhat.com/security/cve/CVE-2024-24791[CVE-2024-24791])
+* (link:https://access.redhat.com/security/cve/CVE-2024-34155[CVE-2024-34155])
+* (link:https://access.redhat.com/security/cve/CVE-2024-34156[CVE-2024-34156])
+* (link:https://access.redhat.com/security/cve/CVE-2024-34158[CVE-2024-34158])
+* (link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+* (link:https://access.redhat.com/security/cve/CVE-2024-45490[CVE-2024-45490]
+* (link:https://access.redhat.com/security/cve/CVE-2024-45491[CVE-2024-45491]
+* (link:https://access.redhat.com/security/cve/CVE-2024-45492[CVE-2024-45492]

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -8,7 +8,9 @@ toc::[]
 
 include::snippets/logging-compatibility-snip.adoc[]
 
-include::snippets/logging-stable-updates-snip.adoc[]
+include::snippets/logging-stable-updates-snip.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-5-9-8.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-9-7.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.13, 4.14, 4.15, 4.16

Issue: [OBSDOCS-1388](https://issues.redhat.com//browse/OBSDOCS-1388)

Link to docs preview: https://83940--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html

QE review:

    QE has approved this change.