### PR TITLE
[RHACS] Fixed the command line argument for init-bundles

### DIFF
--- a/modules/reissue-internal-certificates-secured-clusters.adoc
+++ b/modules/reissue-internal-certificates-secured-clusters.adoc
@@ -40,7 +40,9 @@ You must have the `Admin` user role to create init bundles.
 +
 [source,terminal]
 ----
-$ roxctl -e <endpoint> -p <admin_password> central init-bundle generate <bundle_name> --output-secrets init-bundle.yaml
+$ roxctl -e <endpoint> -p <admin_password> central \
+  init-bundles generate --output-secrets <bundle_name> \
+  init-bundle.yaml
 ----
 
 .Next steps

--- a/modules/roxctl-generate-init-bundle.adoc
+++ b/modules/roxctl-generate-init-bundle.adoc
@@ -63,8 +63,8 @@ endif::cloud-ocp-generate,cloud-other-generate[]
 [source,terminal]
 ----
 $ roxctl -e "$ROX_CENTRAL_ADDRESS" \
-  central init-bundles generate <cluster_init_bundle_name> \
-  --output cluster_init_bundle.yaml
+  central init-bundles generate --output \
+  <cluster_init_bundle_name> cluster_init_bundle.yaml
 ----
 
 * To generate a cluster init bundle containing secrets for Operator installations, run the following command:
@@ -72,8 +72,8 @@ $ roxctl -e "$ROX_CENTRAL_ADDRESS" \
 [source,terminal]
 ----
 $ roxctl -e "$ROX_CENTRAL_ADDRESS" \
-  central init-bundles generate <cluster_init_bundle_name> \
-  --output-secrets cluster_init_bundle.yaml
+  central init-bundles generate --output-secrets \
+  <cluster_init_bundle_name> cluster_init_bundle.yaml
 ----
 +
 [IMPORTANT]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-26651

Updated the command to fix the issue.

Cherry-pick:
- `rhacs-docs-4.5`
- `rhacs-docs-4.6`

Previews:
- https://84080--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.html#roxctl-generate-init-bundle_init-bundle-cloud-ocp-generate
- https://84080--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/init-bundle-cloud-other-generate.html
- https://84080--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/reissue-internal-certificates.html#reissue-internal-certificates-secured-cluster_reissue-internal-certificates
- https://84080--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/init-bundle-ocp.html#roxctl-generate-init-bundle_init-bundle-ocp
- https://84080--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/init-bundle-other.html#roxctl-generate-init-bundle_init-bundle-other