### PR TITLE
Restored the Ext. Auth. installation for the ROSA doc set

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -34,6 +34,8 @@ Topics:
   File: about-hcp
 - Name: AWS STS and ROSA with HCP explained
   File: cloud-experts-rosa-hcp-sts-explained
+- Name: Architecture models
+  File: rosa-architecture-models
 - Name: Policies and service definition
   Dir: rosa_policy_service_definition
   Distros: openshift-rosa-hcp
@@ -120,8 +122,8 @@ Topics:
 #   File: cloud-experts-deploy-api-data-protection
 # - Name: AWS Load Balancer Operator on ROSA
 #   File: cloud-experts-aws-load-balancer-operator
-# - Name: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
-#   File: cloud-experts-entra-id-idp
+- Name: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
+  File: cloud-experts-entra-id-idp
 # - Name: Using AWS Secrets Manager CSI on ROSA with STS
 #   File: cloud-experts-aws-secret-manager
 # - Name: Using AWS Controllers for Kubernetes on ROSA

--- a/rosa_architecture/rosa-architecture-models.adoc
+++ b/rosa_architecture/rosa-architecture-models.adoc
@@ -1,0 +1,33 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="rosa-architecture-models"]
+= Architecture models
+include::_attributes/attributes-openshift-dedicated.adoc[]
+include::_attributes/common-attributes.adoc[]
+:context: rosa-architecture-models
+
+toc::[]
+
+{product-rosa} (ROSA) has the following cluster topologies:
+
+* Hosted control plane (HCP) - The control plane is hosted in a Red{nbsp}Hat account and the worker nodes are deployed in the customer's AWS account.
+* Classic - The control plane and the worker nodes are deployed in the customer's AWS account.
+
+include::modules/rosa-hcp-classic-comparison.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones]
+ifndef::openshift-rosa-hcp[]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-security-regulation-compliance_rosa-policy-process-security[Security and regulation compliance]
+endif::openshift-rosa-hcp[]
+
+include::modules/rosa-hcp-architecture.adoc[leveloffset=+1]
+include::modules/rosa-architecture.adoc[leveloffset=+1]
+include::modules/osd-aws-privatelink-architecture.adoc[leveloffset=+2]
+include::modules/rosa-architecture-local-zones.adoc[leveloffset=+2]
+
+ifndef::openshift-rosa-hcp[]
+.Additional resources
+
+* xref:../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.html[Configuring machine pools in Local Zones]
+endif::openshift-rosa-hcp[]

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -21,7 +21,9 @@ include::snippets/imp-rosa-hcp-no-shared-vpc-support.adoc[leveloffset=+0]
 ====
 
 .Further reading
+ifdef::openshift-rosa-hcp[]
 * For a comparison between {hcp-title} and ROSA Classic, see the xref:../rosa_architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
+endif::openshift-rosa-hcp[]
 * See the AWS documentation for information about link:https://docs.aws.amazon.com/rosa/latest/userguide/getting-started-hcp.html[Getting started with ROSA with HCP using the ROSA CLI in auto mode].
 
 //.Additional resources

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -20,14 +20,13 @@ include::snippets/imp-rosa-hcp-no-shared-vpc-support.adoc[leveloffset=+0]
 {hcp-title} clusters only support {sts-first} authentication.
 ====
 
-ifndef::openshift-rosa-hcp[]
 .Further reading
-* For a comparison between {hcp-title} and ROSA Classic, see the xref:../architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
+* For a comparison between {hcp-title} and ROSA Classic, see the xref:../rosa_architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
 * See the AWS documentation for information about link:https://docs.aws.amazon.com/rosa/latest/userguide/getting-started-hcp.html[Getting started with ROSA with HCP using the ROSA CLI in auto mode].
 
-.Additional resources
-
-For a full list of the supported certificates, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-compliance_rosa-policy-process-security[Compliance] section of "Understanding process and security for Red{nbsp}Hat OpenShift Service on AWS".
+//.Additional resources
+//
+//For a full list of the supported certificates, see the xref:#../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-compliance_rosa-policy-process-security[Compliance] section of "Understanding process and security for Red{nbsp}Hat OpenShift Service on AWS".
 
 [id="rosa-hcp-external-auth-prereqs"]
 == {hcp-title} Prerequisites
@@ -50,8 +49,9 @@ include::modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-cli.adoc
 [role="_additional-resources"]
 .Additional resources
 * For more information about configuring Entra ID for your IDP, see link:https://learn.microsoft.com/en-us/entra/fundamentals/whatis[What is Microsoft Entra ID?] in the Azure documentation or the xref:../cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc#cloud-experts-entra-id-idp[Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider] tutorial section of the documentation.
-* For information about the similar `idps` tool in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-idp_rosa-managing-objects-cli[`create idp`].
-* For more information about options in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-external-auth-provider_rosa-managing-objects-cli[`create external-auth-provider`], xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-list-external-auth-provider_rosa-managing-objects-cli[`list external-auth-provider`], and xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-delete-external-auth-provider_rosa-managing-objects-cli[`delete external-auth-provider`].
+ifndef::openshift-rosa-hcp[]
+//* For information about the similar `idps` tool in the ROSA CLI, see xref:#../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-idp_rosa-managing-objects-cli[`create idp`].
+//* For more information about options in the ROSA CLI, see xref:#../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-external-auth-provider_rosa-managing-objects-cli[`create external-auth-provider`], xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-list-external-auth-provider_rosa-managing-objects-cli[`list external-auth-provider`], and xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-delete-external-auth-provider_rosa-managing-objects-cli[`delete external-auth-provider`].
 
 // Step 3: Create, list, and revoke a break glass credential
 include::modules/rosa-hcp-sts-creating-a-break-glass-cred-cli.adoc[leveloffset=+1]
@@ -59,7 +59,7 @@ include::modules/rosa-hcp-sts-creating-a-break-glass-cred-cli.adoc[leveloffset=+
 [role="_additional-resources"]
 .Additional resources
 * For more information about creating a {hcp-title} cluster with external authentication enabled, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc#rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli_rosa-hcp-sts-creating-a-cluster-ext-auth[Creating a ROSA with HCP cluster that uses external authentication providers].
-* For more information about CLI configurations, see xref:../cli_reference/openshift_cli/managing-cli-profiles.adoc#managing-cli-profiles[Managing CLI profiles].
+//* For more information about CLI configurations, see xref:#../cli_reference/openshift_cli/managing-cli-profiles.adoc#managing-cli-profiles[Managing CLI profiles].
 
 include::modules/rosa-hcp-sts-accessing-a-break-glass-cred-cli.adoc[leveloffset=+1]
 
@@ -76,9 +76,7 @@ include::modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-delete-c
 [id="additional-resources_rosa-sts-creating-a-cluster-ext-auth"]
 == Additional resources
 
-* For steps to deploy a ROSA cluster using manual mode, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster using customizations].
-* For more information about the AWS Identity Access Management (IAM) resources required to deploy {product-title} with STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for clusters that use STS].
-* To learn more about the default CIDR ranges for {product-title}, see xref:../networking/cidr-range-definitions.adoc#cidr-range-definitions[CIDR range definitions].
+// * To learn more about the default CIDR ranges for {product-title}, see xref:#../networking/cidr-range-definitions.adoc#cidr-range-definitions[CIDR range definitions].
 * For details about optionally setting an Operator role name prefix, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-operator-role-prefixes_rosa-sts-about-iam-resources[About custom Operator IAM role prefixes].
 * For information about the prerequisites to installing ROSA with STS, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
 * For details about using the `auto` and `manual` modes to create the required STS resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-understanding-deployment-modes_rosa-sts-creating-a-cluster-with-customizations[Understanding the auto and manual deployment modes].


### PR DESCRIPTION
This PR fixes an opened conditional that broke the ROSA documentation.
- Preview of [Ext. Auth. installation](https://84092--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.html)