### PR TITLE
Add recommended node practices for CNV environments

### DIFF
--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -8,11 +8,11 @@ toc::[]
 
 This topic provides recommended node practices for a Container Native Virtualization environment to be performant, scalable and resilient in {product-title}.
 
-If a node fails and Node Health Checks operator is not deployed  and configured with an appropriate remediation operator - Self Node Remediation (SNR) and/or Fence Agents Remediation (FAR) on your cluster, Virtual Machines (VMs) will encounter downtime until the node recovers as they are not automatically recovered to other available nodes by default.
+If a node fails and Node Health Checks operator is not deployed and configured with an appropriate remediation operator - Self Node Remediation (SNR) and/or Fence Agents Remediation (FAR) on your cluster, Virtual Machines (VMs) will encounter downtime until the node recovers as they are not automatically recovered to other available nodes by default.
 
-Here are the configurations recommended to avoid virtual machines (VMs) downtime on a critical environment and for your workloads to be resilient under node failure conditions:
+Here are the configurations recommended to avoid VMs downtime on a critical environment and for your workloads to be resilient under node failure conditions:
 
--  Configure virtual machines (VMs) with `runStrategy: Always` to allow the recovery to other available nodes.
+-  Configure VMs with `runStrategy: Always` to allow the recovery to other available nodes.
 
 include::modules/virt-configuring-runstrategy-vm.adoc[leveloffset=+2]
 
@@ -54,7 +54,7 @@ spec:
       duration: <set to lower timings for faster recovery, for example 20s>
 ```
 
-Node Health Check operator supports Self Node Remediation (SNR) or Fence Agents Remediation (FAR) as the remediation operator to apply after detecting a node failure.
+Node Health Check operator supports several remediations. Self Node Remediation (SNR) or Fence Agents Remediation (FAR) remediation operators are few options  to apply after detecting a node failure.
 
 - Self Node Remediation (SNR): Recommended for nodes that do not have a management interface, or the interface might be unreachable, since SNR does not require one to work.
 
@@ -69,10 +69,9 @@ For more information on remediation, fencing, and maintaining nodes, see the lin
 
 [IMPORTANT]
 ====
-- The remediation actions starts after the NHC duration and can take large amounts of time depending on the number of VMS on the failed nodes. For example, 79 VMs with the following spec took 750 seconds to recover with SNR and will be much faster with FAR remediation strategy.
+- The remediation actions starts after the node conditions monitored by NHC exceed the time specified in `spec.unhealthyConditions[].duration` and, can take large amounts of time depending on the number of VMS on the failed nodes. For example, 79 VMs with the following spec took 750 seconds to recover with SNR and will be much faster with FAR remediation strategy.
 
-- FAR is recommended if the environment has access to baseboard management controller (BMC) interface as the it remediates and recovers the VMs quicker when compared to SNR.
-
+- FAR is recommended if the environment has access to baseboard management controller (BMC) interface because it is able to remediate and recover VMs quicker than SNR.
 - Node running self-node-remediation-controller-manager pod getting disrupted will lead to longer recovery times.
 ====
 

--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -54,7 +54,7 @@ spec:
       duration: <set to lower timings for faster recovery, for example 20s>
 ```
 
-Node Health Check operator supports Self Node Remediation ( SNR )or Fence Agents Remediation (FAR) as the remediation strategy to apply after detecting a node failure.
+Node Health Check operator supports Self Node Remediation (SNR) or Fence Agents Remediation (FAR) as the remediation operator to apply after detecting a node failure.
 - Self Node Remediation (SNR): Recommended for nodes that do not have a management interface, or the interface might be unreachable, since SNR does not require one to work.
 
 - Fence Agents Remediation (FAR): Fastest remediation operator in terms of workload recovery time. It also requires a management interface. FAR is recommended when a management interface is available. Also, the management interface must be reachable from the Kubernetes pod network to work.

--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -64,7 +64,7 @@ For more information on remediation, fencing, and maintaining nodes, see the lin
 [IMPORTANT]
 ===
 * The remediation strategy starts the remediation after the NHC duration and can take large amounts of time depending on the number of VMS on the failed nodes. For example, 79 VMs with the following spec took 750 seconds to migrate and recover with SNR and with FAR remediation strategy.
-* FAR is recommended if the environment has access to BMC as the it remediates and migrates the VMs quicker when compared to SNR.
+* FAR is recommended if the environment has access to baseboard management controller (BMC) interface as the it remediates and recovers the VMs quicker when compared to SNR.
 * Node running self-node-remediation-controller-manager pod getting disrupted will lead to longer recovery times.
 ===
 

--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 This topic provides recommended node practices for a Container Native Virtualization environment to be performant, scalable and resilient in {product-title}.
 
-If a node fails and Node Health Checks are not deployed with a appropriate remediation strategy - Self Node Remediation (SNR) and Fence Agents Remediation (FAR) on your cluster, Virtual Machines ( VMs ) will encounter downtime until the node recovers as they are not automatically migrated to other available nodes by default.
+If a node fails and Node Health Checks operator is not deployed  and configured with an appropriate remediation operator - Self Node Remediation (SNR) and/or Fence Agents Remediation (FAR) on your cluster, Virtual Machines (VMs) will encounter downtime until the node recovers as they are not automatically recovered to other available nodes by default.
 
 Here are the mitigation strategies recommended to avoid virtual machines (VMs) downtime on a critical environment and for your workloads to be resilient under node failure conditions:
 

--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -12,12 +12,12 @@ If a node fails and Node Health Checks operator is not deployed  and configured 
 
 Here are the configurations recommended to avoid virtual machines (VMs) downtime on a critical environment and for your workloads to be resilient under node failure conditions:
 
-* Configure virtual machines (VMs) with `runStrategy: Always` to allow migration to other available nodes.
+-  Configure virtual machines (VMs) with `runStrategy: Always` to allow the recovery to other available nodes.
 
 include::modules/virt-configuring-runstrategy-vm.adoc[leveloffset=+2]
 
 
-* Enable Node Health Checks to monitor the node status change from Ready to Unknown or NotReady, when a given node has not been able to contact the control plane for a defined period of time. spec.unhealthyConditions[].duration can be tuned to reduce the recovery timing. For example:
+- Enable Node Health Checks to monitor the node status change from Ready to Unknown or NotReady, when a given node has not been able to contact the control plane for a defined period of time. spec.unhealthyConditions[].duration can be tuned to reduce the recovery timing. For example:
 
 ```
 apiVersion: remediation.medik8s.io/v1alpha1
@@ -55,26 +55,29 @@ spec:
 ```
 
 Node Health Check operator supports Self Node Remediation (SNR) or Fence Agents Remediation (FAR) as the remediation operator to apply after detecting a node failure.
+
 - Self Node Remediation (SNR): Recommended for nodes that do not have a management interface, or the interface might be unreachable, since SNR does not require one to work.
+
 
 - Fence Agents Remediation (FAR): Fastest remediation operator in terms of workload recovery time. It also requires a management interface. FAR is recommended when a management interface is available. Also, the management interface must be reachable from the Kubernetes pod network to work.
 
 For more information on remediation, fencing, and maintaining nodes, see the link:https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift/23.2/html-single/remediation_fencing_and_maintenance/index#about-remediation-fencing-maintenance[Workload Availability for Red Hat OpenShift] documentation.
 
 [IMPORTANT]
-===
-* The remediation actions starts after the NHC duration and can take large amounts of time depending on the number of VMS on the failed nodes. For example, 79 VMs with the following spec took 750 seconds to migrate and recover with SNR and with FAR remediation strategy.
-* FAR is recommended if the environment has access to baseboard management controller (BMC) interface as the it remediates and recovers the VMs quicker when compared to SNR.
-* Node running self-node-remediation-controller-manager pod getting disrupted will lead to longer recovery times.
-===
+- The remediation actions starts after the NHC duration and can take large amounts of time depending on the number of VMS on the failed nodes. For example, 79 VMs with the following spec took 750 seconds to recover with SNR and will be much faster with FAR remediation strategy.
 
-* Capacity planning to ensure nodes have enough resources to host VMs migrated from the failed node(s). It is recommended to monitor the VMs count, resource available -  CPU, memory, disk, network on the cluster and ensure that there are enough resources on the nodes to host the VMs migrated from the failed nodes.
+- FAR is recommended if the environment has access to baseboard management controller (BMC) interface as the it remediates and recovers the VMs quicker when compared to SNR.
+
+- Node running self-node-remediation-controller-manager pod getting disrupted will lead to longer recovery times.
+
+
+
+- Capacity planning to ensure nodes have enough resources to host VMs migrated from the failed node(s). It is recommended to monitor the VMs count, resource available -  CPU, memory, disk, network on the cluster and ensure that there are enough resources on the nodes to host the VMs migrated from the failed nodes.
+
 
 [NOTE]
-===
 Number of VMs that a node can allocate depends on the maxPods set in the kubelet config:
 ```
  kubeletConfig:
     maxPods: <250 or 500>
 ```
-===

--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -63,21 +63,24 @@ Node Health Check operator supports Self Node Remediation (SNR) or Fence Agents 
 
 For more information on remediation, fencing, and maintaining nodes, see the link:https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift/23.2/html-single/remediation_fencing_and_maintenance/index#about-remediation-fencing-maintenance[Workload Availability for Red Hat OpenShift] documentation.
 
+
+- Capacity planning to ensure nodes have enough resources to host VMs migrated from the failed node(s). It is recommended to monitor the VMs count, resource available -  CPU, memory, disk, network on the cluster and ensure that there are enough resources on the nodes to host the VMs migrated from the failed nodes.
+
+
 [IMPORTANT]
+====
 - The remediation actions starts after the NHC duration and can take large amounts of time depending on the number of VMS on the failed nodes. For example, 79 VMs with the following spec took 750 seconds to recover with SNR and will be much faster with FAR remediation strategy.
 
 - FAR is recommended if the environment has access to baseboard management controller (BMC) interface as the it remediates and recovers the VMs quicker when compared to SNR.
 
 - Node running self-node-remediation-controller-manager pod getting disrupted will lead to longer recovery times.
-
-
-
-- Capacity planning to ensure nodes have enough resources to host VMs migrated from the failed node(s). It is recommended to monitor the VMs count, resource available -  CPU, memory, disk, network on the cluster and ensure that there are enough resources on the nodes to host the VMs migrated from the failed nodes.
-
+====
 
 [NOTE]
+====
 Number of VMs that a node can allocate depends on the maxPods set in the kubelet config:
 ```
  kubeletConfig:
     maxPods: <250 or 500>
 ```
+====

--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -10,7 +10,7 @@ This topic provides recommended node practices for a Container Native Virtualiza
 
 If a node fails and Node Health Checks operator is not deployed  and configured with an appropriate remediation operator - Self Node Remediation (SNR) and/or Fence Agents Remediation (FAR) on your cluster, Virtual Machines (VMs) will encounter downtime until the node recovers as they are not automatically recovered to other available nodes by default.
 
-Here are the mitigation strategies recommended to avoid virtual machines (VMs) downtime on a critical environment and for your workloads to be resilient under node failure conditions:
+Here are the configurations recommended to avoid virtual machines (VMs) downtime on a critical environment and for your workloads to be resilient under node failure conditions:
 
 * Configure virtual machines (VMs) with `runStrategy: Always` to allow migration to other available nodes.
 

--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -63,7 +63,7 @@ For more information on remediation, fencing, and maintaining nodes, see the lin
 
 [IMPORTANT]
 ===
-* The remediation strategy starts the remediation after the NHC duration and can take large amounts of time depending on the number of VMS on the failed nodes. For example, 79 VMs with the following spec took 750 seconds to migrate and recover with SNR and with FAR remediation strategy.
+* The remediation actions starts after the NHC duration and can take large amounts of time depending on the number of VMS on the failed nodes. For example, 79 VMs with the following spec took 750 seconds to migrate and recover with SNR and with FAR remediation strategy.
 * FAR is recommended if the environment has access to baseboard management controller (BMC) interface as the it remediates and recovers the VMs quicker when compared to SNR.
 * Node running self-node-remediation-controller-manager pod getting disrupted will lead to longer recovery times.
 ===

--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -30,7 +30,7 @@ spec:
     - <pause-test-cluster>
   remediationTemplate: 
     apiVersion: self-node-remediation.medik8s.io/v1alpha1
-    name: self-node-remediation-resource-deletion-template
+    name: self-node-remediation-automatic-strategy-template
     namespace: openshift-workload-availability
     kind: SelfNodeRemediationTemplate
   escalatingRemediations: 

--- a/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
+++ b/scalability_and_performance/cnv-performance-scale-resilience-practices/recommended-node-practices.adoc
@@ -1,0 +1,80 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="recommended-node-practices"]
+= Recommended node practices
+include::_attributes/common-attributes.adoc[]
+:context: recommended-node-practices
+
+toc::[]
+
+This topic provides recommended node practices for a Container Native Virtualization environment to be performant, scalable and resilient in {product-title}.
+
+If a node fails and Node Health Checks are not deployed with a appropriate remediation strategy - Self Node Remediation (SNR) and Fence Agents Remediation (FAR) on your cluster, Virtual Machines ( VMs ) will encounter downtime until the node recovers as they are not automatically migrated to other available nodes by default.
+
+Here are the mitigation strategies recommended to avoid virtual machines (VMs) downtime on a critical environment and for your workloads to be resilient under node failure conditions:
+
+* Configure virtual machines (VMs) with `runStrategy: Always` to allow migration to other available nodes.
+
+include::modules/virt-configuring-runstrategy-vm.adoc[leveloffset=+2]
+
+
+* Enable Node Health Checks to monitor the node status change from Ready to Unknown or NotReady, when a given node has not been able to contact the control plane for a defined period of time. spec.unhealthyConditions[].duration can be tuned to reduce the recovery timing. For example:
+
+```
+apiVersion: remediation.medik8s.io/v1alpha1
+kind: NodeHealthCheck
+metadata:
+  name: nodehealthcheck-sample
+spec:
+  minHealthy: <set to 1 for critical environments> 
+  pauseRequests: 
+    - <pause-test-cluster>
+  remediationTemplate: 
+    apiVersion: self-node-remediation.medik8s.io/v1alpha1
+    name: self-node-remediation-resource-deletion-template
+    namespace: openshift-workload-availability
+    kind: SelfNodeRemediationTemplate
+  escalatingRemediations: 
+    - remediationTemplate:
+        apiVersion: self-node-remediation.medik8s.io/v1alpha1
+        name: self-node-remediation-resource-deletion-template
+        namespace: openshift-workload-availability
+        kind: SelfNodeRemediationTemplate
+    order: 1
+    timeout: 300s
+  selector: 
+    matchExpressions:
+      - key: node-role.kubernetes.io/worker
+        operator: Exists
+  unhealthyConditions: 
+    - type: Ready
+      status: "False"
+      duration: <set to lower timings for faster recovery, for example 20s> 
+    - type: Ready
+      status: Unknown
+      duration: <set to lower timings for faster recovery, for example 20s>
+```
+
+Node Health Check operator supports Self Node Remediation ( SNR )or Fence Agents Remediation (FAR) as the remediation strategy to apply after detecting a node failure.
+- Self Node Remediation (SNR): Recommended for nodes that do not have a management interface, or the interface might be unreachable, since SNR does not require one to work.
+
+- Fence Agents Remediation (FAR): Fastest remediation operator in terms of workload recovery time. It also requires a management interface. FAR is recommended when a management interface is available. Also, the management interface must be reachable from the Kubernetes pod network to work.
+
+For more information on remediation, fencing, and maintaining nodes, see the link:https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift/23.2/html-single/remediation_fencing_and_maintenance/index#about-remediation-fencing-maintenance[Workload Availability for Red Hat OpenShift] documentation.
+
+[IMPORTANT]
+===
+* The remediation strategy starts the remediation after the NHC duration and can take large amounts of time depending on the number of VMS on the failed nodes. For example, 79 VMs with the following spec took 750 seconds to migrate and recover with SNR and with FAR remediation strategy.
+* FAR is recommended if the environment has access to BMC as the it remediates and migrates the VMs quicker when compared to SNR.
+* Node running self-node-remediation-controller-manager pod getting disrupted will lead to longer recovery times.
+===
+
+* Capacity planning to ensure nodes have enough resources to host VMs migrated from the failed node(s). It is recommended to monitor the VMs count, resource available -  CPU, memory, disk, network on the cluster and ensure that there are enough resources on the nodes to host the VMs migrated from the failed nodes.
+
+[NOTE]
+===
+Number of VMs that a node can allocate depends on the maxPods set in the kubelet config:
+```
+ kubeletConfig:
+    maxPods: <250 or 500>
+```
+===


### PR DESCRIPTION
This commit adds recommendations based on chaos testing:
- Guidance to avoid extended VMs downtime during node outages.
- Guidance on Node Health Check and Self Node Remediation/FAR remediation mechanisms - setup, tunings and recovery timing based on the VMs load.
- Capacity planning guidance to support VMs migration when remediations are enabled during node outages.