### PR TITLE
OCPBUGS43801: CMA fix spacing in secret example

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
+++ b/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
@@ -60,7 +60,7 @@ metadata:
   name: thanos-token
   annotations:
     kubernetes.io/service-account.name: thanos <1>
-  type: kubernetes.io/service-account-token
+type: kubernetes.io/service-account-token
 ----
 +
 <1> Specifies the name of the service account.


### PR DESCRIPTION
Per [Slack conversation](https://redhat-internal.slack.com/archives/C02F1J9UJJD/p1729760931747139).

https://issues.redhat.com/browse/OCPBUGS-43801

Preview: [Configuring the custom metrics autoscaler to use OpenShift Container Platform monitoring](https://84099--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger.html#nodes-cma-autoscaling-custom-prometheus-config_nodes-cma-autoscaling-custom-trigger) -> Fixed formatting in Step 2b code example. [Current docs](https://docs.openshift.com/container-platform/4.17/nodes/cma/nodes-cma-autoscaling-custom-trigger.html#nodes-cma-autoscaling-custom-prometheus-config_nodes-cma-autoscaling-custom-trigger).