### PR TITLE
OCPBUGS#43265: Clarified IPI and UPI on Converting to a dual-stack cl…

### DIFF
--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -4,7 +4,7 @@
 
 As a cluster administrator, you can convert your single-stack cluster network to a dual-stack cluster network. After converting to a dual-stack network, new and existing pods have dual-stack networking enabled.
 
-Converting a single-stack cluster network to a dual-stack cluster network consists of creating patches and applying them to the cluster's network and infrastructure.
+Converting a single-stack cluster network to a dual-stack cluster network consists of creating patches and applying them to the cluster's network and infrastructure. You can convert to a dual-stack cluster network for a cluster that runs on installer-provisioned infrastructure.
 
 [NOTE]
 ====
@@ -69,7 +69,7 @@ $ oc patch network.config.openshift.io cluster \// <1>
 network.config.openshift.io/cluster patched
 ----
 
-. To specify IPv6 VIPs for API and Ingress services for your cluster, create a YAML configuration patch file that has a similar configuration to the following example:
+. Specify IPv6 VIPs for API and Ingress services for your cluster. Create a YAML configuration patch file that has a similar configuration to the following example:
 +
 [source,yaml]
 ----
@@ -86,9 +86,10 @@ network.config.openshift.io/cluster patched
 <1> Ensure that you specify an address block for the `machineNetwork` network where your machines operate. You must select both API and Ingress IP addresses for the machine network.
 <2> Ensure that you specify each file path according to your platform. The example demonstrates a file path on a bare-metal platform.
 
-. Patch the cluster's infrastructure by entering the following command in your CLI:
+
+. Patch the infrastructure by entering the following command in your CLI:
 +
-[source,terminal,subs="+quotes"]
+[source,terminal,subs="+quotes,"]
 ----
 $ oc patch infrastructure cluster \// <1>
   --type='json' --patch-file <file>.yaml
@@ -130,14 +131,16 @@ Status:
 # ...
 ----
 
-. Show the cluster infrastructure configuration by entering the following command in your CLI:
+. Complete the following additional tasks for a cluster that runs on installer-provisioned infrastructure:
++
+.. Show the cluster infrastructure configuration by entering the following command in your CLI:
 +
 [source,terminal]
 ----
-$ oc describe network
+$ oc describe infrastructure
 ----
-
-. Verify the successful installation of the patch on the cluster infrastructure by checking that the infrastructure recognizes the IPv6 address blocks that you specified in the YAML file.
++
+.. Verify the successful installation of the patch on the cluster infrastructure by checking that the infrastructure recognizes the IPv6 address blocks that you specified in the YAML file.
 +
 .Example output
 [source,text]

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -8,35 +8,28 @@ toc::[]
 
 The {product-title} cluster uses a virtualized network for pod and service networks.
 
-Part of {openshift-networking}, the OVN-Kubernetes network plugin is the default network provider for {product-title}.
-OVN-Kubernetes is based on Open Virtual Network (OVN) and provides an overlay-based networking implementation.
-A cluster that uses the OVN-Kubernetes plugin also runs Open vSwitch (OVS) on each node.
-OVN configures OVS on each node to implement the declared network configuration.
+Part of {openshift-networking}, the OVN-Kubernetes network plugin is the default network provider for {product-title}. OVN-Kubernetes is based on Open Virtual Network (OVN) and provides an overlay-based networking implementation. A cluster that uses the OVN-Kubernetes plugin also runs Open vSwitch (OVS) on each node. OVN configures OVS on each node to implement the declared network configuration.
 
 [NOTE]
 ====
 OVN-Kubernetes is the default networking solution for {product-title} and {sno} deployments.
 ====
 
-OVN-Kubernetes, which arose from the OVS project, uses many of the same constructs, such as open flow rules, to determine how packets travel through the network.
-For more information, see the link:https://www.ovn.org/en/[Open Virtual Network website].
+OVN-Kubernetes, which arose from the OVS project, uses many of the same constructs, such as open flow rules, to determine how packets travel through the network. For more information, see the link:https://www.ovn.org/en/[Open Virtual Network website].
 
-OVN-Kubernetes is a series of daemons for OVS that translate virtual network configurations into `OpenFlow` rules.
-`OpenFlow` is a protocol for communicating with network switches and routers, providing a means for remotely controlling the flow of network traffic on a network device, allowing network administrators to configure, manage, and monitor the flow of network traffic.
+OVN-Kubernetes is a series of daemons for OVS that translate virtual network configurations into `OpenFlow` rules. `OpenFlow` is a protocol for communicating with network switches and routers, providing a means for remotely controlling the flow of network traffic on a network device so that network administrators can configure, manage, and monitor the flow of network traffic.
 
-OVN-Kubernetes provides more of the advanced functionality not available with `OpenFlow`.
-OVN supports distributed virtual routing, distributed logical switches, access control, DHCP and DNS.
-OVN implements distributed virtual routing within logic flows which equate to open flows.
-So for example if you have a pod that sends out a DHCP request on the network, it sends out that broadcast looking for DHCP address there will be a logic flow rule that matches that packet, and it responds giving it a gateway, a DNS server an IP address and so on.
+OVN-Kubernetes provides more of the advanced functionality not available with `OpenFlow`. OVN supports distributed virtual routing, distributed logical switches, access control, Dynamic Host Configuration Protocol (DHCP), and DNS. OVN implements distributed virtual routing within logic flows that equate to open flows. For example, if you have a pod that sends out a DHCP request to the DHCP server on the network, a logic flow rule in the request helps the OVN-Kubernetes handle the packet so that the server can respond with gateway, DNS server, IP address, and other information.
 
-OVN-Kubernetes runs a daemon on each node. There are daemon sets for the databases and for the OVN controller that run on every node.
-The OVN controller programs the Open vSwitch daemon on the nodes to support the network provider features; egress IPs, firewalls, routers, hybrid networking, IPSEC encryption, IPv6, network policy, network policy logs, hardware offloading and multicast.
+OVN-Kubernetes runs a daemon on each node. There are daemon sets for the databases and for the OVN controller that run on every node. The OVN controller programs the Open vSwitch daemon on the nodes to support the network provider features: egress IPs, firewalls, routers, hybrid networking, IPSEC encryption, IPv6, network policy, network policy logs, hardware offloading, and multicast.
 
-
+// OVN-Kubernetes purpose
 include::modules/nw-ovn-kubernetes-features.adoc[leveloffset=+1]
 
+// OVN-Kubernetes IPv6 and dual-stack limitations
 include::modules/nw-ovn-kuberentes-limitations.adoc[leveloffset=+1]
 
+// Session affinity
 include::modules/nw-ovn-kubernetes-session-affinity.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa,openshift-dedicated[]

--- a/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
+++ b/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
@@ -8,12 +8,15 @@ toc::[]
 
 As a cluster administrator, you can convert your IPv4 single-stack cluster to a dual-network cluster network that supports IPv4 and IPv6 address families. After converting to dual-stack networking, new and existing pods have dual-stack networking enabled.
 
-Clusters provisioned on bare metal, {ibm-power-name}, {ibm-z-name} infrastructure, {sno}, and {vmw-full} support dual-stack networking.
-
 [IMPORTANT]
 ====
 When using dual-stack networking where IPv6 is required, you cannot use IPv4-mapped IPv6 addresses, such as `::FFFF:198.51.100.1`.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about platform-specific support for dual-stack networking, see xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#nw-ovn-kubernetes-purpose_about-ovn-kubernetes[OVN-Kubernetes purpose]
 
 // Converting to a dual-stack cluster network
 include::modules/nw-dual-stack-convert.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-43265](https://issues.redhat.com/browse/OCPBUGS-43265)

Link to docs preview:
[Converting to IPv4/IPv6 dual-stack networking](https://84102--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html)
[About the OVN-Kubernetes network plugin](https://84102--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes)

- [x] SME has approved this change.
- [x] QE has approved this change.

