### PR TITLE
MCO add links to runbooks

### DIFF
--- a/modules/machine-config-node-drain.adoc
+++ b/modules/machine-config-node-drain.adoc
@@ -18,6 +18,11 @@ After you make the changes, the MCO generates a new rendered machine config. In 
 
 Throughout this process, the MCO maintains the required number of pods based on the `MaxUnavailable` value set in the machine config pool.
 
+[NOTE]
+====
+There are conditions which can prevent the MCO from draining a node. If the MCO fails to drain a node, the Operator will be unable to reboot the node, preventing any changes made to the node through a machine config. For more information and mitigation steps, see the link:https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/MachineConfigControllerDrainError.md[MCCDrainError] runbook.
+====
+
 If the MCO drains pods on the master node, note the following conditions:
 
 * In {sno} clusters, the MCO skips the drain operation.


### PR DESCRIPTION
Adding links to the current MCO runbooks. 

https://github.com/openshift/openshift-docs/issues/84116

There are precedents for adding links to the runbooks, which are housed in GitHub, see the [team slack](https://redhat-internal.slack.com/archives/C85JYPHL3/p1729699181954389?thread_ts=1729693100.251589&cid=C85JYPHL3).

Previews:
Machine configuration overview -> [Understanding the Machine Config Operator node drain behavior](https://84111--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#machine-config-node-drain_machine-config-overview) -- Added note after paragraph 3.