### PR TITLE
OCPBUGS43810: Add prereq to install python-yq

### DIFF
--- a/modules/checking-mco-status-certs.adoc
+++ b/modules/checking-mco-status-certs.adoc
@@ -16,6 +16,10 @@ The MCC also handles the image registry certificates and its associated user bun
 
 You can get information about the listed certificates, including the underyling bundle the certificate comes from, and the signing and subject data.
 
+.Prerequisites
+
+* This procedure contains optional steps that require that the `python-yq` RPM package is installed. 
+
 .Procedure
 
 * Get detailed certificate information by running the following command:
@@ -27,23 +31,27 @@ $ oc get controllerconfig/machine-config-controller -o yaml | yq -y '.status.con
 +
 .Example output
 +
-[source,text]
+[source,yaml]
 ----
-"controllerCertificates": [
-                   {
-                       "bundleFile": "KubeAPIServerServingCAData",
-                       "signer": "<signer_data1>",
-                       "subject": "CN=openshift-kube-apiserver-operator_node-system-admin-signer@168909215"
-                   },
-                   {
-                       "bundleFile": "RootCAData",
-                       "signer": "<signer_data2>",
-                       "subject": "CN=root-ca,OU=openshift"
-                   }
-                ]
+- bundleFile: KubeAPIServerServingCAData
+  notAfter: '2034-10-23T13:13:02Z'
+  notBefore: '2024-10-25T13:13:02Z'
+  signer: CN=admin-kubeconfig-signer,OU=openshift
+  subject: CN=admin-kubeconfig-signer,OU=openshift
+- bundleFile: KubeAPIServerServingCAData
+  notAfter: '2024-10-26T13:13:05Z'
+  notBefore: '2024-10-25T13:27:14Z'
+  signer: CN=kubelet-signer,OU=openshift
+  subject: CN=kube-csr-signer_@1729862835
+- bundleFile: KubeAPIServerServingCAData
+  notAfter: '2024-10-26T13:13:05Z'
+  notBefore: '2024-10-25T13:13:05Z'
+  signer: CN=kubelet-signer,OU=openshift
+  subject: CN=kubelet-signer,OU=openshift
+# ...
 ----
 
-* Get a simpler version of the information found in the ControllerConfig by checking the machine config pool status using the following command:
+* Get a simpler version of the information found in the `ControllerConfig` resource by checking the machine config pool status using the following command:
 +
 [source,terminal]
 ----
@@ -52,33 +60,51 @@ $ oc get mcp master -o yaml | yq -y '.status.certExpirys'
 +
 .Example output
 +
-[source,text]
+[source,yaml]
 ----
-status:
-  certExpirys:
-  - bundle: KubeAPIServerServingCAData
-    subject: CN=admin-kubeconfig-signer,OU=openshift
-  - bundle: KubeAPIServerServingCAData
-    subject: CN=kube-csr-signer_@1689585558
-  - bundle: KubeAPIServerServingCAData
-    subject: CN=kubelet-signer,OU=openshift
-  - bundle: KubeAPIServerServingCAData
-    subject: CN=kube-apiserver-to-kubelet-signer,OU=openshift
-  - bundle: KubeAPIServerServingCAData
-    subject: CN=kube-control-plane-signer,OU=openshift
+- bundle: KubeAPIServerServingCAData
+  expiry: '2034-10-23T13:13:02Z'
+  subject: CN=admin-kubeconfig-signer,OU=openshift
+- bundle: KubeAPIServerServingCAData
+  expiry: '2024-10-26T13:13:05Z'
+  subject: CN=kube-csr-signer_@1729862835
+- bundle: KubeAPIServerServingCAData
+  expiry: '2024-10-26T13:13:05Z'
+  subject: CN=kubelet-signer,OU=openshift
+- bundle: KubeAPIServerServingCAData
+  expiry: '2025-10-25T13:13:05Z'
+  subject: CN=kube-apiserver-to-kubelet-signer,OU=openshift
+# ...
 ----
 +
 This method is meant for {product-title} applications that already consume machine config pool information.
 
-* Check which image registry certificates are on the nodes by looking at the contents of the `/etc/docker/cert.d` directory:
+* Check which image registry certificates are on the nodes:
++
+.. Log in to a node:
 +
 [source,terminal]
 ----
-# ls /etc/docker/certs.d
+$ oc debug node/<node_name>
+----
+
+.. Set `/host` as the root directory within the debug shell:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
+
+.. Look at the contents of the `/etc/docker/cert.d` directory:
++
+[source,terminal]
+----
+sh-5.1# ls /etc/docker/certs.d
 ----
 +
 .Example output
-[source,text]
+[source,terminal]
 ----
-image-registry.openshift-image-registry.svc.cluster.local:5000 image-registry.openshift-image-registry.svc:5000
+image-registry.openshift-image-registry.svc.cluster.local:5000
+image-registry.openshift-image-registry.svc:5000
 ----


### PR DESCRIPTION
In reviewing a different issue, I noticed that the yq command doesn't take a -y flag. You are required to install the *python-yq* package rather than _vanilla_ yq.

Also, updated the output of steps 1a and 1b to match the output I observed. (Currently, 1a seems to have json-formatted output, rather than yaml-based.

Added an optional prerequisite to install python-jq.

https://issues.redhat.com/browse/OCPBUGS-43810

Before:

```
 $ oc get controllerconfig/machine-config-controller -o yaml | yq -y '.status.controllerCertificates'
Error: unknown shorthand flag: 'y' in -y
```
After:
```
$ oc get controllerconfig/machine-config-controller -o yaml | yq -y '.status.controllerCertificates'
- bundleFile: KubeAPIServerServingCAData
  notAfter: '2034-10-23T13:13:02Z'
  notBefore: '2024-10-25T13:13:02Z'
  signer: CN=admin-kubeconfig-signer,OU=openshift
  subject: CN=admin-kubeconfig-signer,OU=openshift
- bundleFile: KubeAPIServerServingCAData
```
Preview: [Viewing and interacting with certificates](https://84112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#checking-mco-status-certs_machine-config-overview) - New prereq, updated code blocks for steps 1a and 1b.

- [x] QE has approved this change.