### PR TITLE
bugfix: standardise vsphere titles suffix

### DIFF
--- a/installing/installing_vsphere/installing-vsphere-three-node.adoc
+++ b/installing/installing_vsphere/installing-vsphere-three-node.adoc
@@ -14,4 +14,4 @@ include::modules/installation-three-node-cluster-cloud-provider.adoc[leveloffset
 
 == Next steps
 * xref:../../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[Installing a cluster on vSphere with customizations]
-* xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc#installing-vsphere[Installing a cluster on vSphere with user-provisioned infrastructure]
+* xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc#installing-vsphere[Installing a cluster on vSphere]

--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -14,7 +14,7 @@ include::snippets/technology-preview.adoc[]
 [id="prerequisites_installing-restricted-networks-installer-provisioned-vsphere"]
 == Prerequisites
 
-* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
+* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
@@ -16,7 +16,7 @@ include::snippets/technology-preview.adoc[]
 [id="prerequisites_installing-vsphere-installer-provisioned-customizations"]
 == Prerequisites
 
-* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
+* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -17,7 +17,7 @@ include::snippets/technology-preview.adoc[]
 [id="prerequisites_installing-vsphere-installer-provisioned-network-customizations"]
 == Prerequisites
 
-* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
+* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
@@ -15,7 +15,7 @@ include::snippets/technology-preview.adoc[]
 [id="prerequisites_installing-vsphere-installer-provisioned_{context}"]
 == Prerequisites
 
-* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
+* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].

--- a/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
+++ b/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ipi-vsphere-preparing-to-install"]
-= Preparing to install a cluster using installer-provisioned infrastructure
+= Preparing to install a cluster
 include::_attributes/common-attributes.adoc[]
 :context: ipi-vsphere-preparing-to-install
 

--- a/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
+++ b/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
@@ -41,11 +41,11 @@ You can install {product-title} on vSphere by using user-provisioned infrastruct
 User-provisioned infrastructure requires the user to provision all resources required by {product-title}.
 If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
 
-* **xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc#installing-vsphere[Installing a cluster on vSphere with user-provisioned infrastructure]**: You can install {product-title} on VMware vSphere infrastructure that you provision.
+* **xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc#installing-vsphere[Installing a cluster on vSphere]**: You can install {product-title} on VMware vSphere infrastructure that you provision.
 
 * **xref:../../installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[Installing a cluster on vSphere with network customizations with user-provisioned infrastructure]**: You can install {product-title} on VMware vSphere infrastructure that you provision with customized network configuration options.
 
-* **xref:../../installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure]**: {product-title} can be installed on VMware vSphere infrastructure that you provision in a restricted network.
+* **xref:../../installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[Installing a cluster on vSphere in a restricted network]**: {product-title} can be installed on VMware vSphere infrastructure that you provision in a restricted network.
 
 [IMPORTANT]
 ====

--- a/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-vsphere"]
-= Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure
+= Installing a cluster on vSphere in a restricted network
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-vsphere
 
@@ -20,7 +20,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 [id="prerequisites_installing-restricted-networks-vsphere_{context}"]
 == Prerequisites
 
-* You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster using user-provisioned infrastructure].
+* You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].

--- a/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
@@ -27,7 +27,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 [id="prerequisites_installing-vsphere-network-customizations_{context}"]
 == Prerequisites
 
-* You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster using user-provisioned infrastructure].
+* You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].

--- a/installing/installing_vsphere/upi/installing-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-vsphere"]
-= Installing a cluster on vSphere with user-provisioned infrastructure
+= Installing a cluster on vSphere
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere
 :platform: vSphere
@@ -21,7 +21,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 [id="prerequisites_installing-vsphere_{context}"]
 == Prerequisites
 
-* You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster using user-provisioned infrastructure].
+* You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].

--- a/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
+++ b/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="upi-vsphere-installation-reqs"]
-= vSphere installation requirements for user-provisioned infrastructure
+= vSphere installation requirements
 include::_attributes/common-attributes.adoc[]
 :context: upi-vsphere-installation-reqs
 

--- a/installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
+++ b/installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="upi-vsphere-preparing-to-install"]
-= Preparing to install a cluster using user-provisioned infrastructure
+= Preparing to install a cluster
 include::_attributes/common-attributes.adoc[]
 :context: upi-vsphere-preparing-to-install
 


### PR DESCRIPTION
Address comment https://github.com/openshift/openshift-docs/pull/83386#issuecomment-2435695685 and resolve missed readability changes (made in 4.16) for IPI/UPI suffix on assembly titles.

Version(s):
4.17, do not cherry pick as this file is likely to have changed between each version

Issue:
- None (GH or Jira), this is community author contribution

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- n/a

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
