### PR TITLE
OSDOCS-11746: adds 4.17.3 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -124,3 +124,12 @@ Issued: 23 October 2024
 {product-title} release 4.17.2 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:8231[RHBA-2024:8231] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:8229[RHSA-2024:8229] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-3-dp_{context}"]
+=== RHBA-2024:8436 - {microshift-short} 4.17.3 bug fix and enhancement update advisory
+
+Issued: 29 October 2024
+
+{product-title} release 4.17.3 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:8436[RHBA-2024:8436] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:8434[RHSA-2024:8434] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11746](https://issues.redhat.com/browse/OSDOCS-11746)

Link to docs preview:
[4-17-3-dp_release-notes](https://84124--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-3-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
