### PR TITLE
OSDOCS-12437: Documented the 4.15.37 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2771,6 +2771,68 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.15.37
+[id="ocp-4-15-37_{context}"]
+=== RHSA-2024:8425 - {product-title} 4.15.37 bug fix and security update
+
+Issued: 30 October 2024
+
+{product-title} release 4.15.37, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:8425[RHSA-2024:8425] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8428[RHSA-2024:8428] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.37 --pullspecs
+----
+
+[id="ocp-4-15-37-enhancements_{context}"]
+==== Enhancements
+
+* Previously, you could not control log levels for the internal component that selects IP addresses for cluster nodes. With this release, you can now enable debug log levels so that you can either increase or decrease log levels on demand. To adjust log levels, you must create a config map manifest file with a configuration analogous to the following:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  enable-nodeip-debug: "true"
+kind: ConfigMap
+metadata:
+  name: logging
+  namespace: openshift-vsphere-infra
+# ...
+----
++
+(link:https://issues.redhat.com/browse/OCPBUGS-37704[*OCPBUGS-37704*])
+
+[id="ocp-4-15-37-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when you attempted to use the `oc import-image` command to import an image in a {hcp} cluster, the command failed because of access issues with a private image registry. With this release, an update to `openshift-apiserver` pods in a {hcp} cluster resolves names that use the data plane so that the `oc import-image` command now works as expected with private image registries. (link:https://issues.redhat.com/browse/OCPBUGS-43468[*OCPBUGS-43468*])
+
+* Previously, when you used the `must-gather` tool, a Multus Container Network Interface (CNI) log file, `multus.log`, was stored in a node's file system. This situation caused the tool to generate unnecessary debug pods in a node. With this release, the Multus CNI no longer creates a `multus.log` file, and instead uses a CNI plugin pattern to inspect any logs for Multus DaemonSet pods in the `openshift-multus` namespace. (link:https://issues.redhat.com/browse/OCPBUGS-43057[*OCPBUGS-43057*])
+
+* Previously, the Ingress and DNS operators failed to start correctly because of rotating root certificates. With this release, the Ingress and DNS operator Kubeconfigs are conditionally managed by using the annotation that defines when the PKI requires management and the issue is resolved.. (link:https://issues.redhat.com/browse/OCPBUGS-42992[*OCPBUGS-42992*])
+
+* Previously, when you configured the image registry to use an {azure-first} storage account that was located in a resource group other than the cluster's resource group, the Image Registry Operator would become degraded. This occurred because of a validation error. With this release, an update to the Operator allows for authentication only by using a storage account key. Validation of other authentication requirements is not required. (link:https://issues.redhat.com/browse/OCPBUGS-42934[*OCPBUGS-42934*])
+
+* Previously for hosted control planes (HCP), a cluster that used mirroring release images might result in existing node pools to use the hosted cluster's operating system version instead of the `NodePool` version. With this release, a fix ensures that node pools use their own versions. (link:https://issues.redhat.com/browse/OCPBUGS-42881[*OCPBUGS-42881*])
+
+* Previously, creating cron jobs to create pods for your cluster caused the component that fetches the pods to fail. Because of this issue, the *Topology* page on the {product-title} web console failed. With this release, a `3` second delay is configured for the component that fetches pods that are generated from the cron job so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-42611[*OCPBUGS-42611*])
+
+* Previously, the Ingress Operator prevented upgrades from {product-title} 4.15 to 4.16 if any certificate type in the default certificate chain used the SHA-1 hashing algorithm. With this release, the Ingress Operator now only checks default leaf certificates for SHA-1 hash values, so that intermediate and root certificates in the default chain can continue to use SHA-1 hash values without blocking cluster upgrades. (link:https://issues.redhat.com/browse/OCPBUGS-42480[*OCPBUGS-42480*])
+
+* Previously, when installing a cluster on bare metal using installer provisioned infrastructure, the installation could time out if the network to the bootstrap virtual machine is slow. With this update, the timeout duration has been increased to cover a wider range of network performance scenarios. (link:https://issues.redhat.com/browse/OCPBUGS-42335[*OCPBUGS-42335*])
+
+* Previously, Ironic inspection failed if special or invalid characters existed in the serial number of a block device. This occurred because the `lsblk` command failed to escape the characters. With this release, the command escapes the characters so this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-39018[*OCPBUGS-39018*])
+
+[id="ocp-4-15-37-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
+
 //4.15.36
 [id="ocp-4-15-36_{context}"]
 === RHSA-2024:7594 - {product-title} 4.15.36 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12437](https://issues.redhat.com/browse/OSDOCS-12437)

Link to docs preview:
* [4.15.37](https://84126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-37_release-notes)
