### PR TITLE
OCPBUGS#38352-12: Updated the SDN and OVNK plugin matrix tables

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -11,52 +11,35 @@
 .Default CNI network plugin feature comparison
 [cols="50%,25%,25%",options="header"]
 |===
-ifeval::["{context}" == "about-ovn-kubernetes"]
-|Feature|OVN-Kubernetes|OpenShift SDN
 
-|Egress IPs|Supported|Supported
-
-|Egress firewall ^[1]^|Supported|Supported
-
-|Egress router|Supported ^[2]^|Supported
-
-|Hybrid networking|Supported|Not supported
-
-|IPsec encryption for intra-cluster communication|Supported|Not supported
-
-|IPv6|Supported ^[3]^ ^[4]^|Not supported
-
-|Kubernetes network policy|Supported|Supported
-
-|Kubernetes network policy logs|Supported|Not supported
-
-|Hardware offloading|Supported|Not supported
-
-|Multicast|Supported|Supported
-endif::[]
-ifeval::["{context}" == "about-openshift-sdn"]
 |Feature|OpenShift SDN|OVN-Kubernetes
 
 |Egress IPs|Supported|Supported
 
-|Egress firewall ^[1]^|Supported|Supported
+|Egress firewall|Supported|Supported ^[1]^
 
 |Egress router|Supported|Supported ^[2]^
 
 |Hybrid networking|Not supported|Supported
 
-|IPsec encryption|Not supported|Supported
+|IPsec encryption for intra-cluster communication|Not supported|Supported
 
-|IPv6|Not supported|Supported ^[3]^ ^[4]^
+|IPv4 single-stack|Supported|Supported
+
+|IPv6 single-stack|Not supported|Supported ^[3]^
+
+|IPv4/IPv6 dual-stack|Not Supported|Supported ^[4]^
+
+|IPv6/IPv4 dual-stack|Not supported|Supported ^[5]^
 
 |Kubernetes network policy|Supported|Supported
 
 |Kubernetes network policy logs|Not supported|Supported
 
+|Hardware offloading|Not supported|Supported
+
 |Multicast|Supported|Supported
 
-|Hardware offloading|Not supported|Supported
-endif::[]
 |===
 [.small]
 --
@@ -64,7 +47,9 @@ endif::[]
 
 2. Egress router for OVN-Kubernetes supports only redirect mode.
 
-3. IPv6 is supported only on bare metal, {ibmpowerProductName}, and {ibmzProductName} clusters.
+3. IPv6 single-stack networking on a bare-metal platform.
 
-4. IPv6 single stack does not support xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState] and is not supported on {ibmpowerProductName} and {ibmzProductName} clusters.
+4. IPv4/IPv6 dual-stack networking on bare-metal, {ibm-power-name}, and {ibm-z-name} platforms.
+
+5. IPv6/IPv4 dual-stack networking on bare-metal and {ibm-power-name} platforms.
 --


### PR DESCRIPTION
Because vSphere does not support dual-stack networking on 4.12, a separate PR was needed. The changes are almost similar to https://github.com/openshift/openshift-docs/pull/83886

Version(s):
4.12

IBMZ: IPv4/IPv6 dual-stack networking support only and not IPv6/IPv4.

Issue:
[OCPBUGS-38352](https://issues.redhat.com/browse/OCPBUGS-38352)

Link to docs preview:
* [Supported network plugin feature matrix-SDN doc
](https://84129--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/about-openshift-sdn.html)
* [Supported network plugin feature matrix-OVNK doc
](https://84129--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html)
* [RHCOS: Deploying the dual-stack cluster](https://84129--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#install-osp-deploy-dualstack_installing-openstack-installer-custom)

- [x] SME has approved this change (IBM Z: Alexander Klein/Dominik Werle , IBM POWER: Paul Bastide).
- [x] QE has approved this change.

Add resources
* https://issues.redhat.com/browse/MULTIARCH-2116

