### PR TITLE
RHDEVDOCS 6177 RN Pipelines 1.14.5 - undefined workspace info causes error now

### DIFF
--- a/modules/op-release-notes-1-14.adoc
+++ b/modules/op-release-notes-1-14.adoc
@@ -362,3 +362,5 @@ With this update, {pipelines-title} General Availability (GA) 1.14.5 is availabl
 * Before this update, when you used the web console and clicked a pipeline in the overview page, the pipeline details page did not contain information about tasks in the pipeline. With this update, when you click a pipeline in the overview page, the pipeline details page contains the required information.
 
 * Before this update, when you configured {tekton-chains} to disable storing OCI artifacts by setting an empty `artifacts.oci.storage` value in the `TektonConfig` CR, the configuration did not work and {tekton-chains} attempted to store the artifacts and logged a failure in the `chains.tekton.dev/signed` annotation. With this update, when you set an empty `artifacts.oci.storage` value in the `TektonConfig` CR, {tekton-chains} does not attempt to store OCI artifacts.
+
+* Before this update, when you used workspace information, such as `$(workspaces.source.path)`, in a pipeline or task without defining a workspace, {pipelines-shortname} did not report an error. With this update, {pipelines-shortname} reports an error in this case and does not run the pipeline or task.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
cp to pipelines-docs-1.15 and pipelines-docs-main. The PR into 1.14 is intentional as the RN does not display in main.

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6177

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://84146--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/op-release-notes.html#release-notes-1-14-5_op-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
