### PR TITLE
OSDOCS-12158: adds 4.15.37 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -478,3 +478,12 @@ Issued: 9 October 2024
 The {product-title} release 4.15.36 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7596[RHBA-2024:7596] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7594[RHSA-2024:7594] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-37-dp_{context}"]
+=== RHBA-2024:8427 - {microshift-short} 4.15.37 bug fix and enhancement advisory
+
+Issued: 31 October 2024
+
+The {product-title} release 4.15.37 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8427[RHBA-2024:8427] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8425[RHSA-2024:8425] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12158](https://issues.redhat.com/browse/OSDOCS-12158)

Link to docs preview:
[4-15-37-dp_release-notes](https://84148--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-37-dp_release-notes)

QE review:
- NA stock text, no other changes