### PR TITLE
RHDEVDOCS-6134: Removal of kam instances in the content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -27,7 +27,7 @@ Dir: release_notes
 Distros: openshift-gitops
 Topics:
 - Name: OpenShift GitOps release notes
-  File: gitops-release-notes-1-14
+  File: gitops-release-notes-1-15
 ---
 Name: Understanding OpenShift GitOps
 Dir: understanding_openshift_gitops

--- a/modules/gitops-release-notes-1-15-0.adoc
+++ b/modules/gitops-release-notes-1-15-0.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes-1-15-0.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="gitops-release-notes-1-15-0_{context}"]
+= Release notes for {gitops-title} 1.15.0
+
+{gitops-title} 1.15.0 is now available on {OCP} 4.12, 4.13, 4.14, 4.15, and 4.16.
+
+[id="errata-updates-1-15.0_{context}"]
+== Errata updates
+
+[id="RHEA-XXXX:NNNN-gitops-1-15-0-security-update-advisory_{context}"]
+=== RHEA-XXXX:NNNN - {gitops-title} 1.15.0 security update advisory
+
+Issued: XXXX-YY-NN
+
+The list of security fixes that are included in this release are documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHEA-XXXX:NNNN[RHEA-XXXX:NNNN]
+
+If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----
+
+[id="breaking-change-1-15-0_{context}"]
+== Breaking change
+
+[id="removal-of-application-manager-cli-kam_{context}"]
+=== Removal of {gitops-title} Application Manager CLI, kam
+
+* With this release, support for the {gitops-title} Application Manager command-line interface (CLI), `kam`, has been removed because this feature is no longer supported. As a result, all instances of `kam` have been removed from the {gitops-title} documentation. As an alternative to `kam`, you can use the Argo CD CLI that is available from {gitops-title} Operator v1.12.

--- a/modules/go-add-infra-nodes.adoc
+++ b/modules/go-add-infra-nodes.adoc
@@ -8,7 +8,6 @@
 
 You can move the {gitops-shortname} control plane workloads installed by the {gitops-title} to the infrastructure nodes. The following are the control plane workloads that you can move:
 
-* `kam deployment`
 * `cluster deployment` (backend service)
 * `openshift-gitops-applicationset-controller deployment`
 * `openshift-gitops-dex-server deployment`

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -25,22 +25,21 @@ In the table, features are marked with the following statuses:
 |===
 |OpenShift GitOps 8+|Component Versions|OpenShift Versions
 
-s|Version s|`kam`  s|Argo CD CLI  s|Helm  s|Kustomize s|Argo CD s|Argo Rollouts s|Dex     s|RH SSO |
+s|Version s|kam  s|Argo CD CLI  s|Helm  s|Kustomize s|Argo CD s|Argo Rollouts s|Dex     s|RH SSO |
 
-|1.14.0 |0.0.51 TP |2.12.3 TP |3.15.2 GA |5.4.2 GA |2.12.3 GA |1.7.1 GA |2.39.1 GA |7.6.0 GA |4.12-4.17
+|1.14.0 |NA |2.12.3 TP |3.15.2 GA |5.4.2 GA |2.12.3 GA |1.7.1 GA |2.39.1 GA |7.6.0 GA |4.12-4.17
 
-|1.13.0 |0.0.51 TP |2.11.3 TP |3.14.4 GA |5.2.1 GA |2.11.3 GA |1.6.6 GA |2.37.0 GA |7.6.0 GA |4.12-4.16
+|1.13.0 |NA  |2.11.3 TP |3.14.4 GA |5.2.1 GA |2.11.3 GA |1.6.6 GA |2.37.0 GA |7.6.0 GA |4.12-4.16
 
-|1.12.0 |0.0.51 TP |2.10.3 TP |3.14.0 GA |5.2.1 GA |2.10.3 GA |1.6.0 TP |2.36.0 GA |7.6.0 GA |4.12-4.15
+|1.12.0 |NA  |2.10.3 TP |3.14.0 GA |5.2.1 GA |2.10.3 GA |1.6.0 TP |2.36.0 GA |7.6.0 GA |4.12-4.15
 |===
 
-* `kam` is the {gitops-title} Application Manager command-line interface (CLI).
-+
 [IMPORTANT]
 ====
-In {gitops-title} 1.13 or later, the {gitops-title} Application Manager CLI, `kam`, was deprecated and is planned to be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to the {gitops-title} Application Manager CLI, `kam`, you can use the Argo CD CLI that is available from {gitops-title} Operator v1.12.
-====
+* Starting from {gitops-title} 1.15, support is no longer provided for the {gitops-title} Application Manager command-line interface (CLI), `kam`.
+
 * RH SSO is an abbreviation for Red Hat SSO.
+====
 
 // Writer, to update this support matrix, refer to https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
 

--- a/modules/installing-gitops-operator-using-cli.adoc
+++ b/modules/installing-gitops-operator-using-cli.adoc
@@ -118,7 +118,6 @@ $ oc get pods -n openshift-gitops
 ----
 NAME                                                      	  READY   STATUS    RESTARTS   AGE
 cluster-b5798d6f9-zr576                                   	  1/1 	  Running   0          65m
-kam-69866d7c48-8nsjv                                      	  1/1 	  Running   0          65m
 openshift-gitops-application-controller-0                 	  1/1 	  Running   0          53m
 openshift-gitops-applicationset-controller-6447b8dfdd-5ckgh       1/1 	  Running   0          65m
 openshift-gitops-dex-server-569b498bd9-vf6mr                      1/1     Running   0          65m

--- a/observability/monitoring/health-information-for-resources-deployment.adoc
+++ b/observability/monitoring/health-information-for-resources-deployment.adoc
@@ -10,8 +10,6 @@ The {gitops-title} *Environments* page in the *Developer* perspective of the {OC
 
 The *Application environments* page in the *Developer* perspective of the {OCP} web console displays the health status of the application resources, such as routes, synchronization status, deployment configuration, and deployment history.
 
-The environments pages in the *Developer* perspective of the {OCP} web console are decoupled from the {gitops-title} Application Manager command-line interface (CLI), `kam`. You do not have to use `kam` to generate Application Environment manifests for the environments to show up in the *Developer* perspective of the {OCP} web console. You can use your own manifests, but the environments must still be represented by namespaces. In addition, specific labels and annotations are still needed.
-
 // Settings for environment labels and annotations
 include::modules/go-settings-for-environment-labels-and-annotations.adoc[leveloffset=+1]
 

--- a/release_notes/gitops-release-notes-1-15.adoc
+++ b/release_notes/gitops-release-notes-1-15.adoc
@@ -1,0 +1,36 @@
+//OpenShift GitOps Release Notes
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="gitops-release-notes"]
+= {gitops-title} release notes
+:context: gitops-release-notes
+
+toc::[]
+
+[NOTE]
+====
+For additional information about the OpenShift {gitops-shortname} lifecycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] and link:https://access.redhat.com/support/policy/updates/openshift[Red{nbsp}Hat {OCP} Life Cycle Policy].
+====
+
+Release notes contain information about new and deprecated features, breaking changes, and known issues. The following release notes apply for the most recent OpenShift {gitops-shortname} releases on {OCP}.
+
+{gitops-title} is a declarative way to implement continuous deployment for cloud native applications. {gitops-title} ensures consistency in applications when you deploy them to different clusters in different environments, such as development, staging, and production. {gitops-title} helps you automate the following tasks:
+
+* Ensure that the clusters have similar states for configuration, monitoring, and storage
+* Recover or recreate clusters from a known state
+* Apply or revert configuration changes to multiple {OCP} clusters
+* Associate templated configuration with different environments
+* Promote applications across clusters, from staging to production
+
+For an overview of {gitops-title}, see xref:../understanding_openshift_gitops/about-redhat-openshift-gitops.adoc#about-redhat-openshift-gitops[About Red Hat OpenShift GitOps].
+
+// Compatibility and support matrix
+include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
+
+// Making open source more inclusive
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
+
+// Modules included, most to least recent
+
+// Release notes for Red Hat OpenShift GitOps 1.15.0 
+// include::modules/gitops-release-notes-1-15-0.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6134

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Removal of kam instances from the following sections:

[Compatibility and support matrix](https://84149--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-15#GitOps-compatibility-support-matrix_gitops-release-notes)

[Release notes for Red Hat OpenShift GitOps 1.15](https://84149--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-15#gitops-release-notes-1-15-0_gitops-release-notes)

[Installing Red Hat OpenShift GitOps Operator using CLI](https://84149--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/installing-openshift-gitops#installing-gitops-operator-using-cli_installing-openshift-gitops)

[Moving GitOps control plane workloads to infrastructure nodes](https://84149--ocpdocs-pr.netlify.app/openshift-gitops/latest/gitops_workloads_infranodes/running-gitops-control-plane-workloads-on-infrastructure-nodes#add-infra-nodes_running-gitops-control-plane-workloads-on-infrastructure-nodes) 

[Monitoring health information for application resources and deployments](https://84149--ocpdocs-pr.netlify.app/openshift-gitops/latest/observability/monitoring/health-information-for-resources-deployment)

I have also added an RN entry in the [Release notes for Red Hat OpenShift GitOps 1.15](https://84149--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-15#gitops-release-notes-1-15-0_gitops-release-notes) section to document the feature removal for reference. PTAL.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review is performed by: @iam-veeramalla @svghadi @wtam2018 @keithchong 
QE review is performed by: @varshab1210 
Peer review is performed by: @lahinson 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
