### PR TITLE
Fixing typos breaking the nodes book

### DIFF
--- a/nodes/index.adoc
+++ b/nodes/index.adoc
@@ -38,12 +38,12 @@ ifdef::openshift-rosa-hcp[]
 * List all the nodes in a cluster.
 * Get information about a node, such as memory and CPU usage, health, status, and age.
 * List pods running on a node.
-ifndef::openshift-rosa-hcp[]
+endif::openshift-rosa-hcp[]
 ifndef::openshift-rosa-hcp[]
 * xref:../nodes/nodes/nodes-nodes-viewing.adoc#nodes-nodes-viewing-listing_nodes-nodes-viewing[List all the nodes in a cluster].
 * Get information about a node, such as memory and CPU usage, health, status, and age.
 * xref:../nodes/nodes/nodes-nodes-viewing.adoc#nodes-nodes-viewing-listing-pods_nodes-nodes-viewing[List pods running on a node].
-ifndef::openshift-rosa-hcp[]
+endif::openshift-rosa-hcp[]
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [discrete]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
N/A

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

* https://84159--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/index.html
* https://84159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/index.html
* https://84159--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/index.html
* https://84159--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/index.html

Previously, the "Overview of nodes" page was cutting off in the middle of the "About nodes" module (and no other modules would be shown on the right-hand TOC)

On docs.redhat, this completely cut off the entire rest of the Nodes book after this error, but we won't be able to verify that it's fixed until this is merged/synced/published via Pantheon.

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Fixing uneven ifdef/ifndefs to endifs introduced in https://github.com/openshift/openshift-docs/pull/83559/files#diff-a6a0bc6d31aa9060816db5374bb658a3d77e981a4023f6c281e507ed80738ff0R37-R46
