### PR TITLE
[OCPBUGS#43891] Add 'configDrive: true' to some ShiftStack CRs

### DIFF
--- a/modules/machineset-yaml-osp-sr-iov-port-security.adoc
+++ b/modules/machineset-yaml-osp-sr-iov-port-security.adoc
@@ -82,10 +82,12 @@ spec:
           trunk: false
           userDataSecret:
             name: worker-user-data
+          configDrive: true <4>
 ----
 <1> Specify allowed address pairs for the API and ingress ports.
 <2> Specify the machines network and subnet.
 <3> Specify the compute machines security group.
+<4> The value of the `configDrive` parameter must be `true`.
 
 [NOTE]
 ====

--- a/modules/machineset-yaml-osp-sr-iov.adoc
+++ b/modules/machineset-yaml-osp-sr-iov.adoc
@@ -91,6 +91,7 @@ spec:
           userDataSecret:
             name: <node_role>-user-data
           availabilityZone: <optional_openstack_availability_zone>
+          configDrive: true <5> 
 ----
 <1> Enter a network UUID for each port.
 <2> Enter a subnet UUID for each port.
@@ -98,6 +99,7 @@ spec:
 <4> The value of the `portSecurity` parameter must be `false` for each port.
 +
 You cannot set security groups and allowed address pairs for ports when port security is disabled. Setting security groups on the instance applies the groups to all ports that are attached to it.
+<5> The value of the `configDrive` parameter must be `true`.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+ ~(plausibly 4.17, too, but verify)~ not bothering with that per dev
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-43891
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://84170--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-osp.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: 

- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
