### PR TITLE
OSDOCS-11800-4.16: note in install docs about secure access

### DIFF
--- a/modules/microshift-install-system-requirements.adoc
+++ b/modules/microshift-install-system-requirements.adoc
@@ -15,3 +15,8 @@ The following conditions must be met prior to installing {microshift-short}:
 * 10 GB of storage.
 * You have an active {microshift-short} subscription on your Red Hat account. If you do not have a subscription, contact your sales representative for more information.
 * You have a Logical Volume Manager (LVM) Volume Group (VG) with sufficient capacity for the Persistent Volumes (PVs) of your workload.
+
+[IMPORTANT]
+====
+Secure access must be configured before running {microshift-short} to ensure proper functionality and security. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/securing_networks/assembly_using-secure-communications-between-two-systems-with-openssh_securing-networks[Using secure communications between two systems with OpenSSH].
+====


### PR DESCRIPTION
Version(s):
4.14, 4.15 and 4.16

Issue:
[OSDOCS-11800](https://issues.redhat.com/browse/OSDOCS-11800)

Link to docs preview:
[System requirements for installing MicroShift in RPM](https://84171--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#microshift-install-system-requirements_microshift-install-rpm)
[System requirements for installing MicroShift in edge image](https://84171--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html)
[System requirements for installing MicroShift in offline use](https://84171--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use.html#microshift-install-system-requirements_microshift-embed-rpm-ostree-offline-use)

QE review:
- [x] QE has approved this change.

Additional information:
Refer the PR https://github.com/openshift/openshift-docs/pull/84001 for the QE approved note added in version 4.17 and 4.18. Same content is used in this version