### PR TITLE
OSSM-8311 Change docinfo xml for Rel Notes to say Red Hat Service Mesh

### DIFF
--- a/ossm-release-notes/docinfo.xml
+++ b/ossm-release-notes/docinfo.xml
@@ -1,5 +1,5 @@
 <title>Release Notes</title>
-<productname>OpenShift Service Mesh</productname>
+<productname>Red Hat Service Mesh</productname>
 <productnumber>3.0.0tp1</productnumber>
 <subtitle>OpenShift Service Mesh release notes</subtitle>
 <abstract>


### PR DESCRIPTION
**OSSM 3.0 TP1**

**Specific to Pantheon build failures.**

Testing if changing productname to "Red Hat Service Mesh" results in successful builds. In the sync.yaml file for stand alone docs, product is "Red Hat Service Mesh" and not "Red Hat OpenShift Service Mesh."

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

Version(s):

Technology Preview

Issue:
https://issues.redhat.com/browse/OSSM-8311

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
