### PR TITLE
HCIDOCS-472: Add Control Plane Recreation Link to Backup and Restore …

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
@@ -34,6 +34,7 @@ include::modules/restore-determine-state-etcd-member.adoc[leveloffset=+1]
 Depending on the state of your unhealthy etcd member, use one of the following procedures:
 
 * xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose machine is not running or whose node is not ready]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-primary-control-plane-node-unhealthy-cluster_expanding-the-cluster[Installing a primary control plane node on an unhealthy cluster]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose etcd pod is crashlooping]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy stopped baremetal etcd member]
 
@@ -42,6 +43,7 @@ include::modules/restore-replace-stopped-etcd-member.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-primary-control-plane-node-unhealthy-cluster_expanding-the-cluster[Installing a primary control plane node on an unhealthy cluster]
 
 // Replacing an unhealthy etcd member whose etcd pod is crashlooping
 include::modules/restore-replace-crashlooping-etcd-member.adoc[leveloffset=+2]

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * backup_and_restore/replacing-unhealthy-etcd-member.adoc
+// * backup_and_restore/control_plane_backup_and_restore/modules/restore-replace-stopped-etcd-member.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="restore-replace-stopped-etcd-member_{context}"]
@@ -20,7 +20,7 @@ If your cluster uses a control plane machine set, see "Recovering a degraded etc
 +
 [IMPORTANT]
 ====
-You must wait if the other control plane nodes are powered off. The control plane nodes must remain powered off until the replacement of an unhealthy etcd member is complete.
+You must wait if you power off other control plane nodes. The control plane nodes must remain powered off until the replacement of an unhealthy etcd member is complete.
 ====
 +
 * You have access to the cluster as a user with the `cluster-admin` role.
@@ -28,7 +28,7 @@ You must wait if the other control plane nodes are powered off. The control plan
 +
 [IMPORTANT]
 ====
-It is important to take an etcd backup before performing this procedure so that your cluster can be restored if you encounter any issues.
+It is important to take an etcd backup before performing this procedure, so that you can restore your cluster if you experience any issues.
 ====
 
 .Procedure
@@ -139,7 +139,7 @@ etcd cannot tolerate any additional member failure when running with two members
 [source,terminal]
 ----
 $ oc delete node <node_name>
----- 
+----
 +
 .Example command
 [source,terminal]
@@ -190,7 +190,7 @@ $ oc delete secret -n openshift-etcd etcd-serving-ip-10-0-131-183.ec2.internal
 $ oc delete secret -n openshift-etcd etcd-serving-metrics-ip-10-0-131-183.ec2.internal
 ----
 
-. Delete and re-create the control plane machine. After this machine is re-created, a new revision is forced and etcd scales up automatically.
+. Delete and re-create the control plane machine. After this machine is re-created, a new revision is forced and etcd scales up automatically. See "Replacing an unhealthy etcd member whose machine is not running or whose node is not ready" for more information.
 +
 If you are running installer-provisioned infrastructure, or you used the Machine API to create your machines, follow these steps. Otherwise, you must create the new master using the same method that was used to originally create it.
 
@@ -262,7 +262,7 @@ $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides":
 $ oc get etcd/cluster -oyaml
 ----
 
-. If you are using {sno}, restart the node. Otherwise, you might encounter the following error in the etcd cluster Operator:
+. If you are using {sno}, restart the node. Otherwise, you might experience the following error in the etcd cluster Operator:
 +
 .Example output
 [source,terminal]

--- a/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc
@@ -21,7 +21,7 @@ include::modules/etcd-node-scaling.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#adding-hosts-with-the-api_expanding-the-cluster[Adding hosts with the API]
-* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-primary-control-plane-node-healthy-cluster_expanding-the-cluster[Installing a primary control plane node on a healthy cluster]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-control-plane-node-healthy-cluster_expanding-the-cluster[Expanding the cluster]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]
 
 include::modules/move-etcd-different-disk.adoc[leveloffset=+1]


### PR DESCRIPTION
**Fixes:** [HCIDOCS-472](https://issues.redhat.com/browse/HCIDOCS-472)

**For:** OCP 4.15+

[**Preview**](https://84178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member)

**Approvals -** `/lgtm`:
- [x] SME
- [x] Peer Review

**Note:** QE approval is unnecessary, as this PR updates links and is not procedural.