### PR TITLE
OSDOCS#12398: IDPs need workers for DNS resolution

### DIFF
--- a/modules/hcp-configuring-oauth-console.adoc
+++ b/modules/hcp-configuring-oauth-console.adoc
@@ -24,7 +24,7 @@ Adding any identity provider in the OAuth configuration removes the default `kub
 
 [NOTE]
 ====
-When you configure identity providers, you must have at least one `NodePool` replica in your hosted cluster. However, the `htpasswd` and `request-header` identity providers do not need the `NodePool` replicas.
+When you configure identity providers, you must configure at least one `NodePool` replica in your hosted cluster in advance. Traffic for DNS resolution is sent through the worker nodes. You do not need to configure the `NodePool` replicas in advance for the `htpasswd` and `request-header` identity providers.
 ====
 
 .Prerequisites

--- a/modules/hcp-configuring-oauth.adoc
+++ b/modules/hcp-configuring-oauth.adoc
@@ -24,7 +24,7 @@ Adding any identity provider in the OAuth configuration removes the default `kub
 
 [NOTE]
 ====
-When you configure identity providers, you must have at least one `NodePool` replica in your hosted cluster. However, the `htpasswd` and `request-header` identity providers do not need the `NodePool` replicas.
+When you configure identity providers, you must configure at least one `NodePool` replica in your hosted cluster in advance. Traffic for DNS resolution is sent through the worker nodes. You do not need to configure the `NodePool` replicas in advance for the `htpasswd` and `request-header` identity providers.
 ====
 
 .Prerequisites


### PR DESCRIPTION
PR adds this detail-- https://github.com/openshift/openshift-docs/pull/83913#discussion_r1820352135

Version(s): 4.14+

Issue: https://issues.redhat.com/browse/OSDOCS-12398

Link to docs preview:

- https://84194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-authentication-authorization.html#hcp-configuring-oauth_hcp-authentication-authorization
- https://84194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-authentication-authorization.html#hcp-configuring-oauth-console_hcp-authentication-authorization

QE review:
- [x] QE has approved this change.

