### PR TITLE
RHDEVDOCS-5986: Multiple authentication support in Git resolver

### DIFF
--- a/create/remote-pipelines-tasks-resolvers.adoc
+++ b/create/remote-pipelines-tasks-resolvers.adoc
@@ -65,7 +65,9 @@ include::modules/op-resolver-git-anon.adoc[leveloffset=+2]
 You can specify a remote pipeline, task, or `StepAction` definition from a Git repository by using the Git resolver. The repository must contain a YAML file that defines the pipeline or task. You can securely access repositories by using an authenticated API, which supports user authentication.
 
 include::modules/op-resolver-git-config-scm.adoc[leveloffset=+2]
+include::modules/op-resolver-git-config-multiple-providers.adoc[leveloffset=+2]
 include::modules/op-resolver-git-scm.adoc[leveloffset=+2]
+include::modules/op-resolver-git-specify-multiple-providers.adoc[leveloffset=+2]
 include::modules/op-resolver-git-override-scm.adoc[leveloffset=+2]
 
 [id="resolver-http_{context}"]

--- a/modules/op-resolver-git-config-multiple-providers.adoc
+++ b/modules/op-resolver-git-config-multiple-providers.adoc
@@ -1,0 +1,73 @@
+// This module is included in the following assemblies:
+// * create/remote-pipelines-tasks-resolvers.adoc
+// * openshift_pipelines/remote-pipelines-tasks-resolvers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-resolver-git-config-multiple-providers_{context}"]
+= Configuring multiple Git providers
+
+You can configure multiple Git providers, or you can add multiple configurations for the same Git provider, to use in different task runs and pipeline runs.
+
+Add details in the `TektonConfig` custom resource (CR) with your unique identifier key prefix.
+
+.Procedure
+
+. Edit the `TektonConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit TektonConfig config
+----
+
+. In the `TektonConfig` CR, edit the `pipeline.git-resolver-config` spec:
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+# ...
+  pipeline:
+    git-resolver-config:
+      # configuration 1 # <1> 
+      fetch-timeout: "1m"
+      default-url: "https://github.com/tektoncd/catalog.git"
+      default-revision: "main"
+      scm-type: "github"
+      server-url: ""
+      api-token-secret-name: ""
+      api-token-secret-key: ""
+      api-token-secret-namespace: "default"
+      default-org: ""
+      # configuration 2 # <2> 
+      test1.fetch-timeout: "5m"
+      test1.default-url: ""
+      test1.default-revision: "stable"
+      test1.scm-type: "github"
+      test1.server-url: "api.internal-github.com"
+      test1.api-token-secret-name: "test1-secret"
+      test1.api-token-secret-key: "token"
+      test1.api-token-secret-namespace: "test1"
+      test1.default-org: "tektoncd"
+      # configuration 3 # <3>
+      test2.fetch-timeout: "10m"
+      test2.default-url: ""
+      test2.default-revision: "stable"
+      test2.scm-type: "gitlab"
+      test2.server-url: "api.internal-gitlab.com"
+      test2.api-token-secret-name: "test2-secret"
+      test2.api-token-secret-key: "pat"
+      test2.api-token-secret-namespace: "test2"
+      test2.default-org: "tektoncd-infra"
+# ...
+----
+<1> The default configuration to use if no `configKey` key is provided or the key is provided with the `default` value.
+<2> The configuration used if the `configKey` key is passed with the `test1` value.
+<3> The configuration used if the `configKey` key is passed with the `test2` value.
++
+[WARNING]
+====
+`configKey` values with the `.` symbol are not supported. If you try to pass a `configKey` value that contains the `.` symbol, the `TaskRun` or `PipelineRun` resource where you passed the value fails to run.
+====

--- a/modules/op-resolver-git-override-scm.adoc
+++ b/modules/op-resolver-git-override-scm.adoc
@@ -5,7 +5,7 @@
 :_mod-docs-content-type: REFERENCE
 = Specifying a remote pipeline or task by using the Git resolver with the authenticated SCM API overriding the Git resolver configuration
 
-When creating a pipeline run, you can specify a remote pipeline from a Git repository by using the authenticated SCM API. When creating a pipeline or a task run, you can specify a remote task from a Git repository. You can override the initial configuration settings in specific pipeline runs or tasks to customize the behavior according to different use cases.
+You can override the initial configuration settings in specific pipeline runs or tasks to customize the behavior according to different use cases. You can use this method to access an authenticated provider that is not configured in the `TektonConfig` custom resource (CR).
 
 The following example task run references a remote task from a Git repository that overrides the previous resolver configuration:
 

--- a/modules/op-resolver-git-specify-multiple-providers.adoc
+++ b/modules/op-resolver-git-specify-multiple-providers.adoc
@@ -1,0 +1,36 @@
+// This module is included in the following assemblies:
+// * create/remote-pipelines-tasks-resolvers.adoc
+// * openshift_pipelines/remote-pipelines-tasks-resolvers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-resolver-git-specify-multiple-providers_{context}"]
+= Specifying multiple Git providers
+
+You can specify multiple Git providers by passing the unique `configKey` parameter when creating `TaskRun` and `PipelineRun` resources.
+
+If no `configKey` parameter is passed, the default configuration is used. You can also specify default configuration by setting the `configKey` value to `default`.
+
+[WARNING]
+====
+`configKey` values with the `.` symbol are not supported. If you try to pass a `configKey` value that contains the `.` symbol, the `TaskRun` or `PipelineRun` resource where you passed the value fails to run.
+====
+
+.Prerequisites
+
+* Configure multiple Git providers through the `Tektonconfig` custom resource. For more information, see "Configuring multiple Git providers".
+
+.Procedure
+
+* To specify a Git provider, use the following reference format in the `pipelineRef` and `taskRef` spec:
++
+[source,yaml]
+----
+# ...
+  resolver: git
+  params:
+  # ...
+  - name: configKey
+    value: <your_unique_key> # <1>
+# ...
+----
+<1> Your unique key that matches one of the configuration keys, for example, `test1`.


### PR DESCRIPTION
Version(s): `pipelines-docs-1.17`

Issue: [RHDEVDOCS-5986](https://issues.redhat.com/browse/RHDEVDOCS-5986)

Links to docs preview: 
* https://84201--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/remote-pipelines-tasks-resolvers.html#resolver-git-specify_remote-pipelines-tasks-resolvers
* https://84201--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/remote-pipelines-tasks-resolvers.html#op-resolver-git-config-multiple-providers_remote-pipelines-tasks-resolvers

QE review:
- [x] QE has approved this change.

**Additional information:**