### PR TITLE
OCPBUGS-37864: Update removing a cluster from the ZTP pipeline

### DIFF
--- a/modules/ztp-site-cleanup.adoc
+++ b/modules/ztp-site-cleanup.adoc
@@ -17,6 +17,17 @@ You can remove a managed site and the associated installation and configuration 
 .Procedure
 
 . Remove a site and the associated CRs by removing the associated `SiteConfig` and `PolicyGenerator` or `PolicyGentemplate` files from the `kustomization.yaml` file.
+
+. Add the following `syncOptions` field to your `SiteConfig` application.
++
+[source,yaml]
+----
+kind: Application
+spec:
+  syncPolicy:
+    syncOptions:
+    - PrunePropagationPolicy=background
+----
 +
 When you run the {ztp} pipeline again, the generated CRs are removed.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.15, 4.16, 4.17. 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-37864
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://84203--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-sites.html#ztp-site-cleanup_ztp-deploying-far-edge-sites
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
