### PR TITLE
OSDOCS-12095: adding autorecover from manual backups

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -225,6 +225,8 @@ Distros: microshift
 Topics:
 - Name: Backing up and restoring data
   File: microshift-backup-and-restore
+- Name: Auto recovery from manual backups
+  File: microshift-auto-recover-manual-backup
 ---
 Name: Troubleshooting
 Dir: microshift_troubleshooting

--- a/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
+++ b/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-auto-recover-manual-backup"]
+= Auto recovery from manual backups
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-auto-recover-manual-backup
+
+toc::[]
+
+You can automatically restore data from manual backups when {microshift-short} fails to start by using the `auto-recovery` feature.
+
+You can use the following options with the existing `backup` and `restore` commands in this feature:
+
+* `--auto-recovery`: Selects the most recent version of the backup, and then restores it. This option treats the `PATH` argument as a path to a directory that holds all the backups for auto-recovery, and not just as a path to a particular backup file.
+* `--dont-save-failed`: Disables the backup of failed {microshift-short} data.
+
+[NOTE]
+====
+* You can use the `--auto-recovery` option with both the `backup` and `restore` commands.
+* You can use the `--dont-save-failed` option only with the `restore` command.
+====
+
+include::modules/microshift-creating-backups.adoc[leveloffset=+1]
+
+include::modules/microshift-restoring-backups.adoc[leveloffset=+1]
+
+include::modules/microshift-automation-example-rpm-systems.adoc[leveloffset=+1]
+
+include::modules/microshift-automation-example-ostree-systems.adoc[leveloffset=+1]
+
+include::modules/microshift-automation-example-bootc-systems.adoc[leveloffset=+1]

--- a/modules/microshift-automation-example-bootc-systems.adoc
+++ b/modules/microshift-automation-example-bootc-systems.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-automation-example-bootc-systems_{context}"]
+= Automating the integration process with systemd for bootc systems
+
+[IMPORTANT]
+====
+You must include the entire `auto-recovery` process for bootc systems that use `systemd` in the container file.
+====
+
+As a use case, consider the following example situation in which you want to automate the `auto-recovery` process for bootc systems that use systemd.
+
+.Prerequisites
+
+* You have created the `10-auto-recovery.conf` and `microshift-auto-recovery.service` files as explained in the the "Automating the integration process with systemd for RPM systems" section.
+* You have created the `microshift-auto-recovery` script as explained in the the "Automating the integration process with systemd for RPM systems" section.
+
+.Procedure
+
+* Use the following example to update your Containerfile that you use to prepare the bootc image.
++
+[source,text]
+----
+RUN mkdir -p /usr/lib/systemd/system/microshift.service.d
+COPY ./auto-rec/10-auto-recovery.conf /usr/lib/systemd/system/microshift.service.d/10-auto-recovery.conf
+COPY ./auto-rec/microshift-auto-recovery.service /usr/lib/systemd/system/
+COPY ./auto-rec/microshift-auto-recovery /usr/bin/
+RUN chmod +x /usr/bin/microshift-auto-recovery && systemctl daemon-reload
+----

--- a/modules/microshift-automation-example-ostree-systems.adoc
+++ b/modules/microshift-automation-example-ostree-systems.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-automation-example-ostree-systems_{context}"]
+= Automating the integration process with systemd for OSTree systems
+
+[IMPORTANT]
+====
+You must include the entire `auto-recovery` process for OSTree systems that use `systemd` in the blueprint file.
+====
+
+As a use case, consider the following example situation in which you want to automate the `auto-recovery` process for OSTree systems that use systemd.
+
+.Procedure
+
+. Use the following example to create your blueprint file:
++
+[source,terminal]
+----
+[[customizations.files]]
+path = "/usr/lib/systemd/system/microshift.service.d/10-auto-recovery.conf"
+data = """
+[Unit]
+OnFailure=microshift-auto-recovery.service
+"""
+
+[[customizations.files]]
+path = "/usr/lib/systemd/system/microshift-auto-recovery.service"
+data = """
+[Unit]
+Description=MicroShift auto-recovery
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/microshift-auto-recovery
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+[[customizations.files]]
+path = "/usr/bin/microshift-auto-recovery"
+mode = "0755"
+data = """
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# If greenboot uses a non-default file for clearing boot_counter, use boot_success instead.
+if grep -q  "/boot/grubenv" /usr/libexec/greenboot/greenboot-grub2-set-success; then
+    if grub2-editenv - list | grep -q ^boot_success=0; then
+        echo "Greenboot didn't decide the system is healthy after staging a new deployment."
+        echo "Quitting to not interfere with the process"
+        exit 0
+    fi
+else
+    if grub2-editenv - list | grep -q ^boot_counter=; then
+        echo "Greenboot didn't decide the system is healthy after staging a new deployment."
+        echo "Quitting to not interfere with the process"
+        exit 0
+    fi
+fi
+
+/usr/bin/microshift restore --auto-recovery /var/lib/microshift-auto-recovery
+/usr/bin/systemctl reset-failed microshift
+/usr/bin/systemctl start microshift
+
+echo "DONE"
+"""
+----
+. For the next steps, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/embedding_in_a_rhel_for_edge_image/microshift-embed-in-rpm-ostree#preparing-for-image-building_microshift-embed-in-rpm-ostree[Preparing for image building].

--- a/modules/microshift-automation-example-rpm-systems.adoc
+++ b/modules/microshift-automation-example-rpm-systems.adoc
@@ -1,0 +1,91 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-automation-example-rpm-systems_{context}"]
+= Automating the integration process with systemd for RPM systems
+
+[NOTE]
+====
+When the `microshift.service` enters a failed state, `systemd` starts the `microshift-auto-recovery.service` unit. This unit executes the `auto-recovery` restore process and restarts {microshift-short}.
+====
+
+As a use case, consider the following example situation in which you want to automate the `auto-recovery` process for RPM systems that use systemd.
+
+.Procedure
+
+. Create a directory for the `microshift.service` by running the following command:
++
+[source,terminal]
+----
+$ sudo mkdir -p /usr/lib/systemd/system/microshift.service.d
+----
+. To instruct `systemd` to run `microshift-auto-recovery.service` when the `microshift.service` fails, create the `10-auto-recovery.conf` file  by running the following command:
++
+[source,terminal]
+----
+$ sudo tee /usr/lib/systemd/system/microshift.service.d/10-auto-recovery.conf > /dev/null <<'EOF'
+[Unit]
+OnFailure=microshift-auto-recovery.service
+EOF
+----
+. Create the `microshift-auto-recovery.service` file by running the following command:
++
+[source,terminal]
+----
+$ sudo tee /usr/lib/systemd/system/microshift-auto-recovery.service > /dev/null <<'EOF'
+[Unit]
+Description=MicroShift auto-recovery
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/microshift-auto-recovery
+
+[Install]
+WantedBy=multi-user.target
+EOF
+----
+. Create the `microshift-auto-recovery` script by running the following command:
++
+[source,terminal]
+----
+$ sudo tee /usr/bin/microshift-auto-recovery > /dev/null <<'EOF'
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# If greenboot uses a non-default file for clearing boot_counter, use boot_success instead.
+if grep -q  "/boot/grubenv" /usr/libexec/greenboot/greenboot-grub2-set-success; then
+    if grub2-editenv - list | grep -q ^boot_success=0; then
+        echo "Greenboot didn't decide the system is healthy after staging new deployment."
+        echo "Quitting to not interfere with the process"
+        exit 0
+    fi
+else
+    if grub2-editenv - list | grep -q ^boot_counter=; then
+        echo "Greenboot didn't decide the system is healthy after staging a new deployment."
+        echo "Quitting to not interfere with the process"
+        exit 0
+    fi
+fi
+
+/usr/bin/microshift restore --auto-recovery /var/lib/microshift-auto-recovery
+/usr/bin/systemctl reset-failed microshift
+/usr/bin/systemctl start microshift
+
+echo "DONE"
+EOF
+----
+. Make the script executable by running the following command:
++
+[source,terminal]
+----
+$ sudo chmod +x /usr/bin/microshift-auto-recovery
+----
+. Reload the system configuration by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl daemon-reload
+----
+

--- a/modules/microshift-creating-backups.adoc
+++ b/modules/microshift-creating-backups.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-creating-backups_{context}"]
+= Creating backups using the auto-recovery feature
+
+Use the following procedure to create backups.
+
+[NOTE]
+====
+Creating backups require stopping {microshift-short}, so you must determine the best time to stop {microshift-short}.
+====
+
+.Prerequisites
+
+* You have stopped {microshift-short}.
+
+.Procedure
+
+* Create and store backups in the directory you choose by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ sudo microshift backup --auto-recovery _<path_of_directory>_ <1>
+----
+<1> Replace `_<path_of_directory>_` with the path of the directory that stores backups. For example, `/var/lib/microshift-auto-recovery`.
++
+[NOTE]
+====
+The `--auto-recovery` option modifies the interpretation of the `PATH` argument from the final backup path to a directory that holds all the backups for auto-recovery.
+====
++
+.Example output
++
+[source,terminal]
+----
+??? I1104 09:18:52.100725    8906 system.go:58] "OSTree deployments" deployments=[{"id":"default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1","booted":true,"staged":false,"pinned":false},{"id":"default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0","booted":false,"staged":false,"pinned":false}]
+??? I1104 09:18:52.100895    8906 data_manager.go:83] "Copying data to backup directory" storage="/var/lib/microshift-auto-recovery" name="20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1" data="/var/lib/microshift"
+??? I1104 09:18:52.102296    8906 disk_space.go:33] Calculated size of "/var/lib/microshift": 261M - increasing by 10% for safety: 287M
+??? I1104 09:18:52.102321    8906 disk_space.go:44] Calculated available disk space for "/var/lib/microshift-auto-recovery": 1658M
+??? I1104 09:18:52.105700    8906 atomic_dir_copy.go:66] "Made an intermediate copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift /var/lib/microshift-auto-recovery/20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1.tmp.99142"
+??? I1104 09:18:52.105732    8906 atomic_dir_copy.go:115] "Renamed to final destination" src="/var/lib/microshift-auto-recovery/20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1.tmp.99142" dest="/var/lib/microshift-auto-recovery/20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1"
+??? I1104 09:18:52.105749    8906 data_manager.go:120] "Copied data to backup directory" backup="/var/lib/microshift-auto-recovery/20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1" data="/var/lib/microshift"
+/var/lib/microshift-auto-recovery/20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1
+----
+
+.Verification
+
+* To verify that the backup has been created, view the directory you chose to store backups by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ ls -la _<path_of_directory>_ <1>
+----
+<1> Replace `_<path_of_directory>_` with the path of the directory that stores backups. For example, `/var/lib/microshift-auto-recovery`.

--- a/modules/microshift-restoring-backups.adoc
+++ b/modules/microshift-restoring-backups.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-restoring-backups_{context}"]
+= Restoring backups using the auto-recovery feature
+
+You can restore backups after system events that remove or damage required data.
+
+Use the following procedure to restore backups.
+
+.Prerequisites
+
+* You have stopped {microshift-short}.
+
+.Procedure
+
+* Restore the backup from the directory in which you have stored the backups by running the following command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ sudo microshift restore --auto-recovery _<path_of_directory>_ <1>
+----
+<1> Replace `_<path_of_directory>_` with the path of the directory that stores backups. For example, `/var/lib/microshift-auto-recovery`.
++
+[NOTE]
+====
+The `--auto-recovery` option copies the {microshift-short} data to `/var/lib/microshift-auto-recovery/failed/` for later investigation, selects the most recent backup, and restores it.
+The `--dont-save-failed` option disables the backing up of failed {microshift-short} data.
+====
++
+.Example output
++
+[source,terminal]
+----
+??? I1104 09:19:28.617225    8950 state.go:80] "Read state from the disk" state={"LastBackup":"20241022101528_default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0"}
+??? I1104 09:19:28.617323    8950 storage.go:78] "Auto-recovery backup storage read and parsed" dirs=["20241022101255_default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0","20241022101520_default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0","20241022101528_default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0","20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1","restored"] backups=[{"CreationTime":"2024-10-22T10:12:55Z","Version":"default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0"},{"CreationTime":"2024-10-22T10:15:20Z","Version":"default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0"},{"CreationTime":"2024-10-22T10:15:28Z","Version":"default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0"},{"CreationTime":"2024-11-04T09:18:52Z","Version":"default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1"}]
+??? I1104 09:19:28.617350    8950 storage.go:40] "Filtered list of backups - removed previously restored backup" removed="20241022101528_default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0" newList=[{"CreationTime":"2024-10-22T10:12:55Z","Version":"default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0"},{"CreationTime":"2024-10-22T10:15:20Z","Version":"default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0"},{"CreationTime":"2024-11-04T09:18:52Z","Version":"default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1"}]
+??? I1104 09:19:28.633237    8950 system.go:58] "OSTree deployments" deployments=[{"id":"default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1","booted":true,"staged":false,"pinned":false},{"id":"default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0","booted":false,"staged":false,"pinned":false}]
+??? I1104 09:19:28.633258    8950 storage.go:49] "Filtered list of backups by version" version="default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1" newList=[{"CreationTime":"2024-11-04T09:18:52Z","Version":"default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1"}]
+??? I1104 09:19:28.633268    8950 restore.go:170] "Potential backups" bz=[{"CreationTime":"2024-11-04T09:18:52Z","Version":"default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1"}]
+??? I1104 09:19:28.633277    8950 restore.go:173] "Candidate backup for restore" b={"CreationTime":"2024-11-04T09:18:52Z","Version":"default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1"}
+??? I1104 09:19:28.634007    8950 disk_space.go:33] Calculated size of "/var/lib/microshift-auto-recovery/20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1": 261M - increasing by 10% for safety: 287M
+??? I1104 09:19:28.634096    8950 disk_space.go:44] Calculated available disk space for "/var/lib": 1658M
+??? I1104 09:19:28.634507    8950 disk_space.go:33] Calculated size of "/var/lib/microshift": 261M - increasing by 10% for safety: 287M
+??? I1104 09:19:28.634522    8950 disk_space.go:44] Calculated available disk space for "/var/lib/microshift-auto-recovery": 1658M
+??? I1104 09:19:28.649719    8950 system.go:58] "OSTree deployments" deployments=[{"id":"default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1","booted":true,"staged":false,"pinned":false},{"id":"default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0","booted":false,"staged":false,"pinned":false}]
+??? I1104 09:19:28.653880    8950 atomic_dir_copy.go:66] "Made an intermediate copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift /var/lib/microshift-auto-recovery/failed/20241104091928_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1.tmp.22742"
+??? I1104 09:19:28.657362    8950 atomic_dir_copy.go:66] "Made an intermediate copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift-auto-recovery/20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1 /var/lib/microshift.tmp.482"
+??? I1104 09:19:28.657385    8950 state.go:40] "Saving intermediate state" state="{\"LastBackup\":\"20241104091852_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1\"}" path="/var/lib/microshift-auto-recovery/state.json.tmp.41544"
+??? I1104 09:19:28.662438    8950 atomic_dir_copy.go:115] "Renamed to final destination" src="/var/lib/microshift.tmp.482" dest="/var/lib/microshift"
+??? I1104 09:19:28.662451    8950 state.go:46] "Moving state file to final path" intermediatePath="/var/lib/microshift-auto-recovery/state.json.tmp.41544" finalPath="/var/lib/microshift-auto-recovery/state.json"
+??? I1104 09:19:28.662521    8950 atomic_dir_copy.go:115] "Renamed to final destination" src="/var/lib/microshift-auto-recovery/failed/20241104091928_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1.tmp.22742" dest="/var/lib/microshift-auto-recovery/failed/20241104091928_default-b3442053c9ce69310cd54140d8d592234c5306e4c5132de6efe615f79c84300a.1"
+??? I1104 09:19:28.662969    8950 atomic_dir_copy.go:115] "Renamed to final destination" src="/var/lib/microshift-auto-recovery/20241022101528_default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0" dest="/var/lib/microshift-auto-recovery/restored/20241022101528_default-a129624b9233fa54fe3574f1aa211bc2d85e1052b52245fe7d83f10c2f6d28e3.0"
+??? I1104 09:19:28.662983    8950 restore.go:141] "Auto-recovery restore completed".
+----
++
+[NOTE]
+====
+* The `restore` command does not start {microshift-short} after restoration. When you execute this command, {microshift-short} service has already failed or you need to stop it.
+* {microshift-short} does not monitor the disk space of any filesystem. You need to ensure your automation handles old backup removal.
+====
+
+.Verification
+
+* Verify that {microshift-short} has started successfully.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-12095](https://issues.redhat.com/browse/OSDOCS-12095)

Link to docs preview:
[Auto-recovery from manual backups](https://84216--ocpdocs-pr.netlify.app/microshift/latest/microshift_backup_and_restore/microshift-auto-recover-manual-backup.html)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
