### PR TITLE
OCPBUGS-43323-rn:adds KI to rns about IPsec

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2686,6 +2686,8 @@ A proposed fix is to report a `FREERUN` event when the NMEA string is lost.
 
 * Currently, the *YAML* tab of some pages in the web console stops unexpectedly on some browsers when the multicluster engine for Kubernetes operator (MCE) is installed. The following message is displayed: "Oh no! Something went wrong." (link:https://issues.redhat.com/browse/OCPBUGS-29812[*OCPBUGS-29812*])
 
+* If you have IPsec enabled on your cluster, you must disable it prior to upgrading to {product-title} 4.15. There is a known issue where pod-to-pod communication might be interrupted or lost when updating to 4.15 without disabling IPsec. For information on disabling IPsec, see xref:../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]. (link:https://issues.redhat.com/browse/OCPBUGS-43323[*OCPBUGS-43323*])
+
 * If you have IPsec enabled on the cluster and IPsec encryption is configured between the cluster and an external node, stopping the IPsec connection on the external node causes a loss of connectivity to the external node. This connectivity loss occurs because on the {product-title} side of the connection, the IPsec tunnel shutdown is not recognized. (link:https://issues.redhat.com/browse/RHEL-24802[*RHEL-24802*])
 
 * If you have IPsec enabled on the cluster, and your cluster is a hosted control planes for {product-title} cluster, the MTU adjustment to account for the IPsec tunnel for pod-to-pod traffic does not happen automatically. (link:https://issues.redhat.com/browse/OCPBUGS-28757[*OCPBUGS-28757*])
@@ -2769,7 +2771,7 @@ $ oc adm release info 4.15.36 --pullspecs
 
 * Previously, a change in the ordering of the `TextInput` parameters for PatternFly v4 and v5 caused the `until` field to be improperly filled and you could not edit it. With this release, the `until` field is editable so you can input the correct information. (link:https://issues.redhat.com/browse/OCPBUGS-42384[*OCPBUGS-42384*])
 
-* Previously, when the Node Tuning Operator (NTO) was configured using performance profiles, it created the `ocp-tuned-one-shot systemd` service. The service ran before the kubelet and blocked the service execution. The `systemd` service invoked Podman, which used the NTO image. If the NTO image was not present, Podman tried to fetch the image. 
+* Previously, when the Node Tuning Operator (NTO) was configured using performance profiles, it created the `ocp-tuned-one-shot systemd` service. The service ran before the kubelet and blocked the service execution. The `systemd` service invoked Podman, which used the NTO image. If the NTO image was not present, Podman tried to fetch the image.
 +
 With this release, support is added for cluster-wide proxy environment variables that are defined in the `/etc/mco/proxy.env` environment. This allows Podman to pull NTO images in environments that need the HTTP/HTTPS proxy for out-of-cluster connections. (link:https://issues.redhat.com/browse/OCPBUGS-42284[*OCPBUGS-42284*])
 

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -29,6 +29,11 @@ Without the correct micro-architecture requirements, the update process will fai
 
 There are no Kubernetes API removals in {product-title} 4.15.
 
+[IMPORTANT]
+====
+If you have IPsec enabled on your cluster, you must disable it prior to upgrading to {product-title} 4.15. There is a known issue where pod-to-pod communication might be interrupted or lost when updating to 4.15 without disabling IPsec. For information on disabling IPsec, see xref:../../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]. (link:https://issues.redhat.com/browse/OCPBUGS-43323[*OCPBUGS-43323*])
+====
+
 // Commenting out this section because there are no APIs being removed in OCP 4.15 / Kube 1.28. But we'll need this section again for 4.16
 ////
 {product-title} 4.14 uses Kubernetes 1.27, which removed several deprecated APIs.


### PR DESCRIPTION
CM acks on https://github.com/openshift/openshift-docs/pull/83462 and https://github.com/openshift/openshift-docs/pull/83463. Taking this work over for Joe while he's on PPL. Peer review was completed on the previous PR. I only updated the broken xref here.

Version(s):
4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-43323
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://83463--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-known-issues:~:text=If%20you%20have%20IPsec%20enabled%20on%20your%20cluster%2C%20you%20must%20disable%20it%20prior%20to%20upgrading%20to%20OpenShift%20Container%20Platform%204.15.%20There%20is%20a%20known%20issue%20where%20pod%2Dto%2Dpod%20communication%20might%20be%20interupted%20or%20lost%20when%20updating%20to%204.15%20without%20disabling
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
