### PR TITLE
OSSM-8313 Check and update current docinfo.xml files so product reads Red Hat OpenShift Service Mesh

### DIFF
--- a/about/docinfo.xml
+++ b/about/docinfo.xml
@@ -1,5 +1,5 @@
 <title>About</title>
-<productname>OpenShift Service Mesh</productname>
+<productname>Red Hat OpenShift Service Mesh</productname>
 <productnumber>3.0</productnumber>
 <subtitle>About OpenShift Service Mesh</subtitle>
 <abstract>

--- a/install/docinfo.xml
+++ b/install/docinfo.xml
@@ -1,5 +1,5 @@
 <title>Installing</title>
-<productname>OpenShift Service Mesh</productname>
+<productname>Red Hat OpenShift Service Mesh</productname>
 <productnumber>3.0</productnumber>
 <subtitle>Installing OpenShift Service Mesh</subtitle>
 <abstract>

--- a/kiali/docinfo.xml
+++ b/kiali/docinfo.xml
@@ -1,5 +1,5 @@
 <title>Kiali Operator provided by Red Hat</title>
-<productname>OpenShift Service Mesh</productname>
+<productname>Red Hat OpenShift Service Mesh</productname>
 <productnumber>3.0</productnumber>
 <subtitle>Using the Kiali Operator provided by Red Hat</subtitle>
 <abstract>

--- a/metrics/docinfo.xml
+++ b/metrics/docinfo.xml
@@ -1,5 +1,5 @@
 <title>Metrics</title>
-<productname>OpenShift Service Mesh</productname>
+<productname>Red Hat OpenShift Service Mesh</productname>
 <productnumber>3.0</productnumber>
 <subtitle>Using metrics with Service Mesh</subtitle>
 <abstract>

--- a/ossm-release-notes/docinfo.xml
+++ b/ossm-release-notes/docinfo.xml
@@ -1,5 +1,5 @@
 <title>Release Notes</title>
-<productname>Red Hat Service Mesh</productname>
+<productname>Red Hat OpenShift Service Mesh</productname>
 <productnumber>3.0.0tp1</productnumber>
 <subtitle>OpenShift Service Mesh release notes</subtitle>
 <abstract>

--- a/traces/docinfo.xml
+++ b/traces/docinfo.xml
@@ -1,5 +1,5 @@
 <title>Distributed Tracing</title>
-<productname>OpenShift Service Mesh</productname>
+<productname>Red Hat OpenShift Service Mesh</productname>
 <productnumber>3.0</productnumber>
 <subtitle>Using distributed tracing with OpenShift Service Mesh</subtitle>
 <abstract>

--- a/update/docinfo.xml
+++ b/update/docinfo.xml
@@ -1,5 +1,5 @@
 <title>Updating</title>
-<productname>OpenShift Service Mesh</productname>
+<productname>Red Hat OpenShift Service Mesh</productname>
 <productnumber>3.0</productnumber>
 <subtitle>Updating OpenShift Service Mesh</subtitle>
 <abstract>


### PR DESCRIPTION
**OSSM 3.0TP1**

**Changes required for Pantheon builds to build**

[OSSM-8313](https://issues.redhat.com//browse/OSSM-8313) Check and update current docinfo.xml files so product reads Red Hat OpenShift Service Mesh

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology preview

Issue:
https://issues.redhat.com/browse/OSSM-8313

Link to docs preview:
There is no preview as these are docinfo.xml files used behind-the-scenes in Pantheon.

QE review:
QE approval is not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
