### PR TITLE
ExternalDNS Operator update to release notes OSDOCS-12457

### DIFF
--- a/networking/external_dns_operator/external-dns-operator-release-notes.adoc
+++ b/networking/external_dns_operator/external-dns-operator-release-notes.adoc
@@ -18,9 +18,20 @@ These release notes track the development of the External DNS Operator in {produ
 [id="external-dns-operator-release-notes-1.3.0"]
 == External DNS Operator 1.3.0
 
+The following advisory is available for the External DNS Operator version 1.3.0:
+
+*link:https://access.redhat.com/errata/RHEA-2024:8550[RHEA-2024:8550 Produce Enhancement Advisory]
+
 This update includes a rebase to the 0.14.2 version of the upstream project.
 
-* link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/[Kubernetes 0.14.2 Information]
+[id="external-dns-operator-.3.0-bug-fixes"]
+=== Bug fixes
+
+Previously, the ExternalDNS Operator could not deploy operands on HCP clusters. With this release, the Operator deploys operands in a running and ready state. (link:https://issues.redhat.com/browse/OCPBUGS-37059[*OCPBUGS-37059*])
+
+Previously, the ExternalDNS Operator was not using RHEL 9 as its building or base images. With this release, RHEL9 is the base. (link:https://issues.redhat.com/browse/OCPBUGS-41683[*OCPBUGS-41683*])
+
+Previously, the godoc had a broken link for Infoblox provider. With this release, the godoc is revised for accuracy. Some links are removed while some other are replaced with GitHub permalinks. (link:https://issues.redhat.com/browse/OCPBUGS-36797[*OCPBUGS-36797*])
 
 [id="external-dns-operator-release-notes-1.2.0"]
 == External DNS Operator 1.2.0


### PR DESCRIPTION
Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12457
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://84230--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/external-dns-operator-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
