### PR TITLE
OSDOCS#12487: updating agent links

### DIFF
--- a/disconnected/installing.adoc
+++ b/disconnected/installing.adoc
@@ -23,7 +23,9 @@ ifndef::openshift-origin[]
 [id="installing-agent_{context}"]
 == Installing a cluster with the Agent-based Installer
 
-To learn more about installing a cluster in a disconnected environment with the Agent-based installer, see the following procedure:
+To learn more about installing a cluster in a disconnected environment with the Agent-based installer, see the following pages:
+
+* xref:../installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc#understanding-disconnected-installation-mirroring[Understanding disconnected installation mirroring]
 
 * xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer]
 endif::openshift-origin[]

--- a/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
+++ b/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
@@ -20,3 +20,9 @@ You can use one of the following procedures to mirror your {product-title} image
 include::modules/agent-install-about-mirroring-for-disconnected-registry.adoc[leveloffset=+1]
 
 include::modules/agent-install-configuring-for-disconnected-registry.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer]


### PR DESCRIPTION
[OSDOCS-12487](https://issues.redhat.com/browse/OSDOCS-12487)

Version(s):
4.17+

This PR updates some links in disconnected and Agent docs

QE review: IMO QE review not necessary for adding links to existing docs, but reviewers please let me know if you disagree and I can request QE review

Previews:
[Installing a cluster in a disconnected environment](https://84231--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing)
[Understanding disconnected installation mirroring](https://84231--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring)
