### PR TITLE
OSDOCS-12435: z-stream release notes for 4.16.19 

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3325,6 +3325,41 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.19
+[id="ocp-4-16-19_{context}"]
+=== RHSA-2024:8415 - {product-title} {product-version}.19 bug fix and security update
+
+Issued: 30 October 2024
+
+{product-title} release {product-version}.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:8415[RHSA-2024:8415] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8418[RHSA-2024:8418] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.19 --pullspecs
+----
+
+[id="ocp-4-16-19-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when the Image Registry Operator was configured with `NetworkAccess: Internal` in {azure-full}, you could not successfully set `managementState` to `Removed` in the Operator configuration. This was due to an authorization error when the Operator tried to delete the storage container. With this release, the Operator continues to delete the storage account, which automatically deletes the storage container. This results in a successful change to the `Removed` state. (link:https://issues.redhat.com/browse/OCPBUGS-43555[*OCPBUGS-43555*])
+
+* Previously, in managed services, audit logs were sent to a local webhook service. Control plane deployments sent traffic through `konnectivity` and attempted to send the audit webhook traffic through the `konnectivity` proxies: `openshift-apiserver` and `oauth-openshift`.  With this release, the `audit-webhook` is in the list of `no_proxy hosts` for the affected pods, and the audit log traffic that is sent to the `audit-webhook` is successfully sent. (link:https://issues.redhat.com/browse/OCPBUGS-43046[*OCPBUGS-43046*])
+  
+* Previously, when you used the Agent-based Installer to install a cluster, the `assisted-installer-controller` timed out of the installation process, depending on whether `assisted-service` was unavailable on the rendezvous host. This event caused the cluster installation to fail during CSR approval checks. With this release, an update to `assisted-installer-controller` ensures that the controller does not time out if the `assisted-service` is unavailable. The CSR approval check now works as expected. (link:https://issues.redhat.com/browse/OCPBUGS-42710[*OCPBUGS-42710*])
+
+* Previously, the {ibm-name} cloud controller manager (CCM) was reconfigured to use loopback as the bind address in {product-title} {product-version}. The liveness probe was not configured to use loopback, so the CCM constantly failed the liveness probe and continuously restarted. With this release, the {ibm-name} CCM liveness probe is configured to use the loopback for the request host. (link:https://issues.redhat.com/browse/OCPBUGS-42125[*OCPBUGS-42125*])
+
+* Previously, the Messaging Application Programming Interface (MAPI) for {ibm-cloud-title} currently only checks the first group of subnets (50) when searching for subnet details by name. With this release, the search provides pagination support to search all subnets. (link:https://issues.redhat.com/browse/OCPBUGS-36698[*OCPBUGS-36698*])
+
+[id="ocp-4-16-19-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.16.18
 [id="ocp-4-16-18_{context}"]
 === RHSA-2024:8260 - {product-title} {product-version}.18 bug fix and security update


### PR DESCRIPTION
[OSDOCS-12435](https://issues.redhat.com/browse/OSDOCS-12435)

Version:
4.16

Link to docs preview:
[4.16.19](https://84240--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-19_release-notes)

QE review:
n/a

Additional information:
The errata URLs will return 404 until the go-live date of 10/30/24.