### PR TITLE
OCPBUGS-43902: remove FIPS compliance from 4.12 release notes

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -40,15 +40,6 @@ You can observe networking patterns on an {VirtProductName} setup by identifying
 ==== Network policy deploys in the FlowCollector custom resource (CR)
 With this release, you can configure the `FlowCollector` CR to deploy a network policy for Network Observability. Previously, if you wanted a network policy, you had to manually create one. The option to manually create a network policy is still available. For more information, see xref:../../observability/network_observability/network-observability-network-policy.adoc#network-observability-deploy-network-policy_network_observability[Configuring an ingress network policy by using the FlowCollector custom resource].
 
-[id="network-observability-fips-compliance-1-7_{context}"]
-==== FIPS compliance
-* You can install and use the Network Observability Operator in an {product-title} cluster running in FIPS mode.
-+
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a RHEL computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see Installing the system in FIPS mode.
-====
-
 [id="network-observability-dns-enhancements-1-7_{context}"]
 ==== eBPF agent enhancements
 The following enhancements are available for the eBPF agent:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12 only
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-43902
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://84243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-1.7.0-features-enhancements_network-observability-operator-release-notes-v0
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
