### PR TITLE
OSSM-8308: Add disclaimer that Gateway API CRDs are not supported

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -63,6 +63,8 @@
 :JaegerName: Red Hat OpenShift distributed tracing platform (Jaeger)
 :JaegerShortName: distributed tracing platform (Jaeger)
 :JaegerVersion: 1.47.0
+//Kubernetes
+:k8s: Kubernetes
 //distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing platform
 :DTShortName: distributed tracing platform

--- a/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
@@ -3,10 +3,14 @@
 = Accessing the Bookinfo application by using Gateway API
 :context: ossm-accessing-bookinfo-application-using-gateway-API
 
-The Gateway API deploys a gateway by creating a `Gateway` resource. In {ocp-product-title} 4.15 and later versions, the Gateway API CRDs are not available by default
-and must be enabled in order to be used. 
+The {k8s} Gateway API deploys a gateway by creating a `Gateway` resource. In {ocp-product-title} 4.15 and later versions. If you want your cluster to use the Gateway API CRDs, you must enable the CRDs because they are disabled by default.  
 
-.Prerequisties
+[NOTE]
+====
+Red{nbsp}Hat provides support for using the {k8s} Gateway API with {SMProductName}. Red{nbsp}Hat does not provide support for the {k8s} Gateway API custom resource definitions (CRDs). In this procedure, the use of community Gateway API CRDs is shown for demonstration purposes only.
+====
+
+. Prerequisites
 
 * You are logged in to the {ocp-product-title} web console as `cluster-admin`.
 


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-8308
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://84246--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh#ossm-accessing-bookinfo-application-using-gateway-api
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
