### PR TITLE
RHDEVDOCS-6245: Add sane defaults to chains

### DIFF
--- a/modules/op-chains-generating-x509-secret.adoc
+++ b/modules/op-chains-generating-x509-secret.adoc
@@ -1,0 +1,54 @@
+// This module is included in the following assemblies:
+// * secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="chains-generating-x509-secret_{context}"]
+= Generating the x509 key pair by using the TektonConfig CR
+
+To use the `x509` signing scheme for {tekton-chains} secrets, you must generate the `x509` key pair.
+
+You can generate the `x509` key pair by setting the `generateSigningSecret` field in the `TektonConfig` custom resource (CR) to `true`. 
+The {pipelines-title} Operator generates an `ecdsa` type key pair: an `x509.pem` private key and an `x509-pub.pem` public key. The Operator stores the keys in the `signing-secrets` secret in the `openshift-pipelines` namespace.
+
+[WARNING]
+====
+If you set the `generateSigningSecret` field from `true` to `false`, the {pipelines-title} Operator overrides and empties any value in the `signing-secrets` secret. Ensure that you store the `x509-pub.pem` public key outside of the secret to protect the key from the deletion. The Operator can use the key at a later stage to verify artifact attestations.
+====
+
+The {pipelines-title} Operator does not provide the following functions to limit potential security issues:
+
+* Key rotation 
+* Auditing key usage
+* Proper access control to the key
+
+.Prerequisites
+
+* You installed the {oc-first} utility.
+* You are logged in to your {OCP} cluster with administrative rights for the `openshift-pipelines` namespace.
+
+.Procedure
+
+. Edit the `TektonConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit TektonConfig config
+----
+
+. In the `TektonConfig` CR, set the `generateSigningSecret` value to `true`:
++
+.Example of creating an ecdsa key pair by using the TektonConfig CR
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+# ...
+  chain:
+    disabled: false
+    generateSigningSecret: true # <1>
+# ...
+----
+<1> The default value is `false`. Setting the value to `true` generates the `ecdsa` key pair.

--- a/modules/op-chains-signing-secrets-cosign.adoc
+++ b/modules/op-chains-signing-secrets-cosign.adoc
@@ -4,7 +4,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="chains-signing-secrets-cosign_{context}"]
-= Signing using cosign
+= Signing with the cosign tool
 
 You can use the `cosign` signing scheme with {tekton-chains} using the `cosign` tool.
 

--- a/modules/op-chains-signing-secrets-skopeo.adoc
+++ b/modules/op-chains-signing-secrets-skopeo.adoc
@@ -4,7 +4,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="chains-signing-secrets-skopeo_{context}"]
-= Signing using skopeo
+= Signing with the skopeo tool
 
 You can generate keys using the `skopeo` tool and use them in the `cosign` signing scheme with {tekton-chains}.
 

--- a/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
+++ b/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 To verify signatures of task runs using {tekton-chains} with any additional authentication, perform the following tasks:
 
-* Create an encrypted x509 key pair and save it as a Kubernetes secret.
+* Generate an encrypted `x509` or `cosign` key pair and store it as a Kubernetes secret.
 * Configure the {tekton-chains} backend storage.
 * Create a task run, sign it, and store the signature and the payload as annotations on the task run itself.
 * Retrieve the signature and payload from the signed task run.
@@ -23,7 +23,8 @@ Ensure that the following components are installed on the cluster:
 
 .Procedure
 
-. Create an encrypted x509 key pair and save it as a Kubernetes secret. For more information about creating a key pair and saving it as a secret, see "Signing secrets in {tekton-chains}".
+. Generate an encrypted `x509` or `cosign` key pair. For more information about creating a key pair and saving it as a secret, see "Secrets for signing data in {tekton-chains}".
+
 . In the {tekton-chains} configuration, disable the OCI storage, and set the task run storage and format to `tekton`. In the `TektonConfig` custom resource set the following values:
 +
 [source,yaml]

--- a/modules/op-creating-mounting-kms-authentication-token-secret.adoc
+++ b/modules/op-creating-mounting-kms-authentication-token-secret.adoc
@@ -12,7 +12,7 @@ You must create this secret, mount it on the {tekton-chains} controller, and set
 .Prerequisites
 
 * You installed the {oc-first} utility.
-* You are logged in to your {OCP} cluster with administrative rights for the `tekton-chains` namespace.
+* You are logged in to your {OCP} cluster with administrative rights for the `openshift-pipelines` namespace.
 
 .Procedure
 

--- a/modules/op-creating-mounting-mongo-server-url-secret.adoc
+++ b/modules/op-creating-mounting-mongo-server-url-secret.adoc
@@ -10,7 +10,7 @@ You can provide the value of the Mongo server URL to use for `docdb` storage (`M
 .Prerequisites
 
 * You installed the {oc-first} utility.
-* You are logged in to your {OCP} cluster with administrative rights for the `tekton-chains` namespace.
+* You are logged in to your {OCP} cluster with administrative rights for the `openshift-pipelines` namespace.
 
 .Procedure
 

--- a/modules/op-signing-secrets-in-tekton-chains.adoc
+++ b/modules/op-signing-secrets-in-tekton-chains.adoc
@@ -15,4 +15,17 @@ Currently, {tekton-chains} supports the `x509` and `cosign` signature schemes.
 Use only one of the supported signature schemes.
 ====
 
-To use the `x509` signing scheme with {tekton-chains}, store the `x509.pem` private key of the `ed25519` or `ecdsa` type in the `signing-secrets` Kubernetes secret.
+
+.The x509 signing scheme
+To use the `x509` signing scheme with {tekton-chains}, you must fulfill the following requirements:
+
+* Store the private key in the `signing-secrets` with the `x509.pem` structure.
+* Store the private key as an unencrypted `PKCS #8` PEM file.
+* The key is of `ed25519` or `ecdsa` type.
+
+.The cosign signing scheme
+To use the `cosign` signing scheme with {tekton-chains}, you must fulfill the following requirements:
+
+* Store the private key in the `signing-secrets` with the `cosign.key` structure.
+* Store the password in the `signing-secrets` with the `cosign.password` structure.
+* Store the private key as an encrypted PEM file of type `ENCRYPTED COSIGN PRIVATE KEY`.

--- a/modules/op-supported-parameters-tekton-chains-configuration.adoc
+++ b/modules/op-supported-parameters-tekton-chains-configuration.adoc
@@ -24,7 +24,7 @@ Cluster administrators can use various supported parameter keys and values to co
 | `artifacts.taskrun.storage`
 | The storage backend for task run signatures. You can specify multiple backends as a comma-separated list, such as `“tekton,oci”`. To disable storing task run artifacts, provide an empty string `“”`.
 | `tekton`, `oci`, `gcs`, `docdb`, `grafeas`
-| `tekton`
+| `oci`
 
 | `artifacts.taskrun.signer`
 | The signature backend for signing task run payloads.
@@ -55,7 +55,7 @@ Cluster administrators can use various supported parameter keys and values to co
 | `artifacts.pipelinerun.storage`
 | The storage backend for storing pipeline run signatures. You can specify multiple backends as a comma-separated list, such as `“tekton,oci”`. To disable storing pipeline run artifacts, provide an empty string `“”`.
 | `tekton`, `oci`, `gcs`, `docdb`, `grafeas`
-| `tekton`
+| `oci`
 
 | `artifacts.pipelinerun.signer`
 | The signature backend for signing pipeline run payloads.

--- a/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
+++ b/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 Cluster administrators can use {tekton-chains} to sign and verify images and provenances, by performing the following tasks:
 
-* Create an encrypted x509 key pair and save it as a Kubernetes secret.
+* Generate an encrypted `x509` or `cosign` key pair and store it as a Kubernetes secret.
 * Set up authentication for the OCI registry to store images, image signatures, and signed image attestations.
 * Configure {tekton-chains} to generate and sign provenance.
 * Create an image with Kaniko in a task run.
@@ -25,14 +25,7 @@ Ensure that the following are installed on the cluster:
 
 .Procedure
 
-. Create an encrypted x509 key pair and save it as a Kubernetes secret:
-+
-[source,terminal]
-----
-$ cosign generate-key-pair k8s://openshift-pipelines/signing-secrets
-----
-+
-Provide a password when prompted. Cosign stores the resulting private key as part of the `signing-secrets` Kubernetes secret in the `openshift-pipelines` namespace, and writes the public key to the `cosign.pub` local file.
+. Generate an encrypted `x509` or `cosign` key pair. For more information about creating a key pair and saving it as a secret, see "Secrets for signing data in {tekton-chains}".
 
 . Configure authentication for the image registry.
 

--- a/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
+++ b/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
@@ -26,6 +26,7 @@ include::modules/op-creating-mounting-kms-authentication-token-secret.adoc[level
 include::modules/op-enabling-tekton-chains-to-operate-only-in-selected-namespaces.adoc[leveloffset=+2]
 
 include::modules/op-signing-secrets-in-tekton-chains.adoc[leveloffset=+1]
+include::modules/op-chains-generating-x509-secret.adoc[leveloffset=+2]
 include::modules/op-chains-signing-secrets-cosign.adoc[leveloffset=+2]
 include::modules/op-chains-signing-secrets-skopeo.adoc[leveloffset=+2]
 include::modules/op-chains-resolving-existing-secret.adoc[leveloffset=+2]
@@ -33,15 +34,16 @@ include::modules/op-chains-resolving-existing-secret.adoc[leveloffset=+2]
 include::modules/op-authenticating-to-an-oci-registry.adoc[leveloffset=+1]
 
 include::modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc[leveloffset=+1]
-=== Additional resources
 
-* xref:signing-secrets-in-tekton-chains_{context}[]
-* xref:configuring-tekton-chains_{context}[]
+[role="_additional-resources"]
+.Additional resources
+* xref:../secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc#signing-secrets-in-tekton-chains_using-tekton-chains-for-openshift-pipelines-supply-chain-security[Secrets for signing data in {tekton-chains}]
+* xref:../secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc#configuring-tekton-chains_using-tekton-chains-for-openshift-pipelines-supply-chain-security[Configuring {tekton-chains}]
 
 include::modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources-tekton-chains"]
+[id="additional-resources_{context}"]
 == Additional resources
-
+* xref:../secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc#signing-secrets-in-tekton-chains_using-tekton-chains-for-openshift-pipelines-supply-chain-security[Secrets for signing data in {tekton-chains}]
 * xref:../install_config/installing-pipelines.adoc#installing-pipelines[Installing {pipelines-shortname}]


### PR DESCRIPTION
Version(s): `pipelines-docs-1.17`

Issue: [RHDEVDOCS-6245](https://issues.redhat.com/browse/RHDEVDOCS-6245)

Link to docs preview: https://84253--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.html#signing-secrets-in-tekton-chains_using-tekton-chains-for-openshift-pipelines-supply-chain-security

QE review:
- [x] QE has approved this change.

**Additional information:**