### PR TITLE
OSSM-8318 Explanation of Kiali CR in TP1 doc

### DIFF
--- a/modules/ossm-config-otel-kiali.adoc
+++ b/modules/ossm-config-otel-kiali.adoc
@@ -23,34 +23,26 @@ After {KialiProduct} is integrated with {DTProductName}, you can view distribute
 ----
 spec:
   external_services:
-    grafana:
-      enabled: true # <1>
-      in_cluster_url: http://grafana-istio-system.apps-crc.testing/ # <2>
-      url: http://grafana-istio-system.apps-crc.testing/
     tracing:
-      enabled: true
+      enabled: true #<1>
       provider: tempo
       use_grpc: false
       in_cluster_url: http://tempo-sample-query-frontend.tempo:3200
-      url: https://tempo-sample-query-frontend-tempo.apps-crc.testing
-      tempo_config: # <3>
-        org_id: "1"
-        datasource_uid: a8d2ef1c-d31c-4de5-a90b-e7bc5252cd00
+      url: https://tempo-sample-query-frontend-tempo.apps-crc.testing #<2>
 ----
-<1> Required so that you can see the *View in Tracing* link from the *Traces* tab.
-<2> If the Tempo resource is deployed with multiple tenants, then the `in_cluster_url` config must point to the gateway with the tenant name as part of the URL. For example: http://tempo-resource-gateway.tempo:8080/api/traces/v1/{tenantName}/tempo
-<3> Required so that you can see the *View in Tracing*  link from the *Traces* tab and redirect to the proper Tempo `datasource`.
+<1> Enable tracing.
+<2> The {ocp-short-name} route for Jaeger UI must be created in the Tempo namespace. You can either manually create it for the `tempo-sample-query-frontend` service, or update the `Tempo` custom resource with `.spec.template.queryFrontend.jaegerQuery.ingress.type: route`.
 
-. Save the updated `spec` in 'kiali_cr.yaml`.
+. Save the updated `spec` in `kiali_cr.yaml`.
 
 . Run the following command to apply the configuration:
 +
 [source, terminal]
 ----
-oc patch -n istio-system kiali kiali --type merge -p "$(cat kiali_cr.yaml)"
+$ oc patch -n istio-system kiali kiali --type merge -p "$(cat kiali_cr.yaml)"
 ----
 +
-Output:
+.Example output:
 +
 [source, terminal]
 ----
@@ -63,12 +55,16 @@ Output:
 +
 [source, terminal]
 ----
-oc get route kiali ns istio-system
+$ oc get route kiali ns istio-system
 ----
 
 . Navigate to the Kiali UI.
 
 . Navigate to *Workload* → *Traces* tab to see traces in the Kiali UI.
 
+//Notes 10/30/2024:
+//Grafana info removed for TP1. Requires further discussion for GA on the best user path, in addition to changes coming from Tempo that may or may not be ready when OSSM 3.0 GA's.
+
 //Note for later: there are things in here, like Kiali UI, that may need attributes. Attributes will be updated prior to GA.
 //Note that "Kiali UI" is not the same as "Kiali Operator provided by Red Hat", and there currently is only 1 attribute related to Kiali, and it is for "Kiali Operator provided by Red Hat".
+//

--- a/modules/ossm-config-otel.adoc
+++ b/modules/ossm-config-otel.adoc
@@ -103,17 +103,17 @@ Once you verify that you can see traces, lower the `randomSamplingPercentage` va
 +
 [source, terminal]
 ----
-oc create ns bookinfo
+$ oc create ns bookinfo
 ----
 +
 [source, terminal]
 ----
-oc label ns <namespace_name> istio.io/rev= # <1>
+$ oc label ns <namespace_name> istio.io/rev= # <1>
 ----
 +
 [source, terminal]
 ----
-oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.23/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
+$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.23/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
 ----
 <1> If you named your Istio resource `default` and are using the `InPlace` upgrade strategy, use `oc label ns bookinfo istio-injection=enabled`.
 +
@@ -123,7 +123,7 @@ To find your `<revision-name>`, run the following command:
 
 [source, terminal]
 ----
-oc get istiorevisions.sailoperator.io
+$ oc get istiorevisions.sailoperator.io
 ----
 
 .Sample output:
@@ -146,5 +146,10 @@ $ oc exec -it -n bookinfo deployments/productpage-v1 -c istio-proxy -- curl loca
 +
 [source,terminal]
 ----
-$ kubectl get routes -n tempo tempo-sample-query-frontend
+$ oc get routes -n tempo tempo-sample-query-frontend
 ----
++
+[NOTE]
+====
+The {ocp-short-name} route for Jaeger UI must be created in the Tempo namespace. You can either manually create it for the `tempo-sample-query-frontend` service, or update the `Tempo` custom resource with `.spec.template.queryFrontend.jaegerQuery.ingress.type: route`.
+====


### PR DESCRIPTION
**OSSM 3.0 TP1**

[OSSM-8318](https://issues.redhat.com//browse/OSSM-8318) Explanation of Kiali CR in TP1 doc

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology Preview.

OSSM 3.0 is moving to stand alone format is will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8318 

Link to docs preview:

Kiali preview: https://84255--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/kiali/ossm-kiali-assembly.html#ossm-config-otel-kiali_ossm-kiali-assembly

Tracing preview, go to Step 6 to see NOTE added: https://84255--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/traces/ossm-distr-tracing-assembly#ossm-config-otel_ossm-traces-assembly

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
