### PR TITLE
ROX-24197: [rhacs-docs-4.6] Update docs for RHCOS scanning with Scanner V4

### DIFF
--- a/modules/rhcos-enable-node-scan-scannerv4.adoc
+++ b/modules/rhcos-enable-node-scan-scannerv4.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
+// * cloud_service/upgrading-cloud/upgrade-cloudsvc-roxctl.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rhcos-enable-node-scan-scannerv4_{context}"]
+= Enabling {op-system} node scanning with Scanner V4
+
+[role="_abstract"]
+If you use {ocp}, you can enable scanning of {op-system-first} nodes for vulnerabilities by using {rh-rhacs-first}.
+
+:FeatureName: RHCOS node scanning with Scanner V4
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+* For scanning {op-system} node hosts of the secured cluster, you must have installed the following software:
+** Secured Cluster services on {ocp} {ocp-supported-version} or later
+** {product-title-short} version 4.6 or later
++
+For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+
+.Procedure
+
+To enable node indexing, also known as node scanning, by using Scanner V4:
+
+. In the Central pod, on the `central` container, set the `ROX_NODE_INDEX_ENABLED` variable to `true` by running the following command on the Central cluster:
++
+[source,terminal]
+----
+$ kubectl -n stackrox set env deployment/central ROX_NODE_INDEX_ENABLED=true <1>
+----
+<1> For {ocp}, use `oc` instead of `kubectl`.
+. In the Collector Daemonset, in the `compliance` container, set the `ROX_NODE_INDEX_ENABLED` variable to `true` by running the following command on the secured cluster:
++
+[source,terminal]
+----
+$ kubectl -n stackrox set env daemonset/collector ROX_NODE_INDEX_ENABLED=true <1>
+----
+<1> For {ocp}, use `oc` instead of `kubectl`.
+. To verify that node scanning is working, examine the Central logs for the following message:
++
+[source,text]
+----
+Scanned index report and found <number> components for node <node_name>.
+----
++
+where:
+
+<number>:: Specifies the number of discovered components.
+<node_name>:: Specifies the name of the node.

--- a/modules/rhcos-enable-node-scan.adoc
+++ b/modules/rhcos-enable-node-scan.adoc
@@ -4,13 +4,13 @@
 // * cloud_service/upgrading-cloud/upgrade-cloudsvc-roxctl.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rhcos-enable-node-scan_{context}"]
-= Enabling {op-system} node scanning
+= Enabling {op-system} node scanning with the StackRox Scanner
 
 [role="_abstract"]
 If you use {ocp}, you can enable scanning of {op-system-first} nodes for vulnerabilities by using {rh-rhacs-first}.
 
 .Prerequisites
-* For scanning {op-system} node hosts of the Secured cluster, you must have installed Secured cluster on {ocp} {ocp-supported-version} or later. For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+* For scanning {op-system} node hosts of the secured cluster, you must have installed Secured Cluster services on {ocp} {ocp-supported-version} or later. For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
 
 .Procedure
 . Run one of the following commands to update the compliance container.

--- a/modules/rhcos-environment-variables.adoc
+++ b/modules/rhcos-environment-variables.adoc
@@ -29,11 +29,13 @@ You can use the following environment variables to configure {op-system} node sc
 |====
 |Environment Variable|Description
 
+|ROX_NODE_INDEX_ENABLED
+|Controls whether node indexing is enabled for this cluster. The default value is `false`. Set this variable to use Scanner V4-based {op-system} node scanning.
 |ROX_NODE_SCANNING_INTERVAL
-|The base value of the interval duration between node scans. The deafult value is `4h`.
+|The base value of the interval duration between node scans. The default value is `4h`.
 
 |ROX_NODE_SCANNING_INTERVAL_DEVIATION
-|The duration of node scans may differ from the base interval time. However, the maximum value is limited by the `ROX_NODE_SCANNING_INTERVAL`.
+|The duration of node scans can differ from the base interval time. However, the maximum value is limited by the `ROX_NODE_SCANNING_INTERVAL`.
 
 |ROX_NODE_SCANNING_MAX_INITIAL_WAIT
 |The maximum wait time before the first node scan, which is randomly generated. You can set this value to `0` to disable the initial node scanning wait time. The default value is `5m`.

--- a/modules/rhcos-match-vulnerability.adoc
+++ b/modules/rhcos-match-vulnerability.adoc
@@ -9,3 +9,4 @@
 Central services, which include Central and Scanner, perform vulnerability matching. Scanner uses Red{nbsp}Hat's Open Vulnerability and Assessment Language (OVAL) v2 security data streams to match vulnerabilities on {op-system-first} software components.
 
 Unlike the earlier versions, {product-title-short} 4.0 no longer uses the Kubernetes node metadata to find the kernel and container runtime versions. Instead, it uses the installed {op-system} RPMs to assess that information.
+//changes made in https://github.com/openshift/openshift-docs/pull/83406 for 4.6

--- a/operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
+++ b/operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
@@ -7,12 +7,15 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-For {ocp}, {op-system-first} is the only supported operating system for control plane. Whereas, for node hosts, {ocp} supports both {op-system} and {op-system-base-full}.
+For {ocp}, {op-system-first} is the only supported operating system for control plane. For node hosts, {ocp} supports both {op-system} and {op-system-base-full}.
 With {rh-rhacs-first}, you can scan {op-system} nodes for vulnerabilities and detect potential security threats.
 
 {product-title-short} scans {op-system} RPMs installed on the node host, as part of the {op-system} installation, for any known vulnerabilities.
 
-First, {product-title-short} analyzes and detects {op-system} components. Then it matches vulnerabilities for identified components by using {op-system-base} and OpenShift 4.X Open Vulnerability and Assessment Language (OVAL) v2 security data streams.
+First, {product-title-short} analyzes and detects {op-system} components. Then it matches vulnerabilities for identified components by using {op-system-base} and the following data streams:
+
+* OpenShift 4.X Open Vulnerability and Assessment Language (OVAL) v2 security data streams is used if StackRox Scanner is used for node scanning.
+* Red{nbsp}Hat Common Security Advisory Framework (CSAF) Vulnerability Exploitability eXchange (VEX) is used if Scanner V4 is used for node scanning.
 
 [NOTE]
 ====
@@ -24,6 +27,8 @@ First, {product-title-short} analyzes and detects {op-system} components. Then i
 * link:https://access.redhat.com/articles/6907891[RHEL Versions Utilized by RHEL CoreOS and OCP]
 
 include::modules/rhcos-enable-node-scan.adoc[leveloffset=+1]
+
+include::modules/rhcos-enable-node-scan-scannerv4.adoc[leveloffset=+1]
 
 include::modules/rhcos-analyse-detect.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.6+

[Issue
](https://issues.redhat.com/browse/ROX-24197)

Links to docs previews:

- [Scanning RHCOS node hosts](https://84256--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-vulnerabilities/scan-rhcos-node-host.html) - added Scanner V4 node scanning module
- [84256--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/upgrading-cloud/upgrade-cloudsvc-roxctl.html](https://84256--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/upgrading-cloud/upgrade-cloudsvc-roxctl.html) - added link for Scanner v4 node scanning
- [84256--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl.html](https://84256--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl.html) - added link for Scanner V4 node scanning


QE review: **ACS has no QE, approved by SMEs**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
