### PR TITLE
OSSM-8324 docinfo.xml productnumber should say 3.0.0tp1

### DIFF
--- a/about/docinfo.xml
+++ b/about/docinfo.xml
@@ -1,6 +1,6 @@
 <title>About</title>
 <productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0</productnumber>
+<productnumber>3.0.0tp1</productnumber>
 <subtitle>About OpenShift Service Mesh</subtitle>
 <abstract>
     <para>This document provides an overview of {SMProduct} features.

--- a/install/docinfo.xml
+++ b/install/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing</title>
 <productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0</productnumber>
+<productnumber>3.0.0tp1</productnumber>
 <subtitle>Installing OpenShift Service Mesh</subtitle>
 <abstract>
     <para>This documentation provides information about installing {SMProduct} {SMProductVersion}.

--- a/observability/kiali/docinfo.xml
+++ b/observability/kiali/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Kiali Operator provided by Red Hat</title>
 <productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0</productnumber>
+<productnumber>3.0.0tp1</productnumber>
 <subtitle>Using the Kiali Operator provided by Red Hat</subtitle>
 <abstract>
     <para>This documentation provides information about Kiali Operator provided by Red Hat, and how to view the data that flows through your application.

--- a/observability/metrics/docinfo.xml
+++ b/observability/metrics/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Metrics</title>
 <productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0</productnumber>
+<productnumber>3.0.0tp1</productnumber>
 <subtitle>Using metrics with Service Mesh</subtitle>
 <abstract>
     <para>This documentation provides information about how you can monitor the in-cluster health and performance of your applications.

--- a/observability/traces/docinfo.xml
+++ b/observability/traces/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Distributed Tracing</title>
 <productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0</productnumber>
+<productnumber>3.0.0tp1</productnumber>
 <subtitle>Using distributed tracing with OpenShift Service Mesh</subtitle>
 <abstract>
     <para>This document provides an overview of distributed tracing in OpenShift Service Mesh, and how to configure distributed tracing for {SMProductShortName}.

--- a/update/docinfo.xml
+++ b/update/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Updating</title>
 <productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0</productnumber>
+<productnumber>3.0.0tp1</productnumber>
 <subtitle>Updating OpenShift Service Mesh</subtitle>
 <abstract>
     <para>This documentation provides information about how to update {SMProduct} {SMProductVersion}.


### PR DESCRIPTION
**OSSM 3.0 TP1**

Specific to Pantheon setup to publish 3.x content.

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology Preview

**Service Mesh 3.x is moving to stand alone docs and will not be cherry-picked back to OCP core."

Issue:
https://issues.redhat.com/browse/OSSM-8324

Link to docs preview:

These are docinfo.xml files for Pantheon, so there will be no preview link.

QE review:
QE is not required for this change. It is doc-specific, and specific to Pantheon.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
