### PR TITLE
[WIP] Telcodocs 1981 D/S and R/N: MGMT-16635 Better compatibility with OpenShift image settings

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -53,6 +53,9 @@ include::modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc[lev
 .Additional resources
 * link:https://fastbitlab.com/building-a-linux-kernel-module/[Building a linux kernel module]
 
+// Added for TELCODOCS-1981
+include::modules/kmm-configuring-out-of-tree-module-images.adoc[leveloffset=+2]
+
 include::modules/kmm-example-module-cr.adoc[leveloffset=+2]
 // Added for MGMT-16631
 [role="_additional-resources"]

--- a/modules/kmm-configuring-out-of-tree-module-images.adoc
+++ b/modules/kmm-configuring-out-of-tree-module-images.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kmm-configuring-out-of-tree-module-images_{context}"]
+= Configuring out-of-tree module images
+
+If you are using out-of-tree (OOT) modules, you can use the image configuration settings in OpenShift's core image configuration (`image.config.openshift.io/cluster`) to configure the modules instead of configuring each module configuration. 
+
+To configure the registry settings to allow for insecure registries for the OOT modules, use the configuration instructions in xref:../openshift_images/image-configuration.adoc#images-configuration-file_image-configuration[Configuring image registry settings].
+
+[NOTE]
+====
+The `registryTLS`, `baseImageRegistryTLS`, and `unsignedImageRegistryTLS` parameters are still used within the `Module` CR for validation purposes.
+====


### PR DESCRIPTION
[TELCODOCS-1981]: [MGMT-16635](https://issues.redhat.com//browse/MGMT-16635) Better compatibility with OpenShift image settings

Jira: https://issues.redhat.com/browse/TELCODOCS-1981

Version(s): openshift-4.17

Link to docs preview: https://84270--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-configuring-out-of-tree-module-images_kernel-module-management-operator

SME:  @pericnenad
QE review: @ggordaniRed 



