### PR TITLE
OBSDOCS-1467: Separate UWM and core platform monitoring (part 5)

### DIFF
--- a/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
+++ b/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
@@ -3,63 +3,85 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="configuring-pod-topology-spread-constraints_{context}"]
-= Configuring pod topology spread constraints
+
+// The ultimate solution DOES NOT NEED separate IDs and titles, it is just needed for now so that the tests will not break
+
+// tag::CPM[]
+[id="configuring-pod-topology-spread-constraints-cpm_{context}"]
+= Configuring pod topology spread constraints for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="configuring-pod-topology-spread-constraints-uwm_{context}"]
+= Configuring pod topology spread constraints for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:component: prometheusK8s
+:component-name: Prometheus
+:label: prometheus
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:component: thanosRuler
+:component-name: Thanos Ruler
+:label: thanos-ruler
+// end::UWM[]
 
 You can configure pod topology spread constraints for 
-ifndef::openshift-dedicated,openshift-rosa[]
+// tag::CPM[]
 all the pods deployed by the {cmo-full}
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+// end::CPM[]
+// tag::UWM[]
 all the pods for user-defined monitoring
-endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 to control how pod replicas are scheduled to nodes across zones.
 This ensures that the pods are highly available and run more efficiently, because workloads are spread across nodes in different data centers or hierarchical infrastructure zones.
 
-You can configure pod topology spread constraints for monitoring pods by using 
-ifndef::openshift-dedicated,openshift-rosa[]
-the `cluster-monitoring-config` or 
-endif::openshift-dedicated,openshift-rosa[]
-the `user-workload-monitoring-config` config map.
+You can configure pod topology spread constraints for monitoring pods by using the `{configmap-name}` config map.
 
 .Prerequisites
 
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+// end::CPM[]
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are configuring pods for core {product-title} monitoring:*
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` `ConfigMap` object.
-* *If you are configuring pods for user-defined monitoring:*
-** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
+
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
-
+// end::UWM[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-ifndef::openshift-dedicated,openshift-rosa[]
-* *To configure pod topology spread constraints for core {product-title} monitoring:*
-
-. Edit the `cluster-monitoring-config` config map in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
 . Add the following settings under the `data/config.yaml` field to configure pod topology spread constraints:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
     <component>: # <1>
@@ -82,87 +104,36 @@ Specify `ScheduleAnyway` if you want the scheduler to still schedule the pod but
 <5> Specify `labelSelector` to find matching pods. 
 Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
 +
-.Example configuration for Prometheus
-[source,yaml]
+.Example configuration for {component-name}
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
+    {component}:
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: monitoring
+# tag::CPM[]
         whenUnsatisfiable: DoNotSchedule
-        labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: prometheus
-----
-
-. Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
-
-* *To configure pod topology spread constraints for user-defined monitoring:*
-endif::openshift-dedicated,openshift-rosa[]
-
-. Edit the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-
-. Add the following settings under the `data/config.yaml` field to configure pod topology spread constraints:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    <component>: # <1>
-      topologySpreadConstraints:
-      - maxSkew: <n> # <2>
-        topologyKey: <key> # <3>
-        whenUnsatisfiable: <value> # <4>
-        labelSelector: # <5>
-          <match_option>
-----
-<1> Specify a name of the component for which you want to set up pod topology spread constraints.
-<2> Specify a numeric value for `maxSkew`, which defines the degree to which pods are allowed to be unevenly distributed.
-<3> Specify a key of node labels for `topologyKey`.
-Nodes that have a label with this key and identical values are considered to be in the same topology.
-The scheduler tries to put a balanced number of pods into each domain.
-<4> Specify a value for `whenUnsatisfiable`.
-Available options are `DoNotSchedule` and `ScheduleAnyway`.
-Specify `DoNotSchedule` if you want the `maxSkew` value to define the maximum difference allowed between the number of matching pods in the target topology and the global minimum.
-Specify `ScheduleAnyway` if you want the scheduler to still schedule the pod but to give higher priority to nodes that might reduce the skew.
-<5> Specify `labelSelector` to find matching pods. 
-Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
-+
-.Example configuration for Thanos Ruler
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    thanosRuler:
-      topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: monitoring
+# end::CPM[]
+# tag::UWM[]
         whenUnsatisfiable: ScheduleAnyway
+# end::UWM[]
         labelSelector:
           matchLabels:
-            app.kubernetes.io/name: thanos-ruler
+            app.kubernetes.io/name: {label}
 ----
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
+
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!component:
+:!component-name:
+:!label:

--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -3,22 +3,42 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="setting-log-levels-for-monitoring-components_{context}"]
-= Setting log levels for monitoring components
 
-You can configure the log level for
-ifndef::openshift-dedicated,openshift-rosa[]
-Alertmanager, Prometheus Operator, Prometheus, Thanos Querier, and Thanos Ruler.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-Alertmanager, Prometheus Operator, Prometheus, and Thanos Ruler.
-endif::openshift-dedicated,openshift-rosa[]
+// The ultimate solution DOES NOT NEED separate IDs and titles, it is just needed for now so that the tests will not break
 
-The following log levels can be applied to the relevant component in the
-ifndef::openshift-dedicated,openshift-rosa[]
-`cluster-monitoring-config` and
-endif::openshift-dedicated,openshift-rosa[]
-`user-workload-monitoring-config` `ConfigMap` objects:
+// tag::CPM[]
+[id="setting-log-levels-for-monitoring-components-cpm_{context}"]
+= Setting log levels for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="setting-log-levels-for-monitoring-components-uwm_{context}"]
+= Setting log levels for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:prometheus: prometheusK8s
+:alertmanager: alertmanagerMain
+:thanos: thanosQuerier
+:component-name: Thanos Querier
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:prometheus: prometheus
+:alertmanager: alertmanager
+:thanos: thanosRuler
+:component-name: Thanos Ruler
+// end::UWM[]
+
+You can configure the log level for Alertmanager, Prometheus Operator, Prometheus, and {component-name}.
+
+
+The following log levels can be applied to the relevant component in the `{configmap-name}` `ConfigMap` object:
 
 * `debug`. Log debug, informational, warning, and error messages.
 * `info`. Log informational, warning, and error messages.
@@ -29,103 +49,84 @@ The default log level is `info`.
 
 .Prerequisites
 
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+// end::CPM[]
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are setting a log level for Alertmanager, Prometheus Operator, Prometheus, or Thanos Querier in the `openshift-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` `ConfigMap` object.
-* *If you are setting a log level for Prometheus Operator, Prometheus, or Thanos Ruler in the `openshift-user-workload-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
+
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-. Edit the `ConfigMap` object:
-ifndef::openshift-dedicated,openshift-rosa[]
-** *To set a log level for a component in the `openshift-monitoring` project*:
-.. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-.. Add `logLevel: <log_level>` for a component under `data/config.yaml`:
+. Add `logLevel: <log_level>` for a component under `data/config.yaml`:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    <component>: <1>
-      logLevel: <log_level> <2>
+    <component>: # <1>
+      logLevel: <log_level> # <2>
 ----
 <1> The monitoring stack component for which you are setting a log level.
-For default platform monitoring, available component values are `prometheusK8s`, `alertmanagerMain`, `prometheusOperator`, and `thanosQuerier`.
+Available component values are `{prometheus}`, `{alertmanager}`, `prometheusOperator`, and `{thanos}`.
 <2> The log level to set for the component.
 The available values are `error`, `warn`, `info`, and `debug`.
 The default value is `info`.
 
-** *To set a log level for a component in the `openshift-user-workload-monitoring` project*:
-endif::openshift-dedicated,openshift-rosa[]
-
-.. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-
-.. Add `logLevel: <log_level>` for a component under `data/config.yaml`:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    <component>: <1>
-      logLevel: <log_level> <2>
-----
-<1> The monitoring stack component for which you are setting a log level.
-For user workload monitoring, available component values are `alertmanager`, `prometheus`, `prometheusOperator`, and `thanosRuler`.
-<2> The log level to apply to the component. The available values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
-
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
 
-. Confirm that the log-level has been applied by reviewing the deployment or pod configuration in the related project. The following example checks the log level in the `prometheus-operator` deployment in the `openshift-user-workload-monitoring` project:
+. Confirm that the log level has been applied by reviewing the deployment or pod configuration in the related project. 
+The following example checks the log level for the `prometheus-operator` deployment:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-user-workload-monitoring get deploy prometheus-operator -o yaml | grep "log-level"
+$ oc -n {namespace-name} get deploy prometheus-operator -o yaml | grep "log-level"
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
         - --log-level=debug
 ----
 
-. Check that the pods for the component are running. The following example lists the status of pods in the `openshift-user-workload-monitoring` project:
+. Check that the pods for the component are running. The following example lists the status of pods:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-user-workload-monitoring get pods
+$ oc -n {namespace-name} get pods
 ----
 +
 [NOTE]
 ====
 If an unrecognized `logLevel` value is included in the `ConfigMap` object, the pods for the component might not restart successfully.
 ====
+
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!prometheus:
+:!alertmanager:
+:!thanos:
+:!component-name:

--- a/modules/monitoring-setting-query-log-file-for-prometheus.adoc
+++ b/modules/monitoring-setting-query-log-file-for-prometheus.adoc
@@ -3,14 +3,35 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="setting-query-log-file-for-prometheus_{context}"]
-= Enabling the query log file for Prometheus
 
-[role="_abstract"]
+// The ultimate solution DOES NOT NEED separate IDs and titles, it is just needed for now so that the tests will not break
+
+// tag::CPM[]
+[id="setting-query-log-file-for-prometheus-cpm_{context}"]
+= Enabling the query log file for Prometheus for core platform monitoring
+// end::CPM[]
+
+// tag::UWM[]
+[id="setting-query-log-file-for-prometheus-uwm_{context}"]
+= Enabling the query log file for Prometheus for monitoring of user-defined projects
+// end::UWM[]
+
+// Set attributes to distinguish between cluster monitoring example (core platform monitoring - CPM) and user workload monitoring (UWM) examples
+
+// tag::CPM[]
+:configmap-name: cluster-monitoring-config
+:namespace-name: openshift-monitoring
+:component: prometheusK8s
+:pod: prometheus-k8s-0
+// end::CPM[]
+// tag::UWM[]
+:configmap-name: user-workload-monitoring-config
+:namespace-name: openshift-user-workload-monitoring
+:component: prometheus
+:pod: prometheus-user-workload-0
+// end::UWM[]
+
 You can configure Prometheus to write all queries that have been run by the engine to a log file.
-ifndef::openshift-dedicated,openshift-rosa[]
-You can do so for default platform monitoring and for user-defined workload monitoring.
-endif::openshift-dedicated,openshift-rosa[]
 
 [IMPORTANT]
 ====
@@ -19,61 +40,89 @@ Because log rotation is not supported, only enable this feature temporarily when
 
 .Prerequisites
 
+// tag::CPM[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+// end::CPM[]
+// tag::UWM[]
 ifndef::openshift-dedicated,openshift-rosa[]
-* *If you are enabling the query log file feature for Prometheus in the `openshift-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role.
-** You have created the `cluster-monitoring-config` `ConfigMap` object.
-* *If you are enabling the query log file feature for Prometheus in the `openshift-user-workload-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** A cluster administrator has enabled monitoring for user-defined projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
+
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
+// end::UWM[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-ifndef::openshift-dedicated,openshift-rosa[]
-** *To set the query log file for Prometheus in the `openshift-monitoring` project*:
-. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
+. Edit the `{configmap-name}` config map in the `{namespace-name}` project:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+$ oc -n {namespace-name} edit configmap {configmap-name}
 ----
+
+. Add the `queryLogFile` parameter for Prometheus under `data/config.yaml`:
 +
-. Add `queryLogFile: <path>` for `prometheusK8s` under `data/config.yaml`:
-+
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+  name: {configmap-name}
+  namespace: {namespace-name}
 data:
   config.yaml: |
-    prometheusK8s:
-      queryLogFile: <path> <1>
+    {component}:
+      queryLogFile: <path> # <1>
 ----
-<1> The full path to the file in which queries will be logged.
-+
+<1> Add the full path to the file in which queries will be logged.
+
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
+
+. Verify that the pods for the component are running. The following sample command lists the status of pods:
 +
-. Verify that the pods for the component are running. The following sample command lists the status of pods in the `openshift-monitoring` project:
+[source,terminal,subs="attributes+"]
+----
+$ oc -n {namespace-name} get pods
+----
 +
+// tag::CPM[]
+.Example output
 [source,terminal]
 ----
-$ oc -n openshift-monitoring get pods
+...
+prometheus-operator-567c9bc75c-96wkj   2/2     Running   0          62m
+prometheus-k8s-0                       6/6     Running   1          57m
+prometheus-k8s-1                       6/6     Running   1          57m
+thanos-querier-56c76d7df4-2xkpc        6/6     Running   0          57m
+thanos-querier-56c76d7df4-j5p29        6/6     Running   0          57m
+...
 ----
-+
+// end::CPM[]
+// tag::UWM[]
+.Example output
+[source,terminal]
+----
+...
+prometheus-operator-776fcbbd56-2nbfm   2/2     Running   0          132m
+prometheus-user-workload-0             5/5     Running   1          132m
+prometheus-user-workload-1             5/5     Running   1          132m
+thanos-ruler-user-workload-0           3/3     Running   0          132m
+thanos-ruler-user-workload-1           3/3     Running   0          132m
+...
+----
+// end::UWM[]
+
 . Read the query log:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-monitoring exec prometheus-k8s-0 -- cat <path>
+$ oc -n {namespace-name} exec {pod} -- cat <path>
 ----
 +
 [IMPORTANT]
@@ -81,48 +130,8 @@ $ oc -n openshift-monitoring exec prometheus-k8s-0 -- cat <path>
 Revert the setting in the config map after you have examined the logged query information.
 ====
 
-** *To set the query log file for Prometheus in the `openshift-user-workload-monitoring` project*:
-endif::openshift-dedicated,openshift-rosa[]
-. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
-----
-+
-. Add `queryLogFile: <path>` for `prometheus` under `data/config.yaml`:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
-data:
-  config.yaml: |
-    prometheus:
-      queryLogFile: <path> <1>
-----
-<1> The full path to the file in which queries will be logged.
-+
-. Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
-+
-. Verify that the pods for the component are running. The following example command lists the status of pods in the `openshift-user-workload-monitoring` project:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring get pods
-----
-+
-. Read the query log:
-+
-[source,terminal]
-----
-$ oc -n openshift-user-workload-monitoring exec prometheus-user-workload-0 -- cat <path>
-----
-+
-[IMPORTANT]
-====
-Revert the setting in the config map after you have examined the logged query information.
-====
+// Unset the source code block attributes just to be safe.
+:!configmap-name:
+:!namespace-name:
+:!component:
+:!pod:

--- a/modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc
+++ b/modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc
@@ -6,14 +6,7 @@
 [id="using-pod-topology-spread-constraints-for-monitoring_{context}"]
 = Using pod topology spread constraints for monitoring
 
-You can use pod topology spread constraints to control how
-ifndef::openshift-dedicated,openshift-rosa[]
-the monitoring pods
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-the pods for user-defined monitoring
-endif::openshift-dedicated,openshift-rosa[]
-are spread across a network topology when {product-title} pods are deployed in multiple availability zones.
+You can use pod topology spread constraints to control how the monitoring pods are spread across a network topology when {product-title} pods are deployed in multiple availability zones.
 
 Pod topology spread constraints are suitable for controlling pod scheduling within hierarchical topologies in which nodes are spread across different infrastructure levels, such as regions and zones within those regions.
 Additionally, by being able to schedule pods in different zones, you can improve network latency in certain scenarios.

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -320,13 +320,22 @@ endif::openshift-dedicated,openshift-rosa[]
 * link:https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/[Kubernetes Pod Topology Spread Constraints documentation]
 
 // Configuring pod topology spread constraints
-include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=2]
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=2,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=2,tags=**;!CPM;UWM]
 
 // Setting log levels for monitoring components
-include::modules/monitoring-setting-log-levels-for-monitoring-components.adoc[leveloffset=+1]
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-setting-log-levels-for-monitoring-components.adoc[leveloffset=+1,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-setting-log-levels-for-monitoring-components.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
 // Setting query log for Prometheus
-include::modules/monitoring-setting-query-log-file-for-prometheus.adoc[leveloffset=+1]
+// The following module should only include core platform monitoring (CPM tags)
+include::modules/monitoring-setting-query-log-file-for-prometheus.adoc[leveloffset=+1,tags=**;CPM;!UWM]
+// The following module should only include monitoring for user-defined projects (UWM tags)
+include::modules/monitoring-setting-query-log-file-for-prometheus.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s): No version for CP

Issue: [OBSDOCS-1467](https://issues.redhat.com/browse/OBSDOCS-1467)

Link to docs preview (OCP):
**You can ignore the rendering of the ROSA/OSD distributions, those will be correctly separated later.**
**Title of the chapters is also temporary to make it easy for reviewers to identify which is which**

* [Configuring pod topology spread constraints for core platform monitoring](https://84279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#configuring-pod-topology-spread-constraints-cpm_configuring-the-monitoring-stack)
* [Configuring pod topology spread constraints for monitoring of user-defined projects](https://84279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#configuring-pod-topology-spread-constraints-uwm_configuring-the-monitoring-stack)
* [ Setting log levels for core platform monitoring](https://84279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#setting-log-levels-for-monitoring-components-cpm_configuring-the-monitoring-stack)
* [Setting log levels for monitoring of user-defined projects](https://84279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#setting-log-levels-for-monitoring-components-uwm_configuring-the-monitoring-stack)
* [Enabling the query log file for Prometheus for core platform monitoring](https://84279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#setting-query-log-file-for-prometheus-cpm_configuring-the-monitoring-stack)
* [Enabling the query log file for Prometheus for monitoring of user-defined projects](https://84279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#setting-query-log-file-for-prometheus-uwm_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

**Additional information:**
This is the part 5 split of core platform monitoring (CPM) and user workload monitoring (UWM) procedures. The issue is getting merged to only `monitoring-docs-restructure`, not to `main`, therefore this change will not be visible in the documentation.

The tagging is implemented so that once this is moved to two different assemblies, we will still only have one module to maintain. This will ensure content reuse instead of duplication. It also prevents creation of multiple new modules with basically identical content.

This issue also asks for changes in ID, however, in the final product, the two procedures will be in a different assembly, therefore two IDs will not be needed (context parameter will take care of it)

You can see https://github.com/openshift/openshift-docs/pull/83431 for reference.