### PR TITLE
OBSDOCS-1464: Separate Modifying the retention time and size for Prom…

### DIFF
--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -30,31 +30,19 @@
 // end::UWM[]
 
 // The following section will be removed and made into its separate concept module.
-By default, Prometheus retains metrics data for the following durations:
-
-* *Core platform monitoring*: 15 days
-* *Monitoring for user-defined projects*: 24 hours
-
-You can modify the retention time for the Prometheus instance to change how soon the data is deleted. You can also set the maximum amount of disk space the retained metrics data uses. If the data reaches this size limit, Prometheus deletes the oldest data first until the disk space used is again below the limit.
-
-Note the following behaviors of these data retention settings:
-
-* The size-based retention policy applies to all data block directories in the `/prometheus` directory, including persistent blocks, write-ahead log (WAL) data, and m-mapped chunks.
-* Data in the `/wal` and `/head_chunks` directories counts toward the retention size limit, but Prometheus never purges data from these directories based on size- or time-based retention policies.
-Thus, if you set a retention size limit lower than the maximum size set for the `/wal` and `/head_chunks` directories, you have configured the system not to retain any data blocks in the `/prometheus` data directories.
-* The size-based retention policy is applied only when Prometheus cuts a new data block, which occurs every two hours after the WAL contains at least three hours of data.
-* If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 15 days for core platform monitoring and 24 hours for user-defined project monitoring. Retention size is not set.
-* If you define values for both `retention` and `retentionSize`, both values apply.
-If any data blocks exceed the defined retention time or the defined size limit, Prometheus purges these data blocks.
-* If you define a value for `retentionSize` and do not define `retention`, only the `retentionSize` value applies.
-* If you do not define a value for `retentionSize` and only define a value for `retention`, only the `retention` value applies.
-* If you set the `retentionSize` or `retention` value to `0`, the default settings apply. The default settings set retention time to 15 days for core platform monitoring and 24 hours for user-defined project monitoring. By default, retention size is not set.
+By default, Prometheus retains metrics data for 
+// tag::CPM[]
+15 days for core platform monitoring.
+// end::CPM[]
+// tag::UWM[]
+24 hours for monitoring for user-defined projects.
+// end::UWM[]
+You can modify the retention time for the Prometheus instance to change when the data is deleted. You can also set the maximum amount of disk space the retained metrics data uses.
 
 [NOTE]
 ====
 Data compaction occurs every two hours. Therefore, a persistent volume (PV) might fill up before compaction, potentially exceeding the `retentionSize` limit. In such cases, the `KubePersistentVolumeFillingUp` alert fires until the space on a PV is lower than the `retentionSize` limit.
 ====
-// The section above will be removed and made into its separate concept module.
 
 .Prerequisites
 

--- a/modules/monitoring-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/configuring-the-monitoring-stack.adoc
+
+:_mod-docs-content-type: CONCEPT
+
+[id="retention-time-and-size-for-prometheus-metrics-data_{context}"]
+= The retention time and size for Prometheus metrics
+
+By default, Prometheus retains metrics data for the following durations:
+
+* *Core platform monitoring*: 15 days
+* *Monitoring for user-defined projects*: 24 hours
+
+You can modify the retention time for the Prometheus instance to change how soon the data is deleted. You can also set the maximum amount of disk space the retained metrics data uses. If the data reaches this size limit, Prometheus deletes the oldest data first until the disk space used is again below the limit.
+
+Note the following behaviors of these data retention settings:
+
+* The size-based retention policy applies to all data block directories in the `/prometheus` directory, including persistent blocks, write-ahead log (WAL) data, and m-mapped chunks.
+* Data in the `/wal` and `/head_chunks` directories counts toward the retention size limit, but Prometheus never purges data from these directories based on size- or time-based retention policies.
+Thus, if you set a retention size limit lower than the maximum size set for the `/wal` and `/head_chunks` directories, you have configured the system not to retain any data blocks in the `/prometheus` data directories.
+* The size-based retention policy is applied only when Prometheus cuts a new data block, which occurs every two hours after the WAL contains at least three hours of data.
+* If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 15 days for core platform monitoring and 24 hours for user-defined project monitoring. Retention size is not set.
+* If you define values for both `retention` and `retentionSize`, both values apply.
+If any data blocks exceed the defined retention time or the defined size limit, Prometheus purges these data blocks.
+* If you define a value for `retentionSize` and do not define `retention`, only the `retentionSize` value applies.
+* If you do not define a value for `retentionSize` and only define a value for `retention`, only the `retention` value applies.
+* If you set the `retentionSize` or `retention` value to `0`, the default settings apply. The default settings set retention time to 15 days for core platform monitoring and 24 hours for user-defined project monitoring. By default, retention size is not set.
+
+[NOTE]
+====
+Data compaction occurs every two hours. Therefore, a persistent volume (PV) might fill up before compaction, potentially exceeding the `retentionSize` limit. In such cases, the `KubePersistentVolumeFillingUp` alert fires until the space on a PV is lower than the `retentionSize` limit.
+====

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -205,6 +205,10 @@ include::modules/monitoring-resizing-a-persistent-volume.adoc[leveloffset=+2,tag
 * xref:../../storage/expanding-persistent-volumes.adoc#expanding-pvc-filesystem_expanding-persistent-volumes[Expanding persistent volume claims (PVCs) with a file system]
 endif::openshift-dedicated,openshift-rosa[]
 
+// The retention time and size for Prometheus metrics data
+// This section will be moved in the future PR. Therefore, some of the repetition in the introduction for the following procedure modules does not matter for the time being
+include::modules/monitoring-retention-time-and-size-for-prometheus-metrics-data.adoc[leveloffset=+2]
+
 // Modifying the retention time and size for Prometheus metrics data
 // The following module should only include core platform monitoring (CPM tags)
 include::modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc[leveloffset=+2,tags=**;CPM;!UWM]


### PR DESCRIPTION
Version(s): No version for CP

Issue: [OBSDOCS-1464](https://issues.redhat.com/browse/OBSDOCS-1464)

Links to docs preview (OCP)
* [The retention time and size for Prometheus metrics](https://84282--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack)
* [Modifying the retention time and size for Prometheus metrics data for core platform monitoring](https://84282--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#modifying-retention-time-and-size-for-prometheus-metrics-data-cpm_configuring-the-monitoring-stack)
* [Modifying the retention time and size for Prometheus metrics data for user-defined monitoring](https://84282--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#modifying-retention-time-and-size-for-prometheus-metrics-data-uwm_configuring-the-monitoring-stack)

QE review:
- [X] QE has approved this change.

**Additional information:**
This is the part of the  issue to split of core platform monitoring (CPM) and user workload monitoring (UWM) procedures. The issue is getting merged to only `monitoring-docs-restructure`, not to `main`, therefore this change will not be visible in the documentation yet.

You can see https://github.com/openshift/openshift-docs/pull/83910#issuecomment-2443544657 for reference.