### PR TITLE
OSDOCS#44051: Removing the reference to a certificate file

### DIFF
--- a/modules/identity-provider-secret.adoc
+++ b/modules/identity-provider-secret.adoc
@@ -37,7 +37,7 @@ data:
 ----
 ====
 
-* You can define a `Secret` object containing the contents of a file, such as a certificate file, by using the following command:
+* You can define a `Secret` object containing the contents of a file by using the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-44051

Link to docs preview:

* https://84291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-github-identity-provider.html#identity-provider-creating-secret_configuring-github-identity-provider
* https://84291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-gitlab-identity-provider.html#identity-provider-creating-secret_configuring-gitlab-identity-provider
* https://84291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-google-identity-provider.html#identity-provider-creating-secret_configuring-google-identity-provider
* https://84291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-oidc-identity-provider.html#identity-provider-creating-secret_configuring-oidc-identity-provider

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
