### PR TITLE
OSDOCS#38575: Added inferFromVolume to creating VMs from container disks

### DIFF
--- a/modules/virt-creating-vm-import-cli.adoc
+++ b/modules/virt-creating-vm-import-cli.adoc
@@ -32,42 +32,7 @@ When the virtual machine (VM) is created, the data volume with the {object} is i
 
 .Procedure
 
-. If the {data-source} requires authentication, create a `Secret` manifest, specifying the credentials, and save it as a `data-source-secret.yaml` file:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: data-source-secret
-  labels:
-    app: containerized-data-importer
-type: Opaque
-data:
-  accessKeyId: "" <1>
-  secretKey:   "" <2>
-----
-<1> Specify the Base64-encoded key ID or user name.
-<2> Specify the Base64-encoded secret key or password.
-
-. Apply the `Secret` manifest by running the following command:
-+
-[source,terminal]
-----
-$ oc apply -f data-source-secret.yaml
-----
-
-. If the VM must communicate with servers that use self-signed certificates or certificates that are not signed by the system CA bundle, create a config map in the same namespace as the VM:
-+
-[source,terminal]
-----
-$ oc create configmap tls-certs <1>
-  --from-file=</path/to/file/ca.pem> <2>
-----
-<1> Specify the config map name.
-<2> Specify the path to the CA certificate.
-
-. Edit the `VirtualMachine` manifest and save it as a `vm-fedora-datavolume.yaml` file:
+. Edit the `VirtualMachine` manifest and save it as a `vm-rhel-datavolume.yaml` file:
 +
 [%collapsible]
 ====
@@ -77,73 +42,55 @@ apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   creationTimestamp: null
+  name: vm-rhel-datavolume <1>
   labels:
-    kubevirt.io/vm: vm-fedora-datavolume
-  name: vm-fedora-datavolume <1>
+    kubevirt.io/vm: vm-rhel-datavolume
 spec:
   dataVolumeTemplates:
   - metadata:
       creationTimestamp: null
-      name: fedora-dv <2>
+      name: rhel-dv <2>
     spec:
+      sourceRef:
+        kind: DataSource
+        name: rhel9
+        namespace: openshift-virtualization-os-images
       storage:
         resources:
           requests:
             storage: 10Gi <3>
-        storageClassName: <storage_class> <4>
-      source:
-ifdef::url[]
-        http:
-          url: "https://mirror.arizona.edu/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2" <5>
-endif::[]
-ifdef::container-disks[]
-        registry:
-          url: "docker://kubevirt/fedora-cloud-container-disk-demo:latest" <5>
-endif::[]
-          secretRef: data-source-secret <6>
-          certConfigMap: tls-certs <7>
-    status: {}
-  running: true
+  instancetype:
+    name: u1.small <4>
+  preference:
+    inferFromVolume: datavolumedisk1
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null
       labels:
-        kubevirt.io/vm: vm-fedora-datavolume
+        kubevirt.io/vm: vm-rhel-datavolume
     spec:
       domain:
-        devices:
-          disks:
-          - disk:
-              bus: virtio
-            name: datavolumedisk1
-        machine:
-          type: ""
-        resources:
-          requests:
-            memory: 1.5Gi
+        devices: {}
+        resources: {}
       terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
-          name: fedora-dv
+          name: rhel-dv
         name: datavolumedisk1
 status: {}
 ----
 <1> Specify the name of the VM.
 <2> Specify the name of the data volume.
 <3> Specify the size of the storage requested for the data volume.
-<4> Optional: If you do not specify a storage class, the default storage class is used.
-ifdef::url,container-disks[]
-<5> Specify the URL of the {data-source}.
-endif::[]
-<6> Optional: Specify the secret name if you created a secret for the {data-source} access credentials.
-<7> Optional: Specify a CA certificate config map.
+<4> Optional: Specify the instance type to use to control resource sizing of the VM.
 ====
 
 . Create the VM by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f vm-fedora-datavolume.yaml
+$ oc create -f vm-rhel-datavolume.yaml
 ----
 +
 The `oc create` command creates the data volume and the VM. The CDI controller creates an underlying PVC with the correct annotation and the import process begins. When the import is complete, the data volume status changes to `Succeeded`. You can start the VM.
@@ -163,7 +110,7 @@ $ oc get pods
 +
 [source,terminal]
 ----
-$ oc describe dv fedora-dv <1>
+$ oc describe dv rhel-dv <1>
 ----
 <1> Specify the data volume name that you defined in the `VirtualMachine` manifest.
 
@@ -171,7 +118,7 @@ $ oc describe dv fedora-dv <1>
 +
 [source,terminal]
 ----
-$ virtctl console vm-fedora-datavolume
+$ virtctl console vm-rhel-datavolume
 ----
 
 ifeval::["{context}" == "creating-vms-from-web-images"]


### PR DESCRIPTION
Version(s):
4.17 and later

Issue:
https://issues.redhat.com/browse/CNV-38575

Links to docs preview:

https://84294--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-container-disks.html
https://84294--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-web-images.html
https://84294--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-container-disks.html
https://84294--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-web-images.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
