### PR TITLE
restore symlink to modules

### DIFF
--- a/modules/snippets
+++ b/modules/snippets
@@ -1,0 +1,1 @@
+../snippets/


### PR DESCRIPTION
I merged a PR that apparently deleted the modules/snippets/ symlink in https://github.com/openshift/openshift-docs/pull/82199. This PR re-creates the snippets symlink to the `modules` directory. 