### PR TITLE
[OSDOCS-11350]: Adding more versioning details to HCP docs

### DIFF
--- a/hosted_control_planes/index.adoc
+++ b/hosted_control_planes/index.adoc
@@ -14,8 +14,10 @@ include::modules/hosted-control-planes-version-support.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
-* xref:../scalability_and_performance/using-node-tuning-operator.adoc#node-tuning-hosted-cluster_node-tuning-operator[Configuring node tuning in a hosted cluster]
-* xref:../scalability_and_performance/using-node-tuning-operator.adoc#advanced-node-tuning-hosted-cluster_node-tuning-operator[Advanced node tuning for hosted clusters by setting kernel boot parameters]
+* link:https://amd64.ocp.releases.ci.openshift.org/[AMD64 release images]
+* link:https://arm64.ocp.releases.ci.openshift.org/[ARM64 release images]
+* link:https://multi.ocp.releases.ci.openshift.org/[Multi-arch release images]
+//* xref:../scalability_and_performance/using-node-tuning-operator.adoc#node-tuning-hosted-cluster_node-tuning-operator[Configuring node tuning in a hosted cluster]
+//* xref:../scalability_and_performance/using-node-tuning-operator.adoc#advanced-node-tuning-hosted-cluster_node-tuning-operator[Advanced node tuning for hosted clusters by setting kernel boot parameters]
 
 include::modules/hosted-control-planes-concepts-personas.adoc[leveloffset=+1]

--- a/modules/hosted-control-planes-version-support.adoc
+++ b/modules/hosted-control-planes-version-support.adoc
@@ -8,10 +8,31 @@
 [id="hosted-control-planes-version-support_{context}"]
 = Versioning for {hcp}
 
+The {hcp} feature includes the following components, which might require independent versioning and support levels:
+
+* Management cluster
+* HyperShift Operator
+* {hcp-capital} (`hcp`) command-line interface (CLI)
+* `hypershift.openshift.io` API
+* Control Plane Operator
+
+[id="hcp-versioning-mgmt_{context}"]
+== Management cluster
+
+In management clusters for production use, you need {mce}, which is available through OperatorHub. The {mce-short} bundles a supported build of the HyperShift Operator. For your management clusters to remain supported, you must use the version of {product-title} that {mce-short} runs on. In general, a new release of {mce-short} runs on the following versions of {product-title}:
+
+* The latest General Availability version of {product-title}
+* Two versions before the latest General Availability version of {product-title}
+
+The full list of {product-title} versions that you can install through the HyperShift Operator on a management cluster depends on the version of your HyperShift Operator. However, the list always includes at least the same {product-title} version as the management cluster and two previous minor versions relative to the management cluster. For example, if the management cluster is running 4.17 and a supported version of {mce-short}, the HyperShift Operator can install 4.17, 4.16, 4.15, and 4.14 hosted clusters.
+
 With each major, minor, or patch version release of {product-title}, two components of {hcp} are released:
 
 * The HyperShift Operator
 * The `hcp` command-line interface (CLI)
+
+[id="hcp-versioning-ho_{context}"]
+== HyperShift Operator
 
 The HyperShift Operator manages the lifecycle of hosted clusters that are represented by the `HostedCluster` API resources. The HyperShift Operator is released with each {product-title} release. The HyperShift Operator creates the `supported-versions` config map in the `hypershift` namespace. The config map contains the supported hosted cluster versions.
 
@@ -31,10 +52,25 @@ You can host different versions of control planes on the same management cluster
       namespace: hypershift
 ----
 
-You can use the `hcp` CLI to create hosted clusters.
+[id="hcp-versioning-cli_{context}"]
+== {hcp} CLI
+
+You can use the `hcp` CLI to create hosted clusters. You can download the CLI from {mce-short}. When you run the `hcp version` command, the output shows the latest {product-title} that the CLI supports against your `kubeconfig` file.
+
+[id="hcp-versioning-api_{context}"]
+== hypershift.openshift.io API
 
 You can use the `hypershift.openshift.io` API resources, such as, `HostedCluster` and `NodePool`, to create and manage {product-title} clusters at scale. A `HostedCluster` resource contains the control plane and common data plane configuration. When you create a `HostedCluster` resource, you have a fully functional control plane with no attached nodes. A `NodePool` resource is a scalable set of worker nodes that is attached to a `HostedCluster` resource.
 
 The API version policy generally aligns with the policy for link:https://kubernetes.io/docs/reference/using-api/#api-versioning[Kubernetes API versioning].
 
 Updates for {hcp} involve updating the hosted cluster and the node pools. For more information, see "Updates for hosted control planes".
+
+[id="hcp-versioning-cpo_{context}"]
+== Control Plane Operator
+
+The Control Plane Operator is released as part of each {product-title} payload release image for the following architectures:
+
+* amd64
+* arm64
+* multi-arch


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11350
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://84335--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/index.html#hosted-control-planes-version-support_hcp-overview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
