### PR TITLE
[OSDOCS12516] OSD-GCP-Document specific commands that list clusters that are using WIF 

### DIFF
--- a/modules/create-wif-cluster-cli.adoc
+++ b/modules/create-wif-cluster-cli.adoc
@@ -204,3 +204,19 @@ ocm gcp update wif-config --version <version> \ <1>
 ----
 <1> Replace `<version>` with the {product-title} y-stream version you plan to update the cluster to.
 <2> Replace `<wif_name>` with the name of the WIF configuration you want to update.
+
+[id="ocm-cli-list-wif-commands_{context}"]
+== List WIF clusters
+
+To list all of your {product-title} clusters that have been deployed using the WIF authentication type, run the following command:
+
+[source,terminal]
+----
+$ ocm list clusters --parameter search="gcp.authentication.wif_config_id != ''"
+----
+To list all of your {product-title} clusters that have been deployed using a specific wif-config, run the following command:
+[source,terminal]
+----
+$ ocm list clusters --parameter search="gcp.authentication.wif_config_id = '<wif_config_id>'" <1>
+----
+<1> Replace `<wif_config_id>` with the ID of the WIF configuration to list the clusters that have been deployed using that WIF configuration.

--- a/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc
+++ b/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc
@@ -28,6 +28,7 @@ For more information regarding resource quotas and limits, see _Additional resou
 include::modules/create-wif-cluster-ocm.adoc[leveloffset=+1]
 include::modules/create-wif-cluster-cli.adoc[leveloffset=+1]
 
+
 == Additional resources
 
 * For information about {product-title} clusters using a Customer Cloud Subscription (CCS) model on {GCP}, see xref:../osd_planning/gcp-ccs.adoc#ccs-gcp-customer-requirements_gcp-ccs[Customer requirements].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.17+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://issues.redhat.com/browse/OSDOCS-12516
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
https://84336--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.html#ocm-cli-list-wif-commands_osd-creating-a-cluster-on-gcp-with-workload-identity-federation
Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
