### PR TITLE
OSSM-8331 Remove attributes from docinfo.xml files

### DIFF
--- a/about/docinfo.xml
+++ b/about/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>3.0.0tp1</productnumber>
 <subtitle>About OpenShift Service Mesh</subtitle>
 <abstract>
-    <para>This document provides an overview of {SMProduct} features.
+    <para>This document provides an overview of OpenShift Service Mesh features.
     </para>
 </abstract>
 <authorgroup>

--- a/install/docinfo.xml
+++ b/install/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>3.0.0tp1</productnumber>
 <subtitle>Installing OpenShift Service Mesh</subtitle>
 <abstract>
-    <para>This documentation provides information about installing {SMProduct} {SMProductVersion}.
+    <para>This documentation provides information about installing OpenShift Service Mesh.
     </para>
 </abstract>
 <authorgroup>

--- a/update/docinfo.xml
+++ b/update/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>3.0.0tp1</productnumber>
 <subtitle>Updating OpenShift Service Mesh</subtitle>
 <abstract>
-    <para>This documentation provides information about how to update {SMProduct} {SMProductVersion}.
+    <para>This documentation provides information about how to update OpenShift Service Mesh.
     </para>
 </abstract>
 <authorgroup>


### PR DESCRIPTION
**OSSM 3.0 TP1**

**PANTHEON SPECIFIC. There are no previews for docinfo.xml files**

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):
 
Technology Preview

OSSM 3.0 is moving to stand alone format is will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8331

Link to docs preview:

There are no doc previews for docinfo.xml files. They are behind-the-scenes files specific to Pantheon.

QE review:
QE is not required for this change. It is doc-specific to Pantheon.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
