### PR TITLE
OSDOCS-12513: Documented the 4.16.20 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3325,6 +3325,35 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.20
+[id="ocp-4-16-20_{context}"]
+=== RHSA-2024:8683 - {product-title} {product-version}.20 bug fix and security update
+
+Issued: 06 November 2024
+
+{product-title} release {product-version}.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:8683[RHSA-2024:8683] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8686[RHSA-2024:8686] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.20 --pullspecs
+----
+
+[id="ocp-4-16-20-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, an invalid or unreachable identity provider (IDP) blocked updates to {hcp}. With this release, the `ValidIDPConfiguration` condition in the `HostedCluster` object now reports any IDP errors so that these errors do not block updates to {hcp}. (link:https://issues.redhat.com/browse/OCPBUGS-43840[*OCPBUGS-43840*])
+
+* Previously, the Machine Config Operator (MCO) {vmw-short} `resolve-prepender` script used `systemd` directives that were incompatible with old bootimage versions used in {product-title} 4. With this release, nodes can scale using newer boot image versions {product-version} 4.13 or later, through manual intervention, or by updating to a release that includes this fix. (link:https://issues.redhat.com/browse/OCPBUGS-42109[*OCPBUGS-42109*])
+
+[id="ocp-4-16-20-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.16.19
 [id="ocp-4-16-19_{context}"]
 === RHSA-2024:8415 - {product-title} {product-version}.19 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12513](https://issues.redhat.com/browse/OSDOCS-12513)

Link to docs preview:
* [4.16.20](https://84345--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-20_release-notes)
