### PR TITLE
[OSDOCS-11962] what's new writeup for security groups for ROSA with HCP

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,11 +16,13 @@ toc::[]
 [id="rosa-q4-2024_{context}"]
 === Q4 2024
 
+* **Create additional security groups in {hcp-title} clusters.** Starting with ROSA CLI version 1.2.47, you can now create additional security groups using the ROSA CLI when creating {hcp-title} clusters. Note that additional security group IDs attached to the machine pool cannot be modified. To remove or add more security group IDs, replace the entire machine pool with a new one.
+
+* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
+
 * **`VolumeDetachTimeout` configuration applied to machine pools for {hcp-title}.** ROSA is applying a `VolumeDetachTimeout` configuration of 5 minutes to all machine pools. This prevents issues with node deletion when volumes fail to detach. This only applies to {hcp-title}.
 
 * **Configure machine pool disk volume for {hcp-title} clusters.** You can now configure the disk volume size for machine pools in {hcp-title} clusters. The default disk size is 300 GiB, and you can configure it from a minimum of 75 GiB to a maximum of 16,384 GiB. For more information, see xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#configuring-machine-pool-disk-volume_rosa-managing-worker-nodes[Configuring machine pool disk volume].
-
-* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 
 [id="rosa-q3-2024_{context}"]
 === Q3 2024


### PR DESCRIPTION
[OSDOCS-11962] what's new writeup for security groups for ROSA with HCP

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-11962

Link to docs preview:
https://84352--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html#rosa-q4-2024_rosa-whats-new

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
