### PR TITLE
Fix attr precedence error

### DIFF
--- a/scalability_and_performance/telco_ref_design_specs/core/telco-core-rds-overview.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/core/telco-core-rds-overview.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 :telco-core:
-[id="telco-core-ref-design-overview"]
-= {rds-caps} {product-version} reference design overview
 :context: core-ref-design-overview
 include::_attributes/common-attributes.adoc[]
+[id="telco-core-ref-design-overview"]
+= {rds-caps} {product-version} reference design overview
 
 toc::[]
 

--- a/scalability_and_performance/telco_ref_design_specs/core/telco-core-rds-use-cases.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/core/telco-core-rds-use-cases.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 :telco-core:
+include::_attributes/common-attributes.adoc[]
 [id="telco-ran-rds-overview"]
 = {rds-caps} {product-version} use model overview
 :context: ran-core-design-overview
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 :telco-core:
+include::_attributes/common-attributes.adoc[]
 [id="telco-core-ref-du-crs"]
 = {rds-caps} {product-version} reference configuration CRs
 :context: ran-core-ref-design-crs
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-design-components.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-design-components.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 :telco-core:
+include::_attributes/common-attributes.adoc[]
 [id="telco-core-ref-components"]
 = {rds-caps} reference design components
 :context: core-ref-design-components
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-du-overview.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-du-overview.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 :telco-ran:
+include::_attributes/common-attributes.adoc[]
 [id="telco-ran-du-overview"]
 = {rds-caps} use model overview
 :context: ran-ref-design-overview
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-design-spec.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-design-spec.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 :telco-ran:
+include::_attributes/common-attributes.adoc[]
 [id="telco-ran-ref-design-spec"]
 = {rds-caps} {product-version} reference design overview
 :context: ran-ref-design-spec
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 :telco-ran:
+include::_attributes/common-attributes.adoc[]
 [id="telco-ran-ref-du-components"]
 = {rds-caps} {product-version} reference design components
 :context: ran-ref-design-components
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+:telco-ran:
+include::_attributes/common-attributes.adoc[]
 [id="telco-ran-ref-du-crs"]
 = {rds-first} reference configuration CRs
-:telco-ran:
 :context: ran-ref-design-crs
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-software-artifacts.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-software-artifacts.adoc
@@ -1,11 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="telco-ran-ref-software-artifacts"]
-= Telco RAN DU reference configuration software specifications
-:context: ran-ref-design-validation
+:telco-ran:
 include::_attributes/common-attributes.adoc[]
+[id="telco-ran-ref-software-artifacts"]
+= {rds-caps} reference configuration software specifications
+:context: ran-ref-design-validation
 
 toc::[]
 
 The following information describes the telco RAN DU reference design specification (RDS) validated software versions.
 
 include::modules/ztp-telco-ran-software-versions.adoc[leveloffset=+1]
+
+:!telco-ran:


### PR DESCRIPTION
{rds-caps} attribute is not resolved for some pages in DRH build because common-attributes is not read in time.

QE review:
- [x] QE review not required.