### PR TITLE
OSDOCS-11248#port requirement clarification

### DIFF
--- a/modules/installation-special-config-chrony.adoc
+++ b/modules/installation-special-config-chrony.adoc
@@ -59,6 +59,11 @@ storage:
 <1> On control plane nodes, substitute `master` for `worker` in both of these locations.
 <2> Specify an octal value mode for the `mode` field in the machine config file. After creating the file and applying the changes, the `mode` is converted to a decimal value. You can check the YAML file with the command `oc get mc <mc-name> -o yaml`.
 <3> Specify any valid, reachable time source, such as the one provided by your DHCP server.
++
+[NOTE]
+====
+For all-machine to all-machine communication, the Network Time Protocol (NTP) on UDP is port `123`. If an external NTP time server is configured, you must open UDP port `123`.
+====
 ifndef::restricted[Alternately, you can specify any of the following NTP servers: `1.rhel.pool.ntp.org`, `2.rhel.pool.ntp.org`, or `3.rhel.pool.ntp.org`.]
 
 . Use Butane to generate a `MachineConfig` object file, `99-worker-chrony.yaml`, containing the configuration to be delivered to the nodes:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions: 
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-11248

Link to docs preview:

This draft update is reflected in these pages:  
- [Configuring chrony time service](https://84365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.html#installation-special-config-chrony_installing-restricted-networks-vsphere) (vSphere)
- [Configuring chrony time service](https://84365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#installation-special-config-chrony_installing-restricted-networks-bare-metal) (bare metal)
- [Configuring chrony time service](https://84365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-chrony_installing-customizing) (Customizing nodes)
- [Configuring chrony time service](https://84365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure.html#installation-special-config-chrony_machine-configs-configure) (Machine configuration)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
From what I understand, the Vale message isn't valid. I didn't change or add any conditionals.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
