### PR TITLE
OCPBUGS-44122: xref link not working in docs.redhat.com

### DIFF
--- a/scalability_and_performance/index.adoc
+++ b/scalability_and_performance/index.adoc
@@ -28,13 +28,13 @@ xref:../scalability_and_performance/recommended-performance-scale-practices/reco
 [discrete]
 == Telco reference design specifications
 
-xref:../scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-design-spec.adoc#[Telco RAN DU specification]
+xref:../scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-design-spec.adoc#telco-ran-architecture-overview_ran-ref-design-spec[Telco RAN DU specification]
 
-xref:../scalability_and_performance/telco_ref_design_specs/core/telco-core-rds-overview.adoc#[Telco core reference design specification]
+xref:../scalability_and_performance/telco_ref_design_specs/core/telco-core-rds-overview.adoc#telco-core-cluster-service-based-architecture-and-networking-topology_core-ref-design-overview[Telco core reference design specification]
 
 [discrete]
 == Planning, optimization, and measurement
-xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#[Planning your environment according to object maximums]
+xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#cluster-maximums-major-releases_object-limits[Planning your environment according to object maximums]
 
 xref:../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended practices for {ibm-z-title} and {ibm-linuxone-title}]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-44122
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed, this is a presentation bug that manifests on docs.redhat.com and not on docs.openshift.com. No conceptual change to the displayed docs.
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
