### PR TITLE
Oadp 4074 network settings follow up

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-performance/oadp-recommended-network-settings.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-performance/oadp-recommended-network-settings.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="oadp-recommended-network-settings.adoc"]
+[id="oadp-recommended-network-settings"]
 = {oadp-short} recommended network settings
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]


### PR DESCRIPTION
Per @kalexand-rh:  [The ".adoc" part of this ID is making the PV1 builds fail. Will you open a new PR to remove it?](https://github.com/openshift/openshift-docs/pull/84193/files#r1826272173)

Preview: [Nothing to see here. Move along.](https://84386--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-performance/oadp-recommended-network-settings.html)