### PR TITLE
CNV-13372: Add post-copy live migration information to docs.

### DIFF
--- a/modules/virt-configuring-live-migration-heavy.adoc
+++ b/modules/virt-configuring-live-migration-heavy.adoc
@@ -1,0 +1,56 @@
+
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-configuring-live-migration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-live-migration-heavy_{context}"]
+= Configure live migration for heavy workloads
+
+When migrating a VM running a heavy workload (for example, database processing) with higher memory dirty rates, you need a higher bandwidth to complete the migration.
+
+If the dirty rate is too high, the migration from one node to another does not converge. To prevent this, enable post copy mode.
+
+Post copy mode triggers if the initial pre-copy phase does not complete within the defined timeout. During post copy, the VM CPUs pause on the source host while transferring the minimum required memory pages. Then the VM CPUs activate on the destination host, and the remaining memory pages transfer into the destination node at runtime.
+
+Configure live migration for heavy workloads by updating the `HyperConverged` custom resource (CR), which is located in the `{CNVNamespace}` namespace.
+
+.Procedure
+
+. Edit the `HyperConverged` CR and add the necessary parameters for migrating heavy workloads:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+----
++
+.Example configuration file
+[source,yaml,subs="attributes+"]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: {CNVNamespace}
+spec:
+  liveMigrationConfig:
+    bandwidthPerMigration: 0Mi <1>
+    completionTimeoutPerGiB: 150 <2>
+    parallelMigrationsPerCluster: 5 <3>
+    parallelOutboundMigrationsPerNode: 1 <4>
+    progressTimeout: 150 <5>
+    allowPostCopy: true <6>
+----
+<1> Bandwidth limit of each migration, where the value is the quantity of bytes per second. The default is `0`, which is unlimited. 
+<2> The migration is canceled if it is not completed in this time, and triggers post copy mode, when post copy is enabled. This value is measured in seconds per GiB of memory. You can lower `completionTimeoutPerGiB` to trigger post copy mode earlier in the migration process, or raise the  `completionTimeoutPerGiB` to trigger post copy mode later in the migration process.
+<3> Number of migrations running in parallel in the cluster. The default is `5`. Keeping the `parallelMigrationsPerCluster` setting low is better when migrating heavy workloads.
+<4> Maximum number of outbound migrations per node. Configure a single VM per node for heavy workloads.
+<5> The migration is canceled if memory copy fails to make progress in this time. This value is measured in seconds. Increase this parameter for large memory sizes running heavy workloads.
+<6> Use post copy mode when memory dirty rates are high to ensure the migration converges. Set `allowPostCopy` to `true` to enable post copy mode.
+
+. Optional: If your main network is too busy for the migration, configure a secondary, dedicated migration network.
+
+[NOTE]
+====
+Post copy mode can impact performance during the transfer, and should not be used for critical data, or with unstable networks.
+====

--- a/modules/virt-configuring-live-migration-limits.adoc
+++ b/modules/virt-configuring-live-migration-limits.adoc
@@ -8,7 +8,7 @@
 = Configuring live migration limits and timeouts
 
 Configure live migration limits and timeouts for the cluster by updating the `HyperConverged` custom resource (CR), which is located in the
-`openshift-cnv` namespace.
+`{CNVNamespace}` namespace.
 
 .Procedure
 
@@ -34,12 +34,14 @@ spec:
     parallelMigrationsPerCluster: 5 <3>
     parallelOutboundMigrationsPerNode: 2 <4>
     progressTimeout: 150 <5>
+    allowPostCopy: false <6>
 ----
 <1> Bandwidth limit of each migration, where the value is the quantity of bytes per second. For example, a value of `2048Mi` means 2048 MiB/s. Default: `0`, which is unlimited.
 <2> The migration is canceled if it has not completed in this time, in seconds per GiB of memory. For example, a VM with 6GiB memory times out if it has not completed migration in 4800 seconds. If the `Migration Method` is `BlockMigration`, the size of the migrating disks is included in the calculation.
 <3> Number of migrations running in parallel in the cluster. Default: `5`.
 <4> Maximum number of outbound migrations per node. Default: `2`.
 <5> The migration is canceled if memory copy fails to make progress in this time, in seconds. Default: `150`.
+<6> If a VM is running a heavy workload and the memory dirty rate is too high, this can prevent the migration from one node to another from converging. To prevent this, you can enable post copy mode. By default, `allowPostCopy` is set to `false`. 
 
 [NOTE]
 ====

--- a/modules/virt-vm-migration-tuning.adoc
+++ b/modules/virt-vm-migration-tuning.adoc
@@ -1,0 +1,21 @@
+
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-about-live-migration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-vm-migration-tuning_{context}"]
+= VM migration tuning
+
+You can adjust your cluster-wide live migration settings based on the type of workload and migration scenario. This enables you to control how many VMs migrate at the same time, the network bandwidth you want to use for each migration, and how long {VirtProductName} attempts to complete the migration before canceling the process. Configure these settings in the `HyperConverged` custom resource (CR).
+
+If you are migrating multiple VMs per node at the same time, set a `bandwidthPerMigration` limit to prevent a large or busy VM from using a large portion of the node’s network bandwidth. By default, the `bandwidthPerMigration` value is `0`, which means unlimited.
+
+A large VM running a heavy workload (for example, database processing), with higher memory dirty rates, requires a higher bandwidth to complete the migration.
+
+[NOTE]
+====
+Post copy mode, when enabled, triggers if the initial pre-copy phase does not complete within the defined timeout. During post copy, the VM CPUs pause on the source host while transferring the minimum required memory pages. Then the VM CPUs activate on the destination host, and the remaining memory pages transfer into the destination node at runtime. This can impact performance during the transfer.
+
+Post copy mode should not be used for critical data, or with unstable networks.
+====

--- a/virt/live_migration/virt-about-live-migration.adoc
+++ b/virt/live_migration/virt-about-live-migration.adoc
@@ -6,7 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Live migration is the process of moving a running virtual machine (VM) to another node in the cluster without interrupting the virtual workload. By default, live migration traffic is encrypted using Transport Layer Security (TLS).
+Live migration is the process of moving a running virtual machine (VM) to another node in the cluster without interrupting the virtual workload. Live migration enables smooth transitions during cluster upgrades or any time a node needs to be drained for maintenance or configuration changes.
+
+By default, live migration traffic is encrypted using Transport Layer Security (TLS).
 
 [id="live-migration-requirements_virt-about-live-migration"]
 == Live migration requirements
@@ -30,12 +32,15 @@ The default number of migrations that can run in parallel in the cluster is 5.
 * If a VM uses a host model CPU, the nodes must support the CPU.
 * xref:../../virt/vm_networking/virt-dedicated-network-live-migration.adoc#virt-dedicated-network-live-migration[Configuring a dedicated Multus network] for live migration is highly recommended. A dedicated network minimizes the effects of network saturation on tenant workloads during migration.
 
+include::modules/virt-vm-migration-tuning.adoc[leveloffset=+1]
+
 [id="common-live-migration-tasks_virt-about-live-migration"]
 == Common live migration tasks
 
 You can perform the following live migration tasks:
 
 * xref:../../virt/live_migration/virt-configuring-live-migration.adoc#virt-configuring-live-migration[Configure live migration settings]
+* xref:../../virt/live_migration/virt-configuring-live-migration.adoc#virt-configuring-live-migration-heavy_virt-configuring-live-migration[Configure live migration for heavy workloads]
 * xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-initiating-live-migration[Initiate and cancel live migration]
 * Monitor the progress of all live migrations in the *Migration* tab of the {virtproductname} web console.
 * View VM migration metrics in the *Metrics* tab of the web console.
@@ -44,6 +49,5 @@ You can perform the following live migration tasks:
 [id="additional-resources_virt-about-live-migration"]
 == Additional resources
 * xref:../../virt/monitoring/virt-prometheus-queries.adoc#virt-live-migration-metrics_virt-prometheus-queries[Prometheus queries for live migration]
-* link:https://access.redhat.com/articles/6994974#vm-migration-tuning[VM migration tuning]
 * xref:../../virt/nodes/virt-node-maintenance.adoc#run-strategies[VM run strategies]
 * xref:../../virt/nodes/virt-node-maintenance.adoc#eviction-strategies[VM and cluster eviction strategies]

--- a/virt/live_migration/virt-configuring-live-migration.adoc
+++ b/virt/live_migration/virt-configuring-live-migration.adoc
@@ -12,6 +12,13 @@ You can configure live migration policies to apply different migration configura
 
 include::modules/virt-configuring-live-migration-limits.adoc[leveloffset=+1]
 
+include::modules/virt-configuring-live-migration-heavy.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_virt-configuring-live-migration-heavy"]
+== Additional resources
+* xref:../../virt/vm_networking/virt-dedicated-network-live-migration.adoc#virt-configuring-secondary-network-vm-live-migration_virt-dedicated-network-live-migration[Configuring a dedicated network for live migration]
+
 [id="live-migration-policies"]
 == Live migration policies
 


### PR DESCRIPTION
Version(s):
Main, 4.17, 4.18

Issue:
[CNV-13372](https://issues.redhat.com/browse/CNV-13372)

[Link to docs preview](https://84389--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-about-live-migration.html#virt-vm-migration-tuningvirt-about-live-migration)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
