### PR TITLE
update docs for rhel-compute-updating.adoc

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -20,6 +20,11 @@ You can also update your compute machines to another minor version of {product-t
 You cannot update {op-system-base} 7 compute machines to {op-system-base} 8. You must deploy new {op-system-base} 8 hosts, and the old {op-system-base} 7 hosts should be removed.
 ====
 
+[IMPORTANT]
+====
+Before upgrading, ensure that your compute machines are using machine types that are based on RHEL 9 or later. RHEL 8 machine types will cause breaking changes and possible restart failures.
+====
+
 .Prerequisites
 
 * You updated your cluster.


### PR DESCRIPTION
This PR adds important comment to the openshift upgrade docs since starting with OpenShift 4.19, RHEL 10 images will be used by default. This change impacts existing compute machines using machineType based on RHEL 8.

Action Required: Ensure that all compute machines have updated their machineType to maintain compatibility and avoid potential issues during the upgrade.

Version(s):
4.18

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->