### PR TITLE
OSDOCS-12166: adds 4.14.40 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -639,3 +639,12 @@ Issued: 23 October 2024
 {product-title} release 4.14.39 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:8237[RHBA-2024:8237] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8235[RHSA-2024:8235] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-40-dp_{context}"]
+=== RHBA-2024:8699 - {microshift-short} 4.14.40 bug fix and security update advisory
+
+Issued: 8 November 2024
+
+{product-title} release 4.14.40 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:8699[RHBA-2024:8699] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8697[RHSA-2024:8697] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-12166](https://issues.redhat.com/browse/OSDOCS-12166)

Link to docs preview:
[4-14-40-dp_release-notes](https://84391--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-40-dp_release-notes)

QE review:
- NA. stock text, no other changes.