### PR TITLE
OSDOCS-12171: adds 4.16.20 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -316,12 +316,20 @@ Issued: 24 October 2024
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
 
-
 [id="microshift-4-16-19-dp_{context}"]
 === RHBA-2024:8417 - {microshift-short} 4.16.19 bug fix and enhancement advisory
 
 Issued: 30 October 2024
 
 {product-title} release 4.16.19 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8417[RHBA-2024:8417] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8415[RHSA-2024:8415] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-20-dp_{context}"]
+=== RHBA-2024:8685 - {microshift-short} 4.16.20 bug fix and enhancement advisory
+
+Issued: 6 November 2024
+
+{product-title} release 4.16.20 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8685[RHBA-2024:8685] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8683[RHSA-2024:8683] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12171](https://issues.redhat.com/browse/OSDOCS-12171)

Link to docs preview:
[microshift-4-16-20-dp_release-notes](https://84400--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-20-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
