### PR TITLE
[OSDOCS-11832] OCM book for HCP topic map

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -206,6 +206,17 @@ Topics:
 - Name: Creating ROSA with HCP clusters with external authentication
   File: rosa-hcp-sts-creating-a-cluster-ext-auth
 ---
+Name: Red Hat OpenShift Cluster Manager
+Dir: ocm
+Distros: openshift-rosa-hcp
+Topics:
+- Name: Red Hat OpenShift Cluster Manager
+  File: ocm-overview
+#  - Name: Red Hat OpenShift Cluster Manager
+#    File: ocm-overview
+#  - Name: Using the OpenShift web console
+#    File: rosa-using-openshift-console
+---
 Name: Cluster administration
 Dir: rosa_cluster_admin
 Distros: openshift-rosa-hcp

--- a/modules/ocm-addons-tab.adoc
+++ b/modules/ocm-addons-tab.adoc
@@ -5,4 +5,9 @@
 [id="ocm-addons-tab_{context}"]
 = Add-ons tab
 
+ifdef::openshift-rosa[]
 The **Add-ons** tab displays all of the optional add-ons that can be added to the cluster. Select the desired add-on, and then select **Install** below the description for the add-on that displays.
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+The Add-ons tab is not currently supported on hosted control plane clusters.
+endif::openshift-rosa-hcp[]

--- a/modules/ocm-cluster-history-tab.adoc
+++ b/modules/ocm-cluster-history-tab.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// ocm/ocm-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ocm-cluster-history-tab_{context}"]
+= Cluster history tab
+
+The **Cluster history** tab shows every change to the cluster from creation onward for each version. You can specify date ranges for your cluster history and use filters to search based on the description of the notification, the severity of the notification, the type of notification, and which role logged it. You may download your cluster history as a JSON or CSV file.

--- a/modules/ocm-cluster-history.adoc
+++ b/modules/ocm-cluster-history.adoc
@@ -1,9 +1,0 @@
-// Module included in the following assemblies:
-//
-// ocm/ocm-overview.adoc
-
-:_mod-docs-content-type: CONCEPT
-[id="ocm-cluster-history-tab_{context}"]
-= Cluster history tab
-
-The **Cluster history** tab shows all the history of the cluster including: changes made to the cluster, descriptions of changes, severity, dates, and who made the changes. You can also download the information using the **Download history** button.

--- a/modules/ocm-machinepools-tab.adoc
+++ b/modules/ocm-machinepools-tab.adoc
@@ -5,6 +5,10 @@
 [id="ocm-machinepools-tab_{context}"]
 = Machine pools tab
 
-The **Machine pools** tab allows the cluster owner to create new machine pools, if there is enough available quota, or edit an existing machine pool.
+The **Machine pools** tab allows the cluster owner to create new machine pools if there is enough available quota, or edit an existing machine pool.
 
-Selecting the **More options** > **Scale** opens the "Edit node count" dialog. In this dialog, you can change the node count per availability zone. If autoscaling is enabled, you can also set the range for autoscaling.
+Selecting the image:kebab.png[title=Other options] > **Edit** option opens the "Edit machine pool" dialog. In this dialog, you can change the node count per availability zone, edit node labels and taints, and view any associated AWS security groups.
+
+ifdef::openshift-rosa[]
+Select the **Edit cluster autoscaling** button to specify your autoscaling strategy.
+endif::openshift-rosa[]

--- a/modules/ocm-networking-tab-concept.adoc
+++ b/modules/ocm-networking-tab-concept.adoc
@@ -5,18 +5,22 @@
 [id="ocm-networking-tab_{context}"]
 = Networking tab
 
-The **Networking** tab provides a control plane API endpoint as well as the default application router. Both the control plane API endpoint and the default application router can be made private by selecting the respective box below each of them.
+The **Networking** tab provides a control plane API endpoint as well as the default application router. Both the control plane API endpoint and the default application router can be made private by selecting the respective box below label. If applicable, you can also find your virtual private cloud (VPC) details on this tab.
 
+ifdef::openshift-rosa-hcp[]
+You can change your application ingress to private or public by selecting the **Edit application ingress** button then checking or unchecking the "Make router private" checkbox.
+endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa[]
+Select the **Edit application ingress** button to edit the existing application ingress. You can change your application ingress to private or public by checking or unchecking the "Make router private" checkbox.
+
 [IMPORTANT]
 ====
 For Security Token Service (STS) installations, these options cannot be changed. STS installations also do not allow you to change privacy nor allow you to add an additional router.
 ====
 endif::openshift-rosa[]
-
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 {cluster-manager-first} does not support the networking tab for a Google Cloud Platform (GCP), non-CCS cluster running in a Red Hat GCP project.
 ====
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]

--- a/modules/ocm-overview-tab.adoc
+++ b/modules/ocm-overview-tab.adoc
@@ -2,29 +2,45 @@
 //
 // ocm/ocm-overview.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="ocm-overview-tab_{context}"]
 = Overview tab
 
-The **Overview** tab provides information about how your cluster was configured:
+The **Overview** tab provides information about how the cluster was configured:
 
 * **Cluster ID** is the unique identification for the created cluster. This ID can be used when issuing commands to the cluster from the command line.
+* **Domain prefix** is the prefix that is used throughout the cluster. The default value is the cluster's name.
 * **Type** shows the OpenShift version that the cluster is using.
+ifndef::openshift-rosa[]
+* **Control plane type** is the architecture type of the cluster. The field only displays if the cluster uses a hosted control plane architecture.
+endif::openshift-rosa[]
 * **Region** is the server region.
-* **Provider** shows which cloud provider that the cluster was built upon.
 * **Availability** shows which type of availability zone that the cluster uses, either single or multizone.
 * **Version** is the OpenShift version that is installed on the cluster. If there is an update available, you can update from this field.
 * **Created at** shows the date and time that the cluster was created.
 * **Owner** identifies who created the cluster and has owner rights.
-* **Subscription type** shows the subscription model that was selected on creation.
-* **Infrastructure type** is the type of account that the cluster uses.
+* **Delete Protection: <status>** shows whether or not the cluster's delete protection is enabled.
+ifdef::openshift-rosa-hcp[]
+* **Status** displays the current status of the control plane and machine pools of the cluster.
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
 * **Status** displays the current status of the cluster.
+endif::openshift-rosa[]
 * **Total vCPU** shows the total available virtual CPU for this cluster.
 * **Total memory** shows the total available memory for this cluster.
-* **Load balancers**
-* **Persistent storage** displays the amount of storage that is available on this cluster.
+* **Infrastructure AWS account** displays the AWS account that is responsible for cluster creation and maintenance.
+ifdef::openshift-rosa-hcp[]
+* **Billing marketplace account** displays the AWS account that is used for billing purposes.
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
+* **Additional encryption** field shows any applicable additional encryption options.
+endif::openshift-rosa[]
 * **Nodes** shows the actual and desired nodes on the cluster. These numbers might not match due to cluster scaling.
+ifdef::openshift-rosa[]
+* **Cluster autoscaling** field shows whether or not you have enabled autoscaling on the cluster.
+* **Instance Metadata Service (IMDS)** field shows your selected instance metadata service for the cluster.
+endif::openshift-rosa[]
 * **Network** field shows the address and prefixes for network connectivity.
+* **OIDC configuration** field shows the Open ID Connect configuration for the cluster.
 * **Resource usage** section of the tab displays the resources in use with a graph.
-* **Advisor recommendations** section gives insight in relation to security, performance, availability, and stability. This section requires the use of remote health functionality. See _Using Insights to identify issues with your cluster_ in the _Additional resources_ section.
-* **Cluster history** section shows everything that has been done with the cluster including creation and when a new version is identified.
+* **Advisor recommendations** section gives insight in relation to security, performance, availability, and stability. This section requires the use of remote health functionality. See _Using Insights to identify issues with the cluster_ in the _Additional resources_ section.

--- a/modules/ocm-settings-tab.adoc
+++ b/modules/ocm-settings-tab.adoc
@@ -2,12 +2,17 @@
 //
 // ocm/ocm-overview.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="ocm-settings-tab_{context}"]
 = Settings tab
 
 The **Settings** tab provides a few options for the cluster owner:
 
+ifdef::openshift-rosa[]
 * **Monitoring**, which is enabled by default, allows for reporting done on user-defined actions. See link:https://docs.openshift.com/rosa/observability/monitoring/monitoring-overview.html#understanding-the-monitoring-stack_monitoring-overview.html[Understanding the monitoring stack].
+endif::openshift-rosa[]
 * **Update strategy** allows you to determine if the cluster automatically updates on a certain day of the week at a specified time or if all updates are scheduled manually.
+ifdef::openshift-rosa[]
 * **Node draining** sets the duration that protected workloads are respected during updates. When this duration has passed, the node is forcibly removed.
+endif::openshift-rosa[]
 * **Update status** shows the current version and if there are any updates available.

--- a/modules/ocm-support-tab.adoc
+++ b/modules/ocm-support-tab.adoc
@@ -2,6 +2,7 @@
 //
 // ocm/ocm-overview.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="ocm-support-tab_{context}"]
 = Support tab
 

--- a/ocm/ocm-overview.adoc
+++ b/ocm/ocm-overview.adoc
@@ -39,27 +39,28 @@ Selecting an active, installed cluster shows tabs associated with that cluster. 
 * Overview
 * Access control
 * Add-ons
+* Cluster history
 * Networking
-* Insights Advisor
 * Machine pools
 * Support
 * Settings
 
 include::modules/ocm-overview-tab.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using Insights to identify issues with your cluster]
+endif::openshift-rosa-hcp[]
 
 include::modules/ocm-accesscontrol-tab.adoc[leveloffset=+2]
 include::modules/ocm-addons-tab.adoc[leveloffset=+2]
-include::modules/ocm-cluster-history.adoc[leveloffset=+2]
+include::modules/ocm-cluster-history-tab.adoc[leveloffset=+2]
 include::modules/ocm-networking-tab-concept.adoc[leveloffset=+2]
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 include::modules/ocm-networking-tab-adding-ingress.adoc[leveloffset=+3]
-endif::openshift-rosa[]
-include::modules/ocm-insightsadvisor-tab.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-rosa-hcp[]
 include::modules/ocm-machinepools-tab.adoc[leveloffset=+2]
 include::modules/ocm-support-tab.adoc[leveloffset=+2]
 include::modules/ocm-settings-tab.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
`enterprise-4.17+`

Issue:
**[OSDOCS-11832](https://issues.redhat.com/browse/OSDOCS-11832)**

Link to docs preview:
* **[Red Hat OpenShift Cluster Manager](https://84429--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/ocm/ocm-overview.html)** for ROSA
* **[Red Hat OpenShift Cluster Manager](https://84429--ocpdocs-pr.netlify.app/openshift-rosa/latest/ocm/ocm-overview.html)** for ROSA (classic architecture)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Continuation of #81349 