### PR TITLE
OSDOCS-11461:support matrix module for  UDN

### DIFF
--- a/modules/nw-udn-support-matrix-primary-secondary.adoc
+++ b/modules/nw-udn-support-matrix-primary-secondary.adoc
@@ -1,0 +1,148 @@
+//module included in the following assembly:
+//
+// *networkking/multiple_networks/understanding-user-defined-networks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="support-matrix-for-udn-nad_{context}"]
+= UserDefinedNetwork and NetworkAttachmentDefinition support matrix
+
+The `UserDefinedNetwork` and `NetworkAttachmentDefinition` custom resources (CRs) provide cluster administrators and users the ability to create customizable network configurations and define their own network topologies, ensure network isolation, manage IP addressing for workloads, and configure advanced network features. A third CR, `ClusterUserDefinedNetwork`, is also available, which allows administrators the ability to create and define additional networks spanning multiple namespaces at the cluster level. 
+
+User-defined networks and network attachment definitions can serve as both the primary and secondary network interface, and each support `layer2` and `layer3` topologies; a third network topology, Localnet, is also supported with network attachment definitions with secondary networks. 
+
+[NOTE]
+====
+As of {product-title} 4.18, the Localnet topology is unavailable for use with the `UserDefinedNetwork` and `ClusterUserDefinedNetwork` CRs. It is only available for `NetworkAttachmentDefinition` CRs that leverage secondary networks.
+====
+
+The following section highlights the supported features of the `UserDefinedNetwork` and `NetworkAttachmentDefinition` CRs when they are used as either the primary or secondary network. A separate table for the `ClusterUserDefinedNetwork` CR is also included. 
+ 
+.Primary network support matrix for `UserDefinedNetwork` and `NetworkAttachmentDefinition` CRs
+[cols="1a,1a,1a, options="header"]
+|===
+^| Network feature ^| Layer2 topology ^|Layer3 topology
+
+^| east-west traffic
+^| &#10003;
+^| &#10003;
+
+^| north-south traffic
+^| &#10003;
+^| &#10003;
+
+^| Persistent IPs
+^| &#10003;
+^| X
+
+^| Services
+^| &#10003;
+^| &#10003;
+
+^| `EgressIP` resource
+^| &#10003;
+^| &#10003;
+
+^| Multicast ^[1]^
+^| X
+^| &#10003;
+
+^| `NetworkPolicy` resource ^[2]^
+^| &#10003;
+^| &#10003;
+
+^| `MultinetworkPolicy` resource 
+^| X
+^| X
+
+|===
+1. Multicast must be enabled in the namespace, and it is only available between OVN-Kubernetes network pods. For more information about multicast, see "Enabling multicast for a project".
+2. When creating a `UserDefinedNetwork` CR with a primary network type, network policies must be created _after_ the `UserDefinedNetwork` CR.
+
+.Secondary network support matrix for `UserDefinedNetwork` and `NetworkAttachmentDefinition` CRs
+[cols="1a,1a,1a,1a, options="header"]
+|===
+^| Network feature ^| Layer2 topology ^|Layer3 topology ^|Localnet topology ^[1]^
+
+^| east-west traffic
+^| &#10003;
+^| &#10003;
+^| &#10003; (`NetworkAttachmentDefinition` CR only)
+
+^| north-south traffic
+^| X
+^| X
+^| &#10003;
+
+^| Persistent IPs
+^| &#10003;
+^| X
+^| &#10003; (`NetworkAttachmentDefinition` CR only)
+
+^| Services
+^| X
+^| X
+^| X
+
+^| `EgressIP` resource
+^| X
+^| X
+^| X
+
+^| Multicast
+^| X
+^| X
+^| X
+
+^| `NetworkPolicy` resource
+^| X
+^| X
+^| X
+
+^| `MultinetworkPolicy` resource
+^| &#10003;
+^| &#10003;
+^| &#10003; (`NetworkAttachmentDefinition` CR only)
+
+|===
+1. The Localnet topology is unavailable for use with the `UserDefinedNetwork` CR. It is only supported on secondary networks for `NetworkAttachmentDefinition` CRs.
+
+.Support matrix for `ClusterUserDefinedNetwork` CRs
+[cols="1a,1a,1a, options="header"]
+|===
+^| Network feature ^| Layer2 topology ^|Layer3 topology
+
+^| east-west traffic
+^| &#10003;
+^| &#10003;
+
+^| north-south traffic
+^| &#10003;
+^| &#10003;
+
+^| Persistent IPs
+^| &#10003;
+^| X
+
+^| Services
+^| &#10003;
+^| &#10003;
+
+^| `EgressIP` resource
+^| &#10003;
+^| &#10003;
+
+^| Multicast ^[1]^
+^| X
+^| &#10003;
+
+^| `MultinetworkPolicy` resource
+^| X
+^| X
+
+^| `NetworkPolicy` resource ^[2]^
+^| &#10003;
+^| &#10003;
+
+|===
+1. Multicast must be enabled in the namespace, and it is only available between OVN-Kubernetes network pods. For more information, see "About multicast".
+2. When creating a `ClusterUserDefinedNetwork` CR with a primary network type, network policies must be created _after_ the `UserDefinedNetwork` CR.

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -67,4 +67,10 @@ networks in your cluster:
 
 * *TAP*: xref:../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc#nw-multus-tap-object_configuring-additional-network-cni[Configure a TAP-based additional network] to create a tap device inside the container namespace. A TAP device enables user space programs to send and receive network packets.
 
-* *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configure an SR-IOV based additional network] to allow pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.
+ * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configure an SR-IOV based additional network] to allow pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.
+
+include::modules/nw-udn-support-matrix-primary-secondary.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]


### PR DESCRIPTION
This PR is based on Joe's at https://github.com/openshift/openshift-docs/pull/81484. 

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-11461

Link to docs preview:
https://84432--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html#support-matrix-for-primary-secondary-networks_understanding-multiple-networks

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
