### PR TITLE
OSDOCS-40768: Clarifying CSI driver type - take 2

### DIFF
--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -17,7 +17,7 @@ You reserve a LUN through the SCSI persistent reserve options. To enable the res
 
 You can set an error policy for each LUN disk. The error policy controls how the hypervisor behaves when an input/output error occurs on a disk Read or Write. The default behavior stops the guest and generates a Kubernetes event.
 
-For a LUN disk with an iSCSi connection and a persistent reservation, as required for Windows Failover Clustering for shared volumes, you set the error policy to `report`.
+For a LUN disk with an SCSi connection and a persistent reservation, as required for Windows Failover Clustering for shared volumes, you set the error policy to `report`.
 
 .Prerequisites
 
@@ -27,7 +27,7 @@ For a LUN disk with an iSCSi connection and a persistent reservation, as require
 +
 If the VMs that are sharing disks are running on the same node, `ReadWriteOnce` (RWO) volume access mode is sufficient.
 
-* The storage provider must support a Container Storage Interface (CSI) driver that uses the SCSI protocol.
+* The storage provider must support a Container Storage Interface (CSI) driver that uses Fibre Channel (FC), Fibre Channel over Ethernet (FCoE), or iSCSI storage protocols.
 
 * If you are a cluster administrator and intend to configure disk sharing by using LUN, you must enable the cluster's feature gate on the `HyperConverged` custom resource (CR).
 

--- a/modules/virt-enabling-persistentreservation-feature-gate.adoc
+++ b/modules/virt-enabling-persistentreservation-feature-gate.adoc
@@ -14,4 +14,4 @@ The `persistentReservation` feature gate is disabled by default. You can enable 
 
 * Cluster administrator privileges are required.
 * The volume access mode `ReadWriteMany` (RWX) is required if the VMs that are sharing disks are running on different nodes. If the VMs that are sharing disks are running on the same node, the `ReadWriteOnce` (RWO) volume access mode is sufficient.
-* The storage provider must support a Container Storage Interface (CSI) driver that uses the SCSI protocol.
+* The storage provider must support a Container Storage Interface (CSI) driver that uses Fibre Channel (FC), Fibre Channel over Ethernet (FCoE), or iSCSI storage protocols.


### PR DESCRIPTION
Version(s):
4.15 and later

Issue:
https://issues.redhat.com/browse/CNV-40768

Link to docs preview:
TBA

QE review:
- [x] QE has approved this change.

Additional information:
This is a second attempt at merging the changes, after https://github.com/openshift/openshift-docs/pull/78005 went haywire
