### PR TITLE
TELCODOCS-2037 - Add Dynamic ASN

### DIFF
--- a/modules/nw-metallb-bgppeer-cr.adoc
+++ b/modules/nw-metallb-bgppeer-cr.adoc
@@ -26,14 +26,21 @@ The fields for the BGP peer custom resource are described in the following table
 
 |`spec.myASN`
 |`integer`
-|Specifies the Autonomous System number for the local end of the BGP session.
-Specify the same value in all BGP peer custom resources that you add.
+|Specifies the Autonomous System Number (ASN) for the local end of the BGP session.
+In all BGP peer custom resources that you add, specify the same value .
 The range is `0` to `4294967295`.
 
 |`spec.peerASN`
 |`integer`
-|Specifies the Autonomous System number for the remote end of the BGP session.
-The range is `0` to `4294967295`.
+|Specifies the ASN for the remote end of the BGP session.
+The range is `0` to `4294967295`. 
+If you use this field, you cannot specify a value in the `spec.dynamicASN` field.
+
+|`spec.dynamicASN`
+|`string`
+| Detects the ASN to use for the remote end of the session without explicitly setting it.
+Specify `internal` for a peer with the same ASN, or `external` for a peer with a different ASN.
+If you use this field, you cannot specify a value in the `spec.peerASN` field.
 
 |`spec.peerAddress`
 |`string`

--- a/modules/nw-metallb-frr-k8s-configuration-crd.adoc
+++ b/modules/nw-metallb-frr-k8s-configuration-crd.adoc
@@ -224,7 +224,7 @@ The fields for the `FRRConfiguration` custom resource are described in the follo
 
 |`spec.bgp.routers.asn`
 |`integer`
-|The autonomous system number to use for the local end of the session.
+|The Autonomous System Number (ASN) to use for the local end of the session.
 
 |`spec.bgp.routers.id`
 |`string`
@@ -240,7 +240,14 @@ The fields for the `FRRConfiguration` custom resource are described in the follo
 
 |`spec.bgp.routers.neighbors.asn`
 |`integer`
-|Specifies the autonomous system number to use for the local end of the session.
+|Specifies the ASN to use for the remote end of the session.
+If you use this field, you cannot specify a value in the `spec.bgp.routers.neighbors.dynamicASN` field.
+
+|`spec.bgp.routers.neighbors.dynamicASN`
+|`string`
+|Detects the ASN to use for the remote end of the session without explicitly setting it.
+Specify `internal` for a neighbor with the same ASN, or `external` for a neighbor with a different ASN. 
+If you use this field, you cannot specify a value in the `spec.bgp.routers.neighbors.asn` field.
 
 |`spec.bgp.routers.neighbors.address`
 |`string`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[TELCODOCS-2037](https://issues.redhat.com//browse/TELCODOCS-2037) - [CNF-13767](https://issues.redhat.com//browse/CNF-13767) - MetalLB: BGP Dynamic AS Number
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2037
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [Configuring the FRRConfiguration CRD](https://84440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-frr-k8s.html#nw-metallb-frrconfiguration-crd_configure-metallb-frr-k8s)
- [About the BGP peer custom resource](https://84440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-bgppeer-cr_configure-metallb-bgp-peers)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
