### PR TITLE
CNV#50724: TP notice fix for descheduler

### DIFF
--- a/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
@@ -10,8 +10,6 @@ toc::[]
 
 You can use the descheduler to evict pods so that the pods can be rescheduled onto more appropriate nodes. If the pod is a virtual machine, the pod eviction causes the virtual machine to be live migrated to another node.
 
-include::snippets/technology-preview.adoc[]
-
 include::modules/nodes-descheduler-profiles.adoc[leveloffset=+1]
 
 include::modules/nodes-descheduler-installing.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/CNV-50724

Link to docs preview:
https://84448--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
