### PR TITLE
OSOCS-12556: fixes duplicate parameter entry

### DIFF
--- a/modules/microshift-disconnected-host-procedure.adoc
+++ b/modules/microshift-disconnected-host-procedure.adoc
@@ -72,7 +72,7 @@ $ echo "$IP $NAME" | sudo tee -a /etc/hosts >/dev/null
 ----
 sudo tee /etc/microshift/config.yaml > /dev/null <<EOF
 node:
-  hostnameOverride: hostnameOverride: $(echo $NAME)
+  hostnameOverride: $(echo $NAME)
   nodeIP: $(echo $IP)
 EOF
 ----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-12556](https://issues.redhat.com/browse/OSDOCS-12556)

Link to docs preview:
[Configuring the networking settings for fully disconnected hosts, step 5](https://84449--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-disconnected-network-config.html#microshift-disconnected-host-network-config_microshift-networking-disconnected-hosts)

QE review:
- N/A typo fix only

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
