### PR TITLE
[enterprise-4.16] OSDOCS-40768: Clarifying CSI driver type - take 2 - 4.16

### DIFF
--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -27,7 +27,7 @@ For a LUN disk with an iSCSi connection and a persistent reservation, as require
 +
 If the VMs that are sharing disks are running on the same node, `ReadWriteOnce` (RWO) volume access mode is sufficient.
 
-* The storage provider must support a Container Storage Interface (CSI) driver that uses the SCSI protocol.
+* The storage provider must support a Container Storage Interface (CSI) driver that uses Fibre Channel (FC), Fibre Channel over Ethernet (FCoE), or iSCSI storage protocols.
 
 * If you are a cluster administrator and intend to configure disk sharing by using LUN, you must enable the cluster's feature gate on the `HyperConverged` custom resource (CR).
 

--- a/modules/virt-enabling-persistentreservation-feature-gate.adoc
+++ b/modules/virt-enabling-persistentreservation-feature-gate.adoc
@@ -14,4 +14,4 @@ The `persistentReservation` feature gate is disabled by default. You can enable 
 
 * Cluster administrator privileges are required.
 * The volume access mode `ReadWriteMany` (RWX) is required if the VMs that are sharing disks are running on different nodes. If the VMs that are sharing disks are running on the same node, the `ReadWriteOnce` (RWO) volume access mode is sufficient.
-* The storage provider must support a Container Storage Interface (CSI) driver that uses the SCSI protocol.
+* The storage provider must support a Container Storage Interface (CSI) driver that uses Fibre Channel (FC), Fibre Channel over Ethernet (FCoE), or iSCSI storage protocols.


### PR DESCRIPTION

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/CNV-40768

Link to docs preview:
TBA

QE review:
- [x] QE has approved this change.


Additional information:
This is a manual cherry-pick PR for https://github.com/openshift/openshift-docs/pull/84439