### PR TITLE
RHDEVDOCS#6145: Replaced specific task name and namespace name with placeholders for clarity

### DIFF
--- a/modules/op-tkn-task-run.adoc
+++ b/modules/op-tkn-task-run.adoc
@@ -1,6 +1,8 @@
 // This module is included in the following assemblies:
+//
 // * tkn_cli/op-tkn-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="op-tkn-task-run_{context}"]
 = Task run commands
 
@@ -16,35 +18,35 @@ $ tkn taskrun -h
 == taskrun cancel
 Cancel a task run.
 
-.Example: Cancel the `mytaskrun` task run from a namespace
+.Example: Cancel a task run from a namespace
 [source,terminal]
 ----
-$ tkn taskrun cancel mytaskrun -n myspace
+$ tkn taskrun cancel <task_run_name> -n <namespace_name>
 ----
 
 == taskrun delete
 Delete a TaskRun.
 
-.Example: Delete the `mytaskrun1` and `mytaskrun2` task runs from a namespace
+.Example: Delete task runs from a namespace
 [source,terminal]
-----
-$ tkn taskrun delete mytaskrun1 mytaskrun2 -n myspace
+---- 
+$ tkn taskrun delete <task_run_name_1> <task_run_name_2> -n <namespace_name>
 ----
 
 .Example: Delete all but the five most recently executed task runs from a namespace
 [source,terminal]
 ----
-$ tkn taskrun delete -n myspace --keep 5 <1>
+$ tkn taskrun delete -n <namespace_name> --keep 5 <1>
 ----
 <1> Replace `5` with the number of most recently executed task runs you want to retain.
 
 == taskrun describe
 Describe a task run.
 
-.Example: Describe the `mytaskrun` task run in a namespace
+.Example: Describe a task run in a namespace
 [source,terminal]
 ----
-$ tkn taskrun describe mytaskrun -n myspace
+$ tkn taskrun describe <task_run_name> -n <namespace_name>
 ----
 
 == taskrun list
@@ -53,16 +55,16 @@ List task runs.
 .Example: List all the task runs in a namespace
 [source,terminal]
 ----
-$ tkn taskrun list -n myspace
+$ tkn taskrun list -n <namespace_name>
 ----
 
 
 == taskrun logs
 Display task run logs.
 
-.Example: Display live logs for the `mytaskrun` task run in a namespace
+.Example: Display live logs for a task run in a namespace
 
 [source,terminal]
 ----
-$ tkn taskrun logs -f mytaskrun -n myspace
+$ tkn taskrun logs -f <task_run_name> -n <namespace_name>
 ----


### PR DESCRIPTION
This PR replaces specific task names and namespace names with placeholders in the Task run commands for improved clarity

No new information is added. Therefore, no QE review is necessary.

Version(s) for Cherry-Picking:
- pipelines-docs-1.14
- pipelines-docs-1.15
- pipelines-docs-1.16

Issue:
- [RHDEVDOCS-6145](https://issues.redhat.com/browse/RHDEVDOCS-6145)

Link to Documentation Preview:
- [Task run Command Documentation Preview](https://github.com/kalyaniverma/openshift-docs/blob/patch-1/modules/op-tkn-task-run.adoc)

QE Review: Completed by @ppitonak 
- [x] Not required (no changes impacting functionality)