### PR TITLE
Use case for self signed ca cert

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3422,6 +3422,8 @@ Topics:
       File: oadp-usecase-backup-using-odf
     - Name: Restoring a backup to a different namespace
       File: oadp-usecase-restore-different-namespace
+    - Name: Including a self-signed CA certificate during backup
+      File: oadp-usecase-enable-ca-cert
   - Name: Installing and configuring OADP
     Dir: installing
     Topics:

--- a/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-usecase-enable-ca-cert.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-usecase-enable-ca-cert.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="oadp-use-case-enable-ca-cert"]
+= Including a self-signed CA certificate during backup
+include::_attributes/common-attributes.adoc[]
+:context: oadp-use-case-enable-ca-cert
+
+toc::[]
+
+You can include a self-signed Certificate Authority (CA) certificate in the Data Protection Application (DPA) and then back up an application. You store the backup in a NooBaa bucket provided by {odf-first}.
+
+// include a CA cert and run a backup
+include::modules/oadp-usecase-include-ca-cert-backup.adoc[leveloffset=+1]

--- a/modules/oadp-usecase-include-ca-cert-backup.adoc
+++ b/modules/oadp-usecase-include-ca-cert-backup.adoc
@@ -1,0 +1,276 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-usecase-enable-ca-cert.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-usecase-include-ca-cert-backup_{context}"]
+= Backing up an application and its self-signed CA certificate
+
+The `s3.openshift-storage.svc` service, provided by {odf-short}, uses a Transport Layer Security protocol (TLS) certificate that is signed with the self-signed service CA. 
+
+To prevent a `certificate signed by unknown authority` error, you must include a self-signed CA certificate in the backup storage location (BSL) section of `DataProtectionApplication` custom resource (CR). For this situation, you must complete the following tasks:
+
+* Request a NooBaa bucket by creating an object bucket claim (OBC).
+* Extract the bucket details.
+* Include a self-signed CA certificate in the `DataProtectionApplication` CR.
+* Back up an application.
+
+
+.Prerequisites
+
+* You installed the {oadp-short} Operator.
+* You installed the {odf-short} Operator.
+* You have an application with a database running in a separate namespace.
+
+.Procedure
+
+. Create an OBC manifest to request a NooBaa bucket as shown in the following example:
++
+.Example `ObjectBucketClaim` CR
+[source,yaml]
+----
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: test-obc # <1>
+  namespace: openshift-adp
+spec:
+  storageClassName: openshift-storage.noobaa.io
+  generateBucketName: test-backup-bucket # <2>
+----
+<1> Specifies the name of the object bucket claim.
+<2> Specifies the name of the bucket.
+
+. Create the OBC by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <obc_file_name>
+----
+
+. When you create an OBC, {odf-short} creates a `secret` and a `ConfigMap` with the same name as the object bucket claim. The `secret` object contains the bucket credentials, and the `ConfigMap` object contains information to access the bucket. To get the bucket name and bucket host from the generated config map, run the following command:
++
+[source,terminal]
+----
+$ oc extract --to=- cm/test-obc # <1>
+----
+<1> The name of the OBC is `test-obc`.
++
+.Example output
+[source,terminal]
+----
+# BUCKET_NAME
+backup-c20...41fd
+# BUCKET_PORT
+443
+# BUCKET_REGION
+
+# BUCKET_SUBREGION
+
+# BUCKET_HOST
+s3.openshift-storage.svc
+----
+
+. To get the bucket credentials from the `secret` object , run the following command:
++
+[source,terminal]
+----
+$ oc extract --to=- secret/test-obc 
+----
++
+.Example output
+[source,terminal]
+----
+# AWS_ACCESS_KEY_ID
+ebYR....xLNMc
+# AWS_SECRET_ACCESS_KEY
+YXf...+NaCkdyC3QPym
+----
+
+. Create a `cloud-credentials` file with the object bucket credentials by using the following example configuration:
++
+[source,terminal]
+----
+[default]
+aws_access_key_id=<AWS_ACCESS_KEY_ID> 
+aws_secret_access_key=<AWS_SECRET_ACCESS_KEY> 
+----
+
+. Create the `cloud-credentials` secret with the `cloud-credentials` file content by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic \
+  cloud-credentials \
+  -n openshift-adp \
+  --from-file cloud=cloud-credentials
+----
+
+. Extract the service CA certificate from the `openshift-service-ca.crt` config map by running the following command. Ensure that you encode the certificate in `Base64` format and note the value to use in the next step.
++
+[source,terminal]
+----
+$ oc get cm/openshift-service-ca.crt \
+  -o jsonpath='{.data.service-ca\.crt}' | base64 -w0; echo
+----
++
+.Example output
++
+[source,terminal]
+----
+LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0...
+....gpwOHMwaG9CRmk5a3....FLS0tLS0K
+----
+
+. Configure the `DataProtectionApplication` CR manifest file with the bucket name and CA certificate as shown in the following example:
++
+.Example `DataProtectionApplication` CR
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: oadp-backup
+  namespace: openshift-adp
+spec:
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+    velero:
+      defaultPlugins:
+        - aws
+        - openshift
+        - csi
+      defaultSnapshotMoveData: true 
+  backupLocations:
+    - velero:
+        config:
+          profile: "default"
+          region: noobaa
+          s3Url: https://s3.openshift-storage.svc 
+          s3ForcePathStyle: "true" 
+          insecureSkipTLSVerify: "false" # <1>
+        provider: aws
+        default: true
+        credential:
+          key: cloud
+          name:  cloud-credentials 
+        objectStorage:
+          bucket: <bucket_name> # <2>
+          prefix: oadp
+          caCert: <ca_cert> # <3>
+----
+<1> The `insecureSkipTLSVerify` flag can be set to either `true` or `false`. If set to "true", SSL/TLS security is disabled. If set to `false`, SSL/TLS security is enabled.
+<2> Specify the name of the bucket extracted in an earlier step.
+<3> Copy and paste the `Base64` encoded certificate from the previous step.
+
+. Create the `DataProtectionApplication` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <dpa_filename> 
+----
+
+. Verify that the `DataProtectionApplication` CR is created successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get dpa -o yaml
+----
++
+.Example output
++
+[source,yaml]
+----
+apiVersion: v1
+items:
+- apiVersion: oadp.openshift.io/v1alpha1
+  kind: DataProtectionApplication
+  metadata:
+    namespace: openshift-adp
+    #...#
+  spec:
+    backupLocations:
+    - velero:
+        config:
+          #...#
+  status:
+    conditions:
+    - lastTransitionTime: "20....9:54:02Z"
+      message: Reconcile complete
+      reason: Complete
+      status: "True"
+      type: Reconciled
+kind: List
+metadata:
+  resourceVersion: ""
+----
+
+. Verify that the backup storage location (BSL) is available by running the following command:
++
+[source,terminal]
+----
+$ oc get bsl -n openshift-adp 
+----
++
+.Example output
+[source,terminal]
+----
+NAME           PHASE       LAST VALIDATED   AGE   DEFAULT
+dpa-sample-1   Available   3s               15s   true
+----
+
+. Configure the `Backup` CR by using the following example:
++
+.Example `Backup` CR
+[source,yaml]
+----
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: test-backup
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - <application_namespace> # <1>
+----
+<1> Specify the namespace for the application to back up.
+
+. Create the `Backup` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <backup_cr_filename> 
+----
+
+.Verification
+
+* Verify that the `Backup` object is in the `Completed` phase by running the following command:
++
+[source,terminal]
+----
+$ oc describe backup test-backup -n openshift-adp 
+----
++
+.Example output
+[source,terminal]
+----
+Name:         test-backup
+Namespace:    openshift-adp
+# ....#
+Status:
+  Backup Item Operations Attempted:  1
+  Backup Item Operations Completed:  1
+  Completion Timestamp:              2024-09-25T10:17:01Z
+  Expiration:                        2024-10-25T10:16:31Z
+  Format Version:                    1.1.0
+  Hook Status:
+  Phase:  Completed
+  Progress:
+    Items Backed Up:  34
+    Total Items:      34
+  Start Timestamp:    2024-09-25T10:16:31Z
+  Version:            1
+Events:               <none>
+----


### PR DESCRIPTION
## Jira 

* [OADP-4918](https://issues.redhat.com/browse/OADP-4918)

Added a use case enabling a self-signed CA cert

##  Version

* OCP 4.13 → OCP 4.18

## Preview

* [Self-signed CA cert use case](https://84466--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-usecase-enable-ca-cert.html)

## QE Review

* [x] QE has approved this change.

