### PR TITLE
RHDEVDOCS-6252: Remove deprecated tls_hostname_override parameter fro…

### DIFF
--- a/modules/op-installing-results.adoc
+++ b/modules/op-installing-results.adoc
@@ -36,7 +36,6 @@ To install {tekton-results}, you must provide the required resources and then cr
     logs_type: File
     logs_buffer_size: 32768
     auth_disable: true
-    tls_hostname_override: tekton-results-api-service.openshift-pipelines.svc.cluster.local
     db_enable_auto_migration: true
     server_port: 8080
     prometheus_port: 9090


### PR DESCRIPTION
Version(s): `pipelines-docs-1.15`, `pipelines-docs-1.16`

Issue: [RHDEVDOCS-6252](https://issues.redhat.com/browse/RHDEVDOCS-6252)

Link to docs preview: https://84477--ocpdocs-pr.netlify.app/openshift-pipelines/latest/records/using-tekton-results-for-openshift-pipelines-observability.html#installing-results_using-tekton-results-for-openshift-pipelines-observability

QE review:
- [x] QE has approved this change.

**Additional information:**
