### PR TITLE
tls_hostname_override deprecation added to the 1.15 Release Notes

### DIFF
--- a/modules/op-release-notes-1-15.adoc
+++ b/modules/op-release-notes-1-15.adoc
@@ -344,6 +344,8 @@ Use the alternate parameter specs only if you need to use the additional setting
 
 * With this update, you can no longer use the `jaeger` exporter for OpenTelemetry tracing. You can use the `oltptraceexporter` for tracing.
 
+* With this update the `tls_hostname_override` option is deprecated and can no longer be used with the {tekton-results} deployment.
+
 [id="known-issues-1-15_{context}"]
 == Known issues
 


### PR DESCRIPTION
Version(s) for cherry-picking: none

Issue: [RHDEVDOCS-6252](https://issues.redhat.com/browse/RHDEVDOCS-6252)

Link to docs preview: https://84478--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/op-release-notes.html#breaking-changes-1-15_op-release-notes

QE review:
- [X] QE has approved this change.

Other reviews:
* @khrm 
* @zakisk
* @navyatatineni

**Additional information:** This addition requires change manegement