### PR TITLE
OSDOCS-12552 Wrong SLA link in Service Definition 

### DIFF
--- a/modules/rosa-sdpolicy-am-support.adoc
+++ b/modules/rosa-sdpolicy-am-support.adoc
@@ -8,6 +8,6 @@
 
 {product-title} includes Red{nbsp}Hat Premium Support, which can be accessed by using the link:https://access.redhat.com/support?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[Red{nbsp}Hat Customer Portal].
 
-See {product-title} link:https://access.redhat.com/support/offerings/openshift/sla?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[SLAs] for support response times.
+See the Red{nbsp}Hat link:https://access.redhat.com/support/offerings/production/sla[Production Support Terms of Service] for support response times.
 
 AWS support is subject to a customer's existing support contract with AWS.


### PR DESCRIPTION
Fixed inaccurate link in the Support section of the service def pionting to SLA. 

Version(s):
4.17+
Issue:
https://issues.redhat.com/browse/OSDOCS-12552

Link to docs preview:

https://84479--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-support_rosa-service-definition

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
