### PR TITLE
OCPBUGS#21769: Updated the Sharding the default Ingress Controller do…

### DIFF
--- a/modules/nw-ingress-sharding-default.adoc
+++ b/modules/nw-ingress-sharding-default.adoc
@@ -42,7 +42,7 @@ metadata:
 spec:
   namespaceSelector:
     matchExpressions:
-      - key: type
+      - key: name
         operator: NotIn
         values:
           - finance


### PR DESCRIPTION
Version(s):
4.12+ 

Issue:
[OCPBUGS-21769](https://issues.redhat.com/browse/OCPBUGS-21769)

Link to docs preview:
* [Sharding the default Ingress Controller](https://84481--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#nw-ingress-sharding-default_configuring-ingress-cluster-traffic-ingress-controller)


- [x] SME has approved this change (Candace Holman: in a PR review queue).
- [x] QE has approved this change (Melvin Joseph/Hongan Li).
