### PR TITLE
RHDEVDOCS-6249: Add support for step actions in cluster resolver

### DIFF
--- a/create/remote-pipelines-tasks-resolvers.adoc
+++ b/create/remote-pipelines-tasks-resolvers.adoc
@@ -20,16 +20,11 @@ Hub resolver:: Retrieves a task, pipeline, or `StepAction` definition from the P
 Bundles resolver:: Retrieves a task, pipeline, or `StepAction` definition from a Tekton bundle, which is an OCI image available from any OCI repository, such as an OpenShift container repository.
 Git resolver:: Retrieves a task, pipeline, or `StepAction` definition from a Git repository. You must specify the repository, the branch, and the path.
 HTTP resolver:: Retrieves a task, pipeline, or `StepAction` definition from a remote HTTP or HTTPS URL. You must specify the URL for authentication.
-Cluster resolver:: Retrieves a task or pipeline that is already created on the same {OCP} cluster in a specific namespace.
-+
-[NOTE]
-====
-In {pipelines-shortname} version {pipelines-version-number}, the cluster resolver does not support retrieving `StepAction` definitions.
-====
+Cluster resolver:: Retrieves a task, pipeline, or `StepAction` definition that is already created on the same {OCP} cluster in a specific namespace.
 
 An {pipelines-shortname} installation includes a set of standard tasks that you can use in your pipelines. These tasks are located in the {pipelines-shortname} installation namespace, which is normally the `openshift-pipelines` namespace. You can use the cluster resolver to access the tasks.
 
-{pipelines-shortname} also provides a standard `StepAction` definition. You can use the HTTP resolver to access this definition.
+{pipelines-shortname} also provides a standard `StepAction` definition. You can use the cluster resolver to access this definition.
 
 [id="resolver-hub_{context}"]
 == Specifying a remote pipeline, task, or step action from a Tekton catalog
@@ -77,9 +72,9 @@ include::modules/op-resolver-http-config.adoc[leveloffset=+2]
 include::modules/op-resolver-http.adoc[leveloffset=+2]
 
 [id="resolver-cluster_{context}"]
-== Specifying a pipeline or task from the same cluster
+== Specifying a pipeline, task, or step action from the same cluster
 
-You can use the cluster resolver to specify a pipeline or task that is defined in a namespace on the {OCP} cluster where {pipelines-title} is running.
+You can use the cluster resolver to specify a pipeline, task, or `StepAction` definition that is defined in a namespace on the {OCP} cluster where {pipelines-title} is running.
 
 In particular, you can use the cluster resolver to access tasks that {pipelines-shortname} provides in its installation namespace, which is normally the `openshift-pipelines` namespace.
 

--- a/modules/op-resolver-cluster.adoc
+++ b/modules/op-resolver-cluster.adoc
@@ -4,13 +4,13 @@
 // // *openshift_pipelines/remote-pipelines-tasks-resolvers.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="resolver-cluster-specify_{context}"]
-= Specifying a pipeline or task from the same cluster using the cluster resolver
+= Specifying a pipeline, task, or step action from the same cluster using the cluster resolver
 
-When creating a pipeline run, you can specify a pipeline that exists on the same cluster. When creating a pipeline or a task run, you can specify a task that exists on the the same cluster.
+When creating a pipeline run, you can specify a pipeline that exists on the same cluster. When creating a pipeline or a task run, you can specify a task that exists on the the same cluster. When creating a step within a task, you can specify a `StepAction` definition that exists on the the same cluster.
 
 .Procedure
 
-* To specify a pipeline or task from the same cluster, use the following reference format in the `pipelineRef` or `taskRef` spec:
+* To specify a pipeline, task, or `StepAction` definition from the same cluster, use the following reference format in the `pipelineRef`, `taskRef`, or `step.ref` spec:
 +
 [source,yaml]
 ----
@@ -22,7 +22,7 @@ When creating a pipeline run, you can specify a pipeline that exists on the same
   - name: namespace
     value: <namespace>
   - name: kind
-    value: [pipeline|task]
+    value: [pipeline|task|stepaction]
 # ...
 ----
 +
@@ -116,5 +116,30 @@ spec:
       value: task
   params:
   - name: sample-task-parameter
+    value: test
+----
+
+The following example task includes a step that references a `StepAction` definition from the same cluster:
+
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: cluster-stepaction-reference-demo
+spec:
+  steps:
+  - name: example-step
+    ref:
+      resolver: cluster
+      params:
+      - name: name
+        value: some-step
+      - name: namespace
+        value: test-namespace
+      - name: kind
+        value: stepaction
+  params:
+  - name: sample-stepaction-parameter
     value: test
 ----

--- a/modules/op-resolver-stepactions-ref.adoc
+++ b/modules/op-resolver-stepactions-ref.adoc
@@ -6,7 +6,7 @@
 [id="resolver-stepactions-ref_{context}"]
 = Step action provided with {pipelines-shortname}
 
-{pipelines-shortname} provides a standard `StepAction` definition that you can use in your tasks. Use the HTTP resolver to reference this definition.
+{pipelines-shortname} provides a standard `StepAction` definition that you can use in your tasks. Use the cluster resolver to reference this definition.
 
 [discrete]
 [id="op-stepaction-git-clone_{context}"]
@@ -14,12 +14,6 @@
 
 The `git-clone` step action uses Git to initialize and clone a remote repository on a workspace. You can use this step action to define a task that clones a repository at the start of a pipeline that builds or otherwise processes this source code.
 
-To reference this step action in a task, use the HTTP resolver with the following URL:
-
-[source,text]
-----
-https://raw.githubusercontent.com/openshift-pipelines/tektoncd-catalog/p/stepactions/stepaction-git-clone/0.4.1/stepaction-git-clone.yaml
-----
 
 .Example usage of the `git-clone` step action in a task
 [source,yaml,subs="attributes+"]
@@ -29,19 +23,18 @@ kind: Task
 metadata:
   name: clone-repo-anon
 spec:
-  params:
-  - name: url
-    description: The URL of the Git repository to clone
-  workspaces:
-  - name: output
-    description: The git repo will be cloned onto the volume backing this Workspace.
+# ...  
   steps:
-  - name: clone-repo-anon-step
+  - name: clone-repo-step
     ref:
-      resolver: http
+      resolver: cluster
       params:
-      - name: url
-        value: https://raw.githubusercontent.com/openshift-pipelines/tektoncd-catalog/p/stepactions/stepaction-git-clone/0.4.1/stepaction-git-clone.yaml
+      - name: name
+        value: git-clone
+      - name: namespace
+        value: openshift-pipelines
+      - name: kind
+        value: stepaction
     params:
     - name: URL
       value: $(params.url)


### PR DESCRIPTION
Version(s): `pipelines-docs-1.17`

Issue: [RHDEVDOCS-6249](https://issues.redhat.com/browse/RHDEVDOCS-6249)

Link to docs preview: https://84484--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/remote-pipelines-tasks-resolvers.html

QE review:
- [x] QE has approved this change.

**Additional information:**