### PR TITLE
[enterprise-4.17] Add 'Additional release notes' page

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -54,6 +54,8 @@ Distros: openshift-enterprise
 Topics:
 - Name: OpenShift Container Platform 4.17 release notes
   File: ocp-4-17-release-notes
+- Name: Additional release notes
+  File: addtl-release-notes
 ---
 Name: Getting started
 Dir: getting_started

--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -1,0 +1,99 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="addtl-release-notes"]
+= Additional release notes
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-microshift.adoc[]
+include::_attributes/servicebinding-document-attributes.adoc[]
+:context: addtl-release-notes
+
+toc::[]
+
+Release notes for additional related components and products not included in the core xref:../release_notes/ocp-4-17-release-notes.adoc#ocp-4-17-release-notes[{product-title} {product-version} release notes] are available in the following documentation.
+
+[IMPORTANT]
+====
+The following release notes are for downstream Red Hat products only; upstream or community release notes for related products are not included.
+====
+
+[cols="1a,1a,1a",frame=none,grid=none]
+|===
+|A::
+xref:../networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc#aws-load-balancer-operator-release-notes[AWS Load Balancer Operator]
+
+|B::
+link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1/html/about_builds/ob-release-notes#ob-release-notes[{builds-v2title}]
+
+|C::
+xref:../security/cert_manager_operator/cert-manager-operator-release-notes.adoc#cert-manager-operator-release-notes[{cert-manager-operator}] +
+{nbsp} +
+xref:../observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc#cluster-observability-operator-release-notes[{coo-first}] +
+{nbsp} +
+xref:../security/compliance_operator/compliance-operator-release-notes.adoc#compliance-operator-release-notes[Compliance Operator] +
+{nbsp} +
+xref:../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator]
+
+|D::
+link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/#Release%20Notes[{rh-dev-hub} Operator]
+
+|E::
+xref:../networking/external_dns_operator/external-dns-operator-release-notes.adoc#external-dns-operator-release-notes[External DNS Operator]
+
+|F::
+xref:../security/file_integrity_operator/file-integrity-operator-release-notes.adoc#file-integrity-operator-release-notes-v0[File Integrity Operator]
+
+|K::
+xref:../nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc#nodes-descheduler-release-notes[{descheduler-operator}]
+
+|L::
+xref:../observability/logging/logging-6.0/log6x-release-notes.adoc#log6x-release-notes[{logging-uc}]
+
+|M::
+xref:../migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc#mtc-release-notes[{mtc-full} ({mtc-short})]
+
+|N::
+xref:../observability/network_observability/network-observability-operator-release-notes.adoc#network-observability-operator-release-notes[Network Observability Operator] +
+{nbsp} +
+xref:../security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc#nbde-tang-server-operator-release-notes[Network-bound Disk Encryption (NBDE) Tang Server Operator]
+
+|O::
+xref:../backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc#oadp-1-4-release-notes[{oadp-first}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/#Release%20Notes[{openshift-dev-spaces-productname}] +
+{nbsp} +
+xref:../observability/distr_tracing/distr-tracing-rn.adoc#distr-tracing-rn[{DTProductName}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/#Get%20started[{gitops-title}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_local/#Release%20Notes[{openshift-local-productname}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/#Getting%20Started[{pipelines-title}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/#Release%20Notes[{osc}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.33/html/about_openshift_serverless/serverless-release-notes#serverless-release-notes[Red Hat {ServerlessProductName}] +
+{nbsp} +
+xref:../windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.adoc#windows-containers-release-notes-10-17-x[{productwinc}] +
+{nbsp} +
+xref:../virt/release_notes/virt-4-17-release-notes.adoc#virt-4-17-release-notes[Red Hat {VirtProductName}] +
+{nbsp} +
+xref:../observability/otel/otel-rn.adoc#otel-rn[{OTELName}]
+
+|P::
+xref:../observability/power_monitoring/power-monitoring-release-notes.adoc#power-monitoring-release-notes[{PM-title-c}]
+
+|R::
+xref:../nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc#run-once-duration-override-release-notes[{run-once-operator}]
+
+|S::
+xref:../nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc#nodes-secondary-scheduler-release-notes[{secondary-scheduler-operator-full}] +
+{nbsp} +
+xref:../security/security_profiles_operator/spo-release-notes.adoc#spo-release-notes[Security Profiles Operator] +
+{nbsp} +
+xref:../service_mesh/v2x/servicemesh-release-notes.adoc#service-mesh-release-notes[{SMProductName} 2.x] +
+{nbsp} +
+link:https://docs.openshift.com/service-mesh/3.0.0tp1/ossm-release-notes/ossm-release-notes-assembly.html[{SMProductName} 3.x]
+
+|
+|
+
+|===


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/81026 for OCP 4.17.

Omits the `release_notes/ocp-release-notes.adoc` file that was added in https://github.com/openshift/openshift-docs/pull/81026, because that file is only useful on `main`.