### PR TITLE
Minor fix with missed manual CP

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -89,7 +89,7 @@ The annotation value is an array with a single object with fields that provide t
 * `ifaddr`: Specifies the subnet mask for one or both IP address families.
 * `capacity`: Specifies the IP address capacity for the node. On AWS, the IP address capacity is provided per IP address family. On Azure and GCP, the IP address capacity includes both IPv4 and IPv6 addresses.
 
-Automatic attachment and detachment of egress IP addresses for traffic between nodes are available. This allows for traffic from many pods in namespaces to have a consistent source IP address to locations outside of the cluster. This also supports OpenShift SDN and OVN-Kubernetes, which is the default networking plugin in Red Hat OpenShift Networking in {product-title} {product-version}.
+Automatic attachment and detachment of egress IP addresses for traffic between nodes are available. This allows for traffic from many pods in namespaces to have a consistent source IP address to locations outside of the cluster.
 
 [NOTE]
 ====


### PR DESCRIPTION
In this [section](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/networking/index#nw-egress-ips-public-cloud-platform-considerations_configuring-egress-ips-ovn) of our docs, this sentence wasn't removed in 4.17:
 This also supports OpenShift SDN and OVN-Kubernetes, which is the default networking plugin in Red Hat OpenShift Networking in OpenShift Container Platform 4.17.

It should be

Automatic attachment and detachment of egress IP addresses for traffic between nodes are available. This allows for traffic from many pods in namespaces to have a consistent source IP address to locations outside of the cluster.

This was removed by Joe [in this PR](https://github.com/openshift/openshift-docs/pull/79740/files#diff-8c0dca9082fc67d6bab7af1607b520be2c0afad695421b2503bde4e9059a750eR92) based off main, but was missed in his manual CP [here](https://github.com/openshift/openshift-docs/pull/80658/files).

I've removed what I think are the final mentionings of SDN in my own [PR](https://github.com/openshift/openshift-docs/pull/84452), but I didn't pick that change up bc it didn't exist in main. It only exists in 4.17.

Acks to remove this information/line were approved in Joe's original PR. Another QE review is not needed as per Kathryn. 

Thanks!

Versions: 4.17

Preview: https://84501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-public-cloud-platform-considerations_configuring-egress-ips-ovn 
