### PR TITLE
OSDOCS#12512: Update the release notes for the 4.13.53 z-stream 

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4433,3 +4433,30 @@ $ oc adm release info 4.13.52 --pullspecs
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
+// 4.13.53
+[id="ocp-4-13-53_{context}"]
+=== RHSA-2024:8688 - {product-title} 4.13.53 bug fix and security updates
+
+Issued: 06 November 2024
+
+{product-title} release 4.13.53, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:8688[RHSA-2024:8688] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8690[RHSA-2024:8690] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.53 --pullspecs
+----
+
+[id="ocp-4-13-53-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the Cloud Credential Operator (CCO) for a cluster installed on {gcp-first} was degraded. {gcp-short} clusters that were not in manual mode incorrectly required `backupdr` permissions. However, in accounts where the `backupdr` API was not enabled, the clusters correctly determined that they did not have those permissions. Manual mode {gcp-short} clusters were not affected. With this release, the `skipServiceCheck` parameter is set to `true` on the `CredentialsRequest` custom resource (CR), so this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-43856[*OCPBUGS-43856*])
+
+* Previously, updating to {product-title} 4.14 triggered service disruptions in applications that set duplicate `Transfer-Encoding` headers. This resulted in rejected responses, including a gateway error, which affected customer service. With this release, cluster administrators can use a procedure to detect applications that send duplicate `Transfer-Encoding` headers before updating to {product-title} 4.13. Any issues can be corrected before causing service disruption. (link:https://issues.redhat.com/browse/OCPBUGS-43095[*OCPBUGS-43095*])
+
+[id="ocp-4-13-53-updating_{context}"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-12512](https://issues.redhat.com/browse/OSDOCS-12512)

Link to docs preview:
[4.13.53](https://84508--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-53_release-notes)

QE review:
- [ ] QE has approved this change. 
n/a
