### PR TITLE
MIG-1666: adding MTC Operator Lifecycle to clarify suport

### DIFF
--- a/migration_toolkit_for_containers/about-mtc.adoc
+++ b/migration_toolkit_for_containers/about-mtc.adoc
@@ -26,6 +26,7 @@ See xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
 * Configuring your migration plan to exclude resources, support large-scale migrations, and enable automatic PV resizing for direct volume migration.
 
 include::modules/migration-mtc-support.adoc[leveloffset=+1]
+include::modules/mtc-operator-supported.adoc[leveloffset=+2]
 include::modules/migration-terminology.adoc[leveloffset=+1]
 include::modules/migration-mtc-workflow.adoc[leveloffset=+1]
 include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]

--- a/modules/mtc-operator-supported.adoc
+++ b/modules/mtc-operator-supported.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/about-mtc.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="mtc-operator-supported_{context}"]
+= Support for {mtc-first}
+
+.Supported versions of {mtc-short}
+[width="100%",cols="10%,14%,20%,22%,22%,22%,options="header"]
+|===
+|{mtc-short} version
+|{product-title} version
+|General availability
+|Full support ends
+|Maintenance ends
+|Extended Update Support (EUS)
+
+|1.8
+a|
+* 4.14
+* 4.15
+* 4.16
+* 4.17
+|02 Oct 2023
+|Release of 1.9
+|Release of 1.10
+|N/A
+
+|1.7
+a|
+* 3
+* 4.14
+* 4.15
+* 4.16
+|01 Mar 2022
+|01 Jul 2024
+|01 Jul 2025
+|N/A
+|===
+
+For more details about EUS, see link:https://access.redhat.com/support/policy/updates/openshift#eus[Extended Update Support].
+


### PR DESCRIPTION
### JIRA

* [MIG-1666](https://issues.redhat.com/browse/MIG-1666)

### Version(s):

* OCP 4.14++

### Link to docs preview:

* [Support for Migration Toolkit for Containers (MTC)](https://84529--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/about-mtc.html#mtc-operator-supported_about-mtc)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
