### PR TITLE
OSDOCS-11182: Ingress controller feature MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -113,6 +113,8 @@ Topics:
   File: microshift-using-config-yaml
 - Name: Configuring IPv6 networking
   File: microshift-nw-ipv6-config
+- Name: Using ingress control for a MicroShift cluster
+  File: microshift-ingress-controller
 - Name: Cluster access with kubeconfig
   File: microshift-cluster-access-kubeconfig
 - Name: Using custom certificate authorities

--- a/microshift_configuring/microshift-ingress-controller.adoc
+++ b/microshift_configuring/microshift-ingress-controller.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-ingress-controller"]
+= Using ingress control for a {microshift-short} cluster
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-ingress-controller
+
+toc::[]
+
+Use the ingress controller options in the {microshift-short} configuration file to make pods and services accessible outside the cluster.
+
+include::modules/microshift-ingress-controller-conc.adoc[leveloffset=+1]
+
+include::modules/microshift-ingress-controller-config.adoc[leveloffset=+1]
+
+[id="additional-resources_microshift-ingress-controller_{context}"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../microshift_configuring/microshift-using-config-yaml.adoc#microshift-config-snippets_microshift-configuring[Using configuration snippets]
+
+* link:https://docs.openshift.com/container-platform/4.17/networking/networking_operators/ingress-operator.html#nw-http2-haproxy_configuring-ingress[Enabling HTTP/2 Ingress connectivity] (OpenShift Container Platform documentation)

--- a/modules/microshift-config-snippets.adoc
+++ b/modules/microshift-config-snippets.adoc
@@ -6,7 +6,7 @@
 [id="microshift-config-snippets_{context}"]
 = Using configuration snippets
 
-If you want to configure one or two settings, such as adding subject alternative names (SANs), you can use the  `/etc/microshift/config.d/` configuration directory to drop in configuration snippet YAML files. You must restart {microshift-short} for new configurations to apply.
+If you want to configure one or two settings, such as adding subject alternative names (SANs), you can use the `/etc/microshift/config.d/` configuration directory to drop in configuration snippet YAML files. You must restart {microshift-short} for new configurations to apply.
 
 To return to previous values, you can delete a configuration snippet and restart {microshift-short}.
 

--- a/modules/microshift-ingress-controller-conc.adoc
+++ b/modules/microshift-ingress-controller-conc.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * microshift_configuring/microshift-ingress-controller.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-ingress-control-concept_{context}"]
+= Using ingress control in {microshift-short}
+
+When you create your {microshift-short} cluster, each pod and service running on the cluster is allocated an IP address. These IP addresses are accessible to other pods and services running nearby by default, but are not accessible to external clients. {microshift-short} uses a minimal implementation of the {ocp} `IngressController` API to enable external access to cluster services.
+
+With more configuration options, you can fine-tune ingress to meet your specific needs. To use enhanced ingress control, update the parameters in the {microshift-short} configuration file and restart the service. Ingress configuration is useful in a variety of ways, for example:
+
+* If your application starts processing requests from clients but the connection is
+closed before it can respond, you can set the `ingress.tuningOptions.serverTimeout` parameter in the configuration file to a higher value to accommodate the speed of the response from the server.
+
+* If the router has many connections open because an application running on the cluster does not close connections properly, you can set the `ingress.tuningOptions.serverTimeout` and `spec.tuningOptions.serverFinTimeout` parameters to a lower value, forcing those connections to close sooner.

--- a/modules/microshift-ingress-controller-config.adoc
+++ b/modules/microshift-ingress-controller-config.adoc
@@ -1,0 +1,167 @@
+
+// Module included in the following assemblies:
+//
+// * microshift_configuring/microshift-ingress-controller.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-ingress-control-config_{context}"]
+= Configuring ingress control in {microshift-short}
+
+You can use detailed ingress control settings by updating the {microshift-short} service configuration file.
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You have root access to the cluster.
+* Your cluster uses the OVN-Kubernetes network plugin.
+
+.Procedure
+
+. Apply ingress control settings in one of the two following ways:
+
+.. Update the {microshift-short} `config.yaml` configuration file by making a copy of the provided `config.yaml.default` file in the `/etc/microshift/` directory, naming it `config.yaml` and keeping it in the source directory.
+* After you create it, the `config.yaml` file takes precedence over built-in settings. The configuration file is read every time the {microshift-short} service starts.
+
+.. Use a configuration snippet to apply the ingress control settings you want. To do this, create a configuration snippet YAML file and put it in the the `/etc/microshift/config.d/` configuration directory.
+* Configuration snippet YAMLs take precedence over both built-in settings and a `config.yaml` configuration file. See the Additional resources links for more information.
+
+. Replace the default values in the `network` section of the {microshift-short} YAML with your valid values, or create a configuration snippet file with the sections you need.
++
+.Ingress controller configuration fields with default values
+[source,yaml]
+----
+apiServer:
+# ...
+ingress:
+    defaultHTTPVersion: 1
+    forwardedHeaderPolicy: Append
+    httpCompression:
+        mimeTypes:
+            - ""
+    httpEmptyRequestsPolicy: Respond
+# ...
+    logEmptyRequests: Log
+# ...
+    tuningOptions:
+        clientFinTimeout: 1s
+        clientTimeout: 30s
+        headerBufferBytes: 0
+        headerBufferMaxRewriteBytes: 0
+        healthCheckInterval: 5s
+        maxConnections: 0
+        serverFinTimeout: 1s
+        serverTimeout: 30s
+        threadCount: 4
+        tlsInspectDelay: 5s
+        tunnelTimeout: 1h
+# ...
+----
++
+.Ingress controller configuration fields definitions table
+[cols="3a,8a",options="header"]
+|===
+|Parameter |Description
+
+|`defaultHTTPVersion`
+|Sets the HTTP version for the ingress controller. Default value is `1` for HTTP 1.1.
+//Q: do we need to configure a load balancer for 2 and 3?
+
+|`forwardedHeaderPolicy`
+|Specifies when and how the ingress controller sets the `Forwarded`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Proto`, and `X-Forwarded-Proto-Version` HTTP headers. The following values are valid:
+
+* `Append`, preserves any existing headers by specifying that the ingress controller appends them.
+* `Replace`, removes any existing headers by specifying that the ingress controller sets the headers.
+* `IfNone` sets the headers set by specifying that the ingress controller sets the headers if they are not already set.
+* `Never`, preserves any existing headers by specifying that the ingress controller never sets the headers.
+
+|`httpCompression`
+|Defines the policy for HTTP traffic compression.
+
+* `httpCompression.mimeTypes` defines a list of or a single MIME type to which compression is applied. For example, `text/css; charset=utf-8`, `text/html`, `text/*`, `image/svg+xml`, `application/octet-stream`, `X-custom/customsub`, using the format pattern, `type/subtype; [;attribute=value]`. The `types` are: application, image, message, multipart, text, video, or a custom type prefaced by `X-`. To see the full notation for MIME types and subtypes, see link:https://datatracker.ietf.org/doc/html/rfc1341#page-7[RFC1341] (IETF Datatracker documentation).
+
+|`httpEmptyRequestsPolicy`
+|Describes how HTTP connections are handled if the connection times out before a request is received. Allowed values for this field are `Respond` and `Ignore`. The default value is `Respond`. The following are valid values:
+
+* `Respond`, causes the ingress controller to send an HTTP `400` or `408` response, logs the connection if access logging is enabled, and counts the connection in the appropriate metrics.
+* `Ignore`, adds the `http-ignore-probes` parameter in the `HAproxy` configuration. If the field is set to `Ignore`, the ingress controller closes the connection without sending a response, then logs the connection or incrementing metrics.
+
+Usually, empty request connections come from load balancer health probes or web browser preconnects and can be safely ignored. However, network errors and port scans can also create these empty requests, so setting this field to `Ignore` can impede detecting or diagnosing problems and also impede the detection of intrusion attempts.
+
+|`logEmptyRequests`
+|Specifies connections for which no request is received and logged. Usually, these empty requests come from load balancer health probes or web browser speculative connections such as preconnects. Logging these types of empty requests can be undesirable. However, network errors and port scans can also create empty requests, so setting this field to `Ignore` can impede detecting or diagnosing problems and also impede the detection of intrusion attempts.
+
+The following are valid values:
+
+* `Log`, which indicates that an event should be logged.
+* `Ignore`, which sets the `dontlognull` option in the `HAproxy` configuration.
+
+|`tuningOptions`
+|Specifies options for tuning the performance of ingress controller pods.
+
+* The `tuningOptions.clientFinTimeout` parameter specifies how long a connection is held open while waiting for the client response to the server closing the connection. The default timeout is `1s`.
+
+* The `tuningOptions.clientTimeout` parameter specifies how long a connection is held open while waiting for a client response. The default timeout is `30s`.
+
+* The `tuningOptions.headerBufferBytes` parameter specifies how much memory is reserved, in bytes, for Ingress Controller connection sessions. This value must be at least `16384` if HTTP/2 is enabled for the Ingress Controller. If not set, the default value is `32768` bytes.
++
+[IMPORTANT]
+====
+Setting this field not recommended because `headerBufferMaxRewriteBytes` parameter values that are too small can break the ingress controller. Conversely, values for `headerBufferMaxRewriteBytes` that are too large could cause the ingress controller to use significantly more memory than necessary.
+====
+
+* The `tuningOptions.headerBufferMaxRewriteBytes` parameter specifies how much memory should be reserved, in bytes, from `headerBufferBytes` for HTTP header rewriting and appending for Ingress Controller connection sessions. The minimum value for `headerBufferMaxRewriteBytes` is `4096`. The `headerBufferBytes` value must be greater than the `headerBufferMaxRewriteBytes` value for incoming HTTP requests.
+* If not set, the default value is `8192` bytes.
++
+[IMPORTANT]
+====
+Setting this field is not recommended because `headerBufferMaxRewriteBytes` parameter values that are too small can break the ingress controller. Conversely, values for `headerBufferMaxRewriteBytes` that are too large could cause the ingress controller to use significantly more memory than necessary.
+====
+
+* The `tuningOptions.healthCheckInterval` parameter specifies how long the router waits between health checks. The default is `5s`.
+
+* The `tuningOptions.serverFinTimeout` parameter specifies how long a connection is held open while waiting for the server response to the client that is closing the connection. The default timeout is `1s`.
+
+* The `tuningOptions.serverTimeout` parameter specifies how long a connection is held open while waiting for a server response. The default timeout is `30s`.
+
+* The `tuningOptions.threadCount` parameter specifies the number of threads to create per HAProxy process. Creating more threads allows each ingress controller pod to handle more connections, at the cost of more system resources being used. `HAProxy` supports up to `64` threads. If this field is empty, default value is `4` threads.
++
+[IMPORTANT]
+====
+Setting this field is not recommended because increasing the number of `HAProxy` threads allows ingress controller pods to use more CPU time under load, and prevent other pods from receiving the CPU resources they need to perform.
+====
+
+* The `tuningOptions.tlsInspectDelay` parameter specifies how long the router can hold data to find a matching route. Setting this value too short can cause the router to fall back to the default certificate for edge-terminated, re-encrypted, or passthrough routes, even when using a better-matched certificate. The default inspect delay is `5s`.
+
+* The `tuningOptions.tunnelTimeout` parameter specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. The default timeout is `1h`.
+|===
+
+. Complete any other configurations you require, then start or restart {microshift-short} by running one the following commands:
++
+[source,terminal]
+----
+$ sudo systemctl start microshift
+----
++
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----
+
+.Verification
+
+After making ingress configuration changes and restarting {microshift-short}, you can check the age of the router pod to ensure that changes have been applied.
+
+* To check the status of the router pod, run the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ingress
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                              READY   STATUS    RESTARTS   AGE
+router-default-8649b5bf65-w29cn   1/1     Running   0          6m10s
+----


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-11182](https://issues.redhat.com/browse/OSDOCS-11182)

Link to docs preview:
[MicroShift ingress controller feature](https://84542--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-ingress-controller.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Ingress control default values in the config.yaml table](https://github.com/openshift/openshift-docs/pull/84548)
[Ingress control release note](https://github.com/openshift/openshift-docs/pull/84553) 


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
