### PR TITLE
MIG-1665-MTC-1.8.5-attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -64,7 +64,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8.4
+:mtc-version-z: 1.8.5
 :mtc-legacy-image: 1.7
 // builds (Valid only in 4.11 and later)
 :builds-v2title: Builds for Red Hat OpenShift


### PR DESCRIPTION
### JIRA

* [MTV-1665](https://issues.redhat.com/browse/MIG-1665)

Updating MTC z version from `1.8.4` to `1.8.5` to match release

### Version(s):

* OCP 4.14++

### Link to docs preview:

* 

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
