### PR TITLE
OSDOCS-11183: adds ingress control defaults MicroShift

### DIFF
--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -9,7 +9,7 @@
 The following table explains {microshift-short} configuration YAML parameters and valid values for each:
 
 .{microshift-short} `config.yaml` parameters
-[cols="3","20%,10%,70%",options="header"]
+[cols="1,2,3a","15%,10%,75%",options="header"]
 |===
 |Field|Type|Description
 
@@ -50,7 +50,7 @@ The following table explains {microshift-short} configuration YAML parameters an
 |Optional. Add a list of explicit DNS names. Leading wildcards are allowed. If no names are provided, the implicit names are extracted from the certificates.
 
 |`subjectAltNames`
-|Fully qualified domain names (FQDNs), wildcards such as `*.domain.com`, or IP addresses
+|Fully qualified domain names (FQDNs), wildcards such as `*.domain.com`, or IP addresses.
 |Subject Alternative Names for API server certificates. SANs indicate all of the domain names and IP addresses that are secured by a certificate.
 
 |`debugging.logLevel`
@@ -65,26 +65,161 @@ The following table explains {microshift-short} configuration YAML parameters an
 |`number`
 |By default, `etcd` uses as much memory as needed to handle the load on the system. However, in memory constrained systems, it might be preferred or necessary to limit the amount of memory `etcd` can to use at a given time.
 
+|`ingress.defaultHTTPVersion`
+|`number`
+|Determines the default HTTP version to be used for ingress. Default value is `1`, which is the HTTP/1.1 protocol.
+
+|`ingress.forwardedHeaderPolicy`
+|`Append`, `Replace`, `IfNone`, `Never`
+|Specifies when and how the ingress router sets the `Forwarded`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Proto`, and `X-Forwarded-Proto-Version` HTTP headers.
+
+* `Append` specifies that the ingress router appends existing headers. `Append` is the default value.
+
+* `Replace` specifies that the ingress router sets the headers and replaces any existing `Forwarded` or `X-Forwarded-*` headers.
+
+* `IfNone` specifies that the ingress router sets headers if they are not already set.
+
+* `Never` specifies that ingress router never sets the headers, preserving any existing headers.
+
+|`ingress.httpCompression`
+|`object`
+|`httpCompression` defines a policy for HTTP traffic compression. There is no HTTP compression by default.
+
+|`ingress.httpCompression.mimeTypes`
+|`array` or null
+|`mimeTypes` is a list of MIME types to compress. When the list is empty, the ingress controller does not apply any compression. To define a list, use the format of the Content-Type definition in RFC 1341 that specifies the type and subtype of data in the body of a message and the native encoding of the data. For example, `Content-Type := type \"/\" subtype *[\";\" parameter]`.
+
+* The value of `Content-Type` can be one of the following types: application, audio, image, message, multipart, text, video, or a custom type preceded by `\"X-\"` and followed by a token. The token must be defined in one of the following ways:
+
+* The token is a `string` of at least one character, and does not contain white spaces, control characters, or any of the characters in the `tspecials` set.
+
+* The `tspecials` set contains the characters `()\u003c\u003e@,;:\\\"/[]?.=`.
+
+* The subtype in Content-Type is also a token.
+
+* The optional parameters following the subtype are defined as `token \"=\" (token / quoted-string)`.
+
+* The `quoted-string`, as defined in RFC 822, is surrounded by double quotes and can contain white spaces plus any character except `\\`, `\"`, and `CR`. The `quoted-string` can also contain any single ASCII character if it is escaped by the following characters: `\\.",`.
+
+Not all MIME types benefit from compression, but `HAProxy` uses resources to try to compress files when compression is configured. Generally speaking, text formats such as `html`, `ccs`, and `js` benefit from compression. Spending CPU resources to compress file types that are already compressed, such as images, audio, and video, is probably not worth the limited benefit.
+
+|`ingress.httpEmptyRequestsPolicy`
+|`Respond` or `Ignore`
+|The default value is `Respond`. Describes how HTTP connections should be handled if the connection times out before a request is received. These connections typically come from the health probes of a load balancer service health or a web browser's speculative connections, such as a `preconnect`.
+
+* If the field is set to `Respond`, the ingress controller sends an "HTTP 400" or "408" response, logs the connection if access logging is enabled, and counts the connection in the appropriate metrics.
+
+* If the field is set to `Ignore`, the ingress controller closes the connection without sending a response, logging the connection, or incrementing metrics. Setting this field to `Ignore` might impede detection and diagnosis of problems or intrusions, especially when timed-out connections are caused by network errors or port scans. In both cases, logging empty requests can be useful for diagnosing errors and detecting intrusion attempts.
+
 |`ingress.listenAddress`
 |IP address, NIC name, or multiple
 |Value defaults to the entire network of the host. The valid configurable value is a list that can be either a single IP address or NIC name or multiple IP addresses and NIC names.
 
+|`ingress.logEmptyRequests`
+|`Log` or `Ignore`
+|Default value is `Log`. Specifies how connections on which empty requests are received are logged. These connections typically come from the health probes of a load balancer service health or a web browser's speculative connections, such as a `preconnect`. Logging typical requests might be undesirable, but requests can also be caused by network errors or port scans, in which case logging can be useful for diagnosing errors and detecting intrusion attempts.
+
 |`ingress.ports.http`
 |`80`
-|Default port shown. Configurable. Valid value is a single, unique port in the 1-65535 range. The values of the `ports.http` and `ports.https` fields cannot be the same.
+|Default port shown. Configurable. Valid value is a single, unique port in the `1-65535` range. The values of the `ports.http` and `ports.https` fields cannot be the same.
 
 |`ingress.ports.https`
 |`443`
-|Default port shown. Configurable. Valid value is a single, unique port in the 1-65535 range. The values of the `ports.http` and `ports.https` fields cannot be the same.
+|Default port shown. Configurable. Valid value is a single, unique port in the `1-65535` range. The values of the `ports.http` and `ports.https` fields cannot be the same.
 
-|`ingress.routeAdmissionPolicy.
-    namespaceOwnership`
+|`ingress.routeAdmissionPolicy.namespaceOwnership`
 |`Strict` or `InterNamespaceAllowed`
 |Describes how hostname claims across namespaces are handled. By default, allows routes to claim different paths of the same hostname across namespaces. Specifying `Strict` prevents routes in different namespaces from claiming the same hostname. If the value is deleted in a customized {microshift-short} `config.yaml`, the `InterNamespaceAllowed` value is automatically set.
 
 |`ingress.status`
 |`Managed` or `Removed`
 |Router status. Default is `Managed`.
+
+|`ingress.tuningOptions`
+|Objects
+|Specifies options for tuning the performance of ingress controller pods.
+
+|`ingress.tuningOptions.clientFinTimeout`
+|`string` with format `duration`
+|Defines how long a connection is held open while waiting for a client response to the server/backend before closing the connection. The default timeout is `1s`, which is 1 second.
+
+|`ingress.tuningOptions.clientTimeout`
+|`string` with format `duration`
+|Defines how long a connection is held open while waiting for a client response. The default timeout is `30s`, which is 30 seconds.
+
+|`ingress.tuningOptions.headerBufferBytes`
+|An `integer` with the `format` of `int32`; `16384` is the minimum value when HTTP/2 is enabled.
+|Describes how much memory in bytes must be reserved for `IngressController` connection sessions. Default value is `32768` in bytes.
+
+* Setting this field is generally not recommended because `headerBufferBytes` values that are too small can break the `IngressController` and `headerBufferBytes` values that are too large can cause the `IngressController` to use significantly more memory than necessary.
+
+|`ingress.tuningOptions.headerBufferMaxRewriteBytes`
+|`integer`, formatted `int32`; `4096` is the minimum value
+|Describes how much memory in bytes must be reserved from `headerBufferBytes` for HTTP header rewriting and appending for `IngressController` connection sessions. Default value is `8192` bytes. Incoming HTTP requests are limited to the `headerBufferBytes` bytes minus the `headerBufferMaxRewriteBytes` bytes, meaning that the value of `headerBufferBytes` must be greater than the value of `headerBufferMaxRewriteBytes`.
+
+* Setting this field is generally not recommended because `headerBufferMaxRewriteBytes` values that are too small can break the `IngressController` and `headerBufferMaxRewriteBytes` values that are too large can cause the `IngressController` to use significantly more memory than necessary.
+
+|`ingress.tuningOptions.healthCheckInterval: ""`
+|`string` with pattern: `^(0\|([0-9]+(\\.[0-9]+)?(ns\|us\|µs\|μs\|ms\|s\|m\|h))+)$`
+|The default `healthCheckInterval` value is `5s`, which is 5 seconds. This parameter value defines how long the router waits between two consecutive health checks on the router's configured backends. Currently the minimum allowed value is `1s` and the maximum allowed value is `2147483647ms`, which is 24.85 days. The range might change in future releases.
+
+* This value is applied globally as a default for all routes, but can be overridden per-route by the route annotation `router.openshift.io/haproxy.health.check.interval`.
+
+* Requires an unsigned duration string of decimal numbers, each with an optional fraction and unit suffix, such as `300ms`, `1.5h` or `2h45m`. Valid time units are `ns`, `us` (or `µs` U+00B5 or `μs` U+03BC), `ms`, `s`, `m`, `h`.
+
+* Setting this parameter value to less than `5s` can cause excess traffic due to too frequent TCP health checks and accompanying SYN packet storms.
+
+* Setting this parameter value too high can result in increased latency because of backend servers that are no longer available, but have not yet been detected as such.
+
+* An empty or `0` value means "no opinion" and the ingress controller chooses a default. Note that the default value might change in future releases.
+
+|`ingress.tuningOptions.maxConnections`
+|`integer`, valid values are: `empty`, `0`, `-1`, and the range `2000-2000000`
+|Default value is `0`. defines the maximum number of simultaneous connections that can be established per `HAProxy` process. Increasing this value allows each ingress controller pod to handle more connections at the cost of additional system resources being consumed.
+
+* If this field is empty or `0`, the `IngressController` uses the default value of `50000`, but the default is subject to change in future releases.
+
+* If the value is `-1`, then `HAProxy` dynamically computes a maximum value based on the available resources set with `ulimit` values in the running container. Selecting `-1`, which means `auto`, results in a large value being computed, and therefore each `HAProxy` process incurs significant memory usage compared with the current default of `50000`.
+
+* Setting a value that is greater than the current operating system limit prevents the `HAProxy` process from starting.
+
+* You can monitor memory usage for router containers with the following metric:
++
+[source,terminal]
+----
+container_memory_working_set_bytes{container=`router`,namespace=`openshift-ingress`}`
+----
++
+* You can monitor memory usage of individual `HAProxy`processes in router containers with the following metric:
++
+[source,terminal]
+----
+container_memory_working_set_bytes{container=`router`,namespace=`openshift-ingress`}/container_processes{container=`router`,namespace=`openshift-ingress`}
+----
+
+|`ingress.tuningOptions.serverFinTimeout`
+|`string` in the format `duration`
+|Defines how long a connection is held open while waiting for a server or backend response to the client before closing the connection. The default timeout is `1s`.
+
+|`ingress.tuningOptions.serverTimeout`
+|`string` in the format `duration`
+|Defines how long a connection is held open while waiting for a server or backend response. The default timeout is `30s`.
+
+|`ingress.tuningOptions.threadCount`
+|`integer` in the form `int32`; minimum value is `1`, maximum is `64`
+|Defines the number of threads created per `HAProxy` process. The default value is `4`. If this field is empty, the default value is used.
+
+* Setting this field is generally not recommended. Creating more threads allows each ingress controller pod to handle more connections at the cost of more system resources being used. Increasing the number of HAProxy threads allows the ingress controller pods to use more CPU time under load, potentially starving other pods if set too high. Conversely, reducing the number of threads may cause the ingress controller to perform poorly.
+
+|`ingress.tuningOptions.tlsInspectDelay`
+|`string` in the format `duration`
+|Defines how long the router can hold data to find a matching route. Setting this interval with too short a value can cause the router to revert to the default certificate for edge-terminated clients or re-encrypt routes, even when a better-matching certificate could be used.
+
+* The default inspect delay is `5s` which is 5 seconds, which is expected to be sufficient for most cases. Increasing the value of this configuration specifically for high-latency networks can cause a delay in finishing the SSL handshake. Any configured value must be transparent to your application.
+
+|`ingress.tuningOptions.tunnelTimeout`
+|`string` in the format `duration`
+|Defines how long a tunnel connection, including websockets, are held open while the tunnel is idle. The default timeout is `1h`, which is 1 hour.
 
 |`kubelet`
 |See the {microshift-short} low-latency instructions

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -6,7 +6,7 @@
 [id="microshift-yaml-default_{context}"]
 = Default settings
 
-If you do not create a `config.yaml` file, default values are used. The following example shows the default configuration settings.
+If you do not create a `config.yaml` file or use a configuration snippet YAML file, default values are used. The following example shows the default configuration settings.
 
 *  To see the default values, run the following command:
 +
@@ -38,14 +38,33 @@ dns:
 etcd:
   memoryLimitMB: 0
 ingress:
+  defaultHTTPVersion: 1
+  forwardedHeaderPolicy: ""
+  httpCompression:
+      mimeTypes:
+          - ""
+  httpEmptyRequestsPolicy: Respond
   listenAddress:
     - ""
+  logEmptyRequests: Log
   ports:
     http: 80
     https: 443
   routeAdmissionPolicy:
     namespaceOwnership: InterNamespaceAllowed
   status: Managed
+  tuningOptions:
+      clientFinTimeout: ""
+      clientTimeout: ""
+      headerBufferBytes: 0
+      headerBufferMaxRewriteBytes: 0
+      healthCheckInterval: ""
+      maxConnections: 0
+      serverFinTimeout: ""
+      serverTimeout: ""
+      threadCount: 0
+      tlsInspectDelay: ""
+      tunnelTimeout: ""
 kubelet:
 manifests:
   kustomizePaths:


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-11183](https://issues.redhat.com/browse/OSDOCS-11183)

Link to docs preview:
[Default values example config YAML](https://84548--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-yaml-default_microshift-configuring)
[Configuration parameters table](https://84548--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-config-parameters-table_microshift-configuring)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Feature is https://github.com/openshift/openshift-docs/pull/84542

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
