### PR TITLE
OSDOCS-12533: ABI on OCI GA

### DIFF
--- a/installing/installing_oci/installing-oci-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-oci-agent-based-installer.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 In {product-title} {product-version}, you can use the Agent-based Installer to install a cluster on {oci-first}, so that you can run cluster workloads on infrastructure that supports dedicated, hybrid, public, and multiple cloud environments.
 
+Installing a cluster on {oci} is supported for virtual machines (VMs) and bare-metal machines.
+
 // The Agent-based Installer and OCI overview
 include::modules/installing-oci-about-agent-based-installer.adoc[leveloffset=+1]
 
@@ -20,6 +22,22 @@ include::modules/installing-oci-about-agent-based-installer.adoc[leveloffset=+1]
 * link:https://docs.oracle.com/en-us/iaas/Content/Compute/Concepts/computeoverview.htm[Overview of the Compute Service (Oracle documentation)]
 * link:https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm#vpus[Volume Performance Units (Oracle documentation)]
 * link:https://docs.oracle.com/iaas/Content/openshift-on-oci/installing-agent-about-instance-configurations.htm[Instance Sizing Recommendations for {product-title} on {oci} Nodes (Oracle documentation)]
+
+[id="abi-oci-process-checklist_{context}"]
+== Installation process workflow
+
+The following workflow describes a high-level outline for the process of installing an {product-title} cluster on {oci} using the Agent-based Installer:
+
+. Create {oci} resources and services (Oracle).
+. Disconnected environments: Prepare a web server that is accessible by {oci} instances (Red{nbsp}Hat).
+. Prepare configuration files for the Agent-based Installer (Red{nbsp}Hat).
+. Generate the agent ISO image (Red{nbsp}Hat).
+. Disconnected environments: Upload the rootfs image to the web server (Red{nbsp}Hat).
+. Configure your firewall for {product-title} (Red{nbsp}Hat).
+. Upload the agent ISO image to a storage bucket (Oracle).
+. Create a custom image from the uploaded agent ISO image (Oracle).
+. Create compute instances on {oci} (Oracle).
+. Verify that your cluster runs on {oci} (Oracle).
 
 // Creating OCI infrastructure resources and services
 include::modules/abi-oci-resources-services.adoc[leveloffset=+1]
@@ -39,6 +57,7 @@ include::modules/creating-config-files-cluster-install-oci.adoc[leveloffset=+1]
 * xref:../../installing/overview/installing-preparing.adoc#installing-preparing-selecting-cluster-type[Selecting a cluster installation type]
 * xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#about-the-agent-based-installer[Preparing to install with the Agent-based Installer]
 * xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-retrieve_installing-with-agent-based-installer[Downloading the Agent-based Installer]
+* xref:../../disconnected/mirroring/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red{nbsp}Hat OpenShift]
 * xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository]
 * xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-ztp_installing-with-agent-based-installer[Optional: Using ZTP manifests]
 
@@ -55,10 +74,13 @@ include::modules/running-cluster-oci-agent-based.adoc[leveloffset=+1]
 * link:https://docs.oracle.com/iaas/Content/openshift-on-oci/installing-agent-about-instance-configurations.htm[Instance Sizing Recommendations for {product-title} on {oci} Nodes (Oracle documentation)]
 * link:https://docs.oracle.com/iaas/Content/openshift-on-oci/openshift-troubleshooting.htm[Troubleshooting {product-title} on {oci} (Oracle documentation)]
 
-// Verifying a succesful cluster installation on OCI
+// Verifying that your Agent-based cluster installation runs on {oci}
 include::modules/verifying-cluster-install-oci-agent-based.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
 * xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-gather-log_installing-with-agent-based-installer[Gathering log data from a failed Agent-based installation]
+
+* xref:../../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster]

--- a/modules/abi-oci-resources-services.adoc
+++ b/modules/abi-oci-resources-services.adoc
@@ -6,9 +6,9 @@
 [id="abi-oci-resources-services_{context}"]
 = Creating {oci} infrastructure resources and services
 
-You must create an {oci} environment on your virtual machine (VM) shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
+You must create an {oci} environment on your virtual machine (VM) or bare-metal shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
 
-The Agent-based installer method for installing an {product-title} cluster on {oci} requires that you manually create {oci} resources and services.
+The Agent-based Installer method for installing an {product-title} cluster on {oci} requires that you manually create {oci} resources and services.
 
 [IMPORTANT]
 ====

--- a/modules/creating-config-files-cluster-install-oci.adoc
+++ b/modules/creating-config-files-cluster-install-oci.adoc
@@ -6,9 +6,9 @@
 [id="creating-config-files-cluster-install-oci_{context}"]
 = Creating configuration files for installing a cluster on {oci}
 
-You need to create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
+You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
 
-At a later stage, you must follow the steps in the Oracle documentation for uploading your generated agent ISO image to Oracle’s default Object Storage bucket, which is the initial step for integrating your {product-title} cluster on {oci-first}.
+At a later stage, you must follow the steps in the Oracle documentation for uploading your generated agent ISO image to Oracle's default Object Storage bucket, which is the initial step for integrating your {product-title} cluster on {oci-first}.
 
 [NOTE]
 ====
@@ -19,16 +19,12 @@ You can also use the Agent-based Installer to generate or accept Zero Touch Prov
 * You reviewed details about the {product-title} installation and update processes.
 * You read the documentation on selecting a cluster installation method and preparing the method for users.
 * You have read the "Preparing to install with the Agent-based Installer" documentation.
-* You downloaded the Agent-Based Installer and the command-line interface (CLI) from the {hybrid-console}.
-* You have logged in to the {product-title} with administrator privileges.
-
-.Procedure
-
-. For a disconnected environment, mirror the {product-mirror-registry} to your local container image registry.
+* You downloaded the Agent-Based Installer and the command-line interface (CLI) from the link:https://console.redhat.com/openshift/install/metal/agent-based[{hybrid-console}].
+* If you are installing in a disconnected environment, you have prepared a mirror registry in your environment and mirrored release images to the registry.
 +
 [IMPORTANT]
 ====
-Check that your `openshift-install` binary version relates to your local image container registry and not a shared registry, such as {quay}.
+Check that your `openshift-install` binary version relates to your local image container registry and not a shared registry, such as {quay}, by running the following command:
 
 [source,terminal]
 ----
@@ -44,10 +40,20 @@ release image registry.ci.openshift.org/origin/release:4.17ocp-release@sha256:0d
 release architecture amd64
 ----
 ====
+* You have logged in to the {product-title} with administrator privileges.
 
-. Configure the `install-config.yaml` configuration file to meet the needs of your organization.
+.Procedure
+
+. Create an installation directory to store configuration files in by running the following command:
 +
-.Example `install-config.yaml` configuration file that demonstrates setting an external platform
+[source,terminal]
+----
+$ mkdir ~/<directory_name>
+----
+
+. Configure the `install-config.yaml` configuration file to meet the needs of your organization and save the file in the directory you created.
++
+.`install-config.yaml` file that sets an external platform
 +
 [source,yaml]
 ----
@@ -82,26 +88,48 @@ pullSecret: '<pull_secret>' <6>
 # ...
 ----
 <1> The base domain of your cloud provider.
-<2> The IP address from the  virtual cloud network (VCN) that the CIDR allocates to resources and components that operate on your network.
-<3> Depending on your infrastructure, you can select either `x86_64`, or `amd64`.
+<2> The IP address from the virtual cloud network (VCN) that the CIDR allocates to resources and components that operate on your network.
+<3> Depending on your infrastructure, you can select either `arm64` or `amd64`.
 <4> Set `OCI` as the external platform, so that {product-title} can integrate with {oci}.
 <5> Specify your SSH public key.
 <6> The pull secret that you need for authenticate purposes when downloading container images for {product-title} components and services, such as Quay.io. See link:https://console.redhat.com/openshift/install/pull-secret[Install {product-title} 4] from the {hybrid-console}.
 
-. Create a directory on your local system named `openshift`.
+. Create a directory on your local system named `openshift`. This must be a subdirectory of the installation directory.
 +
 [IMPORTANT]
 ====
-Do not move the `install-config.yaml` and `agent-config.yaml` configuration files to the `openshift` directory.
+Do not move the `install-config.yaml` or `agent-config.yaml` configuration files to the `openshift` directory.
 ====
 
-. Complete the steps in the link:https://docs.oracle.com/iaas/Content/openshift-on-oci/install-prereq.htm#install-configuration-files["Configuration Files"] section of the _Oracle_ documentation to download {oci-ccm-full} and {oci-csi-full} manifests as an archive file and save the archive file in your `openshift` directory. You need the {oci-ccm} manifests for deploying the {oci-ccm} during cluster installation so that {product-title} can connect to the external {oci} platform. You need the {oci-csi} custom manifests for deploying the {oci-csi} driver during cluster installation so that {product-title} can claim required objects from {oci}.
+. If you used a stack to provision OCI infrastructure resources: Copy and paste the `dynamic_custom_manifest` output of the OCI stack into a file titled `manifest.yaml` and save the file in the `openshift` directory.
 
-. Access the custom manifest files that are provided in the link:https://docs.oracle.com/iaas/Content/openshift-on-oci/install-prereq.htm#install-configuration-files["Configuration Files"] section of the _Oracle_ documentation.
+. If you did not use a stack to provision OCI infrastructure resources: Download and prepare custom manifests to create an Agent ISO image:
+
+.. Go to link:https://docs.oracle.com/iaas/Content/openshift-on-oci/install-prereq.htm#install-configuration-files[Configuration Files] (Oracle documentation) and follow the link to the custom manifests directory on GitHub.
+
+.. Copy the contents of the `condensed-manifest.yml` file and save it locally to a file in the `openshift` directory.
+
+.. In the `condensed-manifest.yml` file, update the sections marked with `TODO` to specify the compartment {ocid-first}, VCN {ocid}, subnet {ocid} from the load balancer, and the security lists {ocid}.
+
+. Configure the `agent-config.yaml` configuration file to meet your organization's requirements.
 +
-.. Change the `oci-cloud-controller-manager` secret that is defined in the `oci-ccm.yml` configuration file to match your organization's region, compartment {ocid}, VCN {ocid}, and the subnet {ocid} from the load balancer.
+.Sample `agent-config.yaml` file for an IPv4 network.
+[source,yaml]
+----
+apiVersion: v1beta1
+metadata:
+  name: <cluster_name> // <1>
+  namespace: <cluster_namespace> <2>
+rendezvousIP: <ip_address_from_CIDR> <3>
+bootArtifactsBaseURL: <server_URL> <4>
+# ...
+----
+<1> The cluster name that you specified in your DNS record.
+<2> The namespace of your cluster on {product-title}.
+<3> If you use IPv4 as the network IP address format, ensure that you set the `rendezvousIP` parameter to an IPv4 address that the VCN's Classless Inter-Domain Routing (CIDR) method allocates on your network. Also ensure that at least one instance from the pool of instances that you booted with the ISO matches the IP address value you set for the `rendezvousIP` parameter.
+<4> The URL of the server where you want to upload the rootfs image. This parameter is required only for disconnected environments.
 
-. Use the Agent-based Installer to generate a minimal ISO image, which excludes the rootfs image, by entering the following command in your {product-title} CLI. You can use this image later in the process to boot all your cluster’s nodes.
+. Generate a minimal ISO image, which excludes the rootfs image, by entering the following command in your installation directory:
 +
 [source,terminal]
 ----
@@ -116,39 +144,21 @@ The command also completes the following actions:
 +
 [IMPORTANT]
 ====
-The Agent-based Installer uses {op-system-first}. The rootfs image, which is mentioned in a later listed item,  is required for booting, recovering, and repairing your operating system.
+The Agent-based Installer uses {op-system-first}. The rootfs image, which is mentioned in a later step, is required for booting, recovering, and repairing your operating system.
 ====
 
-. Configure the `agent-config.yaml` configuration file to meet your organization’s requirements.
-+
-.Example `agent-config.yaml` configuration file that sets values for an IPv4 formatted network.
-[source,yaml]
-----
-apiVersion: v1alpha1
-metadata:
-  name: <cluster_name> // <1>
-  namespace: <cluster_namespace> <2>
-rendezvousIP: <ip_address_from_CIDR> <3>
-bootArtifactsBaseURL: <server_URL> <4>
-# ...
-----
-<1> The cluster name that you specified in your DNS record.
-<2> The namespace of your cluster on {product-title}.
-<3> If you use IPv4 as the network IP address format, ensure that you set the `rendezvousIP` parameter to an IPv4 address that the VCN’s Classless Inter-Domain Routing (CIDR) method allocates on your network. Also ensure that at least one instance from the pool of instances that you booted with the ISO matches the IP address value you set for `rendezvousIP`.
-<4> The URL of the server where you want to upload the rootfs image.
+. Disconnected environments only: Upload the rootfs image to a web server.
 
-. Apply one of the following two updates to your `agent-config.yaml` configuration file:
+..  Go to the `./<installation_directory>/boot-artifacts` directory that was generated when you created the minimal ISO image.
+
+.. Use your preferred web server, such as any Hypertext Transfer Protocol daemon (`httpd`), to upload the rootfs image to the location specified in the `bootArtifactsBaseURL` parameter of the `agent-config.yaml` file.
 +
-* For a disconnected network:  After you run the command to generate a minimal ISO Image, the Agent-based installer saves the rootfs image into the `./<installation_directory>/boot-artifacts` directory on your local system. Use your preferred web server, such as any Hypertext Transfer Protocol daemon (`httpd`), to upload rootfs to the location stated in the `bootArtifactsBaseURL` parameter in the `agent-config.yaml` configuration file.
-+
-For example, if the `bootArtifactsBaseURL` parameter states `\http://192.168.122.20`, you would upload the generated rootfs image to this location, so that the Agent-based installer can access the image from `\http://192.168.122.20/agent.x86_64-rootfs.img`. After the Agent-based installer boots the minimal ISO for the external platform, the Agent-based Installer downloads the rootfs image from the `\http://192.168.122.20/agent.x86_64-rootfs.img` location into the system memory.
+For example, if the `bootArtifactsBaseURL` parameter states `\http://192.168.122.20`, you would upload the generated rootfs image to this location so that the Agent-based installer can access the image from `\http://192.168.122.20/agent.x86_64-rootfs.img`. After the Agent-based installer boots the minimal ISO for the external platform, the Agent-based Installer downloads the rootfs image from the `\http://192.168.122.20/agent.x86_64-rootfs.img` location into the system memory.
 +
 [NOTE]
 ====
-The Agent-based Installer also adds the value of the `bootArtifactsBaseURL` to the minimal ISO Image’s configuration, so that when the Operator boots a cluster’s node, the Agent-based Installer downloads the rootfs image into system memory.
+The Agent-based Installer also adds the value of the `bootArtifactsBaseURL` to the minimal ISO Image's configuration, so that when the Operator boots a cluster's node, the Agent-based Installer downloads the rootfs image into system memory.
 ====
-+
-* For a connected network: You do not need to specify the `bootArtifactsBaseURL` parameter in the `agent-config.yaml` configuration file. The default behavior of the Agent-based Installer reads the rootfs URL location from `\https://rhcos.mirror.openshift.com`. After the Agent-based Installer boots the minimal ISO for the external platform, the Agent-based Installer then downloads the rootfs file into your system’s memory from the default {op-system} URL.
 +
 [IMPORTANT]
 ====

--- a/modules/installing-oci-about-agent-based-installer.adoc
+++ b/modules/installing-oci-about-agent-based-installer.adoc
@@ -6,11 +6,13 @@
 [id="installing-oci-about-agent-based-installer_{context}"]
 = The Agent-based Installer and {oci} overview
 
-You can install an {product-title} cluster on {oci-first} by using the Agent-based Installer. Both Red Hat and Oracle test, validate, and support running {oci} and {ocvs-first} workloads in an {product-title} cluster on {oci}.
+You can install an {product-title} cluster on {oci-first} by using the Agent-based Installer. Red{nbsp}Hat and Oracle test, validate, and support running {oci} workloads in an {product-title} cluster.
 
-The Agent-based installer provides the ease of use of the Assisted Installation service, but with the capability to install a cluster in either a connected or disconnected environment.
+The Agent-based Installer provides the ease of use of the Assisted Installation service, but with the capability to install a cluster in either a connected or disconnected environment.
 
 The following diagrams show workflows for connected and disconnected environments:
+
+// TODO: update these images in light of new changes
 
 .Workflow for using the Agent-based installer in a connected environment to install a cluster on {oci}
 image::684_OpenShift_Installing_on_OCI_0624-connected.png[Image of a high-level workflow for using the Agent-based installer in a connected environment to install a cluster on {oci}]
@@ -31,7 +33,9 @@ By running your {product-title} cluster on {oci}, you can access the following c
 
 * Block Volume storage, where you can configure scaling and auto-tuning settings for your storage volume, so that the Block Volume service automatically adjusts the performance level to optimize performance.
 
-* {ocvs}, where you can deploy a cluster in a public-cloud environment that operates on a VMware® vSphere software-defined data center (SDDC). You continue to retain full-administrative control over your VMware vSphere environment, but you can use {oci} services to improve your applications on flexible, scalable, and secure infrastructure.
+// Should I remove the reference below of ocvs? If so, what should the new phrasing be?
+
+* {ocvs-first}, where you can deploy a cluster in a public-cloud environment that operates on a VMware® vSphere software-defined data center (SDDC). You continue to retain full-administrative control over your VMware vSphere environment, but you can use {oci} services to improve your applications on flexible, scalable, and secure infrastructure.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
[OSDOCS-12533](https://issues.redhat.com/browse/OSDOCS-12533)

Version(s): 4.17+

This PR makes updates to add GA support for Agent-based installs on Oracle.

QE review:
- [x] QE has approved this change.

Previews: [Installing a cluster on Oracle Cloud Infrastructure by using the Agent-based Installer](https://84551--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer)
