### PR TITLE
Fixed problematic ifeval

### DIFF
--- a/modules/olm-overriding-operator-pod-affinity.adoc
+++ b/modules/olm-overriding-operator-pod-affinity.adoc
@@ -11,15 +11,15 @@ ifeval::["{context}" == "nodes-scheduler-node-affinity"]
 :node:
 endif::[]
 ifeval::["{context}" == "olm-adding-operators-to-a-cluster"]
-:olm:
+:oplm:
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="olm-overriding-operator-pod-affinity_{context}"]
 
-ifdef::olm[]
+ifdef::oplm[]
 = Controlling where an Operator is installed
-endif::olm[]
+endif::oplm[]
 
 ifdef::pod[]
 = Using pod affinity and anti-affinity to control where an Operator is installed
@@ -40,9 +40,9 @@ endif::openshift-dedicated,openshift-rosa[]
 * If you want Operators that work together scheduled on the same host or on hosts located on the same rack
 * If you want Operators dispersed throughout the infrastructure to avoid downtime due to network or hardware issues
 
-ifdef::olm[]
+ifdef::oplm[]
 You can control where an Operator pod is installed by adding node affinity, pod affinity, or pod anti-affinity constraints to the Operator's `Subscription` object. Node affinity is a set of rules used by the scheduler to determine where a pod can be placed. Pod affinity enables you to ensure that related pods are scheduled to the same node. Pod anti-affinity allows you to prevent a pod from being scheduled on a node.
-endif::olm[]
+endif::oplm[]
 
 ifdef::pod[]
 You can control where an Operator pod is installed by adding a pod affinity or anti-affinity to the Operator's `Subscription` object.
@@ -52,9 +52,9 @@ ifdef::node[]
 You can control where an Operator pod is installed by adding a node affinity constraints to the Operator's `Subscription` object.
 endif::node[]
 
-ifdef::olm[]
+ifdef::oplm[]
 The following examples show how to use node affinity or pod anti-affinity to install an instance of the Custom Metrics Autoscaler Operator to a specific node in the cluster:
-endif::olm[]
+endif::oplm[]
 ifdef::node[]
 The following examples show how to use node affinity to install an instance of the Custom Metrics Autoscaler Operator to a specific node in the cluster:
 endif::node[]
@@ -188,7 +188,7 @@ To control the placement of an Operator pod, complete the following steps:
 . Edit the Operator `Subscription` object to add an affinity:
 +
 ifndef::pod[]
-ifdef::olm[]
+ifdef::oplm[]
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -213,7 +213,7 @@ spec:
 #...
 ----
 <1> Add a `nodeAffinity`, `podAffinity`, or `podAntiAffinity`. See the Additional resources section that follows for information about creating the affinity.
-endif::olm[]
+endif::oplm[]
 
 ifdef::node[]
 [source,yaml]


### PR DESCRIPTION
Fixing a problematic `ifeval` attribute.   

I am told that ifeval attributes and substitution variables are treated the same in the code. As such an `ifeval` that uses the same name as an variable is ignored, as the condition is always true.

This PR renames an ifeval variable to make it work properly. The `olm` material is appearing in the `node` and `pod` docs. 

4.16+ as the `olm` common attribute was added to 4.16 [here]( https://github.com/openshift/openshift-docs/pull/76372/files#diff-8f8ad76b1fd362614680cd9cd3719aa7d275414cd3c3e5e52b00bb3b6e5de67bR208):

Previews:
Using node affinity to control where an Operator is installed -- [Current docs](https://docs.openshift.com/container-platform/4.17/nodes/scheduling/nodes-scheduler-node-affinity.html#olm-overriding-operator-pod-affinity_nodes-scheduler-node-affinity), note double heading and repeated 3rd/4th paragraphs. [Fixed docs](https://84552--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity#olm-overriding-operator-pod-affinity_nodes-scheduler-node-affinity), one heading and no repeated paragraph.  There are other examples further down, if you feel the need to look.

Using node affinity to control where an Operator is installed -- [Current docs](https://docs.openshift.com/container-platform/4.17/nodes/scheduling/nodes-scheduler-node-affinity.html#olm-overriding-operator-pod-affinity_nodes-scheduler-node-affinity), note double heading and repeated 3rd/4th paragraphs. [Fixed docs](https://84552--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity#olm-overriding-operator-pod-affinity_nodes-scheduler-node-affinity), one heading and no repeated paragraph. There are other examples further down, if you feel the need to look.

Controlling where an Operator is installed -- [Current docs](https://docs.openshift.com/container-platform/4.17/operators/admin/olm-adding-operators-to-cluster.html#olm-overriding-operator-pod-affinity_olm-adding-operators-to-a-cluster) and [Fixed docs](https://84552--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster#olm-overriding-operator-pod-affinity_olm-adding-operators-to-a-cluster) are fine. The `node` and `pod` do not show, as those `ifevl`s work properly. 

@michaelryanpeter  @adellape  FYI 