### PR TITLE
OSDOCS-11181: adds ingress control release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -47,11 +47,15 @@ Updating two minor EUS versions in a single step is supported in 4.18. Updates f
 ==== Drop-in configuration snippets now available
 With this release, make configuring your {microshift-short} instances easier by using drop-in configuration snippets. See xref:../microshift_configuring/microshift-using-config-yaml.adoc#microshift-config-snippets_microshift-configuring[Using configuration snippets] for details.
 
+[id="microshift-4-18-ingress-controller-config_{context}"]
+==== Control ingress for your use case with additional parameters
+With this update, you have greater control over ingress to your {microshift-short} cluster by configuring more parameters. You can use these parameters to define secure connections and the number of connections per pod, plus more. See xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller_microshift-configuring[Using ingress control for a {microshift-short} cluster] for details.
+
 //[id="microshift-4-18-networking_{context}"]
 //=== Networking
 
-//[id="microshift-4-18-ingress-controller_{context}"]
-//==== Ingress controller for the router included
+//[id="microshift-4-18-nw-feature_{context}"]
+//==== tbd nw feature here
 
 //[id="microshift-4-18-storage_{context}"]
 //=== Storage


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-11181](https://issues.redhat.com/browse/OSDOCS-11181)

Link to docs preview:
[ingress-controller-config_release-notes](https://84553--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-ingress-controller-config_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updated default values are here https://github.com/openshift/openshift-docs/pull/84548
Feature is here https://github.com/openshift/openshift-docs/pull/84542

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
