### PR TITLE
[enterprise-4.13] OSDOCS#10737: Changed note for clarity reg IPI parameter 

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1965,7 +1965,7 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 |Virtual IP (VIP) addresses that you configured for control plane API access.
 [NOTE]
 ====
-This parameter applies only to installer-provisioned infrastructure.
+This parameter applies only to installer-provisioned infrastructure without an external load balancer configured. You must not specify this parameter in user-provisioned infrastructure.
 ====
 |Multiple IP addresses
 
@@ -2047,7 +2047,7 @@ If you do not specify a value, the installation program installs the resources i
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
 [NOTE]
 ====
-This parameter applies only to installer-provisioned infrastructure.
+This parameter applies only to installer-provisioned infrastructure without an external load balancer configured. You must not specify this parameter in user-provisioned infrastructure.
 ====
 |Multiple IP addresses
 


### PR DESCRIPTION
CP'ed from #83853 