### PR TITLE
OSDOCS#11845:MTO Operator Upgrate from TP to GA

### DIFF
--- a/modules/multi-arch-installing-using-cli.adoc
+++ b/modules/multi-arch-installing-using-cli.adoc
@@ -58,12 +58,12 @@ metadata:
   name: openshift-multiarch-tuning-operator
   namespace: openshift-multiarch-tuning-operator
 spec:
-  channel: tech-preview
+  channel: stable
   name: multiarch-tuning-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic
-  startingCSV: multiarch-tuning-operator.v0.9.0
+  startingCSV: multiarch-tuning-operator.v1.0.0
 ----
 
 .. Create the `Subscription` object by running the following command:
@@ -91,8 +91,8 @@ $ oc get csv -n openshift-multiarch-tuning-operator
 .Example output
 [source,terminal]
 ----
-NAME                               DISPLAY                     VERSION   REPLACES   PHASE
-multiarch-tuning-operator.v0.9.0   Multiarch Tuning Operator   0.9.0                Succeeded
+NAME                               DISPLAY                     VERSION   REPLACES                              PHASE
+multiarch-tuning-operator.v1.0.0   Multiarch Tuning Operator   1.0.0     multiarch-tuning-operator.v0.9.0      Succeeded
 ----
 +
 The installation is successful if the Operator is in `Succeeded` phase.
@@ -121,6 +121,6 @@ $ oc get subscription -n openshift-multiarch-tuning-operator
 .Example output
 [source,terminal]
 ----
-NAME                        PACKAGE                     SOURCE                              CHANNEL
-multiarch-tuning-operator   multiarch-tuning-operator   multiarch-tuning-operator-catalog   tech-preview
+NAME                        PACKAGE                     SOURCE                  CHANNEL
+multiarch-tuning-operator   multiarch-tuning-operator   redhat-operators        stable
 ----

--- a/modules/multi-arch-installing-using-web-console.adoc
+++ b/modules/multi-arch-installing-using-web-console.adoc
@@ -23,7 +23,7 @@ You can install the Multiarch Tuning Operator by using the {product-title} web c
 . Select the *Multiarch Tuning Operator* version from the *Version* list.
 . Click *Install*
 . Set the following options on the *Operator Installation* page:
-.. Set *Update Channel* to *tech-preview*.
+.. Set *Update Channel* to *stable*.
 .. Set *Installation Mode* to *All namespaces on the cluster*.
 .. Set *Installed Namespace* to *Operator recommended Namespace* or *Select a Namespace*.
 +

--- a/modules/multi-arch-uninstalling-using-cli.adoc
+++ b/modules/multi-arch-uninstalling-using-cli.adoc
@@ -33,7 +33,7 @@ $ oc get subscription.operators.coreos.com -n <namespace> <1>
 [source,terminal]
 ----
 NAME                                  PACKAGE                     SOURCE             CHANNEL
-openshift-multiarch-tuning-operator   multiarch-tuning-operator   redhat-operators   tech-preview
+openshift-multiarch-tuning-operator   multiarch-tuning-operator   redhat-operators   stable
 ----
 
 . Get the `currentCSV` value for the Multiarch Tuning Operator by running the following command:
@@ -47,7 +47,7 @@ $ oc get subscription.operators.coreos.com <subscription_name> -n <namespace> -o
 .Example output
 [source,terminal]
 ----
-currentCSV: multiarch-tuning-operator.v0.9.0
+currentCSV: multiarch-tuning-operator.v1.0.0
 ----
 
 . Delete the `Subscription` object by running the following command:
@@ -70,12 +70,12 @@ subscription.operators.coreos.com "openshift-multiarch-tuning-operator" deleted
 ----
 $ oc delete clusterserviceversion <currentCSV_value> -n <namespace> <1>
 ----
-<1> Replace `<currentCSV>` with the `currentCSV` value for the Multiarch Tuning Operator. For example: `multiarch-tuning-operator.v0.9.0`. Replace `<namespace>` with the name of the namespace where you want to uninstall the Multiarch Tuning Operator.
+<1> Replace `<currentCSV>` with the `currentCSV` value for the Multiarch Tuning Operator. For example: `multiarch-tuning-operator.v1.0.0`. Replace `<namespace>` with the name of the namespace where you want to uninstall the Multiarch Tuning Operator.
 +
 .Example output
 [source,terminal]
 ----
-clusterserviceversion.operators.coreos.com "multiarch-tuning-operator.v0.9.0" deleted
+clusterserviceversion.operators.coreos.com "multiarch-tuning-operator.v1.0.0" deleted
 ----
 
 .Verification


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-11845](https://issues.redhat.com/browse/OSDOCS-11845)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Installing the Multiarch Tuning Operator by using the web console](https://84587--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html#multi-architecture-installing-using-web-console_multiarch-tuning-operator)
- [Installing the Multiarch Tuning Operator by using the CLI](https://84587--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html#multi-architecture-installing-using-cli_multiarch-tuning-operator)
- [Uinstalling the Multiarch Tuning Operator by using the CLI](https://84587--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html#multi-architecture-uninstalling-using-cli_multiarch-tuning-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
