### PR TITLE
[enterprise-4.15] OSDOCS#12312:  hcp import limitations

### DIFF
--- a/hosted_control_planes/hcp-updating.adoc
+++ b/hosted_control_planes/hcp-updating.adoc
@@ -34,3 +34,12 @@ include::modules/hcp-update-ocp-hc.adoc[leveloffset=+1]
 
 // Updating a hosted cluster by using the mce console
 include::modules/hcp-update-using-mce-console.adoc[leveloffset=+1]
+
+include::modules/hcp-import-limitations.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]
+* xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-ocp-hc_hcp-updating[Updating a control plane in a hosted cluster]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#discover-hosted-acm[Discovering {mce} hosted clusters in Red Hat Advanced Cluster Management]

--- a/modules/hcp-import-limitations.adoc
+++ b/modules/hcp-import-limitations.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-updating.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-import-limitations_{context}"]
+= Limitations of managing imported hosted clusters
+
+Hosted clusters are automatically imported into the local {mce}, unlike a standalone {product-title} or third party clusters. Hosted clusters run some of their agents in the _hosted mode_ so that the agents do not use the resources of your cluster.
+
+If you choose to automatically import hosted clusters, you can update node pools and the control plane in hosted clusters by using the `HostedCluster` resource on the management cluster. To update node pools and a control plane, see "Updating node pools in a hosted cluster" and "Updating a control plane in a hosted cluster".
+
+You can import hosted clusters into a location other than the local {mce-short} by using the {rh-rhacm-first}. For more information, see "Discovering {mce} hosted clusters in Red Hat Advanced Cluster Management".
+
+In this topology, you must update your hosted clusters by using the command-line interface or the console of the local {mce} where the cluster is hosted. You cannot update the hosted clusters through the {rh-rhacm} hub cluster.


### PR DESCRIPTION
Manual CP of https://github.com/openshift/openshift-docs/pull/83506

Reason of conflict in the cherry-pick command: content migration is done from 4.17+ only.