### PR TITLE
OBSDOCS-1473: Prepare Enabling alert routing for user-defined project…

### DIFF
--- a/modules/monitoring-enabling-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-alert-routing-for-user-defined-projects.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="enabling-alert-routing-for-user-defined-projects_{context}"]
+= Enabling alert routing for user-defined projects
+
+In {product-title}, an administrator can enable alert routing for user-defined projects.
+This process consists of the following steps:
+
+ifndef::openshift-dedicated,openshift-rosa[]
+* Enable alert routing for user-defined projects to use the default platform Alertmanager instance or, optionally, a separate Alertmanager instance only for user-defined projects.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* Enable alert routing for user-defined projects to use a separate Alertmanager instance.
+endif::openshift-dedicated,openshift-rosa[]
+* Grant users permission to configure alert routing for user-defined projects.
+
+After you complete these steps, developers and other users can configure custom alerts and alert routing for their user-defined projects.

--- a/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
+++ b/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
@@ -6,14 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[role="_abstract"]
-ifndef::openshift-dedicated,openshift-rosa[]
-In {product-title} {product-version}, a cluster administrator can enable alert routing for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-In {product-title}, a `dedicated-admin` can enable alert routing for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-This process consists of two general steps:
+// Preparing the following short assembly introduction into a module, because this assembly will be deleted and divided into just modules
+// Introduction enabling alert routing for user-defined projects
+//include::modules/monitoring-enabling-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
+
+In {product-title}, an administrator can enable alert routing for user-defined projects.
+This process consists of the following steps:
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * Enable alert routing for user-defined projects to use the default platform Alertmanager instance or, optionally, a separate Alertmanager instance only for user-defined projects.


### PR DESCRIPTION
Version(s) for cherry-picking: none

Issue: [OBSDOCS-1473](https://issues.redhat.com/browse/OBSDOCS-1473)

Link to docs preview: https://84593--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/enabling-alert-routing-for-user-defined-projects.html

QE review:
- [x] QE has approved this change.

**Additional information:**