### PR TITLE
release-notes-context-var

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -10,7 +10,7 @@ Red Hat {product-title} provides developers and IT organizations with a hybrid c
 
 Built on {op-system-base-full} and Kubernetes, {product-title} provides a more secure and scalable multitenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.
 
-[id="ocp-4-13-about-this-release"]
+[id="ocp-4-13-about-this-release_{context}"]
 == About this release
 
 // TODO: Update with the relevant information closer to release.
@@ -38,25 +38,25 @@ You must use {op-system} machines for the control plane, and you can use either 
 //Maintenance support ends for version 4.8 in January 2023 and goes to extended life phase. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
 
-[id="ocp-4-13-add-on-support-status"]
+[id="ocp-4-13-add-on-support-status_{context}"]
 == {product-title} layered and dependent component support and compatibility
 
 The scope of support for layered and dependent components of {product-title} changes independently of the {product-title} version. To determine the current support status and compatibility for an add-on, refer to its release notes. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
-[id="ocp-4-13-new-features-and-enhancements"]
+[id="ocp-4-13-new-features-and-enhancements_{context}"]
 == New features and enhancements
 
 This release adds improvements related to the following components and concepts.
 
-[id="ocp-4-13-rhcos"]
+[id="ocp-4-13-rhcos_{context}"]
 === {op-system-first}
 
-[id="ocp-4-13-rhcos-rhel-9-2-packages"]
+[id="ocp-4-13-rhcos-rhel-9-2-packages_{context}"]
 ==== {op-system} now uses {op-system-base} 9.2
 
 {op-system} now uses {op-system-base-full} 9.2 packages in {product-title} {product-version}. This enables you to have the latest fixes, features, and enhancements, as well as the latest hardware support and driver updates.
 
-[id="ocp-4-13-rhel-9-considerations"]
+[id="ocp-4-13-rhel-9-considerations_{context}"]
 ===== Considerations for upgrading to {product-title} with {op-system-base} 9.2
 
 With this release, {product-title} {product-version} introduces a {op-system-base} 9.2 based {op-system} and there are some considerations you must make before upgrading:
@@ -69,14 +69,14 @@ With this release, {product-title} {product-version} introduces a {op-system-bas
 
 * Some device drivers have been deprecated, see the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/considerations_in_adopting_rhel_9/assembly_hardware-enablement_considerations-in-adopting-rhel-9#unmaintained-hardware-support[{op-system-base} documentation] for more information.
 
-[id="ocp-4-13-ipi-powervs"]
+[id="ocp-4-13-ipi-powervs_{context}"]
 ==== {ibmpowerProductName} Virtual Server using installer-provisioned infrastructure (Technology Preview)
 
 Installer-provisioned Infrastructure (IPI) provides a full-stack installation and setup of {product-title}.
 
 For more information, see xref:../installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc#preparing-to-install-on-ibm-power-vs[Preparing to install on {ibmpowerProductName} Virtual Server].
 
-[id="ocp-4-13-secure-execution-z-linux-one"]
+[id="ocp-4-13-secure-execution-z-linux-one_{context}"]
 ==== IBM Secure Execution on {ibmzProductName} and {linuxoneProductName}
 
 This feature was introduced as a Technology Preview in
@@ -88,25 +88,25 @@ To use IBM Secure Execution, you must have host keys for your host machine(s) an
 
 For more information, see xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-rhcos-using-ibm-secure-execution_installing-ibm-z-kvm[Installing {op-system} using IBM Secure Execution].
 
-[id="ocp-4-13-assisted-installer-p-z-linuxone"]
+[id="ocp-4-13-assisted-installer-p-z-linuxone_{context}"]
 ==== {ai-full} SaaS provides platform integration support for {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName}
 
 {ai-full} SaaS on link:https://console.redhat.com[console.redhat.com] supports installation of {product-title} on the {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName} platforms using either the {ai-full} user interface or the REST API. Integration enables users to manage their infrastructure from a single interface. There are a few additional installation steps to enable {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName} integration with Assisted Installer SaaS.
 
 For more information, see xref:../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#installing-on-prem-assisted[Installing an on-premise cluster using the {ai-full}].
 
-[id="ocp-4-13-lsof-rhcos"]
+[id="ocp-4-13-lsof-rhcos_{context}"]
 ==== {op-system} now includes lsof
 {product-title} {product-version} now includes the `lsof` command in {op-system}.
 
-[id="ocp-4-13-installation-and-update"]
+[id="ocp-4-13-installation-and-update_{context}"]
 === Installation and update
 
-[id="ocp-4-13-installation-vsphere-8-support"]
+[id="ocp-4-13-installation-vsphere-8-support_{context}"]
 ==== Support for VMware vSphere version 8.0
 {product-title} {product-version} supports VMware vSphere version 8.0. You can continue to install an {product-title} cluster on VMware vSphere version 7.0 Update 2.
 
-[id="ocp-4-13-installation-vsphere-region-zone"]
+[id="ocp-4-13-installation-vsphere-region-zone_{context}"]
 ==== VMware vSphere region and zone enablement
 You can deploy an {product-title} cluster to multiple vSphere datacenters or regions that run in a single VMware vCenter. Each datacenter can run multiple clusters or zones. This configuration reduces the risk of a hardware failure or network outage causing your cluster to fail.
 
@@ -119,58 +119,58 @@ A cluster that was upgraded from a previous release defaults to using the in-tre
 
 For more information, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installation-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations[VMware vSphere region and zone enablement].
 
-[id="ocp-4-13-installation-vsphere-default-config-yaml"]
+[id="ocp-4-13-installation-vsphere-default-config-yaml_{context}"]
 ==== Changes to the default vSphere install-config.yaml file
 After you run the installation program for {product-title} on vSphere, the default `install-config.yaml` file now includes `vcenters` and `failureDomains` fields, so that you can choose to specify multiple datacenters, region, and zone information for your cluster. You can leave these fields blank if you want to install an {product-title} cluster in a vSphere environment that consists of single datacenter running in a VMware vCenter.
 
 For more information, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations[Configuring regions and zones for a VMware vCenter].
 
-[id="ocp-4-13-installation-vsphere-external-lb-multisubnets"]
+[id="ocp-4-13-installation-vsphere-external-lb-multisubnets_{context}"]
 ==== External load balancers that support multiple vSphere subnets
 
 You can configure an {product-title} cluster to use an external load balancer that supports multiple subnets. If you use multiple subnets, you can explicitly list all the IP addresses in any networks that are used by your load balancer targets. This configuration can reduce maintenance overhead because you can create and destroy nodes within those networks without reconfiguring the load balancer targets.
 
 For more information, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#nw-osp-configuring-external-load-balancer_installing-vsphere-installer-provisioned[Configuring an external load balancer].
 
-[id="ocp-4-13-installation-vsphere-encrypt-vm"]
+[id="ocp-4-13-installation-vsphere-encrypt-vm_{context}"]
 ==== Support for encrypting a VM before installing a cluster on VMware vSphere
 
 For {product-title} {product-version}, you can encrypt your virtual machines before you install a cluster on VMware vSphere with user-provisioned infrastructure.
 
 For more information, see xref:../installing/installing_vsphere/installing-vsphere.adoc#installation-vsphere-encrypted-vms_installing-vsphere[Requirements for encrypting virtual machines]
 
-[id="ocp-4-13-installation-and-upgrade-three-node"]
+[id="ocp-4-13-installation-and-upgrade-three-node_{context}"]
 ==== Three-node cluster support
 
 Beginning with {product-title} {product-version}, deploying a three-node cluster is supported on Amazon Web Services (AWS), Microsoft Azure, Google Cloud Platform (GCP), and VMware vSphere. This type of {product-title} cluster is a smaller, more resource efficient cluster, as it consists of only three control plane machines, which also act as compute machines.
 
 For more information, see xref:../installing/installing_aws/installing-aws-three-node.adoc#installing-aws-three-node[Installing a three-node cluster on AWS], xref:../installing/installing_azure/installing-azure-three-node.adoc#installing-azure-three-node[Installing a three-node cluster on Azure], xref:../installing/installing_gcp/installing-gcp-three-node.adoc#installing-gcp-three-node[Installing a three-node cluster on GCP], and xref:../installing/installing_vsphere/installing-vsphere-three-node.adoc#installing-vsphere-three-node[Installing a three-node cluster on vSphere].
 
-[id="ocp-4-13-installation-and-upgrade-ibm-cloud-vpc"]
+[id="ocp-4-13-installation-and-upgrade-ibm-cloud-vpc_{context}"]
 ==== IBM Cloud VPC and existing VPC resources
 If you are deploying an {product-title} cluster to an existing virtual private cloud (VPC), you can now use the `networkResourceGroupName` parameter to specify the name of the resource group that contains these existing resources. This enhancement lets you keep the existing VPC resources and subnets separate from the cluster resources that the installation program provisions. You can then use the `resourceGroupName` parameter to specify the name of an existing resource group that the installation program can use to deploy all of the installer-provisioned cluster resources. If `resourceGroupName` is undefined, a new resource group is created for the cluster.
 
 For more information, see xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installation-configuration-parameters-additional-ibm-cloud_installing-ibm-cloud-customizations[Additional IBM Cloud VPC configuration parameters].
 
-[id="ocp-4-13-installation-gcp-required-permissions"]
+[id="ocp-4-13-installation-gcp-required-permissions_{context}"]
 ==== Minimum required permissions for GCP to install and delete an {product-title} cluster
 In {product-title} {product-version}, instead of using the predefined roles, you can now define your custom roles to include the minimum required permissions for Google Cloud Platform (GCP) to install and delete an {product-title} cluster. These permissions are available for installer-provisioned infrastructure and user-provisioned infrastructure.
 
-[id="ocp-4-13-user-defined-tags-azure"]
+[id="ocp-4-13-user-defined-tags-azure_{context}"]
 ==== User-defined tags for Azure
 In {product-title} {product-version}, you can configure the tags in Azure for grouping resources and for managing resource access and cost. Support for tags is available only for the resources created in the Azure Public Cloud, and in {product-title} {product-version} as a Technology Preview (TP). You can define the tags on the Azure resources in the `install-config.yaml` file only during {product-title} cluster creation.
 
-[id="ocp-4-13-gcp-shared-vpc"]
+[id="ocp-4-13-gcp-shared-vpc_{context}"]
 ==== Installing an {product-title} cluster on GCP into a shared Virtual Private Cloud (VPC)
 In {product-title} {product-version}, you can install a cluster into a shared Virtual Private Cloud (VPC) on Google Cloud Platform (GCP). This installation method configures the cluster to share a VPC with another GCP project. A shared VPC enables an organization to connect resources from multiple projects over a common VPC network. A common VPC network can increase the security and efficiency of organizational communications by using internal IP addresses.
 
 For more information, see xref:../installing/installing_gcp/installing-gcp-shared-vpc.adoc#installing-gcp-shared-vpc[Installing a cluster on GCP into a shared VPC].
 
-[id="ocp-4-13-installation-gcp-shielded-vms"]
+[id="ocp-4-13-installation-gcp-shielded-vms_{context}"]
 ==== Installing a cluster on GCP using Shielded VMs
 In {product-title} {product-version}, you can use Shielded VMs when installing your cluster. Shielded VMs have extra security features including secure boot, firmware and integrity monitoring, and rootkit detection. For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-enabling-shielded-vms_installing-gcp-customizations[Enabling Shielded VMs] and Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
 
-[id="ocp-4-13-installation-gcp-confidential-vms"]
+[id="ocp-4-13-installation-gcp-confidential-vms_{context}"]
 ==== Installing a cluster on GCP using Confidential VMs
 In {product-title} {product-version}, you can use Confidential VMs when installing your cluster. Confidential VMs encrypt data while it is being processed. For more information, see Google's documentation about link:https://cloud.google.com/confidential-computing[Confidential Computing]. You can enable Confidential VMs and Shielded VMs at the same time, although they are not dependent on each other.
 
@@ -179,17 +179,17 @@ In {product-title} {product-version}, you can use Confidential VMs when installi
 Due to a known issue in {product-title} 4.13.3 and earlier versions, you cannot use persistent volume storage on a cluster with Confidential VMs on Google Cloud Platform (GCP). This issue was resolved in {product-title} 4.13.4. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-11768[OCPBUGS-11768].
 ====
 
-[id="ocp-4-13-installation-aws-local-zones"]
+[id="ocp-4-13-installation-aws-local-zones_{context}"]
 ==== Installing a cluster on AWS into an existing Virtual Private Cloud (VPC) improvements
 
 In {product-title} {product-version}, the installation process for clusters that use AWS VPCs is simplified. This release also introduces the _edge pool_, a pool of machines that are optimized for AWS Local Zones.
 
 For more information, see xref:../installing/installing_aws/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster using AWS Local Zones].
 
-[id="ocp-4-13-admin-ack-upgrading"]
+[id="ocp-4-13-admin-ack-upgrading_{context}"]
 ==== Required administrator acknowledgment when upgrading from {product-title} 4.12 to 4.13
 
-{product-title} 4.13 uses Kubernetes 1.26, which removed xref:../release_notes/ocp-4-13-release-notes.adoc#ocp-4-13-removed-kube-1-26-apis[several deprecated APIs].
+{product-title} 4.13 uses Kubernetes 1.26, which removed xref:../release_notes/ocp-4-13-release-notes.adoc#ocp-4-13-removed-kube-1-26-apis_release-notes[several deprecated APIs].
 
 A cluster administrator must provide a manual acknowledgment before the cluster can be upgraded from {product-title} 4.12 to 4.13. This is to help prevent issues after upgrading to {product-title} 4.13, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
 
@@ -197,25 +197,25 @@ All {product-title} 4.12 clusters require this administrator acknowledgment befo
 
 For more information, see xref:../updating/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.13].
 
-[id="ocp-4-13-installation-minimum-required-permissions-azure"]
+[id="ocp-4-13-installation-minimum-required-permissions-azure_{context}"]
 ==== Minimum required permissions for Microsoft Azure to install and delete an {product-title} cluster
 In {product-title} {product-version}, instead of using the built-in roles, you can now define your custom roles to include the minimum required permissions for Microsoft Azure to install and delete an {product-title} cluster. These permissions are available for installer-provisioned infrastructure and user-provisioned infrastructure.
 
-[id="ocp-4-13-updating-clusters-migrating-cluster-to-multi-arch"]
+[id="ocp-4-13-updating-clusters-migrating-cluster-to-multi-arch_{context}"]
 ==== Single-architecture to multi-architecture payload migration
 {product-title} {product-version} introduces the `oc adm upgrade --to-multi-arch` command, which lets you migrate a cluster with single-architecture compute machines to a cluster with multi-architecture compute machines. By updating to a multi-architecture, manifest-listed payload, you can add mixed architecture compute machines to your cluster.
 
-[id="ocp-4-13-install-configure-vips-to-run-on-control-plane"]
+[id="ocp-4-13-install-configure-vips-to-run-on-control-plane_{context}"]
 ==== Configuring network components to run on the control plane in vSphere
 
 If you need the virtual IP (VIP) addresses to run on the control plane nodes in a vSphere installation, you must configure the `ingressVIP` addresses to run exclusively on the control plane nodes. By default, {product-title} allows any node in the worker machine configuration pool to host the `ingressVIP` addresses. Because vSphere environments deploy worker nodes in separate subnets from the control plane nodes, configuring the `ingressVIP` addresses to run exclusively on the control plane nodes prevents issues from arising due to deploying worker nodes in separate subnets. For additional details, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#configure-network-components-to-run-on-the-control-plane_installing-vsphere-installer-provisioned-network-customizations[Configuring network components to run on the control plane in vSphere].
 
-[id="ocp-4-13-install-aws-on-a-single-node"]
+[id="ocp-4-13-install-aws-on-a-single-node_{context}"]
 ==== Installing an {product-title} cluster on AWS with a single node
 
 In {product-title} {product-version}, you can install a cluster with a single node on Amazon Web Services (AWS). Installing on a single node increases the resource requirements for the node. For additional details, see xref:../installing/installing_aws/preparing-to-install-on-aws.adoc#choosing-an-method-to-install-ocp-on-aws-single-node[Installing a cluster on a single node].
 
-[id="ocp-4-13-upi-scaling-hosts-with-bmo"]
+[id="ocp-4-13-upi-scaling-hosts-with-bmo_{context}"]
 ==== Scale bare metal hosts in a user-provisioned cluster by using the Bare Metal Operator
 
 With {product-title} {product-version}, you can scale bare metal hosts in an existing user-provisioned infrastructure cluster by using the Bare Metal Operator (BMO) and other metal^3^ components. By using the Bare Metal Operator in a user-provisioned cluster, you can simplify and automate the management and scaling of hosts.
@@ -229,16 +229,16 @@ You cannot use a provisioning network to scale user-provisioned infrastructure c
 
 For more information about scaling a user-provisioned cluster by using the BMO, see xref:../installing/installing_bare_metal/scaling-a-user-provisioned-cluster-with-the-bare-metal-operator.adoc#scaling-a-user-provisioned-cluster-with-the-bare-metal-operator[Scaling a user-provisioned cluster with the Bare Metal Operator].
 
-[id="ocp-4-13-OCP-on-ARM"]
+[id="ocp-4-13-OCP-on-ARM_{context}"]
 ==== {product-title} on 64-bit ARM
 {product-title} {product-version} is now supported on 64-bit ARM architecture-based Azure user-provisioned installations. The Agent based installation program is also now supported on 64-bit ARM systems. For more information about instance availability and installation documentation, see xref:../installing/overview/installing-preparing.adoc#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms].
 
 // OCPBUGS-8431
-[id="ocp-4-13-jenkins-git-lfs"]
+[id="ocp-4-13-jenkins-git-lfs_{context}"]
 ====  Support for the git-lfs package
 The OpenShift Jenkins image now supports the `git-lfs` package. With this package, you can use artifacts larger than 200 megabytes (MB) in your OpenShift Jenkins image.
 
-[id="ocp-4-13-installation-oc-mirror-oci-ga"]
+[id="ocp-4-13-installation-oc-mirror-oci-ga_{context}"]
 ==== Using the oc-mirror plugin to include local OCI Operator catalogs is now generally available
 
 You can now use the oc-mirror plugin to mirror local OCI Operator catalogs on disk to a mirror registry. This feature was previously introduced as a Technology Preview in {product-title} 4.12 and is now generally available in {product-title} 4.13.
@@ -260,52 +260,50 @@ This release introduces support for the following features when local OCI catalo
 
 For more information, see xref:../installing/disconnected_install/installing-mirroring-disconnected.adoc#oc-mirror-oci-format_installing-mirroring-disconnected[Including local OCI Operator catalogs].
 
-[id="ocp-4-13-installation-openstack-failure-domains"]
+[id="ocp-4-13-installation-openstack-failure-domains_{context}"]
 ==== Deploy clusters that use failure domains on {rh-openstack} (Technology Preview)
 
 You can now deploy clusters that span multiple failure domains on {rh-openstack}. For deployments at scale, failure domains improve resilience and performance.
 
 For more information, see xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installation-configuration-parameters-failure-domains-osp_installing-openstack-installer-custom[{rh-openstack} parameters for failure domains].
 
-[id="ocp-4-13-installation-openstack-external-load-balancers"]
+[id="ocp-4-13-installation-openstack-external-load-balancers_{context}"]
 ==== Deploy clusters with user-managed load balancers on {rh-openstack} (Technology Preview)
 
 You can now deploy clusters on {rh-openstack} with user-managed load balancers rather than the default, internal load balancer.
 
 For more information, see xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#install-osp-external-lb-config_installing-openstack-installer-custom[Installation configuration for a cluster on OpenStack with a user-managed load balancer].
 
-[id="ocp-4-13-installation-nutanix-projects-categories"]
+[id="ocp-4-13-installation-nutanix-projects-categories_{context}"]
 ==== Using projects and categories when installing a cluster on Nutanix
 
 In {product-title} {product-version}, you can use projects and categories to organize compute plane virtual machines in a cluster installed on Nutanix. Projects define logical groups of user roles for managing permissions, networks, and other parameters. You can use categories to apply policies to groups of virtual machines based on shared characteristics.
 
 For more information, see xref:../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installation-configuration-parameters-additional-vsphere_installing-nutanix-installer-provisioned[Installing a cluster on Nutanix].
 
-[id="ocp-4-13-installation-agent-console-application"]
+[id="ocp-4-13-installation-agent-console-application_{context}"]
 ==== Agent-based Installer now performs network connectivity checks
 
 For installations of {product-title} {product-version} using the Agent-based Installer, a console application (with a textual user interface) performs a pull check early in the installation process to verify that the current host can retrieve the configured release image. The console application supports troubleshooting issues by allowing users to directly modify network configurations.
 
 For more information, see xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-tui_installing-with-agent-based-installer[Verifying that the current installation host can pull release images].
 
-[id="ocp-4-13-post-installation"]
+[id="ocp-4-13-post-installation_{context}"]
 === Post-installation configuration
 
-[id="ocp-4-13-multi-arch-compute-machines-ga"]
+[id="ocp-4-13-multi-arch-compute-machines-ga_{context}"]
 ==== {product-title} clusters with multi-architecture compute machines
 
 {product-title} {product-version} clusters with multi-architecture compute machines is now generally available. As a Day 2 operation, you can now create a cluster with compute nodes of different architectures on AWS and Azure installer provisioned infrastructures. User-provisioned installation on bare metal are in Technology Preview. For more information on creating a cluster with multi-architecture compute machines, see xref:../post_installation_configuration/multi-architecture-configuration.adoc#multi-architecture-configuration[Configuring multi-architecture compute machines on an {product-title} cluster].
 
 
-[id="ocp-4-13-post-installation-vsphere-failure-domains"]
+[id="ocp-4-13-post-installation-vsphere-failure-domains_{context}"]
 ==== Specifying multiple failure domains for your cluster on VSphere
 As an administrator, you can specify multiple failure domains for your {product-title} cluster that runs on a VMware VSphere instance. This means that you can distribute key control planes and workload elements among varied hardware resources for a datacenter. Additionally, you can configure your cluster to use a multiple layer 2 network configuration, so that data transfer among nodes can span across multiple networks.
 
 For more information, see xref:../installing/installing_vsphere/post-install-vsphere-zones-regions-configuration.adoc#specifying-regions-zones-infrastructure-vsphere_post-install-vsphere-zones-regions-configuration[Specifying multiple regions and zones for your cluster on vSphere].
 
-[id="ocp-4-13-web-console"]
-=== Web console
-[id="ocp-4-13-developer-perspective"]
+[id="ocp-4-13-developer-perspective_{context}"]
 ==== Developer Perspective
 
 With this release, you can now perform the following actions in the *Developer* perspective of the web console:
@@ -320,14 +318,14 @@ With this release, you can now perform the following actions in the *Developer* 
 * Customize the timeout period or provide your own image when instantiating a *Web Terminal*.
 * As an administrator, set default resources to be pre-pinned in the *Developer* perspective navigation for all users.
 
-[id="ocp-4-13-pipelines-page-improvements"]
+[id="ocp-4-13-pipelines-page-improvements_{context}"]
 ===== Pipelines page improvements
 In {product-title} 4.13, you can see the following navigation improvements on the *Pipelines* page:
 
 * The tab you previously selected remains visible when you return to the *Pipelines* page.
 * The default tab for the *Repository details* page is now *PipelinesRuns*, but when you are following the *Create Git Repository* flow, the default tab is *Details*.
 
-[id="ocp-4-13-helm-page-improvements"]
+[id="ocp-4-13-helm-page-improvements_{context}"]
 ===== Helm page improvements
 In {product-title} 4.13, the *Helm* page now contains the following new and updated features:
 
@@ -336,17 +334,17 @@ In {product-title} 4.13, the *Helm* page now contains the following new and upda
 * The Helm release list now includes a *Status* column.
 
 
-[id="ocp-4-13-oc"]
+[id="ocp-4-13-oc_{context}"]
 === OpenShift CLI (oc)
 
-[id="ocp-4-13-oc-must-gather-namespace"]
+[id="ocp-4-13-oc-must-gather-namespace_{context}"]
 ==== New flag added to run must-gather in a specified namespace
 
 With {product-title} 4.13, the `--run-namespace` flag is now available for the `oc adm must-gather` command. You can use this flag to specify an existing namespace to run the must-gather tool in.
 
 For more information, see xref:../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[About the must-gather tool].
 
-[id="ocp-4-13-import-image"]
+[id="ocp-4-13-import-image_{context}"]
 ==== Importing manifests with the OpenShift CLI (oc)
 
 With {product-title} {product-version}, a new `oc` command line interface (CLI) flag, `--import-mode`, has been added to the following `oc` commands:
@@ -358,12 +356,12 @@ With this enhancement, users can set the `--import-mode` flag to `Legacy` or `Pr
 
 For more information, see xref:../openshift_images/image-streams-manage.adoc#images-imagestream-import-import-mode_image-streams-managing[Working with manifest lists].
 
-[id="ocp-4-13-oc-describe-enhancement"]
+[id="ocp-4-13-oc-describe-enhancement_{context}"]
 ==== Returning os/arch and digests of an image
 
 With {product-title} {product-version}, running `oc describe` on an image now returns os/arch and digests of each manifest.
 
-[id="ocp-4-13-ibm-z"]
+[id="ocp-4-13-ibm-z_{context}"]
 === {ibmzProductName} and {linuxoneProductName}
 
 With this release, {ibmzProductName} and {linuxoneProductName} are now compatible with {product-title} {product-version}. The installation can be performed with z/VM or {op-system-base-full} Kernel-based Virtual Machine (KVM). For installation instructions, see the following documentation:
@@ -403,7 +401,7 @@ For installation instructions, see the following documentation:
 
 * xref:../installing/installing_ibm_z/installing-ibm-z-kvm.html#installing-rhcos-using-ibm-secure-execution_installing-ibm-z-kvm[Installing {op-system} using IBM Secure Execution]
 
-[id="ocp-4-13-ibm-power"]
+[id="ocp-4-13-ibm-power_{context}"]
 === {ibmpowerProductName}
 
 With this release, {ibmpowerProductName} is now compatible with {product-title} {product-version}. For installation instructions, see the following documentation:
@@ -695,18 +693,18 @@ This release introduces support for the following features on {ibmpowerProductNa
 |Supported
 |====
 
-[id="ocp-4-13-images"]
+[id="ocp-4-13-images_{context}"]
 === Images
 
-[id="ocp-4-13-manifest-list-support"]
+[id="ocp-4-13-manifest-list-support_{context}"]
 ==== Support for manifest listed images on image streams
 
 With {product-title} {product-version}, support for manifest listed images on image streams is now generally available.
 
-[id="ocp-4-13-security"]
+[id="ocp-4-13-security_{context}"]
 === Security and compliance
 
-[id="ocp-4-13-aesgcm-encryption"]
+[id="ocp-4-13-aesgcm-encryption_{context}"]
 ==== AES-GCM encryption is now supported
 
 The AES-GCM encryption type is now supported when enabling etcd encryption for {product-title}. Encryption keys for the AES-GCM encryption type are rotated weekly.
@@ -716,47 +714,47 @@ For more information, see xref:../security/encrypting-etcd.adoc#etcd-encryption-
 //[id="ocp-4-13-auth"]
 //=== Authentication and authorization
 
-[id="ocp-4-13-networking"]
+[id="ocp-4-13-networking_{context}"]
 === Networking
 
-[id="ocp-4-13-networking-metrics"]
+[id="ocp-4-13-networking-metrics_{context}"]
 ==== Enhancements to networking metrics
 
-[id="ocp-4-13-egress-ips-rebalance-total"]
+[id="ocp-4-13-egress-ips-rebalance-total_{context}"]
 ===== egress_ips_rebalance_total
 * Metric name: `ovnkube_master_egress_ips_rebalance_total`
 * *Help message:* `The total number of times assigned egress IP(s) needed to be moved to a different node.`
 
-[id="ocp-4-13-egress-ips-node-unreachable"]
+[id="ocp-4-13-egress-ips-node-unreachable_{context}"]
 ===== egress_ips_node_unreachable_total
 * Metric name: `ovnkube_master_egress_ips_node_unreachable_total`
 * *Help message*: `The total number of times assigned egress IP(s) were unreachable.`
 
-[id="ocp-4-13-egress-ips-unassign-latency-seconds"]
+[id="ocp-4-13-egress-ips-unassign-latency-seconds_{context}"]
 ===== egress_ips_unassign_latency_seconds
 * Metric name: `ovnkube_master_egress_ips_unassign_latency_seconds`
 * *Help message*: `The latency of egress IP unassignment from OVN northbound database.`
 
-[id="ocp-4-13-interface-total"]
+[id="ocp-4-13-interface-total_{context}"]
 ===== interfaces_total
 * Metric name: `ovs_vswitchd_interfaces_total`
 * *Help message*: `The total number of Open vSwitch interface(s) created for pods` and  `Open vSwitch interface until its available.`
 
-[id="ocp-4-13-interface-up-wait"]
+[id="ocp-4-13-interface-up-wait_{context}"]
 ===== interface_up_wait_seconds_total
 * Metric name: `ovs_vswitchd_interface_up_wait_seconds_total`
 * *Help message*: `The total number of seconds that is required to wait for pod.` and `Open vSwitch interface until its available.`
 
-[id="ocp-4-13-ovnkube-resources-retry-failures-total"]
+[id="ocp-4-13-ovnkube-resources-retry-failures-total_{context}"]
 ===== ovnkube_resource_retry_failures_total
 * Metric name: `ovnkube_resource_retry_failures_total`
 * *Help message*: `The total number of times processing a Kubernetes resource reached the maximum retry limit and was no longer processed.`
 
-[id="ocp-4-13-networking-alerts"]
+[id="ocp-4-13-networking-alerts_{context}"]
 ==== Enhancements to networking alerts
 * OVN Kubernetes retries a claim up to 15 times before dropping it. With this update, if this failure happens, {product-title} alerts the cluster administrator. A description of each alert can be viewed in the console.
 
-[id="ocp-4-13-noovnmasterleader"]
+[id="ocp-4-13-noovnmasterleader_{context}"]
 ===== NoOvnMasterLeader
 * Summary: There is no ovn-kubernetes master leader.
 * Description in console:
@@ -766,7 +764,7 @@ For more information, see xref:../security/encrypting-etcd.adoc#etcd-encryption-
 Networking control plane is degraded. Networking configuration updates applied to the cluster will not be implemented while there is no OVN Kubernetes leader. Existing workloads should continue to have connectivity. OVN-Kubernetes control plane is not functional.
 ----
 
-[id="ocp-4-13-NodeOVSOverflowUserspace"]
+[id="ocp-4-13-NodeOVSOverflowUserspace_{context}"]
 ===== OVNKubernetesNodeOVSOverflowUserspace
 * Summary: OVS vSwitch daemon drops packets due to buffer overflow.
 * Description in console:
@@ -776,7 +774,7 @@ Networking control plane is degraded. Networking configuration updates applied t
 Netlink messages dropped by OVS vSwitch daemon due to netlink socket buffer overflow. This will result in packet loss.
 ----
 
-[id="ocp-4-13-NodeOVSOverflowKernel"]
+[id="ocp-4-13-NodeOVSOverflowKernel_{context}"]
 ===== OVNKubernetesNodeOVSOverflowKernel
 * Summary: OVS kernel module drops packets due to buffer overflow.
 * Description in console:
@@ -786,13 +784,13 @@ Netlink messages dropped by OVS vSwitch daemon due to netlink socket buffer over
 Netlink messages dropped by OVS kernel module due to netlink socket buffer overflow. This will result in packet loss.
 ----
 
-[id="ocp-4-13-nw-metallb-ipaddresspool-assignment"]
+[id="ocp-4-13-nw-metallb-ipaddresspool-assignment_{context}"]
 ==== Assign IP addresses in MetalLB IPAddressPool resources to specific namespaces and services
 With this update, you can assign IP addresses from a MetalLB `IPAddressPool` resource to services, namespaces, or both. This is useful in a muti-tenant, bare-metal environment that requires MetalLB to pin IP addresses from an IP address pool to specific services and namespaces. You can assign IP addresses from many IP address pools to services and namespaces. You can then define the prioritization for these IP address pools so that MetalLB assigns IP addresses starting from the higher priority IP address pool.
 
 For more information about assigning IP addresses from an IP address pool to services and namespaces, see xref:../networking/metallb/metallb-configure-address-pools.adoc#nw-metallb-configure-address-pool_configure-metallb-address-pools[Configuring MetalLB address pools].
 
-[id="ocp-4-13-supporting-ocp-nodes-with-dual-port-nics"]
+[id="ocp-4-13-supporting-ocp-nodes-with-dual-port-nics_{context}"]
 ==== Supporting {product-title} installation on nodes with dual-port NICs (Technology Preview)
 
 With this update, {product-title} cluster can be deployed on a bond interface with 2 virtual function (VFs) on 2 physical functions (PFs) using the following methods:
@@ -803,43 +801,43 @@ With this update, {product-title} cluster can be deployed on a bond interface wi
 
 For more information about installing {product-title} on nodes with dual-port NICs, see xref:../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal[NIC partitioning for SR-IOV devices].
 
-[id="ocp-4-13-bf2-switching-dpu-nic"]
+[id="ocp-4-13-bf2-switching-dpu-nic_{context}"]
 ==== Support for switching the BlueField-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode is now GA
 
 In this release, switching the BlueField-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode is now generally available.
 
 For more information, see xref:../networking/hardware_networks/switching-bf2-nic-dpu.adoc#switching-bf2-nic-dpu[Switching BlueField-2 from DPU to NIC].
 
-[id="ocp-4-13-networking-supported-hardware-for-ovs"]
+[id="ocp-4-13-networking-supported-hardware-for-ovs_{context}"]
 ==== Hardware offload for the MT2892 Family [ConnectX-6 Dx] of network cards is GA
 
 {product-title} 4.13 adds OvS Hardware Offload support for the MT2892 Family [ConnectX-6 Dx] of network cards.
 
 For more information, see xref:../networking/hardware_networks/configuring-hardware-offloading.adoc#supported_devices_configuring-hardware-offloading[Supported devices].
 
-[id="ocp-4-13-migrate-to-openshift-sdn-network-plugin"]
+[id="ocp-4-13-migrate-to-openshift-sdn-network-plugin_{context}"]
 ==== Migrating to the OpenShift SDN network plugin
 
 If you are using the OVN-Kubernetes network plugin, you can migrate to the OpenShift SDN network plugin.
 
 For more information, see xref:../networking/openshift_sdn/migrate-to-openshift-sdn.adoc#migrate-to-openshift-sdn[Migrating to the OpenShift SDN network plugin].
 
-[id="ocp-4-13-core-dns-update"]
+[id="ocp-4-13-core-dns-update_{context}"]
 ==== CoreDNS updated to 1.10.1
 
 {product-title} {product-version} updates CoreDNS to 1.10.1. CoreDNS now uses the DNSSEC DO Bit that was specified on the originating client query. This reduces the DNS response UDP packet size when a client is not requesting DNSSEC. Consequently, the smaller packet size reduces both the chance of DNS truncation decreasing by TCP connection retries and overall DNS bandwidth.
 
-[id="ocp-4-13-expand-cluster-network-ip-address-range"]
+[id="ocp-4-13-expand-cluster-network-ip-address-range_{context}"]
 ==== Expand cluster network IP address range
 
 The cluster network can be expanded to support the addition of nodes to the cluster. For example, if you deployed a cluster and specified `10.128.0.0/19` as the cluster network range and a host prefix of `23`, you are limited to 16 nodes. You can expand that to 510 nodes by changing the CIDR mask on a cluster to `/14`. For more information, see xref:../networking/configuring-cluster-network-range.adoc#configuring-cluster-network-range[Configuring the cluster network range].
 
-[id="ocp-4-13-dual-stack-vmware-vsphere-clusters"]
+[id="ocp-4-13-dual-stack-vmware-vsphere-clusters_{context}"]
 ==== Dual-stack IPv4/IPv6 on VMware vSphere clusters
 
 On installer-provisioned vSphere clusters, you can use dual-stack networking with IPv4 as the primary IP family, and IPv6 as the secondary address family. For more information, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installation-configuration-parameters-network_installing-vsphere-installer-provisioned-network-customizations[Network configuration parameters].
 
-[id="ocp-4-13-ipv6-primary-address-family-bare-metal-dual-stack-clusters"]
+[id="ocp-4-13-ipv6-primary-address-family-bare-metal-dual-stack-clusters_{context}"]
 ==== IPv6 as primary IP address family on bare metal dual-stack clusters
 
 During cluster installation on bare metal, you can configure IPv6 as the primary IP address family on a dual-stack cluster. To enable this feature when installing a new cluster, specify an IPv6 address family before an IPv4 address family for the machine network, cluster network, service network, API VIPs, and ingress VIPs.
@@ -849,31 +847,31 @@ For more information, refer to the following sources:
 * Installer-provisioned infrastructure: xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow[Deploying with dual-stack networking]
 * User-provisioned infrastructure: xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-configuration-parameters-network_installing-bare-metal-network-customizations[Network configuration parameters]
 
-[id="ocp-4-13-ovn-kubernetes-plugin-secondary-network"]
+[id="ocp-4-13-ovn-kubernetes-plugin-secondary-network_{context}"]
 ==== OVN-Kubernetes is available as a secondary network (Technology Preview)
 
 With this release, the {openshift-networking} OVN-Kubernetes network plug-in allows the configuration of secondary network interfaces for pods. As a secondary network, OVN-Kubernetes supports a layer 2 (switched) topology network. This is available as a Technology Preview feature.
 
 For more information about OVN-Kubernetes as a secondary network, see xref:../networking/multiple_networks/configuring-additional-network.html#configuration-ovnk-additional-networks_configuring-additional-network[Configuration for an OVN-Kubernetes additional network].
 
-[id="ocp-4-13-nodeselector-egressfirewall-enhancement"]
+[id="ocp-4-13-nodeselector-egressfirewall-enhancement_{context}"]
 ==== Node selector added to egress firewall for OVN-Kubernetes network plugin
 
 In {product-title} {product-version}, `nodeSelector` has been added to the egress firewall destination spec in OVN-Kubernetes network plug-in. This feature allows users to add a label to one or multiple nodes and the IP addresses of the selected nodes are included in the associated rule. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuringNodeSelector-example_configuring-egress-firewall-ovn[Example nodeSelector for EgressFirewall]
 
-[id="ocp-4-13-nw-openstack-kuryr-migration"]
+[id="ocp-4-13-nw-openstack-kuryr-migration_{context}"]
 ==== Kuryr to OVN-Kubernetes migration procedure for clusters that run on {rh-openstack} (Technology Preview)
 
 You can now migrate a cluster that runs on {rh-openstack} and uses Kuryr to OVN-Kubernetes.
 
 For more information, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc#migrate-from-kuryr-sdn[Migrating from the Kuryr network plugin to the OVN-Kubernetes network plugin].
 
-[id="ocp-4-13-nw-openstack-egressip"]
+[id="ocp-4-13-nw-openstack-egressip_{context}"]
 ==== Improved egress IP support for clusters that run on {rh-openstack}
 
 For clusters that run on {rh-openstack} and use OVN-Kubernetes, manually reassigning floating IP addresses for reservation ports is no longer necessary. If a reservation port is removed from one node and recreated on another one, the reassignment now happens automatically.
 
-[id="ocp-4-13-networking-supported-hardware-for-sr-iov"]
+[id="ocp-4-13-networking-supported-hardware-for-sr-iov_{context}"]
 ==== Supported hardware for SR-IOV (Single Root I/O Virtualization)
 
 {product-title} {product-version} adds support for the following SR-IOV devices:
@@ -883,28 +881,28 @@ For clusters that run on {rh-openstack} and use OVN-Kubernetes, manually reassig
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
 
-[id="ocp-4-13-storage"]
+[id="ocp-4-13-storage_{context}"]
 === Storage
 
-[id="ocp-4-13-aws-customer-managed-keys-kms"]
+[id="ocp-4-13-aws-customer-managed-keys-kms_{context}"]
 ==== Support for customer-managed keys for re-encryption in the KMS
 
 With this update, the default credentials request for AWS has been modified to allow customer-managed keys to be used for re-encryption in the Key Management Service (KMS). For clusters with the Cloud Credential Operator (CCO) configured to use manual mode, administrators must apply those changes manually by adding `kms:ReEncrypt*` permission to their key policy. Other administrators are not impacted by this change. (link:https://issues.redhat.com/browse/OCPBUGS-5410[*OCPBUGS-5410*])
 
-[id="ocp-4-13-storage-lvms-dual-stack-support"]
+[id="ocp-4-13-storage-lvms-dual-stack-support_{context}"]
 ==== Dual-stack support for {lvms-first}
 In {product-title} {product-version}, {lvms} is supported in dual-stack for IPv4 and IPv6 network environments. For more information, see xref:../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc#nw-dual-stack-convert_converting-to-dual-stack[Converting to a dual-stack cluster network].
 
-[id="ocp-4-13-storage-lvms-in-zpt"]
+[id="ocp-4-13-storage-lvms-in-zpt_{context}"]
 ==== Support for {lvms} in GitOps ZTP
 In {product-title} {product-version}, you can add and configure {lvms-first} through {ztp}. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-provisioning-lvm-storage_ztp-advanced-policy-config[Configuring LVM Storage using PolicyGenTemplate CRs] and xref:../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#lvms-configuring-lvms-on-sno_sno-configure-for-vdu[LVM Storage].
 
-[id="ocp-4-13-storage-lvms-in-disconnected-env"]
+[id="ocp-4-13-storage-lvms-in-disconnected-env_{context}"]
 ==== Support for {lvms} in disconnected environments
 
 In {product-title} {product-version}, you can install {lvms} in disconnected environments. For more information, see xref:../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-installing-lvms-disconnected-env_logical-volume-manager-storage[Installing LVM Storage in a disconnected environment].
 
-[id="ocp-4-13-storage-user-managed-encryption"]
+[id="ocp-4-13-storage-user-managed-encryption_{context}"]
 ==== User-managed encryption is generally available
 The user-managed encryption feature allows you to provide keys during installation that encrypt {product-title} node root volumes, and enables all managed storage classes to use these keys to encrypt provisioned storage volumes. This allows you to encrypt storage volumes with your selected key, instead of the platform’s default account key.
 
@@ -916,31 +914,31 @@ This features supports the following storage types:
 
 * Google Cloud Platform (GCP) persistent disk (PD) storage (for more information, see xref:../storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc#byok_persistent-storage-csi-gcp-pd[User-managed encryption])
 
-[id="ocp-4-13-storage-csi-vol-detach-non-graceful-shutdown"]
+[id="ocp-4-13-storage-csi-vol-detach-non-graceful-shutdown_{context}"]
 ==== Detach CSI volumes after non-graceful node shutdown (Technology Preview)
 Container Storage Interface (CSI) drivers can now automatically detach volumes when a node goes down non-gracefully. When a non-graceful node shutdown occurs, you can then manually add an out-of-service taint on the node to allow volumes to automatically detach from the node. This feature is supported with Technology Preview status.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc[Detach CSI volumes after non-graceful node shutdown].
 
-[id="ocp-4-13-storage-vsphere-encryption-support"]
+[id="ocp-4-13-storage-vsphere-encryption-support_{context}"]
 ==== VMware vSphere encryption support is generally available
 You can encrypt virtual machines (VMs) and persistent volumes (PVs) on {product-title} running on vSphere.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[vSphere persistent disks encryption].
 
-[id="ocp-4-13-storage-vpshere-top-support-multi-datacenters"]
+[id="ocp-4-13-storage-vpshere-top-support-multi-datacenters_{context}"]
 ==== VMware vSphere CSI topology support for multiple datacenters is generally available
 {product-title} 4.12 introduced the ability to deploy {product-title} for vSphere on different zones and regions, which allows you to deploy over multiple compute clusters, thus helping to avoid a single point of failure. {product-title} 4.13 introduces support for deploying over multiple datacenters and to set up the topology using failure domains created during installation or post-installation.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[vSphere CSI topology].
 
-[id="ocp-4-13-storage-multiple-default-sc"]
+[id="ocp-4-13-storage-multiple-default-sc_{context}"]
 ==== Creating more than one default storage class is generally available
 {product-title} 4.13 allows you create more than one default storage class. This feature makes it easier to change the default storage class because you can create a second storage class defined as the default. You then temporarily have two default storage classes before removing default status from the previous default storage class. While it is acceptable to have multiple default storage classes for a short time, you should ensure that eventually only one default storage class exists.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#change-default-storage-class_persistent-storage-csi-sc-manage[Changing the default storage class] and xref:../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#multiple-default-storage-classes[Multiple default storage classes].
 
-[id="ocp-4-13-storage-managing-default-sc"]
+[id="ocp-4-13-storage-managing-default-sc_{context}"]
 ==== Managing the default storage class is generally available
 {product-title} 4.13 introduces the `spec.storageClassState` field in the `ClusterCSIDriver` object, which allows you to manage the default storage class generated by {product-title} to accomplish several different objectives:
 
@@ -952,7 +950,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc[Managing the default storage class].
 
-[id="ocp-4-13-storage-retroactive-default-sc-assignment"]
+[id="ocp-4-13-storage-retroactive-default-sc-assignment_{context}"]
 ==== Retroactive default StorageClass assignment (Technology Preview)
 Previously, if there was no default storage class, persistent volumes claims (PVCs) that were created that requested the default storage class remained stranded in the pending state indefinitely, unless you manually delete and recreate them. {product-title} can now retroactively assign a default storage class to these PVCs, so that they do not remain in the pending state. With this feature enabled, after a default storage class is created, or one of the existing storage classes is declared the default, these previously stranded PVCs are assigned to the default storage class.
 
@@ -960,14 +958,14 @@ This feature is supported with Technology Preview status.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#absent-default-storage-class[Absent default storage class].
 
-[id="ocp-4-13-powervs-csi-driver-operator"]
+[id="ocp-4-13-powervs-csi-driver-operator_{context}"]
 ==== {ibmpowerProductName} Virtual Server Block CSI Driver Operator (Technology Preview)
 
 {product-title} is capable of provisioning persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for {ibmpowerProductName} Virtual Server Block Storage.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block.adoc#persistent-storage-csi-ibm-powervs-block[{ibmpowerProductName} Virtual Server Block CSI Driver Operator].
 
-[id="ocp-4-13-storage-csi-inline-ephemeral-vols-GA"]
+[id="ocp-4-13-storage-csi-inline-ephemeral-vols-GA_{context}"]
 ==== CSI inline ephemeral volumes is generally available
 Container Storage Interface (CSI) inline ephemeral volumes were introduced in {product-title} 4.5 as a Technology Preview feature, which allows you to define a pod spec that creates inline ephemeral volumes when a pod is deployed and delete them when a pod is destroyed. This feature is now generally available.
 
@@ -977,7 +975,7 @@ This feature also includes the CSI Volume Admission plug-in, which provides a me
 
 For more information, see xref:../storage/container_storage_interface/ephemeral-storage-csi-inline.adoc[CSI inline ephemeral volumes].
 
-[id="ocp-4-13-storage-csi-migration-azure-file-GA"]
+[id="ocp-4-13-storage-csi-migration-azure-file-GA_{context}"]
 ==== Automatic CSI migration for Microsoft Azure File is generally available
 Starting with {product-title} 4.8, automatic migration for in-tree volume plugins to their equivalent Container Storage Interface (CSI) drivers became available as a Technology Preview feature. Support for Azure File was provided in this feature in {product-title} 4.10. {product-title} 4.13 now supports automatic migration for Azure File as generally available. CSI migration for Azure File is now enabled by default and requires no action by an administrator.
 
@@ -987,7 +985,7 @@ Although storage class referencing to the in-tree storage plug-in will continue 
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-migration.adoc[CSI Automatic Migration].
 
-[id="ocp-4-13-storage-csi-migration-vsphere-GA"]
+[id="ocp-4-13-storage-csi-migration-vsphere-GA_{context}"]
 ==== Automatic CSI migration for VMware vSphere is generally available
 This feature automatically translates in-tree objects to their counterpart CSI representations and should be completely transparent to users. Although storage class referencing to the in-tree storage plug-in will continue working, it is recommended that you switch the default storage class to the CSI storage class.
 
@@ -1005,26 +1003,26 @@ Updates from {product-title} 4.12 to 4.13 and from 4.13 to 4.14 are blocked if *
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-migration.adoc[CSI Automatic Migration].
 
-[id="ocp-4-13-storage-aws-efs-cross-account-support"]
+[id="ocp-4-13-storage-aws-efs-cross-account-support_{context}"]
 ==== Cross account support for AWS EFS CSI driver is generally available
 Cross account support allows you to have an {product-title} cluster in one Amazon Web Services (AWS) account and mount your file system in another AWS account using the AWS Elastic File System (EFS) Container Storage Interface (CSI) driver.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-efs-cross-account_persistent-storage-csi-aws-efs[AWS EFS CSI cross account support].
 
-[id="ocp-4-13-storage-fsgroup-to-csi-driver"]
+[id="ocp-4-13-storage-fsgroup-to-csi-driver_{context}"]
 ==== Delegate FSGroup to CSI Driver instead of Kubelet is generally available
 This feature allows {product-title} to supply a pod's FSGroup to a Container Storage Interface (CSI) driver when a volume is mounted. Microsoft Azure File CSI driver depends on this feature.
 
-[id="ocp-4-13-storage-azure-file-nfs"]
+[id="ocp-4-13-storage-azure-file-nfs_{context}"]
 ==== Azure File supporting NFS is generally available
 {product-title} 4.13 supports Azure File Container Storage Interface (CSI) Driver Operator with Network File System (NFS) as generally available.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-azure-file.adoc#persistent-storage-csi-azure-file-nfs_persistent-storage-csi-azure-file[NFS support].
 
-[id="ocp-4-13-olm"]
+[id="ocp-4-13-olm_{context}"]
 === Operator lifecycle
 
-[id=ocp-4-13-olm-discover-operator-versions]
+[id="ocp-4-13-olm-discover-operator-versions_{context}"]
 ==== Finding Operator versions by using the OpenShift CLI
 In {product-title} 4.13, you can find which versions and channels of an Operator you can install on your system by running the following {oc-first} command:
 
@@ -1044,7 +1042,7 @@ $ oc get packagemanifests <operator_name> -n <catalog_namespace> -o <output_form
 
 For more information, see xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-specific-version-cli_olm-adding-operators-to-a-cluster[Installing a specific version of an Operator].
 
-[id=ocp-4-13-olm-multitenant]
+[id="ocp-4-13-olm-multitenant_{context}"]
 ==== Operators in multitenant clusters
 
 The default behavior for Operator Lifecycle Manager (OLM) aims to provide simplicity during Operator installation. However, this behavior can lack flexibility, especially in multitenant clusters.
@@ -1054,7 +1052,7 @@ Guidance and a recommended solution for Operator management in multitenant clust
 * xref:../operators/understanding/olm-multitenancy.adoc#olm-multitenancy[Operators in multitenant clusters]
 * xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-preparing-operators-multitenant_olm-adding-operators-to-a-cluster[Preparing for multiple instances of an Operator for multitenant clusters]
 
-[id=ocp-4-13-olm-colocation-namespace]
+[id="ocp-4-13-olm-colocation-namespace_{context}"]
 ==== Colocation of Operators in a namespace
 
 Operator Lifecycle Manager (OLM) handles OLM-managed Operators that are installed in the same namespace, meaning their Subscription resources are colocated in the same namespace, as related Operators. Even if they are not actually related, OLM considers their states, such as their version and update policy, when any one of them is updated.
@@ -1064,7 +1062,7 @@ Guidance on Operator colocation and an alternative procedure that uses custom na
 * xref:../operators/understanding/olm/olm-colocation.adoc#olm-colocation-namespaces_olm-colocation[Colocation of Operators in a namespace]
 * xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-global-namespaces_olm-adding-operators-to-a-cluster[Installing global Operators in custom namespaces]
 
-[id=ocp-4-13-olm-disabled-csvs]
+[id="ocp-4-13-olm-disabled-csvs_{context}"]
 ==== Updated web console behavior when disabling copied CSVs
 
 The {product-title} web console has been updated to provide better Operator discovery when copied cluster service versions (CSVs) are disabled on a cluster.
@@ -1073,25 +1071,25 @@ When copied CSVs are disabled by a cluster administrator, the web console is mod
 
 For more information, see xref:../operators/admin/olm-config.adoc#olm-disabling-copied-csvs_olm-config[Disabling copied CSVs].
 
-[id="ocp-4-13-osdk"]
+[id="ocp-4-13-osdk_{context}"]
 === Operator development
 
-[id="ocp-4-13-suggested-namespace-template"]
+[id="ocp-4-13-suggested-namespace-template_{context}"]
 ==== Setting a suggested namespace template with default node selector
 
 With this release, Operator authors can set a default node selector on the suggested namespace where the Operator runs. The suggested namespace is created using the namespace manifest in the YAML which is included in the `ClusterServiceVersion` (CSV).  When adding the Operator to a cluster using OperatorHub, the web console automatically populates the suggested namespace for the cluster administrator during the installation process.
 
 For more information, see xref:../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-suggested-namespace-default-node_osdk-generating-csvs[Setting a suggested namespace with default node selector].
 
-[id="ocp-4-13-nto"]
+[id="ocp-4-13-nto_{context}"]
 ==== Node Tuning Operator
 
 The Node Tuning Operator (NTO) can now be enabled/disabled using the `NodeTuning` cluster capability. If disabled at cluster install, it can be re-enabled later. For more information, see xref:../installing/overview/cluster-capabilities.adoc#about-node-tuning-operator_cluster-capabilities[Node Tuning capability].
 
-[id="ocp-4-13-machine-api"]
+[id="ocp-4-13-machine-api_{context}"]
 === Machine API
 
-[id="ocp-4-13-mapi-cpms-platform-support"]
+[id="ocp-4-13-mapi-cpms-platform-support_{context}"]
 ==== Additional platform support for control plane machine sets
 
 * With this release, control plane machine sets are supported for Google Cloud Platform clusters.
@@ -1106,34 +1104,34 @@ The Node Tuning Operator (NTO) can now be enabled/disabled using the `NodeTuning
 
 For more information, see xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with the Control Plane Machine Set Operator].
 
-[id="ocp-4-13-machine-config-operator"]
+[id="ocp-4-13-machine-config-operator_{context}"]
 === Machine Config Operator
 
-[id="ocp-4-13-machine-config-operator-layering"]
+[id="ocp-4-13-machine-config-operator-layering_{context}"]
 ==== {op-system-first} image layering is generally available
 
 {op-system-first} image layering is now generally available. With this feature, you can extend the functionality of your base RHCOS image by layering additional images onto the base image.
 
 For more information, see  xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[{op-system-first} image layering].
 
-[id="ocp-4-13-machine-config-operator-layering-third-party"]
+[id="ocp-4-13-machine-config-operator-layering-third-party_{context}"]
 ==== Support for adding third party and custom content to {op-system}
 
 You can now use {op-system-first} image layering to add {op-system-base-full} and third-party packages to cluster nodes.
 
 For more information, see  xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[{op-system-first} image layering].
 
-[id="ocp-4-13-machine-config-operator-core"]
+[id="ocp-4-13-machine-config-operator-core_{context}"]
 ==== Support for setting the core user password
 
 You can now create a password for the {op-system} `core` user. If you cannot use SSH or the `oc debug node` command to access a node, this password allows you to use the `core` user to access the node through a cloud provider serial console or a bare metal baseboard controller manager (BMC).
 
 For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#core-user-password_post-install-machine-configuration-tasks[Changing the core user password for node access].
 
-[id="ocp-4-13-nodes"]
+[id="ocp-4-13-nodes_{context}"]
 === Nodes
 
-[id="ocp-4-13-nodes-mirror"]
+[id="ocp-4-13-nodes-mirror_{context}"]
 ==== Image registry repository mirroring by tags
 
 You can now pull images from a mirrored registry by using image tags in addition to digest specifications. To accomplish this change, the `ImageContentSourcePolicy` (ICSP) object is deprecated. You can now use an `ImageDigestMirrorSet` (IDMS) object to pull images by using digest specifications or an `ImageTagMirrorSet` (ITMS) object to pull images by using image tags.
@@ -1144,17 +1142,17 @@ For more information on these new objects, see xref:../post_installation_configu
 
 For more information on converting existing ICSP YAML files to IDMS YAML files, see xref:../post_installation_configuration/preparing-for-users.adoc#images-configuration-registry-mirror-convert_post-install-preparing-for-users[Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring].
 
-[id="ocp-4-13-nodes-crun-ga"]
+[id="ocp-4-13-nodes-crun-ga_{context}"]
 ==== crun general availability
 
 The crun low-level container runtime is now generally available in {product-title} 4.13. There is no new functionality in the GA version.
 
-[id="ocp-4-13-nodes-cgroup-v2-ga"]
+[id="ocp-4-13-nodes-cgroup-v2-ga_{context}"]
 ==== Linux Control Group version 2 (cgroup v2) general availability
 
 Linux Control Group version 2 (cgroup v2) is now generally available in {product-title} 4.13. There is no new functionality in the GA version.
 
-[id="ocp-4-13-pdb-eviction-policy"]
+[id="ocp-4-13-pdb-eviction-policy_{context}"]
 ==== Pod disruption budget (PDB) unhealthy pod eviction policy (Technology Preview)
 
 With this release, specifying an unhealthy pod eviction policy for pod disruption budgets (PDBs) is available as a Technology Preview feature. This can help evict malfunctioning applications during a node drain.
@@ -1181,18 +1179,18 @@ To configure graceful node shutdowns, you can specify a termination grace period
 For further information see xref:../nodes/nodes/nodes-nodes-graceful-shutdown.adoc#nodes-nodes-graceful-shutdown[Managing graceful node shutdown].
 ////
 
-[id="ocp-4-13-metal3-remediation-support"]
+[id="ocp-4-13-metal3-remediation-support_{context}"]
 ==== Metal3 remediation support
 
 Previously, Machine Health Checks could self-remediate or use the Self Node Remediation provider. With this release, the new Metal3 remediation provider is also supported on bare metal clusters.
 
 For more information, see xref:../machine_management/deploying-machine-health-checks.html#mgmt-power-remediation-baremetal-about_deploying-machine-health-checks[About power-based remediation of bare metal].
 
-[id="ocp-4-13-monitoring"]
+[id="ocp-4-13-monitoring_{context}"]
 === Monitoring
 The monitoring stack for this release includes the following new and modified features.
 
-[id="ocp-4-13-monitoring-updates-to-monitoring-stack-components-and-dependencies"]
+[id="ocp-4-13-monitoring-updates-to-monitoring-stack-components-and-dependencies_{context}"]
 ==== Updates to monitoring stack components and dependencies
 This release includes the following version updates for monitoring stack components and dependencies:
 
@@ -1204,7 +1202,7 @@ This release includes the following version updates for monitoring stack compone
 * prometheus-operator to 0.63.0
 * Thanos to 0.30.2
 
-[id="ocp-4-13-monitoring-changes-to-alerting-rules"]
+[id="ocp-4-13-monitoring-changes-to-alerting-rules_{context}"]
 ==== Changes to alerting rules
 
 [NOTE]
@@ -1214,12 +1212,12 @@ Red Hat does not guarantee backward compatibility for recording rules or alertin
 
 * The `NodeFilesystemAlmostOutOfSpace` alert no longer fires for certain `tmpfs` mount points that are always full by design.
 
-[id="ocp-4-13-monitoring-new-option-to-add-secrets-to-the-alertmanager-configuration"]
+[id="ocp-4-13-monitoring-new-option-to-add-secrets-to-the-alertmanager-configuration_{context}"]
 ==== New option to add secrets to the Alertmanager configuration
 With this release, you can add secrets to the Alertmanager configuration for core platform monitoring and for user-defined projects.
 If you need to authenticate with a receiver so that Alertmanager can send alerts to it, you can now configure Alertmanager to use a secret that contains authentication credentials for the receiver.
 
-[id="ocp-4-13-monitoring-new-option-to-configure-node-exporter-collectors"]
+[id="ocp-4-13-monitoring-new-option-to-configure-node-exporter-collectors_{context}"]
 ==== New option to configure node-exporter collectors
 With this release, you can customize {cmo-first} config map settings for the following node-exporter collectors.
 The following node-exporter collectors are now optional and can be enabled or disabled:
@@ -1231,24 +1229,24 @@ The following node-exporter collectors are now optional and can be enabled or di
 * `netlink` backend for the `netclass` collector
 * `tcpstat` collector
 
-[id="ocp-4-13-monitoring-new-option-to-filter-node-related-dashboards-by-node-role"]
+[id="ocp-4-13-monitoring-new-option-to-filter-node-related-dashboards-by-node-role_{context}"]
 ==== New option to filter node-related dashboards by node role
 In the {product-title} web console, you can now filter data in node-related monitoring dashboards based on node roles.
 You can use this new filter to quickly select relevant node roles if you want to see dashboard data only for nodes with certain roles, such as worker nodes.
 
-[id="ocp-4-13-monitoring-new-option-to-enable-metrics-collection-profiles-technology-preview"]
+[id="ocp-4-13-monitoring-new-option-to-enable-metrics-collection-profiles-technology-preview_{context}"]
 ==== New option to enable metrics collection profiles (Technology Preview)
 This release introduces a Technology Preview feature for default platform monitoring in which an administrator can set a metrics collection profile to collect either the default amount of metrics data or a minimal amount of metrics data.
 When you enable the minimal profile, basic monitoring features such as alerting continue to work, but the CPU and memory resources required by Prometheus decrease.
 
-[id="ocp-4-13-network-observability-1_1-1_2"]
+[id="ocp-4-13-network-observability-1_1-1_2_{context}"]
 === Network Observability Operator
 The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, rolling stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator can be found in the xref:../observability/network_observability/network-observability-operator-release-notes.adoc[Network Observability release notes].
 
-[id="ocp-4-13-scalability-and-performance"]
+[id="ocp-4-13-scalability-and-performance_{context}"]
 === Scalability and performance
 
-[id="ocp-4-13-NUMA-scheduler-ga"]
+[id="ocp-4-13-NUMA-scheduler-ga_{context}"]
 ==== NUMA-aware scheduling with the NUMA Resources Operator is generally available
 
 NUMA-aware scheduling with the NUMA Resources Operator was previously introduced as a Technology Preview in {product-title} 4.10 and is now generally available in {product-title} {product-version}.
@@ -1262,7 +1260,7 @@ This update adds the following features:
 
 For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-about-numa-aware-scheduling_numa-aware[Scheduling NUMA-aware workloads].
 
-[id="ocp-4-13-ran-workload-partitioning-three-node-standard-node"]
+[id="ocp-4-13-ran-workload-partitioning-three-node-standard-node_{context}"]
 ==== Support for workload partitioning for three-node clusters and standard clusters (Technology Preview)
 
 Before this update, workload partitioning was supported for {sno} clusters only.
@@ -1271,7 +1269,7 @@ Use workload partitioning to isolate {product-title} services, cluster managemen
 
 For more information, see xref:../scalability_and_performance/enabling-workload-partitioning.adoc#enabling-workload-partitioning[Workload partitioning].
 
-[id="ocp-4-13-configuring-power-states-using-ztp"]
+[id="ocp-4-13-configuring-power-states-using-ztp_{context}"]
 ==== Configuring power states using {ztp}
 
 {product-title} 4.12 introduced the ability to set power states for critical and non-critical workloads.
@@ -1279,7 +1277,7 @@ In {product-title} 4.13, you can now configure power states with {ztp}.
 
 For more information about the feature, see xref:../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-using-pgt-to-configure-power-saving-states_ztp-advanced-policy-config[Configuring power states using PolicyGenTemplates CRs].
 
-[id="ocp-4-13-scalability-and-performance-talm-updates"]
+[id="ocp-4-13-scalability-and-performance-talm-updates_{context}"]
 ==== Pre-caching container images for managed cluster updates with {cgu-operator} and {ztp}
 
 This release adds two new {cgu-operator-first} features for use with {ztp}:
@@ -1291,7 +1289,7 @@ Now, during container image pre-caching, {cgu-operator} compares the available h
 
 For more information see xref:../scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades.adoc#talo-precache-feature-image-filter_cnf-topology-aware-lifecycle-manager[Using the container image pre-cache filter].
 
-[id="ocp-4-13-ran-http-transport"]
+[id="ocp-4-13-ran-http-transport_{context}"]
 ==== HTTP transport replaces AMQP for PTP and bare-metal events (Technology Preview)
 
 HTTP is now the default transport in the PTP and bare-metal events infrastructure.
@@ -1299,7 +1297,7 @@ AMQ Interconnect is end of life (EOL) from 30 June 2024.
 
 For more information, see xref:../networking/using-ptp.adoc#cnf-about-ptp-fast-event-notifications-framework_using-ptp[About the PTP fast event notifications framework].
 
-[id="ocp-4-13-ran-westport-channel-grandmaster"]
+[id="ocp-4-13-ran-westport-channel-grandmaster_{context}"]
 ==== Support for Intel E810 Westport Channel NIC as PTP grandmaster clock (Technology Preview)
 
 You can now configure the Intel E810 Westport Channel NIC as a PTP grandmaster clock by using the PTP Operator.
@@ -1307,7 +1305,7 @@ PTP grandmaster clocks use `ts2phc` (time stamp 2 physical clock) for system clo
 
 For more information, see xref:../networking/using-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock_using-ptp[Configuring linuxptp services as a grandmaster clock].
 
-[id="ocp-413-ran-ztp-crun-container-runtime"]
+[id="ocp-413-ran-ztp-crun-container-runtime_{context}"]
 ==== Configuring crun as the default container runtime for managed clusters in {ztp}
 A `ContainerRuntimeConfig` CR that configures crun as the default container runtime has been added to the GitOps ZTP `ztp-site-generate` container.
 
@@ -1315,12 +1313,12 @@ For optimal performance in clusters that you install with {ztp}, enable crun for
 
 For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-configuring-crun-container-runtime_sno-configure-for-vdu[Configuring crun as the default container runtime].
 
-[id="ocp-4-13-etcd-overview"]
+[id="ocp-4-13-etcd-overview_{context}"]
 ==== Documentation enhancement: Overview of etcd is now available
 
 An overview of etcd, including the benefits it provides and how it works, is now available in the {product-title} documentation. As the primary data store for Kubernetes, etcd provides a reliable approach to cluster configuration and management on {product-title} through the etcd Operator. For more information, see xref:../architecture/control-plane.adoc#etcd-overview_control-plane[Overview of etcd].
 
-[id="ocp-4-13-insights-operator"]
+[id="ocp-4-13-insights-operator_{context}"]
 === Insights Operator
 In OpenShift Container Platform 4.13, the Insights Operator now collects the following information:
 // https://issues.redhat.com/browse/OCPBUGS-6832
@@ -1331,25 +1329,25 @@ In OpenShift Container Platform 4.13, the Insights Operator now collects the fol
 
 * The default `ingresscontroller.operator.openshift.io` resource to inform Insights if the Authentication Operator is degraded.
 
-[id="ocp-4-13-hcp"]
+[id="ocp-4-13-hcp_{context}"]
 === Hosted control planes (Technology Preview)
 
-[id="ocp-4-13-hcp-book"]
+[id="ocp-4-13-hcp-book_{context}"]
 ==== Hosted control planes section is now available in the documentation
 
 The {product-title} documentation now includes a section dedicated to hosted control planes, where you can find an overview of the feature and information about configuring and managing hosted clusters. For more information, see xref:../hosted_control_planes/index.adoc#hosted-control-planes-overview_hcp-overview[Hosted control planes].
 
-[id="ocp-4-13-hosted-control-planes-updates"]
+[id="ocp-4-13-hosted-control-planes-updates_{context}"]
 ==== Updating hosted control planes
 
 The {product-title} documentation now includes information about updating hosted control planes. Updating hosted control planes involves updating the hosted cluster and the node pools. For more information, see xref:../hosted_control_planes/hcp-managing.adoc#updates-for-hosted-control-planes_hcp-managing[Updates for hosted control planes].
 
-[id="install-sno-requirements-for-installing-on-a-single-node"]
+[id="install-sno-requirements-for-installing-on-a-single-node_{context}"]
 === Requirements for installing {product-title} on a single node
 
 {product-version} now supports `x86_64` and `arm64` CPU architectures.
 
-[id="ocp-4-13-notable-technical-changes"]
+[id="ocp-4-13-notable-technical-changes_{context}"]
 == Notable technical changes
 
 {product-title} {product-version} introduces the following notable technical changes.
@@ -1357,7 +1355,7 @@ The {product-title} documentation now includes information about updating hosted
 // Note: use [discrete] for these sub-headings.
 
 [discrete]
-[id="ocp-4-13-cluster-cloud-controller-manager-operator"]
+[id="ocp-4-13-cluster-cloud-controller-manager-operator_{context}"]
 === Cloud controller managers for additional cloud providers
 
 The Kubernetes community plans to deprecate the use of the Kubernetes controller manager to interact with underlying cloud platforms in favor of using cloud controller managers. As a result, there is no plan to add Kubernetes controller manager support for any new cloud platforms.
@@ -1371,7 +1369,7 @@ To manage the cloud controller manager and cloud node manager deployments and li
 For more information, see the xref:../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_cluster-operators-ref[Cluster Cloud Controller Manager Operator] entry in the _Platform Operators reference_.
 
 [discrete]
-[id="ocp-4-13-mco-certificate-changes"]
+[id="ocp-4-13-mco-certificate-changes_{context}"]
 === The MCD now syncs kubelet CA certificates on paused pools
 
 Previously, the Machine Config Operator (MCO) updated the kubelet client certificate authority (CA) certificate, `/etc/kubernetes/kubelet-ca.crt`, as a part of the regular machine config update. Starting with {product-title} {product-version}, the `kubelet-ca.crt` no longer gets updated as a part of the regular machine config update. As a result of this change, the Machine Config Daemon (MCD) automatically keeps the `kubelet-ca.crt` up to date whenever changes to the certificate occur.
@@ -1381,14 +1379,14 @@ Also, if a machine config pool is paused, the MCD is now able to push the newly 
 Also, the `MachineConfigControllerPausedPoolKubeletCA` alert has been removed, because the nodes should always have the most up-to-date `kubelet-ca.crt`.
 
 [discrete]
-[id="ocp-4-13-rhcos-ssh-key-location"]
+[id="ocp-4-13-rhcos-ssh-key-location_{context}"]
 === Change in SSH key location
 {product-title} {product-version} introduces a {op-system-base} 9.2 based {op-system}. Before this update, SSH keys were located in `/home/core/.ssh/authorized_keys` on {op-system}. With this update, on {op-system-base} 9.2 based {op-system}, SSH keys are located in `/home/core/.ssh/authorized_keys.d/ignition`.
 
 If you customized the default OpenSSH `/etc/ssh/sshd_config` server configuration file, you must update it according to this link:https://access.redhat.com/solutions/7030537[Red Hat Knowledgebase article].
 
 [discrete]
-[id="ocp-4-13-psa-restricted-enforcement"]
+[id="ocp-4-13-psa-restricted-enforcement_{context}"]
 === Future restricted enforcement for pod security admission
 
 Currently, pod security violations are shown as warnings and logged in the audit logs, but do not cause the pod to be rejected.
@@ -1408,7 +1406,7 @@ If you are receiving pod security violations, see the following resources:
 * If necessary, you can set a custom admission profile on the namespace or pod by setting the `pod-security.kubernetes.io/enforce` label.
 
 [discrete]
-[id="ocp-4-13-oc-mirror-openshift-endpoint"]
+[id="ocp-4-13-oc-mirror-openshift-endpoint_{context}"]
 === The oc-mirror plugin now retrieves graph data container images from an OpenShift API endpoint
 
 The oc-mirror {oc-first} plugin now downloads the graph data tarball from an OpenShift API endpoint instead of downloading the entire graph data repository from GitHub. Retrieving this data from Red Hat instead of an external vendor is more suitable for users with stringent security and compliance restrictions on external content.
@@ -1418,7 +1416,7 @@ The data that the oc-mirror plugin downloads now excludes content that is in the
 These changes do not affect the user workflow for the oc-mirror plugin.
 
 [discrete]
-[id="ocp-4-13-graph-data-openshift-endpoint"]
+[id="ocp-4-13-graph-data-openshift-endpoint_{context}"]
 === The Dockerfile for the graph data container image is now retrieved from an OpenShift API endpoint
 
 If you are creating a graph data container image for the OpenShift Update Service by using the Dockerfile, note that the graph data tarball is now downloaded from an OpenShift API endpoint instead of GitHub.
@@ -1426,13 +1424,13 @@ If you are creating a graph data container image for the OpenShift Update Servic
 For more information, see xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-graph-data_updating-restricted-network-cluster-osus[Creating the OpenShift Update Service graph data container image].
 
 [discrete]
-[id="ocp-4-13-ocm-nodeip-configuration-service"]
+[id="ocp-4-13-ocm-nodeip-configuration-service_{context}"]
 === The nodeip-configuration service is now enabled on a vSphere user-provisioned infrastructure cluster
 
 In {product-title} {product-version}, the `nodeip-configuration` service is now enabled on a vSphere user-provisioned infrastructure cluster. This service determines the network interface controller (NIC) that {product-title} uses for communication with the Kubernetes API server when the node boots. In rare circumstances, the service might select an incorrect node IP after an upgrade. If this happens, you can use the `NODEIP_HINT` feature to restore the original node IP. See xref:../support/troubleshooting/troubleshooting-network-issues.adoc#troubleshooting-network-issues[Troubleshooting network issues].
 
 [discrete]
-[id="ocp-4-13-operator-sdk-1-28-z"]
+[id="ocp-4-13-operator-sdk-1-28-z_{context}"]
 === Operator SDK 1.28
 
 {product-title} {product-version} supports Operator SDK 1.28. See xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Installing the Operator SDK CLI] to install or update to this latest version.
@@ -1456,7 +1454,7 @@ If you have Operator projects that were previously created or maintained with Op
 * xref:../operators/operator_sdk/java/osdk-java-updating-projects.adoc#osdk-upgrading-projects_osdk-java-updating-projects[Updating Java-based Operator projects]
 
 [discrete]
-[id="ocp-4-13-rhcos-symbolic-disk-naming-change"]
+[id="ocp-4-13-rhcos-symbolic-disk-naming-change_{context}"]
 === Change in disk ordering behavior for {op-system} based on {op-system-base} 9.2
 {product-title} {product-version} introduces a {op-system-base} 9.2 based {op-system}. With this update, symbolic disk naming can change across reboots. This can cause issues if you apply configuration files after installation or when provisioning a node that references a disk which uses symbolic naming, such as `/dev/sda`, for creating services. The effects of this issue depend on the component you are configuring. It is recommended to use a specific naming scheme for devices, including for any specific disk references, such as `dev/disk/by-id`.
 
@@ -1465,11 +1463,11 @@ With this change, you might need to adjust existing automation workflows in the 
 For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_file_systems/assembly_overview-of-persistent-naming-attributes_managing-file-systems[{op-system-base} documentation].
 
 [discrete]
-[id="ocp-4-13-hosted-control-planes-moved-content"]
+[id="ocp-4-13-hosted-control-planes-moved-content_{context}"]
 === Documentation about backup, restore, and disaster recovery for hosted control planes moved
 In the documentation for {product-title} {product-version}, the procedures to back up and restore etcd on a hosted cluster and to restore a hosted cluster within an AWS region were moved from the "Backup and restore" section to the "Hosted control planes" section. The content itself was not changed.
 
-[id="ocp-4-13-deprecated-removed-features"]
+[id="ocp-4-13-deprecated-removed-features_{context}"]
 == Deprecated and removed features
 
 Some features available in previous releases have been deprecated or removed.
@@ -1728,25 +1726,25 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[id="ocp-4-13-deprecated-features"]
+[id="ocp-4-13-deprecated-features_{context}"]
 === Deprecated features
 
-[id="ocp-4-13-rhv-deprecations"]
+[id="ocp-4-13-rhv-deprecations_{context}"]
 ==== Red Hat Virtualization (RHV) deprecation
 
 Red Hat Virtualization (RHV) as a host platform for {product-title} is now deprecated.
 
-[id="ocp-4-13-ne-deprecations"]
+[id="ocp-4-13-ne-deprecations_{context}"]
 ==== Wildcard DNS queries for the cluster.local domain are deprecated
 
 CoreDNS will stop supporting wildcard DNS queries for names under the `cluster.local` domain. These queries will resolve in {product-title} {product-version} as they do in earlier versions, but support will be removed from a future {product-title} release.
 
-[id="ocp-4-13-ne-kuryr"]
+[id="ocp-4-13-ne-kuryr_{context}"]
 ==== Kuryr support for clusters that run on {rh-openstack}
 
 In {product-title} 4.12, support for Kuryr on clusters that run on {rh-openstack} was deprecated. Support will be removed no earlier than {product-title} 4.14.
 
-[id="ocp-4-13-icsp"]
+[id="ocp-4-13-icsp_{context}"]
 ==== ImageContentSourcePolicy objects
 
 The `ImageContentSourcePolicy` (ICSP) object is now deprecated. You can now use an `ImageDigestMirrorSet` (IDMS) object to pull images by using digest specifications or an `ImageTagMirrorSet` (ITMS) object to pull images by using image tags.
@@ -1755,20 +1753,20 @@ For more information on these new objects, see xref:../post_installation_configu
 
 For more information on converting existing ICSP YAML files to IDMS YAML files, see xref:../post_installation_configuration/preparing-for-users.adoc#images-configuration-registry-mirror-convert_post-install-preparing-for-users[Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring].
 
-[id="ocp-4-13-deprecation-sbo"]
+[id="ocp-4-13-deprecation-sbo_{context}"]
 ==== Service Binding Operator
 
 The Service Binding Operator is deprecated and will be removed with the {product-title} 4.16 release. Red Hat will provide critical bug fixes and support for this component during the current release lifecycle, but this component will no longer receive feature enhancements.
 
-[id="ocp-4-13-toolbox-deprecation"]
+[id="ocp-4-13-toolbox-deprecation_{context}"]
 ==== Toolbox is deprecated in {op-system}
 The toolbox script is deprecated and support will be removed from a future {product-title} release.
 
-[id="ocp-4-13-rhel-9-device-driver-deprecation"]
+[id="ocp-4-13-rhel-9-device-driver-deprecation_{context}"]
 ==== {op-system-base} 9 driver deprecations
 {product-title} {product-version} introduces a {op-system-base} 9.2 based {op-system}. Some kernel device drivers are deprecated in {op-system-base} 9. See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/considerations_in_adopting_rhel_9/assembly_hardware-enablement_considerations-in-adopting-rhel-9[{op-system-base} documentation] for more information.
 
-[id="ocp-4-13-vSphere-configuration-parameters"]
+[id="ocp-4-13-vSphere-configuration-parameters_{context}"]
 ==== VMware vSphere configuration parameters
 
 {product-title} {product-version} deprecates the following vSphere configuration parameters. You can continue to use these parameters, but the installation program does not automatically specify these parameters in the `install-config.yaml` file.
@@ -1787,17 +1785,17 @@ The toolbox script is deprecated and support will be removed from a future {prod
 
 For more information, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#deprecated-parameters-vsphere_installing-vsphere-installer-provisioned-customizations[Deprecated VMware vSphere configuration parameters].
 
-[id="ocp-4-13-node-dep-topology-labels"]
+[id="ocp-4-13-node-dep-topology-labels_{context}"]
 ==== Kubernetes topology labels
 
 Two commonly used Kubernetes topology labels are being replaced. The `failure-domain.beta.kubernetes.io/zone` label is replaced with `topology.kubernetes.io/zone`. The `failure-domain.beta.kubernetes.io/region` label is replaced with `topology.kubernetes.io/region`. The replacement labels are available starting with Kubernetes 1.17 and {product-title} version 4.4.
 
 Currently, both the deprecated and replacement labels are supported, but support for the deprecated labels is planned to be removed in a future release. To prepare for the removal, you can modify any resources (such as volumes, deployments, or other workloads) that reference the deprecated labels to use the replacement labels instead.
 
-[id="ocp-4-13-removed-features"]
+[id="ocp-4-13-removed-features_{context}"]
 === Removed features
 
-[id="ocp-4-13-removed-kube-1-26-apis"]
+[id="ocp-4-13-removed-kube-1-26-apis_{context}"]
 ==== Beta APIs removed from Kubernetes 1.26
 
 Kubernetes 1.26 removed the following deprecated APIs, so you must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26[Kubernetes documentation].
@@ -1821,7 +1819,7 @@ Kubernetes 1.26 removed the following deprecated APIs, so you must migrate manif
 
 |===
 
-[id="ocp-4-13-future-removals"]
+[id="ocp-4-13-future-removals_{context}"]
 === Future Kubernetes API removals
 
 The next minor release of {product-title} is expected to use Kubernetes 1.27. Currently, Kubernetes 1.27 is scheduled to remove a deprecated API.
@@ -1830,7 +1828,7 @@ See the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v
 
 See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API deprecations and removals] for information about how to check your cluster for Kubernetes APIs that are planned for removal.
 
-[id="ocp-4-13-z13-power8-x86v1-remove"]
+[id="ocp-4-13-z13-power8-x86v1-remove_{context}"]
 ==== Specific hardware models on ppc64le, s390x, and x86_64 v1 CPU architectures are removed
 
 In {product-title} 4.13, support for {op-system} functionality is removed for the following deprecated hardware models:
@@ -1844,7 +1842,7 @@ In {product-title} 4.13, support for {op-system} functionality is removed for th
 * {linuxoneProductName} Rockhopper (`s390x`)
 * AMD64 (`x86_64`) v1 CPU
 
-[id="ocp-4-13-bug-fixes"]
+[id="ocp-4-13-bug-fixes_{context}"]
 == Bug fixes
 
 //[discrete]
@@ -1873,7 +1871,7 @@ In {product-title} 4.13, support for {op-system} functionality is removed for th
 //Telco Edge / ZTP
 
 [discrete]
-[id="ocp-4-13-bare-metal-hardware-bug-fixes"]
+[id="ocp-4-13-bare-metal-hardware-bug-fixes_{context}"]
 ==== Bare Metal Hardware Provisioning
 
 * Previously, when you attempted to deploy an {product-title} cluster node on a server that is configured with the Integrated Lights-Out (iLO) Management Interface Driver, provisioning of the node would fail. The failure occurs because of a missing `[ilo]/use_web_server_for_images` configuration parameter in the iLO drive that caused the driver to attempt to use object storage as the default storage mechanism. Object storage is not present in the product. With this update, {product-title} {product-version} and later versions includes `[ilo]/use_web_server_for_images` in the iLO driver's configuration, so that the driver uses a web server that runs in the `metal3` pod. (link:https://issues.redhat.com/browse/OCPBUGS-5068[*OCPBUGS-5068*])
@@ -1883,7 +1881,7 @@ In {product-title} 4.13, support for {op-system} functionality is removed for th
 //==== Builds
 
 [discrete]
-[id="ocp-4-13-cloud-compute-bug-fixes"]
+[id="ocp-4-13-cloud-compute-bug-fixes_{context}"]
 ==== Cloud Compute
 
 * For some configurations of Google Cloud Platform clusters, the internal load balancer uses instance groups that are created by the installation program. Previously, when a control plane machine was replaced manually, the new control plane node was not assigned to a control plane instance group. This prevented the node from being reachable via the internal load balancer. To resolve the issue, administrators had to manually move the control plane machine to the correct instance group by using the Google Cloud console.
@@ -1906,13 +1904,13 @@ With this release, replacement control plane nodes are assigned to the correct i
 * The Kubernetes 1.26 release introduced changes to the node infrastructure, such as removing an unhealthy node with a `NotReady` status from the public load balancer to prevent the node from receiving routing traffic. These changes impacted a node that ran inside a cluster on Microsoft Azure. As a result, the node was unable to regain a `Ready` status and subsequently establish an outbound connection. With this update, a node marked with a `NotReady` status is now detected by `kube-proxy` health probes without the need of node detachment from the public load balancer. This means that a node can retain an outbound internet connection throughout these phases. (link:https://issues.redhat.com/browse/OCPBUGS-7359[*OCPBUGS-7359*])
 
 [discrete]
-[id="ocp-4-13-cloud-cred-operator-bug-fixes"]
+[id="ocp-4-13-cloud-cred-operator-bug-fixes_{context}"]
 ==== Cloud Credential Operator
 
 * Amazon Simple Storage Service (Amazon S3) updated their Amazon S3 bucket configuration so a bucket created in an Amazon Web Services (AWS) region has S3 Block Public Access enabled and access control limits (ACLs) disabled by default. This configuration limits S3 bucket resources to private use. The {product-title} {product-version} updates the CCO utility (`ccoctl`) and the installation program to account for the default S3 bucket configuration so that S3 bucket resources are publicly available. (link:https://issues.redhat.com/browse/OCPBUGS-11706[*OCPBUGS-11706*] and link:https://issues.redhat.com/browse/OCPBUGS-11661[*OCPBUGS-11661*])
 
 [discrete]
-[id="ocp-4-13-dev-console-bug-fixes"]
+[id="ocp-4-13-dev-console-bug-fixes_{context}"]
 ==== Developer Console
 
 * Previously, the {product-title} used API version `v1alpha1` for Knative Serving and Eventing but because of a bug, API version `v1beta1` was not supported. With this fix, the {product-title} supports both the API versions. (link:https://issues.redhat.com/browse/OCPBUGS-5164[*OCPBUGS-5164*])
@@ -1924,19 +1922,19 @@ With this release, replacement control plane nodes are assigned to the correct i
 * Previously, the *Samples* page in the {product-title} did not allow distinguishing between the types of samples listed. With this fix, you can identify the sample from the badges displayed on the *Samples* page. (link:https://issues.redhat.com/browse/OCPBUGS-10679[*OCPBUGS-10679*])
 
 [discrete]
-[id="ocp-4-13-documentation-bug-fixes"]
+[id="ocp-4-13-documentation-bug-fixes_{context}"]
 ==== Documentation
 
 Previously, the {product-title} documentation included a sub-section titled "Expanding a cluster with on-premise bare metal nodes." However, this has been removed in order to maintain accurate, up to date documentation.
 
 [discrete]
-[id="ocp-4-13-cloud-etcd-operator-bug-fixes"]
+[id="ocp-4-13-cloud-etcd-operator-bug-fixes_{context}"]
 ==== etcd Cluster Operator
 
 * Previously, the Control Plane Machine Set Operator attempted to recreate a control plane machine before the cluster bootstrapping completed. This resulted in the removal of the bootstrap node from the etcd cluster membership that caused etcd quorum loss and the cluster to go offline. With this update, the Control Plane Machine Set Operator only recreates a control plane machine after the etcd Cluster Operator removes the bootstrap node. (link:https://issues.redhat.com/browse/OCPBUGS-10960[*OCPBUGS-10960*])
 
 [discrete]
-[id="ocp-4-13-hosted-control-plane-bug-fixes"]
+[id="ocp-4-13-hosted-control-plane-bug-fixes_{context}"]
 ==== Hosted Control Plane
 
 * Previously, the `HostedControlPlane` object did not identify changes to scheduler profiles that were set by a `HostedCluster` resource. Further, `HostedControlPlane` did not propagate changes to the scheduler, so the scheduler did not restart control plane pods for them to receive the latest scheduler profile changes. With this update, `HostedControlPlane` now recognizes changes to scheduler profiles and then dynamically restarts the scheduler, so that the scheduler can apply profile changes to pods. (link:https://issues.redhat.com/browse/OCPBUGS-7091[*OCPBUGS-7091*])
@@ -1951,7 +1949,7 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 //==== Image Registry
 
 [discrete]
-[id="ocp-4-13-installer-bug-fixes"]
+[id="ocp-4-13-installer-bug-fixes_{context}"]
 ==== Installer
 
 * Previously, DNS records that the installation program created were not removed when uninstalling a private cluster. With this update, the installation program now correctly removes these DNS records. (link:https://issues.redhat.com/browse/OCPBUGS-7973[*OCPBUGS-7973*])
@@ -1975,7 +1973,7 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 //==== Kubernetes Controller Manager
 
 [discrete]
-[id="ocp-4-13-kube-scheduler-bug-fixes"]
+[id="ocp-4-13-kube-scheduler-bug-fixes_{context}"]
 ==== Kubernetes Scheduler
 
 * Previously, when the `LifeCycleUtilization` profile was excluded to test namespace filtering, the following error was logged in the Descheduler Operator logs: `belowE0222 12:43:14.331258 1 target_config_reconciler.go:668] key failed with : only namespace exclusion supported with LowNodeUtilization`. Consequently, the descheduler cluster pod would not start. With this update, the namespace exclusion now works with the `LifeCycleUtilization` profile. (link:https://issues.redhat.com/browse/OCPBUGS-7876[*OCPBUGS-7876*])
@@ -1985,7 +1983,7 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 //==== Machine Config Operator
 
 [discrete]
-[id="ocp-4-13-management-console-bug-fixes"]
+[id="ocp-4-13-management-console-bug-fixes_{context}"]
 ==== Management Console
 * Previously, user permissions were not checked when rendering the *Create Pod* button, and the button rendered for users without needed permissions. With this update, user permissions are checked when rendering the *Create Pod* button, and it renders for users for users with the needed permissions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2005232[*BZ#2005232*])
 
@@ -2012,7 +2010,7 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 * Previously, a regression was introduced causing the *Cluster Settings* page to return an error when the `clusterversion` `status.availableUpdates` had a value of `null` and `Upgradeable=False`. With this update, `status.availableUpdates` are allowed to have a `null` value. (link:https://issues.redhat.com/browse/OCPBUGS-6053[*OCPBUGS-6053*])
 
 [discrete]
-[id="ocp-4-13-monitoring-bug-fixes"]
+[id="ocp-4-13-monitoring-bug-fixes_{context}"]
 ==== Monitoring
 
 * Previously, the Kubernetes scheduler could skip scheduling certain pods for a node that received multiple restart operations. {product-title} {product-version} counteracts this issue by including the `KubePodNotScheduled` alert for pods that cannot be scheduled within 30 minutes. (link:https://issues.redhat.com/browse/OCPBUGS-2260[*OCPBUGS-2260*])
@@ -2022,7 +2020,7 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 * With this release, the `NodeFilesystemAlmostOutOfSpace` no longer launches for certain read-only `tmpfs` instances. This change fixes an issue in which the alert launches for certain `tmpfs` mount points that were full by design. (link:https://issues.redhat.com/browse/OCPBUGS-6577[*OCPBUGS-6577*])
 
 [discrete]
-[id="ocp-4-13-networking-bug-fixes"]
+[id="ocp-4-13-networking-bug-fixes_{context}"]
 ==== Networking
 
 * Previously, the Ingress Operator displayed a success message for the `updateIngressClass` function logs when an error message should be displayed. With this update, the log message for Ingress Operator is accurate. (link:https://issues.redhat.com/browse/OCPBUGS-6700[*OCPBUGS-6700*])
@@ -2036,7 +2034,7 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 * Previously, CoreDNS was using the old toolchain for building of the main binary and the old base image. With this update, {product-title} is using {product-version} for the build toolchain and the base image. (link:https://issues.redhat.com/browse/OCPBUGS-6228[*OCPBUGS-6228*])
 
 [discrete]
-[id="ocp-4-13-node-bug-fixes"]
+[id="ocp-4-13-node-bug-fixes_{context}"]
 ==== Node
 
 * Previously, the `LowNodeUtilization` strategy, which is enabled by the `LifecycleAndUtilization` descheduler profile, did not support namespace exclusion. With this release, namespaces are excluded properly when the `LifecycleAndUtilization` descheduler profile is set. (link:https://issues.redhat.com/browse/OCPBUGS-513[*OCPBUGS-513*])
@@ -2044,13 +2042,13 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 * Previously, a regression in behavior caused Machine Config Operator (MCO) to create a duplicate `MachineConfig` object in the `kubeletconfig` or `containerruntimeconfig` custom resource (CR). The duplicate object degraded and the cluster failed to upgrade. With this update, the `kubeletconfig` and `containerruntimeconfig` controllers can detect any duplicate objects and then delete them. This action removes the degraded `MachineConfig` object error and does not impact the cluster upgrade operation. (link:https://issues.redhat.com/browse/OCPBUGS-7719[*OCPBUGS-7719*])
 
 [discrete]
-[id="ocp-4-13-node-tuning-operator-bug-fixes"]
+[id="ocp-4-13-node-tuning-operator-bug-fixes_{context}"]
 ==== Node Tuning Operator (NTO)
 
 * Previously, the `hwlatdetect` tool that the Cloud-native Functions (CNF) tests image uses for running latency tests on a CNF-enabled {product-title} cluster was configured with a detection period of 10 seconds. This configuration when combined with the detection width configuration of 0.95 of a second increased the likelihood of `hwlatdetect` missing a latency spike, because the tool monitors a node about 9.5% of the time over the allocated detection period. With this update, the detection period is set to 1 second, so that the tool can now monitor nodes for about 95% of the time over the allocated detection period. The remaining 5% of monitoring time is left unallocated so that the kernel can perform system tasks. (link:https://issues.redhat.com/browse/OCPBUGS-12433[*OCPBUGS-12433*])
 
 [discrete]
-[id="ocp-4-13-openshift-cli-bug-fixes"]
+[id="ocp-4-13-openshift-cli-bug-fixes_{context}"]
 ==== OpenShift CLI (oc)
 
 * Previously, `oc adm upgrade` command did not read `Failing=True` status in ClusterVersion. With this update, `oc adm upgrade` includes `Failing=True` condition information when summarizing cluster state. This raises the visibility of `Degraded=True` status for `ClusterOperators` and other issues which can impact the behavior of the current cluster or future updates. (link:https://issues.redhat.com/browse/OCPBUGS-3714[*OCPBUGS-3714*])
@@ -2060,7 +2058,7 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 * Previously, the oc-mirror {oc-first} plugin added the Operator catalog as an entry in the `ImageContentSourcePolicy` resource. This resource does not require this entry, because the Operator catalog is consumed directly from the destination registry in the `CatalogSource` resource. This issue impacted the cluster from receiving the release image signature resources because of an unexpected entry in the `ImageContentSourcePolicy` resource. With this update, the oc-mirror plugin removes Operator catalog entry from the `ImageContentSourcePolicy` resource, so that a cluster receives signature resources from the Operator catalog in the `CatalogSource` resource. (link:https://issues.redhat.com/browse/OCPBUGS-10320[*OCPBUGS-10320*])
 
 [discrete]
-[id="ocp-4-13-olm-bug-fixes"]
+[id="ocp-4-13-olm-bug-fixes_{context}"]
 ==== Operator Lifecycle Manager (OLM)
 
 * The status of an Operator’s custom resource (CR) includes a list of components owned by the Operator. This list is ordered by `group/version/kind` (GVK), but the order of objects with the same GVK might change. If an Operator owns many components with the same GVK, it can cause Operator Lifecycle Manager (OLM) to continuously update the status of the Operator CR, because the order of its components has changed. This bug fix updates OLM so that the order of an Operator's component references is deterministic. As a result, OLM no longer attempts to update the CR repeatedly when the list of components remains constant. (link:https://issues.redhat.com/browse/OCPBUGS-2556[*OCPBUGS-2556*])
@@ -2084,20 +2082,20 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 //==== OpenShift API server
 
 [discrete]
-[id="ocp-4-13-rhcos-bug-fixes"]
+[id="ocp-4-13-rhcos-bug-fixes_{context}"]
 ==== {op-system-first}
 
 * Previously, on Azure, the SR-IOV interface was configured by NetworkManager during boot because the udev rule that marks it as `NM_UNMANAGED` was not in the `initramfs` file. With this update, the udev rule is now in the `initramfs` file and the SR-IOV interface should always be unmanaged by NetworkManager. (link:https://issues.redhat.com/browse/OCPBUGS-7173[*OCPBUGS-7173*])
 
 [discrete]
-[id="ocp-4-13-security-profiles-operator-bug-fixes"]
+[id="ocp-4-13-security-profiles-operator-bug-fixes_{context}"]
 ==== Security Profiles Operator
 
 * Previously, a Security Profiles Operator (SPO) SELinux policy did not inherit low-level policy definitions from the container template if you selected another template, such as `net_container`. The policy would not work because it required low-level policy definitions that only existed in the container template. This issue occured when the SPO SELinux policy attempted to translate SELinux policies from the SPO custom format to the Common Intermediate Language (CIL) format. With this update, the container template appends to any SELinux policies that require translation from SPO to CIL. Additionally, the SPO SELinux policy can now inherit low-level policy definitions from any supported policy template. (link:https://issues.redhat.com/browse/OCPBUGS-12879[*OCPBUGS-12879*])
 
 
 [discrete]
-[id="ocp-4-13-scalability-and-performance-bug-fixes"]
+[id="ocp-4-13-scalability-and-performance-bug-fixes_{context}"]
 ==== Scalability and performance
 
 * Previously, when a performance profile was generated, the CRI-O runtime files created automatically were configured to use `runc` as the CRI-O runtime.
@@ -2105,13 +2103,13 @@ Previously, the {product-title} documentation included a sub-section titled "Exp
 Now that setting `crun` as the container runtime is generally available when a performance profile is generated, the runtime CRI-O files created match the `defaultRuntime` configured in the `ContainerRuntimeConfig` CR. This can be either `crun` or `runc`. The default is `runc`. (link:https://issues.redhat.com/browse/OCPBUGS-11813[*OCPBUGS-11813*])
 
 [discrete]
-[id="ocp-4-13-storage-bug-fixes"]
+[id="ocp-4-13-storage-bug-fixes_{context}"]
 ==== Storage
 
 * Previously, the `openshift-manila-csi-driver` namespace did not include labels that are required for the management of workload partitioning. These missing labels impacted the operation of restricting Manila CSI pods to run on a selected set of CPUs. With this update, the `openshift-manila-csi-driver` namespace now includes the `workload.openshift.io/allowed` label. (link:https://issues.redhat.com/browse/OCPBUGS-11341[*OCPBUGS-11341*])
 
 [discrete]
-[id="ocp-4-13-windows-containers-bug-fixes"]
+[id="ocp-4-13-windows-containers-bug-fixes_{context}"]
 ==== Windows containers
 
 * Previously, Microsoft Windows container workloads were not completely emptied during the Windows node upgrade process. This resulted in service disruptions because the workloads remained on the node being upgraded. With this update, the Windows Machine Config Operator (WMCO) drains workloads and then cordons nodes until node upgrades finish. This action ensures a seamless upgrade for Microsoft Windows instances. (link:https://issues.redhat.com/browse/OCPBUGS-5732[*OCPBUGS-5732*])
@@ -2120,7 +2118,7 @@ Now that setting `crun` as the container runtime is generally available when a p
 
 * Previously, the `containerd` container runtime reported an incorrect version on each Windows node because repository tags were not propagated to the build system. This configuration caused `containerd` to report its Go build version as the version for each Windows node. With this update, the correct version is injected into the binary during build time, so that `containerd` reports the correct version for each Windows node. (link:https://issues.redhat.com/browse/OCPBUGS-5378[*OCPBUGS-5378*])
 
-[id="ocp-4-13-technology-preview"]
+[id="ocp-4-13-technology-preview_{context}"]
 == Technology Preview features
 
 Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
@@ -2473,7 +2471,7 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
-[id="ocp-413-scalability-tech-preview"]
+[id="ocp-413-scalability-tech-preview_{context}"]
 === Scalability and performance Technology Preview features
 
 .Scalability and performance Technology Preview tracker
@@ -2743,7 +2741,7 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[id="ocp-4-13-known-issues"]
+[id="ocp-4-13-known-issues_{context}"]
 == Known issues
 
 * For a cloud controller manager (CCM) with the `--cloud-provider=external` option set to `cloud-provider-vsphere`, a known issue exists for a cluster that operates in a networking environment with multiple subnets.
@@ -2852,7 +2850,7 @@ The following code provides an example of the policy updates with both names bei
 * Resetting a MAC address on an SR-IOV virtual function (VF) upon pod deletion might fail for Intel E810 NICs.
 As a result, creating a pod with an SR-IOV VF might take up to 2 minutes on Intel E810 NIC cards. (link:https://issues.redhat.com/browse/OCPBUGS-5892[*OCPBUGS-5892*])
 
-[id="ocp-4-13-ran-known-issues"]
+[id="ocp-4-13-ran-known-issues_{context}"]
 * If you specify an invalid subscription channel in the subscription policy that you use to perform a cluster upgrade, the {cgu-operator-first} indicates that the upgrade is successful immediately after {cgu-operator} enforces the policy because the `Subscription` resource remains in the `AtLatestKnown` state.
 (link:https://issues.redhat.com/browse/OCPBUGS-9239[*OCPBUGS-9239*])
 
@@ -2885,7 +2883,7 @@ mount: /var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/local-pv-bc42d
 To workaround the issue, delete the `cloud-event-proxy-store-storage-class-http-events` `PVC` CR and re-deploy the PTP Operator.
 (link:https://issues.redhat.com/browse/OCPBUGS-12358[*OCPBUGS-12358*])
 
-[id="ocp-4-13-ran-known-issues-post-ga"]
+[id="ocp-4-13-ran-known-issues-post-ga_{context}"]
 * During {ztp-first} provisioning of a {sno} managed cluster with secure boot enabled in the `SiteConfig` CR, multiple `ProvisioningError` errors are reported for the `BareMetalHost` CR during host provisioning.
 The error indicates that the secure boot setting is successfully applied in the Baseboard Management Controller (BMC), but the host is not powered on after the `BareMetalHost` CR is applied.
 To workaround this issue, perform the following steps:
@@ -3026,7 +3024,7 @@ Contact Red Hat Support for additional details and assistance.
 
 (link:https://issues.redhat.com/browse/OCPBUGS-23119[*OCPBUGS-23119*])
 
-[id="ocp-4-13-asynchronous-errata-updates"]
+[id="ocp-4-13-asynchronous-errata-updates_{context}"]
 == Asynchronous errata updates
 
 Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
@@ -3046,7 +3044,7 @@ For any {product-title} release, always review the instructions on xref:../updat
 ====
 
 //Update with relevant advisory information
-[id="ocp-4-13-0-ga"]
+[id="ocp-4-13-0-ga_{context}"]
 === RHSA-2023:1326 - {product-title} 4.13.0 image release, bug fix, and security update advisory
 
 Issued: 17 May 2023
@@ -3062,7 +3060,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.0 --pullspecs
 ----
 //replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.
-[id="ocp-4-13-1"]
+[id="ocp-4-13-1_{context}"]
 === RHSA-2023:3304 - {product-title} 4.13.1 bug fix and security update
 
 Issued: 30 May 2023
@@ -3078,18 +3076,18 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.1 --pullspecs
 ----
 
-[id="ocp-4-13-1-bug-fixes"]
+[id="ocp-4-13-1-bug-fixes_{context}"]
 ==== Bug fixes
 * Previously, assisted installations could encounter a transient error. If that error occurred, the installation failed to recover. With this update, transient errors are re-tried correctly. (link:https://issues.redhat.com/browse/OCPBUGS-13138[*OCPBUGS-13138*])
 
 * Previously, oc-mirror {oc-first} plugin would fail with a `401 unauthorized` error for some registries when a nested path exceeded the expected maximum path-components. With this update, the default integer of the `--max-nested-paths` flag is set to 0 (no limit). As a result, the generated `ImageContentSourcePolicy` will contain source and mirror references up to the repository level as opposed to the namespace level used by default. (link:https://issues.redhat.com/browse/OCPBUGS-13591[*OCPBUGS-13591*])
 
-[id="ocp-4-13-1-updating"]
+[id="ocp-4-13-1-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-2"]
+[id="ocp-4-13-2_{context}"]
 === RHSA-2023:3367 - {product-title} 4.13.2 bug fix and security update
 
 Issued: 7 June 2023
@@ -3105,12 +3103,12 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.2 --pullspecs
 ----
 
-[id="ocp-4-13-2-updating"]
+[id="ocp-4-13-2-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-3"]
+[id="ocp-4-13-3_{context}"]
 === RHSA-2023:3537 - {product-title} 4.13.3 bug fix and security update
 
 Issued: 13 June 2023
@@ -3126,10 +3124,10 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.3 --pullspecs
 ----
 
-[id="ocp-4-13-3-features"]
+[id="ocp-4-13-3-features_{context}"]
 ==== Features
 
-[id="ocp-4-13-ipxe-ztp"]
+[id="ocp-4-13-ipxe-ztp_{context}"]
 ===== Support for iPXE network booting with ZTP
 {ztp-first} uses the Bare Metal Operator (BMO) to boot {op-system-first} on the target host as part of the deployment of spoke clusters. With this update, {ztp} leverages the capabilities of the BMO by adding the option of Preboot Execution Environment (iPXE) network booting for these RHCOS installations.
 
@@ -3140,7 +3138,7 @@ To use iPXE network booting, you must use {rh-rhacm-first} 2.8 or later.
 
 For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and {ztp}].
 
-[id="ocp-4-13-3-bug-fixes"]
+[id="ocp-4-13-3-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously on {sno}, in case of node reboot there was a race condition that could result in admission of application pods requesting devices on the node even if devices were unhealthy or unavailable to be allocated. This resulted in runtime failures when the application tried to access devices. With this update, the resources requested by the pod are only allocated if the device plugin has registered itself to kubelet and healthy devices are present on the node to be allocated.
@@ -3151,12 +3149,12 @@ If these conditions are not met, the pod can fail at admission with `UnexpectedA
 
 * Previously, because client TLS (mTLS) was configured on an Ingress Controller, mismatches between the distributing certificate authority (CA) and the issuing CA caused the incorrect certificate revocation list (CRL) to be downloaded. As a result, the incorrect CRL was downloaded instead of the correct CRL, causing connections with valid client certificates to be rejected with the error message `unknown ca`. With this update, downloaded CRLs are now tracked by the CA that distributes them. This ensures that valid client certificates are no longer rejected. (link:https://issues.redhat.com/browse/OCPBUGS-13964[*OCPBUGS-13964*])
 
-[id="ocp-4-13-3-updating"]
+[id="ocp-4-13-3-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-4"]
+[id="ocp-4-13-4_{context}"]
 === RHSA-2023:3614 - {product-title} 4.13.4 bug fix and security update
 
 Issued: 23 June 2023
@@ -3172,7 +3170,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.4 --pullspecs
 ----
 
-[id="ocp-4-13-4-bug-fixes"]
+[id="ocp-4-13-4-bug-fixes_{context}"]
 ==== Bug fixes
 * Previously, you could not use persistent volume storage on a cluster with Confidential virtual machines (VMs) on Google Cloud Platform (GCP). This issue persists with {product-title} 4.13.3 and earlier versions. From {product-title} 4.13.4 and later versions, you can now use persistent volume storage on a cluster with Confidential VMs on GCP. (link:https://issues.redhat.com/browse/OCPBUGS-11768[*OCPBUGS-11768*])
 
@@ -3188,12 +3186,12 @@ $ oc adm release info 4.13.4 --pullspecs
 * Previously, during scale upgrades of multiple clusters, a cluster upgrade `CGU` CR occasionally failed to upgrade with a `BackupTimeout` error.
 (link:https://issues.redhat.com/browse/OCPBUGS-7422[*OCPBUGS-7422*])
 
-[id="ocp-4-13-4-updating"]
+[id="ocp-4-13-4-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-5"]
+[id="ocp-4-13-5_{context}"]
 === RHSA-2023:4091 - {product-title} 4.13.5 bug fix and security update
 
 Issued: 20 July 2023
@@ -3209,7 +3207,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.5 --pullspecs
 ----
 
-[id="ocp-4-13-5-bug-fixes"]
+[id="ocp-4-13-5-bug-fixes_{context}"]
 ==== Bug fixes
 * Previously, the Gateway API feature did not provide DNS records with a trailing dot for the Gateway domain. This caused the status of the DNS record to never become available on the GCP platform. With this update, the DNS records for Gateway API Gateways are properly provisioned and the Gateway API feature works on GCP because the gateway service dns controller now adds a trailing dot if it is missing in the domain. (link:https://issues.redhat.com/browse/OCPBUGS-15434[*OCPBUGS-15434*])
 
@@ -3221,12 +3219,12 @@ $ oc adm release info 4.13.5 --pullspecs
 
 * Previously, if you tried to edit a Helm chart repository in the *Developer* console by navigating to *Helm*, clicking the *Repositories* tab, then selecting *Edit HelmChartRepository* through the kebab menu for your Helm chart repository, an *Error* page was displayed that showed a *404: Page Not Found* error. This was caused by a component path that was not up to date. This issue is now fixed. (link:https://issues.redhat.com/browse/OCPBUGS-15130[*OCPBUGS-15130*])
 
-[id="ocp-4-13-5-updating"]
+[id="ocp-4-13-5-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-6"]
+[id="ocp-4-13-6_{context}"]
 === RHSA-2023:4226 - {product-title} 4.13.6 bug fix and security update
 
 Issued: 27 July 2023
@@ -3242,12 +3240,12 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.6 --pullspecs
 ----
 
-[id="ocp-4-13-6-updating"]
+[id="ocp-4-13-6-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-8"]
+[id="ocp-4-13-8_{context}"]
 === RHSA-2023:4456 - {product-title} 4.13.8 bug fix and security update
 
 Issued: 8 August 2023
@@ -3263,16 +3261,16 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.8 --pullspecs
 ----
 
-[id="ocp-4-13-8-bug-fixes"]
+[id="ocp-4-13-8-bug-fixes_{context}"]
 ==== Bug fixes
 * Previously, the real load balancer address in the {rh-openstack-first} was not visible. With this update, the real load balancer address has been added and is visible in the {rh-openstack} load balancer object annotation. (link:https://issues.redhat.com/browse/OCPBUGS-15973[*OCPBUGS-15973*])
 
-[id="ocp-4-13-8-updating"]
+[id="ocp-4-13-8-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-9"]
+[id="ocp-4-13-9_{context}"]
 === RHSA-2023:4603 - {product-title} 4.13.9 bug fix and security update
 
 Issued: 16 August 2023
@@ -3288,12 +3286,12 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.9 --pullspecs
 ----
 
-[id="ocp-4-13-9-updating"]
+[id="ocp-4-13-9-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-10"]
+[id="ocp-4-13-10_{context}"]
 === RHSA-2023:4731 - {product-title} 4.13.10 bug fix and security update
 
 Issued: 30 August 2023
@@ -3309,22 +3307,22 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.10 --pullspecs
 ----
 
-[id="ocp-4-13-10-bug-fixes"]
+[id="ocp-4-13-10-bug-fixes_{context}"]
 ==== Bug fixes
 * Previously, clusters using Mint mode and had their root secret removed would encounter an issue during an upgrade from 4.13.8 to 4.13.9. This was caused by a modification in the credentials request of the Ingress Operator that was backported to 4.13.9. With this update, these clusters have no issues updating to versions 4.13.9 and greater. (link:https://issues.redhat.com/browse/OCPBUGS-17733[*OCPBUGS-17733*])
 
-[id="ocp-4-13-10-known-issue"]
+[id="ocp-4-13-10-known-issue_{context}"]
 ==== Known issue
 * The addition of a new feature in {product-title} 4.12 that enables UDP generic receive offload (GRO) also causes all virtual ethernet pair (veth) devices to have one RX queue per available CPU. Previously each veth had one queue. Those queues are dynamically configured by Open Virtual Network (OVN) and there is no synchronization between latency tuning and this queue creation.
 +
 The latency tuning logic monitors the veth NIC creation events and starts configuring the Receive Packet Steering (RPS) queue CPU masks before all the queues are properly created. This means that some of the RPS queue masks are not configured. Since not all NIC queues are configured properly, there is a chance of latency spikes in a real-time application that uses timing sensitive CPUs for communicating with services in other containers. Applications that do not use kernel networking stack are not affected. (link:https://issues.redhat.com/browse/OCPBUGS-17794[*OCPBUGS-17794*])
 
-[id="ocp-4-13-10-updating"]
+[id="ocp-4-13-10-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-11"]
+[id="ocp-4-13-11_{context}"]
 === RHBA-2023:4905 - {product-title} 4.13.11 bug fix
 
 Issued: 5 September 2023
@@ -3340,18 +3338,18 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.11 --pullspecs
 ----
 
-[id="ocp-4-13-11-bug-fixes"]
+[id="ocp-4-13-11-bug-fixes_{context}"]
 ==== Bug fix
 
 * Previously, an issue was observed in {product-title} with some pods getting stuck in the `terminating` state. This affected the reconciliation loop of the allowlist controller, which resulted in unwanted retries that caused the creation of multiple pods.
 With this update, the allowlist controller only inspects pods that belong to the current daemon set. As a result, retries no longer occur when one or more pods are not ready. (link:https://issues.redhat.com/browse/OCPBUGS-16019[*OCPBUGS-16019*])
 
-[id="ocp-4-13-11-updating"]
+[id="ocp-4-13-11-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-12"]
+[id="ocp-4-13-12_{context}"]
 === RHBA-2023:5011 - {product-title} 4.13.12 bug fix
 
 Issued: 12 September 2023
@@ -3367,10 +3365,10 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.12 --pullspecs
 ----
 
-[id="ocp-4-13-12-features"]
+[id="ocp-4-13-12-features_{context}"]
 ==== Features
 
-[id="ocp-4-13-12-networking-sriov-exclude-topology"]
+[id="ocp-4-13-12-networking-sriov-exclude-topology_{context}"]
 ===== Exclude SR-IOV network topology for NUMA-aware scheduling
 
 With this release, you can exclude advertising the Non-Uniform Memory Access (NUMA) node for the SR-IOV network to the Topology Manager. By not advertising the NUMA node for the SR-IOV network, you can permit more flexible SR-IOV network deployments during NUMA-aware pod scheduling.
@@ -3379,7 +3377,7 @@ For example, in some scenarios, it is a priority to maximize CPU and memory reso
 
 For more information about this more flexible SR-IOV network deployment during NUMA-aware pod scheduling, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#nw-sriov-exclude-topology-manager_configuring-sriov-device[Exclude the SR-IOV network topology for NUMA-aware scheduling].
 
-[id="ocp-4-13-12-custom-rhcos-image-for-gcp"]
+[id="ocp-4-13-12-custom-rhcos-image-for-gcp_{context}"]
 ===== Using a custom {op-system-first} image for a Google Cloud Provider cluster
 
 By default, the installation program downloads and installs the {op-system-first} image that is used to start control plane and compute machines. With this enhancement, you can now override the default behavior by modifying the installation configuration file (install-config.yaml) to specify a custom {op-system} image. Before you deploy the cluster, you can modify the following installation parameters:
@@ -3393,20 +3391,20 @@ By default, the installation program downloads and installs the {op-system-first
 
 For more information about these parameters, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-configuration-parameters-additional-gcp_installing-gcp-customizations[Additional Google Cloud Platform configuration parameters].
 
-[id="ocp-4-13-12-allocatedloabalancernodepors-network-api"]
+[id="ocp-4-13-12-allocatedloabalancernodepors-network-api_{context}"]
 ===== Support for allocateLoadBalancerNodePorts in Service object of Network API
 The `ServiceSpec` component in Network API under the `Service` object describes the attributes that a user creates on a service. The `allocateLoadBalancerNodePorts` attribute within the `ServiceSpec` component is now supported in {product-title} 4.13. The `allocateLoadBalancerNodePorts` attribute defines whether the `NodePorts` will be automatically allocated for services of the `LoadBalancer` type.
 
-[id="ocp-4-13-12-bug-fixes"]
+[id="ocp-4-13-12-bug-fixes_{context}"]
 ==== Bug fixes
 * Previously, the {product-title} router directed traffic to a route with a weight of 0 when it had only one back end. With this update, the router will not send traffic to routes with a single back end with weight 0. (link:https://issues.redhat.com/browse/OCPBUGS-17107[*OCPBUGS-17107*])
 
-[id="ocp-4-13-12-updating"]
+[id="ocp-4-13-12-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-13"]
+[id="ocp-4-13-13_{context}"]
 === RHSA-2023:5155 - {product-title} 4.13.13 bug fix and security update
 
 Issued: 20 September 2023
@@ -3422,12 +3420,12 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.13 --pullspecs
 ----
 
-[id="ocp-4-13-13-updating"]
+[id="ocp-4-13-13-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-14"]
+[id="ocp-4-13-14_{context}"]
 === RHBA-2023:5382 - {product-title} 4.13.14 bug fix
 
 Issued: 5 October 2023
@@ -3443,12 +3441,12 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.14 --pullspecs
 ----
 
-[id="ocp-4-13-14-updating"]
+[id="ocp-4-13-14-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-15"]
+[id="ocp-4-13-15_{context}"]
 === RHBA-2023:5467 - {product-title} 4.13.15 bug fix
 
 Issued: 10 October 2023
@@ -3464,12 +3462,12 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.15 --pullspecs
 ----
 
-[id="ocp-4-13-15-updating"]
+[id="ocp-4-13-15-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-17"]
+[id="ocp-4-13-17_{context}"]
 === RHSA-2023:5672 - {product-title} 4.13.17 bug fix and security update
 
 Issued: 17 October 2023
@@ -3485,17 +3483,17 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.17 --pullspecs
 ----
 
-[id="ocp-4-13-17-bug-fixes"]
+[id="ocp-4-13-17-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, CoreDNS terminated unexpectedly if a user created an `EndpointSlice` port without a port number. With this update, validation was added to CoreDNS to prevent it from unexpectedly terminating. (link:https://issues.redhat.com/browse/OCPBUGS-19985[*OCPBUGS-19985*])
 
-[id="ocp-4-13-17-updating"]
+[id="ocp-4-13-17-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-18"]
+[id="ocp-4-13-18_{context}"]
 === RHSA-2023:5902 - {product-title} 4.13.18 bug fix and security update
 
 Issued: 24 October 2023
@@ -3511,16 +3509,16 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.18 --pullspecs
 ----
 
-[id="ocp-4-13-18-bug-fixes"]
+[id="ocp-4-13-18-bug-fixes_{context}"]
 ==== Bug fixes
 * The `etcdctl` binary was cached on the local machine indefinitely, which made updates impossible. The binary is now pulled on every invocation of the `cluster-backup.sh` script. (link:https://issues.redhat.com/browse/OCPBUGS-20488[*OCPBUGS-20488*])
 
-[id="ocp-4-13-18-updating"]
+[id="ocp-4-13-18-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-19"]
+[id="ocp-4-13-19_{context}"]
 === RHSA-2023:6130 - {product-title} 4.13.19 bug fix and security update
 
 Issued: 31 October 2023
@@ -3536,29 +3534,29 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.19 --pullspecs
 ----
 
-[id="ocp-4-13-19-features"]
+[id="ocp-4-13-19-features_{context}"]
 ==== Features
 
-[id="ocp-4-13-19-APIServer-insights-operator"]
+[id="ocp-4-13-19-APIServer-insights-operator_{context}"]
 ===== APIServer.config.openshift.io is now tracked by Insights Operator
 
 After running the Insights Operator, a new file is now available in the archive in the path `config/apiserver.json` with the information about the audit profile for `APIServer.config.openshift.io`.
 
 Access to audit profiles help you to understand what audit policy is common practice, what profiles are most commonly used, what differences there are between industries, and what kind of customization is applied.
 
-[id="ocp-4-13-19-bug-fixes"]
+[id="ocp-4-13-19-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, the Cluster Version Operator (CVO) did not reconcile `SecurityContextConstraints` (SCC) resources as expected. CVO now properly reconciles the `Volumes` field in SCC resources towards the state defined in the release image. User modifications to system SCC resources are tolerated.
 +
 Future {product-title} versions will stop tolerating user modifications of system SCC resources, so CVO now imposes a minor version update gate when it detects a user-modified SCC. Users must make workloads compliant to unmodified system SCC resources before they update to future minor {product-title} versions. See link:https://access.redhat.com/solutions/7033949[*Resolving "Detected modified SecurityContextConstraints" update gate before upgrading to 4.14*] for more information. (link:https://issues.redhat.com/browse/OCPBUGS-19472[*OCPBUGS-19472*])
 
-[id="ocp-4-13-19-updating"]
+[id="ocp-4-13-19-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-21"]
+[id="ocp-4-13-21_{context}"]
 === RHSA-2023:6257 - {product-title} 4.13.21 bug fix and security update
 
 Issued: 8 November 2023
@@ -3574,12 +3572,12 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.21 --pullspecs
 ----
 
-[id="ocp-4-13-21-bug-fixes"]
+[id="ocp-4-13-21-bug-fixes_{context}"]
 ==== Bug fixes
 
 *  Previously, egress IP could not be applied to the egress node on an Azure private cluster. This patch enables egress IP for Azure setups that use outbound rules to achieve outbound connectivity. An architectural constraint in Azure prevents the secondary IP acting as egress IP from having outbound connectivity in such setups. With this release, matching pods will have no outbound connectivity to the internet, but will be able to reach external servers in the infrastructure network. (link:https://issues.redhat.com/browse/OCPBUGS-22299[*OCPBUGS-22299*])
 
-[id="ocp-4-13-21-known-issue"]
+[id="ocp-4-13-21-known-issue_{context}"]
 ==== Known issue
 
 * TALM skips remediating a policy if all selected clusters are compliant when the `ClusterGroupUpdate` CR is started.
@@ -3587,12 +3585,12 @@ The update of operators with a modified catalog source policy and a subscription
 +
 As a workaround, add a trivial change to one CR in the common-subscription policy, for example `metadata.annotations.upgrade: "1"`. This makes the policy non-compliant prior to the start of the `ClusterGroupUpdate` CR. (link:https://issues.redhat.com/browse/OCPBUGS-2812[*OCPBUGS-2812*])
 
-[id="ocp-4-13-21-updating"]
+[id="ocp-4-13-21-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-22"]
+[id="ocp-4-13-22_{context}"]
 === RHSA-2023:6846 - {product-title} 4.13.22 bug fix and security update
 
 Issued: 15 November 2023
@@ -3608,19 +3606,19 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.22 --pullspecs
 ----
 
-[id="ocp-4-13-22-bug-fixes"]
+[id="ocp-4-13-22-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, the copy command was missing the `-p` flag option. Now the command supports the `-p` flag so that the command preserves timestamps. (link:https://issues.redhat.com/browse/OCPBUGS-23021[*OCPBUGS-23021*])
 
 * Previously, a `Burstable` container could only run on reserved CPUs for nodes that were configured with a performance profile. This caused {op-system-base-full} 9 to change the behavior of CPU affinity and `cpuset` components, so that CPU affinity would not reset when `cpuset` was changed. Now, any component that interacts with the `cpuset` component of a newly running container will have its CPU affinity reset. This means that a `Burstable` container can now access all CPUs not currently assigned to a pinned `Guaranteed` container. (link:https://issues.redhat.com/browse/OCPBUGS-20365[*OCPBUGS-20365*])
 
-[id="ocp-4-13-22-updating"]
+[id="ocp-4-13-22-updating_{context}"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-23"]
+[id="ocp-4-13-23_{context}"]
 === RHSA-2023:7323 - {product-title} 4.13.23 bug fix and security update
 
 Issued: 21 November 2023
@@ -3636,10 +3634,10 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.23 --pullspecs
 ----
 
-[id="ocp-4-13-23-features"]
+[id="ocp-4-13-23-features_{context}"]
 ==== Features
 
-[id="ocp-4-13-23-oc-logging-in-browser"]
+[id="ocp-4-13-23-oc-logging-in-browser_{context}"]
 ===== Logging in to the CLI using a web browser
 
 With this release, a new `oc` command-line interface (CLI) flag, `--web` is now available for the `oc login` command.
@@ -3648,18 +3646,18 @@ With this enhancement, you can log in using a web browser, which allows you to a
 
 For more information, see xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-logging-in-web_cli-developer-commands[Logging in to the OpenShift CLI using a web browser].
 
-[id="ocp-4-13-23-bug-fixes"]
+[id="ocp-4-13-23-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, Ironic was not able to provision Cisco UCS hardware as a new baremetalhost because not all Redfish Virtual Media devices could be used to provision the hardware. With this release, Ironic looks at all possible devices to provision the hardware so Cisco UCS Hardware can now be provisioned using Redfish Virtual Media. (link:https://issues.redhat.com/browse/OCPBUGS-19078[*OCPBUGS-19078*])
 
 * Previously, metallb's controller restarted while having an IP assigned and unassigned LB services. This caused metallb's controller to move an already assigned IP to a different LB service which would break workloads. With this release, metallb's controller processes the services which already have an IP assigned. (link:https://issues.redhat.com/browse/OCPBUGS-23160[*OCPBUGS-23160*])
 
-[id="ocp-4-13-23-updating"]
+[id="ocp-4-13-23-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-24"]
+[id="ocp-4-13-24_{context}"]
 === RHSA-2023:7475 - {product-title} 4.13.24 bug fix and security update
 
 Issued: 29 November 2023
@@ -3675,16 +3673,16 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.24 --pullspecs
 ----
 
-[id="ocp-4-13-24-bug-fixes"]
+[id="ocp-4-13-24-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, using a cluster autoscaler with nodes that have CSI storage could cause a `CrashBackoff` loop. With this release, dependencies have been updated to improve error handling so the `CrashBackoff` loop will not occur. (link:https://issues.redhat.com/browse/OCPBUGS-23272[*OCPBUGS-23272*])
 
-[id="ocp-4-13-24-updating"]
+[id="ocp-4-13-24-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-25"]
+[id="ocp-4-13-25_{context}"]
 === RHSA-2023:7604 - {product-title} 4.13.25 bug fix and security update
 
 Issued: 6 December 2023
@@ -3700,16 +3698,16 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.25 --pullspecs
 ----
 
-[id="ocp-4-13-25-bug-fixes"]
+[id="ocp-4-13-25-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, the Image Registry Operator made API calls to the Storage Account List endpoint as part of obtaining access keys every 5 minutes. In projects with many {product-title} clusters, this could lead to API limits being reached causing 429 errors when attempting to create new clusters. With this release, the time between calls is increased from 5 minutes to 20 minutes. (link:https://issues.redhat.com/browse/OCPBUGS-22126[*OCPBUGS-22126*])
 
-[id="ocp-4-13-25-updating"]
+[id="ocp-4-13-25-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-26"]
+[id="ocp-4-13-26_{context}"]
 === RHSA-2023:7687 - {product-title} 4.13.26 bug fix and security update
 
 Issued: 13 December 2023
@@ -3725,11 +3723,11 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.26 --pullspecs
 ----
 
-[id="ocp-4-13-26-updating"]
+[id="ocp-4-13-26-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-27"]
+[id="ocp-4-13-27_{context}"]
 === RHSA-2023:7827 - {product-title} 4.13.27 bug fix and security update
 
 Issued: 4 January 2024
@@ -3745,7 +3743,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.27 --pullspecs
 ----
 
-[id="ocp-4-13-27-bug-fixes"]
+[id="ocp-4-13-27-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS) objects could not be used if there were any `ImageContentSourcePolicy` (ICSP) objects in the cluster. As a result, to use IDMS or ITMS objects, you needed to delete any ICSP objects in the cluster, which required a cluster reboot. With this release, ICSP, IDMS, and ITMS objects now function in the same cluster at the same time. As a result, you can use any or all of the three types of objects to configure repository mirroring after the cluster is installed. For more information, see xref:../post_installation_configuration/preparing-for-users.html#images-configuration-registry-mirror_post-install-preparing-for-users[Understanding image registry repository mirroring]. (link:https://issues.redhat.com/browse/RHIBMCS-185[RHIBMCS-185])
@@ -3755,11 +3753,11 @@ $ oc adm release info 4.13.27 --pullspecs
 Using an ICSP object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported. However, it might be removed in a future release of this product. Because it is deprecated functionality, avoid using it for new deployments.
 ====
 
-[id="ocp-4-13-27-updating"]
+[id="ocp-4-13-27-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-28"]
+[id="ocp-4-13-28_{context}"]
 === RHBA-2024:0055 - {product-title} 4.13.28 bug fix and security update
 
 Issued: 10 January 2024
@@ -3775,17 +3773,17 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.28 --pullspecs
 ----
 
-[id="ocp-4-13-28-bug-fixes"]
+[id="ocp-4-13-28-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, due to a different DNS suffix, `ccoctl` failed to create AWS security token service (STS) resources in China. With this release, `ccoctl` can be used to create STS resources in China regions and the cluster can be installed successfully. (link:https://issues.redhat.com/browse/OCPBUGS-25369[*OCPBUGS-25369*])
 
-[id="ocp-4-13-28-updating"]
+[id="ocp-4-13-28-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 
-[id="ocp-4-13-29"]
+[id="ocp-4-13-29_{context}"]
 === RHSA-2024:0193 - {product-title} 4.13.29 bug fix and security update
 
 Issued: 17 January 2024
@@ -3801,11 +3799,11 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.29 --pullspecs
 ----
 
-[id="ocp-4-13-29-updating"]
+[id="ocp-4-13-29-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-30"]
+[id="ocp-4-13-30_{context}"]
 === RHBA-2024:0286 - {product-title} 4.13.30 bug fix and security update
 
 Issued: 24 January 2024
@@ -3821,17 +3819,17 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.30 --pullspecs
 ----
 
-[id="ocp-4-13-30-bug-fixes"]
+[id="ocp-4-13-30-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, using EUS channels for mirroring releases was causing a failure in mirroring with the `oc-mirror` command. This issue occurred because `oc-mirror` did not acknowledge that EUS channels are for even-numbered releases only. With this release, users of the `oc-mirror` command can now use EUS channels for mirroring releases. (link:https://issues.redhat.com/browse/OCPBUGS-26595[*OCPBUGS-26595*])
 
-[id="ocp-4-13-30-updating"]
+[id="ocp-4-13-30-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 
-[id="ocp-4-13-31"]
+[id="ocp-4-13-31_{context}"]
 === RHSA-2024:0484 - {product-title} 4.13.31 bug fix and security update
 
 Issued: 1 February 2024
@@ -3847,18 +3845,18 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.31 --pullspecs
 ----
 
-[id="ocp-4-13-31-bug-fixes"]
+[id="ocp-4-13-31-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, pods assigned an IP from the pool created by the Whereabouts CNI plugin were getting stuck in `ContainerCreating` state after a node force reboot. With this release, the Whereabouts CNI plugin issue associated with the IP allocation after a node force reboot is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-27367[*OCPBUGS-27367*])
 
 * Previously by default, the `container_t` SELinux context could not access the `dri_device_t` object, which provides access to DRI devices. Now, a new container policy `container-selinux` ensures that pods can use a device plugin to access the `dri_device_t` object. (link:https://issues.redhat.com/browse/OCPBUGS-27416[*OCPBUGS-27416*])
 
-[id="ocp-4-13-31-updating"]
+[id="ocp-4-13-31-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-32"]
+[id="ocp-4-13-32_{context}"]
 === RHSA-2024:0660 - {product-title} 4.13.32 bug fix and security update
 
 Issued: 7 February 2024
@@ -3874,22 +3872,22 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.32 --pullspecs
 ----
 
-[id="ocp-4-13-32-features"]
+[id="ocp-4-13-32-features_{context}"]
 ==== Features
 
 The following feature is included in this z-stream release:
 
-[id="ocp-4-13-32-wherabouts-cron-schedule"]
+[id="ocp-4-13-32-wherabouts-cron-schedule_{context}"]
 ===== Enabling configuration of Whereabouts cron schedule
 
 * The Whereabouts reconciliation schedule was hard-coded to run once per day and could not be reconfigured. With this release, a `ConfigMap` resource has enabled the configuration of the whereabouts cron schedule. For more information, see xref:../networking/multiple_networks/configuring-additional-network.html#nw-multus-configuring-whereabouts-ip-reconciler-schedule_configuring-additional-network[Configuring the Whereabouts IP reconciler schedule].
 
-[id="ocp-4-13-32-updating"]
+[id="ocp-4-13-32-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 
-[id="ocp-4-13-33"]
+[id="ocp-4-13-33_{context}"]
 === RHSA-2024:0741 - {product-title} 4.13.33 bug fix and security update
 
 Issued: 14 February 2024
@@ -3905,18 +3903,18 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.33 --pullspecs
 ----
 
-[id="ocp-4-13-33-bug-fixes"]
+[id="ocp-4-13-33-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, upgrading {product-title} could lead to DNS queries failing due to upstream returning a payload larger than 512 bytes for non-EDNS queries using CoreDNS 1.10.1. With this release, clusters with a noncompliant upstream can retry with TCP upon overflow errors which can prevent disruption of function when upgrading. (link:https://issues.redhat.com/browse/OCPBUGS-28205[*OCPBUGS-28205*])
 
 *  Previously, CPU limits applied on the Amazon Elastic File System (EFS) Container Storage Interface (CSI) driver container caused performance degradation issues for I/O operations to EFS volumes. Now, the CPU limits for the EFS CSI driver are removed so the performance degradation issue no longer exist. (link:https://issues.redhat.com/browse/OCPBUGS-28979[*OCPBUGS-28979*])
 
-[id="ocp-4-13-33-updating"]
+[id="ocp-4-13-33-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-34"]
+[id="ocp-4-13-34_{context}"]
 === RHSA-2024:0845 - {product-title} 4.13.34 bug fix and security update
 
 Issued: 22 February 2024
@@ -3932,17 +3930,17 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.34 --pullspecs
 ----
 
-[id="ocp-4-13-34-bug-fixes"]
+[id="ocp-4-13-34-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, when you selectively mirrored the most recent and default channel and a new release introduced a new channel, the current default channel became invalid. This caused the automatic assignment of the new default channel to fail. With this release, you can now define a `defaultChannel` field in the `ImageSetConfig` custom resource (CR) that overrides the `currentDefault` channel.
 (link:https://issues.redhat.com/browse/OCPBUGS-28899[*OCPBUGS-28899*])
 
-[id="ocp-4-13-34-updating"]
+[id="ocp-4-13-34-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-35"]
+[id="ocp-4-13-35_{context}"]
 === RHSA-2024:0946 - {product-title} 4.13.35 bug fix and security update
 
 Issued: 28 February 2024
@@ -3958,11 +3956,11 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.35 --pullspecs
 ----
 
-[id="ocp-4-13-35-updating"]
+[id="ocp-4-13-35-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-36"]
+[id="ocp-4-13-36_{context}"]
 === RHSA-2024:1037 - {product-title} 4.13.36 bug fix and security update
 
 Issued: 6 March 2024
@@ -3978,17 +3976,17 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.36 --pullspecs
 ----
 
-[id="ocp-4-13-36-bug-fixes"]
+[id="ocp-4-13-36-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, a race condition between `udev` events and the creation queues associated with physical device led to some of the queues being configured with the wrong Receive Packet Steering (RPS) mask while they should be reset to zero. This resulted in the RPS mask being configured on the queues of the physical devices, meaning they were using RPS instead of Receive Side Scaling (RSS) which could impact the performance. With this fix, the event was changed to be triggered per queue creation instead of on device creation. This guarantees that no queue will be missing. The queues of all physical devices are now set up with the correct RPS mask which is empty.
 (link:https://issues.redhat.com/browse/OCPBUGS-24353[*OCPBUGS-24353*])
 
-[id="ocp-4-13-36-updating"]
+[id="ocp-4-13-36-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-37"]
+[id="ocp-4-13-37_{context}"]
 === RHBA-2024:1200 - {product-title} 4.13.37 bug fix
 
 Issued: 13 March 2024
@@ -4004,18 +4002,18 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.37 --pullspecs
 ----
 
-[id="ocp-4-13-37-bug-fixes"]
+[id="ocp-4-13-37-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, the `ovn-ipsec-containerized` and the `ovn-ipsec-host` daemons contained a typographical error for a `openssl` parameter: `-checkedn` instead of `checkend`. This error caused certificate rotation to occur after every `ovn-ipsec` pod restart. With this release, the parameter name is fixed, and the certificate that is used by the Internet Protocol Security (IPsec) now automatically rotates as expected. (link:https://issues.redhat.com/browse/OCPBUGS-30150[*OCPBUGS-30150*])
 
 * Previously, the `nodeStatusUpdateFrequency` mechanism for the Machine Config Operator (MCO) had its default value changed from `0` seconds to `10` seconds. This caused the mechanism to increase node status reporting, determined by the `nodeStatusReportFrequency` parameter, and this impacted control plane CPU resources. With this release, the `nodeStatusReportFrequency` default value is set to `5` minutes, and the CPU resource issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-30285[*OCPBUGS-30285*])
 
-[id="ocp-4-13-37-updating"]
+[id="ocp-4-13-37-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-38"]
+[id="ocp-4-13-38_{context}"]
 === RHSA-2024:1454 - {product-title} 4.13.38 bug fix and security update
 
 Issued: 27 March 2024
@@ -4031,18 +4029,18 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.38 --pullspecs
 ----
 
-[id="ocp-4-13-38-bug-fixes"]
+[id="ocp-4-13-38-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, machine sets that ran on Microsoft Azure regions with no availability zone support always created `AvailabilitySets` objects for Spot instances. This operation caused Spot instances to fail because the instances did not support availability sets. Now, machine sets do not create `AvailabilitySets` objects for Spot instances that operate in non-zonal configured regions. (link:https://issues.redhat.com/browse/OCPBUGS-29906[*OCPBUGS-29906*])
 
 * Previously, the `manila-csi-driver-controller-metrics` service had empty endpoints caused by an incorrect name for the app selector. With this release the app selector name is changed to `openstack-manila-csi` and the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-26224[*OCPBUGS-26224*])
 
-[id="ocp-4-13-38-updating"]
+[id="ocp-4-13-38-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-39"]
+[id="ocp-4-13-39_{context}"]
 === RHSA-2024:1683 - {product-title} 4.13.39 bug fix and security update
 
 Issued: 8 April 2024
@@ -4058,11 +4056,11 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.39 --pullspecs
 ----
 
-[id="ocp-4-13-39-updating"]
+[id="ocp-4-13-39-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-40"]
+[id="ocp-4-13-40_{context}"]
 === RHBA-2024:1761 - {product-title} 4.13.40 bug fix update
 
 Issued: 18 April 2024
@@ -4078,11 +4076,11 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.40 --pullspecs
 ----
 
-[id="ocp-4-13-40-updating"]
+[id="ocp-4-13-40-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-41"]
+[id="ocp-4-13-41_{context}"]
 === RHSA-2024:2047 - {product-title} 4.13.41 bug fix update
 
 Issued: 2 May 2024
@@ -4098,7 +4096,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.41 --pullspecs
 ----
 
-[id="ocp-4-13-41-bug-fixes"]
+[id="ocp-4-13-41-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, both tuned and irqbalanced were modifying the Interrupt Request (IRQ) CPU affinity which caused issues. With this release, only irqbalanced configures interrupt affinity. (link:https://issues.redhat.com/browse/OCPBUGS-31936[*OCPBUGS-31936*])
@@ -4111,11 +4109,11 @@ $ oc adm release info 4.13.41 --pullspecs
 
 * Previously, Observability dashboards used expensive queries to show data which caused frequent timeouts on clusters with a large number of nodes. With this release, observability dashboards use recording rules that are precalculated to ensure reliability on clusters with a large number of nodes. (link:https://issues.redhat.com/browse/OCPBUGS-25922[*OCPBUGS-25922*])
 
-[id="ocp-4-13-41-updating"]
+[id="ocp-4-13-41-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-42"]
+[id="ocp-4-13-42_{context}"]
 === RHSA-2024:2875 - {product-title} 4.13.42 bug fix update
 
 Issued: 23 May 2024
@@ -4131,7 +4129,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.42 --pullspecs
 ----
 
-[id="ocp-4-13-42-bug-fixes"]
+[id="ocp-4-13-42-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, for the `cluster:capacity_cpu_cores:sum` metric, nodes with the`infra` role but not `master` role were not assigned a value of `infra` for the `label_node_role_kubernetes_io` label. With this update, nodes with the `infra` role but not `master` role are now correctly labeled as `infra` for this metric.(link:https://issues.redhat.com/browse/OCPBUGS-33581[*OCPBUGS-33581*])
@@ -4149,7 +4147,7 @@ $ oc adm release info 4.13.42 --pullspecs
 * Previously, following a node reboot, sometimes the server real time clock (RTC) time is not correct. This can occur when the server has a depleted RTC battery.
 With this release, the {ztp} {sno} DU profile includes a sync-time-once `MachineConfig` custom resource (CR) that is applied during cluster installation. The CR configures a oneshot job that runs when the server boots and uses the the `chronyd` service to set the server RTC time using network time protocol (NTP). (link:https://issues.redhat.com/browse/OCPBUGS-33349[*OCPBUGS-33349*])
 
-[id="ocp-4-13-42-known-issue"]
+[id="ocp-4-13-42-known-issue_{context}"]
 ==== Known issue
 
 * Sometimes, the Console Operator status can get stuck in a failed state when the Operator is removed.
@@ -4163,11 +4161,11 @@ $ oc patch console.operator.openshift.io/cluster --type='merge' -p='{"status":{"
 +
 (link:https://issues.redhat.com/browse/OCPBUGS-18674[*OCPBUGS-18674*])
 
-[id="ocp-4-13-42-updating"]
+[id="ocp-4-13-42-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-43"]
+[id="ocp-4-13-43_{context}"]
 === RHSA-2024:3494 - {product-title} 4.13.43 bug fix update
 
 Issued: 5 June 2024
@@ -4183,7 +4181,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.43 --pullspecs
 ----
 
-[id="ocp-4-13-43-bug-fixes"]
+[id="ocp-4-13-43-bug-fixes_{context}"]
 
 ==== Bug fixes
 
@@ -4201,12 +4199,12 @@ $ oc adm release info 4.13.43 --pullspecs
 
 * Previously, the *Topology* view in the {product-title} web console did not show the visual connector between a virtual machine (VM) node and other non-VM components. With this release, the visual connector shows interaction activity of a component.  (link:https://issues.redhat.com/browse/OCPBUGS-33749[*OCPBUGS-33749*])
 
-[id="ocp-4-13-43-updating"]
+[id="ocp-4-13-43-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.13.44
-[id="ocp-4-13-44"]
+[id="ocp-4-13-44_{context}"]
 === RHSA-2024:3885 - {product-title} 4.13.44 bug fix and security updates
 
 Issued: 19 June 2024
@@ -4222,7 +4220,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.44 --pullspecs
 ----
 
-[id="ocp-4-13-44-bug-fixes"]
+[id="ocp-4-13-44-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, when an `IngressController` object was configured with client SSL/TLS, but did not have the `clientca-configmap` finalizer, the Ingress Operator would try to add the finalizer without checking whether the `IngressController` object was marked for deletion. Consequently, if an `IngressController` object was configured with client SSL/TLS and was subsequently deleted, the Operator would correctly remove the finalizer. It would then repeatedly, and erroneously, try and fail to update the `IngressController` object to add the finalizer back, resulting in error messages in the Operator's logs.
@@ -4237,11 +4235,11 @@ With this update, the Ingress Operator no longer adds the `clientca-configmap` f
 
 * Previously, the Helm Plugin index view did not display the same number of charts as the Helm CLI if the chart names varied. With this release, the Helm catalog now looks for `charts.openshift.io/name` and `charts.openshift.io/provider` so that all versions are grouped together in a single catalog title. (link:https://issues.redhat.com/browse/OCPBUGS-33978[*OCPBUGS-33978*])
 
-[id="ocp-4-13-44-updating"]
+[id="ocp-4-13-44-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-45"]
+[id="ocp-4-13-45_{context}"]
 === RHSA-2024:4484 - {product-title} 4.13.45 bug fix and security updates
 
 Issued: 17 July 2024
@@ -4257,7 +4255,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.45 --pullspecs
 ----
 
-[id="ocp-4-13-45-bug-fixes"]
+[id="ocp-4-13-45-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, a bug in `growpart` caused the device to lock, which prevented the LUKS-encrypted devices from opening. The system failed to start. With this release, `growpart` is removed from the process and the system starts. (link:https://issues.redhat.com/browse/OCPBUGS-35990[*OCPBUGS-35990*])
@@ -4268,11 +4266,11 @@ $ oc adm release info 4.13.45 --pullspecs
 
 * Previously, the Machine API controller did not determine the zone of machines in vSphere clusters that use multiple zones. With this release, the zone lookup logic is based on the host of a VM. As a result, machine objects indicate proper zones. (link:https://issues.redhat.com/browse/OCPBUGS-32015[*OCPBUGS-32015*])
 
-[id="ocp-4-13-45-updating"]
+[id="ocp-4-13-45-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-46"]
+[id="ocp-4-13-46_{context}"]
 === RHSA-2024:4846 - {product-title} 4.13.46 bug fix and security updates
 
 Issued: 31 July 2024
@@ -4288,7 +4286,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.46 --pullspecs
 ----
 
-[id="ocp-4-13-46-bug-fixes"]
+[id="ocp-4-13-46-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, the DNS Operator did not verify that a cluster had ready nodes with available CPU in at least two availability zones, and the DNS daemon set did not use surge for rolling updates. As a result, clusters in which all nodes were in the same availability zone would repeatedly emit TopologyAwareHintsDisabled events for the cluster DNS service. With this release, the `TopologyAwareHintsDisabled` events are no longer emitted on clusters that do not have nodes in multiple availability zones and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-11449[*OCPBUGS-11449*])
@@ -4297,11 +4295,11 @@ $ oc adm release info 4.13.46 --pullspecs
 
 * Previously, a change of dependency targets was introduced in {product-title} 4.14 that prevented disconnected Azure Red Hat OpenShift (ARO) installs from scaling up new nodes after they upgraded to affected versions. With this release, disconnected ARO installs can scale up new nodes after upgrading to {product-title} 4.14. (link:https://issues.redhat.com/browse/OCPBUGS-37160[*OCPBUGS-37160*])
 
-[id="ocp-4-13-46-updating"]
+[id="ocp-4-13-46-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-48"]
+[id="ocp-4-13-48_{context}"]
 === RHSA-2024:5444 - {product-title} 4.13.48 bug fix and security updates
 
 Issued: 22 August 2024
@@ -4317,7 +4315,7 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.48 --pullspecs
 ----
 
-[id="ocp-4-13-48-bug-fixes"]
+[id="ocp-4-13-48-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, an alert for `OVNKubernetesNorthdInactive` would not start in circumstances where it should. With this release, the issue is fixed so that the alert for `OVNKubernetesNorthdInactive` starts as expected. (link:https://issues.redhat.com/browse/OCPBUGS-38403[*OCPBUGS-38403*])
@@ -4328,12 +4326,12 @@ $ oc adm release info 4.13.48 --pullspecs
 
 * Previously, the vSphere connection configuration interface showed the network name instead of the cluster name in the "vCenter cluster" field. With this update, the "vCenter cluster" field has been updated to display the cluster name. (link:https://issues.redhat.com/browse/OCPBUGS-35259[*OCPBUGS-35259*])
 
-[id="ocp-4-13-48-updating"]
+[id="ocp-4-13-48-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 
-[id="ocp-4-13-49"]
+[id="ocp-4-13-49_{context}"]
 === RHSA-2024:6009 - {product-title} 4.13.49 bug fix and security updates
 
 Issued: 04 September 2024
@@ -4349,11 +4347,11 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.49 --pullspecs
 ----
 
-[id="ocp-4-13-49-updating"]
+[id="ocp-4-13-49-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
-[id="ocp-4-13-50"]
+[id="ocp-4-13-50_{context}"]
 === RHSA-2024:6691 - {product-title} 4.13.50 bug fix and security updates
 
 Issued: 19 September 2024
@@ -4369,12 +4367,12 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.50 --pullspecs
 ----
 
-[id="ocp-4-13-50-updating"]
+[id="ocp-4-13-50-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.13.51
-[id="ocp-4-13-51"]
+[id="ocp-4-13-51_{context}"]
 === RHSA-2024:6811 - {product-title} 4.13.51 bug fix and security updates
 
 Issued: 25 September 2024
@@ -4390,23 +4388,23 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.51 --pullspecs
 ----
 
-[id="ocp-4-13-51-enhancements"]
+[id="ocp-4-13-51-enhancements_{context}"]
 ==== Enhancements
 
 * CentOS 8 has recently ended its lifecycle. This release updates the CentOS 8 references in the {product-title} installer to CentOS 9. (link:https://issues.redhat.com/browse/OCPBUGS-39160[*OCPBUGS-39160*])
 
-[id="ocp-4-13-51-bug-fixes"]
+[id="ocp-4-13-51-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, Open vSwitch (OVS) could function by using older configurations after a cluster upgrade operations. These older configurations might have caused issues for networking components that interact with OVS. With this release, OVS is restarted after an upgrade operation so that OVS is forced to receive the latest configurations. (link:https://issues.redhat.com/browse/OCPBUGS-41723[*OCPBUGS-41723*])
 
 
-[id="ocp-4-13-51-updating"]
+[id="ocp-4-13-51-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.13.52
-[id="ocp-4-13-52"]
+[id="ocp-4-13-52_{context}"]
 === RHSA-2024:7939 - {product-title} 4.13.52 bug fix and security updates
 
 Issued: 16 October 2024
@@ -4422,14 +4420,14 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.52 --pullspecs
 ----
 
-[id="ocp-4-13-52-bug-fixes"]
+[id="ocp-4-13-52-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, a group ID was not added to the `/etc/group` in the container when the `spec.securityContext.runAsGroup` attribute was set in the pod resource. With this release, this issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-41247[*OCPBUGS-41247*])
 
 * Previously, enabling FIPS for a cluster causes SR-IOV device plugin pods to fail. With this release, SR-IOV device plugin pods have FIPS enabled so that when you enable FIPS for the cluster, the pods do not fail. (link:https://issues.redhat.com/browse/OCPBUGS-23018[*OCPBUGS-23018*])
 
-[id="ocp-4-13-52-updating"]
+[id="ocp-4-13-52-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 


### PR DESCRIPTION
:page_facing_up: INTERNAL UPDATE (No SME or QE reviews needed) :page_facing_up: 

https://github.com/openshift/openshift-docs/pull/84508/files identified that the context variable is missing from the ocp-4-13-release-notes.adoc file. I raised this PR to add the variable to each ID tag.

Version(s):
4.13

Preview:
https://84594--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html
