### PR TITLE
CNV-33381: Added RN for windows server 2025 support

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -90,6 +90,8 @@ Overcommitting memory on a highly utilized system can decrease workload performa
 //CNV-40005 Application-aware resource quota
 * You can now use the xref:../../virt/virtual_machines/advanced_vm_management/virt-understanding-aaq-operator.adoc#virt-understanding-aaq-operator[Application-Aware Quota (AAQ) Operator] to customize and manage resource quotas for individual components in an {product-title} cluster. The AAQ Operator provides the `ApplicationAwareResourceQuota` and `ApplicationAwareClusterResourceQuota` custom resource definitions (CRDs) that can be used to allocate resources without interfering with cluster-level activities such as upgrades and node maintenance.
 
+//CNV-33381 Release note: Windows Server 2025 guest support
+* {VirtProductName} release 4.17.1 introduces support for Microsoft Windows Server 2025 as a certified guest operating system. See link:https://access.redhat.com/articles/4234591[Certified Guest Operating Systems in OpenShift Virtualization] for more details.
 
 //[id="virt-4-17-networking"]
 //=== Networking


### PR DESCRIPTION
Version(s):
4.17

Issue: [CNV-33381](https://issues.redhat.com/browse/CNV-33381)

[Link to docs preview](https://84607--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-17-virtualization)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
