### PR TITLE
adding node : redhat-support-tool has been deprecated in RHEL 8 and will not be shipped in RHEL 9 onwards

### DIFF
--- a/modules/support-providing-diagnostic-data-to-red-hat.adoc
+++ b/modules/support-providing-diagnostic-data-to-red-hat.adoc
@@ -96,4 +96,14 @@ If an existing `toolbox` pod is already running, the `toolbox` command outputs `
 ----
 # redhat-support-tool addattachment -c 01234567 /host/var/tmp/my-diagnostic-data.tar.gz <1>
 ----
++
+ifndef::openshift-rosa,openshift-dedicated[]
+[NOTE]
+====
+The `redhat-support-tool` has been deprecated in RHEL 8 and will not be shipped in RHEL 9 onwards.
+See link:https://access.redhat.com/articles/445443[Red Hat Access: Red Hat Support Tool] for more complete information on `redhat-support-tool`.
+====
++
+endif::openshift-rosa,openshift-dedicated[]
+
 <1> The toolbox container mounts the host's root directory at `/host`. Reference the absolute path from the toolbox container's root directory, including `/host/`, when specifying files to upload through the `redhat-support-tool` command.


### PR DESCRIPTION
adding node : redhat-support-tool has been deprecated in RHEL 8 and will not be shipped in RHEL 9 onwards

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13
4.14
4.15
4.16
4.17



Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-44342


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://84632--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#support-providing-diagnostic-data-to-red-hat_gathering-cluster-data


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
