### PR TITLE
[OSDOCS-12371] adding rosa create network documentation

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -861,6 +861,73 @@ Add a machine pool with tags to a cluster.
 $ rosa create machinepool --cluster=mycluster --replicas=2 --instance-type=r5.2xlarge --tags='foo bar,bar baz' --name=mp-1
 ----
 
+[id="rosa-create-network_{context}"]
+== create network
+
+Create a network that creates any necessary AWS resources through AWS CloudFormation templates. This helper command is intended to help create and configure a VPC for use with {hcp-title}. This command also supports zero egress clusters.
+
+[IMPORTANT]
+====
+Running this command creates resources within your AWS account.
+====
+
+[NOTE]
+====
+For custom or advanced configuration, it is highly recommended to use the AWS CLI directly using the `aws cloudformation` command or create a new custom template with the required configurations.
+====
+
+.Syntax
+[source,terminal]
+----
+$ rosa create network [flags]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+|<template-name>
+|Allows you to use a custom template. Templates must be in the template folder, structured as `templates/<template-name>/cloudformation.yaml`. If no template name is provided, the command uses the default template. For binary builds, this template directory must be referenced manually after it is downloaded.
+
+|===
+
+.Default template YAML
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift/rosa/refs/heads/master/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml[]
+----
+
+.Flags
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--template-dir
+|Allows you to specify the path to the template directory. Overrides the `OCM_TEMPLATE_DIR` environment variable. Required if not running the command inside the template directory.
+
+|--param Name
+|Define the name of your network. A required parameter when using a custom template file.
+
+|--param Region
+|Define the region of your network. A required parameter when using a custom template file.
+
+|--param <various>
+|Available parameters depend on the template. Use `--help` when in the template directory to find available parameters.
+
+|--mode=manual
+|Provides AWS commands to create the network stack.
+
+|===
+
+.Example
+Create a basic network with regular arguments and flags.
+
+[source,terminal]
+----
+$ rosa create network rosa-quickstart-default-vpc --param Tags=key1=value1,key2=value2 --param Name=example-stack --param Region=us-west-2
+----
+
 [id="rosa-create-ocm-role_{context}"]
 == create ocm-role
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 [id="rosa-q4-2024_{context}"]
 === Q4 2024
 
+* **`rosa create network` command added for {hcp-title} clusters.** You can now use the `rosa create network` command when creating {hcp-title} clusters to create networks using AWS CloudFormation templates. This helper command is intended to help create and configure a VPC for use with {hcp-title}. This command also supports zero egress clusters. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-network_rosa-managing-objects-cli[create network].
+
 * **Create additional security groups in {hcp-title} clusters.** Starting with ROSA CLI version 1.2.47, you can now create additional security groups using the ROSA CLI when creating {hcp-title} clusters. Note that additional security group IDs attached to the machine pool cannot be modified. To remove or add more security group IDs, replace the entire machine pool with a new one.
 
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].


### PR DESCRIPTION
[OSDOCS-12371] adding rosa create network documentation

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12371

Link to docs preview:
https://84636--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-create-network_rosa-managing-objects-cli
https://84636--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html#rosa-q4-2024_rosa-whats-new

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
