### PR TITLE
OADP-5191: Fix Attributes in Support for OpenShift API for Data Prote…

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-oadp-data-mover.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-oadp-data-mover.adoc
@@ -18,7 +18,7 @@ toc::[]
 The {oadp-short} built-in Data Mover, which was introduced in {oadp-short} 1.3 as a Technology Preview, is now fully supported for both containerized and virtual machine workloads.
 ====
 
-[id="enabling-oadp-data-mover"]
+[id="enabling-oadp-data-mover_{context}"]
 == Enabling the built-in Data Mover
 
 To enable the built-in Data Mover, you must include the CSI plugin and enable the node agent in the `DataProtectionApplication` custom resource (CR). The node agent is a Kubernetes daemonset that hosts data movement modules. These include the Data Mover controller, uploader, and the repository.
@@ -63,5 +63,3 @@ The built-in Data Mover feature introduces three new API objects defined as CRDs
 * `BackupRepository`: Represents and manages the lifecycle of the backup repositories. {oadp-short} creates a backup repository per namespace when the first CSI snapshot backup or restore for a namespace is requested.
 
 include::modules/oadp-incremental-backup-support.adoc[leveloffset=+1]
-
-

--- a/modules/oadp-operator-supported.adoc
+++ b/modules/oadp-operator-supported.adoc
@@ -11,7 +11,7 @@
 |===
 
 |Version
-|{OCP-short} version
+|OCP version
 |General availability
 |Full support ends
 |Maintenance ends
@@ -29,11 +29,11 @@ a|
 a|
 27 Jun 2026
 
-EUS must be on {OCP-short} 4.16
+EUS must be on OCP 4.16
 a|
 27 Jun 2027
 
-EUS Term 2 must be on {OCP-short} 4.16
+EUS Term 2 must be on OCP 4.16
 
 |1.3
 a|
@@ -47,11 +47,11 @@ a|
 a|
 31 Oct 2025
 
-EUS must be on {OCP-short} 4.14
+EUS must be on OCP 4.14
 a|
 31 Oct 2026
 
-EUS Term 2 must be on {OCP-short} 4.14
+EUS Term 2 must be on OCP 4.14
 |===
 
 [id="oadp-operator-unsupported_{context}"]


### PR DESCRIPTION
### JIRA

* [OADP-5191](https://issues.redhat.com/browse/OADP-5191)

    Fixes coming from [Cherrypick -  4.14 - OADP-4941: Removing OADP 1.2 references from docs ](https://github.com/openshift/openshift-docs/pull/84520) 
    
    * [Misformatting in table](https://github.com/openshift/openshift-docs/pull/84520#discussion_r1832996274)
    * [Missing `_context` in ID](https://github.com/openshift/openshift-docs/pull/84520#discussion_r1832967051)

### Versions

* OCP 4.15, 4.16, 4.17, 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

### Link to docs preview:

* [Support for OpenShift API for Data Protection](https://84648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-intro.html#oadp-operator-supported_oadp-api)