### PR TITLE
[enterprise-4.17] [OSDOCS-12033]: Removing TP boilerplate and MCE version reference

### DIFF
--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
@@ -13,7 +13,7 @@ You can deploy hosted control planes by configuring a cluster to function as a h
 The _management_ cluster is not the _managed_ cluster. A managed cluster is a cluster that the hub cluster manages.
 ====
 
-The {mce-short} version 2.5 supports only the default `local-cluster`, which is a hub cluster that is managed, and the hub cluster as the hosting cluster.
+The {mce-short} supports only the default `local-cluster`, which is a hub cluster that is managed, and the hub cluster as the hosting cluster.
 
 To provision {hcp} on bare metal, you can use the Agent platform. The Agent platform uses the central infrastructure management service to add worker nodes to a hosted cluster. For more information, see "Enabling the central infrastructure management service".
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
@@ -15,12 +15,9 @@ The _management_ cluster is not the _managed_ cluster. A managed cluster is a cl
 
 You can convert a managed cluster to a management cluster by using the `hypershift` add-on to deploy the HyperShift Operator on that cluster. Then, you can start to create the hosted cluster.
 
-The {mce-short} 2.5 supports only the default `local-cluster`, which is a hub cluster that is managed, and the hub cluster as the management cluster.
+The {mce-short} supports only the default `local-cluster`, which is a hub cluster that is managed, and the hub cluster as the management cluster.
 
-:FeatureName: {hcp-capital} on {ibm-z-title}
-include::snippets/technology-preview.adoc[]
-
-To provision {hcp} on bare metal, you can use the Agent platform. The Agent platform uses the central infrastructure management service to add worker nodes to a hosted cluster. For more information, see _Enabling the central infrastructure management service_.
+To provision {hcp} on bare metal, you can use the Agent platform. The Agent platform uses the central infrastructure management service to add worker nodes to a hosted cluster. For more information, see "Enabling the central infrastructure management service".
 
 Each {ibm-z-title} system host must be started with the PXE images provided by the central infrastructure management. After each host starts, it runs an Agent process to discover the details of the host and completes the installation. An Agent custom resource represents each host.
 


### PR DESCRIPTION
This is a cherry pick of https://github.com/openshift/openshift-docs/pull/84638
