### PR TITLE
OSDOCS12625: Highlight UPI support for platform:none and update pre-req docs OCP 4.17

### DIFF
--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x-prereqs.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x-prereqs.adoc
@@ -4,7 +4,14 @@
 = Windows Machine Config Operator prerequisites
 include::_attributes/common-attributes.adoc[]
 
-The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator. See the vSphere documentation for any information that is relevant to only that platform.
+The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator (WMCO). See the vSphere documentation for any information that is relevant to only that platform.
+
+[id="wmco-prerequisites-supported-install-10.17.0_{context}"]
+== WMCO supported installation method
+
+The WMCO fully supports installing Windows nodes into installer-provisioned infrastructure (IPI) clusters. This is the preferred {product-title} installation method.
+
+For user-provisioned infrastructure (UPI) clusters, the WMCO supports installing Windows nodes only into a UPI cluster installed with the `platform: none` field set in the `install-config.yaml` file (bare-metal or provider-agnostic) and only for the xref:../../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[BYOH (Bring Your Own Host)] use case. UPI is not supported for any other platform.
 
 [id="wmco-prerequisites-supported-10.17.0_{context}"]
 == WMCO 10.17.0 supported platforms and Windows Server versions
@@ -42,7 +49,7 @@ a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic
 
 == Supported networking
 
-Hybrid networking with OVN-Kubernetes is the only supported networking configuration. See the additional resources below for more information on this functionality. The following tables outline the type of networking configuration and Windows Server versions to use based on your platform. You must specify the network configuration when you install the cluster. 
+Hybrid networking with OVN-Kubernetes is the only supported networking configuration. See the additional resources below for more information on this functionality. The following tables outline the type of networking configuration and Windows Server versions to use based on your platform. You must specify the network configuration when you install the cluster.
 
 [NOTE]
 ====
@@ -89,3 +96,7 @@ a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic
 |Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
 
 |===
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[Hybrid networking]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-12625

Add info from [WMCO docs](https://github.com/openshift/windows-machine-config-operator/pull/2509/files#diff-7288c3766836fccd27562bcb1fc64927f66e877e9eadcdb8e030eed77a224738R5-R10).

Preview: [WMCO supported Installation method](https://84653--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x-prereqs.html#wmco-prerequisites-supported-install-10.17.0_windows-containers-release-notes-10-17-x-prereqs)

Changes will need to be manually CPd to the WMCO release notes for each supported version. Not to main.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
