### PR TITLE
Obsdocs 1360 - 1x.pico sizing for loki

### DIFF
--- a/modules/log6x-loki-sizing.adoc
+++ b/modules/log6x-loki-sizing.adoc
@@ -1,0 +1,93 @@
+// Module is included in the following assemblies:
+// * observability/logging/logging-6.0/
+
+:_mod-docs-content-type: CONCEPT
+[id="log6x-loki-sizing_{context}"]
+= Loki deployment sizing
+
+Sizing for Loki follows the format of `1x.<size>` where the value `1x` is number of instances and `<size>` specifies performance capabilities.
+
+For logging 6.1+, `1x.pico` configuration defines a single Loki deployment with minimal resource and limit requirements, offering high availability (HA) support for all Loki components. This configuration is suited for deployments that do not require a single replication factor or auto-compaction.
+
+Disk requests are similar across size configurations, allowing customers to test different sizes to determine the best fit for their deployment needs.
+
+
+[IMPORTANT]
+====
+It is not possible to change the number `1x` for the deployment size.
+====
+
+.Loki sizing
+[cols="1h,5*",options="header"]
+|===
+|
+|1x.demo
+|1x.pico [6.1+ only]
+|1x.extra-small
+|1x.small
+|1x.medium
+
+|Data transfer
+|Demo use only
+|50GB/day
+|100GB/day
+|500GB/day
+|2TB/day
+
+|Queries per second (QPS)
+|Demo use only
+|1-25 QPS at 200ms
+|1-25 QPS at 200ms
+|25-50 QPS at 200ms
+|25-75 QPS at 200ms
+
+|Replication factor
+|None
+|2
+|2
+|2
+|2
+
+|Total CPU requests
+|None
+|7 vCPUs
+|14 vCPUs
+|34 vCPUs
+|54 vCPUs
+
+|Total CPU requests if using the ruler
+|None
+|8 vCPUs
+|16 vCPUs
+|42 vCPUs
+|70 vCPUs
+
+|Total memory requests
+|None
+|17Gi
+|31Gi
+|67Gi
+|139Gi
+
+
+|Total memory requests if using the ruler
+|None
+|18Gi
+|35Gi
+|83Gi
+|171Gi
+
+|Total disk requests
+|40Gi
+|590Gi
+|430Gi
+|430Gi
+|590Gi
+
+|Total disk requests if using the ruler
+|80Gi
+|910Gi
+|750Gi
+|750Gi
+|910Gi
+|===

--- a/observability/logging/logging-6.0/log6x-loki.adoc
+++ b/observability/logging/logging-6.0/log6x-loki.adoc
@@ -21,6 +21,7 @@ include::snippets/log6x-loki-statement-snip.adoc[leveloffset=+1]
 == Core Setup and Configuration
 *Role-based access controls, basic monitoring, and pod placement to deploy Loki.*
 
+include::modules/log6x-loki-sizing.adoc[leveloffset=+1]
 include::modules/log6x-loki-rbac-rules-perms.adoc[leveloffset=+1]
 include::modules/log6x-enabling-loki-alerts.adoc[leveloffset=+1]
 include::modules/log6x-loki-memberlist-ip.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.15, 4.16, 4.17, 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OBSDOCS-1360](https://issues.redhat.com//browse/OBSDOCS-1360)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://84655--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-loki.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


