### PR TITLE
TELCODOCS#2019: Removed the OCPBUGS-19838 known issue

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3171,11 +3171,6 @@ An upstream change is currently being developed to handle the holdover state fun
 * The DPLL subsystem and DPLL support is not currently enabled in the Intel Westport Channel e810 NIC ice driver.
 (link:https://issues.redhat.com/browse/RHELPLAN-165955[*RHELPLAN-165955*])
 
-* The current grandmaster clock (T-GM) implementation has a single NMEA sentence generator sourced from the GNSS without a backup NMEA sentence generator.
-If NMEA sentences are lost on their way to the e810 NIC, the T-GM cannot synchronize the devices in the network synchronization chain and the PTP Operator reports an error.
-A proposed fix is to report a `FREERUN` event when the NMEA string is lost.
-(link:https://issues.redhat.com/browse/OCPBUGS-19838[*OCPBUGS-19838*])
-
 * Currently, due to differences in setting up a container's cgroup hierarchy, containers that use the `crun` OCI runtime along with a `PerformanceProfile` configuration encounter performance degradation.
 As a workaround, use the `runc` OCI container runtime.
 Although the `runc` container runtime has lower performance during container startup, shutdown operations, and `exec` probes, the `crun` and `runc` container runtimes are functionally identical.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2019](https://issues.redhat.com/browse/TELCODOCS-2019)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Known issues](https://84661--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-known-issues)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->