### PR TITLE
OCPBUGS#12622: Fixed Statically provisioning hostPath volumes bug

### DIFF
--- a/modules/persistent-storage-hostpath-static-provisioning.adoc
+++ b/modules/persistent-storage-hostpath-static-provisioning.adoc
@@ -10,30 +10,30 @@ A pod that uses a hostPath volume must be referenced by manual (static) provisio
 
 .Procedure
 
-. Define the persistent volume (PV). Create a file, `pv.yaml`, with the `PersistentVolume` object definition:
+. Define the persistent volume (PV) by creating a `pv.yaml` file with the `PersistentVolume` object definition:
 +
 [source,yaml]
 ----
-  apiVersion: v1
-  kind: PersistentVolume
-  metadata:
-    name: task-pv-volume <1>
-    labels:
-      type: local
-  spec:
-    storageClassName: manual <2>
-    capacity:
-      storage: 5Gi
-    accessModes:
-      - ReadWriteOnce <3>
-    persistentVolumeReclaimPolicy: Retain
-    hostPath:
-      path: "/mnt/data" <4>
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: task-pv-volume <1>
+  labels:
+    type: local
+spec:
+  storageClassName: manual <2>
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce <3>
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: "/mnt/data" <4>
 ----
-<1> The name of the volume. This name is how it is identified by persistent volume claims or pods.
-<2> Used to bind persistent volume claim requests to this persistent volume.
+<1> The name of the volume. This name is how the volume is identified by persistent volume (PV) claims or pods.
+<2> Used to bind persistent volume claim (PVC) requests to the PV.
 <3> The volume can be mounted as `read-write` by a single node.
-<4> The configuration file specifies that the volume is at `/mnt/data` on the cluster's node. Do not mount to the container root, `/`, or any path that is the same in the host and the container. This can corrupt your host system. It is safe to mount the host by using `/host`.
+<4> The configuration file specifies that the volume is at `/mnt/data` on the cluster's node. To avoid corrupting your host system, do not mount to the container root, `/`, or any path that is the same in the host and the container. You can safely mount the host by using `/host` 
 
 . Create the PV from the file:
 +
@@ -42,7 +42,7 @@ A pod that uses a hostPath volume must be referenced by manual (static) provisio
 $ oc create -f pv.yaml
 ----
 
-. Define the persistent volume claim (PVC). Create a file, `pvc.yaml`, with the `PersistentVolumeClaim` object definition:
+. Define the PVC by creating a `pvc.yaml` file with the `PersistentVolumeClaim` object definition:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-12622](https://issues.redhat.com/browse/OSDOCS-12622)

Link to docs preview:
* [Statically provisioning hostPath volumes](https://84664--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-hostpath.html#hostpath-static-provisioning_persistent-storage-hostpath)

- [x] SME has approved this change.
- [x] QE has approved this change.
