### PR TITLE
OCPBUGS-12622-br-ex: Added note to creating-manifest-file-customized-…

### DIFF
--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -151,6 +151,11 @@ endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 ifdef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 . Create a `NodeNetworkConfigurationPolicy` (NNCP) CR and define a customized `br-ex` bridge network configuration. Depending on your needs, ensure that you set a masquerade IP for either the `ipv4.address.ip`, `ipv6.address.ip`, or both parameters. A masquerade IP address must match an in-use IP address block.
 +
+[IMPORTANT]
+====
+As a post-installation task, you can configure most parameters for a customized `br-ex` bridge that you defined in an existing NNCP CR, except for the IP address.
+====
++
 .Example of an NNCP CR that sets IPv6 and IPv4 masquerade IP addresses
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-12622](https://issues.redhat.com/browse/OSDOCS-12622)

Link to docs preview:

* [Setting up the environment for an OpenShift installation](https://84665--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow)
* [**Postinstallation configuration**](https://84665--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.html#creating-manifest-file-customized-br-ex-bridge_ipi-install-post-installation-configuration)
* [Installing a user-provisioned cluster on bare metal](https://84665--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal)
* [Installing a user-provisioned bare metal cluster with network customizations](https://84665--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal-network-customizations)
* [Installing a user-provisioned bare metal cluster on a restricted network](https://84665--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#creating-manifest-file-customized-br-ex-bridge_installing-restricted-networks-bare-metal)

- [x] SME has approved this change.
- [x] QE has approved this change.
