### PR TITLE
OSDOCS-12159: adds 4.15.38 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -487,3 +487,12 @@ Issued: 31 October 2024
 The {product-title} release 4.15.37 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8427[RHBA-2024:8427] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8425[RHSA-2024:8425] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-38-dp_{context}"]
+=== RHBA-2024:8993 - {microshift-short} 4.15.38 bug fix and enhancement advisory
+
+Issued: 13 November 2024
+
+The {product-title} release 4.15.38 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8993[RHBA-2024:8993] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8991[RHSA-2024:8991] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12159](https://issues.redhat.com/browse/OSDOCS-12159)

Link to docs preview:
[4-15-38-dp_release-notes](https://84673--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-38-dp_release-notes)

QE review:
 - NA. stock text, no other changes.