### PR TITLE
WMCO 10.17.1 Release Notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2847,8 +2847,8 @@ Topics:
   Topics:
   - Name: Red Hat OpenShift support for Windows Containers release notes
     File: windows-containers-release-notes-10-17-x
-#  - Name: Past releases
-#    File: windows-containers-release-notes-10-17-x-past
+  - Name: Past releases
+    File: windows-containers-release-notes-10-17-x-past
   - Name: Windows Machine Config Operator prerequisites
     File: windows-containers-release-notes-10-17-x-prereqs
   - Name: Windows Machine Config Operator known limitations

--- a/modules/images-configuration-registry-mirror-configuring.adoc
+++ b/modules/images-configuration-registry-mirror-configuring.adoc
@@ -17,9 +17,7 @@ You can create postinstallation mirror configuration custom resources (CR) to re
 ifdef::winc[]
 [IMPORTANT]
 ====
-Windows images mirrored through `ImageDigestMirrorSet` and `ImageTagMirrorSet` objects have specific naming requirements. 
-
-include::snippets/wmco-mirror-naming-requirements.adoc[]
+Windows images mirrored through `ImageDigestMirrorSet` and `ImageTagMirrorSet` objects have specific naming requirements as described in "Using Windows containers with a mirror registry".
 ====
 endif::winc[]
 

--- a/modules/windows-containers-release-notes-10-17-0.adoc
+++ b/modules/windows-containers-release-notes-10-17-0.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes-10-17-x-past.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-17-0_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.17.0
+
+This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.17.0 were released in link:https://access.redhat.com/errata/RHSA-2024:7436[RHSA-2024:7436].
+
+[id="wmco-10-17-0-new-features"]
+== New features and improvements
+
+[id="wmco-10-17-0-new-features-kubernetes"]
+=== Kubernetes upgrade
+
+The WMCO now uses Kubernetes 1.30.
+
+[id="wmco-10-17-0-bug-fixes"]
+== Bug fixes
+
+* Previously, if a Windows VM had its PowerShell `ExecutionPolicy` set to `Restricted`, the Windows Instance Config Daemon (WICD) could not run the commands on that VM that are necessary for creating Windows nodes. With this fix, the WICD now bypasses the execution policy on the VM when running PowerShell commands. As a result, the WICD can create Windows nodes on the VM as expected. (link:https://issues.redhat.com/browse/OCPBUGS-30995[*OCPBUGS-30995*])
+
+// Copied from 4.16 release notes. 
+* Previously, if reverse DNS lookup failed due to an error, such as the reverse DNS lookup services being unavailable, the WMCO would not fall back to using the VM hostname to determine if a certificate signing requests (CSR) should be approved. As a consequence, Bring-Your-Own-Host (BYOH) Windows nodes configured with an IP address would not become available. With this fix, BYOH nodes are properly added if reverse DNS is not available. (link:https://issues.redhat.com/browse/OCPBUGS-36643[*OCPBUGS-36643*])
+
+// Copied from 4.16 release notes. 
+* Previously, if there were multiple service account token secrets in the WMCO namespace, scaling Windows nodes would fail. With this fix, the WMCO uses only the secret it creates, ignoring any other service account token secrets in the WMCO namespace. As a result, Windows nodes scale properly. (link:https://issues.redhat.com/browse/OCPBUGS-29253[*OCPBUGS-29253*])

--- a/modules/windows-containers-release-notes-10-17-1.adoc
+++ b/modules/windows-containers-release-notes-10-17-1.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-17-1_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.17.1
+
+This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.17.1 were released in link:https://access.redhat.com/errata/RHSA-2025:8704[RHSA-2025:8704].
+
+[id="wmco-10-17-1-new-features"]
+== New features and improvements
+
+[id="wmco-10-17-1-new-features-debuglogging"]
+=== WMCO now defaults to info-level logging
+The WMCO is configured to use the `info` log level by default. You can change the log level to `debug` by editing the WMCO subscription object. 
+// Based on https://issues.redhat.com/browse/WINC-1345
+
+For more information, see _Configuring debug-level logging for the Windows Machine Config Operator_.
+
+[id="wmco-10-17-1-bug-fixes"]
+== Bug fixes
+
+* Previously, Windows nodes were unable to pull from image mirror registries if an organization name or namespace was included in the source of the `ImageTagMirrorSet` (ITMS) object. With this fix, you can include an organization name or namespace in the `ITMS` object. With this change, additional guidelines and requirements around using mirror registries have been added to the {product-title} documentation. For more information, see _Using Windows containers with a mirror registry_. (link:https://issues.redhat.com/browse/OCPBUGS-55915[*OCPBUGS-55915*])
+
+* Previously, the {product-title} documentation lacked information about WMCO support for the installer-provisioned infrastructure (IPI) and the user-provisioned infrastructure (UPI) installation methods. With this fix, the documentation reports that the IPI method is the preferred installation method and can be used with all platforms. The UPI method is limited to specific use cases. For more information, see _WMCO supported installation method_. (link:https://issues.redhat.com/browse/OCPBUGS-44237[*OCPBUGS-44237*])

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -55,22 +55,27 @@ include::modules/wmco-configure-debug-logging.adoc[leveloffset=+1]
 
 include::modules/wmco-cluster-wide-proxy.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
-
 * xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[Configuring the cluster-wide proxy].
 
 include::modules/wmco-disconnected-cluster.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
-
 * xref:../disconnected/mirroring/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../windows_containers/enabling-windows-container-workloads.adoc#wmco-disconnected-cluster_enabling-windows-container-workloads[Using Windows containers with a mirror registry]
+
 include::modules/nodes-nodes-rebooting-gracefully.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
 * xref:../nodes/nodes/nodes-nodes-rebooting.adoc#nodes-nodes-rebooting-gracefully_nodes-nodes-rebooting[Rebooting a {product-title} node gracefully]
 * xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd data]

--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x-past.adoc
@@ -10,16 +10,4 @@ The following release notes are for previous versions of the Windows Machine Con
 
 For the current version, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.adoc#windows-containers-release-notes-10-17-x[{productwinc} release notes].
 
-[id="wmco-10-17-"]
-== Release notes for Red Hat Windows Machine Config Operator 10.17.0
-
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.17.0 were released in
-
-
-[id="wmco-10-17-past-new-features"]
-=== New features and improvements
-
-[id="wmco-10-17-bug-fixes"]
-=== Bug fixes
-
-
+include::modules/windows-containers-release-notes-10-17-0.adoc[leveloffset=+1]

--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.adoc
@@ -6,27 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/windows-containers-release-notes-10-17-1.adoc[leveloffset=+1]
 
-[id="wmco-10-17-0"]
-== Release notes for Red Hat Windows Machine Config Operator 10.17.0
+[role="_additional-resources"]
+.Additional resources
+* xref:../../windows_containers/enabling-windows-container-workloads.adoc#wmco-disconnected-cluster_enabling-windows-container-workloads[Using Windows containers with a mirror registry]
+* xref:../../windows_containers/enabling-windows-container-workloads.adoc#wmco-configure-debug-logging_enabling-windows-container-workloads[Configuring debug-level logging for the Windows Machine Config Operator]
+* xref:../../windows_containers/wmco_rn/windows-containers-release-notes-10-17-x-prereqs.adoc#wmco-prerequisites-supported-install-10.17.0_windows-containers-release-notes-10-17-x-prereqs[WMCO supported installation method]
 
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.17.0 were released in link:https://access.redhat.com/errata/RHSA-2024:TBD[RHSA-2024:TBD].
 
-[id="wmco-10-17-0-new-features"]
-=== New features and improvements
-
-[id="wmco-10-17-0-new-features-kubernetes"]
-==== Kubernetes upgrade
-
-The WMCO now uses Kubernetes 1.30.
-
-[id="wmco-10-17-0-bug-fixes"]
-=== Bug fixes
-
-* Previously, if a Windows VM had its PowerShell `ExecutionPolicy` set to `Restricted`, the Windows Instance Config Daemon (WICD) could not run the commands on that VM that are necessary for creating Windows nodes. With this fix, the WICD now bypasses the execution policy on the VM when running PowerShell commands. As a result, the WICD can create Windows nodes on the VM as expected. (link:https://issues.redhat.com/browse/OCPBUGS-30995[*OCPBUGS-30995*])
-
-// Copied from 4.16 release notes. 
-* Previously, if reverse DNS lookup failed due to an error, such as the reverse DNS lookup services being unavailable, the WMCO would not fall back to using the VM hostname to determine if a certificate signing requests (CSR) should be approved. As a consequence, Bring-Your-Own-Host (BYOH) Windows nodes configured with an IP address would not become available. With this fix, BYOH nodes are properly added if reverse DNS is not available. (link:https://issues.redhat.com/browse/OCPBUGS-36643[*OCPBUGS-36643*])
-
-// Copied from 4.16 release notes. 
-* Previously, if there were multiple service account token secrets in the WMCO namespace, scaling Windows nodes would fail. With this fix, the WMCO uses only the secret it creates, ignoring any other service account token secrets in the WMCO namespace. As a result, Windows nodes scale properly. (link:https://issues.redhat.com/browse/OCPBUGS-29253[*OCPBUGS-29253*])


### PR DESCRIPTION
https://issues.redhat.com/browse/WINC-1345

Previews:
[Release notes for Red Hat Windows Machine Config Operator 10.17.1](https://84675--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.html) -- New text. Errata link will not work until GA, planned for 6/2/25.
[Release notes for Red Hat Windows Machine Config Operator 10.17.0](https://84675--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x-past) -- Moved [current 10.17.0 release notes](https://docs.openshift.com/container-platform/4.17/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.html#wmco-10-17-0) to the _Past releases_ assembly. Updated advisory link. **NO CHANGES TO TEXT. NO NEED TO REVIEW** 

Cherrypick https://github.com/openshift/openshift-docs/pull/92629 to 4.17 when WMCO 10.17.1 is released.  