### PR TITLE
MIG-1664: MTC-1.8.5-release-notes

### DIFF
--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,7 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-5.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-4.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-3.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-2.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-5.adoc
+++ b/modules/migration-mtc-release-notes-1-8-5.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-5_{context}"]
+= {mtc-full} 1.8.5 release notes
+
+[id="technical-changes-1-8-5_{context}"]
+== Technical changes
+
+{mtc-first} 1.8.5 has the following technical changes:
+
+.Federal Information Processing Standard (FIPS)
+
+FIPS is a set of computer security standards developed by the United States federal government in accordance with the Federal Information Security Management Act (FISMA).
+
+Starting with version 1.8.5, {mtc-short} is designed for FIPS compliance.
+
+[id="mtc-resolved-issues-1-8-5_{context}"]
+== Resolved issues
+
+
+For more information, see the list of link:https://issues.redhat.com/issues/?filter=12447122[{mtc-short} 1.8.5 resolved issues] in Jira.
+
+[id="known-issues-1-8-5_{context}"]
+== Known issues
+
+{mtc-short} 1.8.5 has the following known issues:
+
+.The associated SCC for service account cannot be migrated in {OCP} 4.12
+
+The associated Security Context Constraints (SCCs) for service accounts in {OCP} 4.12 cannot be migrated. This issue is planned to be resolved in a future release of {mtc-short}. link:https://issues.redhat.com/browse/MIG-1454[(MIG-1454)]
+
+.{mtc-short} does not patch `statefulset.spec.volumeClaimTemplates[].spec.storageClassName` on storage class conversion
+
+While running a Storage Class conversion for a StatefulSet application, {mtc-short} updates the persistent volume claims (PVC) references in `.spec.volumeClaimTemplates[].metadata.name` to use the migrated PVC names. {mtc-short} does not update `spec.volumeClaimTemplates[].spec.storageClassName`, which causes the application to scale up. Additionally, new replicas consume PVCs created under the old Storage Class instead of the migrated Storage Class. link:https://issues.redhat.com/browse/MIG-1660[(MIG-1660)]
+
+.Performing a StorageClass conversion triggers the scale-down of all applications in the namespace
+
+When running a `StorageClass` conversion on more than one application, {mtc-short} scales down all the applications in the cutover phase, including those not involved in the migration. link:https://issues.redhat.com/browse/MIG-1661[(MIG-1661)]
+
+.`MigPlan` cannot be edited to have the same target namespace as the source cluster after it is changed
+
+After changing the target namespace to something different from the source namespace while creating a `MigPlan` in the {mtc-short} UI, you cannot edit the `MigPlan` again to make the target namespace the same as the source namespace. link:https://issues.redhat.com/browse/MIG-1600[(MIG-1600)]
+
+
+.Migrated builder pod fails to push to the image registry
+
+When migrating an application that includes `BuildConfig` from the source to the target cluster, the builder pod encounters an error, failing to push the image to the image registry.
+link:https://bugzilla.redhat.com/show_bug.cgi?id=2234781[(BZ#2234781)]
+
+.Conflict condition clears briefly after it is displayed
+
+When creating a new state migration plan that results in a conflict error, the error is cleared shortly after it is displayed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2144299[(BZ#2144299)]
+
+.`PvCapacityAdjustmentRequired` warning not displayed after setting `pv_resizing_threshold`
+
+The `PvCapacityAdjustmentRequired` warning does not appear in the migration plan after the `pv_resizing_threshold` is adjusted. link:https://bugzilla.redhat.com/show_bug.cgi?id=2270160[(BZ#2270160)]
+
+For a complete list of all known issues, see the list of link:https://issues.redhat.com/issues/?filter=12447121[{mtc-short} 1.8.5 known issues] in Jira.


### PR DESCRIPTION
### JIRA

* [MIG-1664](https://issues.redhat.com/browse/MIG-1664)

### Versions:

* 4.14 
* 4.15 
* 4.16
* 4.17
* 4.18

### Link to docs preview:

* [MTC 1.8.5 release notes](https://84677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes.html#migration-mtc-release-notes-1-8-5_mtc-release-notes)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
