### PR TITLE
OSDOCS-12595: Documented the 4.12.69 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4987,3 +4987,23 @@ $ oc adm release info 4.12.68 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.12.69
+[id="ocp-4-12-69_{context}"]
+=== RHBA-2024:8996 - {product-title} 4.12.69 bug fix
+
+Issued: 14 November 2024
+
+{product-title} release 4.12.69 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:8996[RHBA-2024:8996] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:8998[RHBA-2024:8998] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.69 --pullspecs
+----
+
+[id="ocp-4-12-69-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-12595](https://issues.redhat.com/browse/OSDOCS-12595)

Link to docs preview:
* [4.12.69](https://84685--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-69_release-notes)
