### PR TITLE
TELCODOCS-2028 Release Note

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1100,6 +1100,12 @@ The 1.6.2 version of the Network Observability Operator fixes a compatibility is
 
 In this release, the firmware search path has been updated to copy the contents of the specified path into the path specified in `worker.setFirmwareClassPath` (default: `/var/lib/firmware`). For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-example-cr_kernel-module-management-operator[Example Module CR].
 
+
+[id="ocp-4-17-kmmo-rhel-els-minimal_{context}"]
+==== Kernel Module Management Operator on rhel-els-minimal
+
+KMM images are now based on rhel-els-minimal container images instead of the rhel-els images. This change results in a greatly reduced image footprint, while still maintaining FIPS compliance.   
+
 [id="ocp-4-17-etcd-4-5-nodes_{context}"]
 ==== Node scaling for etcd
 


### PR DESCRIPTION
R/N only: [MGMT-18836](https://issues.redhat.com//browse/MGMT-18836) Move to the rhel-els-minimal base image

Jira: https://issues.redhat.com/browse/TELCODOCS-2028

Applies to OCP version : 4.17

Fix version: KMMO 2.2

Docs Preview: https://84690--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-kmmo-rhel-els-minimal_release-notes

Dev review: @pericnenad
QE review: @ggordaniRed
