### PR TITLE
OSDOCS#45783: Added a Release Note on CentOS 7+8 support removal

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -207,6 +207,11 @@ Removed features are not supported in the current release.
 //CNV-27160 Release note: REMOVED RHEL 7/virtctl RPMs
 * Installing the `virtctl` client as an RPM is no longer supported for {op-system-base-full} 7 and {op-system-base} 9.
 
+//CNV-45783
+
+* CentOS 7 and CentOS Stream 8 are now in the End of Life phase. As a consequence, the container images for these operating systems have been removed from OpenShift Virtualization and are no longer link:https://access.redhat.com/articles/4234591#community[community supported].
+
+
 //[id="virt-4-14-changes"]
 //== Notable technical changes
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/CNV-45783

Link to docs preview:
https://84704--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->