### PR TITLE
OSDOCS#45783: Added a Release Note on CentOS 7+8 support removal

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -152,7 +152,8 @@ Deprecated features are included in the current release and supported. However, 
 
 Removed features are those that were deprecated in earlier releases. They are now removed from {VirtProductName} and are no longer supported.
 
-No features were removed in this release.
+//CNV-45783
+* CentOS 7 and CentOS Stream 8 are now in the End of Life phase. As a consequence, the container images for these operating systems have been removed from OpenShift Virtualization and are no longer link:https://access.redhat.com/articles/4234591#community[community supported].
 
 [id="virt-4-16-technology-preview_{context}"]
 == Technology Preview features


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17

Issue:
https://issues.redhat.com/browse/CNV-45783

Link to docs preview:
https://84709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
A sort-of-clone of https://github.com/openshift/openshift-docs/pull/84704 , https://github.com/openshift/openshift-docs/pull/84705 , and https://github.com/openshift/openshift-docs/pull/84706

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
