### PR TITLE
OCPBUGS-44416: Directory name fix in installation workflow for IBM cloud bare metal (classic)

### DIFF
--- a/modules/install-ibm-cloud-classic-configuring-the-install-config-file.adoc
+++ b/modules/install-ibm-cloud-classic-configuring-the-install-config-file.adoc
@@ -86,7 +86,7 @@ $ mkdir ~/clusterconfigs
 +
 [source,terminal]
 ----
-$ cp install-config.yaml ~/clusterconfig
+$ cp install-config.yaml ~/clusterconfigs
 ----
 
 . Ensure all bare metal nodes are powered off prior to installing the {product-title} cluster:


### PR DESCRIPTION
Directory name fix in installation workflow for IBM cloud bare metal (classic)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17, 4.16, 4.15, 4.14, 4.13, 4.12, 4.11, 4.10, 4.9
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [Jira ticket](https://issues.redhat.com/browse/OCPBUGS-44416)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:  `cd: clusterconfig: No such file or directory` failed to change directory as created directory name `~/clusterconfigs` is not matching with provided directory name`~/clusterconfig`

Issue is resolved by replacing the directory name `~/clusterconfig` with created directory name `~/clusterconfigs`.

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
