### PR TITLE
OCPBUGS-44417: Removed extra indentation from agent-config.yaml

### DIFF
--- a/modules/agent-install-networking.adoc
+++ b/modules/agent-install-networking.adoc
@@ -39,40 +39,40 @@ rendezvousIP: 192.168.111.80 <1>
 +
 [source,yaml]
 ----
-  cat > agent-config.yaml << EOF
-  apiVersion: v1alpha1
-  kind: AgentConfig
-  metadata:
-    name: sno-cluster
-  rendezvousIP: 192.168.111.80 <1>
-  hosts:
-    - hostname: master-0
+cat > agent-config.yaml << EOF
+apiVersion: v1alpha1
+kind: AgentConfig
+metadata:
+  name: sno-cluster
+rendezvousIP: 192.168.111.80 <1>
+hosts:
+  - hostname: master-0
+    interfaces:
+      - name: eno1
+        macAddress: 00:ef:44:21:e6:a5 <2>
+    networkConfig:
       interfaces:
         - name: eno1
-          macAddress: 00:ef:44:21:e6:a5 <2>
-      networkConfig:
-        interfaces:
-          - name: eno1
-            type: ethernet
-            state: up
-            mac-address: 00:ef:44:21:e6:a5
-            ipv4:
-              enabled: true
-              address:
-                - ip: 192.168.111.80 <3>
-                  prefix-length: 23 <4>
-              dhcp: false
-        dns-resolver:
-          config:
-            server:
-              - 192.168.111.1 <5>
-        routes:
-          config:
-            - destination: 0.0.0.0/0
-              next-hop-address: 192.168.111.1 <6>
-              next-hop-interface: eno1
-              table-id: 254
-  EOF
+          type: ethernet
+          state: up
+          mac-address: 00:ef:44:21:e6:a5
+          ipv4:
+            enabled: true
+            address:
+              - ip: 192.168.111.80 <3>
+                prefix-length: 23 <4>
+            dhcp: false
+      dns-resolver:
+        config:
+          server:
+            - 192.168.111.1 <5>
+      routes:
+        config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.168.111.1 <6>
+            next-hop-interface: eno1
+            table-id: 254
+EOF
 ----
 <1> If a value is not specified for the `rendezvousIP` field, one address will be chosen from the static IP addresses specified in the `networkConfig` fields.
 <2> The MAC address of an interface on the host, used to determine which host to apply the configuration to.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13, 4.12, 4.14, 4.15, 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [ JIRA](https://issues.redhat.com/browse/OCPBUGS-44417)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Using the provided sample agent-config.yaml file, the AgentConfig is not being created as expected due to an EOF error. which is likely caused by incorrect indentation leading to a failure in parsing the YAML structure correctly.
 To resolve this, ensure that all indentation is consistent and properly aligned.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
