### PR TITLE
[enterprise-4.14] TELCODOCS#1889: Size info for LVMS

### DIFF
--- a/modules/lvms-about-lvmcluster-cr.adoc
+++ b/modules/lvms-about-lvmcluster-cr.adoc
@@ -134,6 +134,24 @@ For example, if this field is set to 10, you can provision up to 10 times the am
 
 To disable over-provisioning, set this field to 1.
 
+|`thinPoolConfig.chunkSize`
+|`integer`
+|Specifies the statically calculated chunk size for the thin pool. This field is only used when the `ChunkSizeCalculationPolicy` field is set to `Static`. The value for this field must be configured in the range of 64 KiB to 1 GiB because of the underlying limitations of `lvm2`. 
+
+If you do not configure this field and the `ChunkSizeCalculationPolicy` field is set to `Static`, the default chunk size is set to 128 KiB.
+
+For more information, see "Overview of chunk size".
+
+|`thinPoolConfig.chunkSizeCalculationPolicy`
+|`string`
+|Specifies the policy to calculate the chunk size for the underlying volume group. You can set this field to either `Static` or `Host`. By default, this field is set to `Static`. 
+
+If this field is set to `Static`, the chunk size is set to the value of the `chunkSize` field. If the `chunkSize` field is not configured, chunk size is set to 128 KiB.
+
+If this field is set to `Host`, the chunk size is calculated based on the configuration in the `lvm.conf` file.
+
+For more information, see "Limitations to configure the size of the devices used in LVM Storage".
+
 |====
 
 

--- a/modules/lvms-limitations-to-configure-size-of-devices.adoc
+++ b/modules/lvms-limitations-to-configure-size-of-devices.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="limitations-to-configure-size-of-devices_{context}"]
-= Limitations to configure the size of the devices used in LVM Storage
+= Limitations to configure the size of the devices used in {lvms}
 
 The limitations to configure the size of the devices that you can use to provision storage using {lvms} are as follows:
 
@@ -14,35 +14,58 @@ The limitations to configure the size of the devices that you can use to provisi
 ** The default PE and LE size is 4 MB.
 ** If the size of the PE is increased, the maximum size of the LVM is determined by the kernel limits and your disk space.
 
-.Size limits for different architectures using the default PE and LE size
-[cols="1,1,1,1,1", width="100%", options="header"]
+ifndef::microshift[]
+
+The following tables describe the chunk size and volume size limits for static and host configurations:
+
+.Tested configuration
+[cols="1,1", width="100%", options="header"]
 |====
-|Architecture
-|RHEL 6
-|RHEL 7
-|RHEL 8
-|RHEL 9
 
-|32-bit
-|16 TB
-|-
-|-
-|-
+|Parameter
+|Value
 
-|64-bit
+|Chunk size
+|128 KiB
 
-|8 EB ^[1]^
-
-100 TB ^[2]^
-|8 EB ^[1]^
-
-500 TB ^[2]^
-|8 EB
-|8 EB
+|Maximum volume size
+|32 TiB
 
 |====
-[.small]
---
-1. Theoretical size.
-2. Tested size.
---
+
+.Theoretical size limits for static configuration
+[cols="1,1,1", width="100%", options="header"]
+|====
+
+|Parameter
+|Minimum value
+|Maximum value
+
+|Chunk size
+|64 KiB
+|1 GiB
+
+|Volume size
+|Minimum size of the underlying {op-system-first} system.
+|Maximum size of the underlying {op-system} system.
+
+|====
+
+.Theoretical size limits for a host configuration
+[cols="1,1", width="100%", options="header"]
+|====
+
+|Parameter
+|Value
+
+|Chunk size
+|This value is based on the configuration in the `lvm.conf` file. By default, this value is set to 128 KiB.
+
+|Maximum volume size
+|Equal to the maximum volume size of the underlying {op-system} system.
+
+|Minimum volume size
+|Equal to the minimum volume size of the underlying {op-system} system.
+
+|====
+endif::microshift[]

--- a/snippets/lvms-creating-lvmcluster.adoc
+++ b/snippets/lvms-creating-lvmcluster.adoc
@@ -1,0 +1,43 @@
+:_mod-docs-content-type: SNIPPET
+.Example `LVMCluster` CR YAML file
+[source,yaml]
+----
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: my-lvmcluster
+  namespace: openshift-storage
+spec:
+  tolerations:
+  - effect: NoSchedule
+    key: xyz
+    operator: Equal
+    value: "true"
+  storage:
+    deviceClasses: 
+    - name: vg1  
+      fstype: ext4 <1>
+      default: true 
+      nodeSelector: <1>
+        nodeSelectorTerms: 
+        - matchExpressions:
+          - key: mykey
+            operator: In
+            values:
+            - ssd
+      deviceSelector: <1>
+        paths: 
+        - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
+        - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
+        optionalPaths:
+        - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
+        - /dev/disk/by-path/pci-0000:90:00.0-nvme-1
+        forceWipeDevicesAndDestroyAllData: true
+      thinPoolConfig: 
+        name: thin-pool-1
+        sizePercent: 90 <1>
+        overprovisionRatio: 10 
+        chunkSize: 128Ki <1>
+        chunkSizeCalculationPolicy: Static <1>
+----
+<1> Optional field

--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -54,9 +54,6 @@ include::modules/lvms-installing-logical-volume-manager-operator-using-rhacm.ado
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/install/installing#installing-while-connected-online[Red Hat Advanced Cluster Management for Kubernetes: Installing while connected online]
 
-// Limitations to configure the size of the devices to be used in LVM Storage
-include::modules/lvms-limitations-to-configure-size-of-devices.adoc[leveloffset=+1]
-
 // About the LVMCluster custom resource
 
 include::modules/lvms-about-lvmcluster-cr.adoc[leveloffset=+1]
@@ -64,9 +61,16 @@ include::modules/lvms-about-lvmcluster-cr.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/configuring_and_managing_logical_volumes/index#overview-of-chunk-size_creating-and-managing-thin-provisioned-volumes[Overview of chunk size]
+
+* xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#limitations-to-configure-size-of-devices_logical-volume-manager-storage[Limitations to configure the size of the devices used in {lvms}]
+
 * xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-adding-devices-to-a-vg_logical-volume-manager-storage[About adding devices to a volume group]
 
 * xref:../../../nodes/nodes/nodes-sno-worker-nodes.adoc[Adding worker nodes to {sno} clusters]
+
+// Limitations to configure the size of the devices to be used in LVM Storage
+include::modules/lvms-limitations-to-configure-size-of-devices.adoc[leveloffset=+2]
 
 // About adding devices to a volume group
 include::modules/lvms-about-adding-devices-to-a-vg.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Cherry-picked from: 458e51300c5ba9df23864620e4e882e8c483d083

xref: https://github.com/openshift/openshift-docs/pull/78981

