### PR TITLE
[enterprise-4.13] TELCODOCS#1889: Size info for LVMS

### DIFF
--- a/modules/lvms-limitations-to-configure-size-of-devices.adoc
+++ b/modules/lvms-limitations-to-configure-size-of-devices.adoc
@@ -14,35 +14,52 @@ The limitations to configure the size of the devices that you can use to provisi
 ** The default PE and LE size is 4 MB.
 ** If the size of the PE is increased, the maximum size of the LVM is determined by the kernel limits and your disk space.
 
-.Size limits for different architectures using the default PE and LE size
-[cols="1,1,1,1,1", width="100%", options="header"]
+The following tables describe the chunk size and volume size limits for static and host configurations:
+
+.Tested configuration
+[cols="1,1", width="100%", options="header"]
 |====
-|Architecture
-|RHEL 6
-|RHEL 7
-|RHEL 8
-|RHEL 9
+|Parameter
+|Value
+|Chunk size
 
-|32-bit
-|16 TB
-|-
-|-
-|-
-
-|64-bit
-
-|8 EB ^[1]^
-
-100 TB ^[2]^
-|8 EB ^[1]^
-
-500 TB ^[2]^
-|8 EB
-|8 EB
+|128 KiB
+|Maximum volume size
+|32 TiB
 
 |====
-[.small]
---
-1. Theoretical size.
-2. Tested size.
---
+
+.Theoretical size limits for static configuration
+[cols="1,1,1", width="100%", options="header"]
+|====
+
+|Parameter
+|Minimum value
+|Maximum value
+
+|Chunk size
+|64 KiB
+|1 GiB
+
+|Volume size
+|Minimum size of the underlying {op-system-first} system.
+|Maximum size of the underlying {op-system} system.
+|====
+
+.Theoretical size limits for a host configuration
+[cols="1,1", width="100%", options="header"]
+|====
+
+|Parameter
+|Value
+
+|Chunk size
+|This value is based on the configuration in the `lvm.conf` file. By default, this value is set to 128 KiB.
+
+|Maximum volume size
+|Equal to the maximum volume size of the underlying {op-system} system.
+
+|Minimum volume size
+|Equal to the minimum volume size of the underlying {op-system} system.
+
+|====

--- a/modules/lvms-reference-file.adoc
+++ b/modules/lvms-reference-file.adoc
@@ -41,18 +41,20 @@ spec:
         name: thin-pool-1 <7>
         sizePercent: 90 <8>
         overprovisionRatio: 10 <9>
+        chunkSize: 128Ki <10>
+        chunkSizeCalculationPolicy: Static <11>
 status:
-    deviceClassStatuses: <10>
+    deviceClassStatuses: <12>
     - name: vg1
-      nodeStatus: <11>
-      - devices: <12>
+      nodeStatus: <13>
+      - devices: <14>
         - /dev/nvme0n1
         - /dev/nvme1n1
         - /dev/nvme2n1
-        node: my-node.example.com <13>
-        status: Ready <14>
-    ready: true <15>
-    state: Ready <16>
+        node: my-node.example.com <15>
+        status: Ready <16>
+    ready: true <17>
+    state: Ready <18>
 ----
 <1> The LVM volume groups to be created on the cluster. Currently, only a single `deviceClass` is supported.
 <2> The name of the LVM volume group to be created on the nodes.
@@ -63,10 +65,12 @@ status:
 <7> The name of the thin pool to be created in the LVM volume group.
 <8> The percentage of remaining space in the LVM volume group that should be used for creating the thin pool.
 <9> The factor by which additional storage can be provisioned compared to the available storage in the thin pool.
-<10> The status of the `deviceClass`.
-<11> The status of the LVM volume group on each node.
-<12> The list of devices used to create the LVM volume group.
-<13> The node on which the `deviceClass` was created.
-<14> The status of the LVM volume group on the node.
-<15> This field is deprecated.
-<16> The status of the `LVMCluster`.
+<10> Specifies the statically calculated chunk size for the thin pool. This field is only used when the `ChunkSizeCalculationPolicy` field is set to `Static`. The value for this field must be configured in the range of 64 KiB to 1 GiB because of the underlying limitations of `lvm2`. If you do not configure this field and the `ChunkSizeCalculationPolicy` field is set to `Static`, the default chunk size is set to 128 KiB. For more information, see "Overview of chunk size".
+<11> Specifies the policy to calculate the chunk size for the underlying volume group. You can set this field to either `Static` or `Host`. By default, this field is set to `Static`. If this field is set to `Static`, the chunk size is set to the value of the `chunkSize` field. If the `chunkSize` field is not configured, chunk size is set to 128 KiB.
+<12> The status of the `deviceClass`.
+<13> The status of the LVM volume group on each node.
+<14> The list of devices used to create the LVM volume group.
+<15> The node on which the `deviceClass` was created.
+<16> The status of the LVM volume group on the node.
+<17> This field is deprecated.
+<18> The status of the `LVMCluster`.


### PR DESCRIPTION
Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-1889](https://issues.redhat.com/browse/TELCODOCS-1889)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Limitations to configure the size of the devices used in LVM Storage](https://84715--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#limitations-to-configure-size-of-devices_logical-volume-manager-storage)
- [LVM Storage reference YAML file](https://84715--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-reference-file_logical-volume-manager-storage)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

