### PR TITLE
OSSM-7828 OSSM 2.6.3 (At Stage): [DOC] Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -173,7 +173,7 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.2
+:SMProductVersion: 2.6.3
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-4-12.adoc
+++ b/modules/ossm-release-2-4-12.adoc
@@ -1,0 +1,26 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-4-12_{context}"]
+= {SMProductName} version 2.4.12
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.3, addresses Common Vulnerabilities and Exposures (CVEs), and is supported on {product-title} 4.14 and later.
+
+[id=ossm-release-2-4-12-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Kiali Server
+|1.65.17
+|===

--- a/modules/ossm-release-2-5-2.adoc
+++ b/modules/ossm-release-2-5-2.adoc
@@ -46,6 +46,8 @@ This release addresses Common Vulnerabilities and Exposures (CVEs), contains bug
 
 * https://issues.redhat.com/browse/OSSM-6299[OSSM-6299] Previously, in {product-title} 4.15, when you clicked the **Node graph** menu option of any node menu within the traffic graph, the node graph was not displayed. Instead, the page refreshed with the same traffic graph. Now, clicking the **Node graph** menu option correctly displays the node graph.
 
+* https://issues.redhat.com/browse/OSSM-6267[OSSM-6267] Previously, configuring a data source in {SMProductName} 2.5 Grafana caused a data query authentication error, and users could not view data in the Istio service and workload dashboards. Now, upgrading an existing 2.5 SMCP to version 2.5.2 or later resolves the Grafana error.
+//OSSM-6267 moved from known issues to fixed issues.
 //Keeping to make next release easier in case there are Known issues.
 // [id="ossm-known-issues-RELEASE_{context}"]
 // == Service Mesh known issues

--- a/modules/ossm-release-2-5-6.adoc
+++ b/modules/ossm-release-2-5-6.adoc
@@ -1,0 +1,27 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-5-6_{context}"]
+= {SMProductName} version 2.5.6
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.3, addresses Common Vulnerabilities and Exposures (CVEs), and is supported on {product-title} 4.14 and later.
+
+
+[id=ossm-release-2-5-6-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.18.7
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali Server
+|1.73.16
+|===

--- a/modules/ossm-release-2-6-2.adoc
+++ b/modules/ossm-release-2-6-2.adoc
@@ -11,8 +11,6 @@ This release of {SMProductName} updates the {SMProductName} Operator version to 
 
 This release addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.14 and later.
 
-include::snippets/ossm-current-version-support-snippet.adoc[]
-
 The most current version of the {KialiProduct} can be used with all supported versions of {SMProductName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
 [id=ossm-release-2-6-2-components_{context}]

--- a/modules/ossm-release-2-6-3.adoc
+++ b/modules/ossm-release-2-6-3.adoc
@@ -1,0 +1,32 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-3_{context}"]
+= {SMProductName} version 2.6.3
+
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.3, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.3, 2.5.6, and 2.4.12.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+The most current version of the {KialiProduct} can be used with all supported versions of {SMProductName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id=ossm-release-2-6-3-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.7
+
+|Kiali Server
+|1.73.16
+|===

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -35,9 +35,6 @@ endif::openshift-rosa[]
 == {SMProductShortName} known issues
 
 These are the known issues in {SMProductName}:
-//OSSM-6267 was in 2.5.1, which has not been moved to its own module, so it stays here. Had mistakenly put it in the new 2.5.2 module.
-* https://issues.redhat.com/browse/OSSM-6267[OSSM-6267] After a data source is configured correctly in Grafana, a data query returns authentication error. Users are not able to view data in the **Istio service** and **Istio workload** dashboards. Currently, no workaround exists for this issue.
-
 * https://issues.redhat.com/browse/OSSM-5556[OSSM-5556] Gateways are skipped when istio-system labels do not match discovery selectors.
 +
 Workaround: Label the control plane namespace to match discovery selectors to avoid skipping the Gateway configurations.

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -10,6 +10,12 @@ toc::[]
 
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
+include::modules/ossm-release-2-6-3.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-5-6.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-4-12.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-2.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-5-5.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.3 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-7828

Fix Version: 4.14+

Doc Preview: https://84725--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-3_ossm-release-notes

SME Review: @ctartici 
QE Review: @mkralik3 
Peer Review: @kcarmichael08 