### PR TITLE
[enterprise-4.16] TELCODOCS#1889:Deleting the chunksize related info

### DIFF
--- a/modules/lvms-about-lvmcluster-cr.adoc
+++ b/modules/lvms-about-lvmcluster-cr.adoc
@@ -130,24 +130,6 @@ For example, if this field is set to 10, you can provision up to 10 times the am
 
 To disable over-provisioning, set this field to 1.
 
-|`thinPoolConfig.chunkSize`
-|`integer`
-|Specifies the statically calculated chunk size for the thin pool. This field is only used when the `ChunkSizeCalculationPolicy` field is set to `Static`. The value for this field must be configured in the range of 64 KiB to 1 GiB because of the underlying limitations of `lvm2`. 
-
-If you do not configure this field and the `ChunkSizeCalculationPolicy` field is set to `Static`, the default chunk size is set to 128 KiB.
-
-For more information, see "Overview of chunk size".
-
-|`thinPoolConfig.chunkSizeCalculationPolicy`
-|`string`
-|Specifies the policy to calculate the chunk size for the underlying volume group. You can set this field to either `Static` or `Host`. By default, this field is set to `Static`. 
-
-If this field is set to `Static`, the chunk size is set to the value of the `chunkSize` field. If the `chunkSize` field is not configured, chunk size is set to 128 KiB.
-
-If this field is set to `Host`, the chunk size is calculated based on the configuration in the `lvm.conf` file.
-
-For more information, see "Limitations to configure the size of the devices used in LVM Storage".
-
 |====
 
 

--- a/modules/lvms-limitations-to-configure-size-of-devices.adoc
+++ b/modules/lvms-limitations-to-configure-size-of-devices.adoc
@@ -1,11 +1,10 @@
 // Module included in the following assemblies:
 //
 // * storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
-// * microshift_storage/microshift-storage-plugin-overview.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="limitations-to-configure-size-of-devices_{context}"]
-= Limitations to configure the size of the devices used in {lvms}
+= Limitations to configure the size of the devices used in LVM Storage
 
 The limitations to configure the size of the devices that you can use to provision storage using {lvms} are as follows:
 
@@ -23,57 +22,36 @@ ifdef::microshift[]
 endif::microshift[]
 
 ifndef::microshift[]
-
-The following tables describe the chunk size and volume size limits for static and host configurations:
-
-.Tested configuration
-[cols="1,1", width="100%", options="header"]
+.Size limits for different architectures using the default PE and LE size
+[cols="1,1,1,1,1", width="100%", options="header"]
 |====
+|Architecture
+|RHEL 6
+|RHEL 7
+|RHEL 8
+|RHEL 9
 
-|Parameter
-|Value
+|32-bit
+|16 TB
+|-
+|-
+|-
 
-|Chunk size
-|128 KiB
+|64-bit
 
-|Maximum volume size
-|32 TiB
+|8 EB ^[1]^
 
-|====
+100 TB ^[2]^
+|8 EB ^[1]^
 
-.Theoretical size limits for static configuration
-[cols="1,1,1", width="100%", options="header"]
-|====
-
-|Parameter
-|Minimum value
-|Maximum value
-
-|Chunk size
-|64 KiB
-|1 GiB
-
-|Volume size
-|Minimum size of the underlying {op-system-first} system.
-|Maximum size of the underlying {op-system} system.
+500 TB ^[2]^
+|8 EB
+|8 EB
 
 |====
-
-.Theoretical size limits for a host configuration
-[cols="1,1", width="100%", options="header"]
-|====
-
-|Parameter
-|Value
-
-|Chunk size
-|This value is based on the configuration in the `lvm.conf` file. By default, this value is set to 128 KiB.
-
-|Maximum volume size
-|Equal to the maximum volume size of the underlying {op-system} system.
-
-|Minimum volume size
-|Equal to the minimum volume size of the underlying {op-system} system.
-
-|====
+[.small]
+--
+1. Theoretical size.
+2. Tested size.
+--
 endif::microshift[]

--- a/snippets/lvms-creating-lvmcluster.adoc
+++ b/snippets/lvms-creating-lvmcluster.adoc
@@ -37,7 +37,5 @@ spec:
         name: thin-pool-1
         sizePercent: 90 <1>
         overprovisionRatio: 10 
-        chunkSize: 128Ki <1>
-        chunkSizeCalculationPolicy: Static <1>
 ----
 <1> Optional field


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Note: The doc updates that are deleted in this PR are applicable only to 4.17. Hence, deleting them. These were added for [TELCODOCS-1889](https://issues.redhat.com/browse/TELCODOCS-1889).
