### PR TITLE
[SRVKS-1061] Update readiness/liveness default availability

### DIFF
--- a/eventing/tuning/overriding-config-eventing.adoc
+++ b/eventing/tuning/overriding-config-eventing.adoc
@@ -16,11 +16,6 @@ The `replicas` spec cannot override the number of replicas for deployments that 
 [NOTE]
 ====
 You can only override probes that are defined in the deployment by default.
-
-All Knative Serving deployments define a readiness and a liveness probe by default, with these exceptions:
-
-* `net-kourier-controller` and `3scale-kourier-gateway` only define a readiness probe.
-* `net-istio-controller` and `net-istio-webhook` define no probes.
 ====
 
 include::modules/knative-eventing-CR-system-deployments.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
serverless-docs-1.32+

Issue:
https://issues.redhat.com/browse/SRVKS-1061

Link to docs preview:
https://84727--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/tuning/overriding-config-eventing.html 
(first NOTE)

QE review:
- [x] QE has approved this change.
