### PR TITLE
OSDOCS-12624: Removed labels and annotations from the K8S NMState Ope…

### DIFF
--- a/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
+++ b/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
@@ -24,9 +24,6 @@ $ cat << EOF | oc apply -f -
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    kubernetes.io/metadata.name: openshift-nmstate
-    name: openshift-nmstate
   name: openshift-nmstate
 spec:
   finalizers:
@@ -42,8 +39,6 @@ $ cat << EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  annotations:
-    olm.providedAPIs: NMState.v1.nmstate.io
   name: openshift-nmstate
   namespace: openshift-nmstate
 spec:
@@ -59,8 +54,6 @@ $ cat << EOF| oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  labels:
-    operators.coreos.com/kubernetes-nmstate-operator.openshift-nmstate: ""
   name: kubernetes-nmstate-operator
   namespace: openshift-nmstate
 spec:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-12624](https://issues.redhat.com/browse/OSDOCS-12624)

Link to docs preview:
[Installing the Kubernetes NMState Operator using the CLI](https://84728--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html#installing-the-kubernetes-nmstate-operator-CLI_k8s-nmstate-operator)


- [x] SME has approved this change.
- [ ] QE has approved this change.


