### PR TITLE
TELCODOCS-1960-RE: Expanded a sentence for offline migration to the O…

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -80,7 +80,7 @@ The following sections highlight the differences in configuration between the af
 
 The OpenShift SDN plugin allows application of the `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) to the primary interface on a node. The OVN-Kubernetes network plugin does not have this capability.
 
-If you have an NNCP applied to the primary interface, you must delete the NNCP before migrating to the OVN-Kubernetes network plugin. Deleting the NNCP does not remove the configuration from the primary interface, but the Kubernetes-NMState cannot manage this configuration. Instead, the `configure-ovs.sh` shell script manages the primary interface and the configuration attached to this interface.
+If you have an NNCP applied to the primary interface, you must delete the NNCP before migrating to the OVN-Kubernetes network plugin. Deleting the NNCP does not remove the configuration from the primary interface, but with OVN-Kubernetes, the Kubernetes NMState cannot manage this configuration. Instead, the `configure-ovs.sh` shell script manages the primary interface and the configuration attached to this interface.
 
 [discrete]
 [id="namespace-isolation_{context}"]


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[TELCODOC-1960](https://issues.redhat.com/browse/TELCODOCS-1960)

Link to docs preview:

[Considerations for offline migration to the OVN-Kubernetes network plugin](https://84737--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)

