### PR TITLE
Draft for OADP 1.3.4 release notes

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -9,6 +9,7 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-3-4.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-3.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-2.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-1.adoc[leveloffset=+1]

--- a/modules/oadp-release-notes-1-3-4.adoc
+++ b/modules/oadp-release-notes-1-3-4.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="oadp-release-notes-1-3-4_{context}"]
+= {oadp-short} 1.3.4 release notes
+
+The {oadp-first} 1.3.4 release notes list resolved issues and known issues.
+
+[id="resolved-issues-1-3-4_{context}"]
+== Resolved issues
+
+.The backup spec.resourcepolicy.kind parameter is now case-insensitive
+
+Previously, the `backup spec.resourcepolicy.kind` parameter was only supported with a lower-level string. With this fix, it is now case-insensitive. link:https://issues.redhat.com/browse/OADP-2944[{oadp-short}-2944]
+
+.Use olm.maxOpenShiftVersion to prevent cluster upgrade to OCP 4.16 version
+
+The cluster `operator-lifecycle-manager` operator must not be upgraded between minor {OCP} versions. Using the `olm.maxOpenShiftVersion` parameter prevents upgrading to {OCP} 4.16 version when {oadp-short} 1.3 is installed. 
+To upgrade to {OCP} 4.16 version, upgrade {oadp-short} 1.3 on OCP 4.15 version to {oadp-short} 1.4. link:https://issues.redhat.com/browse/OADP-4803[{oadp-short}-4803]
+
+.BSL and VSL are removed from the cluster
+
+Previously, when any Data Protection Application (DPA) was modified to remove the Backup Storage Locations (BSL) or Volume Snapshot Locations (VSL) from the `backupLocations` or `snapshotLocations` section, BSL or VSL were not removed from the cluster until the DPA was deleted.
+With this update, BSL/VSL are removed from the cluster. link:https://issues.redhat.com/browse/OADP-3050[{oadp-short}-3050]
+
+.DPA reconciles and validates the secret key
+
+Previously, the Data Protection Application (DPA) reconciled successfully on the wrong Volume Snapshot Locations (VSL) secret key name.
+With this update, DPA validates the secret key name before reconciling on any VSL. link:https://issues.redhat.com/browse/OADP-3052[{oadp-short}-3052]
+
+
+.Velero's cloud credential permissions are now restrictive
+
+Previously, Velero's cloud credential permissions were mounted with the 0644 permissions. As a consequence, any one could read the `/credentials/cloud` file apart from the owner and group making it easier to access sensitive information such as storage access keys.
+With this update, the permissions of this file are updated to 0640, and this file cannot be accessed by other users except the owner and group.
+
+
+.Warning is displayed when ArgoCD managed namespace is included in the backup
+
+A warning is displayed during the backup operation when ArgoCD and Velero manage the same namespace. link:https://issues.redhat.com/browse/OADP-4736[{oadp-short}-4736]
+
+
+//The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2024:137004[RHSA-2024:137004] advisory.
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12443310[{oadp-short} 1.3.4 resolved issues] in Jira.
+
+[id="known-issues-1-3-4_{context}"]
+== Known issues
+
+.Cassandra application pods enter into the `CrashLoopBackoff` status after restore
+
+After {oadp-short} restores, the Cassandra application pods might enter the `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods that are returning an error or the `CrashLoopBackoff` state after restoring {oadp-short}. The `StatefulSet` controller recreates these pods and it runs normally. 
+link:https://issues.redhat.com/browse/OADP-3767[OADP-3767]
+
+.defaultVolumesToFSBackup and defaultVolumesToFsBackup flags are not identical 
+
+The `dpa.spec.configuration.velero.defaultVolumesToFSBackup` flag is not identical to the `backup.spec.defaultVolumesToFsBackup` flag, which can lead to confusion. link:https://issues.redhat.com/browse/OADP-3692[OADP-3692]
+
+.PodVolumeRestore works even though the restore is marked as failed
+
+The `podvolumerestore` continues the data transfer even though the restore is marked as failed. link:https://issues.redhat.com/browse/OADP-3039[OADP-3039]
+
+.Velero is unable to skip restoring of initContainer spec
+
+Velero might restore the `restore-wait init` container even though it is not required. link:https://issues.redhat.com/browse/OADP-3759[OADP-3759]
+


### PR DESCRIPTION
Version(s):
OCP 4.12 → OCP 4.15

Issue:
[OADP-4831](https://issues.redhat.com/browse/OADP-4831)

Link to docs preview: https://84744--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html#oadp-release-notes-1-3-4_oadp-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Initial QE review is completed in this [release note document](https://docs.google.com/document/d/1Hu5aywmY0Zc_E1VagOoD5vPWAPD3lZZx7c7LmV4AWWo/edit?pli=1&tab=t.0#heading=h.vxpl2ort0bu).


