### PR TITLE
TRACING-4935: Add missing documentation healthcheck extension

### DIFF
--- a/observability/otel/otel-collector/otel-collector-extensions.adoc
+++ b/observability/otel/otel-collector/otel-collector-extensions.adoc
@@ -355,10 +355,6 @@ include::snippets/technology-preview.adoc[]
           cert_file: "/path/to/cert.crt"
           key_file: "/path/to/key.key"
         path: "/health/status" # <3>
-        check_collector_pipeline: # <4>
-          enabled: true # <5>
-          interval: "5m" # <6>
-          exporter_failure_threshold: 5 # <7>
 
     receivers:
       otlp:
@@ -376,13 +372,74 @@ include::snippets/technology-preview.adoc[]
           exporters: [otlp]
 # ...
 ----
-<1> The target IP address for publishing the health check status. The default is `0.0.0.0:13133`.
+<1> The target IP address for publishing the health check status..
 <2> The TLS server-side configuration. Defines paths to TLS certificates. If omitted, the TLS is disabled.
-<3> The path for the health check server. The default is `/`.
+<3> The path for the health check server.
 <4> Settings for the Collector pipeline health check.
-<5> Enables the Collector pipeline health check. The default is `false`.
-<6> The time interval for checking the number of failures. The default is `5m`.
-<7> The threshold of multiple failures until which a container is still marked as healthy. The default is `5`.
+<5> Enables the Collector pipeline health check.
+<6> The time interval for checking the number of failures.
+<7> The threshold of multiple failures until which a container is still marked as healthy.
+
+.Parameters used by the Health Check Extension
+[options="header"]
+[cols="a,a,a"]
+|===
+|Parameter |Description |Default
+
+|`endpoint`
+|The target IP address for publishing the health check status. This can be used as a liveness or readiness probe.
+|`localhost:13133`
+
+|`path`
+|Specifies the path to be configured for the health check server.
+|`/`
+
+|`response_body`
+|Specifies a static body that overrides the default response returned by the health check service.
+|`""`
+
+|`tls`
+|The TLS server-side configuration, defining paths to TLS certificates. If omitted, TLS is disabled.
+|N/A
+
+|===
+
+=== Troubleshooting
+
+The Health Check Extension provides an HTTP endpoint to check the status of the OpenTelemetry Collector. It can be used as a liveness and readiness probe in environments such as OpenShift.
+
+==== Health check URL not reachable
+
+If the health check URL is not reachable, consider the following:
+
+.Procedure
+
+- Verify the `endpoint`: ensure the `endpoint` is correctly configured and that the port is open and accessible from the network where the health check is being performed.
++
+- Confirm the service and port address: the service is `<OpenTelemetry Collector instance name>-collector` and the port is `13133`.
+
+==== TLS-related issues
+
+If the health check endpoint using TLS is not working as expected, consider the following:
+
+.Procedure
+
+- Verify the TLS certificate paths: ensure the `ca_file`, `cert_file`, and `key_file` paths are correct and accessible by the OpenTelemetry Collector.
++
+- Check file permissions: confirm that the OpenTelemetry Collector has the necessary read permissions for the TLS certificate and key files.
++
+- Ensure TLS is enabled: if using TLS, ensure the TLS configuration is correctly set and not omitted.
+
+==== Incorrect health check path
+
+If the health check URL is returning 404 or an incorrect path is being used, consider the following:
+
+.Procedure
+
+- Verify the `path`: ensure the health check `path` is correctly configured and matches the one being accessed. The default path is `/`, but it can be customized as needed (e.g., `/health/status`).
++
+- Check the HTTP request: confirm that the correct HTTP request is being made to the right URL, including the correct port and path.
+
 
 [id="memory-ballast-extension_{context}"]
 == Memory Ballast Extension


### PR DESCRIPTION
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [TRACING-4935](https://issues.redhat.com//browse/TRACING-4935)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
