### PR TITLE
TELCODOCS-2064: Docs and RN: CNF-14082 SR-IOV Operator support for Intel C741 Emmitsburg Chipset

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -96,6 +96,13 @@ By default, this field is set to `2`.
 |`boolean`
 |Specifies whether to enable or disable the SR-IOV Network Operator metrics. By default, this field is set to `false`.
 
+|`spec.featureGates.mellanoxFirmwareReset`
+|`boolean`
+|Specifies whether to reset the firmware on virtual function (VF) changes in the SR-IOV Network Operator. Some chipsets, such as the Intel C740 Series, do not completely power off the PCI-E devices, which is required to configure VFs on NVIDIA/Mellanox NICs. By default, this field is set to `false`.
+
+:FeatureName: The `spec.featureGates.mellanoxFirmwareReset` parameter
+include::snippets/technology-preview.adoc[]
+
 |====
 
 [id="about-network-resource-injector_{context}"]


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-2064: Docs and RN: [CNF-14082](https://issues.redhat.com//browse/CNF-14082) SR-IOV Operator support for Intel C741 Emmitsburg Chipset

Applies to OCP version : 4.18+

Preview: [SR-IOV Network Operator config custom resource](https://84760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html#nw-sriov-operator-cr_configuring-sriov-operator)

Dev review completed by @cgoncalves 
Dev review completed by @SchSeba
Peer review completed by @cbippley 

Thank you.