### PR TITLE
Updates IR docs to include Podman references

### DIFF
--- a/modules/images-allow-pods-to-reference-images-from-secure-registries.adoc
+++ b/modules/images-allow-pods-to-reference-images-from-secure-registries.adoc
@@ -6,11 +6,19 @@
 [id="images-allow-pods-to-reference-images-from-secure-registries_{context}"]
 = Allowing pods to reference images from other secured registries
 
-The `.dockercfg` `$HOME/.docker/config.json` file for Docker clients is a Docker credentials file that stores your authentication information if you have previously logged into a secured or insecure registry.
+To pull a secured container from other private or secured registries, you must create a pull secret from your container client credentials, such as Docker or Podman, and add it to your service account. 
 
-To pull a secured container image that is not from {product-registry}, you must create a pull secret from your Docker credentials and add it to your service account.
+Both Docker and Podman use a configuration file to store authentication details to log in to secured or insecure registry:
 
-The Docker credentials file and the associated pull secret can contain multiple references to the same registry, each with its own set of credentials.
+* *Docker*: By default, Docker uses `$HOME/.docker/config.json`.
+* *Podman*: By default, Podman uses `$HOME/.config/containers/auth.json`.
+
+These files store your authentication information if you have previously logged in to a secured or insecure registry. 
+
+[NOTE]
+====
+Both Docker and Podman credential files and the associated pull secret can contain multiple references to the same registry if they have unique paths, for example, `quay.io` and `quay.io/<example_repository>`. However, neither Docker nor Podman support multiple entries for the exact same registry path. 
+====
 
 .Example `config.json` file
 [source,json]
@@ -51,22 +59,24 @@ type: Opaque
 
 .Procedure
 
-* If you already have a `.dockercfg` file for the secured registry, you can create a secret from that file by running:
-+
-[source,terminal]
-----
-$ oc create secret generic <pull_secret_name> \
-    --from-file=.dockercfg=<path/to/.dockercfg> \
-    --type=kubernetes.io/dockercfg
-----
+* Create a secret from an existing authentication file:
 
-* Or if you have a `$HOME/.docker/config.json` file:
+** For Docker clients using `.docker/config.json`, enter the following command:
 +
 [source,terminal]
 ----
 $ oc create secret generic <pull_secret_name> \
     --from-file=.dockerconfigjson=<path/to/.docker/config.json> \
     --type=kubernetes.io/dockerconfigjson
+----
+
+** For Podman clients using `.config/containers/auth.json`, enter the following command:
++
+[source,terminal]
+----
+$ oc create secret generic <pull_secret_name> \
+     --from-file=<path/to/.config/containers/auth.json> \
+     --type=kubernetes.io/podmanconfigjson
 ----
 
 * If you do not already have a Docker credentials file for the secured registry, you can create a secret by running:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-29359

Link to docs preview:
https://84761--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/managing_images/using-image-pull-secrets#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
