### PR TITLE
OSDOCS#12596: Document the 4.15.38 z-stream release note

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2773,6 +2773,36 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.15.38
+[id="ocp-4-15-38_{context}"]
+=== RHSA-2024:8991 - {product-title} 4.15.38 bug fix and security update
+
+Issued: 13 November 2024
+
+{product-title} release 4.15.38, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:8991[RHSA-2024:8991] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8994[RHSA-2024:8994] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.38 --pullspecs
+----
+
+[id="ocp-4-15-38-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, an invalid or unreachable identity provider (IDP) blocked updates to {hcp}. With this release, the `ValidIDPConfiguration` condition in the `HostedCluster` object now reports any IDP errors and these errors do not block updates of {hcp}. (link:https://issues.redhat.com/browse/OCPBUGS-44201[*OCPBUGS-44201*])
+
+* Previously, the Machine Config Operator (MCO) vSphere `resolv-prepender` script used systemd directives that were not compatible with old boot image versions of {product-title} 4. With this release, these {product-title} nodes are compatible with old boot images with one of the following solutions: scaling with a boot image 4.13 or later, by using manual intervention, or upgrading to a release with this fix. (link:https://issues.redhat.com/browse/OCPBUGS-42110[*OCPBUGS-42110*])
+
+* Previously, when the Image Registry Operator was configured in {azure-short} with `networkAccess:Internal`, you could not successfully set `managementState` to `Removed` in the Operator configuration. This issue was caused by an authorization error that occurred when the Operator started to delete the storage. With this release, the Operator successfully deletes the storage account, which automatically deletes the storage container. The `managementState` status in the Operator configuration is updated to the `Removed` state. (link:https://issues.redhat.com/browse/OCPBUGS-43656[*OCPBUGS-43656*])
+
+[id="ocp-4-15-38-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 //4.15.37
 [id="ocp-4-15-37_{context}"]
 === RHSA-2024:8425 - {product-title} 4.15.37 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Jira:
[OSDOCS-12596](https://issues.redhat.com/browse/OSDOCS-12596)

Link to docs preview:
[4.15.38](https://84781--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-38_release-notes)

QE review:
- [ ] QE has approved this change.
n/a

Additional information:
The errata URLs will return 404 until the go-live date of 11/13.  Reviewers: I will squash commits after the peer review and before the merge request.