### PR TITLE
OSDOCS#12650: adding back docs to BM IPI postinstall config doc

### DIFF
--- a/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
@@ -8,12 +8,20 @@ toc::[]
 
 After successfully deploying an installer-provisioned cluster, consider the following postinstallation procedures.
 
+// Configuring NTP for disconnected clusters
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+1]
 
+// Enabling a provisioning network after installation
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
 
 // Creating a manifest object that includes a customized `br-ex` bridge
 include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+
+// Services for a user-managed load balancer
+include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
+
+// Configuring a user-managed load balancer
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
 
 // Using the Bare Metal Operator
 include::modules/bmo-config-using-bare-metal-operator.adoc[leveloffset=+1]

--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -2,6 +2,7 @@
 
 // Bare metal
 // * installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+// * installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
 // OpenStack
 // * networking/load-balancing-openstack.adoc
 // Nutanix

--- a/modules/nw-osp-services-external-load-balancer.adoc
+++ b/modules/nw-osp-services-external-load-balancer.adoc
@@ -2,6 +2,7 @@
 
 // Bare metal
 // * installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+// * installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
 // OpenStack
 // * networking/load-balancing-openstack.adoc
 // Nutanix


### PR DESCRIPTION
[OSDOCS-12650](https://issues.redhat.com/browse/OSDOCS-12650)

Version(s): 4.16+

This PR adds a few sections for user-managed load balancers that were deleted from bare metal IPI postinstall docs in [this PR](https://github.com/openshift/openshift-docs/pull/76524/files#diff-22f6e1dc5f61bb3bfaef5633ac8a882d54b382346a23f46bf2b2f163b082a688).

QE review:
- [x] QE has approved this change.

Preview: [Services for a user-managed load balancer](https://84830--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.html#nw-osp-services-external-load-balancer_ipi-install-post-installation-configuration)