### PR TITLE
OSDOCS-12654:Replace Accessing service logs link with Rosa cluster notifications link

### DIFF
--- a/support/approved-access.adoc
+++ b/support/approved-access.adoc
@@ -15,7 +15,7 @@ Elevated access requests to clusters on {product-rosa} clusters and the correspo
 
 When _Approved Access_ is enabled and an SRE creates an access request, _cluster owners_ receive an email notification informing them of a new access request. The email notification contains a link allowing the cluster owner to quickly approve or deny the access request. You must respond in a timely manner otherwise there is a risk to your SLA for {product-rosa}.
 
-* If customers require additional users that are not the cluster owner to receive the email, they can link:https://docs.openshift.com/rosa/observability/logging/sd-accessing-the-service-logs.html#adding-cluster-notification-contacts_sd-accessing-the-service-logs[add additional cluster contacts].
+* If customers require additional users that are not the cluster owner to receive the email, they can link:https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cluster-notifications.html#add-notification-contact_rosa-cluster-notifications[add notification cluster contacts].
 * Pending access requests are available in the {hybrid-console-second} on the clusters list or *Access Requests* tab on the cluster overview for the specific cluster.
 
 [NOTE]


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-12654

Link to docs preview:
https://84835--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/approved-access.html


