### PR TITLE
CNV-45771: Added instructions to remove custom machine config pool

### DIFF
--- a/modules/virt-configuring-cluster-dpdk.adoc
+++ b/modules/virt-configuring-cluster-dpdk.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/vm_networking/virt-connecting-vm-to-sriov.adoc
+// * virt/vm_networking/virt-using-dpdk-with-sriov.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-configuring-cluster-dpdk_{context}"]
@@ -17,7 +17,9 @@ You can configure an {product-title} cluster to run Data Plane Development Kit (
 .Procedure
 // Cannot label nodes in ROSA/OSD, but can edit machine pools
 . Map your compute nodes topology to determine which Non-Uniform Memory Access (NUMA) CPUs are isolated for DPDK applications and which ones are reserved for the operating system (OS).
-. Label a subset of the compute nodes with a custom role; for example, `worker-dpdk`:
+. If your {product-title} cluster uses separate control plane and compute nodes for high-availability:
+
+.. Label a subset of the compute nodes with a custom role; for example, `worker-dpdk`:
 +
 ifndef::openshift-rosa[]
 [source,terminal]
@@ -33,7 +35,7 @@ $ rosa edit machinepool --cluster=<cluster_name> <machinepool_ID> node-role.kube
 ----
 endif::openshift-rosa[]
 
-. Create a new `MachineConfigPool` manifest that contains the `worker-dpdk` label in the `spec.machineConfigSelector` object:
+.. Create a new `MachineConfigPool` manifest that contains the `worker-dpdk` label in the `spec.machineConfigSelector` object:
 +
 .Example `MachineConfigPool` manifest
 [source,yaml]

--- a/modules/virt-removing-custom-mcp.adoc
+++ b/modules/virt-removing-custom-mcp.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-using-dpdk-with-sriov.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-removing-custom-mcp_{context}"]
+= Removing a custom machine config pool for high-availability clusters
+
+You can delete a custom machine config pool that you previously created for your high-availability cluster.
+
+.Prerequisites
+* You have access to the cluster as a user with `cluster-admin` permissions.
+* You have installed the OpenShift CLI (`oc`).
+* You have created a custom machine config pool by labeling a subset of the compute nodes with a custom role and creating a `MachineConfigPool` manifest with that label.
+
+.Procedure
+
+. Remove the `worker-dpdk` label from the compute nodes by running the following command:
++
+[source,terminal]
+----
+$ oc label node <node_name> node-role.kubernetes.io/worker-dpdk-
+----
+
+. Delete the `MachineConfigPool` manifest that contains the `worker-dpdk` label by entering the following command:
++
+[source,terminal]
+----
+$ oc delete mcp worker-dpdk
+----

--- a/virt/vm_networking/virt-using-dpdk-with-sriov.adoc
+++ b/virt/vm_networking/virt-using-dpdk-with-sriov.adoc
@@ -24,6 +24,8 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * link:https://access.redhat.com/solutions/5688941[Creating a custom machine config pool]
 endif::openshift-rosa,openshift-dedicated[]
 
+include::modules/virt-removing-custom-mcp.adoc[leveloffset=+2]
+
 include::modules/virt-configuring-vm-project-dpdk.adoc[leveloffset=+1]
 
 [role="_additional-resources_configuring-project-dpdk"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-45771](https://issues.redhat.com//browse/CNV-45771)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://84850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-using-dpdk-with-sriov.html#virt-configuring-cluster-dpdk_virt-using-dpdk-with-sriov
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
