### PR TITLE
OCPBUGS-31933: Updating note to clarifying postinstallation CPU config options

### DIFF
--- a/modules/enabling-workload-partitioning.adoc
+++ b/modules/enabling-workload-partitioning.adoc
@@ -12,7 +12,7 @@ Workload partitioning isolates user workloads from platform workloads using stan
 
 [NOTE]
 ====
-Workload partitioning can only be enabled during cluster installation. You cannot disable workload partitioning postinstallation.
+You can enable workload partitioning during cluster installation only. You cannot disable workload partitioning postinstallation. However, you can change the CPU configuration for `reserved` and `isolated` CPUs postinstallation.
 ====
 
 Use this procedure to enable workload partitioning cluster wide:  


### PR DESCRIPTION
OCPBUGS-31933: Updating note to clarifying postinstallation CPU config options

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-31933

Link to docs preview:
https://84862--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/enabling-workload-partitioning.html#enabling-workload-partitioning_enabling-workload-partitioning

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
