### PR TITLE
Update log6x-upgrading-to-6.adoc

### DIFF
--- a/observability/logging/logging-6.0/log6x-upgrading-to-6.adoc
+++ b/observability/logging/logging-6.0/log6x-upgrading-to-6.adoc
@@ -358,8 +358,8 @@ spec:
   - name: parse-json
     type: parse
   - name: labels
-    type: openShiftLabels
-    openShiftLabels:
+    type: openshiftLabels
+    openshiftLabels:
       foo: bar
   pipelines:
   - name: application-logs


### PR DESCRIPTION
openShiftLabels is wrongly mentioned here.
It should be openshiftLabels, not openShiftLabels.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> Incorrect code block mentioned for RHOL 6.0 Filters and Pipeline Configuration

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> RHCOP 4.17, RHCOP 4.16, RHOCP  4.15, RHOCP 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/OBSDOCS-1487

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. ---> https://84864--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-upgrading-to-6.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
