### PR TITLE
OCPBUGS-41971-ent18: Added note to the Ingress capability docs

### DIFF
--- a/modules/ingress-operator.adoc
+++ b/modules/ingress-operator.adoc
@@ -20,9 +20,12 @@ ifdef::cluster-caps[= Ingress Capability]
 == Purpose
 
 ifdef::cluster-caps[]
+The Ingress Operator provides the features for the Ingress Capability. The Ingress Capability is enabled by default.
 
-The Ingress Operator provides the features for the `Ingress` capability.
-
+[IMPORTANT]
+====
+If you set the `baselineCapabilitySet` field to `None`, you must explicitly enable the Ingress Capability, because the installation of a cluster fails if the Ingress Capability is disabled.
+====
 endif::cluster-caps[]
 
 The Ingress Operator configures and manages the {product-title} router.


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OCPBUGS-41971](https://issues.redhat.com/browse/OCPBUGS-41971)

Link to docs preview:
* [Ingress Capability](https://84867--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities.html#ingress-operator_cluster-capabilities)
* [Cluster Operators reference](https://84867--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#ingress-operator_cluster-operators-ref)

- [x] SME has approved this change (Trevor King/Seth Jennings/Cesar Wong).
- [x] QE has approved this change (QE on [84252](https://github.com/openshift/openshift-docs/pull/84252)).


Additional information:
* Do not turn off the Ingress Capability feature for 4.16 plus on OCP core and HCPs? 

SETH confirmed that the ingress capability is out of scope for 4.16 and 4.17.
