### PR TITLE
Update common-attributes.adoc to resolve formatting issues

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -73,12 +73,12 @@ ifdef::openshift-origin[]
 :builds-v2shortname: Shipwright
 :builds-v1shortname: Builds v1
 endif::[]
-//gitops
+// gitops
 :gitops-title: Red Hat OpenShift GitOps
 :gitops-shortname: GitOps
 :gitops-ver: 1.1
 :rh-app-icon: image:red-hat-applications-menu-icon.jpg[title="Red Hat applications"]
-//pipelines
+// pipelines
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: OpenShift Pipelines
 :pipelines-ver: pipelines-1.13
@@ -87,13 +87,13 @@ endif::[]
 :tekton-hub: Tekton Hub
 :artifact-hub: Artifact Hub
 :pac: Pipelines as Code
-//odo
+// odo
 :odo-title: odo
-//OpenShift Kubernetes Engine
+// OpenShift Kubernetes Engine
 :oke: OpenShift Kubernetes Engine
-//OpenShift Platform Plus
+// OpenShift Platform Plus
 :opp: OpenShift Platform Plus
-//openshift virtualization (cnv)
+// openshift virtualization (cnv)
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.16
 :HCOVersion: 4.16.3
@@ -109,7 +109,7 @@ ifdef::openshift-origin[]
 :CNVSubscriptionSpecSource: community-operators
 :CNVSubscriptionSpecName: community-kubevirt-hyperconverged
 endif::[]
-//distributed tracing
+// distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing platform
 :DTShortName: distributed tracing platform
 :DTProductVersion: 3.1
@@ -126,7 +126,7 @@ endif::[]
 :TempoShortName: distributed tracing platform (Tempo)
 :TempoOperator: Tempo Operator
 :TempoVersion: 2.3.1
-//telco
+// telco
 ifdef::telco-ran[]
 :rds: telco RAN DU
 :rds-caps: Telco RAN DU
@@ -136,10 +136,10 @@ ifdef::telco-core[]
 :rds: telco core
 :rds-caps: Telco core
 endif::[]
-//lightspeed
+// lightspeed
 :ols-official: Red Hat OpenShift Lightspeed
 :ols: OpenShift Lightspeed
-//logging
+// logging
 :logging: logging
 :logging-uc: Logging
 :for: for Red Hat OpenShift
@@ -147,26 +147,26 @@ endif::[]
 :loki-op: Loki Operator
 :es-op: OpenShift Elasticsearch Operator
 :log-plug: logging Console plugin
-//observability
+// observability
 :ObservabilityLongName: Red Hat OpenShift Observability
 :ObservabilityShortName: Observability
 // Cluster Monitoring Operator
 :cmo-first: Cluster Monitoring Operator (CMO)
 :cmo-full: Cluster Monitoring Operator
 :cmo-short: CMO
-//power monitoring
+// power monitoring
 :PM-title-c: Power monitoring for Red Hat OpenShift
 :PM-title: power monitoring for Red Hat OpenShift
 :PM-shortname: power monitoring
 :PM-shortname-c: Power monitoring
 :PM-operator: Power monitoring Operator
 :PM-kepler: Kepler
-//serverless
+// serverless
 :ServerlessProductName: OpenShift Serverless
 :ServerlessProductShortName: Serverless
 :ServerlessOperatorName: OpenShift Serverless Operator
 :FunctionsProductName: OpenShift Serverless Functions
-//service mesh v2
+// service mesh v2
 :product-dedicated: Red Hat OpenShift Dedicated
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
@@ -176,9 +176,9 @@ endif::[]
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
 :SMPluginShort: OSSMC plugin
-//Service Mesh v1
+// Service Mesh v1
 :SMProductVersion1x: 1.1.18.2
-//Windows containers
+// Windows containers
 :productwinc: Red{nbsp}Hat OpenShift support for Windows Containers
 // Red Hat Quay Container Security Operator
 :rhq-cso: Red Hat Quay Container Security Operator
@@ -188,12 +188,12 @@ endif::[]
 :sno-caps: Single-node OpenShift
 :sno-okd: single-node OKD
 :sno-caps-okd: Single-node OKD
-//TALO and Redfish events Operators
+// TALO and Redfish events Operators
 :cgu-operator-first: Topology Aware Lifecycle Manager (TALM)
 :cgu-operator-full: Topology Aware Lifecycle Manager
 :cgu-operator: TALM
 :redfish-operator: Bare Metal Event Relay
-//Formerly known as CodeReady Containers and CodeReady Workspaces
+// Formerly known as CodeReady Containers and CodeReady Workspaces
 :openshift-local-productname: Red Hat OpenShift Local
 :openshift-dev-spaces-productname: Red Hat OpenShift Dev Spaces
 // Factory-precaching-cli tool
@@ -201,25 +201,25 @@ endif::[]
 :factory-prestaging-tool-caps: Factory-precaching-cli tool
 :openshift-networking: Red Hat OpenShift Networking
 // TODO - this probably needs to be different for OKD
-//ifdef::openshift-origin[]
-//:openshift-networking: OKD Networking
-//endif::[]
+// ifdef::openshift-origin[]
+// :openshift-networking: OKD Networking
+// endif::[]
 // logical volume manager storage
 :lvms-first: Logical Volume Manager (LVM) Storage
 :lvms: LVM Storage
-//Operator SDK version
+// Operator SDK version
 :osdk_ver: 1.31.0
-//Operator SDK version that shipped with the previous OCP 4.x release
+// Operator SDK version that shipped with the previous OCP 4.x release
 :osdk_ver_n1: 1.28.0
-//Version-agnostic OLM
+// Version-agnostic OLM
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-//Initial version of OLM that shipped with OCP 4, aka "v0"
+// Initial version of OLM that shipped with OCP 4, aka "v0"
 :olmv0: legacy OLM
 :olmv0-caps: Legacy OLM
 :olmv0-first: legacy Operator Lifecycle Manager (OLM)
 :olmv0-first-caps: Legacy Operator Lifecycle Manager (OLM)
-//Next-gen (OCP 4.14+) Operator Lifecycle Manager, aka "v1"
+// Next-gen (OCP 4.14+) Operator Lifecycle Manager, aka "v1"
 :olmv1: OLM 1.0
 :olmv1-first: Operator Lifecycle Manager (OLM) 1.0
 //
@@ -237,18 +237,13 @@ endif::[]
 :coo-first: Cluster Observability Operator (COO)
 :coo-full: Cluster Observability Operator
 :coo-short: COO
-//ODF
+// ODF
 :odf-first: Red Hat OpenShift Data Foundation (ODF)
 :odf-full: Red Hat OpenShift Data Foundation
 :odf-short: ODF
 :rh-dev-hub: Red Hat Developer Hub
-//IBU
+// IBU
 :lcao: Lifecycle Agent
-
-
-
-
-
 // Cloud provider names
 // Alibaba Cloud
 :alibaba: Alibaba Cloud
@@ -269,7 +264,7 @@ endif::[]
 // IBM Cloud Bare Metal (Classic)
 :ibm-cloud-bm: IBM Cloud(R) Bare Metal (Classic)
 :ibm-cloud-bm-title: IBM Cloud Bare Metal (Classic)
-//IBM Cloud Object Storage (COS)
+// IBM Cloud Object Storage (COS)
 :ibm-cloud-object-storage: IBM Cloud Object Storage (COS)
 // IBM Power
 :ibm-power-name: IBM Power(R)
@@ -285,7 +280,7 @@ endif::[]
 :azure-first: Microsoft Azure
 :azure-full: Microsoft Azure
 :azure-short: Azure
-//Oracle
+// Oracle
 :oci-first: Oracle(R) Cloud Infrastructure (OCI)
 :oci-first-no-rt: Oracle Cloud Infrastructure (OCI)
 :oci: OCI
@@ -310,18 +305,14 @@ endif::openshift-origin[]
 :vmw-first: VMware vSphere
 :vmw-full: VMware vSphere
 :vmw-short: vSphere
-
-
-//Token-based auth products
-//AWS Security Token Service
+// Token-based auth products
+// AWS Security Token Service
 :sts-first: Security Token Service (STS)
 :sts-full: Security Token Service
 :sts-short: STS
-//Microsoft Entra Workload ID (FKA Azure Active Directory Workload Identities)
+// Microsoft Entra Workload ID (FKA Azure Active Directory Workload Identities)
 :entra-first: Microsoft Entra Workload ID
 :entra-short: Workload ID
-
-
 // Cluster API terminology
 // Cluster CAPI Operator
 :cluster-capi-operator: Cluster CAPI Operator
@@ -352,7 +343,6 @@ endif::openshift-origin[]
 // Cluster API Provider VMware vSphere
 :cap-vsphere-first: Cluster API Provider VMware vSphere
 :cap-vsphere-short: Cluster API Provider vSphere
-
 // Hosted control planes related attributes
 :hcp-capital: Hosted control planes
 :hcp: hosted control planes


### PR DESCRIPTION
### JIRA

* No JIRA ticket created as I am trying to fix something quickly

    There is a problem in the attributes with spaces and mis-formatting causing problems, for example in the IBM attributes:

![image](https://github.com/user-attachments/assets/49a04bcb-9e57-4d13-8571-a762a9d94f88)

As you can see from the attached, the [preview](https://84869--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ibm-cloud) for this PR looks like it resolves the issue:
    
![image](https://github.com/user-attachments/assets/f25cc706-a509-4c88-9899-9ef6c6cb46be)

See [PR for 4.15](https://github.com/openshift/openshift-docs/pull/84873) also. Thanks    
    

### Version 

* OCP 4.16


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

### QE review:
- [No QE approval as no content changed ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
