### PR TITLE
[SRVCOM-3387] Integrations - add mention of supported OSSM version

### DIFF
--- a/integrations/serverless-ossm-setup.adoc
+++ b/integrations/serverless-ossm-setup.adoc
@@ -8,6 +8,13 @@ toc::[]
 
 The {ServerlessOperatorName} provides Kourier as the default ingress for Knative. However, you can use {SMProductShortName} with {ServerlessProductName} whether Kourier is enabled or not. Integrating with Kourier disabled allows you to configure additional networking and routing options that the Kourier ingress does not support, such as mTLS functionality.
 
+[IMPORTANT]
+====
+Integration of {SMProductName} 3 with {ServerlessProductName} is not supported.
+
+For a list of supported versions, see link:https://access.redhat.com/articles/4912821[Red Hat OpenShift Serverless Supported Configurations].
+====
+
 Note the following assumptions and limitations:
 
 * All Knative internal components, as well as Knative Services, are part of the {SMProductShortName} and have sidecars injection enabled. This means that strict mTLS is enforced within the whole mesh. All requests to Knative Services require an mTLS connection, with the client having to send its certificate, except calls coming from OpenShift Routing.


### PR DESCRIPTION
Version(s):
serverless-docs-1.35+

Issue:
https://issues.redhat.com/browse/SRVCOM-3387

Link to docs preview:
[Integrating Service Mesh with OpenShift Serverless](https://84870--ocpdocs-pr.netlify.app/openshift-serverless/latest/integrations/serverless-ossm-setup.html)

QE review:
- [x] QE has approved this change.