### PR TITLE
4.14: Update common-attributes.adoc to resolve formatting issues

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -76,12 +76,12 @@ ifdef::openshift-origin[]
 :builds-v2shortname: Shipwright
 :builds-v1shortname: Builds v1
 endif::[]
-//gitops
+// gitops
 :gitops-title: Red Hat OpenShift GitOps
 :gitops-shortname: GitOps
 :gitops-ver: 1.1
 :rh-app-icon: image:red-hat-applications-menu-icon.jpg[title="Red Hat applications"]
-//pipelines
+// pipelines
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: OpenShift Pipelines
 :pipelines-ver: pipelines-1.13
@@ -90,13 +90,13 @@ endif::[]
 :tekton-hub: Tekton Hub
 :artifact-hub: Artifact Hub
 :pac: Pipelines as Code
-//odo
+// odo
 :odo-title: odo
-//OpenShift Kubernetes Engine
+// OpenShift Kubernetes Engine
 :oke: OpenShift Kubernetes Engine
-//OpenShift Platform Plus
+// OpenShift Platform Plus
 :opp: OpenShift Platform Plus
-//openshift virtualization (cnv)
+// openshift virtualization (cnv)
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.14
 :KubeVirtVersion: v0.59.0
@@ -113,7 +113,7 @@ ifdef::openshift-origin[]
 :CNVSubscriptionSpecSource: community-operators
 :CNVSubscriptionSpecName: community-kubevirt-hyperconverged
 endif::[]
-//distributed tracing
+// distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing platform
 :DTShortName: distributed tracing platform
 :DTProductVersion: 3.1
@@ -130,7 +130,7 @@ endif::[]
 :TempoShortName: distributed tracing platform (Tempo)
 :TempoOperator: Tempo Operator
 :TempoVersion: 2.3.1
-//telco
+// telco
 ifdef::telco-ran[]
 :rds: telco RAN DU
 :rds-caps: Telco RAN DU
@@ -140,7 +140,7 @@ ifdef::telco-core[]
 :rds: telco core
 :rds-caps: Telco core
 endif::[]
-//logging
+// logging
 :logging: logging
 :logging-uc: Logging
 :for: for Red Hat OpenShift
@@ -148,26 +148,26 @@ endif::[]
 :loki-op: Loki Operator
 :es-op: OpenShift Elasticsearch Operator
 :log-plug: logging Console plugin
-//observability
+// observability
 :ObservabilityLongName: Red Hat OpenShift Observability
 :ObservabilityShortName: Observability
 // Cluster Monitoring Operator
 :cmo-first: Cluster Monitoring Operator (CMO)
 :cmo-full: Cluster Monitoring Operator
 :cmo-short: CMO
-//power monitoring
+// power monitoring
 :PM-title-c: Power monitoring for Red Hat OpenShift
 :PM-title: power monitoring for Red Hat OpenShift
 :PM-shortname: power monitoring
 :PM-shortname-c: Power monitoring
 :PM-operator: Power monitoring Operator
 :PM-kepler: Kepler
-//serverless
+// serverless
 :ServerlessProductName: OpenShift Serverless
 :ServerlessProductShortName: Serverless
 :ServerlessOperatorName: OpenShift Serverless Operator
 :FunctionsProductName: OpenShift Serverless Functions
-//service mesh v2
+// service mesh v2
 :product-dedicated: Red Hat OpenShift Dedicated
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
@@ -177,9 +177,9 @@ endif::[]
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
 :SMPluginShort: OSSMC plugin
-//Service Mesh v1
+// Service Mesh v1
 :SMProductVersion1x: 1.1.18.2
-//Windows containers
+// Windows containers
 :productwinc: Red Hat OpenShift support for Windows Containers
 // Red Hat Quay Container Security Operator
 :rhq-cso: Red Hat Quay Container Security Operator
@@ -189,12 +189,12 @@ endif::[]
 :sno-caps: Single-node OpenShift
 :sno-okd: single-node OKD
 :sno-caps-okd: Single-node OKD
-//TALO and Redfish events Operators
+// TALO and Redfish events Operators
 :cgu-operator-first: Topology Aware Lifecycle Manager (TALM)
 :cgu-operator-full: Topology Aware Lifecycle Manager
 :cgu-operator: TALM
 :redfish-operator: Bare Metal Event Relay
-//Formerly known as CodeReady Containers and CodeReady Workspaces
+// Formerly known as CodeReady Containers and CodeReady Workspaces
 :openshift-local-productname: Red Hat OpenShift Local
 :openshift-dev-spaces-productname: Red Hat OpenShift Dev Spaces
 // Factory-precaching-cli tool
@@ -202,17 +202,17 @@ endif::[]
 :factory-prestaging-tool-caps: Factory-precaching-cli tool
 :openshift-networking: Red Hat OpenShift Networking
 // TODO - this probably needs to be different for OKD
-//ifdef::openshift-origin[]
-//:openshift-networking: OKD Networking
-//endif::[]
+// ifdef::openshift-origin[]
+// :openshift-networking: OKD Networking
+// endif::[]
 // logical volume manager storage
 :lvms-first: Logical Volume Manager (LVM) Storage
 :lvms: LVM Storage
-//Operator SDK version
+// Operator SDK version
 :osdk_ver: 1.31.0
-//Operator SDK version that shipped with the previous OCP 4.x release
+// Operator SDK version that shipped with the previous OCP 4.x release
 :osdk_ver_n1: 1.28.0
-//Next-gen (OCP 4.14+) Operator Lifecycle Manager, aka "v1"
+// Next-gen (OCP 4.14+) Operator Lifecycle Manager, aka "v1"
 :olmv1: OLM 1.0
 :olmv1-first: Operator Lifecycle Manager (OLM) 1.0
 :ztp-first: GitOps Zero Touch Provisioning (ZTP)
@@ -229,15 +229,13 @@ endif::[]
 :coo-first: Cluster Observability Operator (COO)
 :coo-full: Cluster Observability Operator
 :coo-short: COO
-//ODF
+// ODF
 :odf-first: Red Hat OpenShift Data Foundation (ODF)
 :odf-full: Red Hat OpenShift Data Foundation
 :odf-short: ODF
 :rh-dev-hub: Red Hat Developer Hub
-//IBU
+// IBU
 :lcao: Lifecycle Agent
-
-
 // Cloud provider names
 // Alibaba Cloud
 :alibaba: Alibaba Cloud
@@ -274,7 +272,7 @@ endif::[]
 :azure-first: Microsoft Azure
 :azure-full: Microsoft Azure
 :azure-short: Azure
-//Oracle
+// Oracle
 :oci-first: Oracle(R) Cloud Infrastructure (OCI)
 :oci-first-no-rt: Oracle Cloud Infrastructure (OCI)
 :oci: OCI
@@ -299,18 +297,14 @@ endif::openshift-origin[]
 :vmw-first: VMware vSphere
 :vmw-full: VMware vSphere
 :vmw-short: vSphere
-
-
-//Token-based auth products
-//AWS Security Token Service
+// Token-based auth products
+// AWS Security Token Service
 :sts-first: Security Token Service (STS)
 :sts-full: Security Token Service
 :sts-short: STS
-//Microsoft Entra Workload ID (FKA Azure Active Directory Workload Identities)
+// Microsoft Entra Workload ID (FKA Azure Active Directory Workload Identities)
 :entra-first: Microsoft Entra Workload ID
 :entra-short: Workload ID
-
-
 // Cluster API terminology
 // Cluster CAPI Operator
 :cluster-capi-operator: Cluster CAPI Operator
@@ -341,7 +335,6 @@ endif::openshift-origin[]
 // Cluster API Provider VMware vSphere
 :cap-vsphere-first: Cluster API Provider VMware vSphere
 :cap-vsphere-short: Cluster API Provider vSphere
-
 // Hosted control planes related attributes
 :hcp-capital: Hosted control planes
 :hcp: hosted control planes


### PR DESCRIPTION
* No JIRA ticket created as I am trying to fix something quickly

    There is a problem in the attributes with spaces and mis-formatting causing problems, for example in the IBM attributes:
        
![image](https://github.com/user-attachments/assets/c667d8d3-8f74-4298-95af-088a20018ec8)

As you can see from the attached, the [Preview](https://84874--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ibm-cloud) for this PR looks like it resolves the issue:

![image](https://github.com/user-attachments/assets/cf2d2bc2-609b-4ebc-9ab7-c57e34a66569)

### Version

* OCP 4.14

### QE review:
- [No QE approval as no content changed ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->