### PR TITLE
[RHACS] Clarify image deprecation in 4.5 release notes

### DIFF
--- a/release_notes/45-release-notes.adoc
+++ b/release_notes/45-release-notes.adoc
@@ -341,7 +341,7 @@ a|Reference image pull secret names for the secured cluster components:
 |REM
 |NA
 
-| `rhacs-collector*` and `rhacs-collector-slim*` images
+| `rhacs-collector-slim*` images
 |NA
 |NA
 |DEP
@@ -364,7 +364,7 @@ The following section provides information about deprecated features listed in t
 ** In the next {product-title-short} release, Red{nbsp}Hat will remove the `grpcCode`, `httpCode`, and `httpStatus` fields in returned error response for gRPC stream APIs. Instead, the response will include a new field, `code` which includes the `grpcCode` data.
 * The `/v1/summary/counts` API has been deprecated.
 * The `/v1/cve/requests` API for managing vulnerability exceptions is deprecated. Use the new `/v2/vulnerability-exceptions/` API.
-* The `rhacs-collector*` and `rhacs-collector-slim*` images have been deprecated. They are now functionally same and do not include kernel drivers.
+* The `rhacs-collector-slim*` images have been deprecated. `rhacs-collector` images used to contain kernel modules and eBPF probes, but those items are no longer needed by {product-title-short}. The `rhacs-collector*` image and the `rhacs-collector-slim*` images are now functionally the same. The `rhacs-collector-slim*` image is planned for removal in a future release.
 * Kernel support packages and driver download functionality are deprecated.
 * The *Dashboard* view under *Vulnerability Management* is deprecated. Use the *Workload CVEs*, *Exception Management*, *Platform CVEs*, and *Node CVEs* views as alternatives.
 * The Amazon S3 external backup integration interoperability with Google Cloud Storage is deprecated. You must use the xref:../integration/integrate-with-google-cloud-storage.adoc#integrate-with-google-cloud-storage[Google Cloud Storage integration] for backups.


### PR DESCRIPTION
Version(s): 4.5

Issue: none
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://84878--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/45-release-notes.html#deprecated-features_release-notes-45

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
