### PR TITLE
[SRVCOM-3368] Add Installing kn CLI links for OSL plugin

### DIFF
--- a/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
@@ -10,7 +10,7 @@ If you are using a Linux distribution that does not have RPM or another package 
 
 .Prerequisites
 
-* You have installed the Knative (`kn`) command-line interface (CLI).
+* You have installed the xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) command-line interface (CLI)].
 
 * If you are not using {op-system-base} or Fedora, ensure that the *libc* library is installed in a directory on your path.
 +

--- a/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
@@ -15,7 +15,7 @@ On macOS, some systems might block the application from running due to security 
 
 .Prerequisites
 
-* You have installed the Knative (`kn`) command-line interface (CLI).
+* You have installed the xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) command-line interface (CLI)].
 
 .Procedure
 

--- a/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
@@ -10,7 +10,7 @@ If you are using Windows, you can install the Knative Workflow plugin.
 
 .Prerequisites
 
-* You have installed the Knative (`kn`) command-line interface (CLI).
+* You have installed the xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) command-line interface (CLI)].
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
serverless-docs-1.33+

Issue:
https://issues.redhat.com/browse/SRVCOM-3368

Link to docs preview:
https://84881--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/serverless-logic-install-kn-workflow-plugin-cli.html

QE review:
- [x] QE has approved this change.
