### PR TITLE
OSDOCS-12595-re: Documented the 4.17.4 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2855,6 +2855,71 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.4
+[id="ocp-4-17-4_{context}"]
+=== RHSA-2024:8981 - {product-title} {product-version}.4 bug fix, and security update advisory
+
+Issued: 13 November 2024
+
+{product-title} release {product-version}.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:8981[RHSA-2024:8981] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8984[RHSA-2024:8984] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.4 --pullspecs
+----
+
+[id="ocp-4-17-4-enhancements_{context}"]
+==== Enhancements
+
+[id="ocp-4-17-4-enhancements-nodes-pods-short-term-auth_{context}"]
+===== Authenticating customer workloads with {gcp-wid-short}
+
+With this release, applications in customer workloads on {product-title} clusters that use {gcp-wid-first} can authenticate by using {gcp-wid-short}.
+
+To use this authentication method with your applications, you must complete configuration steps on the cloud provider console and your {product-title} cluster.
+
+//For more information, see xref:../nodes/pods/nodes-pods-short-term-auth.adoc#nodes-pods-short-term-auth-configuring-gcp_nodes-pods-short-term-auth[Configuring {gcp-wid-short} authentication for applications on {gcp-short}].
+
+[id="ocp-4-17-4-enhancements-ansible-operator_{context}"]
+===== ansible-operator upstream version information
+
+* The `ansible-operator` version now shows the corresponding upstream version information. (link:https://issues.redhat.com/browse/OCPBUGS-43836[*OCPBUGS-43836*])
+
+[id="ocp-4-17-4-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when installing a cluster on an {ibm-title} platform and adding an existing VPC to the cluster, the {cap-ibm-first} would not add ports 443, 5000, and 6443 to the security group of the VPC. This situation prevented the VPC from being added to the cluster. With this release, a fix ensures that the {cap-ibm-first} adds the ports to the security group of the VPC so that the VPC gets added to your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-44226[*OCPBUGS-44226*])
+
+* Previously, the installation program populated the `network.devices`, `template` and `workspace` fields in the `spec.template.spec.providerSpec.value` section of the {vmw-full} control plane machine set custom resource (CR). These fields should be set in the {vmw-short} failure domain, and the installation program populating them caused unintended behaviors.
++
+Updating these fields did not trigger an update to the control plane machines, and these fields were cleared when the control plane machine set was deleted. With this release, the installation program is updated to no longer populate values that are included in the failure domain configuration. If these values are not defined in a failure domain configuration, for instance on a cluster that is updated to {product-title} {product-version} from an earlier version, the values defined by the installation program are used. (link:https://issues.redhat.com/browse/OCPBUGS-44047[*OCPBUGS-44047*])
+
+* Previously, enabling ESP hardware offload using IPSec on attached interfaces in Open vSwitch broke connectivity due to a bug in Open vSwitch. With this release, OpenShift automatically disables ESP hardware offload on the Open vSwitch attached interfaces, and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-43917[*OCPBUGS-43917*])
+
+* Previously, if you configured the identity provider (IDP) name for OAuth custom resource (CR) to contain whitespaces, `oauth-server` crashed. With this release, an identity provider (IDP) name that contains whitespaces does not cause `oauth-server` to crash. (link:https://issues.redhat.com/browse/OCPBUGS-44118[*OCPBUGS-44118*])
+
+* Previously, due to a behavior regression in Go 1.22, `oauth-server` pods crashed if the IDP configuration contained multiple password-based IDPs, such as `htpasswd`, with at least one of them having spaces in its name. Note that if the bootstrap user ,`kubeadmin`, still exists in a cluster, the user also counts as a password-based IDP. With this release, a fix to the `oauth-server` resolves this issue and prevents the server from crashing. (link:https://issues.redhat.com/browse/OCPBUGS-43587[*OCPBUGS-43587*])
+
+* Previously, when you used the Agent-based Installer to install a cluster on a node that had an incorrect date, the cluster installation failed. With this release, a patch is applied to the Agent-based Installer live ISO time synchronization. The patch configures the `/etc/chrony.conf` file with the list of additional Network Time Protocol (NTP) servers, so that you can set any of these additional NTP servers in the `agent-config.yaml` without experiencing a cluster installation issue. (link:https://issues.redhat.com/browse/OCPBUGS-43846[*OCPBUGS-43846*])
+
+* Previously, when you installed a private cluster on {gcp-first}, the API firewall rule used the source range of `0.0.0.0/0`. This address allowed non-cluster resources unintended access to the private cluster. With this release, the API firewall rule now only allows resources that have source ranges in the Machine Network to access the private cluster. (link:https://issues.redhat.com/browse/OCPBUGS-43786[*OCPBUGS-43786*])
+
+* Previously, an invalid or unreachable identity provider (IDP) blocked updates to {hcp}. With this release, the `ValidIDPConfiguration` condition in the `HostedCluster` object now reports any IDP errors so that these errors do not block updates to {hcp}. (link:https://issues.redhat.com/browse/OCPBUGS-43746[*OCPBUGS-43746*])
+
+* Previously, the `attach`, `oc exec`, and `port-forward` commands received an error if you ran the commands through a proxy. With this release, a patch applied to kubectl ensures kubectl can handle any proxy errors with these commands, so that the commands run as expected. (link:https://issues.redhat.com/browse/OCPBUGS-43696[*OCPBUGS-43696*])
+
+* Previously, {op-system-base-full} CoreOS templates that were shipped by the  Machine Config Operator (MCO) caused node scaling to fail on {rh-openstack-first}. This issue happened because of an issue with `systemd` and the presence of a legacy boot image from older versions of {product-title}. With this release, a patch fixes the issue with `systemd` and removes the legacy boot image, so that node scaling can continue as expected. (link:https://issues.redhat.com/browse/OCPBUGS-42577[*OCPBUGS-42577*])
+
+* Previously, a restart of a Cluster Version Operator (CVO) pod while the pod was initializing a syncing operation caused the guard of a blocked upgrade request to fail. This meant that the blocked upgrade request was unexpectedly accepted. With this release, a CVO pod postpones reconciliation of requests during initialization, so that the guard of a blocked upgrade requests persists after the CVO pod restarts. (link:https://issues.redhat.com/browse/OCPBUGS-42386[*OCPBUGS-42386*]) 
+
+[id="ocp-4-17-4-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.3
 [id="ocp-4-17-3_{context}"]
 === RHSA-2024:8434 - {product-title} {product-version}.3 bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12594](https://issues.redhat.com/browse/OSDOCS-12594)

Link to docs preview:
[4.17.4](https://84883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-4_release-notes)

