### PR TITLE
ROX-26894: Emphasize need to keep stackrox scanner enabled for node scanning

### DIFF
--- a/integration/integrate-with-image-vulnerability-scanners.adoc
+++ b/integration/integrate-with-image-vulnerability-scanners.adoc
@@ -36,7 +36,12 @@ You can set up {product-title-short} to obtain image vulnerability data from the
 === Scanners included in {product-title-short}
 
 * Scanner V4: Beginning with {product-title-short} version 4.4, a new scanner is introduced that is built on link:https://github.com/quay/claircore[ClairCore], which also powers the link:https://github.com/quay/clair[Clair] scanner. Scanner V4 supports scanning of language and OS-specific image components. You do not have to create an integration to use this scanner, but you must enable it during or after installation. For version 4.4, if you enable this scanner, you must also enable the StackRox Scanner. For more information about Scanner V4, including links to the installation documentation, see xref:../operating/examine-images-for-vulnerabilities.adoc#about-scanner-v4_examine-images-for-vulnerabilities[About {product-title-short} Scanner V4].
-* StackRox Scanner: This scanner is the default scanner in {product-title-short}. It originates from a fork of the Clair v2 open source scanner. If you have Scanner V4 enabled, you must also enable this scanner to provide scanning of RHCOS nodes and platform vulnerabilities such as {osp}, Kubernetes, and Istio. Support for that functionality in Scanner V4 is planned for a future release.
+* StackRox Scanner: This scanner is the default scanner in {product-title-short}. It originates from a fork of the Clair v2 open source scanner.
++
+[IMPORTANT]
+====
+Even if you have Scanner V4 enabled, at this time, the StackRox Scanner must still be enabled to provide scanning of RHCOS nodes and platform vulnerabilities such as {osp}, Kubernetes, and Istio. Support for that functionality in Scanner V4 is planned for a future release. Do not disable the StackRox Scanner.
+====
 
 [discrete]
 === Alternative scanners

--- a/modules/scanning-images.adoc
+++ b/modules/scanning-images.adoc
@@ -9,6 +9,11 @@
 
 For version 4.4, {product-title-short} provides two scanners: the StackRox Scanner and Scanner V4. Both scanners can examine images in secured clusters connected in your network. Secured cluster scanning is enabled by default in {osp} environments deployed by using the Operator or when delegated scanning is used. See "Accessing delegated image scanning" for more information.
 
+[IMPORTANT]
+====
+Even if you have Scanner V4 enabled, at this time, the StackRox Scanner must still be enabled to provide scanning of RHCOS nodes and platform vulnerabilities such as {osp}, Kubernetes, and Istio. Support for that functionality in Scanner V4 is planned for a future release. Do not disable the StackRox Scanner.
+====
+
 When using the StackRox Scanner, {product-title-short} performs the following actions:
 
 * Central submits image scanning requests to the StackRox Scanner.


### PR DESCRIPTION
Version(s):
4.5+

[Issue](https://issues.redhat.com/browse/ROX-26894)

Link to docs preview:

[84901--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-image-vulnerability-scanners.html](https://84901--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-image-vulnerability-scanners.html)
[84901--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html](https://84901--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html)

QE review:
- [x] QE has approved this change. **ACS has no QE, approved by SME**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
