### PR TITLE
OSDOCS-11383: remove version constraint for 4.18 and later

### DIFF
--- a/modules/pod-short-term-auth-gcp-cloud-sa.adoc
+++ b/modules/pod-short-term-auth-gcp-cloud-sa.adoc
@@ -11,7 +11,7 @@ You can use the Google Cloud console to create a workload identity pool and prov
 
 .Prerequisites
 
-* Your {gcp-short} cluster is running {product-title} version 4.17.4 or later and uses {gcp-wid-short}.
+* Your {gcp-short} cluster uses {gcp-wid-short}.
 
 * You have access to the Google Cloud console as a user with privileges to manage Identity and Access Management (IAM) and workload identity configurations.
 

--- a/modules/pod-short-term-auth-gcp-cluster-sa.adoc
+++ b/modules/pod-short-term-auth-gcp-cluster-sa.adoc
@@ -11,7 +11,7 @@ You create an {product-title} service account and annotate it to impersonate a {
 
 .Prerequisites
 
-* Your {gcp-short} cluster is running {product-title} version 4.17.4 or later and uses {gcp-wid-short}.
+* Your {gcp-short} cluster uses {gcp-wid-short}.
 
 * You have created a federated {gcp-short} service account.
 

--- a/modules/pod-short-term-auth-gcp-deploy-pod.adoc
+++ b/modules/pod-short-term-auth-gcp-deploy-pod.adoc
@@ -14,7 +14,7 @@ The following example demonstrates how to deploy a pod that uses the {product-ti
 
 .Prerequisites
 
-* Your {gcp-short} cluster is running {product-title} version 4.17.4 or later and uses {gcp-wid-short}.
+* Your {gcp-short} cluster uses {gcp-wid-short}.
 
 * You have created a federated {gcp-short} service account.
 

--- a/nodes/pods/nodes-pods-short-term-auth.adoc
+++ b/nodes/pods/nodes-pods-short-term-auth.adoc
@@ -56,7 +56,7 @@ You can only authenticate workloads with short-term credentials by using the sam
 
 |{gcp-short} with {gcp-wid-short}
 |Unsupported
-|*Supported* ^[1]^
+|*Supported*
 |Unsupported
 
 |{gcp-short} without {gcp-wid-short}
@@ -74,7 +74,6 @@ You can only authenticate workloads with short-term credentials by using the sam
 |Unsupported
 |Unsupported
 |====
-1. With {product-title} version 4.17.4 or later.
 ////
 
 // Content stub for later addition:


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-11383](https://issues.redhat.com//browse/OSDOCS-11383)

Link to docs preview:
[Configuring GCP Workload Identity authentication for applications on GCP](https://84909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-short-term-auth#nodes-pods-short-term-auth-configuring-gcp_nodes-pods-short-term-auth)

QE review:
- [ ] QE has approved this change.

Additional information:
Followup on #83682 (backport into 4.17.4) to remove version constraint for normal 4.18+ support