### PR TITLE
OSDOCS-11383: adds previously missing xref to 4.17.4 RNs

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2882,7 +2882,7 @@ With this release, applications in customer workloads on {product-title} cluster
 
 To use this authentication method with your applications, you must complete configuration steps on the cloud provider console and your {product-title} cluster.
 
-//For more information, see xref:../nodes/pods/nodes-pods-short-term-auth.adoc#nodes-pods-short-term-auth-configuring-gcp_nodes-pods-short-term-auth[Configuring {gcp-wid-short} authentication for applications on {gcp-short}].
+For more information, see xref:../nodes/pods/nodes-pods-short-term-auth.adoc#nodes-pods-short-term-auth-configuring-gcp_nodes-pods-short-term-auth[Configuring {gcp-wid-short} authentication for applications on {gcp-short}].
 
 [id="ocp-4-17-4-enhancements-ansible-operator_{context}"]
 ===== ansible-operator upstream version information


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11383](https://issues.redhat.com//browse/OSDOCS-11383)

Link to docs preview:
[4.17.4](https://84910--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-4_release-notes)

QE review:
N/A

Additional information:
Followup on #83682 (backport into 4.17.4) to add link that was waiting for main PR merge and CP (original RN PR #84883)