### PR TITLE
OSSM 3.0TP1 OSSM-8377 Testing Add {product-title} to <productname> and <para> in rel notes docinfo.xml

### DIFF
--- a/ossm-release-notes/docinfo.xml
+++ b/ossm-release-notes/docinfo.xml
@@ -1,9 +1,9 @@
 <title>Release Notes</title>
-<productname>Red Hat OpenShift Service Mesh</productname>
+<productname>{product-title}</productname>
 <productnumber>3.0.0tp1</productnumber>
 <subtitle>OpenShift Service Mesh release notes</subtitle>
 <abstract>
-    <para>This documentation provides information about each OpenShift Service Mesh release.
+    <para>This documentation provides information about each {product-title} release.
     </para>
 </abstract>
 <authorgroup>


### PR DESCRIPTION
**OSSM 3.0TP1**

[OSSM-8377](https://issues.redhat.com//browse/OSSM-8377) Testing Add {product-title} to productname and para in rel notes docinfo.xml

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick** to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology Preview

OSSM 3.0 is moving to stand alone format is will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8377

Link to docs preview:

There is no preview for docinfo.xml
docinfo.xml is required for Pantheon

QE review:

QE review is not needed for this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
