### PR TITLE
networking-operators-redirects: Created redirects for AWS Operator docs

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -175,14 +175,49 @@ AddType text/vtt                            vtt
     # Redirect for renamed external DNS page
     RewriteRule ^container-platform/4\.10/networking/external_dns_operator/nw-installing-external-dns-operator.html /container-platform/4.10/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.html [NE,R=301]
 
-   # Redirect for renamed Ingress Controller document
+    # Redirect for renamed Ingress Controller document
     RewriteRule ^container-platform/(4\.1[2-6])/networking/nw-ingress-controller-endpoint-publishing-strategies\.html$ /container-platform/$1/networking/nw-configuring-ingress-controller-endpoint-publishing-strategy.html [NE,R=302,L]
 
     # Redirect for Networking operators move per https://github.com/openshift/openshift-docs/pull/85085
     RewriteRule ^container-platform/(4\.1[6-8])/networking/aws_load_balancer_operator/(.*)? /container-platform/$1/networking/networking_operators/aws_load_balancer_operator/$2 [NE,R=302]
+
+    RewriteRule rosa/networking/aws-load-balancer-operator/(.*)? /rosa/networking/networking_operators/aws-load-balancer-operator/$1 [NE,R=302]
+
     RewriteRule ^container-platform/(4\.1[6-8])/networking/ingress-operator.html /container-platform/$1/networking/networking_operators/ingress-operator.html [NE,R=302]
+
     RewriteRule ^container-platform/(4\.17|4\.18)/networking/network_security/ebpf_manager/(.*)? /container-platform/$1/networking/networking_operators/ebpf_manager/$2 [NE,R=302]
+    
     RewriteRule ^container-platform/(4\.17|4\.18)/networking/external_dns_operator/(.*)? /container-platform/$1/networking/networking_operators/external_dns_operator/$2 [NE,R=302]
+
+    # PR https://github.com/openshift/openshift-docs/pull/85085
+    # Redirect for the About MetalLB and the MetalLB Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/metallb/about-metallb.html /container-platform/$1/networking/networking_operators/metallb-operator/about-metallb.html [NE,R=302]
+    # Redirect for the Installing the MetalLB Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/metallb/metallb-operator-install.html /container-platform/$1/networking/networking_operators/metallb-operator/metallb-operator-install.html [NE,R=302]
+    # Redirect for the Upgrading the MetalLB Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/metallb/metallb-upgrading-operator.html /container-platform/$1/networking/networking_operators/metallb-operator/metallb-upgrading-operator.html [NE,R=302]
+    # Redirect for the Cluster Network Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/cluster-network-operator.html /container-platform/$1/networking/networking_operators/cluster-network-operator.html [NE,R=302]
+    # Redirect for the DNS Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/dns-operator.html /container-platform/$1/networking/networking_operators/dns-operator.html [NE,R=302]
+    # ROSA/Dedicated Redirect for the DNS Operator document
+    RewriteRule ^(rosa|dedicated)/networking/dns-operator.html /$1/networking/networking_operators/dns-operator.html [NE,R=302]
+    # Redirect for the Ingress Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/ingress-operator.html /container-platform/$1/networking/networking_operators/ingress-operator.html [NE,R=302]
+    # ROSA/Dedicated Redirect for the Ingress Operator document
+    RewriteRule ^(rosa|dedicated)/networking/ingress-operator.html /$1/networking/networking_operators/ingress-operator.html [NE,R=302]
+    # Redirect for the Node Firewall Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/ingress-node-firewall-operator.html /container-platform/$1/networking/networking_operators/ingress-node-firewall-operator.html [NE,R=302]
+    # ROSA Redirect for the Node Firewall Operator document
+    RewriteRule ^(rosa)/networking/ingress-node-firewall-operator.html /$1/networking/networking_operators/ingress-node-firewall-operator.html [NE,R=302]
+    
+    # PR https://github.com/openshift/openshift-docs/pull/85441
+    # Redirect for the Installing the SR-IOV Network Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/hardware_networks/installing-sriov-operator.html /container-platform/$1/networking/networking_operators/sr-iov-operator/installing-sriov-operator.html [NE,R=302]
+    # Redirect for the Configuring the SR-IOV Network Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/hardware_networks/configuring-sriov-operator.html /container-platform/$1/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.html [NE,R=302]
+    # Redirect for the Uninstalling the SR-IOV Network Operator document
+    RewriteRule ^container-platform/(4\.1[6-8])/networking/hardware_networks/uninstalling-sriov-operator.html /container-platform/$1/networking/networking_operators/sr-iov-operator/uninstalling-sriov-operator.html [NE,R=302]
 
     # Redirect for cluster logging per Ashleigh Brennan
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/logging/troubleshooting/cluster-logging-must-gather.html /container-platform/$1/logging/cluster-logging-support.html [NE,R=302]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
Redirects for https://github.com/openshift/openshift-docs/pull/84683

