### PR TITLE
OSDOCS#12039: Adding note of future Kubernetes API removal

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -804,6 +804,16 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-18-future-deprecation_{context}"]
 === Notice of future deprecation
 
+[id="ocp-4-18-future-removals"]
+=== Future Kubernetes API removals
+
+// Kubernetes 1.32 isn't released yet, but it will be by the time OCP 4.18 comes out
+The next minor release of {product-title} is expected to use Kubernetes 1.32. Kubernetes 1.32 removed a deprecated API.
+
+See the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-32[Deprecated API Migration Guide] in the upstream Kubernetes documentation for the list of planned Kubernetes API removals.
+
+See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API deprecations and removals] for information about how to check your cluster for Kubernetes APIs that are planned for removal.
+
 [id="ocp-4-18-bug-fixes_{context}"]
 == Bug fixes
 //Bug fix work for TELCODOCS-750


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-12039

Link to docs preview:
https://84972--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-future-removals

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
