### PR TITLE
OSDOCS-12680 update cloudformation template info

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -873,7 +873,7 @@ Running this command creates resources within your AWS account.
 
 [NOTE]
 ====
-For custom or advanced configuration, it is highly recommended to use the AWS CLI directly using the `aws cloudformation` command or create a new custom template with the required configurations.
+For custom or advanced configurations, it is highly recommended to use the AWS CLI directly using the `aws cloudformation` command or create a new custom template with the required configurations. If you use a custom CloudFormation template with the ROSA CLI, the minimum required version is 1.2.47 or later.
 ====
 
 .Syntax
@@ -892,7 +892,7 @@ $ rosa create network [flags]
 
 |===
 
-.Default template YAML
+.Default CloudFormation template
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/rosa/refs/heads/master/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml[]


### PR DESCRIPTION
Updated the wording about using the cloudformation template in the ROSA CLI docs. 

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12680


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://84974--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-create-network_rosa-managing-objects-cli



QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
