### PR TITLE
TELCODOCS-2022: Worker: pull images via cri-o

### DIFF
--- a/modules/kmm-example-module-cr.adoc
+++ b/modules/kmm-example-module-cr.adoc
@@ -30,44 +30,44 @@ spec:
         - regexp: '^.+\fc37\.x86_64$' <6>
           containerImage: "some.other.registry/org/<my_kmod>:${KERNEL_FULL_VERSION}"
         - regexp: '^.+$' <7>
-          containerImage: "some.registry/org/<my_kmod>:${KERNEL_FULL_VERSION}"
+          containerImage: "some.registry/org/<my_kmod>:${KERNEL_FULL_VERSION}"  <8>
           build:
-            buildArgs:  <8>
+            buildArgs:  <9>
               - name: ARG_NAME
                 value: <some_value>
             secrets:
-              - name: <some_kubernetes_secret>  <9>
-            baseImageRegistryTLS: <10>
+              - name: <some_kubernetes_secret>  <10>
+            baseImageRegistryTLS: <11>
               insecure: false
-              insecureSkipTLSVerify: false <11>
-            dockerfileConfigMap:  <12>
+              insecureSkipTLSVerify: false  <12>
+            dockerfileConfigMap:  <13>
               name: <my_kmod_dockerfile>
           sign:
             certSecret:
-              name: <cert_secret>  <13>
+              name: <cert_secret>  <14>
             keySecret:
-              name: <key_secret>  <14>
+              name: <key_secret>  <15>
             filesToSign:
               - /opt/lib/modules/${KERNEL_FULL_VERSION}/<my_kmod>.ko
-          registryTLS: <15>
-            insecure: false <16>
+          registryTLS: <16>
+            insecure: false <17>
             insecureSkipTLSVerify: false
-    serviceAccountName: <sa_module_loader>  <17>
-  devicePlugin:  <18>
+    serviceAccountName: <sa_module_loader>  <18>
+  devicePlugin:  <19>
     container:
-      image: some.registry/org/device-plugin:latest  <19>
+      image: some.registry/org/device-plugin:latest  <20>
       env:
         - name: MY_DEVICE_PLUGIN_ENV_VAR
           value: SOME_VALUE
-      volumeMounts:  <20>
+      volumeMounts:  <21>
         - mountPath: /some/mountPath
           name: <device_plugin_volume>
-    volumes:  <21>
+    volumes:  <22>
       - name: <device_plugin_volume>
         configMap:
           name: <some_configmap>
-    serviceAccountName: <sa_device_plugin> <22>
-  imageRepoSecret:  <23>
+    serviceAccountName: <sa_device_plugin> <23>
+  imageRepoSecret:  <24>
     name: <secret_name>
   selector:
     node-role.kubernetes.io/worker: ""
@@ -79,24 +79,25 @@ spec:
 <5> At least one kernel item is required.
 <6> For each node running a kernel matching the regular expression, KMM checks if you have included a tag or a digest. If you have not specified a tag or digest in the container image, then the validation webhook returns an error and does not apply the module.
 <7> For any other kernel, build the image using the Dockerfile in the `my-kmod` ConfigMap.
-<8> Optional.
-<9> Optional: A value for `some-kubernetes-secret` can be obtained from the build environment at `/run/secrets/some-kubernetes-secret`.
-<10> This field has no effect. When building kmod images or signing kmods within a kmod image,
+<8> The container image that holds the customer's kmods. This container should contain the `cp` binary.
+<9> Optional.
+<10> Optional: A value for `some-kubernetes-secret` can be obtained from the build environment at `/run/secrets/some-kubernetes-secret`.
+<11> This field has no effect. When building kmod images or signing kmods within a kmod image,
 you might sometimes need to pull base images from a registry that serves a certificate signed by an
 untrusted Certificate Authority (CA). In order for KMM to trust that CA, it must also trust the new CA
 by replacing the cluster's CA bundle.
 +
 See "Additional resources" to learn how to replace the cluster's CA bundle.
-<11> Optional: Avoid using this parameter. If set to `true`, the build will skip any TLS server certificate validation when pulling the image in the Dockerfile `FROM` instruction using plain HTTP.
-<12> Required.
-<13> Required: A secret holding the public secureboot key with the key 'cert'.
-<14> Required: A secret holding the private secureboot key with the key 'key'.
-<15> Optional: Avoid using this parameter. If set to `true`, KMM will be allowed to check if the container image already exists using plain HTTP.
-<16> Optional: Avoid using this parameter. If set to `true`, KMM will skip any TLS server certificate validation when checking if the container image already exists.
-<17> Optional.
+<12> Optional: Avoid using this parameter. If set to `true`, the build skips any TLS server certificate validation when pulling the image in the Dockerfile `FROM` instruction using plain HTTP.
+<13> Required.
+<14> Required: A secret holding the public secureboot key with the key 'cert'.
+<15> Required: A secret holding the private secureboot key with the key 'key'.
+<16> Optional: Avoid using this parameter. If set to `true`, KMM is allowed to check if the container image already exists using plain HTTP.
+<17> Optional: Avoid using this parameter. If set to `true`, KMM skips any TLS server certificate validation when checking if the container image already exists.
 <18> Optional.
-<19> Required: If the device plugin section is present.
-<20> Optional.
+<19> Optional.
+<20> Required: If the device plugin section is present.
 <21> Optional.
 <22> Optional.
-<23> Optional: Used to pull module loader and device plugin images.
+<23> Optional.
+<24> Optional: Used to pull module loader and device plugin images.


### PR DESCRIPTION
D/S and R/N: [MGMT-17144](https://issues.redhat.com//browse/MGMT-17144) - Worker: pull images via cri-o

Jira: https://issues.redhat.com/browse/TELCODOCS-2022

Applies to OCP version : 4.17+

Fix version: KMMO 2.2

Docs Preview: https://84978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-example-cr_kernel-module-management-operator

Dev review: @ybettan
QE review: @ggordaniRed