### PR TITLE
OSDOCS-12094: Add auto-recovery to Backup and restore section

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -72,6 +72,13 @@ With this release, you can delete or upgrade the Kustomize manifest resources. F
 //[id="microshift-4-18-support_{context}"]
 //=== Support
 
+[id="microshift-4-18-backup_and_restore_{context}"]
+=== Backup and restore
+
+[id="microshift-4-18-autorecovery-from-manual-backup_{context}"]
+==== Auto recovery from manual backups now documented
+With this release, you can automatically restore data from manual backups when {microshift-short} fails to start by using the `auto-recovery` feature. For more information, see xref:../microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc#microshift-auto-recover-manual-backup[Auto recovery from manual backups].
+
 //[id="microshift-4-18-doc-enhancements_{context}"]
 //=== Documentation enhancements
 //Doc enhancements include additions for RFEs and other continuous improvement items that are substantial and are not tied to new features or bug fixes already listed here. These can also go under the relevant section as applicable.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-12094](https://issues.redhat.com/browse/OSDOCS-12094)

Link to docs preview:
[Auto recovery from manual backups now documented](https://85006--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-backup_and_restore_release-notes)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
