### PR TITLE
OSDOCS-12167: adds 4.14.41 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -648,3 +648,12 @@ Issued: 8 November 2024
 {product-title} release 4.14.40 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:8699[RHBA-2024:8699] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8697[RHSA-2024:8697] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-41-dp_{context}"]
+=== RHBA-2024:9622 - {microshift-short} 4.14.41 bug fix and security update advisory
+
+Issued: 20 November 2024
+
+{product-title} release 4.14.41 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:9622[RHBA-2024:9622] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:9620[RHSA-2024:9620] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-12167](https://issues.redhat.com/browse/OSDOCS-12167)

Link to docs preview:
[4-14-41-dp_release-notes](https://85010--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-41-dp_release-notes)

QE review:
- NA. stock text, no other changes.