### PR TITLE
RHDEVDOCS-6184: Content creation to enable HA in Argo rollouts

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -127,6 +127,8 @@ Topics:
   File: enable-support-for-namespace-scoped-argo-rollouts-installation
 - Name: Configuring traffic management and metric plugins in Argo Rollouts
   File: configuring_traffic_management_and_metric_plugins_in_argo_rollouts
+- Name: Enabling high availability support for Argo Rollouts
+  File: enabling-ha-support-for-argo-rollouts
 ---
 Name: Security
 Dir: securing_openshift_gitops

--- a/argo_rollouts/enabling-ha-support-for-argo-rollouts.adoc
+++ b/argo_rollouts/enabling-ha-support-for-argo-rollouts.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="enabling-ha-support-for-argo-rollouts"]
+= Enabling high availability support for Argo Rollouts
+:context: enabling-ha-support-for-argo-rollouts
+
+toc::[]
+
+Argo Rollouts support enabling high availability (HA) in the `RolloutManager` Custom Resource (CR). When you configure high availability in Argo Rollouts, the {gitops-title} Operator automatically sets the number of pods to 2 for the Argo Rollouts controller using the `.spec.ha` field in the `RolloutManager` CR. It also activates leader election, allowing the pods to run in an active-passive process. A single pod actively manages rollouts, while the other pod remains in a passive state, ensuring the additional replica provides redundancy and availability if a node fails.
+
+This feature benefits the Rollouts controller by ensuring it runs without downtime or manual intervention. It also operates during planned maintenance, as the second replica ensures the controller runs smoothly. Enabling high availability in Argo Rollouts ensures the controller remains reliable and resilient, even during node failures or heavy workloads.
+
+The {gitops-title} Operator also ensures that anti-affinity rules apply by default. Although these rules are not user-defined, they ensure the controller pods distribute across different nodes to avoid a single point of failure, providing resilience against node failure.
+
+.Prerequisites
+* You are logged in to the {OCP} cluster as an administrator.
+* You installed xref:../installing_gitops/installing-openshift-gitops.adoc#installing-openshift-gitops[{gitops-title}] on your {OCP} cluster.
+* You installed xref:../argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc#gitops-creating-rolloutmanager-custom-resource_using-argo-rollouts-for-progressive-deployment-delivery[Argo Rollouts] on your {OCP} cluster.
+
+// Configuring high availability for Argo Rollouts
+include::modules/gitops-configuring-high-availability-for-argo-rollouts.adoc[leveloffset=+1]

--- a/modules/gitops-configuring-high-availability-for-argo-rollouts.adoc
+++ b/modules/gitops-configuring-high-availability-for-argo-rollouts.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * argo_rollouts/enabling-ha-support-for-argo-rollouts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-configuring-high-availability-for-argo-rollouts_{context}"]
+= Configuring high availability for Argo Rollouts
+
+To enable high availability, configure the `ha` specification in the `RolloutManager` custom resource (CR) by completing the following steps:
+
+.Procedure
+
+.  Log in to the {OCP} web console as a cluster administrator. 
+
+. In the *Administrator* perspective, click *Operators* -> *Installed Operators*.
+
+. Create or select the project where you want to create and configure a `RolloutManager` CR from the *Project* drop-down menu.
+
+. Select *{gitops-title}* from the installed Operators.
+
+. In the *Details* tab, under the *Provided APIs* section, click *Create instance* in the *RolloutManager* pane.
+
+. On the *Create RolloutManager* page, select the *YAML view* and edit the YAML.
++
+.Example enabling the `ha` field in the `RolloutManager` CR
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: RolloutManager
+metadata:
+  name: argo-rollouts
+  namespace: openshift-gitops
+spec:
+  ha:
+    enabled: true #<1>
+----
+<1> Specifies whether high availability is enabled or not. If the value is set to `true`, high availability is enabled.
+
+. Click *Create*.
+
+. In the *RolloutManager* tab, under the *RolloutManagers* section, verify that the *Status* field of the RolloutManager instance shows *Phase: Available*.
+
+. Verify the status of the Rollouts deployment by completing the following steps:
+.. In the *Administrator* perspective, click *Workloads* -> *Deployments*.
+.. Click the *argo-rollouts* deployment.
++
+.. Click the *Details* tab and confirm that the number of replicas in the Rollouts deployment is now set to 2. 
+.. Click the *YAML* tab and confirm that the following configuration is displayed:
++
+.Example Argo Rollouts deployment configuration file
+[source,yaml]
+----
+kind: Deployment
+metadata:
+  name: argo-rollouts
+  namespace: openshift-gitops
+spec:
+  replicas: 2 #<1>
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-rollouts
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/name: argo-rollouts
+    spec:
+      containers:
+          args:
+            - '--leader-elect'
+            - 'true' #<2>
+----
+<1> Specifies the number of pods.
+<2> Specifies that the `--leader-elect=true` flag is passed to the Rollouts deployment. Although this flag is set to `true` by default, explicitly setting it ensures that leader election remains consistently enforced.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6184

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Enabling high availability support for Argo Rollouts](https://85013--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/enabling-ha-support-for-argo-rollouts.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @Rizwana777 @jgwest 
Peer review: @skrthomas 
QE review: @varshab1210 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
