### PR TITLE
Add serverless 1.35 to distro map

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -360,6 +360,9 @@ openshift-serverless:
     serverless-docs-1.34:
       name: '1.34'
       dir: serverless/1.34
+    serverless-docs-1.35:
+      name: '1.35'
+      dir: serverless/1.35
 openshift-gitops:
   name: Red Hat OpenShift GitOps
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: [SRVCOM-3407](https://issues.redhat.com/browse/SRVCOM-3407) Update _distro_map.yml

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[SRVCOM-3407](https://issues.redhat.com/browse/SRVCOM-3407)

Link to docs preview:


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
