### PR TITLE
WMCO reorg release notes 4.15/10.15

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2634,6 +2634,10 @@ Topics:
     File: windows-containers-release-notes-10-15-x
   - Name: Past releases
     File: windows-containers-release-notes-10-15-x-past
+  - Name: Windows Machine Config Operator prerequisites
+    File: windows-containers-release-notes-10-15-x-prereqs
+  - Name: Windows Machine Config Operator known limitations
+    File: windows-containers-release-notes-10-15-x-known-limitations
 - Name: Getting support
   File: windows-containers-support
   Distros: openshift-enterprise

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -33,7 +33,7 @@ Windows instances deployed by the WMCO are configured with the containerd contai
 
 [role="_additional-resources"]
 .Additional resources
-* For the comprehensive prerequisites for the Windows Machine Config Operator, see windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-past.adoc#wmco-prerequisites_windows-containers-release-notes-10-15-x-past[Windows Machine Config Operator prerequisites].
+* For the comprehensive prerequisites for the Windows Machine Config Operator, see xref:../windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-prereqs.adoc#windows-containers-release-notes-10-15-x-prereqs[Windows Machine Config Operator prerequisites].
 
 [id="installing-the-wmco"]
 == Installing the Windows Machine Config Operator

--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-known-limitations.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-known-limitations.adoc
@@ -1,9 +1,8 @@
-// Module included in the following assemblies:
-//
-// * windows_containers/windows-containers-release-notes-#-x
-
-[id="windows-containers-release-notes-limitations_{context}"]
-= Known limitations
+:_mod-docs-content-type: ASSEMBLY
+:context: windows-containers-release-notes-10-15-x-known-limitations
+[id="windows-containers-release-notes-10-15-x-known-limitations"]
+= Windows Machine Config Operator known limitations
+include::_attributes/common-attributes.adoc[]
 
 Note the following limitations when working with Windows nodes managed by the WMCO (Windows nodes):
 

--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-past.adoc
@@ -71,7 +71,3 @@ The WMCO now uses Kubernetes 1.28.
 
 // Also in 7.2.1, 8.1.2
 * Previously, because of bad logic in the networking configuration script, the WICD was incorrectly reading carriage returns in the CNI configuration file as changes, and identified the file as modified. This caused the CNI configuration to be unnecessarily reloaded, potentially resulting in container restarts and brief network outages. With this fix, the WICD now reloads the CNI configuration only when the CNI configuration is actually modified. (link:https://issues.redhat.com/browse/OCPBUGS-25756[*OCPBUGS-25756*])
-
-include::modules/wmco-prerequisites.adoc[leveloffset=+1]
-
-include::modules/windows-containers-release-notes-limitations.adoc[leveloffset=+1]

--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-prereqs.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-prereqs.adoc
@@ -1,9 +1,10 @@
-// Module included in the following assemblies:
-//
-// * windows_containers/understanding-windows-container-workloads.adoc
-
-[id="wmco-prerequisites_{context}"]
+:_mod-docs-content-type: ASSEMBLY
+:context: windows-containers-release-notes-10-15-x-prereqs
+[id="windows-containers-release-notes-10-15-x-prereqs"]
 = Windows Machine Config Operator prerequisites
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
 
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator. See the vSphere documentation for any information that is relevant to only that platform.
 

--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x.adoc
@@ -28,5 +28,3 @@ This release of the WMCO provides new features and bug fixes for running Windows
 * Previously, if reverse DNS lookup failed due to an error, such as the reverse DNS lookup services being unavailable, the WMCO would not fall back to using the VM hostname to determine if a certificate signing requests (CSR) should be approved. As a consequence, Bring-Your-Own-Host (BYOH) Windows nodes configured with an IP address would not become available. With this fix, BYOH nodes are properly added if reverse DNS is not available. (link:https://issues.redhat.com/browse/OCPBUGS-37533[*OCPBUGS-37533*])
 
 * Previously, if there were multiple service account token secrets in the WMCO namespace, the scaling of Windows nodes would fail. With this fix, the WMCO uses only the secret it creates, ignoring any other service account token secrets in the WMCO namespace. As a result, Windows nodes scale properly.  (link:https://issues.redhat.com/browse/OCPBUGS-38485[*OCPBUGS-38485*])
-
-include::modules/windows-containers-release-notes-limitations.adoc[leveloffset=+1]


### PR DESCRIPTION
Created new assemblies for the existing Prereqs and Known Limitation modules.  **NO NEW TEXT**

Previews
[Windows Machine Config Operator prerequisites](https://85023--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-prereqs.html) -- New assembly that houses an existing module.  **NO NEW TEXT** [Current docs](https://docs.openshift.com/container-platform/4.15/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-past.html#wmco-prerequisites_windows-containers-release-notes-10-15-x-past).
[Windows Machine Config Operator known limitations](https://85023--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-known-limitations.html) -- New assembly that houses an existing module. **NO NEW TEXT**  [Current docs](https://docs.openshift.com/container-platform/4.15/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-past.html#windows-containers-release-notes-limitations_windows-containers-release-notes-10-15-x-past).
[Enabling Windows container workloads](https://85023--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html) -- Updated link in Additional Resources under Prerequisites.  


