### PR TITLE
OCPBUGS-41971-ent16: Returned the Ingress Capability docs

### DIFF
--- a/installing/overview/cluster-capabilities.adoc
+++ b/installing/overview/cluster-capabilities.adoc
@@ -77,6 +77,9 @@ include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+2]
 // DeploymentConfig capability
 include::modules/deployment-config-capability.adoc[leveloffset=+2]
 
+// Ingress capability
+include::modules/ingress-operator.adoc[leveloffset=+2]
+
 // Insights capability
 include::modules/insights-operator.adoc[leveloffset=+2]
 

--- a/modules/ingress-operator.adoc
+++ b/modules/ingress-operator.adoc
@@ -1,13 +1,32 @@
 // Module included in the following assemblies:
 //
 // * operators/operator-reference.adoc
+// * installing/overview/cluster-capabilities.adoc
+
+ifeval::["{context}" == "cluster-capabilities"]
+:cluster-caps:
+endif::[]
+
+ifeval::["{context}" == "cluster-operators-ref"]
+:operator-ref:
+endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="ingress-operator_{context}"]
-= Ingress Operator
+ifdef::operator-ref[= Ingress Operator]
+ifdef::cluster-caps[= Ingress Capability]
 
 [discrete]
 == Purpose
+
+ifdef::cluster-caps[]
+The Ingress Operator provides the features for the Ingress capability. Ingress capability is enabled by default.
+
+[IMPORTANT]
+====
+If you set `baselineCapabilitySet` to `None`, you must explicitly enable Ingress capability, because installation of a cluster fails if Ingress capability is disabled.
+====
+endif::cluster-caps[]
 
 The Ingress Operator configures and manages the {product-title} router.
 
@@ -61,3 +80,11 @@ $ oc get network/cluster -o jsonpath='{.status.clusterNetwork[*]}'
 ----
 map[cidr:10.128.0.0/14 hostPrefix:23]
 ----
+
+ifeval::["{context}" == "cluster-operators-ref"]
+:!operator-ref:
+endif::[]
+
+ifeval::["{context}" == "cluster-caps"]
+:!cluster-caps:
+endif::[]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OCPBUGS-41971](https://issues.redhat.com/browse/OCPBUGS-41971)

Link to docs preview:
* [Ingress Capability](https://84252--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities.html#ingress-operator_cluster-capabilities)
* [Cluster Operators reference](https://84252--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#ingress-operator_cluster-operators-ref)
* [Ingress capability: bug fixes in Management Console
](https://84252--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html)

- [ ] SME has approved this change (Trevor King/Seth Jennings/Cesar Wong).
- [ ] QE has approved this change.


Additional information:
* Do not turn off the Ingress Capability feature for 4.16 plus on OCP core and HCPs? 

SETH confirmed that the ingress capability is out of scope for 4.16 and 4.17.
