### PR TITLE
WMCO reorg release notes 4.14/9.x

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2598,6 +2598,10 @@ Topics:
     File: windows-containers-release-notes-9-x
   - Name: Past releases
     File: windows-containers-release-notes-9-x-past
+  - Name: Windows Machine Config Operator prerequisites
+    File: windows-containers-release-notes-9-x-prereqs
+  - Name: Windows Machine Config Operator known limitations
+    File: windows-containers-release-notes-9-x-known-limitations
 - Name: Getting support
   File: windows-containers-support
   Distros: openshift-enterprise

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -33,7 +33,7 @@ Windows instances deployed by the WMCO are configured with the containerd contai
 
 [role="_additional-resources"]
 .Additional resources
-* For the comprehensive prerequisites for the Windows Machine Config Operator, see xref:../windows_containers/wmco_rn/windows-containers-release-notes-9-x-past.html#wmco-prerequisites_windows-containers-release-notes-9-x-past[Windows Machine Config Operator prerequisites].
+* For the comprehensive prerequisites for the Windows Machine Config Operator, see xref:../windows_containers/wmco_rn/windows-containers-release-notes-9-x-prereqs.adoc#windows-containers-release-notes-9-x-prereqs[Windows Machine Config Operator prerequisites].
 
 [id="installing-the-wmco"]
 == Installing the Windows Machine Config Operator

--- a/windows_containers/wmco_rn/windows-containers-release-notes-9-x-known-limitations.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-9-x-known-limitations.adoc
@@ -1,9 +1,10 @@
-// Module included in the following assemblies:
-//
-// * windows_containers/windows-containers-release-notes-#-x
+:_mod-docs-content-type: ASSEMBLY
+:context: windows-containers-release-notes-9-x-known-limitations
+[id="windows-containers-release-notes-9-x-known-limitations"]
+= Windows Machine Config Operator known limitations
+include::_attributes/common-attributes.adoc[]
 
-[id="windows-containers-release-notes-limitations_{context}"]
-= Known limitations
+toc::[]
 
 Note the following limitations when working with Windows nodes managed by the WMCO (Windows nodes):
 

--- a/windows_containers/wmco_rn/windows-containers-release-notes-9-x-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-9-x-past.adoc
@@ -29,7 +29,7 @@ This release of the WMCO provides new features and bug fixes for running Windows
 [id="wmco-9-0-1-bug-fixes"]
 === Bug fixes
 
-// Reviewed in WMCO 10.15.0 RN PR 
+// Reviewed in WMCO 10.15.0 RN PR
 * Previously, because of a lack of synchronization between Windows machine set nodes and Bring-Your-Own-Host (BYOH) instances, during an update the machine set nodes and the BYOH instances could update simultaneously. This could impact running workloads. This fix introduces a locking mechanism so that machine set nodes and BYOH instances update individually. (link:https://issues.redhat.com/browse/OCPBUGS-22984[*OCPBUGS-22984*])
 
 // Reviewed in WMCO 10.15.0 RN PR
@@ -58,7 +58,7 @@ Clusters that use a cluster-wide proxy now support WMCO. Starting with {product-
 [id="wmco-9-0-0-nutanix"]
 ==== Support Windows Containers on Nutanix
 
-Clusters installed on Nutanix now support Windows Server 2022 nodes. You can create a Windows machine set on Nutanix to host Windows Server 2022 compute nodes. For more information, see xref:../../windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix.adoc#creating-windows-machineset-nutanix[Creating a Windows machine set on Nutanix]. 
+Clusters installed on Nutanix now support Windows Server 2022 nodes. You can create a Windows machine set on Nutanix to host Windows Server 2022 compute nodes. For more information, see xref:../../windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix.adoc#creating-windows-machineset-nutanix[Creating a Windows machine set on Nutanix].
 
 [id="wmco-9-0-0-priority-class"]
 ==== New scheduling priority class
@@ -70,7 +70,7 @@ WMCO now supports the `windows-priorityclass` kubelet parameter, which ensures t
 
 WMCO now supports the use of persistent storage for Windows workloads, without the use of in-tree storage drivers, by running the CSI Proxy service on each Windows node. Windows pods on each node now have access to storage through persistent volume claims.
 
-With CSI proxy running on a cluster's Windows nodes, you can deploy the Container Storage Interface (CSI) storage drivers of your choice as a Windows daemon set. For more information on CSI Proxy, see link:https://kubernetes.io/blog/2021/08/09/csi-windows-support-with-csi-proxy-reaches-ga/[CSI Windows Support (with CSI Proxy)] in the Kubernetes documentation. For information on CSI, see xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes] in the {product-title} documentation. 
+With CSI proxy running on a cluster's Windows nodes, you can deploy the Container Storage Interface (CSI) storage drivers of your choice as a Windows daemon set. For more information on CSI Proxy, see link:https://kubernetes.io/blog/2021/08/09/csi-windows-support-with-csi-proxy-reaches-ga/[CSI Windows Support (with CSI Proxy)] in the Kubernetes documentation. For information on CSI, see xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes] in the {product-title} documentation.
 
 [id="wmco-9-0-0-technical-changes"]
 === Notable technical changes
@@ -91,8 +91,3 @@ Install-WindowsFeature : Win32 internal error "Access is denied" 0x5 occurred wh
 ----
 +
 The failure occurred because the Microsoft `Install-WindowsFeature` cmdlet displays a progress bar that cannot be sent over an SSH connection. This fix hides the progress bar. As a result, Windows instances can be deployed as nodes. (link:https://issues.redhat.com/browse/OCPBUGS-13244[*OCPBUGS-13244*])
-
-include::modules/wmco-prerequisites.adoc[leveloffset=+1]
-
-include::modules/windows-containers-release-notes-limitations.adoc[leveloffset=+1] 
-

--- a/windows_containers/wmco_rn/windows-containers-release-notes-9-x-prereqs.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-9-x-prereqs.adoc
@@ -1,9 +1,10 @@
-// Module included in the following assemblies:
-//
-// * windows_containers/understanding-windows-container-workloads.adoc
-
-[id="wmco-prerequisites_{context}"]
+:_mod-docs-content-type: ASSEMBLY
+:context: windows-containers-release-notes-9-x-prereqs
+[id="windows-containers-release-notes-9-x-prereqs"]
 = Windows Machine Config Operator prerequisites
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
 
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator (WMCO). See the vSphere documentation for any information that is relevant to only that platform.
 


### PR DESCRIPTION
Created new assemblies for the existing Prereqs and Known Limitation modules.  **NO NEW TEXT**

Previews
[Windows Machine Config Operator prerequisites](https://85025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-9-x-prereqs.html) -- New assembly that houses an existing module.  **NO NEW TEXT** [Current docs](https://docs.openshift.com/container-platform/4.14/windows_containers/wmco_rn/windows-containers-release-notes-9-x-past.html#wmco-prerequisites_windows-containers-release-notes-9-x-past).
[Windows Machine Config Operator known limitations](https://85025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-9-x-known-limitations.html) -- New assembly that houses an existing module. **NO NEW TEXT**  [Current docs](https://docs.openshift.com/container-platform/4.14/windows_containers/wmco_rn/windows-containers-release-notes-9-x-past.html#windows-containers-release-notes-limitations_windows-containers-release-notes-9-x-past).
[Enabling Windows container workloads](https://85025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html) -- Updated link in Additional Resources under Prerequisites.  