### PR TITLE
OSDOCS-11748: adds 4.17.5 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -142,3 +142,12 @@ Issued: 13 November 2024
 {product-title} release 4.17.4 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:8983[RHBA-2024:8983] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:8981[RHSA-2024:8981] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-5-dp_{context}"]
+=== RHBA-2024:9612 - {microshift-short} 4.17.5 bug fix and enhancement update advisory
+
+Issued: 19 November 2024
+
+{product-title} release 4.17.5 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:9612[RHBA-2024:9612] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:9610[RHSA-2024:9610] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11748](https://issues.redhat.com/browse/OSDOCS-11748)

Link to docs preview:
[4-17-5-dp_release-notes](https://85045--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-5-dp_release-notes)

QE review:
- N/A. Stock text is updated. No technical changes