### PR TITLE
OSDOCS-11935: adds bootc updates to greenboot checks

### DIFF
--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -96,7 +96,7 @@ The following table explains {microshift-short} configuration YAML parameters an
 
 |`network.clusterNetwork`
 |IP address block
-|A block of IP addresses from which pod IP addresses are allocated. IPv4 is the default. Dual-stack entries are supported. The first entry in this field is immutable after {microshift-short} starts. Default range is `10.42.0.0/16`.
+|A block of IP addresses from which pod IP addresses are allocated. IPv4 is the default network. Dual-stack entries are supported. The first entry in this field is immutable after {microshift-short} starts. Default range is `10.42.0.0/16`.
 
 |`network.serviceNetwork`
 |IP address block

--- a/modules/microshift-greenboot-testing-workload-script.adoc
+++ b/modules/microshift-greenboot-testing-workload-script.adoc
@@ -9,9 +9,14 @@
 .Prerequisites
 
 * You have root access.
-* You have installed a workload.
-* You have created a health check script for the workload.
-* The {product-title} service is enabled.
+* You installed a workload.
+* You created a health check script for the workload.
+* The {microshift-short} service is enabled.
+
+[NOTE]
+====
+The output of the greenboot workload health check script varies with the host system type. Example outputs are included for your reference.
+====
 
 .Procedure
 
@@ -34,7 +39,7 @@ $ sudo journalctl -o cat -u greenboot-healthcheck.service
 {microshift-short} core service health checks run before the workload health checks.
 ====
 +
-.Example output
+.Example output for a RHEL for Edge system
 [source,terminal]
 ----
 GRUB boot variables:
@@ -42,10 +47,39 @@ boot_success=0
 boot_indeterminate=0
 Greenboot variables:
 GREENBOOT_WATCHDOG_CHECK_ENABLED=true
-...
-...
-FINISHED
-Script '40_microshift_running_check.sh' SUCCESS
-Running Wanted Health Check Scripts...
-Finished greenboot Health Checks Runner.
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+System installation type:
+ostree
+System installation status:
+* rhel 19619bd269094510180c845c44d0944fd9aa15925376f249c4d680a3355e51ae.0
+    Version: 9.4
+    origin refspec: edge:rhel-9.4-microshift-4.18
+----
++
+.Example output for an image mode for RHEL system
+[source,terminal]
+----
+GRUB boot variables:
+boot_success=0
+Greenboot variables:
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+MICROSHIFT_WAIT_TIMEOUT_SEC=600
+System installation type:
+bootc
+System installation status:
+bootcHost
+----
++
+.Example output for an RPM system
+[source,terminal]
+----
+GRUB boot variables:
+boot_success=1
+boot_indeterminate=0
+Greenboot variables:
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+System installation type:
+RPM
+System installation status:
+Not an ostree / bootc system
 ----


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-11935](https://issues.redhat.com/browse/OSDOCS-11935)

Link to docs preview:
[Workload health check scripts](https://85052--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-greenboot-workload-scripts.html#microshift-greenboot-test-workload-health-check-script_microshift-greenboot-workload-scripts)

QE review:
- [x] QE has approved this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
