### PR TITLE
MGMT-19293: Clarifying varlibcontainers label

### DIFF
--- a/edge_computing/image_base_install/ibi-factory-image-based-install.adoc
+++ b/edge_computing/image_base_install/ibi-factory-image-based-install.adoc
@@ -23,11 +23,11 @@ The following are the high-level steps to preinstall a {sno} cluster using an im
 
 include::modules/ibi-create-iso-for-bmh.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install-standalone.adoc#ibi-installer-configuration-config_ibi-edge-image-based-install[Reference specifications for the `image-based-installation-config.yaml` manifest]
-
 include::modules/ibi-provision-install-iso-to-bmh.adoc[leveloffset=+1]
 
 include::modules/ibi-installer-installation-config.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../edge_computing/image_base_install/ibi-preparing-for-image-based-install.adoc#cnf-image-based-upgrade-shared-container-partition_ibi-preparing-image-based-install[Configuring a shared container partition between ostree stateroots]

--- a/modules/ibi-installer-installation-config.adoc
+++ b/modules/ibi-installer-installation-config.adoc
@@ -34,7 +34,13 @@ If the seed image requires a separate private registry authentication, add the a
 |Specification|Type|Description
 |`shutdown`|`boolean`|Specifies if the host shuts down after the installation process completes. The default value is `false`.
 |`extraPartitionStart`|`string`|Specifies the start of the extra partition used for `/var/lib/containers`. The default value is `-40Gb`, which means that the partition will be exactly 40Gb in size and uses the space 40Gb from the end of the disk. If you specify a positive value, the partition will start at that position of the disk and extend to the end of the disk.
-|`extraPartitionLabel`|`string`|The label of the extra partition you use for `/var/lib/containers`. The default label is `varlibcontainers`.
+|`extraPartitionLabel`|`string`|The label of the extra partition you use for `/var/lib/containers`. The default partition label is `varlibcontainers`.
+
+[NOTE]
+====
+You must ensure that the partition label in the installation ISO matches the partition label set in the machine configuration for the seed image. If the partition labels are different, the partition mount fails during installation on the host. For more information, see "Configuring a shared container partition between ostree stateroots".
+====
+
 |`extraPartitionNumber`|`unsigned integer`|The number of the extra partition you use for `/var/lib/containers`. The default number is `5`.
 |`skipDiskCleanup`|`boolean`|The installation process formats the disk on the host. Set this specification to 'true' to skip this step. The default is `false`.
 |`networkConfig`|`string`|Specifies networking configurations for the host, for example:


### PR DESCRIPTION
[MGMT-19293](https://issues.redhat.com//browse/MGMT-19293): Clarifying that the partition label you set in the seed image must be the same as the partition label in any subsequent installation config custom specs.

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/MGMT-19293

Link to docs preview:
https://85062--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi-factory-image-based-install.html#ibi-installer-installation-config_ibi-factory-image-based-install 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

