### PR TITLE
OCPBUGS-44659-RE: Removed note from the Disabling IPsec encryption doc

### DIFF
--- a/modules/nw-ovn-ipsec-disable.adoc
+++ b/modules/nw-ovn-ipsec-disable.adoc
@@ -8,11 +8,6 @@
 
 As a cluster administrator, you can disable IPsec encryption only if you enabled IPsec after cluster installation.
 
-[NOTE]
-====
-If you enabled IPsec when you installed your cluster, you cannot disable IPsec with this procedure.
-====
-
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).


### PR DESCRIPTION
Version(s):
4.12 to 4.14

Issue:
[OCPBUGS-44659](https://issues.redhat.com/browse/OCPBUGS-44659)

Link to docs preview:
[Disabling IPsec encryption](https://85066--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.html#nw-ovn-ipsec-disable_configuring-ipsec-ovn)

- [x] SME has approved this change (Pablo Alonso).
- [x] QE has approved this change (Anurag Saxena).
