### PR TITLE
OCPBUGS-44070: adding instruction to get kubeconfig post-install

### DIFF
--- a/modules/ibi-create-config-iso.adoc
+++ b/modules/ibi-create-config-iso.adoc
@@ -294,7 +294,7 @@ $ oc apply -f ibi-managed.yaml
 
 .Verification
 
-* Check the status of the `ImageClusterInstall` in the hub cluster to monitor the progress of the target host installation by running the following command:
+. Check the status of the `ImageClusterInstall` in the hub cluster to monitor the progress of the target host installation by running the following command:
 +
 [source,terminal]
 ----
@@ -312,3 +312,14 @@ target-0   HostValidationSucceeded   ClusterInstallationSucceeded  ibi-bmh
 ====
 If the `ImageClusterInstall` resource is deleted, the IBI Operator reattaches the `BareMetalHost` resource and reboots the machine.
 ====
+
+. When the installation completes, you can retrieve the `kubeconfig` secret to log in to the managed cluster by running the following command:
++
+[source,terminal]
+----
+$ oc extract secret/<cluster_name>-admin-kubeconfig -n <cluster_namespace>  --to - > <directory>/<cluster_name>-kubeconfig
+----
++
+* `<cluster_name>` is the name of the cluster.
+* `<cluster_namespace>` is the namespace of the cluster.
+* `<directory>` is the directory in which to create the file.


### PR DESCRIPTION
OCPBUGS-44070: adding instruction to get kubeconfig post IBI install from managed cluster

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-44070

Link to docs preview:
https://85070--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install.html#ibi-create-config-iso_ibi-edge-image-based-install 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

