### PR TITLE
OSDOCS#43713: 4.18 Added IPsec enabled node known issue to RNs

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1624,6 +1624,8 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-18-known-issues_{context}"]
 == Known issues
 
+* A regression in the behaviour of `libreswan` caused some nodes with IPsec enabled to lose communication with pods on other nodes in the same cluster. To resolve this issue, consider disabling IPsec for your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-43713[*OCPBUGS-43713*])
+
 [id="ocp-telco-ran-4-18-known-issues_{context}"]
 
 * When you run Cloud-native Network Functions (CNF) latency tests on an {product-title} cluster, the test can sometimes return results greater than the latency threshold for the test; for example, 20 microseconds for `cyclictest` testing. This results in a test failure.


### PR DESCRIPTION
**Note:**  CM WILL BE SENT AFTER SME ACK.

**Note:** In error I used the engineering Jira number to represent the feature branch name. This number will not interfere with engineering PRs. OCPBUGS-44672 is the correct docs Jira for this issue.

Version(s):
4.18

Issue:
[OCPBUGS-44672](https://issues.redhat.com/browse/OCPBUGS-44672)

Link to docs preview:
* [Known issues](https://85072--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-known-issues_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.



