### PR TITLE
OCPBUGS#43715: 4.16 Added IPsec enabled node known issue to RNs

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3224,6 +3224,8 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-16-known-issues_{context}"]
 == Known issues
 
+* A regression in the behaviour of `libreswan` caused some nodes with IPsec enabled to lose communication with pods on other nodes in the same cluster. To resolve this issue, consider disabling IPsec for your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-43715[*OCPBUGS-43715*])
+
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 


### PR DESCRIPTION
**Note:**  CM WILL BE SENT AFTER SME ACK.

**Note:** In error I used the engineering Jira number to represent the feature branch name. This number will not interfere with engineering PRs. OCPBUGS-44672 is the correct docs Jira for this issue.

Version(s):
4.16

Issue:
[OCPBUGS-44672](https://issues.redhat.com/browse/OCPBUGS-44672)

Link to docs preview:
* [Known issues](https://85076--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-known-issues_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.



