### PR TITLE
OCPBUGS#44672: 4.14 Added IPsec enabled node known issue to RNs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2963,6 +2963,8 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-14-known-issues"]
 == Known issues
 
+* A regression in the behaviour of `libreswan` caused some nodes with IPsec enabled to lose communication with pods on other nodes in the same cluster. To resolve this issue, consider disabling IPsec for your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-44672[*OCPBUGS-44672*])
+
 // TODO: This known issue should carry forward to 4.8 and beyond! This needs some SME/QE review before being updated for 4.11. Need to check if KI should be removed or should stay.
 * In {product-title} 4.1, anonymous users could access discovery endpoints. Later releases revoked this access to reduce the possible attack surface for security exploits because some discovery endpoints are forwarded to aggregated API servers. However, unauthenticated access is preserved in upgraded clusters so that existing use cases are not broken.
 +


### PR DESCRIPTION
**Note:**  CM WILL BE SENT AFTER SME ACK.

**Note:** In error I used the engineering Jira number to represent the feature branch name. This number will not interfere with engineering PRs. OCPBUGS-44672 is the correct docs Jira for this issue.

Version(s):
4.14

Issue:
[OCPBUGS-44672](https://issues.redhat.com/browse/OCPBUGS-44672)

Link to docs preview:
* [Known issues](https://85076--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-known-issues_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.



