### PR TITLE
OSSM-8385: Installing multi-primary multi-network mesh

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -51,6 +51,7 @@
 :pipelines-shortname: OpenShift Pipelines
 //Istio
 :istio: Istio
+:istio-latest: 1.24.1
 //Used infrequently
 //ROSA
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS

--- a/install/ossm-multi-cluster-topologies.adoc
+++ b/install/ossm-multi-cluster-topologies.adoc
@@ -12,3 +12,7 @@ include::modules/ossm-about-multi-cluster-mesh-topologies.adoc[leveloffset=+1]
 include::modules/ossm-multi-cluster-configuration-overview.adoc[leveloffset=+1]
 include::modules/ossm-creating-certificates-for-a-multi-cluster-topology.adoc[leveloffset=+2]
 include::modules/ossm-applying-certificates-to-a-multi-cluster-topology.adoc[leveloffset=+2]
+include::modules/ossm-installing-multi-primary-multi-network-mesh.adoc[leveloffset=+1]
+include::modules/ossm-verifying-multi-cluster-topology.adoc[leveloffset=+2]
+include::modules/ossm-removing-multi-cluster-installation-from-development-environment.adoc[leveloffset=+2]
+

--- a/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
@@ -1,0 +1,144 @@
+// This procedure is used in the following assembly:
+// * install/ossm-multi-cluster-topologies.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-installing-multi-primary-multi-network-mesh_{context}"]
+= Installing a multi-primary multi-network mesh 
+
+Install {istio} in the multi-primary multi-network topology on two {ocp-product-title} clusters. 
+
+[NOTE]
+====
+In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster. 
+====
+
+You can adapt these instructions for a mesh spanning more than two clusters.
+
+.Prerequisites
+
+* You have installed the {SMProduct} 3 Operator on all of the clusters that comprise the mesh.
+
+* You have completed "Creating certificates for a multi-cluster mesh". 
+
+* You have completed "Applying certificates to a multi-cluster topology".
+
+* You have created an {istio} Container Network Interface (CNI) resource.
+
+* You have `istioctl` installed on the laptop you can use to run these instructions.
+
+.Procedure
+
+. Create an `ISTIO_VERSION` environment variable that defines the {istio} version to install by running the following command:
++
+[source,terminal]
+----
+$ export ISTIO_VERSION=1.24.1
+----
+
+. Install {istio} on the East cluster:
+
+.. Create an `Istio` resource on the East cluster by running the following command:
++
+[source,terminal]
+----
+$ cat <<EOF | oc --context "${CTX_CLUSTER1}" apply -f -
+apiVersion: sailoperator.io/v1alpha1
+kind: Istio
+metadata:
+  name: default
+spec:
+  version: v${ISTIO_VERSION}
+  namespace: istio-system
+  values:
+    global:
+      meshID: mesh1
+      multiCluster:
+        clusterName: cluster1
+      network: network1
+EOF
+----
+
+.. Wait for the control plane to return the `Ready` status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" wait --for condition=Ready istio/default --timeout=3m
+----
+
+.. Create an East-West gateway on the East cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/east-west-gateway-net1.yaml
+----
+
+.. Expose the services through the gateway by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/expose-services.yaml
+----
+
+. Install {istio} on the West cluster:
+
+.. Create an `Istio` resource on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ cat <<EOF | oc --context "${CTX_CLUSTER2}" apply -f -
+apiVersion: sailoperator.io/v1alpha1
+kind: Istio
+metadata:
+  name: default
+spec:
+  version: v${ISTIO_VERSION}
+  namespace: istio-system
+  values:
+    global:
+      meshID: mesh1
+      multiCluster:
+        clusterName: cluster2
+      network: network2
+EOF
+----
+
+.. Wait for the control plane to return the `Ready` status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER2}" wait --for condition=Ready istio/default --timeout=3m
+----
+
+.. Create an East-West gateway on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER2}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/east-west-gateway-net2.yaml
+----
+
+.. Expose the services through the gateway by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER2}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/expose-services.yaml
+----
+
+. Install a remote secret on the East cluster that provides access to the API server on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ istioctl create-remote-secret \
+  --context="${CTX_CLUSTER2}" \
+  --name=cluster2 | \
+  oc --context="${CTX_CLUSTER1}" apply -f -
+----
+
+. Install a remote secret on the West cluster that provides access to the API server on the East cluster by running the following command:
++
+[source,terminal]
+----
+$ istioctl create-remote-secret \
+  --context="${CTX_CLUSTER1}" \
+  --name=cluster1 | \
+  oc --context="${CTX_CLUSTER2}" apply -f -
+----

--- a/modules/ossm-removing-multi-cluster-installation-from-development-environment.adoc
+++ b/modules/ossm-removing-multi-cluster-installation-from-development-environment.adoc
@@ -1,0 +1,33 @@
+// This procedure is used in the following assembly:
+// * install/ossm-multi-cluster-topologies.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-removing-multi-cluster-installation-from-development-environment_{context}"]
+= Removing a multi-cluster topology from a development environment
+
+After experimenting with the multi-cluster functionality in a development environment, remove the multi-cluster topology from all the clusters. 
+
+[NOTE]
+====
+In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster. 
+====
+
+.Prerequisites
+
+* You have installed a multi-cluster topology. 
+
+.Procedure
+
+. Remove {istio} and the sample applications from the East cluster of the development environment by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" delete istio/default ns/istio-system ns/sample ns/istio-cni
+----
+
+. Remove {istio} and the sample applications from the West cluster of development environment by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" delete istio/default ns/istio-system ns/sample ns/istio-cni
+----

--- a/modules/ossm-verifying-multi-cluster-topology.adoc
+++ b/modules/ossm-verifying-multi-cluster-topology.adoc
@@ -1,0 +1,169 @@
+// This procedure is used in the following assembly:
+// * install/ossm-multi-cluster-topologies.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-verifying-multi-cluster-topology_{context}"]
+= Verifying a multi-cluster topology
+
+Deploy sample applications and verify traffic on a multi-cluster topology on two {ocp-product-title} clusters. 
+
+[NOTE]
+====
+In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster. 
+====
+
+.Prerequisites
+
+* You have installed the {SMProduct} Operator on all of the clusters that comprise the mesh.
+
+* You have completed "Creating certificates for a multi-cluster mesh". 
+
+* You have completed "Applying certificates to a multi-cluster topology".
+
+* You have created an {istio} Container Network Interface (CNI) resource.
+
+* You have `istioctl` installed on the laptop you will use to run these instructions.
+
+* You have installed a multi-cluster topology.
+
+.Procedure
+
+. Deploy sample applications on the East cluster:
+
+.. Create a sample application namespace on the East cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" get project sample || oc --context="${CTX_CLUSTER1}" new-project sample
+----
+
+.. Label the application namespace to support sidecar injection by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" label namespace sample istio-injection=enabled
+----
+
+.. Deploy the `helloworld` application:
+
+... Create the `helloworld` service by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -l service=helloworld -n sample
+----
+
+... Create the `helloworld-v1` deployment by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -l version=v1 -n sample
+----
+
+.. Deploy the `sleep` application by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/sleep/sleep.yaml -n sample
+----
+
+.. Wait for the `helloworld` application on the East cluster to return the `Ready` status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" wait --for condition=available -n sample deployment/helloworld-v1
+----
+
+.. Wait for the `sleep` application on the East cluster to return the `Ready` status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" wait --for condition=available -n sample deployment/sleep
+----
+
+. Deploy the sample applications on the West cluster:
+
+.. Create a sample application namespace on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER2}" get project sample || oc --context="${CTX_CLUSTER2}" new-project sample
+----
+
+.. Label the application namespace to support sidecar injection by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" label namespace sample istio-injection=enabled
+----
+
+.. Deploy the `helloworld` application:
+
+... Create the `helloworld` service by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -l service=helloworld -n sample
+----
+
+... Create the `helloworld-v2` deployment by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -l version=v2 -n sample
+----
+
+.. Deploy the `sleep` application by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/sleep/sleep.yaml -n sample
+----
+
+.. Wait for the `helloworld` application on the West cluster to return the `Ready` status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" wait --for condition=available -n sample deployment/helloworld-v2
+----
+
+.. Wait for the `sleep` application on the West cluster to return the `Ready` status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" wait --for condition=available -n sample deployment/sleep
+----
+
+.Verifying traffic flows between clusters
+
+. For the East cluster, send 10 requests to the `helloworld` service by running the following command:
++
+[source,terminal]
+----
+$ for i in {0..9}; do \
+  oc --context="${CTX_CLUSTER1}" exec -n sample deploy/sleep -c sleep -- curl -sS helloworld.sample:5000/hello; \
+done
+----
++
+Verify that you see responses from both clusters. This means version 1 and version 2 of the service can be seen in the responses. 
+
+. For the West cluster, send 10 requests to the `helloworld` service:
++
+[source,terminal]
+----
+$ for i in {0..9}; do \
+  oc --context="${CTX_CLUSTER2}" exec -n sample deploy/sleep -c sleep -- curl -sS helloworld.sample:5000/hello; \
+done
+----
++
+Verify that you see responses from both clusters. This means version 1 and version 2 of the service can be seen in the responses. 


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OSSM-8385
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://85091--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html#ossm-installing-multi-primary-multi-network-mesh_ossm-multi-cluster-topologies

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
