### PR TITLE
CMA 2.15.1 release notes

### DIFF
--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -10,6 +10,21 @@ The following release notes are for previous versions of the Custom Metrics Auto
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+[id="nodes-pods-autoscaling-custom-rn-2141-467_{context}"]
+== Custom Metrics Autoscaler Operator 2.14.1-467 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.14.1-467 provides a CVE and a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-2024:7348[RHSA-2024:7348].
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2141-467-bugs_{context}"]
+=== Bug fixes
+
+* Previously, the root file system of the Custom Metrics Autoscaler Operator pod was writable, which is unnecessary and could present security issues. This update makes the pod root file system read-only, which addresses the potential security issue. (link:https://issues.redhat.com/browse/OCPBUGS-37989[*OCPBUGS-37989*])
+
 [id="nodes-pods-autoscaling-custom-rn-2141_{context}"]
 == Custom Metrics Autoscaler Operator 2.14.1-454 release notes
 

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -26,38 +26,53 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |{product-title} version
 |General availability
 
-|2.14.1
+|2.15.1
+|4.18
+|General availability
+
+
+|2.15.1
+|4.17
+|General availability
+
+|2.15.1
 |4.16
 |General availability
 
-|2.14.1
+|2.15.1
 |4.15
 |General availability
 
-|2.14.1
+|2.15.1
 |4.14
 |General availability
 
-|2.14.1
+|2.15.1
 |4.13
 |General availability
 
-|2.14.1
+|2.15.1
 |4.12
 |General availability
 |===
 
-[id="nodes-pods-autoscaling-custom-rn-2141-467_{context}"]
-== Custom Metrics Autoscaler Operator 2.14.1-467 release notes
+[id="nodes-pods-autoscaling-custom-rn-2151-4_{context}"]
+== Custom Metrics Autoscaler Operator 2.15.1-4 release notes
 
-This release of the Custom Metrics Autoscaler Operator 2.14.1-467 provides a CVE and a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-2024:7348[RHSA-2024:7348].
+Issued: 31 March 2025
+
+This release of the Custom Metrics Autoscaler Operator 2.15.1-4 addresses Common Vulnerabilities and Exposures (CVEs). The following advisory is available for the Custom Metrics Autoscaler Operator: 
+
+* link:https://access.redhat.com/errata/RHSA-2025:3501[RHSA-2025:3501]
 
 [IMPORTANT]
 ====
 Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
 ====
 
-[id="nodes-pods-autoscaling-custom-rn-2141-467-bugs_{context}"]
-=== Bug fixes
+[id="nodes-pods-autoscaling-custom-rn-2151-4-new-features_{context}"]
+=== New features and enhancements
 
-* Previously, the root file system of the Custom Metrics Autoscaler Operator pod was writable, which is unnecessary and could present security issues. This update makes the pod root file system read-only, which addresses the potential security issue. (link:https://issues.redhat.com/browse/OCPBUGS-37989[*OCPBUGS-37989*])
+[id="nodes-pods-autoscaling-custom-rn-2151-4-new-features-arm_{context}"]
+==== CMA multi-arch builds
+With this version of the Custom Metrics Autoscaler Operator, you can now install and run the Operator on an ARM64 {product-title} cluster.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-12701

Custom Metrics AutoScaler Operator release notes: 
[Supported versions](https://85095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-rn) - Updated the table. 
[Custom Metrics Autoscaler Operator 2.15.1-4 release notes](https://85095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2151-4_nodes-cma-autoscaling-custom-rn) -- New module, all new text. 

Release notes for past releases of the Custom Metrics Autoscaler Operator - [Custom Metrics Autoscaler Operator 2.14.1-467 release notes](https://85095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past#nodes-pods-autoscaling-custom-rn-2141-467_nodes-cma-autoscaling-custom-rn-past) -- Moved the existing module from the release notes assembly to the past releases assembly. **NO NEW TEXT. No need for a proofread review.**  See the [current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator#nodes-pods-autoscaling-custom-rn-2141-467_nodes-cma-autoscaling-custom-rn).
