### PR TITLE
OBSDOCS-1519 - Power monitoring Tech Preview 0.3 release notes

### DIFF
--- a/observability/power_monitoring/power-monitoring-release-notes.adoc
+++ b/observability/power_monitoring/power-monitoring-release-notes.adoc
@@ -15,6 +15,35 @@ These release notes track the development of {PM-title} in the {product-title}.
 
 For an overview of the {PM-operator}, see xref:../power_monitoring/power-monitoring-overview.adoc#power-monitoring-about-power-monitoring_power-monitoring-overview[About {PM-shortname}].
 
+[id="power-monitoring-release-notes-0-3"]
+== {PM-shortname-c} 0.3 (Technology Preview)
+
+This release includes the following version updates:
+
+* {PM-kepler} 0.7.12
+* {PM-operator} 0.15.0
+
+The following advisory is available for {PM-shortname} 0.3:
+
+* link:https://access.redhat.com/errata/RHEA-2024:9961[RHEA-2024:9961]
+
+[id="power-monitoring-bug-fix-0-3-features"]
+=== Bug fixes
+
+* Before this update, the {PM-operator} dashboard used an invalid Prometheus rule, which caused the panel for `OTHER Power Consumption(W) by Pods` to display incorrect data. With this update, the rule is corrected, ensuring the dashboard now shows accurate power consumption data.
+
+[id="power-monitoring-release-notes-0-3-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-37920[CVE-2023-37920]
+* link:https://access.redhat.com/security/cve/CVE-2024-2236[CVE-2024-2236]
+* link:https://access.redhat.com/security/cve/CVE-2024-2511[CVE-2024-2511]
+* link:https://access.redhat.com/security/cve/CVE-2024-3596[CVE-2024-3596]
+* link:https://access.redhat.com/security/cve/CVE-2024-4603[CVE-2024-4603]
+* link:https://access.redhat.com/security/cve/CVE-2024-4741[CVE-2024-4741]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+* link:https://access.redhat.com/security/cve/CVE-2024-34397[CVE-2024-34397]
+
 [id="power-monitoring-release-notes-0-2"]
 == {PM-shortname-c} 0.2 (Technology Preview)
 


### PR DESCRIPTION
Change type: Doc update; Power Monitoring - Tech Preview Release Notes 0.3
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1519

Fix Version: 4.14+

Doc Preview: https://85107--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/power_monitoring/power-monitoring-release-notes.html#power-monitoring-release-notes-0-3

NOTE TO THE REVIEWER: Removed the known issue section, as it is no longer applicable, on QE's request.

SME Review: @sthaha 
QE Review: @vprashar2929 
Peer Review: @bergerhoffer 