### PR TITLE
MGMT-19225: Adding new option install config

### DIFF
--- a/modules/ibi-installer-configuration-config.adoc
+++ b/modules/ibi-installer-configuration-config.adoc
@@ -45,4 +45,12 @@ The name of the interface must match the actual NIC name as shown in the operati
 
 |`releaseRegistry`|`string`| Specifies the container image registry that you used for the release image of the seed cluster. 
 
+|`nodeLabels` |`map[string]string`| Specifies custom node labels for the {sno} node, for example:
+[source,yaml]
+----
+nodeLabels:
+  node-role.kubernetes.io/edge: true
+  environment: production
+----
+
 |====


### PR DESCRIPTION
[MGMT-19225](https://issues.redhat.com//browse/MGMT-19225): Adding new option for install config

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/MGMT-19225

Link to docs preview:
https://85111--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install-standalone.html#ibi-installer-configuration-config_ibi-edge-image-based-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
