### PR TITLE
CNV-45177: Remove ambiguity from a release note

### DIFF
--- a/virt/release_notes/virt-4-16-release-notes.adoc
+++ b/virt/release_notes/virt-4-16-release-notes.adoc
@@ -96,7 +96,7 @@ This release adds new features and enhancements related to the following compone
 === Web console
 
 //CNV-34687 Release note: Generally available (GA) CPU Hotplug
-* Hot plugging virtual machines is now generally available. If a virtual machine cannot be hot plugged, the condition `RestartRequired` is applied to the VM. You can view this condition in the *Diagnostics* tab of the web console.
+* Hot plugging virtual CPUs (vCPUs) into virtual machines is now generally available. If a vCPU cannot be hot plugged, the condition `RestartRequired` is applied to the VM. You can view this condition in the *Diagnostics* tab of the web console.
 
 //CNV-37545 RN: enhancement Specializing a Windows VM flow during VM creation
 * You can now select `sysprep` options when you create a Microsoft Windows VM from an instance type. Previously, you had to set the `sysprep` options by customizing the VM after its creation.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-45177](https://issues.redhat.com/browse/CNV-45177)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* https://85112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-16-release-notes.html#virt-4-16-web_virt-4-16-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The original phrasing of the release note could have been misleading as it did not specify what is being hot-plugged where. This fix removes this ambiguity.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
