### PR TITLE
OSSM 3.0.0TP1: OSSM-8380 Revision Based label set is missing in the Distributed Tracing doc

### DIFF
--- a/modules/ossm-config-otel.adoc
+++ b/modules/ossm-config-otel.adoc
@@ -99,41 +99,51 @@ spec:
 Once you verify that you can see traces, lower the `randomSamplingPercentage` value or set it to `default` to reduce the number of requests.
 ====
 
-. Deploy the `bookinfo` application in `bookinfo` namespace:
+. Create the `bookinfo` namespace by running the following command:
 +
 [source, terminal]
 ----
 $ oc create ns bookinfo
 ----
+
+. Depending on the update strategy you are using, enable sidecar injection in the namespace by running the appropriate commands:
+
+.. If you are using the `InPlace` update strategy, run the following command:
 +
-[source, terminal]
+[source,terminal]
 ----
-$ oc label ns <namespace_name> istio.io/rev= # <1>
+$ oc label namespace curl istio-injection=enabled
 ----
+
+.. If you are using the `RevisionBased` update strategy, run the following commands:
+
+... Display the revision name by running the following command:
++
+[source,terminal]
+----
+$ oc get istiorevisions.sailoperator.io
+----
++
+.Example output
+[source,terminal]
+----
+NAME              TYPE    READY   STATUS    IN USE   VERSION   AGE
+default-v1-23-0   Local   True    Healthy   True     v1.23.0   3m33s
+----
+
+... Label the namespace with the revision name to enable sidecar injection by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace curl istio.io/rev=default-v1-23-0
+----
+
+. Deploy the `bookinfo` application in the `bookinfo` namespace by running the following command:
 +
 [source, terminal]
 ----
 $ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.23/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
 ----
-<1> If you named your Istio resource `default` and are using the `InPlace` upgrade strategy, use `oc label ns bookinfo istio-injection=enabled`.
-+
-[NOTE]
-====
-To find your `<revision-name>`, run the following command:
-
-[source, terminal]
-----
-$ oc get istiorevisions.sailoperator.io
-----
-
-.Sample output:
-
-[source,terminal]
-----
-NAME              TYPE    READY   STATUS    IN USE   VERSION   AGE
-default-v1-23-0   Local   True    Healthy   False    v1.23.0   3m33s
-----
-====
 
 . Generate traffic to the `productpage` pod to generate traces:
 +


### PR DESCRIPTION
**OSSM 3.0 TP1**

[OSSM-8380](https://issues.redhat.com//browse/OSSM-8380) Revision Based label set is missing in the Distributed Tracing doc

**Merge to:** https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick** to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology Preview.

OSSM 3.0 is moving to stand alone format and will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8380

Link to docs preview:
https://85117--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/traces/ossm-distr-tracing-assembly#ossm-config-otel_ossm-traces-assembly

Step 4 has been broken out into sub-steps as user must run different commands depending on the update strategy they chose when they installed OSSM 3.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Reference PR for consistency in phrasing and steps: https://github.com/openshift/openshift-docs/pull/84144

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
