### PR TITLE
OSDOCS-12674-re: Documented the 4.16.23 z-stream notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3336,6 +3336,41 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.23
+[id="ocp-4-16-23_{context}"]
+=== RHSA-2024:9615 - {product-title} {product-version}.23 bug fix
+
+Issued: 20 November 2024
+
+{product-title} release {product-version}.23 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:9615[RHSA-2024:9615] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:9618[RHSA-2024:9618] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.23 --pullspecs
+----
+
+[id="ocp-4-16-23-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when the Cluster Resource Override Operator failed to run its operand controller, the Operator attempted to re-run the controller. Each re-run operation generated a new set of secrets that eventually constrained cluster namespace resources. With this release, the service account for a cluster now includes annotations that prevent the Operator from creating additional secrets when a secret already exists for the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-44351[*OCPBUGS-44351*])
+
+* Previously, when the {vmw-full} vCenter cluster contained an ESXi host that did not have a standard port group defined, and the installation program tried to select that host to import the OVA, the import failed and the error `Invalid Configuration for device 0` was reported. With this release, the installation program verifies whether a standard port group for an ESXi host is defined and, if not, continues until it locates an ESXi host with a defined standard port group, or reports an error message if it fails to locate one, resolving the issue. (link:https://issues.redhat.com/browse/OCPBUGS-38930[*OCPBUGS-38930*])
+
+* Previously, when installing a cluster on {ibm-cloud-name} into an existing VPC, the installation program retrieved an unsupported VPC region. Attempting to install into a supported VPC region that follows the unsupported VPC region alphabetically caused the installation program to crash. With this release, the installation program is updated to ignore any VPC regions that are not fully available during resource lookups. (link:https://issues.redhat.com/browse/OCPBUGS-36290[*OCPBUGS-36290*])
+
+* Previously, when you used the limited live migration method, and a namespace in your cluster included a network policy that allowed communication with the host network, a communication issues existed for nodes in the cluster. More specifically, host network pods on nodes managed by different Container Network Interfaces could not communicate with pods in the namespace. With this release, a fix ensures that you can now use the live migration on a namespace that includes a network policy that allows communication with the host network without experiencing the communication issue. (link:https://issues.redhat.com/browse/OCPBUGS-43344[*OCPBUGS-43344*])
+
+[id="ocp-4-16-23-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
+// 4.16.22 is skipped and issues repromoted to 4.16.23
+
 //4.16.21
 [id="ocp-4-16-21_{context}"]
 === RHBA-2024:8986 - {product-title} {product-version}.21 bug fix
@@ -3371,7 +3406,7 @@ With this release, the installation program is updated to no longer populate val
 [id="ocp-4-16-21-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
 
 // 4.16.20
 [id="ocp-4-16-20_{context}"]
@@ -3400,7 +3435,7 @@ $ oc adm release info 4.16.20 --pullspecs
 [id="ocp-4-16-20-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
 
 // 4.16.19
 [id="ocp-4-16-19_{context}"]
@@ -3435,7 +3470,7 @@ $ oc adm release info 4.16.19 --pullspecs
 [id="ocp-4-16-19-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
 
 // 4.16.18
 [id="ocp-4-16-18_{context}"]
@@ -3479,7 +3514,7 @@ $ oc adm release info 4.16.18 --pullspecs
 [id="ocp-4-16-18-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
 
 // 4.16.17
 [id="ocp-4-16-17_{context}"]
@@ -3516,7 +3551,7 @@ $ oc adm release info 4.16.17 --pullspecs
 [id="ocp-4-16-17-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
 
 // 4.16.16
 [id="ocp-4-16-16_{context}"]
@@ -3553,7 +3588,7 @@ $ oc adm release info 4.16.16 --pullspecs
 [id="ocp-4-16-16-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.16.15
 [id="ocp-4-16-15_{context}"]
@@ -3594,7 +3629,7 @@ $ oc adm release info 4.16.15 --pullspecs
 [id="ocp-4-16-15-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.16.14
 [id="ocp-4-16-14_{context}"]
@@ -3656,7 +3691,7 @@ With this release, you can configure the proxy on the Konnectivity sidecar of th
 [id="ocp-4-16-14-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.16.13
 [id="ocp-4-16-13_{context}"]
@@ -3678,7 +3713,7 @@ $ oc adm release info 4.16.13 --pullspecs
 [id="ocp-4-16-13-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.16.12
 [id="ocp-4-16-12_{context}"]
@@ -3743,7 +3778,7 @@ The following enhancements are included in this z-stream release:
 [id="ocp-4-16-12-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 
 [id="ocp-4-16-11_{context}"]
@@ -3783,7 +3818,7 @@ $ oc adm release info 4.16.11 --pullspecs
 [id="ocp-4-16-11-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.16.10
 [id="ocp-4-16-10_{context}"]
@@ -3824,7 +3859,7 @@ $ oc adm release info 4.16.10 --pullspecs
 [id="ocp-4-16-10-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.16.9
 [id="ocp-4-16-9_{context}"]
@@ -3852,7 +3887,7 @@ $ oc adm release info 4.16.9 --pullspecs
 [id="ocp-4-16-9-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.16.8
 [id="ocp-4-16-8_{context}"]
@@ -3892,7 +3927,7 @@ $ oc adm release info 4.16.8 --pullspecs
 [id="ocp-4-16-8-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-16-7_{context}"]
 === RHSA-2024:5107 - {product-title} {product-version}.7 bug fix and security update
@@ -3946,7 +3981,7 @@ $ oc adm release info 4.16.7 --pullspecs
 [id="ocp-4-16-7-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-16-6_{context}"]
 === RHSA-2024:4965 - {product-title} {product-version}.6 bug fix
@@ -4024,7 +4059,7 @@ metadata:
 [id="ocp-4-16-6-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.16.5
 [id="ocp-4-16-5_{context}"]
@@ -4078,7 +4113,7 @@ With this release, the machine that runs oc-mirror receives an automatic update 
 [id="ocp-4-16-5-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 //4.16.4
 [id="ocp-4-16-4_{context}"]
@@ -4135,7 +4170,7 @@ $ oc adm release info 4.16.4 --pullspecs
 [id="ocp-4-16-4-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 //4.16.3
 [id="ocp-4-16-3_{context}"]
@@ -4194,7 +4229,7 @@ For more information, see _Configuring Capacity Reservation by using machine set
 [id="ocp-4-16-3-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 //4.16.2
 [id="ocp-4-16-2_{context}"]
@@ -4266,7 +4301,7 @@ With this release, stale data is removed from older {product-title} versions and
 [id="ocp-4-16-2-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-16-1_{context}"]
 === RHSA-2024:4156 - {product-title} {product-version}.1 bug fix and security update
@@ -4312,7 +4347,7 @@ $ oc adm release info 4.16.1 --pullspecs
 [id="ocp-4-16-1-updating_{context}"]
 ==== Updating
 
-To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 //Update with relevant advisory information
 [id="ocp-4-16-0-ga_{context}"]


### PR DESCRIPTION
Approvals on https://github.com/openshift/openshift-docs/pull/85019


Version(s):
4.16

Issue:
[OSDOCS-12674](https://issues.redhat.com/browse/OSDOCS-12674)

Link to docs preview:
* [4.16.23](https://85122--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-23_release-notes)


