### PR TITLE
[enterprise-4.17] OSDOCS-12650: adding back docs to BM IPI postinstall config doc

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -8,12 +8,20 @@ toc::[]
 
 After successfully deploying an installer-provisioned cluster, consider the following postinstallation procedures.
 
+// Configuring NTP for disconnected clusters
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+1]
 
+// Enabling a provisioning network after installation
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
 
 // Creating a manifest object that includes a customized `br-ex` bridge
 include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+
+// Services for a user-managed load balancer
+include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
+
+// Configuring a user-managed load balancer
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
 
 // Using the Bare Metal Operator
 include::modules/bmo-config-using-bare-metal-operator.adoc[leveloffset=+1]

--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 
 // Bare metal
-// * installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+// * installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+// * installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
 // OpenStack
 // * networking/load-balancing-openstack.adoc
 // Nutanix

--- a/modules/nw-osp-services-external-load-balancer.adoc
+++ b/modules/nw-osp-services-external-load-balancer.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 
 // Bare metal
-// * installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+// * installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+// * installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
 // OpenStack
 // * networking/load-balancing-openstack.adoc
 // Nutanix


### PR DESCRIPTION
Manual CP of https://github.com/openshift/openshift-docs/pull/84830

https://github.com/openshift/openshift-docs/commit/06c98febba79cf5d923462a53377930d8139bb4e