### PR TITLE
OSDOCS-12642 RODOO 1.0.2 Release Notes OCP 4.14

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -14,6 +14,20 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
+[id="run-once-duration-override-operator-release-notes-1-0-2"]
+== {run-once-operator} 1.0.2
+
+Issued: 26 November 2024
+
+The following advisory is available for the {run-once-operator} 1.0.2:
+
+* link:https://access.redhat.com/errata/RHEA-2024:9999[RHEA-2024:9999]
+
+[id="run-once-duration-override-operator-1.0.2-bug-fixes"]
+=== Bug fixes
+
+* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
 [id="run-once-duration-override-operator-release-notes-1-0-1"]
 == {run-once-operator} 1.0.1
 


### PR DESCRIPTION
Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-12642](https://issues.redhat.com/browse/OSDOCS-12642)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview:](https://85162--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#run-once-duration-override-operator-release-notes-1-0-2)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory link will not work until November 26th.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
