### PR TITLE
OSDOCS#12676: Update z-stream release notes for 4.14.41 

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3390,6 +3390,33 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.41
+[id="ocp-4-14-41_{context}"]
+=== RHSA-2024:9620 - {product-title} 4.14.41 bug fix and security update
+
+Issued: 20 November 2024
+
+{product-title} release 4.14.41, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:9620[RHSA-2024:9620] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:9623[RHSA-2024:9623] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.41 --pullspecs
+----
+
+[id="ocp-4-14-41-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the Machine Config Operator (MCO) on the vSphere `resolv-prepender` script used systemd directives that were not compatible with old boot image versions of {product-title} 4. With this release, {product-title} nodes are compatible with old boot images with one of the following solutions: scaling with a boot image 4.13 or later by using manual intervention, or upgrading to a release with this fix. (link:https://issues.redhat.com/browse/OCPBUGS-42111[*OCPBUGS-42111*])
+
+[id="ocp-4-14-41-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.40
 [id="ocp-4-14-40_{context}"]
 === RHSA-2024:8697 - {product-title} 4.14.40 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-1276](https://issues.redhat.com//browse/OSDOCS-12676)

Link to docs preview:
[4.14.41](https://85166--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-41_release-notes)

QE review:
- [ ] QE has approved this change.
n/a

Additional information:
The errata URLs will return 404 until the go-live date of 11/20/24.
