### PR TITLE
OSDOCS#12500: Release notes for descheduler 5.0.2

### DIFF
--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -12,6 +12,32 @@ These release notes track the development of the {descheduler-operator}.
 
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
 
+[id="descheduler-operator-release-notes-5.0.2"]
+== Release notes for {descheduler-operator} 5.0.2
+
+Issued: 2 December 2024
+
+The following advisory is available for the {descheduler-operator} 5.0.2:
+
+* link:https://access.redhat.com/errata/RHSA-2024:8704[RHSA-2024:8704]
+
+// TODO: Anything to list?
+// [id="descheduler-operator-5.0.2-notable-changes"]
+// === New features and enhancements
+//
+// * TODO
+
+[id="descheduler-operator-5.0.2-bug-fixes"]
+=== Bug fixes
+
+* This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+// No known issues to list
+// [id="descheduler-operator-5.0.2-known-issues"]
+// === Known issues
+//
+// * TODO
+
 [id="descheduler-operator-release-notes-5.0.1"]
 == Release notes for {descheduler-operator} 5.0.1
 
@@ -29,6 +55,8 @@ The following advisory is available for the {descheduler-operator} 5.0.1:
 --
 include::snippets/fips-snippet.adoc[]
 --
+
+* This release of the {descheduler-operator} updates the Kubernetes version to 1.29.
 
 [id="descheduler-operator-5.0.1-bug-fixes"]
 === Bug fixes


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15 and 4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-12500

Link to docs preview:
https://85173--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-release-notes.html#descheduler-operator-release-notes-5.0.2

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Advisory link won't work until release date, currently scheduled for 2 December.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
