### PR TITLE
[RHACS] Reworded "Manual Upgrade Required" on clusters page

### DIFF
--- a/modules/automatic-upgrade-status.adoc
+++ b/modules/automatic-upgrade-status.adoc
@@ -21,9 +21,8 @@ The *Clusters* view lists all clusters and their upgrade statuses.
 |The previous automatic upgrade failed.
 //TODO: Add link to automatic upgrade failure module
 
-|Manual upgrade required
-|The Sensor and Collector version is older than version 2.5.29.0. You must manually upgrade your secured clusters.
-//TODO: Add link to the upgrade topic.
+|Secured cluster version is not managed by {product-title-short}.
+|External tools such as Helm or the Operator control the secured cluster version. You can upgrade the secured cluster using external tools.
 
 |Pre-flight checks complete
 |The upgrade is in progress. Before performing automatic upgrade, the upgrade installer runs a pre-flight check. During the pre-flight check, the installer verifies if certain conditions are satisfied and then only starts the upgrade process.


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-26646

Based on the changes in https://github.com/stackrox/stackrox/pull/12833

Cherrypick in `rhacs-docs-4.6`