### PR TITLE
oc mirror delete command is incorrect in 4.17 OCP doc.

### DIFF
--- a/modules/oc-mirror-procedure-delete-v2.adoc
+++ b/modules/oc-mirror-procedure-delete-v2.adoc
@@ -30,7 +30,7 @@ Where:
 +
 [source,terminal]
 ----
-$ oc mirror delete --v2 --delete-yaml-file <previously_mirrored_work_folder>/delete/delete-images.yaml docker:/ <remote_registry>
+$ oc mirror delete --v2 --delete-yaml-file <previously_mirrored_work_folder>/working-dir/delete/delete-images.yaml docker://<remote_registry>
 ----
 Where:
 - `<previously_mirrored_work_folder>`: Specify your previously mirrored work folder.


### PR DESCRIPTION
oc mirror delete command is incorrect.

Current:
~~~
$ oc mirror delete --v2 --delete-yaml-file <previously_mirrored_work_folder>/delete/delete-images.yaml docker:/ <remote_registry>
 ~~~

Expected:
~~~
$ oc mirror delete --v2 --delete-yaml-file <previously_mirrored_work_folder>/working-dir/delete/delete-images.yaml docker://<remote_registry> 
~~~

Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OCPBUGS-44781

Link to docs preview:
https://docs.openshift.com/container-platform/4.17/disconnected/mirroring/about-installing-oc-mirror-v2.html#oc-mirror-procedure-delete-v2_about-installing-oc-mirror-v2
