### PR TITLE
OADP-5246: Slight update to OADP / ROSA documentation

### DIFF
--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -11,7 +11,17 @@ AWS Security Token Service (AWS STS) is a global web service that provides short
 
 [IMPORTANT]
 ====
-Restic and Kopia are not supported in the OADP on ROSA with {aws-short} {sts-short} environment. Verify that the Restic and Kopia node agent is disabled.
+Restic is unsupported.
+
+Kopia file system backup (FSB) is supported when backing up file systems that do not have Container Storage Interface (CSI) snapshotting support.
+
+Example file systems include the following:
+
+* Amazon Elastic File System (EFS)
+* Network File System (NFS)
+* `emptyDir` volumes
+* Local volumes
+
 For backing up volumes, OADP on ROSA with {aws-short} {sts-short} supports only native snapshots and Container Storage Interface (CSI) snapshots.
 
 In an Amazon ROSA cluster that uses STS authentication, restoring backed-up data in a different {aws-short} region is not supported.


### PR DESCRIPTION
### JIRA

* [OADP-5246](https://issues.redhat.com/browse/OADP-5246)

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
 * OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18

### Link to docs preview:

* [Installing the OADP Operator and providing the IAM role](https://85241--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html#installing-oadp-rosa-sts_oadp-rosa-backing-up-applications)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
