### PR TITLE
OSSM-8388: Add conceptual information for egress gateway

### DIFF
--- a/modules/ossm-about-directing-egress-traffic-through-a-gateway.adoc
+++ b/modules/ossm-about-directing-egress-traffic-through-a-gateway.adoc
@@ -5,4 +5,8 @@
 [id="ossm-about-directing-egress-traffic-through-a-gateway_{context}"]
 = About directing egress traffic through a gateway
 
-You can configure a gateway to define exit points from a mesh. This allows you to apply {istio} features, such as monitoring and route rules, to the traffic exiting the mesh.
+You can configure a gateway installed using gateway injection as an exit point for the traffic leaving a service mesh. In this configuration, the gateway acts as a forward proxy for requests sent to the services that are external to the mesh. 
+
+Configuring a gateway for egress traffic can help fulfill security requirements. For example, an egress gateway can be used in environments where traffic restrictions require that all traffic exiting a mesh flows through a dedicated set of nodes. Similarly, a gateway can be used when network policies prevent application nodes from directly accessing external services. In such scenarios, gateway proxies are deployed on dedicated egress nodes capable of accessing external services. These nodes can then be subjected to strict network policy enforcement or additional monitoring to enhance security.
+
+To configure a gateway installed using gateway injection to direct the egress traffic, use a combination of the {istio} `ServiceEntry`, `Gateway`, `VirtualService`, and `DestinationRule` resources. Use the `ServiceEntry` resource to define the properties of an external service. The external service is added to the {istio} service registry for the mesh. This enables you to apply {istio} features, such as monitoring and routing rules, to the traffic exiting the mesh that is destined for an external service. Use the `Gateway`, `VirtualService`, and `DestinationRule` resources to set up rules that route traffic from the mesh to the external service using the gateway proxy.


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue:
https://issues.redhat.com/browse/OSSM-8388

Link to docs preview:
https://85246--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/gateways/ossm-directing-outbound-traffic.html#ossm-about-directing-egress-traffic-through-a-gateway_ossm-directing-outbound-traffic-through-a-gateway

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
