### PR TITLE
OSSM-8215 [DOC] Document using multiple control planes on a single cluster

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -36,6 +36,8 @@ Topics:
   File: ossm-cert-manager-assembly
 - Name: Multi-Cluster topologies
   File: ossm-multi-cluster-topologies
+- Name: Deploying multiple service meshes on a single cluster
+  File: ossm-deploying-multiple-service-meshes-on-single-cluster
 ---
 Name: Updating
 Dir: update

--- a/install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
+++ b/install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
@@ -1,0 +1,47 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ossm-deploying-multiple-service-meshes-on-single-cluster_{context}"]
+= Deploying multiple service meshes on a single cluster
+include::_attributes/common-attributes.adoc[]
+:context: ossm-deploying-multiple-service-meshes-on-single-cluster
+
+toc::[]
+
+You can use the {SMProductName} to operate multiple service meshes in a single cluster, with each mesh managed by a separate control plane. Using discovery selectors and revisions prevents conflicts between control planes.
+
+[id="prerqs-ossm-deploying-multiple-control-planes_{context}"]
+== Prerequisites
+* You have installed the {SMProduct} operator.
+* You have created an {istio} Container Network Interface (CNI) resource.
++
+[NOTE]
+====
+You can run the following command to check for existing `{istio}` instances:
+[source,terminal]
+----
+$ oc get istios
+----
+====
+
+* You have installed the `istioctl` binary on your localhost.
+
+include::modules/ossm-about-deploying-multiple-control-planes.adoc[leveloffset=+1]
+include::modules/ossm-multiple-control-planes-single-cluster.adoc[leveloffset=+1]
+
+[id="ossm-deploying-multiple-control-planes_{context}"]
+== Deploying multiple control planes
+
+You can have extended support for more than two control planes. The maximum number of service meshes in a single cluster depends on the available cluster resources.
+
+include::modules/ossm-deploying-first-control-plane.adoc[leveloffset=+2]
+
+include::modules/ossm-deploying-second-control-plane.adoc[leveloffset=+2]
+
+include::modules/ossm-verifying-multiple-control-planes.adoc[leveloffset=+2]
+
+include::modules/ossm-deploy-application-workloads-in-each-mesh.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources-ossm-deploying-multiple-service-meshes-on-single-cluster"]
+== Additional resources
+
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-about-discoveryselectors_ossm-scoping-service-mesh-with-discoveryselectors[Discovery selectors]

--- a/modules/ossm-about-deploying-multiple-control-planes.adoc
+++ b/modules/ossm-about-deploying-multiple-control-planes.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-about-deploying-multiple-control-planes_{context}"]
+= About deploying multiple control planes
+
+To configure a cluster to host two control planes, set up separate {istio} resources with unique names in independent {istio} system namespaces. Assign a unique revision name to each {istio} resource to identify the control planes, workloads, or namespaces it manages. Apply these revision names using injection or `istio.io/rev` labels to specify which control plane injects the sidecar proxy into application pods.
+
+Each `{istio}` resource must also configure discovery selectors to specify which namespaces the {istio} control plane observes. Only namespaces with labels that match the configured discovery selectors can join the mesh. Additionally, discovery selectors determine which control plane creates the `istio-ca-root-cert` config map in each namespace, which is used to encrypt traffic between services with mutual TLS within each mesh.
+
+When adding an additional {istio} control plane to a cluster with an existing control plane, ensure that the existing `{istio}` instance has discovery selectors configured to avoid overlapping with the new control plane.
+
+[NOTE]
+====
+Only one `IstioCNI` resource is shared by all control planes in a cluster, and you must update this resource independent of other cluster resources.
+====

--- a/modules/ossm-deploy-application-workloads-in-each-mesh.adoc
+++ b/modules/ossm-deploy-application-workloads-in-each-mesh.adoc
@@ -1,0 +1,186 @@
+// Module included in the following assemblies:
+// install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-deploy-application-workloads-in-each-mesh_{context}"]
+= Deploy application workloads in each mesh
+
+To deploy application workloads, assign each workload to a separate namespace.
+
+.Procedure
+
+. Create an application namespace called `app-ns-1` by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace app-ns-1
+----
+
+. To ensure that the namespace is discovered by the first control plane, add the `istio-discovery=mesh-1` label by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace app-ns-1 istio-discovery=mesh-1
+----
+
+. To enable sidecar injection into all the pods by default while ensuring that pods in this namespace are mapped to the first control plane, add the `istio.io/rev=mesh-1` label to the namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace app-ns-1 istio.io/rev=mesh-1
+----
+
+. Optional: You can verify the `mesh-1` revision name by running the following command:
++
+[source,terminal]
+----
+$ oc get istiorevisions
+----
+
+. Deploy the `sleep` and `httpbin` applications by running the following command:
++
+[source,terminal]
+----
+$ oc apply -n app-ns-1 \
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/sleep/sleep.yaml \
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/httpbin/httpbin.yaml
+----
+
+. Wait for the `httpbin` and `sleep` pods to run with sidecars injected by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n app-ns-1
+----
++
+.Example output
+[source,terminal]
+----
+NAME                       READY   STATUS    RESTARTS   AGE
+httpbin-7f56dc944b-kpw2x   2/2     Running   0          2m26s
+sleep-5577c64d7c-b5wd2     2/2     Running   0          91m
+----
+
+. Create a second applicatiom namespace called `app-ns-2` by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace app-ns-2
+----
+
+. Create a third application namespace called `app-ns-3` by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace app-ns-3
+----
+
+. Add the label `istio-discovery=mesh-2` to both namespaces and the revision label `mesh-2` to match the discovery selector of the second control plane by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace app-ns-2 app-ns-3 istio-discovery=mesh-2 istio.io/rev=mesh-2
+----
+
+. Deploy the `sleep` and `httbin` applications to the `app-ns-2` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc apply -n app-ns-2 \
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/sleep/sleep.yaml \
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/httpbin/httpbin.yaml
+----
+
+. Deploy the `sleep` and `httbin` applications to the `app-ns-3` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc apply -n app-ns-3 \
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/sleep/sleep.yaml \
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/httpbin/httpbin.yaml
+----
+
+. Optional: Use the following command to wait for a deployment to be available:
++
+[source,terminal]
+----
+$ oc wait deployments -n app-ns-2 --all --for condition=Available
+----
+
+.Verification
+
+. Verify that each application workload is managed by its assigned control plane by using the `istioctl ps` command after deploying the applications:
+
+.. Verify that the workloads are assigned to the control plane in `istio-system-1` by running the following command:
++
+[source,terminal]
+----
+$ istioctl ps -i istio-system-1
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                  CLUSTER        CDS              LDS              EDS              RDS              ECDS        ISTIOD                            VERSION
+httpbin-7f56dc944b-vwfm5.app-ns-1     Kubernetes     SYNCED (11m)     SYNCED (11m)     SYNCED (11m)     SYNCED (11m)     IGNORED     istiod-mesh-1-b69646b6f-kxrwk     1.23.0
+sleep-5577c64d7c-d675f.app-ns-1       Kubernetes     SYNCED (11m)     SYNCED (11m)     SYNCED (11m)     SYNCED (11m)     IGNORED     istiod-mesh-1-b69646b6f-kxrwk     1.23.0
+----
+
+.. Verify that the workloads are assigned to the control plane in `istio-system-2` by running the following command:
++
+[source,terminal]
+----
+$ istioctl ps -i istio-system-2
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                  CLUSTER        CDS                LDS                EDS                RDS                ECDS        ISTIOD                            VERSION
+httpbin-7f56dc944b-54gjs.app-ns-3     Kubernetes     SYNCED (3m59s)     SYNCED (3m59s)     SYNCED (3m59s)     SYNCED (3m59s)     IGNORED     istiod-mesh-2-8666fdfc6-mqp45     1.23.0
+httpbin-7f56dc944b-gnh72.app-ns-2     Kubernetes     SYNCED (4m1s)      SYNCED (4m1s)      SYNCED (3m59s)     SYNCED (4m1s)      IGNORED     istiod-mesh-2-8666fdfc6-mqp45     1.23.0
+sleep-5577c64d7c-k9mxz.app-ns-2       Kubernetes     SYNCED (4m1s)      SYNCED (4m1s)      SYNCED (3m59s)     SYNCED (4m1s)      IGNORED     istiod-mesh-2-8666fdfc6-mqp45     1.23.0
+sleep-5577c64d7c-m9hvm.app-ns-3       Kubernetes     SYNCED (4m1s)      SYNCED (4m1s)      SYNCED (3m59s)     SYNCED (4m1s)      IGNORED     istiod-mesh-2-8666fdfc6-mqp45     1.23.0
+----
+
+. Verify that the application connectivity is restricted to workloads within their respective mesh:
+
+.. Send a request from the `sleep` pod in `app-ns-1` to the `httpbin` service in `app-ns-2` to check that the communication fails by running the following command:
++
+[source,terminal]
+----
+$ oc -n app-ns-1 exec deploy/sleep -c sleep -- curl -sIL http://httpbin.app-ns-2.svc.cluster.local:8000
+----
++
+The `PeerAuthentication` resources created earlier enforce mutual TLS (mTLS) traffic in `STRICT` mode within each mesh. Each mesh uses its own root certificate, managed by the `istio-ca-root-cert` config map, which prevents communication between meshes. The output indicates a communication failure, similar to the following example:
++
+.Example output
+[source,terminal]
+----
+HTTP/1.1 503 Service Unavailable
+content-length: 95
+content-type: text/plain
+date: Wed, 16 Oct 2024 12:05:37 GMT
+server: envoy
+----
+
+.. Confirm that the communication works by sending a request from the `sleep` pod to the `httpbin` service that are present in the `app-ns-2` namespace which is managed by `mesh-2`. Run the following command:
++
+[source,terminal]
+----
+$ oc -n app-ns-2 exec deploy/sleep -c sleep -- curl -sIL http://httpbin.app-ns-3.svc.cluster.local:8000
+----
++
+.Example output
+[source,terminal]
+----
+HTTP/1.1 200 OK
+access-control-allow-credentials: true
+access-control-allow-origin: *
+content-security-policy: default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' camo.githubusercontent.com
+content-type: text/html; charset=utf-8
+date: Wed, 16 Oct 2024 12:06:30 GMT
+x-envoy-upstream-service-time: 8
+server: envoy
+transfer-encoding: chunked
+----

--- a/modules/ossm-deploying-first-control-plane.adoc
+++ b/modules/ossm-deploying-first-control-plane.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+// install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-deploying-first-control-plane_{context}"]
+= Deploying the first control plane
+
+You deploy the first control plane by creating its assigned namespace.
+
+.Procedure
+
+. Create the namespace for the first {istio} control plane called `istio-system-1` by running the following command:
++
+[source,terminal]
+----
+$ oc new-project istio-system-1
+----
+
+. Add the following label to the first namespace, which is used with the {istio} `discoverySelectors` field by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace istio-system-1 istio-discovery=mesh-1
+----
+
+. Create a YAML file named `istio-1.yaml` with the name `mesh-1` and the `discoverySelector` as `mesh-1`:
++
+.Example configuration
+[source,yaml,subs="attributes,verbatim"]
+----
+kind: Istio
+apiVersion: sailoperator.io/v1alpha1
+metadata:
+  name: mesh-1
+spec:
+  namespace: istio-system-1
+  values:
+    meshConfig:
+      discoverySelectors:
+        - matchLabels:
+            istio-discovery: mesh-1
+# ...
+----
+
+. Create the first `{istio}` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f istio-1.yaml
+----
+
+. To restrict workloads in `mesh-1` from communicating freely with decrypted traffic between meshes, deploy a `PeerAuthentication` resource to enforce mutual TLS (mTLS) traffic within the `mesh-1` data plane. Apply the `PeerAuthentication` resource in the `istio-system-1` namespace by using a configuration file, such as `peer-auth-1.yaml`:
++
+[source,terminal]
+----
+$ oc apply -f peer-auth-1.yaml
+----
++
+.Example configuration
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: "mesh-1-peerauth"
+  namespace: "istio-system-1"
+spec:
+  mtls:
+    mode: STRICT
+----

--- a/modules/ossm-deploying-second-control-plane.adoc
+++ b/modules/ossm-deploying-second-control-plane.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+// install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-deploying-second-control-plane_{context}"]
+= Deploying the second control plane
+
+After deploying the first control plane, you can deploy the second control plane by creating its assigned namespace.
+
+.Procedure
+
+. Create a namespace for the second {istio} control plane called `istio-system-2` by running the following command:
++
+[source,terminal]
+----
+$ oc new-project istio-system-2
+----
+
+. Add the following label to the second namespace, which is used with the {istio} `discoverySelectors` field by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace istio-system-2 istio-discovery=mesh-2
+----
+
+. Create a YAML file named `istio-2.yaml`:
++
+.Example configuration
+[source,yaml,subs="attributes,verbatim"]
+----
+kind: Istio
+apiVersion: sailoperator.io/v1alpha1
+metadata:
+  name: mesh-2
+spec:
+  namespace: istio-system-2
+  values:
+    meshConfig:
+      discoverySelectors:
+        - matchLabels:
+            istio-discovery: mesh-2
+# ...
+----
+
+. Create the second `{istio}` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f istio-2.yaml
+----
+
+. Deploy a policy for workloads in the `istio-system-2` namespace to only accept mutual TLS traffic `peer-auth-2.yaml` by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f peer-auth-2.yaml
+----
++
+.Example configuration
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: security.istio.io/v1
+kind: PeerAuthentication
+metadata:
+  name: "mesh-2-peerauth"
+  namespace: "istio-system-2"
+spec:
+  mtls:
+    mode: STRICT
+----

--- a/modules/ossm-multiple-control-planes-single-cluster.adoc
+++ b/modules/ossm-multiple-control-planes-single-cluster.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+// install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-multiple-control-planes-single-cluster_{context}"]
+= Using multiple control planes on a single cluster
+
+You can use discovery selectors to limit the visibility of an {istio} control plane to specific namespaces in a cluster. By combining discovery selectors with control plane revisions, you can deploy multiple control planes in a single cluster, ensuring that each control plane manages only its assigned namespaces. This approach avoids conflicts between control planes and enables soft multi-tenancy for service meshes.

--- a/modules/ossm-verifying-multiple-control-planes.adoc
+++ b/modules/ossm-verifying-multiple-control-planes.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+// install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-verifying-multiple-control-planes_{context}"]
+= Verifying multiple control planes
+
+Verify that both of the {istio} control planes are deployed and running properly. You can validate that the `istiod` pod is successfully running in each {istio} system namespace.
+
+. Verify that the workloads are assigned to the control plane in `istio-system-1` by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n istio-system-1
+----
++
+.Example output
+[source,terminal]
+----
+NAME                            READY   STATUS    RESTARTS   AGE
+istiod-mesh-1-b69646b6f-kxrwk   1/1     Running   0          4m14s
+----
+
+. Verify that the workloads are assigned to the control plane in `istio-system-2` by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n istio-system-2
+----
++
+.Example output
+[source,terminal]
+----
+NAME                            READY   STATUS    RESTARTS   AGE
+istiod-mesh-2-8666fdfc6-mqp45   1/1     Running   0          118s
+----


### PR DESCRIPTION
Change type: Doc update; Document using multiple control planes on a single cluster

Doc JIRA: https://issues.redhat.com/browse/OSSM-8215

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)

Doc Preview: https://85272--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-deploying-multiple-service-meshes-on-single-cluster.html

SME/QE Review: @longmuir @pbajjuri20 @luksa 
Peer Review: @maxwelldb @dfitzmau 