### PR TITLE
TELCODOCS-2113 - PTP events subscription status codes

### DIFF
--- a/modules/cnf-fast-event-notifications-api-reference-v2.adoc
+++ b/modules/cnf-fast-event-notifications-api-reference-v2.adoc
@@ -65,7 +65,7 @@ Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code 
 === Description
 
 Creates a new subscription for the required event by passing the appropriate payload.
-If a subscription is successfully created, or if it already exists, a `201 Created` status code is returned.
+
 You can subscribe to the following PTP events:
 
 * `sync-state` events
@@ -139,6 +139,27 @@ You can subscribe to the following PTP events:
     "UriLocation": "http://ptp-event-publisher-service-compute-1.openshift-ptp.svc.cluster.local:9043/api/ocloudNotifications/v2/subscriptions/620283f3-26cd-4a6d-b80a-bdc4b614a96a"
 }
 ----
+
+The following subscription status events are possible:
+
+.PTP events REST API v2 subscription status codes
+[cols="1,2", width="90%", options="header"]
+|====
+|Status code
+|Description
+
+|`201 Created`
+|Indicates that the subscription is created
+
+|`400 Bad Request`
+|Indicates that the server could not process the request because it was malformed or invalid
+
+|`404 Not Found`
+|Indicates that the subscription resource is not available
+
+|`409 Conflict`
+|Indicates that the subscription already exists
+|====
 
 [discrete]
 === HTTP method


### PR DESCRIPTION
Updating PTP events subscription status codes

Version(s):
enterprise-4.16+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2113

Link to docs preview:
https://85273--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/ptp-events-rest-api-reference-v2.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->