### PR TITLE
OSDOCS-12732: Documented the 4.17.6 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2857,13 +2857,67 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.17.6
+[id="ocp-4-17-6_{context}"]
+=== RHBA-2024:10137 - {product-title} {product-version}.6 bug fix, and security update advisory
+
+Issued: 26 November 2024
+
+{product-title} release {product-version}.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:10137[RHBA-2024:10137] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10140[RHBA-2024:10140] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.6 --pullspecs
+----
+
+[id="ocp-4-17-6-enhancements_{context}"]
+==== Enhancements
+
+[id="ocp-4-17-6-kubernetes-1-30-6_{context}"]
+===== Updating to Kubernetes version 1.30.6
+
+{product-title} release {product-version}.6 contains the changes that come from the update to Kubernetes version 1.30.6. (link:https://issues.redhat.com/browse/OCPBUGS-44512[*OCPBUGS-44512*])
+
+[id="ocp-4-17-6-bug-fixes_{context}"]
+==== Bug fixes
+
+//OCPBUGS-44760 Need to confirm with SME.
+
+* Previously, if you set custom annotations in a custom resource (CR), the SR-IOV Operator would override all the default annotations in the `SriovNetwork` CR. With this release, when you define custom annotations in a CR, the SR-IOV Operator does not override the default annotations. (link:https://issues.redhat.com/browse/OCPBUGS-42252[*OCPBUGS-42252*])
+
+* Previously, in the Red{nbsp}Hat {product-title} web console *Notifications* section, silenced alerts were visible in the notification drawer because the alerts did not include external labels. With this release, the alerts include external labels so that silenced alerts are not visible on the notification drawer. (link:https://issues.redhat.com/browse/OCPBUGS-44722[*OCPBUGS-44722*])
+
+* Previously, when you clicked the `start lastrun` option in the Red{nbsp}Hat {product-title} web console *Edit BuildConfig* page, an error prevented the `lastrun` operation from running. With this release, a fix ensures that `start lastrun` option runs as expected. (link:https://issues.redhat.com/browse/OCPBUGS-44587[*OCPBUGS-44587*])
+
+* Previously, {product-title} {product-version} introduced collapsing and expanding the *Getting started* section on the *Administrator perspective* of the Red{nbsp}Hat {product-title} web console. When you either collapsed or expanded the section, you could not close the section. With this release, a fix ensures that you can now close the *Getting started* section. (link:https://issues.redhat.com/browse/OCPBUGS-44586[*OCPBUGS-44586*])
+
+* Previously, the `MachineConfig` tab on the *Details* page of the Red{nbsp}Hat {product-title} web console displayed an error when one or more `spec.config.storage.files` did not include data fields that were marked as optional. With this update, a fix ensures that this error no longer displays if you populated no values in the optional fields. (link:https://issues.redhat.com/browse/OCPBUGS-44479[*OCPBUGS-44479*])
+
+* Previously, a {hcp-capital} cluster that used the {ibm-name} platform was unable to accept authenticatation from an `oc login` command. This behavior caused an error for the web broswer where the browser could not fetch the token from the cluster. With this release, a fix ensures that cloud-based endpoints do not get proxied so that authentication by using the `oc login` command works as expected. (link:https://issues.redhat.com/browse/OCPBUGS-44276[*OCPBUGS-44276*])
+
+* Previously, if the `RendezvousIP` matched a substring in the `next-hop-address` field of a compute node configuration, a validation error. The `RendezvousIP` must match only a control plane host address. With this release, a substring comparison for `RendezvousIP` is used only against a control plane host address, so that the error no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-44261[*OCPBUGS-44261*])
+
+* Previously, when you created load balancers for a cluster that you wanted to install on {ibm-power-name} and the creation of the load balancers timed out, the installation of the cluster failed and did not report the error. The cluster failed because both internal and external DNS load balancer names were not created. With this release, if internal and external DNS load balancer names do not exist during cluster installation, the installation program outputs an error so that you have an opportunity to add the names so that the cluster installation process can continue. (link:https://issues.redhat.com/browse/OCPBUGS-44247[*OCPBUGS-44247*])
+
+* Previously, when you attempted to run a disk cleanup operation on a physical storage device that used thin provisioning, the cleanup operation failed. With this release, a bug fix now ensures that you can run a disk cleanup operation on a physical storage device without the cleanup operation failing. (link:https://issues.redhat.com/browse/OCPBUGS-31570[*OCPBUGS-31570*])
+
+* Previously, if the {olm-first} was unable to access the secret associated with a service account, {olm} would rely on the Kubernetes API server to automatically create a bearer token. With this release, Kubernetes versions 1.22 and later do not automatically create the bearer token. Instead, {olm} now uses the `TokenRequest` API to request a new Kubernetes API token. (link:https://issues.redhat.com/browse/OCPBUGS-44760[*OCPBUGS-44760*])
+
+[id="ocp-4-17-6-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.17.5
 [id="ocp-4-17-5_{context}"]
 === RHSA-2024:9610 - {product-title} {product-version}.5 bug fix, and security update advisory
 
 Issued: 19 November 2024
 
-{product-title} release {product-version}.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:9610[RHSA-2024:9610] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:9613[RRHSA-2024:9613] advisory.
+{product-title} release {product-version}.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:9610[RHSA-2024:9610] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:9613[RHSA-2024:9613] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12732](https://issues.redhat.com/browse/OSDOCS-12732)

Link to docs preview:
* [4.17.6](https://85277--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-6_release-notes)

