### PR TITLE
RHDEVDOCS-6238: [DOC] Import jib-maven task

### DIFF
--- a/modules/op-resolver-cluster-tasks-ref.adoc
+++ b/modules/op-resolver-cluster-tasks-ref.adoc
@@ -258,6 +258,65 @@ spec:
 * The `gitInitImage` parameter was removed.
 
 [discrete]
+[id="op-taskref-jib-maven_{context}"]
+== jib-maven
+
+The `jib-maven` task builds Java, Kotlin, Groovy, and Scala sources into a container image by using the Jib tool for Maven projects. The Jib tool then pushes the image to the specified registry and provides an image digest for reference.
+
+.Example usage of the `jib-maven` task
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: build-and-deploy
+spec:
+# ...
+  tasks:
+# ...
+  - name: build-from-source
+    taskRef:
+      resolver: cluster
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: jib-maven
+      - name: namespace
+        value: openshift-pipelines
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+# ...
+----
+
+.Supported parameters for the `jib-maven` task
+[cols="1,2,1,1",options="header"]
+|===
+| Parameter | Description | Type | Default value
+|`IMAGE` | The fully qualified name of the image to build. |`string` |
+|`DIRECTORY` | The directory that contains the app, relative to the source repository root. |`string` | `.`
+|`INSECUREREGISTRY` | Allow an insecure registry. |`string` | `"false"`
+|`CACERTFILE` | CA certification file name for insecure registry service. |`string` | `service-ca.crt`
+|===
+
+.Supported workspaces for the `jib-maven` task
+[cols="1,3",options="header"]
+|===
+| Workspace | Description
+|`source` |The workspace that contains the Maven project.
+|`sslcertdirt` |The optional workspace that contains SSL certificates.
+|`dockerconfig` |The optional workspace that contains the `docker` configuration.
+|===
+
+.Results that the `jib-maven` task returns
+[cols="1,1,2",options="header"]
+|===
+| Result | Type | Description
+|`IMAGE_DIGEST` |`string` |Digest of the image that was built.
+|===
+
+[discrete]
 [id="op-taskref-kn_{context}"]
 == kn
 


### PR DESCRIPTION
Version(s): `pipelines-docs-1.17`

Issue: [RHDEVDOCS-62138](https://issues.redhat.com/browse/RHDEVDOCS-6283)

Link to docs preview:  https://85280--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/remote-pipelines-tasks-resolvers.html#op-taskref-jib-maven_remote-pipelines-tasks-resolvers

QE review:
- [ ] QE has approved this change.

**Additional information:**