### PR TITLE
HCIDOCS-549: Add iLO6 to our supported hardware

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -17,6 +17,7 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 [cols="1,1,1",options="header"]
 |====
 | Model | Management | Firmware versions
+| 11th Generation | iLO6 | 1.57 or later
 | 10th Generation | iLO5 | 2.63 or later
 
 |====


### PR DESCRIPTION
**Fixes:** [HCIDOCS-549](https://issues.redhat.com/browse/HCIDOCS-549)

**For:** OCP 4.16, 4.17, 4.18

[**Preview**](https://85304--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites)

**Approvals -** `/lgtm`:
- [x] SME
- [x] QE
- [x] Peer Review