### PR TITLE
OSDOCS-12743: added product compliance link to docs

### DIFF
--- a/security/compliance_operator/co-overview.adoc
+++ b/security/compliance_operator/co-overview.adoc
@@ -18,7 +18,7 @@ remediations, but actual compliance is your responsibility. You are required to
 work with an authorized auditor to achieve compliance with a standard. For the
 latest updates, see the
 xref:../../security/compliance_operator/compliance-operator-release-notes.adoc#compliance-operator-release-notes[Compliance
-Operator release notes]
+Operator release notes]. For more information on compliance support for all Red{nbsp}Hat products, see link:https://access.redhat.com/compliance[Product Compliance].
 
 [discrete]
 ==== Compliance Operator concepts

--- a/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
+++ b/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
@@ -17,6 +17,8 @@ Joint Authorization Board (JAB), or other industry recognized regulatory
 authority to assess your environment. You are required to work with an
 authorized auditor to achieve compliance with a standard.
 
+For more information on compliance support for all Red{nbsp}Hat products, see link:https://access.redhat.com/compliance[Product Compliance].
+
 
 [IMPORTANT]
 ====

--- a/security/compliance_operator/co-support.adoc
+++ b/security/compliance_operator/co-support.adoc
@@ -21,3 +21,4 @@ include::modules/compliance-must-gather.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[About the must-gather tool]
+* link:https://access.redhat.com/compliance[Product Compliance]

--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -15,6 +15,8 @@ For an overview of the Compliance Operator, see xref:../../security/compliance_o
 
 To access the latest release, see xref:../../security/compliance_operator/co-management/compliance-operator-updating.adoc#olm-preparing-upgrade_compliance-operator-updating[Updating the Compliance Operator].
 
+For more information on compliance support for all Red{nbsp}Hat products, see link:https://access.redhat.com/compliance[Product Compliance].
+
 [id="compliance-operator-release-notes-1-6-0_{context}"]
 == OpenShift Compliance Operator 1.6.0
 


### PR DESCRIPTION
Version(s):
4.12+ (except 4.13)

Issue:
https://issues.redhat.com/browse/OSDOCS-12743

Link to docs preview:
[85308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html](https://85308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html)
[85308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-overview.html](https://85308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-overview.html)
[85308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-supported-profiles.html](https://85308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-supported-profiles.html)
[85308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-support.html](https://85308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-support.html)

Additional information:
QE review not needed as this does not change the meaning of the docs.
