### PR TITLE
OSDOCS#12731: Update the compatibility matrix section for the OPP user guide

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -38,27 +38,27 @@
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
 // These variable are the current product release versions for the OPP products
-:ocp-supported-version: 4.16
-:rhacs-version: 4.5
-:quay-version: 3.12
-:rhacm-version: 2.11
-:odf-version: 4.16
+:ocp-supported-version: 4.17
+:rhacs-version: 4.6
+:quay-version: 3.13
+:rhacm-version: 2.12
+:odf-version: 4.17
 // These variables are for the immediate past 4 OPP product versions that are in the compatibility table
-:ocp-supported-version-1: 4.15
-:rhacs-version-1: 4.4
-:quay-version-1: 3.11
-:rhacm-version-1: 2.10
-:odf-version-1: 4.15
-:ocp-supported-version-2: 4.14
-:rhacs-version-2: 4.3
-:quay-version-2: 3.10
-:rhacm-version-2: 2.9
-:odf-version-2: 4.14
-:ocp-supported-version-3: 4.13
-:rhacs-version-3: 4.0
-:quay-version-3: 3.8
-:rhacm-version-3: 2.8
-:odf-version-3: 4.12
+:ocp-supported-version-1: 4.16
+:rhacs-version-1: 4.5
+:quay-version-1: 3.12
+:rhacm-version-1: 2.11
+:odf-version-1: 4.16
+:ocp-supported-version-2: 4.15
+:rhacs-version-2: 4.4
+:quay-version-2: 3.11
+:rhacm-version-2: 2.10
+:odf-version-2: 4.15
+:ocp-supported-version-3: 4.14
+:rhacs-version-3: 4.3
+:quay-version-3: 3.10
+:rhacm-version-3: 2.9
+:odf-version-3: 4.14
 :ocp-supported-version-4: 4.12
 :rhacs-version-4: 3.7.4
 :quay-version-4: 3.8

--- a/modules/opp-architecture-compatibility-matrix.adoc
+++ b/modules/opp-architecture-compatibility-matrix.adoc
@@ -6,7 +6,12 @@
 [id="opp-architecture-compatibility-matrix_{context}"]
 = {product-title} product release compatibility matrix
 
-{product-title} is based on {ocp} {ocp-supported-version}. To find the verified release number for each {product-title} product, see the following information:
+{product-title} product releases are based on the latest verified {ocp} release. The verified release number for each {product-title} product is listed in this section. See link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] for detailed information about additional supported versions. 
+
+[NOTE]
+====
+This table is updated after each product release is tested and verified with the latest {ocp} release. Use the versions in the matrix for the optimal performance.
+====
 
 [cols="1,1,1,1,1"]
 |===


### PR DESCRIPTION
Version(s):
This PR is based on the ‘opp-docs-main’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Issue:
[OSDOCS-12731](https://issues.redhat.com/browse/OSDOCS-12731)

Link to docs preview:
[Compatibility matrix](https://85309--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture.html#opp-architecture-compatibility-matrix_opp-architecture)

QE review:
- [x] QE has approved this change.

Additional information:
The product versions that are listed might not be the latest available version for the product. The versions listed in the compatibility matrix are the latest verified versions for OPP.
