### PR TITLE
Updating the capabilities set table for 4.18

### DIFF
--- a/snippets/capabilities-table.adoc
+++ b/snippets/capabilities-table.adoc
@@ -28,6 +28,12 @@ The following table describes the `baselineCapabilitySet` values.
 |`v4.16`
 |Specify this option when you want to enable the default capabilities for {product-title} 4.16. By specifying `v4.16`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.16 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, `CloudCredential`, `DeploymentConfig`, and `CloudControllerManager`.
 
+|`v4.17`
+|Specify this option when you want to enable the default capabilities for {product-title} 4.17. By specifying `v4.17`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.17 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, `CloudCredential`, `DeploymentConfig`, and `CloudControllerManager`.
+
+|`v4.18`
+|Specify this option when you want to enable the default capabilities for {product-title} 4.18. By specifying `v4.18`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.18 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `OperatorLifecycleManagerV1`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, `CloudCredential`, `DeploymentConfig`, and `CloudControllerManager`.
+
 |`None`
 |Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via `additionalEnabledCapabilities`.
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
N/A

Link to docs preview:
https://85310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
