### PR TITLE
OADP-5261: Update the OADP introduction to include entire cluster backup unsupported

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-intro.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-intro.adoc
@@ -9,10 +9,13 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-The {oadp-first} product safeguards customer applications on {product-title}. It offers comprehensive disaster recovery protection, covering {product-title} applications, application-related cluster resources, persistent volumes, and internal images. OADP is also capable of backing up both containerized applications and virtual machines (VMs).
+The {oadp-first} product safeguards customer applications on {product-title}. It offers comprehensive disaster recovery protection, covering {product-title} applications, application-related cluster resources, persistent volumes, and internal images. {oadp-short} is also capable of backing up both containerized applications and virtual machines (VMs).
 
-However, OADP does not serve as a disaster recovery solution for xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[etcd] or OpenShift Operators.
+However, {oadp-short} does not serve as a disaster recovery solution for xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[etcd] or {OCP-short} Operators.
 
+{oadp-short} support is provided to customer workload namespaces, and cluster scope resources.
+
+Full cluster xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[backup] and xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#restoring-applications[restore] are not supported.
 
 [id="oadp-apis_{context}"]
 == {oadp-full} APIs
@@ -34,4 +37,3 @@ include::modules/oadp-operator-supported.adoc[leveloffset=+2]
 
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
 // once finished re-work come back and add doc links to the APIs
-


### PR DESCRIPTION
### JIRA

* [https://issues.redhat.com/browse/OADP-5261](https://issues.redhat.com/browse/OADP-5261)

### VERSIONS

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18

### Link to docs preview:

* [Introduction to OpenShift API for Data Protection](https://85311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-intro.html)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
