### PR TITLE
In oc-mirror v2, the targetCatalogSourceTemplate example template for CatalogSource requires update

### DIFF
--- a/modules/oc-mirror-imageset-config-parameters-v2.adoc
+++ b/modules/oc-mirror-imageset-config-parameters-v2.adoc
@@ -181,7 +181,7 @@ Example: `/tmp/catalog-source_template.yaml`
 Example of a template file: 
 [source,yaml]
 ----
-apiVersion: operators.coreos.com/v2alpha1
+apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: discarded
@@ -190,8 +190,8 @@ spec:
   image: discarded
   sourceType: grpc
   updateStrategy:
-registryPoll:
-interval: 30m0s
+    registryPoll:
+      interval: 30m0s
 ----
 
 |`mirror.operators.targetTag`


### PR DESCRIPTION
In oc-mirror v2, the targetCatalogSourceTemplate example template for CatalogSource requires update the API version and proper indentation . 

Current:

~~~
apiVersion: operators.coreos.com/v2alpha1
kind: CatalogSource
metadata:
  name: discarded
  namespace: openshift-marketplace
spec:
  image: discarded
  sourceType: grpc
  updateStrategy:
registryPoll:
interval: 30m0s
~~~

Expected:

~~~
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: discarded
  namespace: openshift-marketplace
spec:
  image: discarded
  sourceType: grpc
  updateStrategy:
    registryPoll:
      interval: 30m0s
~~~

Version(s):
4.18, 4.17, 4.16

Issue:
https://issues.redhat.com/browse/OCPBUGS-44878

Link to docs preview:
https://85314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/about-installing-oc-mirror-v2.html