### PR TITLE
OSDOCS#12733: Update z-stream release notes for 4.15.39

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2775,6 +2775,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.15.39
+[id="ocp-4-15-39_{context}"]
+=== RHSA-2024:10142 - {product-title} 4.15.39 bug fix and security update
+
+Issued: 26 November 2024
+
+{product-title} release 4.15.39, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10142[RHSA-2024:10142] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10145[RHSA-2024:10145] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.39 --pullspecs
+----
+
+[id="ocp-4-15-39-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the approval process for a certificate signing request (CSR) failed because the node name and internal DNS entry for a CSR did not match the case-sensitive check. With this release, an update to the approval process for CSRs avoids the case-sensitive check and a CSR with a matching node name and internal DNS entry does not fail the matching-pair check. (link:https://issues.redhat.com/browse/OCPBUGS-44705[*OCPBUGS-44705*])
+
+* Previously, when the Cluster Resource Override Operator was unable to completely deploy its operand controller, the Operator would restart the process. Each time the Operator attempted the deployment process, the Operator created a new set of secrets. This resulted in a large number of secrets created in the namespace where the Cluster Resource Override Operator was deployed. With this release, the fixed version correctly processes the service account annotations and only one set of secrets is created. (link:https://issues.redhat.com/browse/OCPBUGS-44378[*OCPBUGS-44378*])
+
+* Previously, when the Cluster Version Operator (CVO) pod restarted while it was initializing the synchronization work, the Operator interrupted the guard of the blocked upgrade request. The blocked request was unexpectedly accepted. With this release, the guard of the blocked upgrade request continues after the CVO restarts. (link:https://issues.redhat.com/browse/OCPBUGS-44328[*OCPBUGS-44328*])
+
+* Previously, enabling Encapsulated Security Payload (ESP) hardware offload by using IPSec on attached interfaces in Open vSwitch (OVS) interrupted connectivity because of a bug in OVS. With this release, {product-title} automatically disables ESP hardware offload on the OVS-attached interfaces so that the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-44240[*OCPBUGS-44240*])
+
+[id="ocp-4-15-39-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 //4.15.38
 [id="ocp-4-15-38_{context}"]
 === RHSA-2024:8991 - {product-title} 4.15.38 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12733](https://issues.redhat.com/browse/OSDOCS-12733)

Link to docs preview:
[4.15.39](https://85359--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-39_release-notes)

QE review:
- [ ] QE has approved this change.
n/a

Additional information:
The errata URLs will return 404 until the go-live date of 11/26/24.
