### PR TITLE
Fixed the new docs experience URL for ACS docs

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -59,17 +59,18 @@
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
     <ol class="breadcrumb hide-for-print">
-      <% 
+      <%
         unsupported = (unsupported_versions.include?(version) ||
                       unsupported_versions_acs.include?(version) ||
                       unsupported_versions_builds.include?(version) ||
                       unsupported_versions_gitops.include?(version) ||
                       unsupported_versions_origin.include?(version)
                       unsupported_versions_pipelines.include?(version) ||
-                      unsupported_versions_serverless.include?(version)
+                      unsupported_versions_serverless.include?(version) ||
+                      version == "4.18"
                       );
 
-        if (!["openshift-webscale", "openshift-dpu", "openshift-lightspeed", "openshift-service-mesh", "openshift-origin"].include?(distro_key) || unsupported)
+        if (!["openshift-webscale", "openshift-dpu", "openshift-lightspeed", "openshift-service-mesh", "openshift-origin", "openshift-acs"].include?(distro_key) || unsupported)
       %>
       <span>
         <div class="alert alert-info" role="primary" id="support-info">
@@ -100,6 +101,14 @@
           <strong>OpenShift Service Mesh 3.0 is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. This documentation is a work in progress and might not be complete or fully tested.</strong>.
         </div>
       </span>
+      <% end %>
+
+      <% if (distro_key == "openshift-acs") %>
+        <span>
+          <div class="alert alert-info" role="primary" id="support-info">
+            <strong>OpenShift docs are moving and will soon only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>, the home of all Red Hat product documentation. Explore the <a href="https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/latest" style="color: #0C5460 !important" class="link-primary">new docs experience</a> today.</strong>
+          </div>
+        </span>
       <% end %>
 
       <% if (version == "4.18") && (distro_key != "openshift-webscale" && distro_key != "openshift-dpu" && distro_key != "rosa-hcp") %>


### PR DESCRIPTION
For RHACS docs, the current URL points to https://docs.redhat.com/en/documentation/openshift_container_platform/latest instead of https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/latest. This PR fixes the issue.