### PR TITLE
CNV-51829: added missing prereq in postinstall config section

### DIFF
--- a/modules/virt-enabling-load-balancer-service-web.adoc
+++ b/modules/virt-enabling-load-balancer-service-web.adoc
@@ -13,6 +13,7 @@ You can enable the creation of load balancer services for a virtual machine (VM)
 
 * You have configured a load balancer for the cluster.
 * You are logged in as a user with the `cluster-admin` role.
+* You created a network attachment definition for the network.
 
 .Procedure
 

--- a/modules/virt-selecting-migration-network-ui.adoc
+++ b/modules/virt-selecting-migration-network-ui.adoc
@@ -12,6 +12,7 @@ You can select a dedicated network for live migration by using the {product-titl
 .Prerequisites
 
 * You configured a Multus network for live migration.
+* You created a network attachment definition for the network.
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
Main, 4.14, 4.15, 4.16, 4.17, 4.18

Issue: [CNV-51829](https://issues.redhat.com/browse/CNV-51829)

Link to docs preview:
[Selecting a dedicated network by using the web console](https://85365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config.html#virt-selecting-migration-network-ui_virt-post-install-network-config)
[Selecting a dedicated network by using the web console](https://85365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-dedicated-network-live-migration.html#virt-selecting-migration-network-ui_virt-dedicated-network-live-migration)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->