### PR TITLE
TELCODOCS#2092: Configuring metadatasize for the thin pool

### DIFF
--- a/modules/lvms-about-lvmcluster-cr.adoc
+++ b/modules/lvms-about-lvmcluster-cr.adoc
@@ -140,7 +140,7 @@ For more information, see "Overview of chunk size".
 
 |`thinPoolConfig.chunkSizeCalculationPolicy`
 |`string`
-|Specifies the policy to calculate the chunk size for the underlying volume group. You can set this field to either `Static` or `Host`. By default, this field is set to `Static`. 
+|Specifies the policy to calculate the chunk size for the underlying volume group. You can set this field to either `Static` or `Host`. By default, this field is set to `Static`.
 
 If this field is set to `Static`, the chunk size is set to the value of the `chunkSize` field. If the `chunkSize` field is not configured, chunk size is set to 128 KiB.
 
@@ -148,8 +148,19 @@ If this field is set to `Host`, the chunk size is calculated based on the config
 
 For more information, see "Limitations to configure the size of the devices used in LVM Storage".
 
+|`thinPoolConfig.metadataSize`
+|`integer`
+|Specifies the metadata size for the thin pool. You can configure this field only when the `MetadataSizeCalculationPolicy` field is set to `Static`. 
+
+If this field is not configured, and the `MetadataSizeCalculationPolicy` field is set to `Static`, the default metadata size is set to 1 GiB. 
+
+The value for this field must be configured in the range of 2 MiB to 16 GiB due to the underlying limitations of `lvm2`. You can only increase the value of this field during updates.
+
+|`thinPoolConfig.metadataSizeCalculationPolicy`
+|`string`
+|Specifies the policy to calculate the metadata size for the underlying volume group. You can set this field to either `Static` or `Host`. By default, this field is set to `Host`.
+
+If this field is set to `Static`, the metadata size is calculated based on the value of the `thinPoolConfig.metadataSize` field. 
+
+If this field is set to `Host`, the metadata size is calculated based on the `lvm2` settings. 
 |====
-
-
-
-

--- a/snippets/lvms-creating-lvmcluster.adoc
+++ b/snippets/lvms-creating-lvmcluster.adoc
@@ -39,5 +39,7 @@ spec:
         overprovisionRatio: 10 
         chunkSize: 128Ki <1>
         chunkSizeCalculationPolicy: Static <1>
+        metadataSize: 1Gi <1>
+        metadataSizeCalculationPolicy: Host <1>
 ----
 <1> Optional field


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2092](https://issues.redhat.com/browse/TELCODOCS-2092)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [About the LVMCluster custom resource](https://85366--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#about-lvmcluster_logical-volume-manager-storage)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->