### PR TITLE
TELCODOCS#2091: Release note for editing the over-provisioning ratio

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -457,6 +457,11 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-release-notes-storage_{context}"]
 === Storage
 
+[id="ocp-4-17-storage-editing-overprovisioning-ratio"]
+==== Editing the over-provisioning ratio after creating the LVMCluster custom resource
+
+Previously, the `thinPoolConfig.overprovisionRatio` field in the `LVMCluster` custom resource (CR) could only be configured during the creation of the `LVMCluster` CR. With this release, you can now update the `thinPoolConfig.overprovisionRatio` field even after creating the `LVMCluster` CR.
+
 [id="ocp-release-notes-web-console_{context}"]
 === Web console
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2091](https://issues.redhat.com/browse/TELCODOCS-2091)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Storage](https://85368--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-storage_release-notes) (New features and enhancements)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->