### PR TITLE
OCPBUGS#44420: Added a warning about the change in disk ordering behavior

### DIFF
--- a/modules/lvms-about-adding-devices-to-a-vg.adoc
+++ b/modules/lvms-about-adding-devices-to-a-vg.adoc
@@ -10,6 +10,15 @@ The `deviceSelector` field in the `LVMCluster` CR contains the configuration to 
 
 You can specify the device paths in the `deviceSelector.paths` field, the `deviceSelector.optionalPaths` field, or both. If you do not specify the device paths in both the `deviceSelector.paths` field and the `deviceSelector.optionalPaths` field, {lvms} adds the supported unused devices to the volume group (VG). 
 
+[WARNING]
+====
+It is recommended to avoid referencing disks using symbolic naming, such as `/dev/sdX`, as these names may change across reboots within RHCOS. Instead, you must use stable naming schemes, such as `/dev/disk/by-path/` or `/dev/disk/by-id/`, to ensure consistent disk identification.
+
+With this change, you might need to adjust existing automation workflows in the cases where monitoring collects information about the install device for each node.
+
+For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_file_systems/assembly_overview-of-persistent-naming-attributes_managing-file-systems[{op-system-base} documentation].
+====
+
 You can add the path to the Redundant Array of Independent Disks (RAID) arrays in the `deviceSelector` field to integrate the RAID arrays with {lvms}. You can create the RAID array by using the `mdadm` utility. {lvms} does not support creating a software RAID.
 
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-44420](https://issues.redhat.com/browse/OCPBUGS-44420)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [About adding devices to a volume group](https://85369--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#about-adding-devices-to-a-vg_logical-volume-manager-storage)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->