### PR TITLE
TELCODOCS#1864: Test and validate telco features on AMD CPUs (Genoa and Bergamo)

### DIFF
--- a/modules/telco-core-ref-eng-usecase-model.adoc
+++ b/modules/telco-core-ref-eng-usecase-model.adoc
@@ -9,8 +9,13 @@
 The following engineering considerations are relevant for the telco core common use model.
 
 Worker nodes::
-* Worker nodes should run on Intel 3rd Generation Xeon (IceLake) processors or newer.
+* Worker nodes should run on either of the following CPUs:
+
+** Intel 3rd Generation Xeon (Ice Lake) 2.20 GHz CPUs or newer
+** AMD EPYC Zen 4 CPUs (Genoa, Bergamo, or newer)
 +
+The AMD EPYC Zen 4 CPUs (Genoa, Bergamo, or newer) are fully supported. However, the power consumption evaluations are ongoing. It is recommended to evaluate features, such as per pod power management, to determine any potential impact.
+
 [NOTE]
 ====
 Alternatively, if your worker nodes have Skylake or earlier processors, you must disable the mitigations for silicon security vulnerabilities such as Spectre.

--- a/modules/telco-ran-node-tuning-operator.adoc
+++ b/modules/telco-ran-node-tuning-operator.adoc
@@ -20,7 +20,17 @@ The RAN DU use case requires the cluster to be tuned for low-latency performance
 Limits and requirements::
 The Node Tuning Operator uses the `PerformanceProfile` CR to configure the cluster. You need to configure the following settings in the RAN DU profile `PerformanceProfile` CR:
 
-* Select reserved and isolated cores and ensure that you allocate at least 4 hyperthreads (equivalent to 2 cores) on Intel 3rd Generation Xeon (Ice Lake) 2.20 GHz CPUs or better with firmware tuned for maximum performance.
+* Select reserved and isolated cores and ensure that you allocate at least 4 hyperthreads (equivalent to 2 cores) on either of the following CPUs with firmware tuned for maximum performance:
+
+** Intel 3rd Generation Xeon (Ice Lake) 2.20 GHz CPUs or newer
+** AMD EPYC Zen 4 CPUs (Genoa, Bergamo, or newer)
++
+[NOTE]
+====
+The AMD EPYC Zen 4 CPUs (Genoa, Bergamo, or newer) are fully supported. However, the power consumption evaluations are ongoing. It is recommended to evaluate features, such as per pod power management, to determine any potential impact.
+====
+
+// Should we provide a full list of features that are impacted by this update? Or is there a generic way to refer to these features in the above note?
 
 * Set the reserved `cpuset` to include both hyperthread siblings for each included core.
 Unreserved cores are available as allocatable CPU for scheduling workloads.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
- [TELCODOCS-1864](https://issues.redhat.com/browse/TELCODOCS-1864)
- [TELCODOCS-1865](https://issues.redhat.com/browse/TELCODOCS-1865)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Node Tuning Operator](https://85373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.html#telco-ran-node-tuning-operator_ran-ref-design-components)
- [Telco core RDS engineering considerations](https://85373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/core/telco-core-rds-use-cases#telco-core-ref-eng-usecase-model_ran-core-design-overview)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->