### PR TITLE
OSODCS-12175-1: adds 4.16.24 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -351,3 +351,12 @@ Issued: 20 November 2024
 {product-title} release 4.16.23 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:9617[RHBA-2024:9617] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:9615[RHSA-2024:9615] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-24-dp_{context}"]
+=== RHSA-2024:10149 - {microshift-short} 4.16.24 security and bug fix advisory
+
+Issued: 26 November 2024
+
+{product-title} release 4.16.24 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHSA-2024:10149[RHSA-2024:10149] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10147[RHSA-2024:10147] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12175](https://issues.redhat.com/browse/OSDOCS-12175)

Link to docs preview:
[microshift-4-16-24-dp_release-notes](https://85380--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-24-dp_release-notes)

QE review:
- N/A

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
