### PR TITLE
OSDOCS-12160: adds 4.15.39 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -496,3 +496,12 @@ Issued: 13 November 2024
 The {product-title} release 4.15.38 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8993[RHBA-2024:8993] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8991[RHSA-2024:8991] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-39-dp_{context}"]
+=== RHBA-2024:10144 - {microshift-short} 4.15.39 bug fix advisory
+
+Issued: 26 November 2024
+
+The {product-title} release 4.15.39 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10144[RHBA-2024:10144] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10142[RHSA-2024:10142] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12160](https://issues.redhat.com/browse/OSDOCS-12160)

Link to docs preview:
[microshift-4-15-39-dp_release-notes](https://85381--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-39-dp_release-notes)

QE review:
- N/A

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
