### PR TITLE
PR for SRVCOM-3431: Add release notes entries in Serverless version 1.34.1

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-34-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-34-0.adoc[leveloffset=+1]
 
 // OCP + OSD + ROSA

--- a/modules/serverless-rn-1-34-1.adoc
+++ b/modules/serverless-rn-1-34-1.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-34-1_{context}"]
+= Red Hat {ServerlessProductName} 1.34.1
+
+{ServerlessProductName} 1.34.1 is now available. This release of {ServerlessProductName} addresses identified Common Vulnerabilities and Exposures (CVEs). Fixed issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="fixed-issues-1-34-1_{context}"]
+== Fixed issues
+
+* Previously, requests to Knative Services with slow back-end responses could fail due to the default OpenShift Route timeout being too short. This issue has been addressed by making the `haproxy.router.openshift.io/timeout` setting configurable for automatically created routes.
++
+You can now adjust the timeout by setting the `ROUTE_HAPROXY_TIMEOUT` environment variable in the {ServerlessOperatorName} `Subscription` configuration as follows:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  ...
+spec:
+  channel: stable
+  config:
+    env:
+      - name: ROUTE_HAPROXY_TIMEOUT
+        value: '900'
+----
+
+* Previously, long-running requests to Knative Services could be prematurely terminated if the Activator component was scaled down by using the `HorizontalPodAutoscaler` field. This issue has been resolved. The `terminationGracePeriodSeconds` field for the Activator is now automatically aligned with the `max-revision-timeout-seconds` setting configured for Knative revisions.


### PR DESCRIPTION
**Affecting version:** 
`serverless-docs-1.34`
`serverless-docs-1.35`

**Tracking JIRAs:** https://issues.redhat.com/browse/SRVCOM-3431

**Doc previews:** [Red Hat OpenShift Serverless 1.34.1](https://85382--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-34-1_serverless-release-notes)