### PR TITLE
[RHACS][Docs][4.5 and later] ROX-26762: Adding exposure analysis option

### DIFF
--- a/modules/roxctl-netpol-connectivity-map.adoc
+++ b/modules/roxctl-netpol-connectivity-map.adoc
@@ -21,6 +21,9 @@ $ roxctl netpol connectivity map <folder_path> [flags] <1>
 |===
 |Option |Description
 
+|`--exposure`             
+|Enhance the analysis of permitted connectivity by using exposure analysis. The default value is `false`.
+
 |`--fail`
 |Fail on the first encountered error. The default value is `false`.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.5+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-26762
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://85383--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/command-reference/roxctl-netpol.html#roxctl-netpol-connectivity-map_roxctl-netpol
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Merge into `rhacs-docs-main` and cherry-pick to:
    - `rhacs-docs-4.6`
    - `rhacs-docs-4.5` 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
