### PR TITLE
TELCODOCS-2015: Adding tables that break down the network flow by platform

### DIFF
--- a/modules/network-flow-matrix.adoc
+++ b/modules/network-flow-matrix.adoc
@@ -6,26 +6,100 @@
 [id="network-flow-matrix_{context}"]
 = {product-title} network flow matrix
 
-The network flow matrix describes the ingress flows to {product-title} services.
-The network information in the matrix is accurate for both bare-metal and cloud environments.
-Use the information in the network flow matrix to help you manage ingress traffic.
-You can restrict ingress traffic to essential flows to improve network security.
+The following network flow matrixes describe the ingress flows to {product-title} services for the following environments:
 
-To view or download the raw CSV content, see link:https://raw.githubusercontent.com/openshift/openshift-docs/main/snippets/network-flow-matrix.csv[this resource].
+* {product-title} on bare metal 
+* {sno-caps} on bare metal
+* {product-title} on {aws-first}
+* {sno-caps} on {aws-short}
 
-Additionally, consider the following dynamic port ranges when managing ingress traffic:
+Use the information in the appropriate network flow matrix to help you manage ingress traffic for your specific environment. You can restrict ingress traffic to essential flows to improve network security.
+
+Additionally, consider the following dynamic port ranges when managing ingress traffic for both bare metal and cloud environments:
 
 * `9000-9999`: Host level services
 * `30000-32767`: Kubernetes node ports
 * `49152-65535`: Dynamic or private ports
 
+To view or download the complete raw CSV content for an environment, see the following resources:
+
+* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/bm.csv[{product-title} on bare metal]
+
+* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/bm-sno.csv[{sno-caps} on bare metal]
+
+* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/aws.csv[{product-title} on {aws-short}]
+
+* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/aws-sno.csv[{sno-caps} on {aws-short}]
+
 [NOTE]
 ====
-The network flow matrix describes ingress traffic flows for a base {product-title} installation. It does not describe network flows for additional components, such as optional Operators available from the Red Hat Marketplace. The matrix does not apply for Hosted-Control-Plane, MicroShift, or standalone clusters.
+The network flow matrixes describe ingress traffic flows for a base {product-title} or {sno} installation. It does not describe network flows for additional components, such as optional Operators available from the Red Hat Marketplace. The matrixes do not apply for Hosted-Control-Plane, MicroShift, or standalone clusters.
 ====
 
-.Network flow matrix
+[id="network-flow-matrix-common_{context}"]
+== Base network flows
+
+The following matrixes describe the base ingress flows to {product-title} services.
+
+[NOTE]
+====
+For base ingress flows to {sno} clusters, see the _Control plane node base flows_ matrix only.
+====
+
+[id="network-flow-matrix-control_{context}"]
+.Control plane node base flows
 [%header,format=csv]
 |===
-include::snippets/network-flow-matrix.csv[]
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/common-master.csv[]
+|===
+
+[id="network-flow-matrix-worker_{context}"]
+.Worker node base flows
+[%header,format=csv]
+|===
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/common-worker.csv[]
+|===
+
+[id="network-flow-matrix-bm_{context}"]
+== Additional network flows for {product-title} on bare metal
+
+In addition to the base network flows, the following matrix describes the ingress flows to {product-title} services that are specific to {product-title} on bare metal.
+
+.{product-title} on bare metal
+[%header,format=csv]
+|===
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/bm.csv[]
+|===
+
+[id="network-flow-matrix-sno_{context}"]
+== Additional network flows for {sno} on bare metal
+
+In addition to the base network flows, the following matrix describes the ingress flows to {product-title} services that are specific to {sno} on bare metal.
+
+.{sno-caps} on bare metal
+[%header,format=csv]
+|===
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/bm-sno.csv[]
+|===
+
+[id="network-flow-matrix-aws_{context}"]
+== Additional network flows for {product-title} on {aws-short}
+
+In addition to the base network flows, the following matrix describes the ingress flows to {product-title} services that are specific to {product-title} on {aws-short}.
+
+.{product-title} on AWS 
+[%header,format=csv]
+|===
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/aws.csv[]
+|===
+
+[id="network-flow-matrix-aws-sno_{context}"]
+== Additional network flows for {sno} on {aws-short}
+
+In addition to the base network flows, the following matrix describes the ingress flows to {product-title} services that are specific to {sno} on {aws-short}.
+
+.{sno-caps} on AWS
+[%header,format=csv]
+|===
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/aws-sno.csv[]
 |===


### PR DESCRIPTION
[TELCODOCS-2015](https://issues.redhat.com//browse/TELCODOCS-2015): Adding tables that break down the network flow by platform

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2015

Link to docs preview:
https://85385--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#network-flow-matrix_configuring-firewall

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
