### PR TITLE
OBSDOCS-1499 Logging 5.8.15 rel notes for 4.15 and lower

### DIFF
--- a/modules/logging-release-notes-5-8-15.adoc
+++ b/modules/logging-release-notes-5-8-15.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-15_{context}"]
+= Logging 5.8.15
+This release includes link:https://access.redhat.com/errata/RHBA-2024:10052[RHBA-2024:10052] and link:https://access.redhat.com/errata/RHBA-2024:10053[RHBA-2024:10053].
+
+[id="logging-release-notes-5-8-15-bug-fixes_{context}"]
+== Bug fixes
+*  Before this update, Loki did not correctly load some configurations, which caused issues when using Alibaba Cloud or IBM Cloud object storage. This update fixes the configuration-loading code in Loki, resolving the issue. (link:https://issues.redhat.com/browse/LOG-6294[LOG-6294])
+
+* Before this update, upgrades to version 6.0 failed with errors if a Log File Metric Exporter instance was present. This update fixes the issue, enabling upgrades to proceed smoothly without errors. (link:https://issues.redhat.com/browse/LOG-6328[LOG-6328])
+
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2021-47385[CVE-2021-47385]
+* link:https://access.redhat.com/security/cve/CVE-2023-28746[CVE-2023-28746]
+* link:https://access.redhat.com/security/cve/CVE-2023-48161[CVE-2023-48161]
+* link:https://access.redhat.com/security/cve/CVE-2023-52658[CVE-2023-52658]
+* link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+* link:https://access.redhat.com/security/cve/CVE-2024-6232[CVE-2024-6232]
+* link:https://access.redhat.com/security/cve/CVE-2024-21208[CVE-2024-21208]
+* link:https://access.redhat.com/security/cve/CVE-2024-21210[CVE-2024-21210]
+* link:https://access.redhat.com/security/cve/CVE-2024-21217[CVE-2024-21217]
+* link:https://access.redhat.com/security/cve/CVE-2024-21235[CVE-2024-21235]
+* link:https://access.redhat.com/security/cve/CVE-2024-27403[CVE-2024-27403]
+* link:https://access.redhat.com/security/cve/CVE-2024-35989[CVE-2024-35989]
+* link:https://access.redhat.com/security/cve/CVE-2024-36889[CVE-2024-36889]
+* link:https://access.redhat.com/security/cve/CVE-2024-36978[CVE-2024-36978]
+* link:https://access.redhat.com/security/cve/CVE-2024-38556[CVE-2024-38556]
+* link:https://access.redhat.com/security/cve/CVE-2024-39483[CVE-2024-39483]
+* link:https://access.redhat.com/security/cve/CVE-2024-39502[CVE-2024-39502]
+* link:https://access.redhat.com/security/cve/CVE-2024-40959[CVE-2024-40959]
+* link:https://access.redhat.com/security/cve/CVE-2024-42079[CVE-2024-42079]
+* link:https://access.redhat.com/security/cve/CVE-2024-42272[CVE-2024-42272]
+* link:https://access.redhat.com/security/cve/CVE-2024-42284[CVE-2024-42284]
+* link:https://access.redhat.com/security/cve/CVE-2024-3596[CVE-2024-3596]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-15.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-14.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-13.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.12, 4.13, 4.14, 4.15

Issue:
[OBSDOCS-1499](https://issues.redhat.com//browse/OBSDOCS-1499)

Link to docs preview:
https://85388--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html

Additional Information
This is a re-spin of https://github.com/openshift/openshift-docs/pull/85216, with the link fixed - that PR was already reviewed and approved, so merging this one.
