### PR TITLE
Added a reference link for pre-allocated huge pages

### DIFF
--- a/modules/virt-configuring-huge-pages-for-vms.adoc
+++ b/modules/virt-configuring-huge-pages-for-vms.adoc
@@ -22,7 +22,7 @@ If you edit a running virtual machine, the virtual machine must be rebooted for 
 
 .Prerequisites
 
-* Nodes must have pre-allocated huge pages configured.
+* Nodes must have pre-allocated huge pages configured. For instructions, see link:https://docs.openshift.com/container-platform/{product-version}/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.html#configuring-huge-pages_huge-pages[Configuring huge pages at boot time].
 
 .Procedure
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15 and later

Issue:
https://issues.redhat.com/browse/CNV-50723

Link to docs preview:
https://85399--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-using-huge-pages-with-vms.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
