### PR TITLE
OSDOCS-12752:Separating the AWS and GCP create cluster guides.

### DIFF
--- a/modules/osd-create-cluster-ccs-aws.adoc
+++ b/modules/osd-create-cluster-ccs-aws.adoc
@@ -1,0 +1,220 @@
+// Module included in the following assemblies:
+//
+// * osd_install_access_delete_cluster/creating-an-aws-cluster.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="osd-create-aws-cluster-ccs_{context}"]
+= Creating a cluster on AWS
+
+By using the Customer Cloud Subscription (CCS) billing model, you can create an {product-title} cluster in an existing
+{AWS} account that you own.
+
+You can also select the Red Hat cloud account infrastructure type to deploy {product-title} in a cloud provider account that is owned by Red Hat.
+
+Complete the following prerequisites to use the CCS model to deploy and manage {product-title} into your AWS account.
+
+.Prerequisites
+
+* You have configured your AWS account for use with {product-title}.
+* You have not deployed any services in your AWS account.
+* You have configured the AWS account quotas and limits that are required to support the desired cluster size.
+* You have an `osdCcsAdmin` AWS Identity and Access Management (IAM) user with the `AdministratorAccess` policy attached.
+* You have set up a service control policy (SCP) in your AWS organization. For more information, see _Minimum required service control policy (SCP)_.
+* Consider having *Business Support* or higher from AWS.
+* If you are configuring a cluster-wide proxy, you have verified that the proxy is accessible from the VPC that the cluster is being installed into. The proxy must also be accessible from the private subnets of the VPC.
+
+.Procedure
+
+. Log in to {cluster-manager-url}.
+
+. On the *Overview* page, select *Create cluster* in the *Red Hat OpenShift Dedicated* card.
+
+. Under *Billing model*, configure the subscription type and infrastructure type:
+.. Select a subscription type. For information about {product-title} subscription options, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#assembly-cluster-subscriptions[Cluster subscriptions and registration] in the {cluster-manager} documentation.
++
+[NOTE]
+====
+The subscription types that are available to you depend on your {product-title} subscriptions and resource quotas. For more information, contact your sales representative or Red Hat support.
+====
++
+.. Select the *Customer Cloud Subscription* infrastructure type to deploy {product-title} in an existing cloud provider account that you own or select *Red Hat cloud account* infrastructure type to deploy {product-title} in a cloud provider account that is owned by Red Hat.
+.. Click *Next*.
+. Select *Run on Amazon Web Services*. If you are provisioning your cluster in an AWS account, complete the following substeps:
+.. Review and complete the listed *Prerequisites*.
+.. Select the checkbox to acknowledge that you have read and completed all of the prerequisites.
+.. Provide your AWS account details:
+... Enter your *AWS account ID*.
+... Enter your *AWS access key ID* and *AWS secret access key* for your AWS IAM user account.
++
+[NOTE]
+====
+Revoking these credentials in AWS results in a loss of access to any cluster created with these credentials.
+====
+... Optional: You can select *Bypass AWS service control policy (SCP) checks* to disable the SCP checks.
++
+[NOTE]
+====
+Some AWS SCPs can cause the installation to fail, even if you have the required permissions. Disabling the SCP checks allows an installation to proceed. The SCP is still enforced even if the checks are bypassed.
+====
+. Click *Next* to validate your cloud provider account and go to the *Cluster details* page.
+
+. On the *Cluster details* page, provide a name for your cluster and specify the cluster details:
+.. Add a *Cluster name*.
+.. Optional: Cluster creation generates a domain prefix as a subdomain for your provisioned cluster on `openshiftapps.com`. If the cluster name is less than or equal to 15 characters, that name is used for the domain prefix. If the cluster name is longer than 15 characters, the domain prefix is randomly generated to a 15 character string.
++
+To customize the subdomain, select the *Create customize domain prefix* checkbox, and enter your domain prefix name in the *Domain prefix* field. The domain prefix cannot be longer than 15 characters, must be unique within your organization, and cannot be changed after cluster creation.
+.. Select a cluster version from the *Version* drop-down menu.
+.. Select a cloud provider region from the *Region* drop-down menu.
+.. Select a *Single zone* or *Multi-zone* configuration.
++
+.. Leave *Enable user workload monitoring* selected to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics. This option is enabled by default.
+.. Optional: Expand *Advanced Encryption* to make changes to encryption settings.
+... Accept the default setting *Use default KMS Keys* to use your default AWS KMS key, or select *Use Custom KMS keys* to use a custom KMS key.
+.... With *Use Custom KMS keys* selected, enter the AWS Key Management Service (KMS) custom key Amazon Resource Name (ARN) ARN in the *Key ARN* field.
+The key is used for encrypting all control plane, infrastructure, worker node root volumes, and persistent volumes in your cluster.
+//Commented out due to changes in the UI
+//[IMPORTANT]
+//====
+//Only persistent volumes (PVs) created from the default storage class are encrypted with this specific key.
+//PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
+//====
++
+... Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
++
+[NOTE]
+====
+If *Enable FIPS cryptography* is selected, *Enable additional etcd encryption* is enabled by default and cannot be disabled. You can select *Enable additional etcd encryption* without selecting *Enable FIPS cryptography*.
+====
++
+... Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption. With this option, the etcd key values are encrypted, but the keys are not. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
++
+[NOTE]
+====
+By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Consider enabling etcd encryption only if you specifically require it for your use case.
+====
++
+.. Click *Next*.
+
+. On the *Default machine pool* page, select a *Compute node instance type* from the drop-down menu.
+. Optional: Select the *Enable autoscaling* checkbox to enable autoscaling.
+.. Click *Edit cluster autoscaling settings* to make changes to the autoscaling settings.
+.. Once you have made your desired changes, click *Close*.
+.. Select a minimum and maximum node count. Node counts can be selected by engaging the available plus and minus signs or inputting the desired node count into the number input field.
+. Select a *Compute node count* from the drop-down menu.
++
+[NOTE]
+====
+After your cluster is created, you can change the number of compute nodes in your cluster, but you cannot change the compute node instance type in a machine pool. The number and types of nodes available to you depend on your {product-title} subscription.
+====
+
+. Choose your preference for the Instance Metadata Service (IMDS) type, either using both IMDSv1 and IMDSv2 types or requiring your EC2 instances to use only IMDSv2. You can access instance metadata from a running instance in two ways:
++
+* Instance Metadata Service Version 1 (IMDSv1) - a request/response method
+* Instance Metadata Service Version 2 (IMDSv2) - a session-oriented method
++
+[IMPORTANT]
+====
+The Instance Metadata Service settings cannot be changed after your cluster is created.
+====
++
+[NOTE]
+====
+IMDSv2 uses session-oriented requests. With session-oriented requests, you create a session token that defines the session duration, which can range from a minimum of one second to a maximum of six hours. During the specified duration, you can use the same session token for subsequent requests. After the specified duration expires, you must create a new session token to use for future requests.
+====
++
+For more information regarding IMDS, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[Instance metadata and user data] in the AWS documentation.
+
+. Optional: Expand *Edit node labels* to add labels to your nodes. Click *Add label* to add more node labels and select *Next*.
+. On the *Network configuration* page, select *Public* or *Private* to use either public or private API endpoints and application routes for your cluster.
++
+[IMPORTANT]
+====
+If you are using private API endpoints, you cannot access your cluster until you update the network settings in your cloud provider account.
+====
++
+. Optional: To install the cluster in an existing AWS Virtual Private Cloud (VPC):
+.. Select *Install into an existing VPC*.
+.. If you are installing into an existing VPC and opted to use private API endpoints, you can select *Use a PrivateLink*. This option enables connections to the cluster by Red Hat Site Reliability Engineering (SRE) using only AWS PrivateLink endpoints.
++
+[NOTE]
+====
+The *Use a PrivateLink* option cannot be changed after a cluster is created.
+====
++
+.. If you are installing into an existing VPC and you want to enable an HTTP or HTTPS proxy for your cluster, select *Configure a cluster-wide proxy*.
+. If you opted to install the cluster in an existing AWS VPC, provide your *Virtual Private Cloud (VPC) subnet settings* and select *Next*.
+You must have created the Cloud network address translation (NAT) and a Cloud router. See the "Additional resources" section for information about Cloud NATs and Google VPCs.
++
+[NOTE]
+====
+You must ensure that your VPC is configured with a public and a private subnet for each availability zone that you want the cluster installed into. If you opted to use PrivateLink, only private subnets are required.
+====
++
+.. Optional: Expand *Additional security groups* and select additional custom security groups to apply to nodes in the machine pools that are created by default. You must have already created the security groups and associated them with the VPC that you selected for this cluster. You cannot add or edit security groups to the default machine pools after you create the cluster.
++
+By default, the security groups you specify are added for all node types. Clear the *Apply the same security groups to all node types* checkbox to apply different security groups for each node type.
++
+For more information, see the requirements for _Security groups_ under _Additional resources_.
+. Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*.
+.. Optional: Provide route selector.
+.. Optional: Provide excluded namespaces.
+.. Select a namespace ownership policy.
+.. Select a wildcard policy.
++
+For more information about custom application ingress settings, click the information icon provided for each setting.
++
+. If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
+.. Enter a value in at least one of the following fields:
+** Specify a valid *HTTP proxy URL*.
+** Specify a valid *HTTPS proxy URL*.
+** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required if you use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This requirement applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
++
+.. Click *Next*.
++
+For more information about configuring a proxy with {product-title}, see _Configuring a cluster-wide proxy_.
+
+. In the *CIDR ranges* dialog, configure custom classless inter-domain routing (CIDR) ranges or use the defaults that are provided.
++
+[NOTE]
+====
+If you are installing into a VPC, the *Machine CIDR* range must match the VPC subnets.
+====
++
+[IMPORTANT]
+====
+CIDR configurations cannot be changed later. Confirm your selections with your network administrator before proceeding.
+====
++
+. On the *Cluster update strategy* page, configure your update preferences:
+.. Choose a cluster update method:
+** Select *Individual updates* if you want to schedule each update individually. This is the default option.
+** Select *Recurring updates* to update your cluster on your preferred day and start time, when updates are available.
++
+[NOTE]
+====
+You can review the end-of-life dates in the update lifecycle documentation for {product-title}. For more information, see link:https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#osd-life-cycle[OpenShift Dedicated update life cycle].
+====
++
+.. If you opted for recurring updates, select a preferred day of the week and upgrade start time in UTC from the drop-down menus.
+.. Optional: You can set a grace period for *Node draining* during cluster upgrades. A *1 hour* grace period is set by default.
+.. Click *Next*.
++
+[NOTE]
+====
+If critical security concerns that significantly impact the security or stability of a cluster occur, Red Hat Site Reliability Engineering (SRE) might schedule automatic updates to the latest z-stream version that is not impacted. The updates are applied within 48 hours after customer notifications are provided. For a description of the critical impact security rating, see link:https://access.redhat.com/security/updates/classification[Understanding Red Hat security ratings].
+====
+
+. Review the summary of your selections and click *Create cluster* to start the cluster installation. The installation takes approximately 30-40 minutes to complete.
++
+. Optional: On the *Overview* tab, you can enable the delete protection feature by selecting *Enable*, which is located directly under *Delete Protection: Disabled*. This will prevent your cluster from being deleted. To disable delete protection, select *Disable*.
+By default, clusters are created with the delete protection feature disabled.
+
+.Verification
+
+* You can monitor the progress of the installation in the *Overview* page for your cluster. You can view the installation logs on the same page. Your cluster is ready when the *Status* in the *Details* section of the page is listed as *Ready*.
+
+ifeval::["{context}" == "osd-creating-a-cluster-on-aws"]
+:!osd-on-aws:
+endif::[]
+

--- a/modules/osd-create-cluster-red-hat-account.adoc
+++ b/modules/osd-create-cluster-red-hat-account.adoc
@@ -1,33 +1,13 @@
 // Module included in the following assemblies:
 //
-// * osd_install_access_delete_cluster/creating-an-aws-cluster.adoc
 // * osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc
 
-ifeval::["{context}" == "osd-creating-a-cluster-on-aws"]
-:osd-on-aws:
-endif::[]
-ifeval::["{context}" == "osd-creating-a-cluster-on-gcp"]
-:osd-on-gcp:
-endif::[]
-
 :_mod-docs-content-type: PROCEDURE
-ifdef::osd-on-aws[]
-[id="osd-create-aws-cluster-red-hat-account_{context}"]
-= Creating a cluster on AWS with a Red Hat cloud account
-endif::osd-on-aws[]
-ifdef::osd-on-gcp[]
+
 [id="osd-create-aws-cluster-ccs_{context}"]
 = Creating a cluster on GCP with a Red Hat cloud account
-endif::osd-on-gcp[]
 
-Through {cluster-manager-url}, you can create an {product-title} cluster
-ifdef::osd-on-aws[]
-on {AWS}
-endif::osd-on-aws[]
-ifdef::osd-on-gcp[]
-on {GCP}
-endif::osd-on-gcp[]
-using a standard cloud provider account owned by Red Hat.
+Through {cluster-manager-url}, you can create an {product-title} cluster on {GCP} using a standard cloud provider account owned by Red Hat.
 
 .Procedure
 
@@ -47,15 +27,7 @@ You must have the required resource quota for the *Annual* subscription type to 
 +
 .. Select the *Red Hat cloud account* infrastructure type to deploy {product-title} in a cloud provider account that is owned by Red Hat.
 .. Click *Next*.
-
-ifdef::osd-on-aws[]
-. Select *Run on Amazon Web Services*
-endif::osd-on-aws[]
-ifdef::osd-on-gcp[]
-. Select *Run on Google Cloud Platform*
-endif::osd-on-gcp[]
-and click *Next*.
-
+. Select *Run on Google Cloud Platform* and click *Next*.
 . On the *Cluster details* page, provide a name for your cluster and specify the cluster details:
 .. Add a *Cluster name*.
 .. Optional: Cluster creation generates a domain prefix as a subdomain for your provisioned cluster on `openshiftapps.com`. If the cluster name is less than or equal to 15 characters, that name is used for the domain prefix. If the cluster name is longer than 15 characters, the domain prefix is randomly generated as a 15-character string.
@@ -67,7 +39,6 @@ To customize the subdomain, select the *Create custom domain prefix* checkbox, a
 .. Select a *Persistent storage* capacity for the cluster. For more information, see the _Storage_ section in the {product-title} service definition.
 .. Specify the number of *Load balancers* that you require for your cluster. For more information, see the _Load balancers_ section in the {product-title} service definition.
 +
-ifdef::osd-on-gcp[]
 .. Optional: Select *Enable Secure Boot for Shielded VMs* to use Shielded VMs when installing your cluster. For more information, see link:https://cloud.google.com/security/products/shielded-vm[Shielded VMs].
 +
 [IMPORTANT]
@@ -75,9 +46,7 @@ ifdef::osd-on-gcp[]
 To successfully create a cluster, you must select *Enable Secure Boot support for Shielded VMs* if your organization has the policy constraint `constraints/compute.requireShieldedVm` enabled. For more information regarding GCP organizational policy constraints, see link:https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints[Organization policy constraints].
 ====
 +
-endif::osd-on-gcp[]
 .. Leave *Enable user workload monitoring* selected to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics. This option is enabled by default.
-ifdef::osd-on-gcp[]
 . Optional: Expand *Advanced Encryption* to make changes to encryption settings.
 +
 .. Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
@@ -86,7 +55,7 @@ ifdef::osd-on-gcp[]
 ====
 If *Enable FIPS cryptography* is selected, *Enable additional etcd encryption* is enabled by default and cannot be disabled. You can select *Enable additional etcd encryption* without selecting *Enable FIPS cryptography*.
 ====
-endif::osd-on-gcp[]
+
 .. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption. With this option, the etcd key values are encrypted, but not the keys. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
 +
 [NOTE]
@@ -151,9 +120,3 @@ By default, clusters are created with the delete protection feature disabled.
 
 * You can monitor the progress of the installation in the *Overview* page for your cluster. You can view the installation logs on the same page. Your cluster is ready when the *Status* in the *Details* section of the page is listed as *Ready*.
 
-ifeval::["{context}" == "osd-creating-a-cluster-on-aws"]
-:!osd-on-aws:
-endif::[]
-ifeval::["{context}" == "osd-creating-a-cluster-on-gcp"]
-:!osd-on-gcp:
-endif::[]

--- a/osd_install_access_delete_cluster/creating-an-aws-cluster.adoc
+++ b/osd_install_access_delete_cluster/creating-an-aws-cluster.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can install {product-title} on {AWS} by using your own AWS account through the Customer Cloud Subscription (CCS) model or by using an AWS infrastructure account that is owned by Red Hat.
+You can deploy {product-title} on {AWS} by using your own AWS account through the Customer Cloud Subscription (CCS) model or by using an AWS infrastructure account that is owned by Red Hat.
 
 [id="osd-creating-a-cluster-on-aws-prerequisites_{context}"]
 == Prerequisites
@@ -15,8 +15,7 @@ You can install {product-title} on {AWS} by using your own AWS account through t
 * You reviewed the xref:../osd_architecture/osd-understanding.adoc#osd-understanding[introduction to {product-title}] and the documentation on xref:../architecture/index.adoc#architecture-overview[architecture concepts].
 * You reviewed the xref:../osd_getting_started/osd-understanding-your-cloud-deployment-options.adoc#osd-understanding-your-cloud-deployment-options[{product-title} cloud deployment options].
 
-include::modules/osd-create-cluster-ccs.adoc[leveloffset=+1]
-include::modules/osd-create-cluster-red-hat-account.adoc[leveloffset=+1]
+include::modules/osd-create-cluster-ccs-aws.adoc[leveloffset=+1]
 
 [id="additional-resources_{context}"]
 == Additional resources


### PR DESCRIPTION
This PR is part of a wider restructuring effort to streamline the create an OSD cluster documentation. At present, the create an AWS cluster and create a GCP cluster share the same modules with heavily conditionalized text. This is confusing to maintain and update, but also no longer serves any purpose as OSD on GCP moves to become the main OSD offering. 

There are also a couple of instances where I updated the documentation so it matches the UI including application ingress and Enable autoscaling settings.

Version(s):
4.17+

Issue:
[OSDOCS-12752](https://issues.redhat.com/browse/OSDOCS-12752)

Link to docs preview:

[Creating a cluster on AWS](https://85408--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-an-aws-cluster.html)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
