### PR TITLE
HCIDOCS-577: Broken link included for 'Using and Configuring Red Hat Subscription Manager'

### DIFF
--- a/modules/install-ibm-cloud-classic-preparing-the-provisioner-node.adoc
+++ b/modules/install-ibm-cloud-classic-preparing-the-provisioner-node.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_ibm_cloud_classic/install-ibm-cloud-installing-on-ibm-cloud.adoc
+//
+// As of Dec. 6, 2024, the following link does not have a variable defined. Link is located in the Red Hat Subscription Manager Note on line 66. Please update link to use a defined variable when available:
+// https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_rhel_system_registration/basic-reg-rhel-cli
 
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-the-provisioner-node-for-openshift-install-on-ibm-cloud_{context}"]
@@ -63,7 +66,7 @@ $ sudo subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms \
 +
 [NOTE]
 ====
-For more information about Red Hat Subscription Manager, see link:https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html-single/rhsm/index[Using and Configuring Red Hat Subscription Manager].
+For more information about Red Hat Subscription Manager, see link:https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_rhel_system_registration/basic-reg-rhel-cli[Registering a {op-system-base} system with command-line tools].
 ====
 
 . Install the following packages:

--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+//
+// As of Dec. 6, 2024, the following link does not have a variable defined. Link is located in the Red Hat Subscription Manager Note on line 66. Please update link to use a defined variable when available:
+// https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_rhel_system_registration/basic-reg-rhel-cli
 
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-the-provisioner-node-for-openshift-install_{context}"]
@@ -63,7 +66,7 @@ $ sudo subscription-manager repos --enable=rhel-9-for-<architecture>-appstream-r
 +
 [NOTE]
 ====
-For more information about Red Hat Subscription Manager, see link:https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html-single/rhsm/index[Using and Configuring Red Hat Subscription Manager].
+For more information about Red Hat Subscription Manager, see link:https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_rhel_system_registration/basic-reg-rhel-cli[Registering a {op-system-base} system with command-line tools].
 ====
 endif::openshift-origin[]
 


### PR DESCRIPTION
**Fixes:** [HCIDOCS-577](https://issues.redhat.com/browse/HCIDOCS-577)

**For:** OCP 4.15+

**Previews:**
[ipi-install-installation-workflow](https://85411--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html)
[install-ibm-cloud-installation-workflow](https://85411--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_classic/install-ibm-cloud-installation-workflow.html)

**Approvals -** `/lgtm`:
- [x] Peer Review

**Note:** SME and QE approvals are unnecessary, as this PR updates links and is not procedural.