### PR TITLE
TELCODOCS-2036: Docs and RN: CNF-12678 MLX secure boot: support Disable vendor plugin in SR-IOV operator

### DIFF
--- a/modules/nw-sriov-nic-mlx-secure-boot.adoc
+++ b/modules/nw-sriov-nic-mlx-secure-boot.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-device.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-sriov-nic-mlx-secure-boot_{context}"]
+= Configuring the SR-IOV Network Operator on Mellanox cards when Secure Boot is enabled
+
+The SR-IOV Network Operator supports an option to skip the firmware configuration for Mellanox devices. This option allows you to create virtual functions by using the SR-IOV Network Operator when the system has secure boot enabled. You must manually configure and allocate the number of virtual functions in the firmware before switching the system to secure boot.
+
+[NOTE]
+====
+The number of virtual functions in the firmware is the maximum number of virtual functions that you can request in the policy.
+====
+
+.Procedure
+
+. Configure the virtual functions (VFs) by running the following command when the system is without a secure boot when using the sriov-config daemon:
++
+[source,terminal]
+----
+$ mstconfig -d -0001:b1:00.1 set SRIOV_EN=1 NUM_OF_VFS=16 <1> <2>
+----
+<1> The `SRIOV_EN` environment variable enables the SR-IOV Network Operator support on the Mellanox card.
+<2> The `NUM_OF_VFS` environment variable specifies the number of virtual functions to enable in the firmware.
+
+. Configure the SR-IOV Network Operator by disabling the Mellanox plugin. See the following `SriovOperatorConfig` example configuration:
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-sriov-network-operator
+spec:
+  configDaemonNodeSelector: {}
+  configurationMode: daemon
+  disableDrain: false
+  disablePlugins:
+  - mellanox
+  enableInjector: true
+  enableOperatorWebhook: true
+  logLevel: 2
+----
+
+. Reboot the system to enable the virtual functions and the configuration settings.
+
+. Check the virtual functions (VFs) after rebooting the system by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-sriov-network-operator get sriovnetworknodestate.sriovnetwork.openshift.io worker-0 -oyaml
+----
++
+.Example output 
+[source,yaml]
+----
+- deviceID: 101d
+    driver: mlx5_core
+    eSwitchMode: legacy
+    linkSpeed: -1 Mb/s
+    linkType: ETH
+    mac: 08:c0:eb:96:31:25
+    mtu: 1500
+    name: ens3f1np1
+    pciAddress: 0000:b1:00.1 <1>
+    totalvfs: 16
+    vendor: 15b3
+----
+<1> The `totalvfs` value is the same number used in the `mstconfig` command earlier in the procedure. 
+
+. Enable secure boot to prevent unauthorized operating systems and malicious software from loading during the device's boot process. 
+
+.. Enable secure boot using the BIOS (Basic Input/Output System).
++
+[source,terminal]
+----
+Secure Boot: Enabled
+Secure Boot Policy: Standard
+Secure Boot Mode: Mode Deployed
+----
+
+.. Reboot the system.

--- a/networking/hardware_networks/configuring-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-sriov-device.adoc
@@ -15,6 +15,9 @@ include::modules/nw-sriov-networknodepolicy-object.adoc[leveloffset=+1]
 
 // A direct companion to nw-sriov-networknodepolicy-object
 // Virtual function (VF) partitioning for SR-IOV devices
+
+include::modules/nw-sriov-nic-mlx-secure-boot.adoc[leveloffset=+2]
+
 include::modules/nw-sriov-nic-partitioning.adoc[leveloffset=+2]
 
 // Configuring SR-IOV network devices


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-2036: Docs and RN: [CNF-12678](https://issues.redhat.com//browse/CNF-12678) MLX secure boot: support Disable vendor plugin in SR-IOV operator

Applies to OCP version : 4.18+

Preview: [Mellanox secure boot](https://85440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-nic-mlx-secure-boot_configuring-sriov-device)

QE review completed by @evgenLevin 
Dev review completed by @SchSeba
Peer review completed by @xenolinux @jeana-redhat 

Thank you.