### PR TITLE
CMP-2985: Added FIO 1.3.5 release notes

### DIFF
--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -15,6 +15,15 @@ For an overview of the File Integrity Operator, see xref:../../security/file_int
 
 To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-updating.adoc#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator].
 
+[id="file-integrity-operator-release-notes-1-3-5"]
+== OpenShift File Integrity Operator 1.3.5
+
+The following advisory is available for the OpenShift File Integrity Operator 1.3.5:
+
+* link:https://access.redhat.com/errata/RHBA-2024:10366[RHBA-2024:10366 OpenShift File Integrity Operator Update]
+
+This update includes upgraded dependencies in underlying base images.
+
 [id="file-integrity-operator-release-notes-1-3-4"]
 == OpenShift File Integrity Operator 1.3.4
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/CMP-2985

Link to docs preview:
[85467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-release-notes.html](https://85467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-release-notes.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This update does not change the meaning of the docs; no QE review required.
