### PR TITLE
Updates subnet value in offline migration docs

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -166,7 +166,6 @@ OpenShift-SDN and OVN-Kubernetes have different overlay overhead. MTU values sho
 ====
 * Geneve (Generic Network Virtualization Encapsulation) overlay network port
 * OVN-Kubernetes IPv4 internal subnet
-* OVN-Kubernetes IPv6 internal subnet
 --
 +
 To customize either of the previously noted settings, enter and customize the following command. If you do not need to change the default value, omit the key from the patch.
@@ -181,7 +180,6 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
           "mtu":<mtu>,
           "genevePort":<port>,
           "v4InternalSubnet":"<ipv4_subnet>",
-          "v6InternalSubnet":"<ipv6_subnet>"
     }}}}'
 ----
 +
@@ -194,8 +192,6 @@ The MTU for the Geneve overlay network. This value is normally configured automa
 The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by OpenShift SDN. The default value for the VXLAN port is `4789`.
 `ipv4_subnet`::
 An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
-`ipv6_subnet`::
-An IPv6 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `fd98::/48`.
 --
 +
 .Example patch command to update `mtu` field
@@ -456,3 +452,7 @@ $ oc patch Network.operator.openshift.io cluster --type='merge' \
 ----
 $ oc delete namespace openshift-sdn
 ----
+
+.Next steps
+
+* Optional: After cluster migration, you can convert your IPv4 single-stack cluster to a dual-network cluster network that supports IPv4 and IPv6 address families. For more information, see "Converting to IPv4/IPv6 dual-stack networking".

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -94,6 +94,9 @@ include::modules/live-migration-metrics-information.adoc[leveloffset=+3]
 * xref:../../networking/changing-cluster-network-mtu.adoc#mtu-value-selection_changing-cluster-network-mtu[MTU value selection]
 
 * xref:../../networking/network_security/network_policy/about-network-policy.adoc#nw-networkpolicy-optimize-ovn_about-network-policy[About network policy]
+
+* xref:../../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc#converting-to-dual-stack[Converting to IPv4/IPv6 dual-stack networking]
+
 * OVN-Kubernetes capabilities
 
 - xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]


### PR DESCRIPTION
Version(s):
4.12-4.16

Issue:
https://issues.redhat.com/browse/OCPBUGS-44459

Link to docs preview:
https://85477--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
