### PR TITLE
OCPBUGS-44659-new-note: Added important note for disabling IPsec

### DIFF
--- a/modules/nw-ovn-ipsec-disable.adoc
+++ b/modules/nw-ovn-ipsec-disable.adoc
@@ -8,6 +8,11 @@
 
 As a cluster administrator, you can disable IPsec encryption only if you enabled IPsec after cluster installation.
 
+[IMPORTANT]
+====
+To avoid issues with your installed cluster, ensure that after you disable IPsec that you also delete the associated IPsec daemonsets pods.
+====
+
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
@@ -22,5 +27,57 @@ As a cluster administrator, you can disable IPsec encryption only if you enabled
 $ oc patch networks.operator.openshift.io/cluster --type=json \
   -p='[{"op":"remove", "path":"/spec/defaultNetwork/ovnKubernetesConfig/ipsecConfig"}]'
 ----
+
+. To find the names of the OVN-Kubernetes data plane pods that exist on a node in your cluster, enter the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -l=app=ovnkube-node
+----
++
+.Example output
+[source,terminal]
+----
+ovnkube-node-5xqbf                       8/8     Running   0              28m
+ovnkube-node-6mwcx                       8/8     Running   0              29m
+ovnkube-node-ck5fr                       8/8     Running   0              31m
+...
+----
+
+. To check if a node in your cluster has IPsec disabled, enter the following command. Ensure that you enter this command for each node that exists in your cluster. The command output must state `false` to indicate that the node has IPsec disabled.
++
+[source,terminal]
+----
+$ oc -n openshift-ovn-kubernetes rsh ovnkube-node-<pod_number_sequence> ovn-nbctl --no-leader-only get nb_global . ipsec <1>
+----
+<1> Replace `<pod_number_sequence>` with the random sequence of letters, `5xqbf`, for a data plane pod from the previous step.
+
+. To remove the IPsec `ovn-ipsec-host` daemonset pod from the `openshift-ovn-kubernetes` namespace on a node, enter the following command:
++
+[source,terminal]
+----
+$ oc delete daemonset ovn-ipsec-host -n openshift-ovn-kubernetes <1>
+----
+<1> The `ovn-ipsec-host` daemonset pod configures IPsec connections for east-west traffic on a node.
+
+. To remove the IPsec `ovn-ipsec-containerized` daemonset pod from the `openshift-ovn-kubernetes` namespace on a node, enter the following command:
++
+[source,terminal]
+----
+$ oc delete daemonset ovn-ipsec-containerized -n openshift-ovn-kubernetes <1>
+----
+<1> The `ovn-ipsec-containerized` daemonset pod configures IPsec connections for east-west traffic on a node.
+
+. Verify that the `ovn-ipsec-host` and `ovn-ipsec-containerized` daemonset pods were removed from all the nodes in your cluster by entering the following command. If the command output does not list the pods, the removal operation is successful.
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -l=app=ovn-ipsec
+----
++
+[NOTE]
+====
+You might need to re-run the `oc delete` command for a pod because sometimes the initial command attempt might not delete the pod.
+====
 
 . Optional: You can increase the size of your cluster MTU by `46` bytes because there is no longer any overhead from the IPsec ESP header in IP packets.

--- a/modules/nw-ovn-ipsec-enable.adoc
+++ b/modules/nw-ovn-ipsec-enable.adoc
@@ -12,7 +12,7 @@ As a cluster administrator, you can enable pod-to-pod IPsec encryption after clu
 
 * Install the {oc-first}.
 * You are logged in to the cluster as a user with `cluster-admin` privileges.
-* You have reduced the size of your cluster MTU by `46` bytes to allow for the overhead of the IPsec ESP header.
+* You have reduced the size of your cluster's maximum transmission unit (MTU) by `46` bytes to allow for the overhead of the IPsec ESP header.
 
 .Procedure
 
@@ -44,21 +44,10 @@ ovnkube-node-wgs4l                       8/8     Running   0              33m
 ovnkube-node-zfvcl                       8/8     Running   0              34m
 ----
 
-. Verify that IPsec is enabled on your cluster by running the following command:
+. Verify that IPsec is enabled on your cluster by entering the following command. The command output must state `true` to indicate that the node has IPsec enabled.
 +
 [source,terminal]
 ----
-$ oc -n openshift-ovn-kubernetes rsh ovnkube-node-<XXXXX> ovn-nbctl --no-leader-only get nb_global . ipsec
+$ oc -n openshift-ovn-kubernetes rsh ovnkube-node-<pod_number_sequence> ovn-nbctl --no-leader-only get nb_global . ipsec <1>
 ----
-+
---
-where:
-
-`<XXXXX>`:: Specifies the random sequence of letters for a pod from the previous step.
---
-+
-.Example output
-[source,text]
-----
-true
-----
+<1> Replace `<pod_number_sequence>` with the random sequence of letters, `5xqbf`, for a data plane pod from the previous step


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OCPBUGS-44659](https://issues.redhat.com/browse/OCPBUGS-44659)

Link to docs preview:
[Disabling IPsec encryption](https://85485--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.html#nw-ovn-ipsec-disable_configuring-ipsec-ovn)

- [X] SME has approved this change (Periyasamy Palanisamy).
- [X] QE has approved this change (Anurag Saxena).
