### PR TITLE
Adding an errata link to OADP 1.3.4 release notes

### DIFF
--- a/modules/oadp-release-notes-1-3-4.adoc
+++ b/modules/oadp-release-notes-1-3-4.adoc
@@ -42,7 +42,7 @@ With this update, the permissions of this file are updated to 0640, and this fil
 A warning is displayed during the backup operation when ArgoCD and Velero manage the same namespace. link:https://issues.redhat.com/browse/OADP-4736[{oadp-short}-4736]
 
 
-//The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2024:137004[RHSA-2024:137004] advisory.
+The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2024:9960[RHSA-2024:9960] advisory.
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12443310[{oadp-short} 1.3.4 resolved issues] in Jira.
 


### PR DESCRIPTION
Version(s):
OCP 4.12 → OCP 4.15

Issue:
[OADP-5269](https://issues.redhat.com/browse/OADP-5269)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Additional information:
This PR adds an errata link to the published [OADP 1.3.4 release notes](https://docs.openshift.com/container-platform/4.15/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html#oadp-release-notes-1-3-4_oadp-release-notes).

