### PR TITLE
OSDOCS-12780: Update incorrect GPU values in CAS example spec

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -26,12 +26,9 @@ spec:
       min: 4 # <5>
       max: 256 # <6>
     gpus:
-      - type: nvidia.com/gpu # <7>
-        min: 0 # <8>
-        max: 16 # <9>
-      - type: amd.com/gpu
-        min: 0
-        max: 4
+    - type: <gpu_type> # <7>
+      min: 0 # <8>
+      max: 16 # <9>
   logVerbosity: 4 # <10>
   scaleDown: # <11>
     enabled: true # <12>
@@ -48,9 +45,19 @@ spec:
 <4> Specify the maximum number of cores to deploy in the cluster.
 <5> Specify the minimum amount of memory, in GiB, in the cluster.
 <6> Specify the maximum amount of memory, in GiB, in the cluster.
-<7> Optional: Specify the type of GPU node to deploy. Only `nvidia.com/gpu` and `amd.com/gpu` are valid types.
-<8> Specify the minimum number of GPUs to deploy in the cluster.
-<9> Specify the maximum number of GPUs to deploy in the cluster.
+<7> Optional: To configure the cluster autoscaler to deploy GPU-enabled nodes, specify a `type` value that represents the GPU type to use.
+For example, you might use `nvidia-t4` to represent Nvidia T4 GPUs, or `nvidia-a10g` for A10G GPUs.
++
+--
+[NOTE]
+====
+The `type` value must match the value of the `spec.template.spec.metadata.labels[cluster-api/accelerator]` label in the machine set that manages the GPU-enabled nodes of that type.
+Because you use this value as a label on the machine set, it must consist of alphanumeric characters, `-`, `_`, or `.` and must start and end with an alphanumeric character.
+====
+--
++
+<8> Specify the minimum number of GPUs of the specified type to deploy in the cluster.
+<9> Specify the maximum number of GPUs of the specified type to deploy in the cluster.
 <10> Specify the logging verbosity level between `0` and `10`. The following log level thresholds are provided for guidance:
 +
 --


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-12780](https://issues.redhat.com//browse/OSDOCS-12780)

Link to docs preview:
[Cluster autoscaler resource definition](https://85513--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#cluster-autoscaler-cr_applying-autoscaling)

QE review:
- [x] QE has approved this change.

Additional information: