### PR TITLE
OSDOCS-12677: Edit ROSA Autoscaling Docs

### DIFF
--- a/modules/rosa-cluster-autoscaler-cli-after.adoc
+++ b/modules/rosa-cluster-autoscaler-cli-after.adoc
@@ -6,6 +6,11 @@
 [id="rosa-enable-cluster-autoscale-cli-after_{context}"]
 = Enable autoscaling after cluster creation with the ROSA CLI
 
+[IMPORTANT]
+====
+The following procedure is only supported for ROSA Classic clusters. To enable autoscaling after cluster creation for ROSA with HCP clusters, see link:https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.html#nodes-enabling-autoscaling-nodes[Enabling autoscaling nodes on a cluster].
+====
+
 You can use the ROSA CLI (`rosa`) to set cluster-wide autoscaling after cluster creation.
 
 .Procedure
@@ -25,3 +30,6 @@ $ rosa create autoscaler --cluster=<mycluster>
 ----
 $ rosa create autoscaler --cluster=<mycluster> <parameter>
 ----
+
+.Next steps
+* link:https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cluster-autoscaling.html#rosa-enable-cluster-autoscale-cli-after_rosa-cluster-autoscaling[Enabling autoscaling after cluster creation with the ROSA CLI]


### PR DESCRIPTION
[OSDOCS-12677](https://issues.redhat.com//browse/OSDOCS-12677): Edit ROSA Autoscaling Docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12677

Link to docs preview:

- https://85519--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-cluster-autoscaling.html#rosa-enable-cluster-autoscale-cli-after_rosa-cluster-autoscaling 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
