### PR TITLE
Adding additional resources link to Agent config params

### DIFF
--- a/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
+++ b/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
@@ -15,6 +15,7 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
 * xref:../../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations[Configuring regions and zones for a VMware vCenter]
+* xref:../../installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc#installation-vsphere-installer-infra-requirements-account_ipi-vsphere-installation-reqs[Required vCenter account privileges]
 
 include::modules/agent-configuration-parameters.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.15+

Adding a link to the additional resources section in an Agent doc for configuration parameters.

QE review: QE review not required IMO, just adding a link to an existing doc. Let me know if you disagree though.

Preview: (directly below this section) [Deprecated VMware vSphere configuration parameters](https://85523--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html#deprecated-parameters-vsphere_installation-config-parameters-agent)
