### PR TITLE
[RHACS] Synced build_for_portal script from main

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -25,7 +25,7 @@ cli.init_logging(False, True)
 
 list_of_errors = []
 CLONE_DIR = "."
-BASE_PORTAL_URL = "https://access.redhat.com/documentation/en-us/"
+BASE_PORTAL_URL = "https://docs.redhat.com/en/documentation/"
 # ID_RE = re.compile("^\[(?:\[|id=\'|#)(.*?)(\'?,.*?)?(?:\]|\')?\]", re.M | re.DOTALL)
 ID_RE = re.compile(
     "^\[(?:\[|id='|#|id=\")(.*?)('?,.*?)?(?:\]|'|\")?\]", re.M | re.DOTALL
@@ -623,7 +623,12 @@ def scrub_file(info, book_src_dir, src_file, tag=None, cwd=None):
     # procedure loads the file recognizing that it starts with http
     # it then checks if it exists or not, and if it exists, returns the raw data
     # data that it finds.
-    if base_src_file.startswith("https://raw.githubusercontent.com/openshift/"):
+    # modified 20/Aug/2024 to process https links which are preceded
+    # by an added directory (happens with hugeBook)
+
+    https_pos = base_src_file.find("https://raw.githubusercontent.com/openshift/")
+    if https_pos >=0:
+        base_src_file = base_src_file[https_pos:]
         try:
             response = requests.get(base_src_file)
             if response:


### PR DESCRIPTION
Synced `build_for_portal.py` script from the `main` branch.

Cherry-pick:
- `rhacs-dcos-4.5`
- `rhacs-docs-4.6`