### PR TITLE
CNV-51635: move tekton-tasks-operator from deprecated to removed feaures in RN. Also tracks CNV-41244

### DIFF
--- a/virt/release_notes/virt-4-17-release-notes.adoc
+++ b/virt/release_notes/virt-4-17-release-notes.adoc
@@ -137,9 +137,6 @@ Deprecated features are included in the current release and supported. However, 
 //CNV-48413: TP DevPreviewLongLifecycle to GA LongLifecycle
 * The `DevPreviewLongLifecycle` profile is deprecated. The profile is now `LongLifecycle` and is generally available.
 
-//CNV-26426 [DOCS] Release note: Deprecate TTO
-* The `tekton-tasks-operator` is deprecated and Tekton tasks and example pipelines are now deployed by the `ssp-operator`.
-
 //CNV-26316: Release note: Align tekton tasks with instancestypes
 * The `copy-template`, `modify-vm-template`, and `create-vm-from-template` tasks are deprecated.
 
@@ -156,6 +153,9 @@ Removed features are those that were deprecated in earlier releases. They are no
 
 //CNV-45783
 * CentOS 7 and CentOS Stream 8 are now in the End of Life phase. As a consequence, the container images for these operating systems have been removed from OpenShift Virtualization and are no longer link:https://access.redhat.com/articles/4234591#community[community supported].
+
+//CNV-51829: remove tekton-tasks-operator informaiton form release notes; CNV-41244: Release note: Deprecate
+* The `tekton-tasks-operator` is removed. The Tekton tasks and example pipelines are now available in the task catalog (ArtifactHub).
 
 [id="virt-4-16-technology-preview_{context}"]
 == Technology Preview features


### PR DESCRIPTION
Version(s):
4.17

Issues:
[CNV-51635](https://issues.redhat.com/browse/CNV-51635)
[CNV-41244](https://issues.redhat.com/browse/CNV-41244)

Link to docs preview:
[Deprecated and removed features](https://85538--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-17-release-notes.html#virt-4-17-deprecated-removed)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
