### PR TITLE
CNV-51136: Updated yaml in 'Creating a Linux bridge NAD' to reference standard Linux NNCP bridge name

### DIFF
--- a/modules/virt-creating-linux-bridge-nad-cli.adoc
+++ b/modules/virt-creating-linux-bridge-nad-cli.adoc
@@ -28,16 +28,16 @@ Configuring IP address management (IPAM) in a network attachment definition for 
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: bridge-network # <1>
+  name: bridge-network <1>
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/bridge-interface # <2>
+    k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/br1 <2>
 spec:
   config: |
     {
       "cniVersion": "0.3.1",
       "name": "bridge-network", <3>
       "type": "bridge", <4>
-      "bridge": "bridge-interface", <5>
+      "bridge": "br1", <5>
       "macspoofchk": false, <6>
       "vlan": 100, <7>
       "disableContainerInterface": true,
@@ -45,10 +45,10 @@ spec:
     }
 ----
 <1> The name for the `NetworkAttachmentDefinition` object.
-<2> Optional: Annotation key-value pair for node selection, where `bridge-interface` must match the name of a bridge configured on some nodes. If you add this annotation to your network attachment definition, your virtual machine instances will only run on the nodes that have the `bridge-interface` bridge connected.
+<2> Optional: Annotation key-value pair for node selection for the bridge configured on some nodes. If you add this annotation to your network attachment definition, your virtual machine instances will only run on the nodes that have the defined bridge connected.
 <3> The name for the configuration. It is recommended to match the configuration name to the `name` value of the network attachment definition.
 <4> The actual name of the Container Network Interface (CNI) plugin that provides the network for this network attachment definition. Do not change this field unless you want to use a different CNI.
-<5> The name of the Linux bridge configured on the node.
+<5> The name of the Linux bridge configured on the node. The name should match the interface bridge name defined in the `NodeNetworkConfigurationPolicy` manifest.
 <6> Optional: A flag to enable the MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute allows only a single MAC address to exit the pod, which provides security against a MAC spoofing attack.
 <7> Optional: The VLAN tag. No additional VLAN configuration is required on the node network configuration policy.
 <8> Optional: Indicates whether the VM connects to the bridge through the default VLAN. The default value is `true`.


### PR DESCRIPTION
Version(s):
Main, 4.14, 4.15, 4.16, 4.17, 4.18

Issue:
[CNV-51136](https://issues.redhat.com/browse/CNV-51136)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

