### PR TITLE
RHDEVDOCS-6266 - Replacing with a workable link to install the GitOps CLI

### DIFF
--- a/cli_reference/gitops-argocd-cli-tools.adoc
+++ b/cli_reference/gitops-argocd-cli-tools.adoc
@@ -14,7 +14,7 @@ With the {gitops-shortname} CLI, you can make {gitops-shortname} computing tasks
 [id="installing-argocd-gitops-cli"]
 == Installing the {gitops-shortname} CLI
 
-See link:https://docs.openshift.com/gitops/latest/installing_gitops/installing-argocd-gitops-cli[Installing the {gitops-shortname} CLI].
+See link:https://docs.openshift.com/gitops/latest/installing_gitops/installing-argocd-gitops-cli.html[Installing the {gitops-shortname} CLI].
 
 [id="additional-resources_gitops-argocd-cli-tools"]
 [role="_additional-resources"]


### PR DESCRIPTION
Jira issue: [RHDEVDOCS-6266](https://issues.redhat.com/browse/RHDEVDOCS-6266) 

Aligned team: DevTools 
Cherry-pick to versions: `enterprise-4.12` and later

Docs preview:

- [Installing the GitOps CLI](https://85541--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/gitops-argocd-cli-tools.html)

SME review: Completed by @anandf

QE review: @varshab1210

Peer review:  Completed by @xenolinux 

Additional information: N/A
