### PR TITLE
RHDEVDOCS-6277 - Updating GitOps docs to improve content for argo CD resource, default…

### DIFF
--- a/argocd_instance/setting-up-argocd-instance.adoc
+++ b/argocd_instance/setting-up-argocd-instance.adoc
@@ -8,16 +8,25 @@ toc::[]
 
 By default, {gitops-title} installs an instance of Argo CD in the `openshift-gitops` namespace with additional permissions for managing certain cluster-scoped resources. This default Argo CD instance is also called as the default cluster-scoped instance.
 
+To prevent the default Argo CD instance from starting in the `openshift-gitops` namespace, you can use the `openshift-gitops-operator` subscription and configure the `DISABLE_DEFAULT_ARGOCD_INSTANCE` environment variable in it by setting the string value to `"true"`.
+
 [NOTE]
 ====
 For {gitops-shortname} version 1.13 and later:
 
 * Route TLS termination is set as default to the `reencrypt` mode for both the default and user-defined Argo CD instances. TLS connections to the Argo CD instances now receive the default ingress certificate that is set in {OCP}, instead of the self-signed Argo CD certificate. You can modify the route TLS termination policy by configuring the `.spec.server.route.tls` field of the Argo CD CR.
 
-* Restricted pod security admission (PSA) labels are applied to the `openshift-gitops` namespace to ensure compliance with {OCP} standards. If you are running additional workloads in this namespace, such as monitoring or logging, ensure that they comply with the restricted PSA requirements. If compliance is not feasible, consider using a user-defined, cluster-scoped ArgoCD instance, where PSA labels are not applied or controlled by the {gitops-shortname} Operator.
+* Restricted pod security admission (PSA) labels are applied to the `openshift-gitops` namespace to ensure compliance with {OCP} standards. If you are running additional workloads in this namespace, such as monitoring or logging, ensure that they comply with the restricted PSA requirements. If compliance is not feasible, consider using a user-defined, cluster-scoped Argo CD instance, where PSA labels are not applied or controlled by the {gitops-shortname} Operator.
 ====
 
 To manage cluster configurations or deploy applications, you can install and deploy a new user-defined Argo CD instance. By default, any new user-defined instance has permissions to manage resources only in the namespace where it is deployed.
+
+You can create a user-defined Argo CD instance in any namespace, other than the `openshift-gitops` namespace.
+
+[IMPORTANT]
+====
+If you want to create a user-defined Argo CD instance within the `openshift-gitops` namespace, set the `DISABLE_DEFAULT_ARGOCD_INSTANCE` flag value in the `openshift-gitops-operator` subscription to `"true"` and do not name the instance as `openshift-gitops`.
+====
 
 // Installing an Argo CD instance
 include::modules/gitops-argo-cd-installation.adoc[leveloffset=+1]

--- a/modules/gitops-openshift-go-common-terms.adoc
+++ b/modules/gitops-openshift-go-common-terms.adoc
@@ -65,7 +65,7 @@ An Argo CD component that performs the following actions:
 * Returns the result to the Argo CD Application Controller
 
 Argo CD resource (`ArgoCD` CR)::
-A CR that describes the wanted state for a given Argo CD instance. It allows you to configure the components and settings that make up an Argo CD instance.
+A CR that describes the wanted state for a given Argo CD instance. It allows you to configure the components and settings that make up an Argo CD instance. At any given time, you can have only one `ArgoCD` CR within a namespace.
 
 Argo CD server (Argo CD-server)::
 A server that provides the API and UI for Argo CD.
@@ -153,6 +153,8 @@ The wanted state of application resources, as represented by files in a Git repo
 
 User-defined Argo CD instance::
 A custom Argo CD instance that you install and deploy to manage cluster configurations or deploy applications. By default, any new user-defined instance has permissions to manage resources only in the namespace where it is deployed.
++
+You can create a user-defined Argo CD instance in any namespace, other than the `openshift-gitops` namespace.
 
 Workload::
 Any process, usually defined within resources such as `Deployment`, `StatefulSet`, `ReplicaSet`, `Job`, or `Pod`, running within a container. Examples include a Spring Boot application, a NodeJS Express application, or a Ruby on Rails application.


### PR DESCRIPTION
Jira issue: [RHDEVDOCS-6277](https://issues.redhat.com/browse/RHDEVDOCS-6277) 

Aligned team: DevTools 
Cherry-pick to versions: `gitops-docs-1.13` and later

Docs preview:

- [Glossary of common terms for OpenShift GitOps](https://85542--ocpdocs-pr.netlify.app/openshift-gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html#gitops-openshift-go-common-terms_about-redhat-openshift-gitops)
- [Setting up an Argo CD instance](https://85542--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/setting-up-argocd-instance.html)

SME review: Completed by @anandf

QE review: @varshab1210

Peer review:  

Additional information: N/A
