### PR TITLE
OCPBUGS-44349: config data key cannot be user defined

### DIFF
--- a/modules/ibi-extra-manifests-configmap.adoc
+++ b/modules/ibi-extra-manifests-configmap.adoc
@@ -104,9 +104,9 @@ After you create the `ConfigMap` resource, reference it in the `spec.caBundleRef
 
 .Procedure
 
-. Create a CA bundle file such as the following file:
+. Create a CA bundle file called `tls-ca-bundle.pem`:
 +
-.Example `example-ca.crt`
+.Example `tls-ca-bundle.pem` file
 [source,text]
 ----
 -----BEGIN CERTIFICATE-----
@@ -117,13 +117,16 @@ cA8SMRwpUbz3LXY=
 -----END CERTIFICATE-----
 ----
 
-. Create the ConfigMap object by running the following command: 
+. Create the `ConfigMap` object by running the following command: 
 +
 [source,terminal]
 ----
-$ oc create configmap custom-ca --from-file=example-ca.crt -n ibi-ns <1>
+$ oc create configmap custom-ca --from-file=tls-ca-bundle.pem -n ibi-ns
 ----
-<1> Specify the namespace that has the `ImageClusterInstall` resource.
++ 
+* `custom-ca` specifies the name for the `ConfigMap` resource.
+* `tls-ca-bundle.pem` defines the key for the `data` entry in the `ConfigMap` resource. You must include a `data` entry with the `tls-ca-bundle.pem` key.
+* `ibi-ns` specifies the namespace that has the `ImageClusterInstall` resource.
 +
 .Example output
 [source,terminal]
@@ -141,4 +144,3 @@ configmap/custom-ca created
       name: custom-ca
 #...
 ----
-


### PR DESCRIPTION
OCPBUGS-44349: Config data key cannot be user defined. Specifying the hardcoded required key.


Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-44349

Link to docs preview:
https://85543--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install.html#ibi-create-ca-extra-manifest-configmap_ibi-edge-image-based-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
