### PR TITLE
ROX-26886: Update scanner v4 options in docs

### DIFF
--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -194,8 +194,14 @@ If no PVC with the given name exists, it is created. The default value is `scann
 | `scannerV4.monitoring.exposeEndpoint`
 | Configures a monitoring endpoint for Scanner V4. The monitoring endpoint allows other services to collect metrics from Scanner V4, provided in a Prometheus-compatible format. Use `Enabled` to expose the monitoring endpoint. When you enable monitoring, {product-title-short} creates a new service, `monitoring`, with port 9090, and a network policy allowing inbound connections to the port. By default, this is not enabled.
 
-| `scannerV4.scannerComponent`
-| Enables Scanner V4. The default value is `default`, which is disabled. To enable Scanner V4, set this parameter to `Enabled`.
+a| `scannerV4.scannerComponent`
+| Enables Scanner V4. Valid values are:
+
+* `Default`: Scanner V4 is not enabled and not deployed.
+
+* `AutoSense`: If Central exists in the same namespace, Scanner V4 is not deployed and the existing Scanner V4 that was installed with Central is used. If there is no Central in this namespace, Scanner V4 is deployed.
+
+* `Disabled`: Do not deploy Scanner V4.
 
 |===
 


### PR DESCRIPTION
Version(s): 4.5+

[Issue](https://issues.redhat.com/browse/ROX-26886)

Link to docs preview:

- https://85545--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html#scanner-configuration-settings_install-secured-cluster-config-options-ocp

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
