### PR TITLE
Fix the wrong link reference that breaks the build

### DIFF
--- a/installing/installing-openshift-builds.adoc
+++ b/installing/installing-openshift-builds.adoc
@@ -15,7 +15,7 @@ As a cluster administrator, you can install {builds-shortname} on an {ocp-produc
 * You have access to the {ocp-product-title} web console.
 * You have installed the `oc` CLI.
 * You are logged in to the {ocp-product-title} cluster as an administrator.
-* Your cluster has the link:https://docs.openshift.com/container-platform/latest/installing/cluster-capabilities.html#marketplace-operator_cluster-capabilities[Marketplace capability] enabled or the Red Hat Operator catalog source configured manually.
+* Your cluster has the link:https://docs.openshift.com/container-platform/latest/installing/overview/cluster-capabilities.html#marketplace-operator_cluster-capabilities[Marketplace capability] enabled or the Red Hat Operator catalog source configured manually.
 
 [NOTE]
 ====

--- a/work_with_builds/using-builds.adoc
+++ b/work_with_builds/using-builds.adoc
@@ -30,4 +30,4 @@ include::modules/ob-deleting-a-resource.adoc[leveloffset=+1]
 
 * xref:../authenticating/understanding-authentication-at-runtime.adoc#ob-authentication-to-container-registries_understanding-authentication-at-runtime[Authentication to container registries]
 * xref:../installing/installing-openshift-builds.adoc#creating-a-shipwright-build-resource-console_installing-openshift-builds[Creating a ShipwrightBuild resource by using the web console]
-* xref:https://docs.openshift.com/container-platform/4.17/disconnected/mirroring/installing-mirroring-installation-images.html[Mirroring images for a disconnected installation by using the oc adm command]
+* link:https://docs.openshift.com/container-platform/latest/disconnected/mirroring/installing-mirroring-installation-images.html[Mirroring images for a disconnected installation by using the oc adm command]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): `build-docs-1.2`
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: `n/a`
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

* https://85568--ocpdocs-pr.netlify.app/openshift-builds/latest/work_with_builds/using-builds.html#additional-resources_using-builds
* https://85568--ocpdocs-pr.netlify.app/openshift-builds/latest/installing/installing-openshift-builds

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
