### PR TITLE
PR for SRVLOGIC-401: Added additional resources section in the kn workflow plugin installation guide. 

### DIFF
--- a/modules/serverless-logic-install-kn-workflow-artifact-images.adoc
+++ b/modules/serverless-logic-install-kn-workflow-artifact-images.adoc
@@ -8,7 +8,7 @@
 
 .Prerequisites
 
-* You have installed the Knative (`kn`) CLI.
+* You have installed the Knative (`kn`) CLI. For more information, see the xref:../install/installing-kn.adoc#installing-kn[Installing the Knative CLI] documentation.
 * You have installed Podman on your local machine. 
 
 .Procedure

--- a/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
@@ -6,11 +6,11 @@
 [id="serverless-logic-install-kn-workflow-binary-file-linux_{context}"]
 = Installing the {ServerlessLogicProductName} Knative Workflow plugin for Linux
 
-If you are using a Linux distribution that does not have RPM or another package manager installed, you can install the Knative Workflow plugin.
+If you are using a Linux distribution that does not have RPM or another package manager installed, you can install the Knative Workflow plugin as a binary file.
 
 .Prerequisites
 
-* You have installed the xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) command-line interface (CLI)].
+* You have installed the Knative (`kn`) command-line interface (CLI). For more information, see the xref:../install/installing-kn.adoc#installing-kn[Installing the Knative CLI] documentation.
 
 * If you are not using {op-system-base} or Fedora, ensure that the *libc* library is installed in a directory on your path.
 +
@@ -48,14 +48,14 @@ $ mv <filename> kn-workflow
 +
 [source,terminal]
 ----
-$ chmod +x /usr/local/bin/kn-workflow
+$ chmod +x <path/to/downloaded/kn-workflow>
 ----
 
-.. Copy the `kn-workflow` binary file to a directory in the `/usr/local/bin` path by running the following command:
+.. Move the `kn-workflow` binary file to the `/usr/local/bin`, or a directory on your `PATH` by running the following command:
 +
 [source,terminal]
 ----
-$ cp <path/to/downloaded/kn-workflow> /usr/local/bin/kn-workflow
+$ mv <path/to/downloaded/kn-workflow> /usr/local/bin/kn-workflow
 ----
 
 .Verification

--- a/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
@@ -15,7 +15,7 @@ On macOS, some systems might block the application from running due to security 
 
 .Prerequisites
 
-* You have installed the xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) command-line interface (CLI)].
+* You have installed the Knative (`kn`) command-line interface (CLI). For more information, see the xref:../install/installing-kn.adoc#installing-kn[Installing the Knative CLI] documentation.
 
 .Procedure
 
@@ -41,14 +41,14 @@ $ mv <filename> kn-workflow
 +
 [source,terminal]
 ----
-$ chmod +x /usr/local/bin/kn-workflow
+$ chmod +x <path/to/downloaded/kn-workflow>
 ----
 
-.. Copy the `kn-workflow` binary file to a directory in the `/usr/local/bin` path by running the following command:
+.. Move the `kn-workflow` binary file to the `/usr/local/bin`, or a directory on your `PATH` by running the following command:
 +
 [source,terminal]
 ----
-$ cp <path/to/downloaded/kn-workflow> /usr/local/bin/kn-workflow
+$ mv <path/to/downloaded/kn-workflow> /usr/local/bin/kn-workflow
 ----
 
 .Verification

--- a/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
@@ -6,11 +6,11 @@
 [id="serverless-logic-install-kn-workflow-binary-file-windows_{context}"]
 = Installing the {ServerlessLogicProductName} Knative Workflow plugin for Windows
 
-If you are using Windows, you can install the Knative Workflow plugin.
+If you are using Windows, you can install the Knative Workflow plugin as a binary file.
 
 .Prerequisites
 
-* You have installed the xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) command-line interface (CLI)].
+* You have installed the Knative (`kn`) command-line interface (CLI). For more information, see the xref:../install/installing-kn.adoc#installing-kn[Installing the Knative CLI] documentation.
 
 .Procedure
 
@@ -34,14 +34,7 @@ $ Rename-Item -Path <destination>\<filename>.exe -NewName kn-workflow.exe
 +
 On Windows, files with a `.exe` extension are treated as executable by default, so you do not need to change permissions.
 
-.. Move the `kn-workflow.exe` file to a directory in your `PATH` by running the following command:
-+
-[source,terminal]
-----
-$ move C:\path\to\kn-workflow.exe "C:\Program Files"
-----
-
-.. Copy the `kn-workflow` binary file to a directory in your `PATH` by running the following command:
+* Copy the `kn-workflow` binary file to a directory in your `PATH` by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
**Affecting version:** 
- `serverless-docs-1.35`
- `serverless-docs-1.34`
- `serverless-docs-1.33`

**Tracking JIRAs:** https://issues.redhat.com/browse/SRVLOGIC-401

**Doc previews:** [Installing the OpenShift Serverless Logic Knative Workflow plugin](https://85570--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/serverless-logic-install-kn-workflow-plugin-cli.html#serverless-logic-install-kn-workflow-binary-file-linux_serverless-logic-install-kn-workflow-plugin-cli)

