### PR TITLE
PR for SRVLOGIC-436: Document "Global configuration settings" section in the OSL docs.

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -112,7 +112,7 @@
 :ServerlessOperatorName: OpenShift Serverless Operator
 :ServerlessLogicOperatorName: OpenShift Serverless Logic Operator
 :FunctionsProductName: OpenShift Serverless Functions
-:ServerlessProductVersion: 1.34.0
+:ServerlessProductVersion: 1.35.0
 //service mesh v2
 :product-dedicated: Red Hat OpenShift Dedicated
 :SMProductName: Red Hat OpenShift Service Mesh

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -366,6 +366,8 @@ Topics:
     File: serverless-logic-creating-managing-workflows
   - Name: Deploying workflows
     File: serverless-logic-deploying-workflows
+- Name: Global configuration settings
+  File: serverless-logic-global-config-settings
 - Name: Managing services
   Dir: serverless-logic-managing-services
   Topics:

--- a/modules/serverless-logic-global-config-customization.adoc
+++ b/modules/serverless-logic-global-config-customization.adoc
@@ -1,0 +1,130 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-global-config-settings
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-global-config-customization_{context}"]
+= Customization of global configurations
+
+After installing the {ServerlessLogicOperatorName}, you can access the `logic-operator-rhel8-controllers-config` config map file in the `openshift-serverless-logic` namespace. This configuration file defines how the Operator behaves when it creates new resources in the cluster. However, changes to this configuration does not affect resources that already exist. 
+
+You can modify any of the options within the `controllers_cfg.yaml` key in the config map. 
+
+The following table outlines all the available global configuration options:
+
+[cols=3*,options="header"]
+|===
+|Configuration key
+|Default value
+|Description
+
+|`defaultPvcKanikoSize`
+|`1Gi`
+|The default size of Kaniko persistent volume claim (PVC) when using the internal {ServerlessLogicOperatorName} builder manager.
+
+|`healthFailureThresholdDevMode`
+|`50`
+|How much time (in seconds) to wait for a developer mode workflow to start. This information is used for the controller manager to create new developer mode containers and setup the health check probes.
+
+|`kanikoDefaultWarmerImageTag`
+|`gcr.io/kaniko-project/warmer:v1.9.0`
+|Default image used internally by the Operator managed Kaniko builder to create the warmup pods.
+
+|`kanikoExecutorImageTag`
+|`gcr.io/kaniko-project/executor:v1.9.0`
+|Default image used internally by the Operator managed Kaniko builder to create the executor pods.
+
+|`jobsServicePostgreSQLImageTag`
+|`registry.redhat.io/openshift-serverless-1/logic-jobs-service-postgresql-rhel8:{ServerlessProductVersion}`
+|The Jobs service image for PostgreSQL to use. If empty, the {ServerlessLogicOperatorName} uses the default Apache community image based on the current {ServerlessLogicOperatorName} version.
+
+|`jobsServiceEphemeralImageTag`
+|`registry.redhat.io/openshift-serverless-1/logic-jobs-service-ephemeral-rhel8:{ServerlessProductVersion}`
+|The Jobs service image without persistence to use. If empty, the {ServerlessLogicOperatorName} uses the default Apache community image based on the current {ServerlessLogicOperatorName} version.
+
+|`dataIndexPostgreSQLImageTag`
+|`registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:{ServerlessProductVersion}`
+|The Data Index service image for PostgreSQL to use. If empty, the {ServerlessLogicOperatorName} uses the default Apache community image based on the current {ServerlessLogicOperatorName} version.
+
+|`dataIndexEphemeralImageTag`
+|`registry.redhat.io/openshift-serverless-1/logic-data-index-ephemeral-rhel8:{ServerlessProductVersion}`
+|The Data Index service image without persistence to use. If empty, the {ServerlessLogicOperatorName} uses the default Apache community image based on the current {ServerlessLogicOperatorName} version.
+
+|`sonataFlowBaseBuilderImageTag`
+|`registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:{ServerlessProductVersion}`
+|{ServerlessLogicProductName} base builder image used in the internal Dockerfile to build workflow applications in preview profile. If empty, the {ServerlessLogicOperatorName} uses the default Apache community image based on the current {ServerlessLogicOperatorName} version.
+
+|`sonataFlowDevModeImageTag`
+|`registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:{ServerlessProductVersion}`
+|The image to use to deploy {ServerlessLogicProductName} workflow images in devmode profile. If empty, the {ServerlessLogicOperatorName} uses the default Apache community image based on the current {ServerlessLogicOperatorName} version.
+
+|`builderConfigMapName`
+|`logic-operator-rhel8-builder-config`
+|The default name of the builder config map in the {ServerlessLogicOperatorName} namespace.
+
+|`postgreSQLPersistenceExtensions`
+|next column
+|Quarkus extensions required for workflows persistence. These extensions are used by the {ServerlessLogicOperatorName} builder in cases where the workflow being built has configured PostgreSQL persistence.
+
+|`kogitoEventsGrouping`
+|`true`
+|When set to `true`, configures every workflow deployment with the `gitops` or `preview` profiles to send accumulated workflow status change events to the Data Index service, reducing the number of produced events. You can set the value to `false` to send individual events.
+
+|`kogitoEventsGroupingBinary`
+|`true`
+|When set to `true`, the accumulated workflow status change events are sent in binary mode, reducing the size of the produced events. You can set the value to `false` to send plain JSON events.
+
+|`kogitoEventsGroupingCompress`
+|`false`
+|When set to `true`, the accumulated workflow status change events, if sent in binary mode, are zipped at the cost of some performance.
+
+|===
+
+You can edit this by updating the `logic-operator-controllers-config` config map by using the `oc` command-line tool.
+
+[id="serverless-logic-global-configuration-changes-impact_{context}"]
+== Impact of global configuration changes
+
+When you update the global configurations, the changes immediately affect only newly created resources. For example, if you change the `sonataFlowDevModeImageTag` property and already have a workflow deployed in dev mode, the {ServerlessLogicOperatorName} does not roll out a new deployment with the updated image configuration. Only new deployments reflect the changes.
+
+[id="serverless-logic-customizing-base-builder-image_{context}"]
+== Customizing the base builder image
+
+You can directly change the base builder image in the Dockerfile used by the {ServerlessLogicOperatorName}.
+
+Additionally, you can specify the base builder image in the `SonataFlowPlatform` configuration within the current namespace. This ensures that the specified base image is used exclusively in the given namespace.
+
+.Example of `SonataFlowPlatform` with a custom base builder image
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform
+spec:
+  build:
+    config:
+        baseImage: dev.local/my-workflow-builder:1.0.0
+----
+
+Alternatively, you can also modify the base builder image in the global configuration config map as shown in the following example:
+
+.Example of `ConfigMap` with a custom base builder image
+[source,yaml]
+----
+apiVersion: v1
+data:
+  controllers_cfg.yaml: |
+    sonataFlowBaseBuilderImageTag: dev.local/my-workflow-builder:1.0.0
+kind: ConfigMap
+metadata:
+  name: logic-operator-rhel8-controllers-config
+  namespace: openshift-serverless-logic
+----
+
+When customizing the base builder image, the following order of precedence is applicable:
+
+1. The `SonataFlowPlatform` configuration in the current context.
+2. The global configuration entry in the `ConfigMap` resource.
+3. The `FROM` clause in the Dockerfile within the {ServerlessLogicOperatorName} namespace, defined in the `logic-operator-rhel8-builder-config` config map.
+
+The entry in the `SonataFlowPlatform` configuration always overrides any other value.

--- a/serverless-logic/serverless-logic-global-config-settings.adoc
+++ b/serverless-logic/serverless-logic-global-config-settings.adoc
@@ -1,0 +1,16 @@
+:_content-type: ASSEMBLY
+[id="serverless-logic-global-config-settings"]
+= Global configuration settings
+:context: serverless-logic-global-config-settings
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+You can set global configuration options for the {ServerlessLogicOperatorName}.
+
+[id="prerequisites_serverless-logic-global-config-settings_{context}"]
+== Prerequisites
+
+* You have installed the {ServerlessLogicOperatorName} in the target cluster.
+
+include::modules/serverless-logic-global-config-customization.adoc[leveloffset=+1]


### PR DESCRIPTION
**Affecting version:** `serverless-docs-1.35`

**Tracking JIRAs:** https://issues.redhat.com/browse/SRVLOGIC-436

**Doc previews:** [Global configuration settings](https://85578--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-global-config-settings.html)
