### PR TITLE
OBSDOCS-1526 change default namespace for COO

### DIFF
--- a/modules/monitoring-installing-cluster-observability-operator-using-the-web-console.adoc
+++ b/modules/monitoring-installing-cluster-observability-operator-using-the-web-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 
-// * observability/monitoring/cluster_observability_operator/installing-the-cluster-observability-operator.adoc
+// * observability/cluster_observability_operator/installing-the-cluster-observability-operator.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-the-cluster-observability-operator-in-the-web-console-_{context}"]
@@ -17,15 +17,16 @@ Install the {coo-first} from OperatorHub by using the {product-title} web consol
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
 . Type `cluster observability operator` in the *Filter by keyword* box.
 . Click  *{coo-full}* in the list of results.
-. Read the information about the Operator, and review the following default installation settings:
+. Read the information about the Operator, and configure the following installation settings:
 +
-* *Update channel* -> *development*
-* *Version* -> <most_recent_version>
+* *Update channel* -> *stable*
+* *Version* -> *1.0.0* or later
 * *Installation mode* -> *All namespaces on the cluster (default)*
-* *Installed Namespace* -> *openshift-operators*
+* *Installed Namespace* -> *Operator recommended Namespace: openshift-cluster-observability-operator*
+* Select *Enable Operator recommended cluster monitoring on this Namespace*
 * *Update approval* -> *Automatic*
 
-. Optional: Change default installation settings to suit your requirements.
+. Optional: You can change the installation settings to suit your requirements.
 For example, you can select to subscribe to a different update channel, to install an older released version of the Operator, or to require manual approval for updates to new versions of the Operator.
 . Click *Install*.
 


### PR DESCRIPTION

Version(s):
4.12+

Issue:
[OBSDOCS-1526](https://issues.redhat.com//browse/OBSDOCS-1526)

Link to docs preview:
https://85579--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/installing-the-cluster-observability-operator.html

QE review:
- [ ] QE has approved this change.


Additional information:

