### PR TITLE
OCPBUGS#44659-13: Added important note for disabling IPsec for 4.13 a…

### DIFF
--- a/modules/nw-ovn-ipsec-disable.adoc
+++ b/modules/nw-ovn-ipsec-disable.adoc
@@ -8,6 +8,11 @@
 
 As a cluster administrator, you can disable IPsec encryption only if you enabled IPsec after cluster installation.
 
+[IMPORTANT]
+====
+After disabling IPsec, you must delete the associated IPsec daemonsets pods. If you do not delete these pods, you might experience issues with your cluster.
+====
+
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
@@ -23,24 +28,47 @@ $ oc patch networks.operator.openshift.io/cluster --type=json \
   -p='[{"op":"remove", "path":"/spec/defaultNetwork/ovnKubernetesConfig/ipsecConfig"}]'
 ----
 
-. Optional: You can increase the size of your cluster MTU by `46` bytes because there is no longer any overhead from the IPsec ESP header in IP packets.
-
-. Verify that IPsec is disabled on your cluster:
+. To find the name of the OVN-Kubernetes data plane pod that exists on the `master` node in your cluster, enter the following command:
 +
 [source,terminal]
 ----
-$ oc -n openshift-ovn-kubernetes -c nbdb rsh ovnkube-master-<XXXXX> \
-  ovn-nbctl --no-leader-only get nb_global . ipsec
+$ oc get pods -n openshift-ovn-kubernetes -l=app=ovnkube-master
 ----
-+
---
-where:
-
-`<XXXXX>`:: Specifies the random sequence of letters for a pod from the previous step.
---
 +
 .Example output
-[source,text]
+[source,terminal]
 ----
-false
+ovnkube-master-5xqbf                      8/8     Running   0              28m
+...
 ----
+
+. Verify that the `master` node in your cluster has IPsec disabled by entering the following command. The command output must state `false` to indicate that the node has IPsec disabled.
++
+[source,terminal]
+----
+$ oc -n openshift-ovn-kubernetes -c nbdb rsh ovnkube-master-<pod_number_sequence> \// <1>
+  ovn-nbctl --no-leader-only get nb_global . ipsec 
+----
+<1> Replace `<pod_number_sequence>` with the random sequence of letters, such as `5xqbf`, for the data plane pod from the previous step.
+
+. To remove the IPsec `ovn-ipsec` daemonset pod from the `openshift-ovn-kubernetes` namespace on the node, enter the following command:
++
+[source,terminal]
+----
+$ oc delete daemonset ovn-ipsec -n openshift-ovn-kubernetes <1>
+----
+<1> The `ovn-ipsec` daemonset configures IPsec connections for east-west traffic on the node.
+
+. Verify that the `ovn-ipsec` daemonset pod was removed from the all nodes in your cluster by entering the following command. If the command output does not list the pod, the removal operation is successful.
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -l=app=ovn-ipsec
+----
++
+[NOTE]
+====
+You might need to re-run the command for deleting the pod because sometimes the initial command attempt might not delete the pod.
+====
+
+. Optional: You can increase the size of your cluster MTU by `46` bytes because there is no longer any overhead from the IPsec ESP header in IP packets.

--- a/modules/nw-ovn-ipsec-enable.adoc
+++ b/modules/nw-ovn-ipsec-enable.adoc
@@ -11,8 +11,8 @@ As a cluster administrator, you can enable IPsec encryption after cluster instal
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
-* Log in to the cluster with a user with `cluster-admin` privileges.
-* You have reduced the size of your cluster MTU by `46` bytes to allow for the overhead of the IPsec ESP header.
+* Log in to the cluster as a user with `cluster-admin` privileges.
+* You have reduced the size of your cluster maximum transmission unit (MTU) by `46` bytes to allow for the overhead of the IPsec ESP header.
 
 .Procedure
 
@@ -42,22 +42,11 @@ ovnkube-master-hsgmm   6/6     Running   0          122m
 ovnkube-master-qcmdc   6/6     Running   0          122m
 ----
 
-. Verify that IPsec is enabled on your cluste by running the following command:
+. Verify that IPsec is enabled on your cluster by entering the following command. The command output must state `true` to indicate that the node has IPsec enabled.
 +
 [source,terminal]
 ----
-$ oc -n openshift-ovn-kubernetes rsh ovnkube-master-<XXXXX> \
+$ oc -n openshift-ovn-kubernetes rsh ovnkube-master-<pod_number_sequence> \ <1>
   ovn-nbctl --no-leader-only get nb_global . ipsec
 ----
-+
---
-where:
-
-`<XXXXX>`:: Specifies the random sequence of letters for a pod from the previous step.
---
-+
-.Example output
-[source,text]
-----
-true
-----
+<1> Replace `<pod_number_sequence>` with the random sequence of letters, `fvtnh`, for a data plane pod from the previous step.


### PR DESCRIPTION
Version(s):
4.13 and 4.12

Issue:
[OCPBUGS-44659](https://issues.redhat.com/browse/OCPBUGS-44659)

Link to docs preview:
[Disabling IPsec encryption](https://85581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.html#nw-ovn-ipsec-disable_configuring-ipsec-ovn)

- [x] SME has approved this change (Periyasamy Palanisamy).
- [x] QE has approved this change (Anurag Saxena).

Links:
* 4.14 update: https://github.com/openshift/openshift-docs/pull/85485
