### PR TITLE
OBSDOCS-1523 remove TP notice for COO, but keep for troubleshooting korrel8r

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3233,14 +3233,14 @@ Topics:
     Topics:
     - Name: Observability UI plugins overview
       File: observability-ui-plugins-overview
-    - Name: Dashboard UI plugin
-      File: dashboard-ui-plugin
+    - Name: Logging UI plugin
+      File: logging-ui-plugin
     - Name: Distributed tracing UI plugin
       File: distributed-tracing-ui-plugin
     - Name: Troubleshooting UI plugin
       File: troubleshooting-ui-plugin
-    - Name: Logging UI plugin
-      File: logging-ui-plugin
+#    - Name: Dashboard UI plugin
+#      File: dashboard-ui-plugin
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/observability/cluster_observability_operator/cluster-observability-operator-overview.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-overview.adoc
@@ -6,8 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The Cluster Observability Operator
-include::snippets/technology-preview.adoc[leveloffset=+2]
 
 The {coo-first} is an optional component of the {product-title} designed for creating and managing highly customizable monitoring stacks. It enables cluster administrators to automate configuration and management of monitoring needs extensively, offering a more tailored and detailed view of each namespace compared to the default {product-title} monitoring system.
 

--- a/observability/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service.adoc
+++ b/observability/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The Cluster Observability Operator
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 You can monitor metrics for a service by configuring monitoring stacks managed by the {coo-first}.
 
 To test monitoring a service, follow these steps:

--- a/observability/cluster_observability_operator/installing-the-cluster-observability-operator.adoc
+++ b/observability/cluster_observability_operator/installing-the-cluster-observability-operator.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The Cluster Observability Operator
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 As a cluster administrator, you can install or remove the {coo-first} from OperatorHub by using the {product-title} web console.
 OperatorHub is a user interface that works in conjunction with Operator Lifecycle Manager (OLM), which installs and manages Operators on a cluster.
 

--- a/observability/cluster_observability_operator/ui_plugins/dashboard-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/dashboard-ui-plugin.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The Cluster Observability Operator
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 The dashboard UI plugin supports enhanced dashboards in the OpenShift web console at *Observe* -> *Dashboards* . You can add other Prometheus datasources from the cluster to the default dashboards, in addition to the in-cluster datasource. This results in a unified observability experience across different data sources.
 
 The plugin searches for datasources from `ConfigMap` resources in the `openshift-config-managed` namespace, that have the label `console.openshift.io/dashboard-datasource: 'true'`. 

--- a/observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The Cluster Observability Operator
+:FeatureName: The {coo-full} distributed tracing UI plugin
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
 The distributed tracing UI plugin adds tracing-related features to the Administrator perspective of the OpenShift web console at **Observe** → **Traces**. You can follow requests through the front end and into the backend of microservices, helping you identify code errors and performance bottlenecks in distributed systems. 

--- a/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.adoc
@@ -6,23 +6,25 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The {coo-full}
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 You can use the {coo-first} to install and manage UI plugins to enhance the observability capabilities of the {product-title} web console.
-The plugins extend the default functionality, providing new UI features for monitoring, troubleshooting, distributed tracing, and cluster logging.
+The plugins extend the default functionality, providing new UI features for troubleshooting, distributed tracing, and cluster logging.
 
-[id="dashboards_{context}"]
-== Dashboards
 
-The dashboard UI plugin supports enhanced dashboards in the {product-title} web console at *Observe* -> *Dashboards*.
-You can add other Prometheus data sources from the cluster to the default dashboards, in addition to the in-cluster data source.
-This results in a unified observability experience across different data sources.
 
-For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/dashboard-ui-plugin.adoc#dashboard-ui-plugin[dashboard UI plugin] page.
+[id="cluster-logging_{context}"]
+== Cluster logging
+
+The logging UI plugin surfaces logging data in the web console on the  *Observe* -> *Logs* page. 
+You can specify filters, queries, time ranges and refresh rates. The results displayed a list of collapsed logs, which can then be expanded to show more detailed information for each log.
+
+For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[logging UI plugin] page.
+
 
 [id="troubleshooting_{context}"]
 == Troubleshooting
+
+:FeatureName: The {coo-full} troubleshooting panel UI plugin
+include::snippets/technology-preview.adoc[leveloffset=+2]
 
 The troubleshooting panel UI plugin for {product-title} version 4.16+ provides observability signal correlation, powered by the open source Korrel8r project.
 You can use the troubleshooting panel available from the *Observe* -> *Alerting* page to easily correlate metrics, logs, alerts, netflows, and additional observability signals and resources, across different data stores.
@@ -35,6 +37,9 @@ For more information, see the xref:../../../observability/cluster_observability_
 [id="distributed-tracing_{context}"]
 == Distributed tracing
 
+:FeatureName: The {coo-full} distributed tracing UI plugin
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
 The distributed tracing UI plugin adds tracing-related features to the web console on the *Observe* -> *Traces* page.
 You can follow requests through the front end and into the backend of microservices, helping you identify code errors and performance bottlenecks in distributed systems.
 You can select a supported `TempoStack` or `TempoMonolithic` multi-tenant instance running in the cluster and set a time range and query to view the trace data.
@@ -42,10 +47,14 @@ You can select a supported `TempoStack` or `TempoMonolithic` multi-tenant instan
 For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin.adoc#distributed-tracing-ui-plugin[distributed tracing UI plugin] page.
 
 
-[id="cluster-logging_{context}"]
-== Cluster logging
+////
+[id="dashboards_{context}"]
+== Dashboards
 
-The logging UI plugin surfaces logging data in the web console on the  *Observe* -> *Logs* page. 
-You can specify filters, queries, time ranges and refresh rates. The results displayed a list of collapsed logs, which can then be expanded to show more detailed information for each log.
+The dashboard UI plugin supports enhanced dashboards in the {product-title} web console at *Observe* -> *Dashboards*.
+You can add other Prometheus data sources from the cluster to the default dashboards, in addition to the in-cluster data source.
+This results in a unified observability experience across different data sources.
 
-For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[logging UI plugin] page.
+For more information, see the xref :../../../observability/cluster_observability_operator/ui_plugins/dashboard-ui-plugin.adoc#dashboard-ui-plugin[dashboard UI plugin] page.
+
+////

--- a/observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The Cluster Observability Operator
+:FeatureName: The {coo-full} troubleshooting panel UI plugin
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
 The troubleshooting UI plugin for {product-title} version 4.16+ provides observability signal correlation, powered by the open source Korrel8r project.


### PR DESCRIPTION

Version(s):
4.12+

Issue:
[OBSDOCS-1523](https://issues.redhat.com//browse/OBSDOCS-1523)

Link to docs preview:

- TP notice removed from main COO pages
  
  https://85586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-overview.html
  
  https://85586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/installing-the-cluster-observability-operator.html
  
  https://85586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service.html


- Moved the generic TP notice onto the specific plugins, and removed dasboard plugin overview entirely because it is dev preview

  https://85586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.html

- Added TP note to troubleshooting, distrib tracing plugin overviews

  https://85586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview#troubleshooting_observability-ui-plugins-overview
  
  https://85586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview#distributed-tracing_observability-ui-plugins-overview

- Added TP note to troubleshooting, distrib tracing plugin pages

  https://85586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/distributed-tracing-ui-plugin#distributed-tracing-ui-plugin

  https://85586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/troubleshooting-ui-plugin


- Removed the dashboard UI Plugin content - dev preview - previously published here:

  https://docs.openshift.com/container-platform/4.17/observability/cluster_observability_operator/ui_plugins/dashboard-ui-plugin.html

QE review:
- [ ] QE has approved this change.


Additional information:
