### PR TITLE
OSDOCS-11772: Upgrade ROSA with HCP cluster through  Openshift Cluster manager console

### DIFF
--- a/modules/rosa-deleting-cluster-upgrade-ocm.adoc
+++ b/modules/rosa-deleting-cluster-upgrade-ocm.adoc
@@ -3,7 +3,7 @@
 // * upgrading/rosa_upgrading/rosa-upgrading-sts.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-deleting-cluster-upgrade-ocm_{context}"]
-= Deleting a ROSA cluster upgrade with the {cluster-manager} console
+= Deleting an upgrade with the {cluster-manager} console
 
 You can use the {cluster-manager} console to delete a scheduled upgrade.
 

--- a/modules/rosa-hcp-upgrading-cli-machinepool.adoc
+++ b/modules/rosa-hcp-upgrading-cli-machinepool.adoc
@@ -31,6 +31,11 @@ When your hosted control plane upgrade is complete, you can upgrade one or more 
 endif::[]
 //END WHOLE CLUSTER condition
 
+[NOTE]
+====
+Machine pool configurations such as node drain timeout, max-unavailable, and max-surge can affect the timing and success of upgrades.
+====
+
 .Procedure
 . Verify the current version of your cluster by running the following command:
 +
@@ -85,7 +90,7 @@ Do not upgrade your machine pool to a version higher than your control plane. If
 +
 [source,terminal]
 ----
-$ rosa describe machinepool --cluster=<cluster_name_or_id> <machinepool_name> 
+$ rosa describe machinepool --cluster=<cluster_name_or_id> <machinepool_name>
 ----
 +
 .Example output

--- a/modules/rosa-upgrading-manual-ocm.adoc
+++ b/modules/rosa-upgrading-manual-ocm.adoc
@@ -3,6 +3,14 @@
 // * rosa_upgrading/rosa-upgrading.adoc
 // * rosa_upgrading/rosa-upgrading-sts.adoc
 
+//  adding this ifeval hcp-in-rosa when a hcp procedure appears in the rosa distro as well as the  hcp distro
+
+ifdef::openshift-rosa[]
+ifeval::["{context}" == "rosa-hcp-upgrading"]
+:hcp-in-rosa:
+endif::[]
+endif::openshift-rosa[]
+
 ifeval::["{context}" == "rosa-upgrading-sts"]
 :sts:
 endif::[]
@@ -11,7 +19,7 @@ endif::[]
 [id="rosa-upgrade-ocm_{context}"]
 = Upgrading with the {cluster-manager} console
 
-You can schedule upgrades for a ROSA (classic architecture) cluster manually either one time or on a recurring schedule by using {cluster-manager} console.
+You can schedule upgrades for a ROSA cluster manually either one time or on a recurring schedule by using {cluster-manager} console.
 
 .Procedure
 
@@ -20,20 +28,20 @@ You can schedule upgrades for a ROSA (classic architecture) cluster manually eit
 . Click the *Settings* tab.
 . In the *Update strategy* pane, select which type of update you want:
 ** For individual updates, you can request the upgrade either immediately (to start within an hour) or at a future time.
-** For recurring updates, choose a recurring date and time to start the upgrade automatically to the latest x.y.Z (z-stream) version available.
+** For recurring updates, select a recurring date and time to start the upgrade automatically to the latest x.y.Z (z-stream) version available.
 +
 [IMPORTANT]
 ====
 Recurring updates are applicable only for z-stream updates. Minor version or y-stream updates need to be done manually. You will be notified when a new y-stream update is available.
 ====
-+
+ifndef::hcp-in-rosa,openshift-rosa-hcp[]
 . Optional: In the *Node draining* pane, select a grace period interval from the list. The grace period enables the nodes to gracefully drain before forcing the pod eviction. The default is *1 hour*.
 +
 [IMPORTANT]
 ====
 You cannot change the node drain grace period after you start the upgrade process.
 ====
-+
+endif::[]
 . In the *Update strategy* pane, click *Save* to apply your update strategy.
 . In the *Update status* pane, review the *Update available* information and click *Update*.
 +
@@ -61,3 +69,11 @@ The status is displayed in the *Update status* pane.
 
 .Troubleshooting
 * Sometimes a scheduled upgrade does not trigger. See link:https://access.redhat.com/solutions/6648291[Upgrade maintenance cancelled] for more information.
+
+ifeval::["{context}" == "rosa-upgrading-sts"]
+:!sts:
+endif::[]
+
+ifeval::["{context}" == "rosa-hcp-upgrading"]
+:!hcp-in-rosa:
+endif::[]

--- a/upgrading/rosa-hcp-upgrading.adoc
+++ b/upgrading/rosa-hcp-upgrading.adoc
@@ -65,3 +65,8 @@ ifndef::prevcontext[:!context:]
 //LB: Remove until here if we don't want the "whole cluster" upgrade section
 
 include::modules/rosa-hcp-upgrading-cli-tutorial.adoc[leveloffset=+1]
+
+include::modules/rosa-upgrading-manual-ocm.adoc[leveloffset=+1]
+
+include::modules/rosa-deleting-cluster-upgrade-ocm.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-11772

Link to docs preview:
https://85588--ocpdocs-pr.netlify.app/
https://85588--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/upgrading/rosa-hcp-upgrading.html
https://85588--ocpdocs-pr.netlify.app/openshift-rosa/latest/upgrading/rosa-hcp-upgrading.html
https://85588--ocpdocs-pr.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading-sts.html

New note in:
https://85588--ocpdocs-pr.netlify.app/openshift-rosa/latest/upgrading/rosa-hcp-upgrading#rosa-hcp-upgrading-cli-machinepool_rosa-hcp-upgrading-whole-cluster

https://85588--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/upgrading/rosa-hcp-upgrading#rosa-hcp-upgrading-cli-machinepool_rosa-hcp-upgrading-whole-cluster

QE review:
- [ ] QE none needed

