### PR TITLE
OSDOCS-12799: Documented the 4.14.42 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2963,7 +2963,7 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-14-known-issues"]
 == Known issues
 
-* A regression in the behaviour of `libreswan` caused some nodes with IPsec enabled to lose communication with pods on other nodes in the same cluster. To resolve this issue, consider disabling IPsec for your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-44672[*OCPBUGS-44672*])
+* A regression in the behaviour of `libreswan` caused some nodes with IPsec enabled to lose communication with pods on other nodes in the same cluster. To resolve this issue, consider disabling IPsec for your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-42952[*OCPBUGS-42952*])
 
 // TODO: This known issue should carry forward to 4.8 and beyond! This needs some SME/QE review before being updated for 4.11. Need to check if KI should be removed or should stay.
 * In {product-title} 4.1, anonymous users could access discovery endpoints. Later releases revoked this access to reduce the possible attack surface for security exploits because some discovery endpoints are forwarded to aggregated API servers. However, unauthenticated access is preserved in upgraded clusters so that existing use cases are not broken.
@@ -3391,6 +3391,37 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+// 4.14.42
+[id="ocp-4-14-42_{context}"]
+=== RHSA-2024:10523 - {product-title} 4.14.42 bug fix and security update
+
+Issued: 05 December 2024
+
+{product-title} release 4.14.42, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10523[RHSA-2024:10523] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10526[RHBA-2024:10526] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.42 --pullspecs
+----
+
+[id="ocp-4-14-42-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the approval mechanism for certificate signing requests (CSRs) failed because the node name and internal DNS entry for a CSR did not match in terms of character case differences. With this release, an update to the approval mechanism for CSRs skips case-sensitive checks so that a CSR with a matching node name and internal DNS entry does not fail the check because of character case differences. (link:https://issues.redhat.com/browse/OCPBUGS-44774[*OCPBUGS-44774*])
+
+* Previously, when the Cluster Version Operator (CVO) pod restarted while it was initializing the synchronization work, the Operator interrupted the guard of the blocked upgrade request. The blocked request was unexpectedly accepted. With this release, the guard of the blocked upgrade request continues after the CVO restarts. (link:https://issues.redhat.com/browse/OCPBUGS-44704[*OCPBUGS-44704*])
+
+* Previously, when the Cluster Resource Override Operator was unable to completely deploy its operand controller, the Operator would restart the process. Each time the Operator attempted the deployment process, the Operator created a new set of secrets. This resulted in a large number of secrets created in the namespace where the Cluster Resource Override Operator was deployed. With this release, the fixed version correctly processes the service account annotations and only one set of secrets is created. (link:https://issues.redhat.com/browse/OCPBUGS-44435[*OCPBUGS-44435*])
+
+[id="ocp-4-14-42-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.14.41
 [id="ocp-4-14-41_{context}"]


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-12799](https://issues.redhat.com/browse/OSDOCS-12799)

Link to docs preview:
* [4.14.42](https://85621--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-42_release-notes)

