### PR TITLE
OSDOCS-12800: Documented the 4.17.7 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2857,6 +2857,44 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.7
+[id="ocp-4-17-7_{context}"]
+=== RHSA-2024:10518 - {product-title} {product-version}.7 bug fix, and security update advisory
+
+Issued: 03 December 2024
+
+{product-title} release {product-version}.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10518[RHSA-2024:10518] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10521[RHBA-2024:10521] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.7 --pullspecs
+----
+
+[id="ocp-4-17-7-enhancements_{context}"]
+==== Enhancements
+
+[id="ocp-4-17-7-cluster-tasks-pipelines_{context}"]
+===== Deprecated clusterTasks {pipelines-shortname} version 1.17
+
+* The {product-title} {product-version} release deprecates the `clusterTasks` resource from {pipelines-title} version 1.17. The release also removes `clusterTasks` resource dependencies from the static plugin on the {pipelines-shortname} page of the {product-title} web console. (link:https://issues.redhat.com/browse/OCPBUGS-44183[*OCPBUGS-44183*])
+
+[id="ocp-4-17-7-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, you could not enter multi-line parameters in a custom template, such as private keys. With this release, you can switch between single-line and multi-line modes in a custom template so that you can enter multi-line inputs in a template field. (link:https://issues.redhat.com/browse/OCPBUGS-44699[*OCPBUGS-44699*])
+
+* Previously, when you attempted to use the Cluster Network Operator (CNO) to upgrade a cluster  with existing `localnet` networks, `ovnkube-control-plane` pods would fail to run. This happened because the `ovnkube-cluster-manager` container could not process an OVN-Kubernetes `localnet` topology network that did not have subnets defined. With this release, a fix ensures that the `ovnkube-cluster-manager` container can process an OVN-Kubernetes `localnet` topology network that does not have subnets defined. (link:https://issues.redhat.com/browse/OCPBUGS-43454[*OCPBUGS-43454*]) 
+
+* Previously, when you attempted to scale a `DeploymentConfig` object with an admission webhook that the object's `deploymentconfigs/scale` subresource, the `apiserver` failed to handle the request. This impacted the `DeploymentConfig` object as it could not be scaled. With this release, a fix ensures that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-42752[*OCPBUGS-42752*])
+
+[id="ocp-4-17-7-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.17.6
 [id="ocp-4-17-6_{context}"]
 === RHBA-2024:10137 - {product-title} {product-version}.6 bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12800](https://issues.redhat.com/browse/OSDOCS-12800)

Link to docs preview:
* [4.17.7](https://85628--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-7_release-notes)

