### PR TITLE
RHDEVDOCS 6243 priority class applies to affinity assistant pods

### DIFF
--- a/modules/op-specifying-pipelines-resource-quota-using-priority-class.adoc
+++ b/modules/op-specifying-pipelines-resource-quota-using-priority-class.adoc
@@ -201,7 +201,11 @@ To avoid this error, set a limit range for the namespace, where the defaults fro
 
 For more information about setting limit ranges, refer to _Restrict resource consumption with limit ranges_ in the _Additional resources_ section.
 ====
-
++
+[NOTE]
+====
+Since {pipelines-shortname} 1.17, the priority class that you set for a task applies to all pods created for the task, including the affinity assistant pod that {pipelines-shortname} creates in order to ensure that the task executes on a particular node.
+====
 . After the pods are created, verify the resource quota usage for the pipeline run.
 +
 .Example: Verify resource quota usage for the pipeline


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
pipelines-docs-1.17, pipelines-docs-1.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6243

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://85636--ocpdocs-pr.netlify.app/openshift-pipelines/latest/resource/setting-compute-resource-quota-for-openshift-pipelines.html#specifying-pipelines-resource-quota-using-priority-class_setting-compute-resource-quota-for-openshift-pipelines

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
