### PR TITLE
PR for SRVCOM-3457: Update the Serverless 1.33.3 release notes

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -31,6 +31,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-34-0.adoc[leveloffset=+1]
 
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-33-3.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-33-2.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-33-0.adoc[leveloffset=+1]
 

--- a/modules/serverless-rn-1-33-3.adoc
+++ b/modules/serverless-rn-1-33-3.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-33-3_{context}"]
+= Red Hat {ServerlessProductName} 1.33.3
+
+{ServerlessProductName} 1.33.3 is now available, addressing identified Common Vulnerabilities and Exposures (CVEs) to enhance security and reliability.


### PR DESCRIPTION
Affected versions: serverless-docs-1.35

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3457

**Doc preview:** [Serverless 1.33.3 release notes]()
