### PR TITLE
PR for SRVCOM-3402: Update the Serverless 1.35 release notes

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,9 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-35-0.adoc[leveloffset=+1]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-34-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-34-0.adoc[leveloffset=+1]
 

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -13,12 +13,18 @@ For the most recent list of major functionality deprecated and removed within {S
 .Deprecated and removed features tracker
 [cols="3,1,1,1,1,1,1",options="header"]
 |====
-|Feature |1.29|1.30|1.31|1.32|1.33|1.34
+|Feature 
+|1.30
+|1.31
+|1.32
+|1.33
+|1.34
+|1.35
 
 |EventTypes `v1beta1` API
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
@@ -26,7 +32,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |`domain-mapping` and `domain-mapping-webhook` deployments
 |-
 |-
-|-
+|Removed
 |Removed
 |Removed
 |Removed
@@ -34,13 +40,13 @@ For the most recent list of major functionality deprecated and removed within {S
 |{SMProductName} with {ServerlessProductShortName} when Kourier is enabled
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
 
 |`NamespacedKafka` annotation
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated

--- a/modules/serverless-rn-1-35-0.adoc
+++ b/modules/serverless-rn-1-35-0.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-35-0_{context}"]
+= Red Hat {ServerlessProductName} 1.35
+
+{ServerlessProductName} 1.35 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="new-features-1-35-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.15.
+* {ServerlessProductName} now uses Knative Eventing 1.15.
+* {ServerlessProductName} now uses Kourier 1.15.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.15.
+* {ServerlessProductName} now uses Knative for Apache Kafka 1.15.
+* The `kn func` CLI plugin now uses `func` 1.16.
+
+* Go functions using S2I builder are now available as a Generally Available (GA) feature for Linux and Mac developers, allowing them to implement and build Go functions on these platforms.
+
+* It is now possible to automatically discover and register `EventTypes` based on the structure of incoming events, simplifying the overall configuration and management of `EventTypes`.
+
+* Knative Event catalog is now available in OpenShift Developer Console (ODC). You can explore the catalog to discover different event types, along with their descriptions and associated metadata, making it easier to understand the system capabilities and functionalities.
+
+* Knative Eventing now supports long-running background jobs. This feature separates resource-intensive or time-consuming tasks from the primary event processing flow, boosting application responsiveness and scalability.
+
+* Autoscaling for Knative Kafka subscriptions is now enhanced with Kubernetes Event-Driven Autoscaling (KEDA) as a Technology Preview (TP) feature. Autoscaling with CMA/KEDA optimizes resource allocation for Kafka triggers and `KafkaSource` objects, boosting performance in event-driven workloads by enabling dynamic scaling of Kafka consumer resources.
+
+* {ServerlessLogicProductName} now integrates with Prometheus and Grafana to provide enhanced monitoring support.
+
+* {ServerlessLogicProductName} workflows deployed using the `dev` or `preview` profile are now automatically configured to generate monitoring metrics for Prometheus.
+
+* The Jobs Service supporting service can now be scaled to zero by configuring the `spec.services.jobService.podTemplate.replicas` field in the `SonataFlowPlatform` custom resource (CR).
+
+* {ServerlessLogicProductName} workflows deployed with the `preview` and `gitops` profiles are now automatically configured to send grouped events to the Data Index, optimizing event traffic.
+
+* A more comprehensive list of errors in the workflow definition is now provided, rather than only displaying the first detected error.
+
+* {ServerlessLogicProductName} is now certified for use with PostgreSQL version `15.9`.
+
+* Event performance between {ServerlessLogicProductName} workflows and the Data Index is improved through event batching. Set `kogito.events.grouping=true` to group events. For further optimization, enable `kogito.events.grouping.binary=true` to reduce the size of grouped events with an alternate serialization algorithm. To compress these events, set `kogito.events.grouping.compress=true`, which lowers event size at the cost of additional CPU usage.
+
+* Compensation states are now invoked when a workflow is aborted.
+
+* {ServerlessLogicProductName} now supports configuring the Knative Eventing system to produce and consume events for workflows and supporting services.
+
+* The secret configurations for the Broker and KafkaChannel (Apache Kafka) have been unified.
+
+[id="fixed-issues-1-35-0_{context}"]
+== Fixed issues
+
+* Previously, Horizontal Pod Autoscaler (HPA) scaled down the Activator component prematurely, causing long-running requests against a Knative Service to terminate. This issue is now fixed. The `terminationGracePeriodSeconds` value is automatically set according to the `max-revision-timeout-seconds` configuration for Knative revisions.
+
+* Previously, requests to a Knative Service with a slow back end could time out because the default {product-title} route timeout was too short. You can now configure the route HAProxy timeout by specifying an environment variable in the Operator `Subscription` object for {ServerlessProductName} as follows:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  # ...
+spec:
+  channel: stable
+  config:
+    env:
+      - name: ROUTE_HAPROXY_TIMEOUT
+        value: '900'
+----

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,30 +13,33 @@ The following table provides information about which {ServerlessProductName} fea
 .Generally Available and Technology Preview features tracker
 [cols="2,1,1,1",options="header"]
 |====
-|Feature |1.32|1.33|1.34
+|Feature 
+|1.33
+|1.34
+|1.35
 
 |Eventing Transport encryption
 |-
-|-
+|TP
 |TP
 
 |Serving Transport encryption
 |-
-|-
+|TP
 |TP
 
 |OpenShift Serverless Logic
-|TP
+|GA
 |GA
 |GA
 
 |ARM64 support
-|-
+|TP
 |TP
 |TP
 
 |Custom Metrics Autoscaler Operator (KEDA)
-|-
+|TP
 |TP
 |TP
 
@@ -58,7 +61,7 @@ The following table provides information about which {ServerlessProductName} fea
 |Go function using S2I builder
 |TP
 |TP
-|TP
+|GA
 
 |Installing and using {ServerlessProductShortName} on {sno}
 |GA
@@ -69,11 +72,6 @@ The following table provides information about which {ServerlessProductName} fea
 |TP
 |TP
 |TP
-
-|Serverless Logic
-|TP
-|GA
-|GA
 
 |Overriding `liveness` and `readiness` in functions
 |GA


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.35`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3402

**Doc preview:** 

- [Serverless 1.35 release notes](https://85643--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-35-0_serverless-release-notes)
- [Deprecated and removed features](https://85643--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-deprecated-removed-features_serverless-release-notes)
- [Generally Available and Technology Preview features](https://85643--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes)