### PR TITLE
OSDOCS-12168: adds 4.14.42 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -657,3 +657,12 @@ Issued: 20 November 2024
 {product-title} release 4.14.41 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:9622[RHBA-2024:9622] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:9620[RHSA-2024:9620] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-42-dp_{context}"]
+=== RHSA-2024:10525 - {microshift-short} 4.14.42 security and bug fix update advisory
+
+Issued: 5 December 2024
+
+{product-title} release 4.14.42 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10525[RHSA-2024:10525] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10523[RHSA-2024:10523] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-12168](https://issues.redhat.com/browse/OSDOCS-12168)

Link to docs preview:
[4-14-42-dp_release-notes]()

QE review:
- NA. stock text, no other changes.
