### PR TITLE
[SRVLOGIC-478]: Misleading references to src/main/resources in configur…

### DIFF
--- a/modules/serverless-logic-openAPI-function-definition.adoc
+++ b/modules/serverless-logic-openAPI-function-definition.adoc
@@ -14,7 +14,7 @@
    "functions": [
       {
          "name": "myFunction1",
-         "operation": "classpath:/myopenapi-file.yaml#myFunction1"
+         "operation": "specs/myopenapi-file.yaml#myFunction1"
       }
    ]
 }

--- a/modules/serverless-logic-sending-rest-requests-openAPI-specification.adoc
+++ b/modules/serverless-logic-sending-rest-requests-openAPI-specification.adoc
@@ -22,7 +22,7 @@ To send REST requests that are based on the OpenAPI specification files, you mus
 
 .. Identify and access the OpenAPI specification files for the services you intend to invoke.
 
-.. Copy the OpenAPI specification files into your workflow service directory, such as `src/main/resources/specs`.
+.. Copy the OpenAPI specification files into your workflow service directory, such as `<project_application_dir>/specs`.
 +
 The following example shows the OpenAPI specification for the multiplication REST service:
 +
@@ -91,7 +91,7 @@ components:
 }
 ----
 
-.. Ensure that your function definitions reference the correct paths to the OpenAPI files stored in the `src/main/resources/specs` directory.
+.. Ensure that your function definitions reference the correct paths to the OpenAPI files stored in the `<project_application_dir>/specs` directory.
 
 . To access the defined functions in the workflow states:
 

--- a/serverless-logic/serverless-logic-managing-services/serverless-logic-configuring-openAPI-services-endpoints.adoc
+++ b/serverless-logic/serverless-logic-managing-services/serverless-logic-configuring-openAPI-services-endpoints.adoc
@@ -18,7 +18,7 @@ The `kogito.sw.operationIdStrategy` property supports the following values: `FIL
 quarkus.rest-client.stock_portfolio_svc_yaml.url=http://localhost:8282/ # <1>
 ----
 +
-<1> The OpenAPI File Path is `src/main/resources/openapi/stock-portfolio-svc.yaml`. The generated key that configures the URL for the REST client is `stock_portfolio_svc_yaml`
+<1> The OpenAPI File Path is `<project_application_dir>/specs/stock-portfolio-svc.yaml`. The generated key that configures the URL for the REST client is `stock_portfolio_svc_yaml`
 
 `FULL_URI`:: {ServerlessLogicProductName} uses the complete URI path of the OpenAPI document as the configuration key. The full URI is sanitized to form the key.
 +


### PR DESCRIPTION
…ing openAPI services endpoints

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
 `serverless-docs-1.35` 
 `serverless-docs-1.34`

Issue:
[SRVLOGIC-478](https://issues.redhat.com/browse/SRVLOGIC-478)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[1](https://85646--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-services/serverless-logic-configuring-openAPI-services-endpoints.html)
[2](https://85646--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-services/serverless-logic-configuring-openAPI-services.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

@kaldesai @wmedvede PTAL

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
