### PR TITLE
OSDOCS-12806: Corrected the toolbox image for 4.16+

### DIFF
--- a/modules/support-installing-packages-to-a-toolbox-container.adoc
+++ b/modules/support-installing-packages-to-a-toolbox-container.adoc
@@ -7,16 +7,17 @@
 = Installing packages to a `toolbox` container
 
 ifndef::openshift-origin[]
-By default, running the `toolbox` command starts a container with the `registry.redhat.io/rhel8/support-tools:latest` image. This image contains the most frequently used support tools. If you need to collect node-specific data that requires a support tool that is not part of the image, you can install additional packages.
+By default, running the `toolbox` command starts a container with the `registry.redhat.io/rhel9/support-tools:latest` image. This image contains the most frequently used support tools. If you need to collect node-specific data that requires a support tool that is not part of the image, you can install additional packages.
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-By default, running the `toolbox` command starts a container with the `quay.io/fedora/fedora:36` image. This image contains the most frequently used support tools. If you need to collect node-specific data that requires a support tool that is not part of the image, you can install additional packages.
+By default, running the `toolbox` command starts a container with the `quay.io/fedora/fedora` image. This image contains the most frequently used support tools. If you need to collect node-specific data that requires a support tool that is not part of the image, you can install additional packages.
 endif::openshift-origin[]
 
 .Prerequisites
 
 * You have accessed a node with the `oc debug node/<node_name>` command.
+* You can access your system as a user with root privileges.
 
 .Procedure
 

--- a/modules/support-starting-an-alternative-image-with-toolbox.adoc
+++ b/modules/support-starting-an-alternative-image-with-toolbox.adoc
@@ -7,16 +7,22 @@
 = Starting an alternative image with `toolbox`
 
 ifndef::openshift-origin[]
-By default, running the `toolbox` command starts a container with the `registry.redhat.io/rhel8/support-tools:latest` image. You can start an alternative image by creating a `.toolboxrc` file and specifying the image to run.
+By default, running the `toolbox` command starts a container with the `registry.redhat.io/rhel9/support-tools:latest` image.
+
+[NOTE]
+====
+You can start an alternative image by creating a `.toolboxrc` file and specifying the image to run. However, running an older version of the `support-tools` image, such as `registry.redhat.io/rhel8/support-tools:latest`,  is not supported on {product-title} {product-version}.
+====
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-By default, running the `toolbox` command starts a container with the `quay.io/fedora/fedora:36` image. You can start an alternative image by creating a `.toolboxrc` file and specifying the image to run.
+By default, running the `toolbox` command starts a container with the `quay.io/fedora/fedora` image. You can start an alternative image by creating a `.toolboxrc` file and specifying the image to run.
 endif::openshift-origin[]
 
 .Prerequisites
 
 * You have accessed a node with the `oc debug node/<node_name>` command.
+* You can access your system as a user with root privileges.
 
 .Procedure
 
@@ -27,24 +33,19 @@ endif::openshift-origin[]
 # chroot /host
 ----
 
-. Create a `.toolboxrc` file in the home directory for the root user ID:
-+
-[source,terminal]
-----
-# vi ~/.toolboxrc
-----
+. Optional: If you need to use an alternative image instead of the default image, create a `.toolboxrc` file in the home directory for the root user ID, and specify the image metadata:
 +
 [source,text]
 ----
-REGISTRY=quay.io                <1>
-IMAGE=fedora/fedora:33-x86_64   <2>
-TOOLBOX_NAME=toolbox-fedora-33  <3>
+REGISTRY=quay.io             <1>
+IMAGE=fedora/fedora:latest   <2>
+TOOLBOX_NAME=toolbox-fedora-latest  <3>
 ----
 <1> Optional: Specify an alternative container registry.
 <2> Specify an alternative image to start.
 <3> Optional: Specify an alternative name for the toolbox container.
 
-. Start a toolbox container with the alternative image:
+. Start a toolbox container by entering the following command:
 +
 [source,terminal]
 ----
@@ -53,5 +54,5 @@ TOOLBOX_NAME=toolbox-fedora-33  <3>
 +
 [NOTE]
 ====
-If an existing `toolbox` pod is already running, the `toolbox` command outputs `'toolbox-' already exists. Trying to start...`. Remove the running toolbox container with `podman rm toolbox-` and spawn a new toolbox container, to avoid issues with `sosreport` plugins.
+If an existing `toolbox` pod is already running, the `toolbox` command outputs `'toolbox-' already exists. Trying to start...`. To avoid issues with `sosreport` plugins, remove the running toolbox container with `podman rm toolbox-` and then spawn a new toolbox container. 
 ====


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-12806](https://issues.redhat.com/browse/OSDOCS-12806)

Preview:
* [About toolbox - Dedicated](https://85648--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/gathering-cluster-data.html#about-toolbox_gathering-cluster-data)
* [About toolbox - Core](https://85648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#about-toolbox_gathering-cluster-data)
* [About toolbox - Rosa](https://85648--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/gathering-cluster-data.html#about-toolbox_gathering-cluster-data)

- [x] SME has approved this change (@Timothee Ravier).
- [x] QE has approved this change (Mike Nguyen).

