### PR TITLE
OSDOCS-12494: adds 4.17.7 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -160,3 +160,12 @@ Issued: 26 November 2024
 {product-title} release 4.17.6 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:10139[RHBA-2024:10139] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:10137[RHBA-2024:10137] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-7-dp_{context}"]
+=== RHSA-2024:10520 - {microshift-short} 4.17.7 security and bug fix update advisory
+
+Issued: 3 December 2024
+
+{product-title} release 4.17.7 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2024:10520[RHSA-2024:10520] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:10518[RHSA-2024:10518] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12494](https://issues.redhat.com/browse/OSDOCS-12494)

Link to docs preview:
[microshift-4-17-7-dp_release-notes](https://85653--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-7-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
