### PR TITLE
OSDOCS-12692: adds 4.16.25 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -360,3 +360,12 @@ Issued: 26 November 2024
 {product-title} release 4.16.24 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHSA-2024:10149[RHSA-2024:10149] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10147[RHSA-2024:10147] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-25-dp_{context}"]
+=== RHBA-2024:10530 - {microshift-short} 4.16.25 bug fix and enhancement advisory
+
+Issued: 4 December 2024
+
+{product-title} release 4.16.25 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10530[RHBA-2024:10530] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10528[RHSA-2024:10528] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12692](https://issues.redhat.com/browse/OSDOCS-12692)

Link to docs preview:
[microshift-4-16-25-dp_release-notes](https://85677--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-25-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
