### PR TITLE
OCPBUGS-41344-13: Updated minor version of RHEL 8 for worker nodes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -23,7 +23,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} is designed for FIPS. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the `x86_64`, `ppc64le`, and `s390x` architectures.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.6, 8.7, and 8.8 as well as on {op-system-first} 4.13.
+{product-title} {product-version} is supported on {op-system-base-full} 8.8 and a later version of {op-system-base} 8 that is released before the End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported on {op-system-first} {product-version}.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
NO QE NEEDED. CONFIRMED WITH DPM.


4.13 VARIANT that should match other variant PRs. Example: https://github.com/openshift/openshift-docs/pull/83659

Jira: 
https://issues.redhat.com/browse/OCPBUGS-41344

Version(s):
OpenShift Version: 4.13

Issue:
Updated the RHEL8 versions for worker nodes in release notes for RHOCP4.13 

[About this release](https://83655--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-about-this-release)

- [x] SME has approved this change (Scott Dobson).

Note:

Originally merged in error. Here is the revert PR: https://github.com/openshift/openshift-docs/pull/85678