### PR TITLE
OSSM-8474 TP2 release note updates

### DIFF
--- a/modules/ossm-release-3-0-TP-1.adoc
+++ b/modules/ossm-release-3-0-TP-1.adoc
@@ -9,10 +9,57 @@ Module included in the following assemblies:
 
 This release of {SMProductName} is Technology Preview.
 
-// Simple table to help clarify for users the component versions they can use with OSSM 3.0 TP1. Likely a more complicated table will be needed for GA. OSSM 3.0 separates all the Operators such as OCP, Istio, Envoy, Kiali, OTEL/Tempo, etc. This is only what is known to work with OSSM 3.0 TP1.
+// Simple table to help clarify for users the component versions they can use with OSSM 3.0 TP1. Likely a more complicated table will be needed for GA. OSSM 3.0 separates all the Operators such as OCP, Istio, Envoy, Kiali, OTEL/Tempo, etc. This is only what is known to work with OSSM 3.0 TP1 and TP2, as of 12/09/2024.
+
+[id="ossm-release-3-0-TP1-component-versions-2_{context}"]
+== Supported component versions for Technology Preview 2
+
+|===
+|Component |Version
+
+|{ocp-product-title}
+|4.14 and later
+
+|Istio
+|1.24.1
+
+|Envoy Proxy
+|1.32
+
+|Kiali Operator
+|2.1
+
+|Kiali Server
+|2.1
+|===
+
+[IMPORTANT]
+====
+* You need to remove the Kiali custom resources (CR) from Technology Preview 1 before you update to {KialiProduct} 2.1.
+
+* {KialiProduct} 2.1 is available in the `candidates` channel.
++
+The `candidate` channel offers unsupported early access to releases as soon as they are built. Releases present only in candidate channels might not contain the full feature set of eventual GA releases, or features might be removed before GA. Additionally, these releases have not been subject to full Red{nbsp}Hat Quality Assurance and might not offer update paths to later GA releases. Given these caveats, the candidate channel is suitable only for testing purposes where deleting and re-creating a cluster is acceptable.
+====
+//copied from https://docs.openshift.com/container-platform/4.17/updating/understanding_updates/understanding-update-channels-release.html#candidate-version-channel_understanding-update-channels-releases
+
+[id="ossm-release-3-0-TP1-unavailable-features-2_{context}"]
+== Unavailable features in Technology Preview 2
+
+The following features are not supported in the Technology Preview 2 release:
+
+* Ambient mode in Istio
+* Virtual Machine support in Istio
+
+[id="ossm-release-3-0-TP1-unavailable-clusters-2_{context}"]
+== Unavailable clusters in Technology Preview 2
+
+The following clusters are not supported in the Technology Preview 2 release:
+
+* Production clusters
 
 [id="ossm-release-3-0-TP1-component-versions_{context}"]
-== Supported component versions
+== Supported component versions for Technology Preview 1
 
 |===
 |Component |Version
@@ -34,22 +81,26 @@ This release of {SMProductName} is Technology Preview.
 |===
 
 [id="ossm-release-3-0-TP1-unavailable-features_{context}"]
-== Unavailable features in this release
+== Unavailable features in Technology Preview 1
 
-The following features are not supported in this Technology Preview release:
+The following features are not supported in the Technology Preview 1 release:
 
 * {SMPlugin}
-* Istio's Ambient mode
-* Istio's Virtual Machine support
-* {ibm-power-name} and {ibm-z-name} platforms
+* Ambient mode in Istio
+* Virtual Machine support in Istio
 
 [id="ossm-release-3-0-TP1-unavailable-clusters_{context}"]
-== Unavailable clusters in this release
+== Unavailable clusters in Technology Preview 1
 
-The following clusters are not supported in this Technology Preview release:
+The following clusters are not supported in the Technology Preview 1 release:
 
 * Production clusters
-* Clusters with {SMProductShortName} 2.x
+
+// 12/10/2024: TP2 content from this file will need to be moved to its own file set for the stand alone format prior to GA in order to keep versioning dropdown options consistent. All notes will be removed for GA.
+
+// 12/09/2024: Per Dev, IBM Power® and IBM Z® platforms are not supported on TP2, only TP1. No new doc branch, so had to add new section, and update titles to denote TP1 vs TP2 unsupported features and unavailable clusters.
+
+// 12/02/2024: Per PM, no TP2 doc branch. Just update existing file to remove "IBM Power® and IBM Z® platforms" from "Unsupported features" and remove "Clusters with Service Mesh 2.x" from "Unavailable clusters".
 
 // 09/12/2024: IBM Power and 390x platforms added to unavailable features per https://issues.redhat.com/browse/OSSM-8068
 


### PR DESCRIPTION
**OSSM 3.0 TP1**

12/02/2024: Per PM, no TP2 branch. It merges into serivce-mesh-docs-main and service-mesh-docs-3.0.0tp1. There is no TP 2 page.

**Merge to:** https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick** to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology Preview.

OSSM 3.0 is moving to stand alone format and will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8474

Link to docs preview: https://85681--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-assembly.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
