### PR TITLE
OSDOCS-12797: 4.12.70 z-stream RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5007,3 +5007,23 @@ $ oc adm release info 4.12.69 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.12.70
+[id="ocp-4-12-70_{context}"]
+=== RHBA-2024:10533 - {product-title} 4.12.70 bug fix and security update
+
+Issued: 05 December 2024
+
+{product-title} release 4.12.70 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:10533[RHBA-2024:10533] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10535[RHSA-2024:10535] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.70 --pullspecs
+----
+
+[id="ocp-4-12-70-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-12797](https://issues.redhat.com/browse/OSDOCS-12797)

Link to docs preview:
https://85682--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-70_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (12/5)
