### PR TITLE
OBSDOCS-1416: Add the Network Observability Operator to the OTEL Troubleshooting page

### DIFF
--- a/modules/otel-troubleshoot-network-traffic.adoc
+++ b/modules/otel-troubleshoot-network-traffic.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="using-network-observability-operator-for-troubleshooting_{context}"]
+= Using the Network Observability Operator for troubleshooting
+
+You can debug the traffic between your observability components by visualizing it with the Network Observability Operator.
+
+.Prerequisites
+
+* You have installed the Network Observability Operator as explained in "Installing the Network Observability Operator".
+
+.Procedure
+
+. In the {product-title} web console, go to *Observe* -> *Network Traffic* -> *Topology*.
+
+. Select *Namespace* to filter the workloads by the namespace in which your OpenTelemetry Collector is deployed.
+
+. Use the network traffic visuals to troubleshoot possible issues. See "Observing the network traffic from the Topology view" for more details.

--- a/observability/otel/otel-troubleshooting.adoc
+++ b/observability/otel/otel-troubleshooting.adoc
@@ -11,3 +11,11 @@ The OpenTelemetry Collector offers multiple ways to measure its health as well a
 include::modules/otel-troubleshoot-collector-logs.adoc[leveloffset=+1]
 include::modules/otel-troubleshoot-metrics.adoc[leveloffset=+1]
 include::modules/otel-troubleshoot-logging-exporter-stdout.adoc[leveloffset=+1]
+include::modules/otel-troubleshoot-network-traffic.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../observability/network_observability/installing-operators.adoc#installing-network-observability-operators[Installing the Network Observability Operator]
+
+* xref:../../observability/network_observability/observing-network-traffic.adoc#nw-observe-network-traffic[Observing the network traffic from the Topology view]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16, 4.17, 4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1416

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://85689--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-troubleshooting.html#using-network-observability-operator-for-troubleshooting_otel-troubleshoot

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
