### PR TITLE
adjusting banner for OSD and ROSA

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -70,11 +70,11 @@
                       version == "4.18"
                       );
 
-        if (!["openshift-webscale", "openshift-dpu", "openshift-lightspeed", "openshift-service-mesh", "openshift-origin", "openshift-acs"].include?(distro_key) || unsupported)
+        if (!["openshift-webscale", "openshift-dpu", "openshift-lightspeed", "openshift-service-mesh", "openshift-origin", "openshift-acs", "openshift-rosa", "openshift-dedicated"].include?(distro_key) || unsupported)
       %>
       <span>
         <div class="alert alert-info" role="primary" id="support-info">
-          <strong>OpenShift docs are moving and will soon only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>, the home of all Red Hat product documentation. Explore the <a href="https://docs.redhat.com/en/documentation/openshift_container_platform/latest" style="color: #0C5460 !important" class="link-primary">new docs experience</a> today.</strong>
+          <strong>OpenShift docs are moving and will soon only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>, the home of all Red Hat product documentation. Explore the <a href="https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/about/index" style="color: #0C5460 !important" class="link-primary">new docs experience</a> today.</strong>
         </div>
       </span>
       <% end %>
@@ -107,6 +107,22 @@
         <span>
           <div class="alert alert-info" role="primary" id="support-info">
             <strong>OpenShift docs are moving and will soon only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>, the home of all Red Hat product documentation. Explore the <a href="https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/latest" style="color: #0C5460 !important" class="link-primary">new docs experience</a> today.</strong>
+          </div>
+        </span>
+      <% end %>
+
+      <% if (distro_key == "openshift-dedicated") %>
+        <span>
+          <div class="alert alert-info" role="primary" id="support-info">
+            <strong>OpenShift docs are moving and will soon only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>, the home of all Red Hat product documentation. Explore the <a href="https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/index" style="color: #0C5460 !important" class="link-primary">new docs experience</a> today.</strong>
+          </div>
+        </span>
+      <% end %>
+
+      <% if (distro_key == "openshift-rosa") %>
+        <span>
+          <div class="alert alert-info" role="primary" id="support-info">
+            <strong>OpenShift docs are moving and will soon only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>, the home of all Red Hat product documentation. Explore the <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/about/index" style="color: #0C5460 !important" class="link-primary">new docs experience</a> today.</strong>
           </div>
         </span>
       <% end %>


### PR DESCRIPTION
Similar to #85363, adjusting ROSA to point to https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/about/index and OSD to point to https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/index.