### PR TITLE
Deploying a secondary scheduler has bad link

### DIFF
--- a/modules/nodes-secondary-scheduler-configuring-console.adoc
+++ b/modules/nodes-secondary-scheduler-configuring-console.adoc
@@ -36,7 +36,7 @@ metadata:
   namespace: "openshift-secondary-scheduler-operator" <2>
 data:
   "config.yaml": |
-    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    apiVersion: kubescheduler.config.k8s.io/v1
     kind: KubeSchedulerConfiguration                  <3>
     leaderElection:
       leaderElect: false
@@ -50,7 +50,7 @@ data:
 ----
 <1> The name of the config map. This is used in the *Scheduler Config* field when creating the `SecondaryScheduler` CR.
 <2> The config map must be created in the `openshift-secondary-scheduler-operator` namespace.
-<3> The `KubeSchedulerConfiguration` resource for the secondary scheduler. For more information, see link:https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta3/#kubescheduler-config-k8s-io-v1beta3-KubeSchedulerConfiguration[`KubeSchedulerConfiguration`] in the Kubernetes API documentation.
+<3> The `KubeSchedulerConfiguration` resource for the secondary scheduler. For more information, see link:https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-KubeSchedulerConfiguration[`KubeSchedulerConfiguration`] in the Kubernetes API documentation.
 <4> The name of the secondary scheduler. Pods that set their `spec.schedulerName` field to this value are scheduled with this secondary scheduler.
 <5> The plugins to enable or disable for the secondary scheduler. For a list default scheduling plugins, see link:https://kubernetes.io/docs/reference/scheduling/config/#scheduling-plugins[Scheduling plugins] in the Kubernetes documentation.
 


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/85697

Version(s):
4.12+

Issue:
Bad link in Step 2.c.3. 

Link to docs preview:
[Deploying a secondary scheduler](https://85699--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html#nodes-secondary-scheduler-configuring-console_secondary-scheduler-configuring) -- Updated code block in step 2c, and updated link in callout <3>.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
