### PR TITLE
OCPBUGS#44334: Fixing a hyperlink related to policy generator

### DIFF
--- a/edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
+++ b/edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
@@ -17,7 +17,7 @@ include::snippets/technology-preview.adoc[]
 
 [NOTE]
 ====
-For more information about `PolicyGenerator` resources, see the {rh-rhacm} link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/governance/integrate-third-party-policy-controllers#policy-generator[Policy Generator] documentation.
+For more information about `PolicyGenerator` resources, see the {rh-rhacm} link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/governance/integrate-policy-generator#policy-generator[Policy Generator] documentation.
 ====
 
 include::modules/ztp-deploying-additional-changes-to-clusters.adoc[leveloffset=+1]

--- a/snippets/pgt-deprecation-notice.adoc
+++ b/snippets/pgt-deprecation-notice.adoc
@@ -4,5 +4,5 @@
 Using `PolicyGenTemplate` CRs to manage and deploy polices to managed clusters will be deprecated in an upcoming {product-title} release.
 Equivalent and improved functionality is available using {rh-rhacm-first} and `PolicyGenerator` CRs.
 
-For more information about `PolicyGenerator` resources, see the {rh-rhacm} link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/governance/integrate-third-party-policy-controllers#policy-generator[Policy Generator] documentation.
+For more information about `PolicyGenerator` resources, see the {rh-rhacm} link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/governance/integrate-policy-generator#policy-generator[Policy Generator] documentation.
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
- [OCPBUGS-44334](https://issues.redhat.com/browse/OCPBUGS-44334)
- [OCPBUGS-44335](https://issues.redhat.com/browse/OCPBUGS-44335)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Advanced managed cluster configuration with PolicyGenerator resources](https://85702--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.html)
- [Configuring managed cluster policies by using PolicyGenTemplate resources](https://85702--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-sites.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Note to the merge reviewer: I think this update does not need a QE and peer review. 
