### PR TITLE
OCPBUGS#44258: Updating the items.spec.osImages field example configuration

### DIFF
--- a/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
+++ b/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
@@ -33,7 +33,7 @@ $ oc edit AgentServiceConfig
 - cpuArchitecture: x86_64
     openshiftVersion: "{product-version}"
     rootFSUrl: https://<host>/<path>/rhcos-live-rootfs.x86_64.img
-    url: https://<mirror-registry>/<path>/rhcos-live.x86_64.iso
+    url: https://<host>/<path>/rhcos-live.x86_64.iso
 ----
 +
 where:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-44258](https://issues.redhat.com/browse/OCPBUGS-44258)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Enabling the assisted service](https://85704--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-preparing-the-hub-cluster.html#enabling-assisted-installer-service-on-bare-metal_ztp-preparing-the-hub-cluster)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Note to the merge reviewer: I think this PR does not require a peer review.