### PR TITLE
Update date on 4.6 RNs

### DIFF
--- a/release_notes/46-release-notes.adoc
+++ b/release_notes/46-release-notes.adoc
@@ -355,7 +355,7 @@ With this release, the response includes the new `code` field that includes the 
 [id="bug-fixes_{context}"]
 == Bug fixes in version 4.6.0
 
-*Release date*: 2 December 2024
+*Release date*: 3 December 2024
 
 * Before this release, the timestamp data displayed incorrectly when viewing affected images in the *First discovered* column of the *Workload CVE* single page view. This update resolves the issue.
 


### PR DESCRIPTION
Version: 4.6

Fix RN date due to release being pushed 1 day. 

See: #85706 (missed one instance of date)