### PR TITLE
OBSDOCS-1521 COO GA 1.0 Release notes

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -7,24 +7,83 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The Cluster Observability Operator
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 The {coo-first} is an optional {product-title} Operator that enables administrators to create standalone monitoring stacks that are independently configurable for use by different services and users.
 
 The {coo-short} complements the built-in monitoring capabilities of {product-title}. You can deploy it in parallel with the default platform and user workload monitoring stacks managed by the {cmo-first}.
 
 These release notes track the development of the {coo-full} in {product-title}.
 
+[id="cluster-observability-operator-release-notes-1-0_{context}"]
+== {coo-full} 1.0
+
+// Need to check if there is an advisory generated now that the build system has moved to Konflux
+// The following advisory is available for {coo-full} 1.0:
+//
+// * link:https://access.redhat.com/errata/RHSA-2024:????[RHEA-2024:??? {coo-full} 1.0]
+
+
+[id="cluster-observability-operator-1-0-new-features-enhancements_{context}"]
+=== New features and enhancements
+
+* {coo-short} is now enabled for {product-title} platform monitoring. (link:https://issues.redhat.com/browse/COO-476[*COO-476*])
+** Implements HTTPS support for {coo-short} web server. (link:https://issues.redhat.com/browse/COO-480[*COO-480*])
+** Implements authn/authz for {coo-short} web server. (link:https://issues.redhat.com/browse/COO-481[*COO-481*])
+** Configures ServiceMonitor resource to collect metrics from {coo-short}. (link:https://issues.redhat.com/browse/COO-482[*COO-482*])
+** Adds `operatorframework.io/cluster-monitoring=true` annotation to the OLM bundle. (link:https://issues.redhat.com/browse/COO-483[*COO-483*])
+** Defines the alerting strategy for {coo-short} . (link:https://issues.redhat.com/browse/COO-484[*COO-484*])
+** Configures PrometheusRule for alerting. (link:https://issues.redhat.com/browse/COO-485[*COO-485*])
+
+* Support level annotations have been added to the `UIPlugin` CR when created. The support level is based on the plugin type, with values of `DevPreview`, `TechPreview`, or `GeneralAvailability`. (link:https://issues.redhat.com/browse/COO-318[*COO-318*])
+
+// must-gather postponed to 1.1
+//* You can now gather debugging information about {coo-short} by using the `oc adm must-gather` CLI command. (link:https://issues.redhat.com/browse/COO-194[*COO-194*])
+
+* You can now configure the Alertmanager `scheme` and `tlsConfig` fields in the Prometheus CR. (link:https://issues.redhat.com/browse/COO-219[*COO-219*])
+
+// Dev preview so cannot document 
+//* You can now install the Monitoring UI plugin using {coo-short}. (link:https://issues.redhat.com/browse/COO-262[*COO-262*])
+
+* The extended Technical Preview for the troubleshooting panel adds support for correlating traces with Kubernetes resources and directly with other observable signals including logs, alerts, metrics, and network events. (link:https://issues.redhat.com/browse/COO-450[*COO-450*])
+** You can select a Tempo instance and tenant when you navigate to the tracing page by clicking *Observe -> Tracing* in the web console. The preview troubleshooting panel only works with the `openshift-tracing / platform` instance and the `platform` tenant.
+** The troubleshooting panel works best in the *Administrator* perspective. It has limited functionality in the Developer perspective due to authorization issues with some back ends, most notably Prometheus for metrics and alerts. This will be addressed in a future release.
+
 The following table provides information about which features are available depending on the version of {coo-full} and {product-title}:
+
+[cols="1,1,1,1,1", options="header"]
+|===
+| COO Version   | OCP Versions       | Distributed Tracing   | Logging   | Troubleshooting Panel
+| 1.0+          | 4.12 - 4.15        | ✔                     | ✔         | ✘
+| 1.0+          | 4.16+              | ✔                     | ✔         | ✔
+|===
+
+
+[id="cluster-observability-operator-1-0-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-26159[CVE-2023-26159]
+* link:https://access.redhat.com/security/cve/CVE-2024-28849[CVE-2024-28849]
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]
+
+[id="cluster-observability-operator-1-0-bug-fixes_{context}"]
+=== Bug fixes
+
+* Previously, the default namespace for the {coo-short}  installation was `openshift-operators`. With this release, the defaullt namespace changes to `openshift-cluster-observability-operator`. (link:https://issues.redhat.com/browse/COO-32[*COO-32*])
+
+* Previously, `korrel8r` was only able to parse time series selector expressions. With this release, `korrel8r` can parse any valid PromQL expression to extract the time series selectors that it uses for correlation. (link:https://issues.redhat.com/browse/COO-558[*COO-558*])
+
+* Previously, when viewing a Tempo instance from the Distributed Tracing UI plugin, the scatter plot graph showing the traces duration was not rendered correctly. The bubble size was too large and overlapped the x and y axis. With this release, the graph is rendered correctly. (link:https://issues.redhat.com/browse/COO-319[*COO-319*])
+
+== Features available on older, Technology Preview releases
+
+The following table provides information about which features are available depending on older version of {coo-full} and {product-title}:
 
 [cols="1,1,1,1,1,1", options="header"]
 |===
-| COO Version   | OCP Versions       | Dashboards   | Distributed Tracing   | Logging   | Troubleshooting Panel
+| COO Version    | OCP Versions       | Dashboards   | Distributed Tracing   | Logging   | Troubleshooting Panel
 
-| 0.2.0         | 4.11               | ✔            | ✘                     | ✘         | ✘ 
-| 0.3.0+        | 4.11 - 4.15        | ✔            | ✔                     | ✔         | ✘ 
-| 0.3.0+        | 4.16+              | ✔            | ✔                     | ✔         | ✔ 
+| 0.2.0          | 4.11               | ✔            | ✘                     | ✘         | ✘ 
+| 0.3.0+, 0.4.0+ | 4.11 - 4.15        | ✔            | ✔                     | ✔         | ✘ 
+| 0.3.0+, 0.4.0+ | 4.16+              | ✔            | ✔                     | ✔         | ✔ 
 |===
 
 [id="cluster-observability-operator-release-notes-0-4-1_{context}"]


### PR DESCRIPTION
WIP - DO NOT MERGE


Version(s):
4.12+

Issue:
[OBSDOCS-1521](https://issues.redhat.com//browse/OBSDOCS-1521) 

Link to docs preview:
https://85717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html

QE review:
- [Y] QE has approved this change.


Additional information:
