### PR TITLE
OSDOCS#12812: Remove TP, pull secret, and private catalog snippets

### DIFF
--- a/extensions/arch/catalogd.adoc
+++ b/extensions/arch/catalogd.adoc
@@ -6,15 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 {olmv1-first} uses the catalogd component and its resources to manage Operator and extension catalogs.
-
-[IMPORTANT]
-====
-include::snippets/olmv1-known-issue-private-registries.adoc[]
-====
 
 include::modules/olmv1-about-catalogs.adoc[leveloffset=+1]
 [role="_additional-resources"]

--- a/extensions/arch/components.adoc
+++ b/extensions/arch/components.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 {olmv1-first} comprises the following component projects:
 
 Operator Controller:: xref:../../extensions/arch/operator-controller.adoc#operator-controller[Operator Controller] is the central component of {olmv1} that extends Kubernetes with an API through which users can install and manage the lifecycle of Operators and extensions. It consumes information from catalogd.

--- a/extensions/arch/operator-controller.adoc
+++ b/extensions/arch/operator-controller.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 Operator Controller is the central component of {olmv1-first} and consumes the other {olmv1} component, catalogd. It extends Kubernetes with an API through which users can install Operators and extensions.
 
 include::modules/olmv1-clusterextension-api.adoc[leveloffset=+1]

--- a/extensions/catalogs/creating-catalogs.adoc
+++ b/extensions/catalogs/creating-catalogs.adoc
@@ -6,15 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 Catalog maintainers can create new catalogs in the file-based catalog format for use with {olmv1-first} on {product-title}.
-
-[IMPORTANT]
-====
-include::snippets/olmv1-known-issue-private-registries.adoc[]
-====
 
 include::modules/olm-creating-fb-catalog-image.adoc[leveloffset=+1]
 [role="_additional-resources"]

--- a/extensions/catalogs/fbc.adoc
+++ b/extensions/catalogs/fbc.adoc
@@ -6,15 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 {olmv1-first} in {product-title} supports _file-based catalogs_ for discovering and sourcing cluster extensions, including Operators, on a cluster.
-
-[IMPORTANT]
-====
-include::snippets/olmv1-known-issue-private-registries.adoc[]
-====
 
 include::modules/olm-fb-catalogs.adoc[leveloffset=+1]
 

--- a/extensions/catalogs/managing-catalogs.adoc
+++ b/extensions/catalogs/managing-catalogs.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 Cluster administrators can add _catalogs_, or curated collections of Operators and Kubernetes extensions, to their clusters. Operator authors publish their products to these catalogs. When you add a catalog to your cluster, you have access to the versions, patches, and over-the-air updates of the Operators and extensions that are published to the catalog.
 
 You can manage catalogs and extensions declaratively from the CLI by using custom resources (CRs).
@@ -29,6 +26,5 @@ include::modules/olmv1-about-catalogs.adoc[leveloffset=+1]
 * xref:../../extensions/catalogs/fbc.adoc#fbc[File-based catalogs]
 
 include::modules/olmv1-red-hat-catalogs.adoc[leveloffset=+1]
-include::modules/olmv1-creating-a-pull-secret-for-catalogd.adoc[leveloffset=+1]
 include::modules/olmv1-adding-a-catalog.adoc[leveloffset=+1]
 include::modules/olmv1-deleting-catalog.adoc[leveloffset=+1]

--- a/extensions/catalogs/rh-catalogs.adoc
+++ b/extensions/catalogs/rh-catalogs.adoc
@@ -6,14 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 Red Hat provides several Operator catalogs that are included with {product-title} by default.
-
-[IMPORTANT]
-====
-include::snippets/olmv1-known-issue-private-registries.adoc[]
-====
 
 include::modules/olm-rh-catalogs.adoc[leveloffset=+1]

--- a/extensions/ce/crd-upgrade-safety.adoc
+++ b/extensions/ce/crd-upgrade-safety.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 When you update a custom resource definition (CRD) that is provided by a cluster extension, {olmv1-first} runs a CRD upgrade safety preflight check to ensure backwards compatibility with previous versions of that CRD. The CRD update must pass the validation checks before the change is allowed to progress on a cluster.
 
 [role="_additional-resources"]

--- a/extensions/ce/managing-ce.adoc
+++ b/extensions/ce/managing-ce.adoc
@@ -6,17 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 After a catalog has been added to your cluster, you have access to the versions, patches, and over-the-air updates of the extensions and Operators that are published to the catalog.
 
 You can manage extensions declaratively from the CLI using custom resources (CRs).
-
-[IMPORTANT]
-====
-include::snippets/olmv1-known-issue-private-registries.adoc[]
-====
 
 include::modules/olmv1-supported-extensions.adoc[leveloffset=+1]
 

--- a/extensions/ce/upgrade-edges.adoc
+++ b/extensions/ce/upgrade-edges.adoc
@@ -6,17 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 When determining upgrade edges, also known as upgrade paths or upgrade constraints, for an installed cluster extension, {olmv1-first} supports {olmv0} semantics starting in {product-title} 4.16. This support follows the behavior from {olmv0}, including `replaces`, `skips`, and `skipRange` directives, with a few noted differences.
 
 By supporting {olmv0} semantics, {olmv1} now honors the upgrade graph from catalogs accurately.
-
-[IMPORTANT]
-====
-include::snippets/olmv1-known-issue-private-registries.adoc[]
-====
 
 .Differences from original {olmv0} implementation
 

--- a/extensions/index.adoc
+++ b/extensions/index.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 Extensions enable cluster administrators to extend capabilities for users on their {product-title} cluster.
 
 {olm-first} has been included with {product-title} 4 since its initial release. {product-title} 4.17 includes components for a next-generation iteration of {olm} as a Generally Available (GA) feature, known during this phase as _{olmv1}_. This updated framework evolves many of the concepts that have been part of previous versions of {olm} and adds new capabilities.
@@ -35,14 +32,7 @@ Earlier Technology Preview phases of {olmv1} introduced a new `Operator` API; th
 * The `Catalog` API, provided by the new catalogd component, serves as the foundation for {olmv1}, unpacking catalogs for on-cluster clients so that users can discover installable content, such as Kubernetes extensions and Operators. This provides increased visibility into all available Operator bundle versions, including their details, channels, and update edges.
 --
 +
-[IMPORTANT]
-====
-include::snippets/olmv1-known-issue-private-registries.adoc[]
-====
-+
 For more information, see xref:../extensions/arch/operator-controller.adoc#operator-controller[Operator Controller] and xref:../extensions/arch/catalogd.adoc#catalogd[Catalogd].
-
-
 
 Improved control over extension updates::
 With improved insight into catalog content, administrators can specify target versions for installation and updates. This grants administrators more control over the target version of extension updates. For more information, see xref:../extensions/ce/managing-ce.adoc#olmv1-updating-an-operator_managing-ce[Updating an cluster extension].

--- a/extensions/of-terms.adoc
+++ b/extensions/of-terms.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 The following terms are related to the Operator Framework, including {olmv1-first}.
 
 include::modules/olm-terms.adoc[leveloffset=+1]

--- a/modules/olmv1-adding-a-catalog.adoc
+++ b/modules/olmv1-adding-a-catalog.adoc
@@ -9,21 +9,6 @@
 
 To add a catalog to a cluster, create a catalog custom resource (CR) and apply it to the cluster.
 
-
-[IMPORTANT]
-====
-include::snippets/olmv1-known-issue-private-registries.adoc[]
-====
-
-.Prerequisites
-
-// https://docs.asciidoctor.org/asciidoc/latest/directives/include-list-item-content/
-* {empty}
-+
---
-include::snippets/olmv1-secure-registry-pull-secret.adoc[]
---
-
 .Procedure
 
 . Create a catalog custom resource (CR), similar to the following example:

--- a/modules/olmv1-installing-an-operator.adoc
+++ b/modules/olmv1-installing-an-operator.adoc
@@ -9,12 +9,6 @@
 
 You can install an extension from a catalog by creating a custom resource (CR) and applying it to the cluster. {olmv1-first} supports installing cluster extensions, including {olmv0} Operators via the `registry+v1` bundle format, that are scoped to the cluster. For more information, see _Supported extensions_.
 
-
-[IMPORTANT]
-====
-include::snippets/olmv1-known-issue-private-registries.adoc[]
-====
-
 .Prerequisites
 
 * You have added a catalog to your cluster.

--- a/modules/olmv1-red-hat-catalogs.adoc
+++ b/modules/olmv1-red-hat-catalogs.adoc
@@ -9,24 +9,7 @@
 [id="olmv1-red-hat-catalogs_{context}"]
 = Red Hat-provided Operator catalogs in {olmv1}
 
-{olmv1-first} does not include Red Hat-provided Operator catalogs by default. If you want to add a Red Hat-provided catalog to your cluster, create a custom resource (CR) for the catalog and apply it to the cluster. The following custom resource (CR) examples show how to create a catalog resources for {olmv1}.
-
-[IMPORTANT]
-====
-
-* {empty}
-+
---
-include::snippets/olmv1-known-issue-private-registries.adoc[]
---
-
-* {empty}
-+
---
-include::snippets/olmv1-secure-registry-pull-secret.adoc[]
---
-
-====
+{olmv1-first} includes the following Red Hat-provided Operator catalogs on the cluster by default. If you want to add an additional catalog to your cluster, create a custom resource (CR) for the catalog and apply it to the cluster. The following custom resource (CR) examples show the default catalogs installed on the cluster.
 
 .Example Red Hat Operators catalog
 [source,yaml,subs="attributes+"]
@@ -40,7 +23,6 @@ spec:
     type: image
     image:
       ref: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
-      pullSecret: <pull_secret_name>
       pollInterval: <poll_interval_duration> <1>
 ----
 <1> Specify the interval for polling the remote registry for newer image digests. The default value is `24h`. Valid units include seconds (`s`), minutes (`m`), and hours (`h`). To disable polling, set a zero value, such as `0s`.
@@ -57,7 +39,6 @@ spec:
     type: image
     image:
       ref: registry.redhat.io/redhat/certified-operator-index:v{product-version}
-      pullSecret: <pull_secret_name>
       pollInterval: 24h
 ----
 
@@ -73,7 +54,6 @@ spec:
     type: image
     image:
       ref: registry.redhat.io/redhat/community-operator-index:v{product-version}
-      pullSecret: <pull_secret_name>
       pollInterval: 24h
 ----
 

--- a/operators/olm_v1/index.adoc
+++ b/operators/olm_v1/index.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {olmv1-first}
-include::snippets/technology-preview.adoc[]
-
 {olm-first} has been included with {product-title} 4 since its initial release. {product-title} 4.17 includes components for a next-generation iteration of {olm} as a Technology Preview feature, known during this phase as _{olmv1}_. This updated framework evolves many of the concepts that have been part of previous versions of {olm} and adds new capabilities.
 
 Starting in {product-title} 4.17, documentation for {olmv1} has been moved to the following new guide:


### PR DESCRIPTION
> :notebook: **This PR does not clean up all of the content changes required for catalogs to make the OLM v1 GA release**

* Remove the following snippets in the OLM v1 docs:
    - Tech Preview
    - Known issue with private registries
    - Pull secrets
* Rephrase the abstract for the RH catalogs module since they are now installed by default.


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-12812](https://issues.redhat.com//browse/OSDOCS-12812)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* The only module with a change in phrasing:
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/catalogs/managing-catalogs#olmv1-red-hat-catalogs_managing-catalogs
* Sections with removed content:
    -  https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/arch/catalogd.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/arch/components.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/arch/operator-controller.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/catalogs/creating-catalogs.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/catalogs/fbc.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/catalogs/managing-catalogs.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/catalogs/rh-catalogs.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/crd-upgrade-safety.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/managing-ce.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/upgrade-edges.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/index.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/of-terms.html
    - https://85731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/index.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
