### PR TITLE
OSDOCS#12798: Document the 4.16.25 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3338,6 +3338,39 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.25
+[id="ocp-4-16-25_{context}"]
+=== RHSA-2024:10528 - {product-title} {product-version}.25 bug fix and security update
+
+Issued: 4 December 2024
+
+{product-title} release {product-version}.25 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10528[RHSA-2024:10528] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10531[RHBA-2024:10531] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.25 --pullspecs
+----
+
+[id="ocp-4-16-25-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, in the web console *Notifications* section, silenced alerts were visible on the notification drawer because the alerts did not include external labels. With this release, the alerts include external labels and the silenced alerts are not visible on the notification drawer. (link:https://issues.redhat.com/browse/OCPBUGS-44885[*OCPBUGS-44885*])
+
+* Previously, the installation program failed to parse the `cloudControllerManager` field correctly, passing it as an empty string to the Assisted Service API. This error caused the Assisted Service to fail, blocking successful cluster installations on {oci-first}. With this release, The parsing logic is updated to correctly interpret the `cloudControllerManager` field from the `install-config.yaml` file, ensuring that the expected value is properly sent to the Assisted Service API.(link:https://issues.redhat.com/browse/OCPBUGS-44348[*OCPBUGS-44348*])
+
+* Previously, the `Display Admission Webhook` warning implementation resulted in problems with invalid code. With this release, the unnecessary warning message is removed, preventing problems with invalid code. (link:https://issues.redhat.com/browse/OCPBUGS-44207[*OCPBUGS-44207*])
+
+* Previously, when importing a Git repository using the serverless import strategy, the environment variables from the `func.yaml` file were not automatically loaded into the form. With this release, the environment variables are loaded during the Git repository import process. (link:https://issues.redhat.com/browse/OCPBUGS-43447[*OCPBUGS-43447*])
+
+[id="ocp-4-16-25-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 //4.16.24
 [id="ocp-4-16-24_{context}"]
 === RHSA-2024:10147 - {product-title} {product-version}.24 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12798](https://issues.redhat.com//browse/OSDOCS-12798)

Link to docs preview:
[4.16.25](https://85734--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-25_release-notes)

QE review:
- [ ] QE has approved this change.
n/a

Additional information:
The errata URLs will return 404 until the go-live date of 12/3/24.
