### PR TITLE
ROX-25773: Fix error in declarative config yaml

### DIFF
--- a/modules/declarative-configuration-examples.adoc
+++ b/modules/declarative-configuration-examples.adoc
@@ -110,7 +110,8 @@ rules:
         - cluster: secured-cluster-B <2>
     clusterLabelSelectors:
         - requirements:
-            key: kubernetes.io/metadata.name
+        - requirements:
+          - key: kubernetes.io/metadata.name
             operator: IN <3>
             values:
             - production


### PR DESCRIPTION
Version(s):
4.4+

[Issue](https://issues.redhat.com/browse/ROX-25773)

[Link to docs preview
](https://85754--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/declarative-configuration-using.html#declarative-config-example-access-scope)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
