### PR TITLE
Fix typo in Understanding Machine Config Daemon metrics

### DIFF
--- a/modules/machine-config-daemon-metrics-understanding.adoc
+++ b/modules/machine-config-daemon-metrics-understanding.adoc
@@ -7,7 +7,7 @@
 
 Beginning with {product-title} 4.3, the Machine Config Daemon provides a set of metrics. These metrics can be accessed using the Prometheus Cluster Monitoring stack.
 
-The following table describes this set of metrics. Some entries contain commands for getting specific logs. Hpwever, the most comprehensive set of logs is available using the `oc adm must-gather` command.
+The following table describes this set of metrics. Some entries contain commands for getting specific logs. However, the most comprehensive set of logs is available using the `oc adm must-gather` command.
 
 [NOTE]
 ====


### PR DESCRIPTION
Typo fix. No QE.