### PR TITLE
RHDEVDOCS-6276: Update OCP docs to reflect that Shared Resource CSI Driver is removed from OCP but is GA in Builds

### DIFF
--- a/modules/ephemeral-storage-additional-support-limitations-for-shared-resource-csi-driver.adoc
+++ b/modules/ephemeral-storage-additional-support-limitations-for-shared-resource-csi-driver.adoc
@@ -3,11 +3,6 @@
 [id="ephemeral-storage-additional-support-limitations-for-shared-resource-csi-driver_{context}"]
 = Additional support limitations for the Shared Resource CSI Driver
 
-[IMPORTANT]
-====
-The Shared Resource CSI Driver feature is now generally available in link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1[{builds-v2title} 1.1]. This feature is now deprecated in {product-title}. To use this feature, ensure you are using {builds-v2title} 1.1 or a more recent version.
-====
-
 [role="_abstract"]
 The Shared Resource CSI Driver has the following noteworthy limitations:
 

--- a/modules/ephemeral-storage-csi-inline-overview.adoc
+++ b/modules/ephemeral-storage-csi-inline-overview.adoc
@@ -24,6 +24,3 @@ By default, {product-title} supports CSI inline ephemeral volumes with these lim
 * Community or storage vendors provide other CSI drivers that support these volumes. Follow the installation instructions provided by the CSI driver provider.
 
 CSI drivers might not have implemented the inline volume functionality, including `Ephemeral` capacity. For details, see the CSI driver documentation.
-
-:FeatureName: Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[leveloffset=+0]

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -21,7 +21,6 @@ The following Technology Preview features are enabled by this feature set:
 +
 --
 ** External cloud providers. Enables support for external cloud providers for clusters on vSphere, AWS, Azure, and GCP. Support for OpenStack is GA. This is an internal feature that most users do not need to interact with. (`ExternalCloudProvider`)
-** Shared Resources CSI Driver in OpenShift Builds. Enables the Container Storage Interface (CSI). (`CSIDriverSharedResource`)
 ** Swap memory on nodes. Enables swap memory use for {product-title} workloads on a per-node basis. (`NodeSwap`)
 ** OpenStack Machine API Provider. This gate has no effect and is planned to be removed from this feature set in a future release. (`MachineAPIProviderOpenStack`)
 ** Insights Operator. Enables the `InsightsDataGather` CRD, which allows users to configure some Insights data gathering options. The feature set also enables the `DataGather` CRD, which allows users to run Insights data gathering on-demand. (`InsightsConfigAPI`)

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1474,8 +1474,16 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Removed
 |Removed
-|====
 
+|Shared Resources CSI Driver ^[1]^
+|Deprecated
+|Deprecated
+|Deprecated 
+|====
+[.small]
+--
+1. The Shared Resource CSI Driver feature is now generally available in Builds for Red Hat OpenShift 1.1. This feature is now deprecated in OpenShift Container Platform. To use this feature, ensure you are using Builds for Red Hat OpenShift 1.1 or a more recent version.
+--
 [discrete]
 [id="ocp-4-17-node-dep-rem_{context}"]
 === Node deprecated and removed features
@@ -2259,11 +2267,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 |General Availability
-
-|Shared Resources CSI Driver in OpenShift Builds
-|Technology Preview
-|Technology Preview
-|Technology Preview
 
 |{secrets-store-operator}
 |Technology Preview

--- a/storage/container_storage_interface/ephemeral-storage-shared-resource-csi-driver-operator.adoc
+++ b/storage/container_storage_interface/ephemeral-storage-shared-resource-csi-driver-operator.adoc
@@ -6,14 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
 [role="_abstract"]
+
+[IMPORTANT]
+====
+The Shared Resource CSI Driver feature is now generally available in link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1[{builds-v2title} 1.1]. This feature is now deprecated in {product-title}. To use this feature, ensure you are using {builds-v2title} 1.1 or a more recent version.
+====
+
 As a cluster administrator, you can use the Shared Resource CSI Driver in {product-title} to provision inline ephemeral volumes that contain the contents of `Secret` or `ConfigMap` objects. This way, pods and other Kubernetes types that expose volume mounts, and {product-title} Builds can securely use the contents of those objects across potentially any namespace in the cluster. To accomplish this, there are currently two types of shared resources: a `SharedSecret` custom resource for `Secret` objects, and a `SharedConfigMap` custom resource for `ConfigMap` objects.
 
 // The Shared Resource CSI Driver in {product-title}, as opposed to the driver for upstream Kubernetes...
-
-:FeatureName: The Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[leveloffset=+1]
 
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/RHDEVDOCS-6276
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @adambkaplan , @siamaksade 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
