### PR TITLE
OBSDOCS-1518: Update log6x-input-spec-filter-namespace-container.adoc

### DIFF
--- a/modules/log6x-input-spec-filter-namespace-container.adoc
+++ b/modules/log6x-input-spec-filter-namespace-container.adoc
@@ -32,6 +32,7 @@ spec:
         excludes:
           - container: "other-container*" # <3>
             namespace: "other-namespace" # <4>
+      type: application
 # ...
 ----
 <1> Specifies that the logs are only collected from these namespaces.


### PR DESCRIPTION
The type field in RHOL 6.0 documentation is missing from the Filtering application logs configuration.

https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.0/log6x-clf.html#log6x-input-spec-filter-namespace-container_logging-6x

- type field is missing in the above configuration. 
- type field filed is required while configuring ClusterLogForwarder with the inputs section. 
- spec.inputs.type is required
- type should be `application` here in above configuration.

It needs to look like the following:

~~~
apiVersion: observability.openshift.io/v1
kind: ClusterLogForwarder
# ...
spec:
  serviceAccount:
    name: <service_account_name>
  inputs:
    - name: mylogs 
      application: 
          includes: 
             - namespace: "my-project"  
               container: "my-container" 
           excludes: 
              - container: "other-container*"  
                namespace: "other-namespace" 
       type: application             <<=== Need to add this line
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> Update type field in RHOL 6.0 documentation in Filtering application logs configuration

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> RHCOP 4.18, RHCOP 4.17, RHCOP 4.16, RHOCP 4.15, RHOCP 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/OBSDOCS-1518

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. ---> 
https://85763--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-clf.html
https://85763--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-clf-6.1.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
