### PR TITLE
Fix occurrences of 'polices' used in place of 'policies'

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3341,7 +3341,7 @@ Topics:
   File: ztp-vdu-validating-cluster-tuning
 - Name: Advanced managed cluster configuration with SiteConfig resources
   File: ztp-advanced-install-ztp
-- Name: Managing cluster polices with PolicyGenerator resources
+- Name: Managing cluster policies with PolicyGenerator resources
   Dir: policygenerator_for_ztp
   Distros: openshift-origin,openshift-enterprise
   Topics:
@@ -3351,7 +3351,7 @@ Topics:
     File: ztp-advanced-policygenerator-config
   - Name: Updating managed clusters in a disconnected environment with PolicyGenerator resources and TALM
     File: ztp-talm-updating-managed-policies-pg
-- Name: Managing cluster polices with PolicyGenTemplate resources
+- Name: Managing cluster policies with PolicyGenTemplate resources
   Dir: policygentemplate_for_ztp
   Distros: openshift-origin,openshift-enterprise
   Topics:

--- a/modules/logging-release-notes-5-8-0.adoc
+++ b/modules/logging-release-notes-5-8-0.adoc
@@ -28,7 +28,7 @@ In order to support multi-cluster log forwarding in additional namespaces other 
 
 * With this update, you can configure the log collector to look for HTTP connections and receive logs as an HTTP server, also known as a webhook. (link:https://issues.redhat.com/browse/LOG-4562[LOG-4562])
 
-* With this update, you can configure audit polices to control which Kubernetes and OpenShift API server events are forwarded by the log collector. (link:https://issues.redhat.com/browse/LOG-3982[LOG-3982])
+* With this update, you can configure audit policies to control which Kubernetes and OpenShift API server events are forwarded by the log collector. (link:https://issues.redhat.com/browse/LOG-3982[LOG-3982])
 
 [id="logging-release-notes-5-8-0-log-storage"]
 === Log Storage

--- a/modules/nw-secondary-ext-gw-object.adoc
+++ b/modules/nw-secondary-ext-gw-object.adoc
@@ -22,7 +22,7 @@ Specifies the name of the  `AdminPolicyBasedExternalRoute` object.
 |`spec.from`
 |`string`
 |
-Specifies a namespace selector that the routing polices apply to. Only `namespaceSelector` is supported for external traffic. For example:
+Specifies a namespace selector that the routing policies apply to. Only `namespaceSelector` is supported for external traffic. For example:
 
 [source,yaml]
 ----

--- a/modules/nw-sriov-topology-manager.adoc
+++ b/modules/nw-sriov-topology-manager.adoc
@@ -6,7 +6,7 @@
 [id="nw-sriov-topology-manager_{context}"]
 = Creating a non-uniform memory access (NUMA) aligned SR-IOV pod
 
-You can create a NUMA aligned SR-IOV pod by restricting SR-IOV and the CPU resources allocated from the same NUMA node with `restricted` or `single-numa-node` Topology Manager polices.
+You can create a NUMA aligned SR-IOV pod by restricting SR-IOV and the CPU resources allocated from the same NUMA node with `restricted` or `single-numa-node` Topology Manager policies.
 
 .Prerequisites
 

--- a/modules/rosa-aws-scp.adoc
+++ b/modules/rosa-aws-scp.adoc
@@ -6,7 +6,7 @@
 [id="rosa-minimum-scp_{context}"]
 = Minimum set of effective permissions for service control policies (SCP)
 
-Service control policies (SCP) are a type of organization policy that manages permissions within your organization. SCPs ensure that accounts within your organization stay within your defined access control guidelines. These polices are maintained in AWS Organizations and control the services that are available within the attached AWS accounts. SCP management is the responsibility of the customer.
+Service control policies (SCP) are a type of organization policy that manages permissions within your organization. SCPs ensure that accounts within your organization stay within your defined access control guidelines. These policies are maintained in AWS Organizations and control the services that are available within the attached AWS accounts. SCP management is the responsibility of the customer.
 
 ifeval::["{context}" == "rosa-sts-about-iam-resources"]
 :aws-sts:

--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -12,7 +12,7 @@ The account-wide roles and policies are specific to an {product-title} minor rel
 [id="rosa-sts-account-wide-roles-and-policies-creation-methods_{context}"]
 == Methods of account-wide role creation
 
-You can create account-wide roles by using the {product-title} (ROSA) CLI, `rosa`, or the {cluster-manager-url} guided installation. You can create the roles manually or by using an automatic process that uses predefined names for these roles and polices.
+You can create account-wide roles by using the {product-title} (ROSA) CLI, `rosa`, or the {cluster-manager-url} guided installation. You can create the roles manually or by using an automatic process that uses predefined names for these roles and policies.
 
 [discrete]
 [id="rosa-sts-account-wide-roles-and-policies-creation-methods-manual_{context}"]
@@ -24,7 +24,7 @@ You can use the manual creation method if you have the necessary CLI access to c
 [id="rosa-sts-account-wide-roles-and-policies-creation-methods-auto_{context}"]
 === Automatic ocm-role resource creation
 
-If you created an `ocm-role` resource with administrative permissions, you can use the automatic creation method from {cluster-manager}. The ROSA CLI does not require that you have this admin `ocm-role` IAM resource to automatically create these roles and polices. Selecting this method creates the roles and policies that uses the default names.
+If you created an `ocm-role` resource with administrative permissions, you can use the automatic creation method from {cluster-manager}. The ROSA CLI does not require that you have this admin `ocm-role` IAM resource to automatically create these roles and policies. Selecting this method creates the roles and policies that uses the default names.
 
 If you use the ROSA guided installation on {cluster-manager}, you must have created an `ocm-role` resource with administrative permissions in the first step of the guided cluster installation. Without this role, you cannot use the automatic Operator role and policy creation option, but you can still create the cluster and its roles and policies with the manual process.
 

--- a/modules/ztp-preparing-the-ztp-git-repository.adoc
+++ b/modules/ztp-preparing-the-ztp-git-repository.adoc
@@ -70,7 +70,7 @@ example/
         ├── extra-manifests
         └── kustomization.yaml
 ----
-<1> Using `PolicyGenTemplate` CRs to manage and deploy polices to manage clusters will be deprecated in a future {product-title} release.
+<1> Using `PolicyGenTemplate` CRs to manage and deploy policies to manage clusters will be deprecated in a future {product-title} release.
 Equivalent and improved functionality is available by using {rh-rhacm-first} and `PolicyGenerator` CRs.
 
 . Commit the directory structure and the `kustomization.yaml` files and push to your Git repository.

--- a/modules/ztp-the-policygentemplate.adoc
+++ b/modules/ztp-the-policygentemplate.adoc
@@ -8,7 +8,7 @@
 
 The `{policy-gen-cr}` custom resource definition (CRD) tells the `PolicyGen` policy generator what custom resources (CRs) to include in the cluster configuration, how to combine the CRs into the generated policies, and what items in those CRs need to be updated with overlay content.
 
-The following example shows a `{policy-gen-cr}` CR (`{policy-prefix}common-du-ranGen.yaml`) extracted from the `ztp-site-generate` reference container. The `{policy-prefix}common-du-ranGen.yaml` file defines two {rh-rhacm-first} policies. The polices manage a collection of configuration CRs, one for each unique value of `policyName` in the CR. `{policy-prefix}common-du-ranGen.yaml` creates a single placement binding and a placement rule to bind the policies to clusters based on the labels listed in the `{binding-field}` section.
+The following example shows a `{policy-gen-cr}` CR (`{policy-prefix}common-du-ranGen.yaml`) extracted from the `ztp-site-generate` reference container. The `{policy-prefix}common-du-ranGen.yaml` file defines two {rh-rhacm-first} policies. The policies manage a collection of configuration CRs, one for each unique value of `policyName` in the CR. `{policy-prefix}common-du-ranGen.yaml` creates a single placement binding and a placement rule to bind the policies to clusters based on the labels listed in the `{binding-field}` section.
 
 .Example {policy-gen-cr} CR - {policy-prefix}common-ranGen.yaml
 ifeval::["{policy-gen-cr}" == "PolicyGenTemplate"]

--- a/modules/ztp-updating-gitops-ztp.adoc
+++ b/modules/ztp-updating-gitops-ztp.adoc
@@ -10,7 +10,7 @@ You can update {ztp-first} for a fully operational hub cluster running an earlie
 
 [NOTE]
 ====
-Any changes to policy settings, including adding recommended content, results in updated polices that must be rolled out to the managed clusters and reconciled.
+Any changes to policy settings, including adding recommended content, results in updated policies that must be rolled out to the managed clusters and reconciled.
 ====
 
 At a high level, the strategy for updating the {ztp} infrastructure is as follows:

--- a/snippets/pgt-deprecation-notice.adoc
+++ b/snippets/pgt-deprecation-notice.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: SNIPPET
 [IMPORTANT]
 ====
-Using `PolicyGenTemplate` CRs to manage and deploy polices to managed clusters will be deprecated in an upcoming {product-title} release.
+Using `PolicyGenTemplate` CRs to manage and deploy policies to managed clusters will be deprecated in an upcoming {product-title} release.
 Equivalent and improved functionality is available using {rh-rhacm-first} and `PolicyGenerator` CRs.
 
 For more information about `PolicyGenerator` resources, see the {rh-rhacm} link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/governance/integrate-policy-generator#policy-generator[Policy Generator] documentation.

--- a/snippets/pgt-ztp-adding-new-content-to-gitops-ztp.adoc
+++ b/snippets/pgt-ztp-adding-new-content-to-gitops-ztp.adoc
@@ -32,7 +32,7 @@ spec:
     - fileName: StorageSubscription.yaml
       remediationAction: inform
       policyName: "group-dev-lso-sub"
-    #These are custom local polices that come from the source-crs directory in the git repo
+    #These are custom local policies that come from the source-crs directory in the git repo
     # Performance Addon Operator
     - fileName: PaoSubscriptionNS.yaml
       remediationAction: inform


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- https://85773--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-configuring-managed-clusters-policygenerator.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygentemplate_for_ztp/ztp-configuring-managed-clusters-policies.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-clusters-at-scale.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-sites.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-preparing-the-hub-cluster.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-updating-gitops.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-using-hub-cluster-templates.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/add-pod.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.html
- https://85773--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html
- https://85773--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html
- https://85773--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html
- https://85773--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

While reading the documentation, I noticed that in places the word "police" is sometimes used in place of "policy". This pull request resolves all situations like this within the OpenShift documentation with the exception of the following:

* [cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc](https://github.com/openshift/openshift-docs/blob/main/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc?plain=1#L135) - the word "polices" is used in the section id, changing it might break references to this section.
* [microshift_rest_api/autoscaling_apis/horizontalpodautoscaler-autoscaling-v2.adoc](https://github.com/openshift/openshift-docs/blob/main/microshift_rest_api/autoscaling_apis/horizontalpodautoscaler-autoscaling-v2.adoc) - the word "polices" is repeated four times in four tables. This content is autogenerated, the typo should therefore be fixed in the source material.
* [rest_api/autoscale_apis/horizontalpodautoscaler-autoscaling-v2.adoc](https://github.com/openshift/openshift-docs/blob/main/rest_api/autoscale_apis/horizontalpodautoscaler-autoscaling-v2.adoc) - This content is autogenerated, likely from the same source as the one above.

Related Vale rule has [been already merged](https://github.com/redhat-documentation/vale-at-red-hat/pull/901).

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
