### PR TITLE
TELCODOCS-2128 Create Release Notes topic for KMM

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3392,6 +3392,11 @@ Topics:
   File: psap-node-feature-discovery-operator
 - Name: Kernel Module Management Operator
   File: kmm-kernel-module-management
+- Name: Kernel Module Management Operator release notes
+  Dir: release-notes
+  Topics:
+  - Name: Release notes for Kernel Module Management Operator 2.2
+    File: kmm-release-notes
 ---
 Name: Backup and restore
 Dir: backup_and_restore

--- a/hardware_enablement/release-notes/_attributes
+++ b/hardware_enablement/release-notes/_attributes
@@ -1,0 +1,1 @@
+../_attributes/

--- a/hardware_enablement/release-notes/kmm-release-notes.adoc
+++ b/hardware_enablement/release-notes/kmm-release-notes.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="kmm-release-notes-v2-2"]
+= Kernel Module Management Operator release notes
+include::_attributes/common-attributes.adoc[]
+:context: kmm-release-notes-v2-2
+
+toc::[]
+
+[id="kmm-2-2"]
+== Release notes for Kernel Module Management Operator 2.2
+
+=== New features
+
+// TELCODOCS-2022
+* KMM is now using the CRI-O container engine to pull container images in the worker pod instead of using HTTP calls directly from the worker container. For more information, see xref:../kmm-kernel-module-management.adoc#kmm-example-cr_kernel-module-management-operator[Example Module CR].
+
+// TELCODOCS-2028
+* The Kernel Module Management (KMM) Operator images are now based on `rhel-els-minimal` container images instead of the `rhel-els` images. This change results in a greatly reduced image footprint, while still maintaining FIPS compliance.
+
+// TELCODOCS-1994
+* In this release, the firmware search path has been updated to copy the contents of the specified path into the path specified in worker.setFirmwareClassPath (default: /var/lib/firmware). For more information, see xref:../kmm-kernel-module-management.adoc#kmm-example-cr_kernel-module-management-operator[Example Module CR].
+
+// TELCODOCS-1977
+* For each node running a kernel matching the regular expression, KMM now checks if you have included a tag or a digest. If you have not specified a tag or digest in the container image, then the validation webhook returns an error and does not apply the module. For more information, see xref:../kmm-kernel-module-management.adoc#kmm-example-cr_kernel-module-management-operator[Example Module CR].
+
+

--- a/modules/kmm-example-module-cr.adoc
+++ b/modules/kmm-example-module-cr.adoc
@@ -4,7 +4,6 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="kmm-example-cr_{context}"]
-
 = Example Module CR
 
 The following is an annotated `Module` example:


### PR DESCRIPTION
R/N: [TELCODOCS-2128](https://issues.redhat.com//browse/TELCODOCS-2128): Move KMM release notes from OCP 4.17 release notes to KMM section in hardware enablement.

Jira: https://issues.redhat.com/browse/TELCODOCS-2128

Applies to OCP version : 4.17 4.18

Fix version: KMMO 2.2

Docs Preview: https://85808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/release-notes/kmm-release-notes.html

Dev review: @ybettan 
QE review: @ggordaniRed