### PR TITLE
OCPBUGS-36835 - Adding missing NMState Operator CRs

### DIFF
--- a/modules/telco-core-crs-networking.adoc
+++ b/modules/telco-core-crs-networking.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="networking-crs_{context}"]
@@ -21,6 +21,10 @@ Load balancer,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#tel
 Load balancer,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-metallbopergroup-yaml[metallbOperGroup.yaml],Yes,No
 Load balancer,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-metallbsubscription-yaml[metallbSubscription.yaml],No,No
 Multus - Tap CNI for rootless DPDK pod,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-mc_rootless_pods_selinux-yaml[mc_rootless_pods_selinux.yaml],No,No
+NMState Operator,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-nmstate-yaml[NMState.yaml],Yes,Yes
+NMState Operator,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-nmstatens-yaml[NMStateNS.yaml],Yes,Yes
+NMState Operator,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-nmstateopergroup-yaml[NMStateOperGroup.yaml],Yes,Yes
+NMState Operator,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-nmstatesubscription-yaml[NMStateSubscription.yaml],Yes,Yes
 SR-IOV Network Operator,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-sriovnetwork-yaml[sriovNetwork.yaml],Yes,No
 SR-IOV Network Operator,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-sriovnetworknodepolicy-yaml[sriovNetworkNodePolicy.yaml],No,Yes
 SR-IOV Network Operator,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-sriovoperatorconfig-yaml[SriovOperatorConfig.yaml],No,Yes

--- a/modules/telco-core-crs-other.adoc
+++ b/modules/telco-core-crs-other.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="other-crs_{context}"]

--- a/modules/telco-core-crs-resource-tuning.adoc
+++ b/modules/telco-core-crs-resource-tuning.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="resource-tuning-crs_{context}"]

--- a/modules/telco-core-crs-scheduling.adoc
+++ b/modules/telco-core-crs-scheduling.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="scheduling-crs_{context}"]

--- a/modules/telco-core-crs-storage.adoc
+++ b/modules/telco-core-crs-storage.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="storage-crs_{context}"]
@@ -10,8 +10,8 @@
 [cols="4*", options="header", format=csv]
 |====
 Component,Reference CR,Optional,New in this release
-External {rh-storage-first} configuration,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-01-rook-ceph-external-cluster-details.secret-yaml[01-rook-ceph-external-cluster-details.secret.yaml],No,Yes
-External {rh-storage} configuration,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-02-ocs-external-storagecluster-yaml[02-ocs-external-storagecluster.yaml],No,No
-External {rh-storage} configuration,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-odfns-yaml[odfNS.yaml],No,No
-External {rh-storage} configuration,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-odfopergroup-yaml[odfOperGroup.yaml],No,No
+External ODF configuration,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-01-rook-ceph-external-cluster-details.secret-yaml[01-rook-ceph-external-cluster-details.secret.yaml],No,Yes
+External ODF configuration,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-02-ocs-external-storagecluster-yaml[02-ocs-external-storagecluster.yaml],No,No
+External ODF configuration,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-odfns-yaml[odfNS.yaml],No,No
+External ODF configuration,xref:../../telco_ref_design_specs/core/telco-core-ref-crs.adoc#telco-core-odfopergroup-yaml[odfOperGroup.yaml],No,No
 |====

--- a/modules/telco-core-yaml-ref-networking.adoc
+++ b/modules/telco-core-yaml-ref-networking.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="networking-yaml_{context}"]
@@ -81,6 +81,34 @@ include::snippets/telco-core_metallbSubscription.yaml[]
 [source,yaml]
 ----
 include::snippets/telco-core_mc_rootless_pods_selinux.yaml[]
+----
+
+[id="telco-core-nmstate-yaml"]
+.NMState.yaml
+[source,yaml]
+----
+include::snippets/telco-core_NMState.yaml[]
+----
+
+[id="telco-core-nmstatens-yaml"]
+.NMStateNS.yaml
+[source,yaml]
+----
+include::snippets/telco-core_NMStateNS.yaml[]
+----
+
+[id="telco-core-nmstateopergroup-yaml"]
+.NMStateOperGroup.yaml
+[source,yaml]
+----
+include::snippets/telco-core_NMStateOperGroup.yaml[]
+----
+
+[id="telco-core-nmstatesubscription-yaml"]
+.NMStateSubscription.yaml
+[source,yaml]
+----
+include::snippets/telco-core_NMStateSubscription.yaml[]
 ----
 
 [id="telco-core-sriovnetwork-yaml"]

--- a/modules/telco-core-yaml-ref-other.adoc
+++ b/modules/telco-core-yaml-ref-other.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="other-yaml_{context}"]

--- a/modules/telco-core-yaml-ref-resource-tuning.adoc
+++ b/modules/telco-core-yaml-ref-resource-tuning.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="resource-tuning-yaml_{context}"]

--- a/modules/telco-core-yaml-ref-scheduling.adoc
+++ b/modules/telco-core-yaml-ref-scheduling.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="scheduling-yaml_{context}"]

--- a/modules/telco-core-yaml-ref-storage.adoc
+++ b/modules/telco-core-yaml-ref-storage.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="storage-yaml_{context}"]

--- a/snippets/telco-core_NMState.yaml
+++ b/snippets/telco-core_NMState.yaml
@@ -1,0 +1,5 @@
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate
+spec: {}

--- a/snippets/telco-core_NMStateNS.yaml
+++ b/snippets/telco-core_NMStateNS.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nmstate
+  annotations:
+    workload.openshift.io/allowed: management

--- a/snippets/telco-core_NMStateOperGroup.yaml
+++ b/snippets/telco-core_NMStateOperGroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-nmstate
+  namespace: openshift-nmstate
+spec:
+  targetNamespaces:
+    - openshift-nmstate

--- a/snippets/telco-core_NMStateSubscription.yaml
+++ b/snippets/telco-core_NMStateSubscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubernetes-nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  channel: "stable"
+  name: kubernetes-nmstate-operator
+  source: redhat-operators-disconnected
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+status:
+  state: AtLatestKnown


### PR DESCRIPTION
4.15 Core RDS is missing NMState CRs

Version(s):
enterprise-4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-36835

Link to docs preview:
https://85809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.html

QE review:
- [x] QE review not required. These CRs are QE'd upstream for inclusion in the telco core RDS.