### PR TITLE
OSDOCS#12767: Removing unsupported versions of OSSO for 4.18 until ne…

### DIFF
--- a/nodes/scheduling/secondary_scheduler/index.adoc
+++ b/nodes/scheduling/secondary_scheduler/index.adoc
@@ -8,5 +8,8 @@ toc::[]
 
 You can install the {secondary-scheduler-operator} to run a custom secondary scheduler alongside the default scheduler to schedule pods.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // About the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-about.adoc[leveloffset=+1]

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 You can run a custom secondary scheduler in {product-title} by installing the {secondary-scheduler-operator}, deploying the secondary scheduler, and setting the secondary scheduler in the pod definition.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // Installing the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-install-console.adoc[leveloffset=+1]
 

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -10,51 +10,7 @@ The {secondary-scheduler-operator-full} allows you to deploy a custom secondary 
 
 These release notes track the development of the {secondary-scheduler-operator-full}.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
-
-[id="secondary-scheduler-operator-release-notes-1.3.1_{context}"]
-== Release notes for {secondary-scheduler-operator-full} 1.3.1
-
-Issued: 3 October 2024
-
-The following advisory is available for the {secondary-scheduler-operator-full} 1.3.1:
-
-* link:https://access.redhat.com/errata/RHEA-2024:7073[RHEA-2024:7073]
-
-[id="secondary-scheduler-1.3.1-bug-fixes_{context}"]
-=== Bug fixes
-
-* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-[id="secondary-scheduler-operator-1.3.1-known-issues_{context}"]
-=== Known issues
-
-* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
-
-[id="secondary-scheduler-operator-release-notes-1.3.0_{context}"]
-== Release notes for {secondary-scheduler-operator-full} 1.3.0
-
-Issued: 1 July 2024
-
-The following advisory is available for the {secondary-scheduler-operator-full} 1.3.0:
-
-* link:https://access.redhat.com/errata/RHSA-2024:3637[RHSA-2024:3637]
-
-[id="secondary-scheduler-operator-1.3.0-new-features-and-enhancements_{context}"]
-=== New features and enhancements
-
-* You can now install and use the {secondary-scheduler-operator} in an {product-title} cluster running in FIPS mode.
-+
---
-include::snippets/fips-snippet.adoc[]
---
-
-[id="secondary-scheduler-1.3.0-bug-fixes_{context}"]
-=== Bug fixes
-
-* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-[id="secondary-scheduler-operator-1.3.0-known-issues_{context}"]
-=== Known issues
-
-* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 You can remove the {secondary-scheduler-operator-full} from {product-title} by uninstalling the Operator and removing its related resources.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // Uninstalling the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-uninstall-console.adoc[leveloffset=+1]
 


### PR DESCRIPTION
…xt version releases

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-12767

Link to docs preview:

- https://85813--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/index.html
- https://85813--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html
- https://85813--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html
- https://85813--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
