### PR TITLE
OSDOCS#12788: ABI minimal ISO field

### DIFF
--- a/modules/agent-configuration-parameters.adoc
+++ b/modules/agent-configuration-parameters.adoc
@@ -62,7 +62,9 @@ If this address is not provided, one IP address is selected from the provided ho
 |IPv4 or IPv6 address.
 
 |bootArtifactsBaseURL:
-|The URL of the server to upload Preboot Execution Environment (PXE) assets to when using the Agent-based Installer to generate an iPXE script.
+|When you use the Agent-based Installer to generate a minimal ISO image, this parameter specifies a URL where the rootfs image file can be retrieved from during cluster installation. This parameter is optional for booting minimal ISO images in connected environments.
+
+When you use the Agent-based Installer to generate an iPXE script, this parameter specifies the URL of the server to upload Preboot Execution Environment (PXE) assets to.
 For more information, see "Preparing PXE assets for {product-title}".
 |String.
 
@@ -127,4 +129,12 @@ For more information, see "Root device hints" in the "Setting up the environment
 |The host network definition.
 The configuration must match the Host Network Management API defined in the link:https://nmstate.io/[nmstate documentation].
 |A dictionary of host network configuration objects.
+
+|minimalISO:
+|Defines whether the Agent-based Installer generates a full ISO or a minimal ISO image. When this parameter is set to `True`, the Agent-based Installer generates an ISO without a rootfs image file, and instead contains details about where to pull the rootfs file from.
+
+When you generate a minimal ISO, if you do not specify a rootfs URL through the `bootArtifactsBaseURL` parameter, the Agent-based Installer embeds a default URL that is accessible in environments with an internet connection.
+
+The default value is `False`.
+|Boolean.
 |====


### PR DESCRIPTION
[OSDOCS-12788](https://issues.redhat.com/browse/OSDOCS-12788)

Version(s): 4.18+

This PR documents a new feature for generating a minimal ISO with the ABI for all platforms.

QE review:
- [x] QE has approved this change.

Preview: [Optional configuration parameters](https://85821--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html#agent-configuration-parameters-optional_installation-config-parameters-agent)
