### PR TITLE
RN for Docs for OCPSTRAT-1656 Updated boot images: Phase 3 (AWS GA) 

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -434,6 +434,10 @@ For more information, see xref:../nodes/clusters/nodes-cluster-enabling-features
 [id="ocp-release-notes-machine-config-operator_{context}"]
 === Machine Config Operator
 
+[id="ocp-release-notes-machine-config-operator-aws-boot-ga_{context}"]
+=== Updated boot images for AWS clusters promoted to GA
+Updated boot images has been promoted to GA for Amazon Web Services (AWS) clusters. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
+
 [id="ocp-release-notes-machine-management_{context}"]
 === Machine management
 
@@ -1150,24 +1154,24 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |On-cluster RHCOS image layering
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Node disruption policies
-|Not Available
-|Technology Preview
+|Technology Preview 
+|General Availability
 |General Availability
 
 |Updating boot images for GCP clusters
-|Not Available
 |Technology Preview
+|General Availability
 |General Availability
 
 |Updating boot images for AWS clusters
 |Not Available
-|Not Available
 |Technology Preview
+|General Availability
 
 |====
 


### PR DESCRIPTION
Release notes for https://issues.redhat.com/browse/OSDOCS-11998

Previews:
New features -> [Updated boot images for AWS clusters promoted to GA](https://85839--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-machine-config-operator_release-notes) -- Added RN
Technology Preview features status -> [Table 24. Machine Config Operator Technology Preview tracker](https://85839--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-technology-preview-tables_release-notes) -- Updated Machine Config Operator Technology Preview tracker table