### PR TITLE
OSSM-8516 +1 to leveloffsets

### DIFF
--- a/observability/kiali/ossm-kiali-assembly.adoc
+++ b/observability/kiali/ossm-kiali-assembly.adoc
@@ -8,15 +8,15 @@ toc::[]
 
 Once you have added your application to the mesh, you can use {KialiProduct} to view the data flow through your application.
 
-include::modules/ossm-kiali-about.adoc[leveloffset=1]
+include::modules/ossm-kiali-about.adoc[leveloffset=+1]
 
-include::modules/ossm-install-kiali-operator.adoc[leveloffset=1]
+include::modules/ossm-install-kiali-operator.adoc[leveloffset=+1]
 
 include::modules/ossm-config-openshift-monitoring-kiali.adoc[leveloffset=1]
 
-include::modules/ossm-integrating-kiali-otel.adoc[leveloffset=1]
+include::modules/ossm-integrating-kiali-otel.adoc[leveloffset=+1]
 
-include::modules/ossm-config-otel-kiali.adoc[leveloffset=2]
+include::modules/ossm-config-otel-kiali.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/observability/traces/ossm-distr-tracing-assembly.adoc
+++ b/observability/traces/ossm-distr-tracing-assembly.adoc
@@ -18,4 +18,4 @@ The link:https://opentelemetry.io/docs/collector/[OpenTelemetry Collector] can r
 +
 For more information about {OTELShortName}, its features, installation, and configuration, see: link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/red_hat_build_of_opentelemetry/index[{OTELName}].
 
-include::modules/ossm-config-otel.adoc[leveloffset=1]
+include::modules/ossm-config-otel.adoc[leveloffset=+1]


### PR DESCRIPTION
**OSSM 3.0 TP1**

[OSSM-8516](https://issues.redhat.com//browse/OSSM-8516) +1 to leveloffsets

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):
 
Technology Preview

OSSM 3.0 is moving to stand alone format and will not be cherry-picked back to OCP core branches.
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSSM-8516

Link to docs preview:
Kiali: https://85841--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/kiali/ossm-kiali-assembly.html
Traces: https://85841--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/traces/ossm-distr-tracing-assembly.html

QE review:
QE review is not needed for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
