### PR TITLE
OSSM-8519 docinfo.xml

### DIFF
--- a/migrating/docinfo.xml
+++ b/migrating/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>{product-version}</productnumber>
 <subtitle>Migrating from OpenShift Service Mesh 2.6 to 3</subtitle>
 <abstract>
-    <para>This document provides important information on difference between {product-title} 2.6 and {product-title} 3, including a new operator, new resources, and changes to integrations like OpenShift Observability and Kiali. It also provides information on migrating from OpenShift Serivce Mesh 2.6 to OpenShift Service Mesh 3.
+    <para>This document provides important information on difference between Service Mesh 2.6 and Service Mesh 3, including a new operator, new resources, and changes to integrations such as OpenShift Observability and Kiali. It also provides information on migrating from OpenShift Service Mesh 2.6 to OpenShift Service Mesh 3.
     </para>
 </abstract>
 <authorgroup>


### PR DESCRIPTION
**OSSM 3.0 TP1**

[OSSM-8519](https://issues.redhat.com//browse/OSSM-8519) docinfo.xml

Other OSSM docinfo.xml examples: 

https://gitlab.cee.redhat.com/red-hat-enterprise-openshift-documentation/layered-products-docs/-/blob/service-mesh-docs-3.0.0tp1/gateways/docinfo.xml?ref_type=heads

https://gitlab.cee.redhat.com/red-hat-enterprise-openshift-documentation/layered-products-docs/-/blob/service-mesh-docs-3.0.0tp1/ossm-release-notes/docinfo.xml?ref_type=heads

docinfo.xml files are required for stand alone pages in Pantheon as part of the sync script: you must add docinfo.xml files to every directory in your GitHub repository that corresponds to a Portal book (these are normally the first-level directories such as about, each of these directories is in a Dir parameter in _topic_map.yml).The sync server automatically copies these files alongside the AsciiDoc content.

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):
 
Technology Preview

OSSM 3.0 is moving to stand alone format and will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8519

Link to docs preview:
There are no previews for docinfo.xml files

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
