### PR TITLE
OSSM-8517 Missed a + in Kiali

### DIFF
--- a/observability/kiali/ossm-kiali-assembly.adoc
+++ b/observability/kiali/ossm-kiali-assembly.adoc
@@ -12,7 +12,7 @@ include::modules/ossm-kiali-about.adoc[leveloffset=+1]
 
 include::modules/ossm-install-kiali-operator.adoc[leveloffset=+1]
 
-include::modules/ossm-config-openshift-monitoring-kiali.adoc[leveloffset=1]
+include::modules/ossm-config-openshift-monitoring-kiali.adoc[leveloffset=+1]
 
 include::modules/ossm-integrating-kiali-otel.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**OSSM 3.0 TP1**

[OSSM-8517](https://issues.redhat.com//browse/OSSM-8517) Missed a + in Kiali

+ is necessary for Pantheon to know to nest things.

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):
 
Technology Preview

OSSM 3.0 is moving to stand alone format and will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8517

Link to docs preview:
https://85845--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/kiali/ossm-kiali-assembly.html

QE review:
QE is not needed for this PR

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
