### PR TITLE
OSSM-8432: 2.6.4 (At Stage): [DOC] Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -174,7 +174,7 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.3
+:SMProductVersion: 2.6.4
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-4-13.adoc
+++ b/modules/ossm-release-2-4-13.adoc
@@ -1,0 +1,26 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-4-13_{context}"]
+= {SMProductName} version 2.4.13
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.4 and is supported on {product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+[id=ossm-release-2-4-13-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Kiali Server
+|1.65.18
+|===

--- a/modules/ossm-release-2-5-7.adoc
+++ b/modules/ossm-release-2-5-7.adoc
@@ -1,0 +1,26 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-5-7_{context}"]
+= {SMProductName} version 2.5.7
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.4 and is supported on {product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+[id=ossm-release-2-5-7-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.18.7
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali Server
+|1.73.17
+|===

--- a/modules/ossm-release-2-6-4.adoc
+++ b/modules/ossm-release-2-6-4.adoc
@@ -4,16 +4,18 @@ Module included in the following assemblies:
 ////
 
 :_mod-docs-content-type: REFERENCE
-[id="ossm-release-2-6-3_{context}"]
-= {SMProductName} version 2.6.3
+[id="ossm-release-2-6-4_{context}"]
+= {SMProductName} version 2.6.4
 
-This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.3, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.3, 2.5.6, and 2.4.12.
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.4, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.4, 2.5.7, and 2.4.13.
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
 
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
 The most current version of the {KialiProduct} can be used with all supported versions of {SMProductName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
-[id=ossm-release-2-6-3-components_{context}]
+[id=ossm-release-2-6-4-components_{context}]
 == Component updates
 
 |===
@@ -26,5 +28,5 @@ The most current version of the {KialiProduct} can be used with all supported ve
 |1.28.7
 
 |Kiali Server
-|1.73.16
+|1.73.17
 |===

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -10,6 +10,12 @@ toc::[]
 
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
+include::modules/ossm-release-2-6-4.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-5-7.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-4-13.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-3.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-5-6.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.4 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-8432

Fix Version: 4.14+

Doc Preview: https://85846--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-4_ossm-release-notes

QE Review: @unsortedhashsets 
Peer Review: @lahinson 