### PR TITLE
OCPBUGS#44255: Added important note to the Configuration for a VLAN …

### DIFF
--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
 :_mod-docs-content-type: REFERENCE
 [id="configuration-ovnk-network-plugin-json-object_{context}"]
 = OVN-Kubernetes network plugin JSON configuration table
@@ -18,9 +22,9 @@ The CNI specification version. The required value is `0.3.1`.
 |`string`
 |
 The name of the network. These networks are not namespaced. For example, you can have a network named
-`l2-network` referenced from two different `NetworkAttachmentDefinitions` that exist on two different
-namespaces. This ensures that pods making use of the `NetworkAttachmentDefinition` on their own different
-namespaces can communicate over the same secondary network. However, those two different `NetworkAttachmentDefinitions` must also share the same network specific parameters such as `topology`, `subnets`, `mtu`, and `excludeSubnets`.
+`l2-network` referenced from two different `NetworkAttachmentDefinition` CRDs that exist on two different
+namespaces. This ensures that pods making use of the `NetworkAttachmentDefinition` CRD on their own different
+namespaces can communicate over the same secondary network. However, those two different `NetworkAttachmentDefinition` CRDs must also share the same network specific parameters such as `topology`, `subnets`, `mtu`, and `excludeSubnets`.
 
 |`type`
 |`string`
@@ -49,8 +53,8 @@ The maximum transmission unit (MTU). The default value, `1300`, is automatically
 |`netAttachDefName`
 |`string`
 |
-The metadata `namespace` and `name` of the network attachment definition object where this
-configuration is included. For example, if this configuration is defined in a `NetworkAttachmentDefinition` in namespace `ns1` named `l2-network`, this should be set to `ns1/l2-network`.
+The metadata `namespace` and `name` of the network attachment definition CRD where this
+configuration is included. For example, if this configuration is defined in a `NetworkAttachmentDefinition` CRD in namespace `ns1` named `l2-network`, this should be set to `ns1/l2-network`.
 
 |`excludeSubnets`
 |`string`

--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -10,7 +10,7 @@
 // is split with tags. The tag includes don't pull in the module header above.
 
 // tag::localnet-intro[]
-The switched `localnet` topology interconnects the workloads created as Network Attachment Definitions (NAD) through a cluster-wide logical switch to a physical network.
+The switched `localnet` topology interconnects the workloads created as Network Attachment Definitions (NADs) through a cluster-wide logical switch to a physical network.
 // end::localnet-intro[]
 
 // tag::localnet-content[]
@@ -44,7 +44,7 @@ spec:
 ----
 <1> The name for the configuration object.
 <2> A node selector that specifies the nodes to apply the node network configuration policy to.
-<3> The name for the additional network from which traffic is forwarded to the OVS bridge. This additional network must match the name of the `spec.config.name` field of the `NetworkAttachmentDefinition` object that defines the OVN-Kubernetes additional network.
+<3> The name for the additional network from which traffic is forwarded to the OVS bridge. This additional network must match the name of the `spec.config.name` field of the `NetworkAttachmentDefinition` CRD that defines the OVN-Kubernetes additional network.
 <4> The name of the OVS bridge on the node. This value is required only if you specify `state: present`.
 <5> The state for the mapping. Must be either `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
 
@@ -84,7 +84,7 @@ spec:
 <2> A node selector that specifies the nodes to apply the node network configuration policy to.
 <3> A new OVS bridge, separate from the default bridge used by OVN-Kubernetes for all cluster traffic.
 <4> A network device on the host system to associate with this new OVS bridge.
-<5> The name for the additional network from which traffic is forwarded to the OVS bridge. This additional network must match the name of the `spec.config.name` field of the `NetworkAttachmentDefinition` object that defines the OVN-Kubernetes additional network.
+<5> The name for the additional network from which traffic is forwarded to the OVS bridge. This additional network must match the name of the `spec.config.name` field of the `NetworkAttachmentDefinition` CRD that defines the OVN-Kubernetes additional network.
 <6> The name of the OVS bridge on the node. This value is required only if you specify `state: present`.
 <7> The state for the mapping. Must be either `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
 

--- a/modules/configuring-ovnk-additional-networks.adoc
+++ b/modules/configuring-ovnk-additional-networks.adoc
@@ -6,11 +6,11 @@
 [id="configuration-ovnk-additional-networks_{context}"]
 = Configuration for an OVN-Kubernetes additional network
 
-The {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. To configure secondary network interfaces, you must define the configurations in the `NetworkAttachmentDefinition` custom resource (CR).
+The {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. To configure secondary network interfaces, you must define the configurations in the `NetworkAttachmentDefinition` custom resource definition (CRD).
 
 [NOTE]
 ====
-Pod and multi-network policy creation might remain in a pending state until the OVN-Kubernetes control plane agent in the nodes processes the associated `network-attachment-definition` CR.
+Pod and multi-network policy creation might remain in a pending state until the OVN-Kubernetes control plane agent in the nodes processes the associated `network-attachment-definition` CRD.
 ====
 
 You can configure an OVN-Kubernetes additional network in either _layer 2_ or _localnet_ topologies.
@@ -22,7 +22,7 @@ The following sections provide example configurations for each of the topologies
 
 [NOTE]
 ====
-Networks names must be unique. For example, creating multiple `NetworkAttachmentDefinition` CRs with different configurations that reference the same network is unsupported.
+Networks names must be unique. For example, creating multiple `NetworkAttachmentDefinition` CRDs with different configurations that reference the same network is unsupported.
 ====
 
 [id="configuration-additional-network-types-supported-platforms_{context}"]

--- a/modules/configuring-pods-static-ip.adoc
+++ b/modules/configuring-pods-static-ip.adoc
@@ -40,7 +40,7 @@ spec:
     imagePullPolicy: IfNotPresent
     name: agnhost-container
 ----
-<1> The name of the network. This value must be unique across all `NetworkAttachmentDefinitions`.
+<1> The name of the network. This value must be unique across all `NetworkAttachmentDefinition` CRDs.
 <2> The MAC address to be assigned for the interface.
 <3> The name of the network interface to be created for the pod.
 <4> The IP addresses to be assigned to the network interface.

--- a/modules/nw-about-configuring-master-interface-container.adoc
+++ b/modules/nw-about-configuring-master-interface-container.adoc
@@ -3,12 +3,10 @@
 // * networking/multiple_networks/configuring-additional-network.adoc
 
 :_mod-docs-content-type: CONCEPT
-
 [id="nw-about-configuring-master-interface-container_{context}"]
 = About configuring the master interface in the container network namespace
 
-In {product-title} 4.14 and later, the ability to allow users to create a MAC-VLAN, IP-VLAN, and VLAN subinterface based on a master interface in a container namespace is now generally available.
+You can create a MAC-VLAN, an IP-VLAN, or a VLAN subinterface that is based on a `master` interface that exists in a container namespace. You can also create a `master` interface as part of the pod network configuration in a separate network attachment definition CRD.
 
-This feature allows you to create the master interfaces as part of the pod network configuration in a separate network attachment definition. You can then base the VLAN, MACVLAN, or IPVLAN on this interface without requiring the knowledge of the network configuration of the node.
-
-To ensure the use of a container namespace master interface, specify the `linkInContainer` and set the value to `true` in the VLAN, MACVLAN, or IPVLAN plugin configuration depending on the particular type of additional network.
+To use a container namespace `master` interface, you must specify `true` for the 
+`linkInContainer` parameter that exists in the subinterface configuration of the `NetworkAttachmentDefinition` CRD.

--- a/modules/nw-multus-configure-dualstack-ip-address.adoc
+++ b/modules/nw-multus-configure-dualstack-ip-address.adoc
@@ -3,7 +3,6 @@
 // * networking/multiple_networks/configuring-additional-network.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="nw-multus-configure-dualstack-ip-address_{context}"]
 = Creating a configuration for assignment of dual-stack IP addresses dynamically
 

--- a/modules/nw-multus-configuring-whereabouts-ip-reconciler-schedule.adoc
+++ b/modules/nw-multus-configuring-whereabouts-ip-reconciler-schedule.adoc
@@ -3,7 +3,6 @@
 // * networking/multiple_networks/configuring-additional-network.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="nw-multus-configuring-whereabouts-ip-reconciler-schedule_{context}"]
 = Configuring the Whereabouts IP reconciler schedule
 

--- a/modules/nw-multus-create-master-interface-bridge-cni.adoc
+++ b/modules/nw-multus-create-master-interface-bridge-cni.adoc
@@ -6,7 +6,7 @@
 [id="nw-multus-create-master-interface-bridge-cni_{context}"]
 = Creating a subinterface based on a bridge master interface in a container namespace
 
-Creating a subinterface can be applied to other types of interfaces. Follow this procedure to create a subinterface based on a bridge master interface in a container namespace.
+You can create a subinterface based on a bridge `master` interface that exists in a container namespace. Creating a subinterface can be applied to other types of interfaces. 
 
 .Prerequisites
 * You have installed the OpenShift CLI (`oc`).
@@ -14,14 +14,14 @@ Creating a subinterface can be applied to other types of interfaces. Follow this
 
 .Procedure
 
-. Create a dedicated container namespace where you want to deploy your pod by running the following command:
+. Create a dedicated container namespace where you want to deploy your pod by entering the following command:
 +
 [source,terminal]
 ----
 $ oc new-project test-namespace
 ----
 
-. Using the following YAML example, create a bridge `NetworkAttachmentDefinition` custom resource (CR) file named `bridge-nad.yaml`:
+. Using the following YAML example, create a bridge `NetworkAttachmentDefinition` custom resource definition (CRD) file named `bridge-nad.yaml`:
 +
 [source,yaml]
 ----
@@ -46,14 +46,14 @@ spec:
   }'
 ----
 
-. Run the following command to apply the `NetworkAttachmentDefinition` CR to your {product-title} cluster:
+. Run the following command to apply the `NetworkAttachmentDefinition` CRD to your {product-title} cluster:
 +
 [source,terminal]
 ----
 $ oc apply -f bridge-nad.yaml
 ----
 
-.  Verify that the `NetworkAttachmentDefinition` CR has been created successfully by running the following command:
+.  Verify that you successfully created a `NetworkAttachmentDefinition` CRD by entering the following command:
 +
 [source,terminal]
 ----
@@ -90,7 +90,7 @@ spec:
 ----
 +
 <1> Specifies the ethernet interface to associate with the network attachment. This is subsequently configured in the pod networks annotation.
-<2> Specifies that the master interface is in the container network namespace.
+<2> Specifies that the `master` interface is in the container network namespace.
 
 . Apply the YAML file by running the following command:
 +
@@ -99,7 +99,7 @@ spec:
 $ oc apply -f ipvlan-additional-network-configuration.yaml
 ----
 
-. Verify that the `NetworkAttachmentDefinition` CR has been created successfully by running the following command:
+. Verify that the `NetworkAttachmentDefinition` CRD has been created successfully by running the following command:
 +
 [source,terminal]
 ----
@@ -149,7 +149,7 @@ spec:
         drop: [ALL]
 ----
 +
-<1> Specifies the name to be used as the master for the IPVLAN interface.
+<1> Specifies the name to be used as the `master` for the IPVLAN interface.
 
 . Apply the YAML file by running the following command:
 +

--- a/modules/nw-multus-create-multiple-vlans-sriov.adoc
+++ b/modules/nw-multus-create-multiple-vlans-sriov.adoc
@@ -126,7 +126,7 @@ spec:
     }
 ----
 +
-<1> The VLAN configuration needs to specify the master name. This can be configured in the pod networks annotation.
+<1> The VLAN configuration needs to specify the `master` name. This can be configured in the pod networks annotation.
 <2> The `linkInContainer` parameter must be specified.
 
 .. Apply the YAML file by running the following command:
@@ -194,7 +194,7 @@ spec:
         type: "RuntimeDefault"
 ----
 +
-<1> The name to be used as the master for the VLAN interface.
+<1> The name to be used as the `master` for the VLAN interface.
 
 .. Apply the YAML file by running the following command:
 +

--- a/modules/nw-multus-create-network-apply.adoc
+++ b/modules/nw-multus-create-network-apply.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// * networking/multiple_networks/configuring-additional-network.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-multus-create-network-apply_{context}"]

--- a/modules/nw-multus-create-network.adoc
+++ b/modules/nw-multus-create-network.adoc
@@ -6,15 +6,11 @@
 [id="nw-multus-create-network_{context}"]
 = Creating an additional network attachment with the Cluster Network Operator
 
-The Cluster Network Operator (CNO) manages additional network definitions. When
-you specify an additional network to create, the CNO creates the
-`NetworkAttachmentDefinition` object automatically.
+The Cluster Network Operator (CNO) manages additional network definitions. When you specify an additional network to create, the CNO creates the `NetworkAttachmentDefinition` CRD automatically.
 
 [IMPORTANT]
 ====
-Do not edit the `NetworkAttachmentDefinition` objects that the Cluster Network
-Operator manages. Doing so might disrupt network traffic on your additional
-network.
+Do not edit the `NetworkAttachmentDefinition` CRDs that the Cluster Network Operator manages. Doing so might disrupt network traffic on your additional network.
 ====
 
 .Prerequisites
@@ -75,7 +71,7 @@ spec:
 
 .Verification
 
-* Confirm that the CNO created the `NetworkAttachmentDefinition` object by running the following command. There might be a delay before the CNO creates the object.
+* Confirm that the CNO created the `NetworkAttachmentDefinition` CRD by running the following command. There might be a delay before the CNO creates the CRD.
 +
 [source,terminal]
 ----

--- a/modules/nw-multus-creating-whereabouts-reconciler-daemon-set.adoc
+++ b/modules/nw-multus-creating-whereabouts-reconciler-daemon-set.adoc
@@ -3,7 +3,6 @@
 // * networking/multiple_networks/configuring-additional-network.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="nw-multus-creating-whereabouts-reconciler-daemon-set_{context}"]
 = Creating a whereabouts-reconciler daemon set
 
@@ -11,7 +10,7 @@ The Whereabouts reconciler is responsible for managing dynamic IP address assign
 
 [NOTE]
 ====
-You can also use a `NetworkAttachmentDefinition` custom resource (CR) for dynamic IP address assignment.
+You can also use a `NetworkAttachmentDefinition` custom resource definition (CRD) for dynamic IP address assignment.
 ====
 
 The `whereabouts-reconciler` daemon set is automatically created when you configure an additional network through the Cluster Network Operator. It is not automatically created when you configure an additional network from a YAML manifest.

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -194,7 +194,7 @@ spec:
 
 The Whereabouts CNI plugin allows the dynamic assignment of an IP address to an additional network without the use of a DHCP server. 
 
-The Whereabouts CNI plugin also supports overlapping IP address ranges and configuration of the same CIDR range multiple times within separate `NetworkAttachmentDefinitions`. This provides greater flexibility and management capabilities in multi-tenant environments.
+The Whereabouts CNI plugin also supports overlapping IP address ranges and configuration of the same CIDR range multiple times within separate `NetworkAttachmentDefinition` CRDs. This provides greater flexibility and management capabilities in multi-tenant environments.
 
 [id="dynamic-ip-address-assignment-objects_{context}"]
 === Dynamic IP address configuration objects
@@ -260,7 +260,7 @@ The following example shows a dynamic IP address assignment that uses overlappin
   }
 }
 ----
-<1> Optional. If set, must match the `network_name` of NetworkAttachmentDefinition 2.
+<1> Optional. If set, must match the `network_name` of `NetworkAttachmentDefinition 2`.
 
 .NetworkAttachmentDefinition 2
 [source,json]
@@ -273,7 +273,7 @@ The following example shows a dynamic IP address assignment that uses overlappin
   }
 }
 ----
-<1> Optional. If set, must match the `network_name` of NetworkAttachmentDefinition 1. 
+<1> Optional. If set, must match the `network_name` of `NetworkAttachmentDefinition 1`. 
 
 ifdef::sr-iov[]
 :!sr-iov:

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -8,9 +8,9 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="nw-multus-ipvlan-object_{context}"]
-= Configuration for an ipvlan additional network
+= Configuration for an IPVLAN additional network
 
-The following object describes the configuration parameters for the IPVLAN CNI plugin:
+The following object describes the configuration parameters for the IPVLAN, `ipvlan`, CNI plugin:
 
 .IPVLAN CNI plugin JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
@@ -47,7 +47,7 @@ The following object describes the configuration parameters for the IPVLAN CNI p
 
 |`linkInContainer`
 |`boolean`
-|Optional: Specifies whether the master interface is in the container network namespace or the main network namespace. Set the value to `true` to request the use of a container namespace master interface.
+|Optional: Specifies whether the `master` interface is in the container network namespace or the main network namespace. Set the value to `true` to request the use of a container namespace `master` interface.
 
 |====
 

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -44,7 +44,7 @@ The following object describes the configuration parameters for the MACVLAN CNI 
 
 |`linkInContainer`
 |`boolean`
-|Optional: Specifies whether the master interface is in the container network namespace or the main network namespace. Set the value to `true` to request the use of a container namespace master interface.
+|Optional: Specifies whether the `master` interface is in the container network namespace or the main network namespace. Set the value to `true` to request the use of a container namespace `master` interface.
 
 |====
 

--- a/modules/nw-multus-vlan-object.adoc
+++ b/modules/nw-multus-vlan-object.adoc
@@ -6,9 +6,9 @@
 //
 :_mod-docs-content-type: REFERENCE
 [id="nw-multus-vlan-object_{context}"]
-= Configuration for an VLAN additional network
+= Configuration for a VLAN additional network
 
-The following object describes the configuration parameters for the VLAN CNI plugin:
+The following object describes the configuration parameters for the VLAN, `vlan`, CNI plugin:
 
 .VLAN CNI plugin JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
@@ -33,7 +33,7 @@ The following object describes the configuration parameters for the VLAN CNI plu
 
 |`vlanId`
 |`integer`
-|Set the id of the vlan.
+|Set the ID of the `vlan`.
 
 |`ipam`
 |`object`
@@ -45,18 +45,23 @@ The following object describes the configuration parameters for the VLAN CNI plu
 
 |`dns`
 |`integer`
-|Optional: DNS information to return, for example, a priority-ordered list of DNS nameservers.
+|Optional: DNS information to return. For example, a priority-ordered list of DNS nameservers.
 
 |`linkInContainer`
 |`boolean`
-|Optional: Specifies whether the master interface is in the container network namespace or the main network namespace. Set the value to `true` to request the use of a container namespace master interface.
+|Optional: Specifies whether the `master` interface is in the container network namespace or the main network namespace. Set the value to `true` to request the use of a container namespace `master` interface.
 
 |====
 
-[id="nw-multus-vlan-config-example_{context}"]
-== vlan configuration example
+[IMPORTANT]
+====
+A `NetworkAttachmentDefinition` custom resource definition (CRD) with a `vlan` configuration can be used only on a single pod in a node because the CNI plugin cannot create multiple `vlan` subinterfaces with the same `vlanId` on the same `master` interface.
+====
 
-The following example configures an additional network named `vlan-net`:
+[id="nw-multus-vlan-config-example_{context}"]
+== VLAN configuration example
+
+The following example demonstrates a `vlan` configuration with an additional network that is named `vlan-net`:
 
 [source,json]
 ----

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -19,15 +19,17 @@ As a cluster administrator, you can configure an additional network for your clu
 [id="approaches-managing-additional-network_{context}"]
 == Approaches to managing an additional network
 
-You can manage the lifecycle of an additional network in {product-title} by using one of two approaches: modifying the Cluster Network Operator (CNO) configuration or applying a YAML manifest. Each approach is mutually exclusive and you can only use one approach for managing an additional network at a time. For either approach, the additional network is managed by a Container Network Interface (CNI) plugin that you configure. The two different approaches are summarized here: 
+You can manage the lifecycle of an additional network by choosing one of the two available approaches. Each approach is mutually exclusive and you can only use one approach for managing an additional network at a time. For either approach, the additional network is managed by a Container Network Interface (CNI) plugin that you configure.
 
-* Modifying the Cluster Network Operator (CNO) configuration: Configuring additional networks through CNO is only possible for cluster administrators. The CNO automatically creates and manages the `NetworkAttachmentDefinition` object. By using this approach, you can define `NetworkAttachmentDefinition` objects at install time through configuration of the `install-config`.
+* Modify the Cluster Network Operator (CNO) configuration: The CNO automatically creates and manages the `NetworkAttachmentDefinition` custom resource definition (CRD). In addition to managing an object lifecycle the CNO ensures a DHCP is available for an additional network that uses a DHCP-assigned IP address.
 
-* Applying a YAML manifest: You can manage the additional network directly by creating an `NetworkAttachmentDefinition` object. Compared to modifying the CNO configuration, this approach gives you more granular control and flexibility when it comes to configuration. 
+* Applying a YAML manifest: You can manage the additional network directly by creating a `NetworkAttachmentDefinition` CRD. This approach allows for the chaining of CNI plugins.
+
+For an additional network, IP addresses are provisioned through an IP Address Management (IPAM) CNI plugin that you configure as part of the additional network. The IPAM plugin supports a variety of IP address assignment approaches including Dynamic Host Configuration Protocol (DHCP) and static assignment.
 
 [NOTE]
 ====
-When deploying {product-title} nodes with multiple network interfaces on {rh-openstack-first} with OVN Kubernetes, DNS configuration of the secondary interface might take precedence over the DNS configuration of the primary interface. In this case, remove the DNS nameservers for the subnet ID that is attached to the secondary interface:
+When deploying {product-title} nodes with multiple network interfaces on {rh-openstack-first} with OVN Kubernetes, DNS configuration of the additional interface might take precedence over the DNS configuration of the primary interface. In this case, remove the DNS nameservers for the subnet ID that is attached to the additional interface:
 
 [source,terminal]
 ----
@@ -73,7 +75,7 @@ An additional network is configured by using the `NetworkAttachmentDefinition` A
 
 [IMPORTANT]
 ====
-Do not store any sensitive information or a secret in the `NetworkAttachmentDefinition` object because this information is accessible by the project administration user.
+Do not store any sensitive information or a secret in the `NetworkAttachmentDefinition` CRD because this information is accessible by the project administration user.
 ====
 
 The configuration for the API is described in the following table:
@@ -149,8 +151,7 @@ spec:
       ...
     }
 ----
-<1> The name for the additional network attachment that you are
-creating.
+<1> The name for the additional network attachment that you are creating.
 <2> A CNI plugin configuration in JSON format.
 
 [id="configuration-additional-network-types_{context}"]
@@ -182,8 +183,13 @@ include::modules/nw-multus-tap-object.adoc[leveloffset=+2]
 * For more information about enabling an SELinux boolean on a node, see xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-working-setting-booleans_nodes-nodes-managing[Setting SELinux booleans]
 
 // Set of includes pertains to OVN-Kubernetes additional network
+// Configuration for an OVN-Kubernetes additional network
 include::modules/configuring-ovnk-additional-networks.adoc[leveloffset=+2]
+
+// OVN-Kubernetes network plugin JSON configuration table
 include::modules/configuration-ovnk-network-plugin-json-object.adoc[leveloffset=+3]
+
+// Compatibility with multi-network policy
 include::modules/configuration-ovnk-multi-network-policy.adoc[leveloffset=+3]
 
 //include::modules/configuring-layer-three-routed-topology.adoc[leveloffset=+3]
@@ -192,6 +198,7 @@ include::modules/configuring-layer-two-switched-topology.adoc[leveloffset=+3]
 [id="ovn-kubernetes-configuration-for-a-localnet-topology_{context}"]
 ==== Configuration for a localnet topology
 
+// Configuration for a localnet switched topology
 include::modules/configuring-localnet-switched-topology.adoc[tag=localnet-intro]
 
 // Workaround lack of xref in modules
@@ -203,29 +210,43 @@ include::modules/configuring-localnet-switched-topology.adoc[tag=localnet-intro]
 [id="configuration-additional-network-interface_{context}"]
 ===== Configuration for an OVN-Kubernetes additional network mapping
 
+// Configuration for a localnet switched topology
 include::modules/configuring-localnet-switched-topology.adoc[tag=localnet-content]
+
+// Configuring pods for additional networks
 include::modules/configuring-pods-secondary-network.adoc[leveloffset=+3]
+
+// Configuring pods with a static IP address
 include::modules/configuring-pods-static-ip.adoc[leveloffset=+3]
 // end OVN-Kubernetes includes
 
+// Configuration of IP address assignment for an additional network
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
 
+// Creating a whereabouts-reconciler daemon set
 include::modules/nw-multus-creating-whereabouts-reconciler-daemon-set.adoc[leveloffset=+2]
 
+// Configuring the Whereabouts IP reconciler schedule
 include::modules/nw-multus-configuring-whereabouts-ip-reconciler-schedule.adoc[leveloffset=+2]
 
+// Creating a configuration for assignment of dual-stack IP addresses dynamically
 include::modules/nw-multus-configure-dualstack-ip-address.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../networking/multiple_networks/attaching-pod.adoc#nw-multus-add-pod_attaching-pod[Attaching a pod to an additional network]
 
+// Creating an additional network attachment with the Cluster Network Operator
 include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 
+// Creating an additional network attachment by applying a YAML manifest
 include::modules/nw-multus-create-network-apply.adoc[leveloffset=+1]
 
+// About configuring the master interface in the container network namespace
 include::modules/nw-about-configuring-master-interface-container.adoc[leveloffset=+1]
 
+//Creating multiple VLANs on SR-IOV VFs
 include::modules/nw-multus-create-multiple-vlans-sriov.adoc[leveloffset=+2]
 
+// Creating a subinterface based on a bridge master interface in a container namespace
 include::modules/nw-multus-create-master-interface-bridge-cni.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-44255](https://issues.redhat.com/browse/OCPBUGS-44255)

Link to docs preview:
* [VLAN - core](https://85848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-vlan-object_configuring-additional-network)
* [IPVLAN - MicroShift](https://85848--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus.html#nw-multus-ipvlan-object_microshift-cni-multus)


- [x] SME has approved this change (Chris Fields/[Marcelo Guerrero Viveros](https://github.com/mlguerrero12)).
- [x] QE has approved this change (Weibin Liang).

Additional info:

* https://github.com/openshift/openshift-docs/pull/59607


