### PR TITLE
ClusterLogForwarder example in About logging 6.0 section is not defined properly

### DIFF
--- a/observability/logging/logging-6.0/log6x-about.adoc
+++ b/observability/logging/logging-6.0/log6x-about.adoc
@@ -148,9 +148,9 @@ spec:
       target:
         name: logging-loki
         namespace: openshift-logging
-    authentication:
-      token:
-        from: serviceAccount
+      authentication:
+        token:
+          from: serviceAccount
     tls:
       ca:
         key: service-ca.crt


### PR DESCRIPTION
ClusterLogForwarder example in About logging 6.0 section is not defined properly

Inside About Logging 6.0 section in Quick Start, the step number 9." Create a ClusterLogForwarder CR to configure log forwarding is not defined properly.

Link: 
https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.0/log6x-about.html#quick-start

Current Configuration:
~~~
spec:
  serviceAccount:
    name: collector
  outputs:
  - name: default-lokistack
    type: lokiStack
    lokiStack:
      target:
        name: logging-loki
        namespace: openshift-logging
    authentication:                <<===
      token:                              <<===
        from: serviceAccount  <<===
    tls:
      ca:
        key: service-ca.crt
  ~~~

Need to perform the following changes:
~~~
spec:
  serviceAccount:
    name: collector
  outputs:
  - name: default-lokistack
    type: lokiStack
    lokiStack:
      target:
        name: logging-loki
        namespace: openshift-logging
      authentication:                 <<=== Correct Indentation
        token:                       <<=== Correct Indentation
          from: serviceAccount   <<=== Correct Indentation
    tls:
      ca:
        key: service-ca.crt
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> RHCOP 4.18, RHCOP 4.17, RHCOP 4.16, RHOCP 4.15, RHOCP 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/OBSDOCS-1347

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://85852--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-about.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
