### PR TITLE
Allowing includes to use content from openshift-kni repo as well as openshift repo

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -625,10 +625,19 @@ def scrub_file(info, book_src_dir, src_file, tag=None, cwd=None):
     # data that it finds.
     # modified 20/Aug/2024 to process https links which are preceded
     # by an added directory (happens with hugeBook)
+    # Modified 05/Dec/2024 to allow for https links from openshift-kni repo.
 
+    # Check for both allowed URL patterns
     https_pos = base_src_file.find("https://raw.githubusercontent.com/openshift/")
-    if https_pos >=0:
-        base_src_file = base_src_file[https_pos:]
+    https_kni_pos = base_src_file.find("https://raw.githubusercontent.com/openshift-kni/")
+
+    if https_pos >= 0 or https_kni_pos >= 0:
+        # Ensure we start from the correct URL (either github or openshift-kni)
+        if https_kni_pos >= 0:
+            base_src_file = base_src_file[https_kni_pos:]
+        else:
+            base_src_file = base_src_file[https_pos:]
+
         try:
             response = requests.get(base_src_file)
             if response:

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1008,7 +1008,7 @@ host site.
 [IMPORTANT]
 ====
 You are restricted to only embed files from GitHub repositories managed by the
-`openshift` GitHub user. You must also prefix your external file URI with `https`.
+`openshift` or `openshift-kni` GitHub user. You must also prefix your external file URI with `https`.
 URIs beginning with `http` are forbidden for security reasons and will fail the
 documentation build.
 ====


### PR DESCRIPTION
Allowing includes to use content from openshift-kni repo as well as openshift repo. This updates the docs guidelines and updates build_for_portal to allow openshift and openshift-kni repos only.

Version(s):
4.12+


