### PR TITLE
OSSM-8523 Trying to get matching titles for Pantheon to be happy

### DIFF
--- a/migrating/docinfo.xml
+++ b/migrating/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Migrating</title>
+<title>Migrating from OpenShift Service Mesh 2.6</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
 <subtitle>Migrating from OpenShift Service Mesh 2.6 to 3</subtitle>


### PR DESCRIPTION
**OSSM 3.0 TP1**

[OSSM-8523](https://issues.redhat.com//browse/OSSM-8523) Trying to get matching titles for Pantheon to be happy

Pantheon seems to be pulling from the _topic_map and not <title> of docinfo.xml, so this is an attempt to see if having the docinfo.xml title match the _topic_map results in passing Pantheon builds.

docinfo.xml files are required for stand alone pages in Pantheon as part of the sync script: you must add docinfo.xml files to every directory in your GitHub repository that corresponds to a Portal book (these are normally the first-level directories such as about, each of these directories is in a Dir parameter in _topic_map.yml).The sync server automatically copies these files alongside the AsciiDoc content.

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):
 
Technology Preview

OSSM 3.0 is moving to stand alone format and will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8523

Link to docs preview:
There are not preview for docinfo.xml 

QE review:
QE is not required for this change

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
