### PR TITLE
CNV-45152: Added note about linux bonding mode support

### DIFF
--- a/modules/virt-creating-localnet-nad-cli.adoc
+++ b/modules/virt-creating-localnet-nad-cli.adoc
@@ -38,6 +38,11 @@ spec:
 <3> The name of the additional network from which traffic is forwarded to the OVS bridge. This attribute must match the value of the `spec.config.name` field of the `NetworkAttachmentDefinition` object that defines the OVN-Kubernetes additional network.
 <4> The name of the OVS bridge on the node. This value is required if the `state` attribute is `present`.
 <5> The state of the mapping. Must be either `present` to add the mapping or `absent` to remove the mapping. The default value is `present`.
++
+[NOTE]
+====
+{VirtProductName} does not support Linux bridge bonding modes 0, 5, and 6. For more information, see link:https://access.redhat.com/solutions/67546[Which bonding modes work when used with a bridge that virtual machine guests or containers connect to?].
+====
 
 . Create a `NetworkAttachmentDefinition` object:
 +

--- a/virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
@@ -14,6 +14,11 @@ You can create a Linux bridge network and attach a virtual machine (VM) to the n
 . Create a Linux bridge network attachment definition (NAD) by using the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-cli_virt-connecting-vm-to-linux-bridge[command line].
 . Configure the VM to recognize the NAD by using the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-vm-creating-nic-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[command line].
 
+[NOTE]
+====
+{VirtProductName} does not support Linux bridge bonding modes 0, 5, and 6. For more information, see link:https://access.redhat.com/solutions/67546[Which bonding modes work when used with a bridge that virtual machine guests or containers connect to?].
+====
+
 include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+1]
 
 [id="creating-linux-bridge-nad"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-45152](https://issues.redhat.com//browse/CNV-45152)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://85882--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge.html

https://85882--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.html#virt-creating-localnet-nad-cli_virt-connecting-vm-to-ovn-secondary-network
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
