### PR TITLE
OCPBUGS-45404: GCP Permissions are required for destroy

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -39,7 +39,7 @@ Ensure that the host project applies one of the following configurations to the 
 * `roles/compute.networkUser`
 ====
 
-If you do not supply a service account for control plane nodes in the `install-config.yaml` file, please grant the below permissions to the service account in the host project.
+If you do not supply a service account for control plane nodes in the `install-config.yaml` file, please grant the below permissions to the service account in the host project. If you do not supply a service account for compute nodes in the `install-config.yaml` file, please grant the below permissions to the service account in the host project for cluster destruction.
 
 [%collapsible]
 ====


### PR DESCRIPTION
** The getIamPolicy and setIamPolicy permissions are required for GCP destroy xpn installations whether the control plane service account is provided or not.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

https://issues.redhat.com/browse/OCPBUGS-45404

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.19.0, 4.18.0, 4.17.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-45404

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
