### PR TITLE
OSDOCS#12786: 4/5 node support for ABI

### DIFF
--- a/modules/etcd-node-scaling.adoc
+++ b/modules/etcd-node-scaling.adoc
@@ -6,7 +6,9 @@
 [id="etcd-node-scaling_{context}"]
 = Node scaling for etcd
 
-In general, clusters must have 3 control plane nodes. However, if your cluster is installed on a bare metal platform, you can scale a cluster up to 5 control plane nodes as a postinstallation task. For example, to scale from 3 to 4 control plane nodes after installation, you can add a host and install it as a control plane node. Then, the etcd Operator scales accordingly to account for the additional control plane node.
+In general, clusters must have 3 control plane nodes. However, if your cluster is installed on a bare metal platform, it can have up to 5 control plane nodes. If an existing bare-metal cluster has fewer than 5 control plane nodes, you can scale the cluster up as a postinstallation task.
+
+For example, to scale from 3 to 4 control plane nodes after installation, you can add a host and install it as a control plane node. Then, the etcd Operator scales accordingly to account for the additional control plane node.
 
 Scaling a cluster to 4 or 5 control plane nodes is available only on bare metal platforms.
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -629,7 +629,12 @@ endif::agent[]
 |controlPlane:
   replicas:
 |The number of control plane machines to provision.
+ifndef::agent[]
 |Supported values are `3`, or `1` when deploying {sno}.
+endif::agent[]
+ifdef::agent[]
+|Supported values are `3`, `4`, `5`, or `1` when deploying {sno}.
+endif::agent[]
 
 |credentialsMode:
 |The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported.

--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -57,9 +57,8 @@ Recommended cluster resources for the following topologies:
 |Topology|Number of control plane nodes|Number of compute nodes|vCPU|Memory|Storage
 |Single-node cluster|1|0|8 vCPUs|16 GB of RAM| 120 GB
 |Compact cluster|3|0 or 1|8 vCPUs|16 GB of RAM|120 GB
-|HA cluster|3|2 and above |8 vCPUs|16 GB of RAM|120 GB
+|HA cluster|3 to 5|2 and above |8 vCPUs|16 GB of RAM|120 GB
 |====
-
 
 In the `install-config.yaml`, specify the platform on which to perform the installation. The following platforms are supported:
 


### PR DESCRIPTION
[OSDOCS-12786](https://issues.redhat.com/browse/OSDOCS-12786)

Version(s): 4.18+

This PR adds 4 and 5 node control planes as a supported configuration for the Agent-based Installer.

QE review:
- [x] QE has approved this change.

Preview: 

- [Optional configuration parameters](https://85895--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#installation-configuration-parameters-optional_installation-config-parameters-agent) (Agent docs)
- [Optional configuration parameters](https://85895--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installation-config-parameters-bare-metal#installation-configuration-parameters-optional_installation-config-parameters-bare-metal) (non-Agent example, should be unchanged)
- [Recommended resources for topologies](https://85895--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#recommended-resources-for-topologies)
- [Node scaling for etcd](https://85895--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices#etcd-node-scaling_recommended-etcd-practices)
