### PR TITLE
[OCPBUGS-45655]: Rearranging order of HCP on AWS docs

### DIFF
--- a/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
@@ -34,6 +34,8 @@ include::modules/hcp-aws-create-public-zone.adoc[leveloffset=+1]
 
 include::modules/hcp-aws-create-role-sts-creds.adoc[leveloffset=+1]
 
+include::modules/hcp-aws-enable-private-link.adoc[leveloffset=+1]
+
 include::modules/hcp-aws-enable-ext-dns.adoc[leveloffset=+1]
 
 include::modules/hcp-aws-enable-ext-dns-prereq.adoc[leveloffset=+2]
@@ -43,8 +45,6 @@ include::modules/hcp-aws-set-up-ext-dns.adoc[leveloffset=+2]
 include::modules/hcp-aws-create-dns-hosted-zone.adoc[leveloffset=+2]
 
 include::modules/hcp-aws-hc-ext-dns.adoc[leveloffset=+2]
-
-include::modules/hcp-aws-enable-private-link.adoc[leveloffset=+1]
 
 include::modules/hcp-aws-deploy-hc.adoc[leveloffset=+1]
 

--- a/modules/hcp-aws-enable-ext-dns-prereq.adoc
+++ b/modules/hcp-aws-enable-ext-dns-prereq.adoc
@@ -11,3 +11,5 @@ Before you can set up external DNS for {hcp} on {aws-first}, you must meet the f
 * You created an external public domain.
 
 * You have access to the {aws-short} Route53 Management console.
+
+* You enabled {aws-short} PrivateLink for {hcp}.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-45655
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://85897--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-aws.html#hcp-aws-enable-private-link_hcp-deploy-aws (moved section)
- https://85897--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-aws.html#hcp-aws-enable-ext-dns-prereq_hcp-deploy-aws (new prerequisite)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
