### PR TITLE
OSDOCS-12161: adds 4.15.40 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -505,3 +505,12 @@ Issued: 26 November 2024
 The {product-title} release 4.15.39 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10144[RHBA-2024:10144] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10142[RHSA-2024:10142] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-40-dp"]
+=== RHSA-2024:10841 - {microshift-short} 4.15.40 security and bug fix update advisory
+
+Issued: 12 December 2024
+
+{product-title} release 4.15.40 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10841[RHSA-2024:10841] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10839[RHSA-2024:10839] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12161](https://issues.redhat.com/browse/OSDOCS-12161)

Link to docs preview:
[4-15-40-dp_release-notes](https://85898--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-40-dp)

QE review:
- NA. stock text updated, no other changes.