### PR TITLE
Clarifying FIO documentation

### DIFF
--- a/modules/file-integrity-node-status-failure.adoc
+++ b/modules/file-integrity-node-status-failure.adoc
@@ -2,6 +2,7 @@
 //
 // * security/file_integrity_operator/file-integrity-operator-understanding.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="file-integrity-node-status-failure_{context}"]
 = FileIntegrityNodeStatus CR failure status example
 
@@ -109,4 +110,14 @@ File: /hostroot/etc/resolv.conf
 Events:  <none>
 ----
 
-Due to the config map data size limit, AIDE logs over 1 MB are added to the failure config map as a base64-encoded gzip archive. In this case, you want to pipe the output of the above command to `base64 --decode | gunzip`. Compressed logs are indicated by the presence of a `file-integrity.openshift.io/compressed` annotation key in the config map.
+Due to the config map data size limit, AIDE logs over 1 MB are added to the failure config map as a base64-encoded gzip archive. Use the following command to extract the log:
+
+[source,terminal]
+----
+$ oc get cm <failure-cm-name> -o json | jq -r '.data.integritylog' | base64 -d | gunzip
+----
+
+[NOTE]
+====
+Compressed logs are indicated by the presence of a `file-integrity.openshift.io/compressed` annotation key in the config map.
+====


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-35424

Link to docs preview:
[FileIntegrityNodeStatus CR failure status example](https://85905--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-understanding.html#file-integrity-node-status-failure_file-integrity-operator)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None at this time.