### PR TITLE
OCPBUGS-45217 Degraded machine config

### DIFF
--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -8,19 +8,42 @@ From {product-title} 4.14 the default network behavior is to not allow forwardin
 {product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding. 
 ====
 
-To enable IP forwarding for the secondary interface, you have two options: 
+To enable IP forwarding for the secondary interface, you have two options:
 
+* Enable IP forwarding for a specific interface.
 * Enable IP forwarding for all interfaces.
-* Enable IP forwarding for a specific interface. 
 +
 [NOTE]
 ====
 Enabling IP forwarding for a specific interface provides more granular control, while enabling it for all interfaces applies a global setting.
 ====
 
+[id="nw-enabling-ip-forwarding-specific-interface_{context}"]
+== Enabling IP forwarding for a specific interface
 .Procedure
 
-. Enable forwarding for a specific secondary interface, such as `bridge-net` by creating and applying a `MachineConfig` CR. 
+. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true`, by running the following command: 
++
+[source,terminal]
+----
+$ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig": {"routingViaHost": true} }}}}' --type=merge
+----
+
+. Enable forwarding for a specific secondary interface, such as `bridge-net` by creating and applying a `MachineConfig` CR:
+
+..  Base64-encode the string that is used to configure network kernel parameters by running the following command on your local machine:
++
+[source,terminal]
+----
+$ echo -e "net.ipv4.conf.bridge-net.forwarding = 1\nnet.ipv6.conf.bridge-net.forwarding = 1\nnet.ipv4.conf.bridge-net.rp_filter = 0\nnet.ipv6.conf.bridge-net.rp_filter = 0" | base64 -w0
+----
++
+.Example output
++
+[source,terminal]
+----
+bmV0LmlwdjQuY29uZi5icmlkZ2UtbmV0LmZvcndhcmRpbmcgPSAxCm5ldC5pcHY2LmNvbmYuYnJpZGdlLW5ldC5mb3J3YXJkaW5nID0gMQpuZXQuaXB2NC5jb25mLmJyaWRnZS1uZXQucnBfZmlsdGVyID0gMApuZXQuaXB2Ni5jb25mLmJyaWRnZS1uZXQucnBfZmlsdGVyID0gMAo=
+----
 
 .. Create the `MachineConfig` CR to enable IP forwarding for the specified secondary interface named `bridge-net`.
 
@@ -32,7 +55,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: <node_role> <1>
+    machineconfiguration.openshift.io/role: <node_role> <1> 
   name: 81-enable-global-forwarding
 spec:
   config:
@@ -41,8 +64,8 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,`echo -e "net.ipv4.conf.bridge-net.forwarding = 1\nnet.ipv6.conf.bridge-net.forwarding = 1\nnet.ipv4.conf.bridge-net.rp_filter = 0\nnet.ipv6.conf.bridge-net.rp_filter = 0" | base64 -w0`
-           verification: {}
+          source: data:text/plain;charset=utf-8;base64,bmV0LmlwdjQuY29uZi5icmlkZ2UtbmV0LmZvcndhcmRpbmcgPSAxCm5ldC5pcHY2LmNvbmYuYnJpZGdlLW5ldC5mb3J3YXJkaW5nID0gMQpuZXQuaXB2NC5jb25mLmJyaWRnZS1uZXQucnBfZmlsdGVyID0gMApuZXQuaXB2Ni5jb25mLmJyaWRnZS1uZXQucnBfZmlsdGVyID0gMAo= <2>
+          verification: {}
         filesystem: root
         mode: 644
         path: /etc/sysctl.d/enable-global-forwarding.conf
@@ -50,6 +73,7 @@ spec:
 ----
 +
 <1> Node role where you want to enable IP forwarding, for example, `worker`
+<2> Populate with the generated base64 string 
 
 .. Apply the configuration by running the following command:
 +
@@ -58,8 +82,50 @@ spec:
 $ oc apply -f enable-ip-forward.yaml
 ----
 
-. Alternatively, you can enable IP forwarding globally by running the following command:
+.Verification
+
+.  After you apply the machine config, verify the changes by following this procedure: 
+
+.. Enter into a debug session on the target node by running the following command: 
 +
+[source,terminal]
+----
+$ oc debug node/<node-name>
+----
+This step instantiates a debug pod called `<node-name>-debug`.
+
+.. Set `/host` as the root directory within the debug shell by running the following command:
++
+[source,terminal]
+----
+$ chroot /host
+----
+The debug pod mounts the host’s root file system in `/host` within the pod. By changing the root directory to `/host`, you can run binaries contained in the host’s executable paths.
+
+.. Verify that IP forwarding is enabled by running the following command: 
++
+[source,terminal]
+----
+$ cat /etc/sysctl.d/enable-global-forwarding.conf
+----
++
+.Expected output
+
+[source,terminal]
+----
+net.ipv4.conf.bridge-net.forwarding = 1 
+net.ipv6.conf.bridge-net.forwarding = 1
+net.ipv4.conf.bridge-net.rp_filter = 0
+net.ipv6.conf.bridge-net.rp_filter = 0
+----
++
+The output indicates that IPv4 and IPv6 packet forwarding is enabled on the `bridge-net` interface.
+
+[id="nw-enabling-ip-forwarding-globally_{context}"]
+== Enabling IP forwarding globally 
+
+* Enable IP forwarding globally by running the following command:
+
 [source,terminal]
 ----
 $ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}


### PR DESCRIPTION
[OCPBUGS-45217]: Degraded machine config

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18, 4.17, main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-45217
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://85914--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/about-advertising-ipaddresspool.html#nw-metallb-configure-secondary-interface_about-advertising-ip-address-pool
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
