### PR TITLE
[SRVLOGIC-469]: Deploying workflows chapter does not use kn worklow plugin

### DIFF
--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -21,7 +21,7 @@ You can create a `SonataFlow` custom resource (CR) on {ocp-product-title} and {S
 +
 [source,terminal]
 ----
-$ kn workflow gen-manifest --mode=preview --namespace <your_namespace>
+$ kn workflow gen-manifest --profile=preview --namespace <your_namespace>
 ----
 +
 This command generates {ocp-product-title} YAML manifests based on your `workflow.sw.json|yaml` definition. Default location is `<project_application_dir>/manifests` directory.

--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -12,70 +12,28 @@ You can create a `SonataFlow` custom resource (CR) on {ocp-product-title} and {S
 
 * You have an {ServerlessLogicOperatorName} installed on your cluster.
 * You have access to an {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have installed the {ServerlessLogicProductName} `kn-workflow` CLI plugin.
 * You have installed the OpenShift CLI `(oc)`.
 
 .Procedure
 
-. Create a workflow YAML file similar to the following:
+. In your project application directory, execute the following command:
 +
-[source,yaml]
+[source,terminal]
 ----
-apiVersion: sonataflow.org/v1alpha08
-kind: SonataFlow
-metadata:
-  name: greeting
-  annotations:
-    sonataflow.org/description: Greeting example on k8s!
-    sonataflow.org/version: 0.0.1
-spec:
-  flow:
-    start: ChooseOnLanguage
-    functions:
-      - name: greetFunction
-        type: custom
-        operation: sysout
-    states:
-      - name: ChooseOnLanguage
-        type: switch
-        dataConditions:
-          - condition: "${ .language == \"English\" }"
-            transition: GreetInEnglish
-          - condition: "${ .language == \"Spanish\" }"
-            transition: GreetInSpanish
-        defaultCondition: GreetInEnglish
-      - name: GreetInEnglish
-        type: inject
-        data:
-          greeting: "Hello from JSON Workflow, "
-        transition: GreetPerson
-      - name: GreetInSpanish
-        type: inject
-        data:
-          greeting: "Saludos desde JSON Workflow, "
-        transition: GreetPerson
-      - name: GreetPerson
-        type: operation
-        actions:
-          - name: greetAction
-            functionRef:
-              refName: greetFunction
-              arguments:
-                message:  ".greeting+.name"
-        end: true
+$ kn workflow gen-manifest --mode=preview --namespace <your_namespace>
 ----
++
+This command generates {ocp-product-title} YAML manifests based on your `workflow.sw.json|yaml` definition. Default location is `<project_application_dir>/manifests` directory.
+You can modify these files to your liking, however when you run above command again, the changes are going to be overwritten. Use `--custom-generated-manifests-dir` or `-c` flag to generate the files in different location.
 
-. Apply the `SonataFlow` workflow definition to your {ocp-product-title} namespace by running the following command:
+. Deploy the `SonataFlow` workflow application to your {ocp-product-title} namespace by running the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <workflow-name>.yaml -n <your_namespace>
+$ kn workflow deploy --custom-manifests-dir=./manifests --namespace <your_namespace>
 ----
 +
-.Example command for the `greetings-workflow.yaml` file:
-[source,terminal]
-----
-$ oc apply -f greetings-workflow.yaml -n workflows
-----
 
 . List all the build configurations by running the following command:
 +
@@ -114,3 +72,12 @@ Ensure that the pod corresponding to your workflow is running.
 ----
 $ oc logs pod/<pod-name> -n workflows
 ----
+
+.Cleanup
+. To cleanup the deployment, delete the projects resources running the following command:
++
+[source,terminal]
+----
+$ kn workflow undeploy -n <your_namespace>
+----
++

--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -38,7 +38,7 @@ $ kn workflow deploy --custom-manifests-dir=./manifests --namespace <your_namesp
 +
 [source,terminal]
 ----
-$ oc get buildconfigs -n workflows
+$ oc get buildconfigs -n <namespace>
 ----
 
 . Get the logs of the build process by running the following command:
@@ -47,10 +47,11 @@ $ oc get buildconfigs -n workflows
 ----
 $ oc logs buildconfig/<workflow-name> -n <your_namespace>
 ----
++
 .Example command for a workflow that has ID attribute with value `greeting`:
 [source,terminal]
 ----
-$ oc logs buildconfig/greeting -n workflows
+$ oc logs buildconfig/greeting -n <namespace>
 ----
 
 .Verification
@@ -61,14 +62,14 @@ $ oc logs buildconfig/greeting -n workflows
 ----
 $ oc get pods -n <your_namespace>
 ----
-
++
 Ensure that the pod corresponding to your workflow is running.
 
 . Check the running pods and their logs by running the following command:
 +
 [source,terminal]
 ----
-$ oc logs pod/<pod-name> -n workflows
+$ oc logs pod/<pod-name> -n <namespace>
 ----
 
 .Cleanup

--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -24,8 +24,8 @@ You can create a `SonataFlow` custom resource (CR) on {ocp-product-title} and {S
 $ kn workflow gen-manifest --profile=preview --namespace <your_namespace>
 ----
 +
-This command generates {ocp-product-title} YAML manifests based on your `workflow.sw.json|yaml` definition. Default location is `<project_application_dir>/manifests` directory.
-You can modify these files to your liking, however when you run above command again, the changes are going to be overwritten. Use `--custom-generated-manifests-dir` or `-c` flag to generate the files in different location.
+This command generates {ocp-product-title} YAML manifests based on your `workflow.sw.json|yaml` definition. The default location is the `<project_application_dir>/manifests` directory.
+You can modify these files to your preference, however, when you rerun the above command, the changes will be overwritten. Use the `--custom-generated-manifests-dir` or `-c` flag to generate the files in different locations.
 
 . Deploy the `SonataFlow` workflow application to your {ocp-product-title} namespace by running the following command:
 +

--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -47,9 +47,7 @@ $ oc get buildconfigs -n workflows
 ----
 $ oc logs buildconfig/<workflow-name> -n <your_namespace>
 ----
-
-.Example command for the `greetings-workflow.yaml` file:
-+
+.Example command for a workflow that has ID attribute with value `greeting`:
 [source,terminal]
 ----
 $ oc logs buildconfig/greeting -n workflows

--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -33,7 +33,6 @@ You can modify these files to your liking, however when you run above command ag
 ----
 $ kn workflow deploy --custom-manifests-dir=./manifests --namespace <your_namespace>
 ----
-+
 
 . List all the build configurations by running the following command:
 +

--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -47,8 +47,9 @@ $ oc get buildconfigs -n workflows
 ----
 $ oc logs buildconfig/<workflow-name> -n <your_namespace>
 ----
-+
+
 .Example command for the `greetings-workflow.yaml` file:
++
 [source,terminal]
 ----
 $ oc logs buildconfig/greeting -n workflows
@@ -62,7 +63,7 @@ $ oc logs buildconfig/greeting -n workflows
 ----
 $ oc get pods -n <your_namespace>
 ----
-+
+
 Ensure that the pod corresponding to your workflow is running.
 
 . Check the running pods and their logs by running the following command:
@@ -79,3 +80,7 @@ $ oc logs pod/<pod-name> -n workflows
 ----
 $ kn workflow undeploy -n <your_namespace>
 ----
+<<<<<<< HEAD
+=======
+
+>>>>>>> 650a6ddf00 (SRVLOGC-469: Reorganize Deploying Workflow doc)

--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -79,4 +79,3 @@ $ oc logs pod/<pod-name> -n workflows
 ----
 $ kn workflow undeploy -n <your_namespace>
 ----
-+

--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -80,7 +80,3 @@ $ oc logs pod/<pod-name> -n workflows
 ----
 $ kn workflow undeploy -n <your_namespace>
 ----
-<<<<<<< HEAD
-=======
-
->>>>>>> 650a6ddf00 (SRVLOGC-469: Reorganize Deploying Workflow doc)

--- a/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
+++ b/modules/serverless-logic-building-deploying-workflow-preview-mode.adoc
@@ -21,7 +21,7 @@ You can create a `SonataFlow` custom resource (CR) on {ocp-product-title} and {S
 +
 [source,terminal]
 ----
-$ kn workflow gen-manifest --profile=preview --namespace <your_namespace>
+$ kn workflow gen-manifest --profile=preview -n <namespace>
 ----
 +
 This command generates {ocp-product-title} YAML manifests based on your `workflow.sw.json|yaml` definition. The default location is the `<project_application_dir>/manifests` directory.
@@ -31,7 +31,7 @@ You can modify these files to your preference, however, when you rerun the above
 +
 [source,terminal]
 ----
-$ kn workflow deploy --custom-manifests-dir=./manifests --namespace <your_namespace>
+$ kn workflow deploy --custom-manifests-dir=./manifests -n <namespace>
 ----
 
 . List all the build configurations by running the following command:
@@ -45,7 +45,7 @@ $ oc get buildconfigs -n <namespace>
 +
 [source,terminal]
 ----
-$ oc logs buildconfig/<workflow-name> -n <your_namespace>
+$ oc logs buildconfig/<workflow-name> -n <namespace>
 ----
 +
 .Example command for a workflow that has ID attribute with value `greeting`:
@@ -60,7 +60,7 @@ $ oc logs buildconfig/greeting -n <namespace>
 +
 [source,terminal]
 ----
-$ oc get pods -n <your_namespace>
+$ oc get pods -n <namespace>
 ----
 +
 Ensure that the pod corresponding to your workflow is running.
@@ -77,5 +77,5 @@ $ oc logs pod/<pod-name> -n <namespace>
 +
 [source,terminal]
 ----
-$ kn workflow undeploy -n <your_namespace>
+$ kn workflow undeploy -n <namespace>
 ----

--- a/modules/serverless-logic-deploying-workflows-dev-mode.adoc
+++ b/modules/serverless-logic-deploying-workflows-dev-mode.adoc
@@ -12,69 +12,32 @@ You can deploy your local workflow on {ocp-product-title} in Dev mode. You can u
 
 * You have {ServerlessLogicOperatorName} installed on your cluster.
 * You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have installed the {ServerlessLogicProductName} `kn-workflow` CLI plugin.
 * You have installed the OpenShift CLI `(oc)`.
 
 .Procedure
 
-. Create the workflow configuration YAML file.
-+
-.Example `workflow-dev.yaml` file
-[source,yaml]
-----
-apiVersion: sonataflow.org/v1alpha08
-kind: SonataFlow
-metadata:
-  name: greeting <1>
-  annotations:
-    sonataflow.org/description: Greeting example on k8s!
-    sonataflow.org/version: 0.0.1
-    sonataflow.org/profile: dev <2>
-spec:
-  flow: 
-    start: ChooseOnLanguage
-    functions:
-      - name: greetFunction
-        type: custom
-        operation: sysout
-    states:
-      - name: ChooseOnLanguage
-        type: switch
-        dataConditions:
-          - condition: "${ .language == \"English\" }"
-            transition: GreetInEnglish
-          - condition: "${ .language == \"Spanish\" }"
-            transition: GreetInSpanish
-        defaultCondition: GreetInEnglish
-      - name: GreetInEnglish
-        type: inject
-        data:
-          greeting: "Hello from JSON Workflow, "
-        transition: GreetPerson
-      - name: GreetInSpanish
-        type: inject
-        data:
-          greeting: "Saludos desde JSON Workflow, "
-        transition: GreetPerson
-      - name: GreetPerson
-        type: operation
-        actions:
-          - name: greetAction
-            functionRef:
-              refName: greetFunction
-              arguments:
-                message:  ".greeting + .name"
-        end: true
-----
-+
-<1> is a workflow_name
-<2> indicates that you must deploy the workflow in Dev mode
-
-. To deploy the application, apply the YAML file by entering the following command:
+. Login to your cluster
 +
 [source,terminal]
 ----
-$ oc apply -f <filename> -n <your_namespace>
+$ oc login --token=<your_token> --server=<your_clusters_server_url>
 ----
+
+. Create a namespace in your cluster, by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace <your_namespace>
+----
+
+. Deploy the application, by running the following command:
++
+[source,terminal]
+----
+$ kn workflow deploy --namespace <your_namespace>
+----
++
 
 . Verify the deployment and check the status of the deployed workflow by entering the following command:
 +
@@ -118,7 +81,7 @@ $ oc logs <workflow_pod_name> -n <your_namespace>
 +
 [source,terminal]
 ----
-$ oc delete sonataflow <workflow_name> -n <your_namespace>
+$ kn workflow undeploy -n <your_namespace>
 ----
 
 

--- a/modules/serverless-logic-deploying-workflows-dev-mode.adoc
+++ b/modules/serverless-logic-deploying-workflows-dev-mode.adoc
@@ -17,7 +17,7 @@ You can deploy your local workflow on {ocp-product-title} in Dev mode. You can u
 
 .Procedure
 
-. Login to your cluster.
+. Login to your cluster, by running the following command:
 +
 [source,terminal]
 ----
@@ -28,21 +28,23 @@ $ oc login --token=<your_token> --server=<your_clusters_server_url>
 +
 [source,terminal]
 ----
-$ oc create namespace <your_namespace>
+$ oc create namespace <namespace>
 ----
+
+. In your terminal, navigate to the root directory of your {ServerlessLogicProductName} project.
 
 . Deploy the application, by running the following command:
 +
 [source,terminal]
 ----
-$ kn workflow deploy --namespace <your_namespace>
+$ kn workflow deploy -n <namespace>
 ----
 
 . Verify the deployment and check the status of the deployed workflow by entering the following command:
 +
 [source,terminal]
 ----
-$ oc get workflow -n <your_namespace>
+$ oc get workflow -n <namespace>
 ----
 +
 Ensure that your workflow is listed and the status is `Running` or `Completed`.
@@ -51,7 +53,7 @@ Ensure that your workflow is listed and the status is `Running` or `Completed`.
 +
 [source,terminal]
 ----
-$ oc edit sonataflow <workflow_name> -n <your_namespace>
+$ oc edit sonataflow <workflow_name> -n <namespace>
 ----
 
 . After editing, save the changes. The {ServerlessLogicOperatorName} detects the changes and updates the workflow accordingly.
@@ -64,15 +66,39 @@ $ oc edit sonataflow <workflow_name> -n <your_namespace>
 +
 [source,terminal]
 ----
-$ oc get sonataflows -n <your_namespace>
+$ oc get sonataflows -n <namespace>
+----
+
+.. Find the pod of your application by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n <namespace>
 ----
 
 .. View the workflow logs by running the following command:
 +
 [source,terminal]
 ----
-$ oc logs <workflow_pod_name> -n <your_namespace>
+$ oc logs <workflow_pod_name> -n <namespace>
 ----
+
+.Testing
+
+. The {ServerlessLogicOperatorName} automatically generates a route for workflow deployments using the `dev` profile. To test your workflow, you can use management console that is accessible via the created route. The management console allows you execute the workflow and inspect executed the instances in detail.
+Access the management console by excuting following steps: 
+
+.. Get the <WORKFLOW_URL> by running the following command:
++
+[source,terminal]
+----
+$ oc get route/<workflow_name> -n <namespace>
+----
++
+Note the `HOST/PORT` value, referenced as <WORKFLOW_URL>.
+
+.. Navigate to the `<WORKFLOW_URL>/q/dev-ui/org.apache.kie.sonataflow.sonataflow-quarkus-devui/workflows` in your browser. Please note that it may take some time until the management console is available. 
+
 
 .Next steps
 
@@ -80,7 +106,7 @@ $ oc logs <workflow_pod_name> -n <your_namespace>
 +
 [source,terminal]
 ----
-$ kn workflow undeploy -n <your_namespace>
+$ kn workflow undeploy -n <namespace>
 ----
 
 

--- a/modules/serverless-logic-deploying-workflows-dev-mode.adoc
+++ b/modules/serverless-logic-deploying-workflows-dev-mode.adoc
@@ -42,7 +42,7 @@ $ kn workflow deploy --namespace <your_namespace>
 +
 [source,terminal]
 ----
-$ oc get workflow -n <your_namespace> -w
+$ oc get workflow -n <your_namespace>
 ----
 +
 Ensure that your workflow is listed and the status is `Running` or `Completed`.

--- a/modules/serverless-logic-deploying-workflows-dev-mode.adoc
+++ b/modules/serverless-logic-deploying-workflows-dev-mode.adoc
@@ -37,7 +37,6 @@ $ oc create namespace <your_namespace>
 ----
 $ kn workflow deploy --namespace <your_namespace>
 ----
-+
 
 . Verify the deployment and check the status of the deployed workflow by entering the following command:
 +

--- a/modules/serverless-logic-deploying-workflows-dev-mode.adoc
+++ b/modules/serverless-logic-deploying-workflows-dev-mode.adoc
@@ -17,7 +17,7 @@ You can deploy your local workflow on {ocp-product-title} in Dev mode. You can u
 
 .Procedure
 
-. Login to your cluster
+. Login to your cluster.
 +
 [source,terminal]
 ----

--- a/modules/serverless-logic-deploying-workflows-dev-mode.adoc
+++ b/modules/serverless-logic-deploying-workflows-dev-mode.adoc
@@ -85,17 +85,18 @@ $ oc logs <workflow_pod_name> -n <namespace>
 
 .Testing
 
-. The {ServerlessLogicOperatorName} automatically generates a route for workflow deployments using the `dev` profile. To test your workflow, you can use management console that is accessible via the created route. The management console allows you execute the workflow and inspect executed the instances in detail.
-Access the management console by excuting following steps: 
+The {ServerlessLogicOperatorName} automatically generates a route for workflow deployments using the `dev` profile. To test your workflow, you can use management console that is accessible via the created route. The management console allows you execute the workflow and inspect executed the instances in detail.
 
-.. Get the <WORKFLOW_URL> by running the following command:
+. Access the management console by excuting following steps: 
+
+.. Retrieve the public URL to access the workflow service by running the following command:
 +
 [source,terminal]
 ----
 $ oc get route/<workflow_name> -n <namespace>
 ----
 +
-Note the `HOST/PORT` value, referenced as <WORKFLOW_URL>.
+Note the value of `HOST/PORT` from the result of tis command, referenced as `<WORKFLOW_URL>` in next step.
 
 .. Navigate to the `<WORKFLOW_URL>/q/dev-ui/org.apache.kie.sonataflow.sonataflow-quarkus-devui/workflows` in your browser. Please note that it may take some time until the management console is available. 
 

--- a/modules/serverless-logic-verifying-workflow-deployment-preview-mode.adoc
+++ b/modules/serverless-logic-verifying-workflow-deployment-preview-mode.adoc
@@ -13,62 +13,22 @@ You can verify that your {ServerlessLogicProductName} workflow is running by per
 * You have an {ServerlessLogicOperatorName} installed on your cluster.
 * You have access to an {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have installed the OpenShift CLI `(oc)`.
+* You have deployed your workflow in preview mode in the {ocp-product-title}.
 
 .Procedure
 
-. Create a workflow `YAML` file similar to the following:
+. Retrieve the list of service and identify the one matching ID of your workflow:
 +
-[source,yaml]
+[source,terminal]
 ----
-apiVersion: sonataflow.org/v1alpha08
-kind: SonataFlow
-metadata:
-  name: greeting
-  annotations:
-    sonataflow.org/description: Greeting example on k8s!
-    sonataflow.org/version: 0.0.1
-spec:
-  flow:
-    start: ChooseOnLanguage
-    functions:
-      - name: greetFunction
-        type: custom
-        operation: sysout
-    states:
-      - name: ChooseOnLanguage
-        type: switch
-        dataConditions:
-          - condition: "${ .language == \"English\" }"
-            transition: GreetInEnglish
-          - condition: "${ .language == \"Spanish\" }"
-            transition: GreetInSpanish
-        defaultCondition: GreetInEnglish
-      - name: GreetInEnglish
-        type: inject
-        data:
-          greeting: "Hello from JSON Workflow, "
-        transition: GreetPerson
-      - name: GreetInSpanish
-        type: inject
-        data:
-          greeting: "Saludos desde JSON Workflow, "
-        transition: GreetPerson
-      - name: GreetPerson
-        type: operation
-        actions:
-          - name: greetAction
-            functionRef:
-              refName: greetFunction
-              arguments:
-                message:  ".greeting+.name"
-        end: true
+$ oc get svc -n <namespace>
 ----
 
 . Create a route for the workflow service by running the following command:
 +
 [source,terminal]
 ----
-$ oc expose svc/<workflow-service-name> -n workflows
+$ oc expose svc/<workflow-service-name> -n <namespace>
 ----
 +
 This command creates a public URL to access the workflow service.

--- a/modules/serverless-logic-verifying-workflow-deployment-preview-mode.adoc
+++ b/modules/serverless-logic-verifying-workflow-deployment-preview-mode.adoc
@@ -17,7 +17,7 @@ You can verify that your {ServerlessLogicProductName} workflow is running by per
 
 .Procedure
 
-. Retrieve the list of service and identify the one matching ID of your workflow:
+. Retrieve the list of service and identify the one matching `name` of your workflow:
 +
 [source,terminal]
 ----

--- a/serverless-logic/serverless-logic-getting-started/serverless-logic-deploying-workflows.adoc
+++ b/serverless-logic/serverless-logic-getting-started/serverless-logic-deploying-workflows.adoc
@@ -25,6 +25,10 @@ To deploy a workflow in Preview mode, {ServerlessLogicOperatorName} uses the bui
 
 The following sections explain how to build and deploy your workflow on a cluster using the {ServerlessLogicOperatorName} with a `SonataFlow` custom resource.
 
+include::modules/serverless-logic-building-deploying-workflow-preview-mode.adoc[leveloffset=+2]
+include::modules/serverless-logic-verifying-workflow-deployment-preview-mode.adoc[leveloffset=+2]
+include::modules/serverless-logic-restarting-the-build-preview-mode.adoc[leveloffset=+2]
+
 [id="serverless-logic-configuring-workflows-preview-mode_{context}"]
 === Configuring workflows in Preview mode
 
@@ -34,9 +38,6 @@ include::modules/serverless-logic-workflow-changing-resource-requirements.adoc[l
 include::modules/serverless-logic-workflow-passing-arguments-internal-builder.adoc[leveloffset=+3]
 include::modules/serverless-logic-workflow-env-variables-internal-builder.adoc[leveloffset=+3]
 include::modules/serverless-logic-workflow-changing-base-builder-image.adoc[leveloffset=+3]
-include::modules/serverless-logic-building-deploying-workflow-preview-mode.adoc[leveloffset=+2]
-include::modules/serverless-logic-verifying-workflow-deployment-preview-mode.adoc[leveloffset=+2]
-include::modules/serverless-logic-restarting-the-build-preview-mode.adoc[leveloffset=+2]
 
 include::modules/serverless-logic-editing-workflows.adoc[leveloffset=+1]
 include::modules/serverless-logic-testing-workflows.adoc[leveloffset=+1]


### PR DESCRIPTION
Now it uses the kn workflow plugin

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
`serverless-docs-1.34`
`serverless-docs-1.35`

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[SRVLOGIC-269](https://issues.redhat.com/browse/SRVLOGIC-469)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[Preview](https://85916--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-getting-started/serverless-logic-deploying-workflows.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
  
  @kaldesai @wmedvede @ricardozanini PTAL
