### PR TITLE
OSDOCS-11938: adds greenboot test release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -66,6 +66,10 @@ With this release, make configuring your {microshift-short} instances easier by 
 ==== Deleting or updating Kustomize manifest resources now documented
 With this release, you can delete or upgrade the Kustomize manifest resources. For more information, see xref:../microshift_running_apps/microshift-deleting-resource-manifests.adoc#microshift-deleting-resource-manifests[Deleting or updating Kustomize manifest resources].
 
+[id="microshift-4-18-greenboot-workload-scripts-by-os_{context}"]
+==== Greenboot example outputs for image mode for RHEL available
+With this release, you can see detailed explanations and example outputs to check whether greenboot workload scripts are running properly. For more information, see xref:../microshift_running_apps/microshift-greenboot-workload-scripts.adoc#microshift-greenboot-test-workload-health-check-script_microshift-greenboot-workload-scripts[Testing a workload health check script].
+
 //[id="microshift-4-18-run-apps_{context}"]
 //====  tbd run apps feature here
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-11938](https://issues.redhat.com/browse/OSDOCS-11938)

Link to docs preview:
[microshift-4-18-greenboot-workload-scripts-by-os_release-notes](https://85918--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-greenboot-workload-scripts-by-os_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
