### PR TITLE
Need to remove blank line from Create an OpenShift Logging instance YAML Field

### DIFF
--- a/modules/logging-loki-gui-install.adoc
+++ b/modules/logging-loki-gui-install.adoc
@@ -153,7 +153,6 @@ spec:
     type: ocp-console
     ocpConsole:
       logsLimit: 15
-
   managementState: Managed
 ----
 <1> Name must be `instance`.


### PR DESCRIPTION
- Need to remove the blank line from Create an OpenShift Logging instance YAML Field.
- Here is the documentation link:  https://docs.openshift.com/container-platform/4.16/observability/logging/cluster-logging-deploying.html#logging-loki-gui-install_cluster-logging-deploying

- Here is the step 11.e YAML config: 
~~~
apiVersion: logging.openshift.io/v1
kind: ClusterLogging
metadata:
  name: instance 
  namespace: openshift-logging 
spec:
  collection:
    type: vector
  logStore:
    lokistack:
      name: logging-loki
    retentionPolicy:
      application:
        maxAge: 7d
      audit:
        maxAge: 7d
      infra:
        maxAge: 7d
    type: lokistack
  visualization:
    type: ocp-console
    ocpConsole:
      logsLimit: 15
                                                          <<===== This is an extra line
  managementState: Managed
 ~~~

- One extra line exists between the `visualization` section and the `managementState` field.
- This extra blank line needs to be removed.
- There should be no extra newline characters between the `visualization` section and `managementState`.

- Here is the updated configuration looks: 
~~~
apiVersion: logging.openshift.io/v1
kind: ClusterLogging
metadata:
  name: instance 
  namespace: openshift-logging 
spec:
  collection:
    type: vector
  logStore:
    lokistack:
      name: logging-loki
    retentionPolicy:
      application:
        maxAge: 7d
      audit:
        maxAge: 7d
      infra:
        maxAge: 7d
    type: lokistack
  visualization:
    type: ocp-console
    ocpConsole:
      logsLimit: 15
  managementState: Managed
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> RHCOP 4.17, RHCOP 4.16, RHOCP 4.15, RHOCP 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/OBSDOCS-1557

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://85923--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/cluster-logging-deploying.html
https://85923--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/log_storage/installing-log-storage.html

https://85923--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/cluster-logging-deploying.html
https://85923--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_storage/installing-log-storage.html

https://85923--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/cluster-logging-deploying.html
https://85923--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/log_storage/installing-log-storage.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
