### PR TITLE
OSSM-8325 Update _attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -9,29 +9,53 @@
 :toc-title:
 :imagesdir: images
 :prewrap!:
+//Used most
 //OpenShift
 :ocp-product-title: OpenShift Container Platform
 :ocp-short-name: OpenShift
 //service mesh v3
-:SMProductName: Red Hat OpenShift Service Mesh
+:SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
 :SMProductVersion: 3.0
-//Kiali
-:KialiProduct: Kiali Operator provided by Red Hat
-//Console
+//Kiali Operator
+:KialiProduct: Kiali Operator provided by Red{nbsp}Hat
+//Kiali Server
+:KialiServer: Kiali Server
+//Kiali Console
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
 :SMPluginShort: OSSMC plugin
+//cert-manager
+:cert-manager-operator: cert-manager Operator for Red{nbsp}Hat OpenShift
+//observability
+:ObservabilityLongName: Red{nbsp}Hat OpenShift Observability
+:ObservabilityShortName: Observability
+//distributed tracing
+:DTProductName: Red{nbsp}Hat OpenShift distributed tracing platform
+:DTShortName: distributed tracing platform
+:DTProductVersion: 2.9
+:OTELName: Red{nbsp}Hat OpenShift distributed tracing data collection
+:OTELShortName: distributed tracing data collection
+:OTELOperator: Red{nbsp}Hat OpenShift distributed tracing data collection Operator
+:OTELVersion: 0.81.0
+:TempoName: Red{nbsp}Hat OpenShift distributed tracing platform (Tempo)
+:TempoShortName: distributed tracing platform (Tempo)
+:TempoOperator: Tempo Operator
+:TempoVersion: 2.1.1
+//gitops
+:gitops-title: Red{nbsp}Hat OpenShift GitOps
+:gitops-shortname: GitOps
+:gitops-ver: 1.1
+//pipelines
+:pipelines-title: Red{nbsp}Hat OpenShift Pipelines
+:pipelines-shortname: OpenShift Pipelines
 //Istio
 :istio: Istio
+//Used infrequently
 //ROSA
-:product-rosa: Red Hat OpenShift Service on AWS
+:product-rosa: Red{nbsp}Hat OpenShift Service on AWS
 //Dedicated
-:product-dedicated: Red Hat OpenShift Dedicated
-:istio: Istio
-//service mesh v2
-:SMProductVersion: 2.4.5
-:MaistraVersion: 2.4
+:product-dedicated: Red{nbsp}Hat OpenShift Dedicated
 //AWS
 :aws-first: Amazon Web Services (AWS)
 :aws-full: Amazon Web Services
@@ -59,21 +83,18 @@
 :gcp-first: Google Cloud Platform (GCP)
 :gcp-full: Google Cloud Platform
 :gcp-short: GCP
-//Jaeger
-:JaegerName: Red Hat OpenShift distributed tracing platform (Jaeger)
-:JaegerShortName: distributed tracing platform (Jaeger)
-:JaegerVersion: 1.47.0
 //Kubernetes
 :k8s: Kubernetes
-//distributed tracing
-:DTProductName: Red Hat OpenShift distributed tracing platform
-:DTShortName: distributed tracing platform
-:DTProductVersion: 2.9
-:OTELName: Red Hat OpenShift distributed tracing data collection
-:OTELShortName: distributed tracing data collection
-:OTELOperator: Red Hat OpenShift distributed tracing data collection Operator
-:OTELVersion: 0.81.0
-:TempoName: Red Hat OpenShift distributed tracing platform (Tempo)
-:TempoShortName: distributed tracing platform (Tempo)
-:TempoOperator: Tempo Operator
-:TempoVersion: 2.1.1
+//OpenShift Kubernetes Engine
+:oke: OpenShift Kubernetes Engine
+//Version-agnostic OLM
+:olm-first: Operator Lifecycle Manager (OLM)
+:olm: OLM
+//service mesh v2
+:SMProductVersion: 2.4.5
+:MaistraVersion: 2.4
+//Jaeger
+//Deprecated
+:JaegerName: Red{nbsp}Hat OpenShift distributed tracing platform (Jaeger)
+:JaegerShortName: distributed tracing platform (Jaeger)
+:JaegerVersion: 1.47.0


### PR DESCRIPTION
**OSSM 3.0**

[OSSM-8325](https://issues.redhat.com//browse/OSSM-8325) Update _attributes

**Merge to:** https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick** to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology Preview.

OSSM 3.0 is moving to stand alone format and will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8325

Link to docs preview:
No preview for _attributes

QE review:
QE is not required for this change.

Additional information:
OSSM 3.x is missing a few attributes it needs, or will need in the future. Most were copy/pasted from https://github.com/openshift/openshift-docs/blob/main/_attributes/common-attributes.adoc 

Per  https://redhat-documentation.github.io/supplementary-style-guide/#non-breaking-spaces  also added {nbsp} between "Red" and "Hat"  so it read "Red{nbsp}Hat" for applicable attributes. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
