### PR TITLE
OSDOCS-12495: adds 4.17.8 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -169,3 +169,12 @@ Issued: 3 December 2024
 {product-title} release 4.17.7 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2024:10520[RHSA-2024:10520] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:10518[RHSA-2024:10518] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-8-dp_{context}"]
+=== RHBA-2024:10820 - {microshift-short} 4.17.8 bug fix and enhancement advisory
+
+Issued: 11 December 2024
+
+{product-title} release 4.17.8 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:10820[RHBA-2024:10820] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:10818[RHSA-2024:10818] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12495](https://issues.redhat.com/browse/OSDOCS-12495)

Link to docs preview:
[microshift-4-17-8-dp_release-notes](https://85925--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-8-dp_release-notes)

QE review:
- N/A stock text


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
