### PR TITLE
OSSM-8536: Add procedure section title

### DIFF
--- a/modules/ossm-deploying-bookinfo-application.adoc
+++ b/modules/ossm-deploying-bookinfo-application.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="deploying-book-info_{context}"]
 = Deploying the Bookinfo application
 
@@ -13,6 +13,8 @@
 * You have installed the {SMProductName} Operator, created the {istio} resource, and the Operator has deployed {istio}.
 * You have created IstioCNI resource, and the Operator has deployed the necessary IstioCNI pods.
 
+.Procedure
+
 . In the {ocp-product-title} web console, navigate to the *Home* -> *Projects* page.
 
 . Click *Create Project*.
@@ -23,7 +25,7 @@ The *Display name* and *Description* fields provide supplementary information an
 
 . Click *Create*.
 
-. Apply the {Istio} discovery selector and injection label to the `bookinfo` namespace by entering the following command at the CLI:
+. Apply the {Istio} discovery selector and injection label to the `bookinfo` namespace by entering the following command:
 +
 [source,terminal]
 ----
@@ -35,7 +37,7 @@ $ oc label namespace bookinfo istio-discovery=enabled istio-injection=enabled
 In this example, the name of the Istio resource is `default`. If the Istio resource name is different, you must set the `istio.io/rev` label to the name of the Istio resource instead of adding the `istio-injection=enabled` label.
 ====
 
-. Apply the `bookinfo` YAML file to deploy the `bookinfo` application by entering the following command at the CLI:
+. Apply the `bookinfo` YAML file to deploy the `bookinfo` application by entering the following command:
 +
 [source,terminal]
 ----
@@ -44,7 +46,7 @@ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.23/samples/b
 
 .Verification
 
-. Verify that the `bookinfo` service is available by running the following command at the CLI:
+. Verify that the `bookinfo` service is available by running the following command:
 +
 [source,terminal]
 ----
@@ -61,7 +63,7 @@ ratings       ClusterIP   172.30.33.85    <none>        9080/TCP   44s
 reviews       ClusterIP   172.30.175.88   <none>        9080/TCP   44s
 ----
 
-. Verify that the `bookinfo` pods are available by running the following command at the CLI:
+. Verify that the `bookinfo` pods are available by running the following command:
 +
 [source,terminal]
 ----
@@ -80,9 +82,9 @@ reviews-v2-5b667bcbf8-4lsfd      2/2     Running   0          65s
 reviews-v3-5b9bd44f4-44hr6       2/2     Running   0          65s
 ----
 +
-When the `Ready` columns displays `2/2` the proxy sidecar was successfully injected. Confirm that `Running` appears in the `Status` column for each pod.
+When the `Ready` columns displays `2/2`, the proxy sidecar was successfully injected. Confirm that `Running` appears in the `Status` column for each pod.
 
-. Verify that the `bookinfo` application running by sending a request to the `bookinfo` page. Run the following command at the CLI:
+. Verify that the `bookinfo` application is running by sending a request to the `bookinfo` page. Run the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OSSM-8536
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://85933--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#deploying-book-info_ossm-about-bookinfo-application
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
