### PR TITLE
Update machineconfig-garbage-collect-removing.adoc

### DIFF
--- a/modules/machineconfig-garbage-collect-removing.adoc
+++ b/modules/machineconfig-garbage-collect-removing.adoc
@@ -44,7 +44,7 @@ where:
 
 `--count`:: Optional: Specifies the maximum number of unused rendered machine configs you want to delete, starting with the oldest.
 
-`--confirm`:: Optional: Specifies the maximum number of unused rendered machine configs you want to delete, starting with the oldest.
+`--confirm`:: Optional: Indicate that pruning should occur, instead of performing a dry-run.
 
 `--pool-name`:: Optional: Specifies the machine config pool from which you want to delete the machine. If not specified, all the pools are evaluated.
 


### PR DESCRIPTION
`confirm` description is currently just a duplicate of the `count` description. Borrow the description from the Pruning Objects page.

Version(s): 4.16

Issue: 

QE review:
- [ ] QE has approved this change.

Additional information:
