### PR TITLE
OSDOCS-12872: updating the heading to automated recovery

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -229,7 +229,7 @@ Distros: microshift
 Topics:
 - Name: Backing up and restoring data
   File: microshift-backup-and-restore
-- Name: Auto recovery from manual backups
+- Name: Automated recovery from manual backups
   File: microshift-auto-recover-manual-backup
 ---
 Name: Troubleshooting

--- a/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
+++ b/microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-auto-recover-manual-backup"]
-= Auto recovery from manual backups
+= Automated recovery from manual backups
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-auto-recover-manual-backup
 
@@ -10,7 +10,7 @@ You can automatically restore data from manual backups when {microshift-short} f
 
 You can use the following options with the existing `backup` and `restore` commands in this feature:
 
-* `--auto-recovery`: Selects the most recent version of the backup, and then restores it. This option treats the `PATH` argument as a path to a directory that holds all the backups for auto-recovery, and not just as a path to a particular backup file.
+* `--auto-recovery`: Selects the most recent version of the backup, and then restores it. This option treats the `PATH` argument as a path to a directory that holds all the backups for automated recovery, and not just as a path to a particular backup file.
 * `--dont-save-failed`: Disables the backup of failed {microshift-short} data.
 
 [NOTE]

--- a/modules/microshift-creating-backups.adoc
+++ b/modules/microshift-creating-backups.adoc
@@ -30,7 +30,7 @@ $ sudo microshift backup --auto-recovery _<path_of_directory>_ <1>
 +
 [NOTE]
 ====
-The `--auto-recovery` option modifies the interpretation of the `PATH` argument from the final backup path to a directory that holds all the backups for auto-recovery.
+The `--auto-recovery` option modifies the interpretation of the `PATH` argument from the final backup path to a directory that holds all the backups for automated recovery.
 ====
 +
 .Example output


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-12872](https://issues.redhat.com/browse/OSDOCS-12872)

Link to docs preview:
[Automated recovery from manual backups](https://85937--ocpdocs-pr.netlify.app/microshift/latest/microshift_backup_and_restore/microshift-auto-recover-manual-backup.html)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Related to PR https://github.com/openshift/openshift-docs/pull/85006
