### PR TITLE
RHDEVDOCS-6228 Update _distro_map.yml

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -394,6 +394,9 @@ openshift-gitops:
     gitops-docs-1.14:
       name: '1.14'
       dir: gitops/1.14
+    gitops-docs-1.15:
+      name: '1.15'
+      dir: gitops/1.15
 openshift-pipelines:
   name: Red Hat OpenShift Pipelines
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 6228](https://issues.redhat.com/browse/RHDEVDOCS-6228)

**Link to docs preview:** N/A
**SME and QE review:** Not applicable


**Additional information:** This PR updates the distro map in main for the 1.15 GitOps standalone doc. It does not alter documentation content, so no documentation preview is available.