### PR TITLE
OCPBUGS#45841:clarifies overlapping ANP rules

### DIFF
--- a/modules/nw-ovn-k-adminnetwork-policy.adoc
+++ b/modules/nw-ovn-k-adminnetwork-policy.adoc
@@ -63,7 +63,7 @@ spec:
             custom-anp: tenant-1
 ----
 <1> Specify a name for your ANP.
-<2> The `spec.priority` field supports a maximum of 100 ANP in the values of 0-99 in a cluster. The lower the value the higher the precedence. Creating `AdminNetworkPolicy` with the same priority creates a nondeterministic outcome.
+<2> The `spec.priority` field supports a maximum of 100 ANPs in the range of values `0-99` in a cluster. The lower the value, the higher the precedence because the range is read in order from the lowest to highest value. Because there is no guarantee which policy takes precedence when ANPs are created at the same priority, set ANPs at different priorities so that precedence is deliberate.
 <3> Specify the namespace to apply the ANP resource.
 <4> ANP have both ingress and egress rules. ANP rules for `spec.ingress` field accepts values of `Pass`, `Deny`, and `Allow` for the `action` field.
 <5> Specify a name for the `ingress.name`.

--- a/modules/nw-ovn-k-anp-best-practices.adoc
+++ b/modules/nw-ovn-k-anp-best-practices.adoc
@@ -9,7 +9,7 @@
 
 When building `AdminNetworkPolicy` (ANP) resources, you might consider the following when creating your policies:
 
-* Because there is no guarantee which policy will take precedence when overlapping ANP are created, you should create ANP at different priorities so that precedence is well defined.
+* You can create ANPs that have the same priority. If you do create two ANPs at the same priority, ensure that they do not apply overlapping rules to the same traffic. Only one rule per value is applied and there is no guarantee which rule is applied when there is more than one at the same priority value. Because there is no guarantee which policy takes precedence when overlapping ANPs are created, set ANPs at different priorities so that precedence is well defined.
 
 * Administrators must create ANP that apply to user namespaces not system namespaces.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-45841
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
To CR example [update](https://85972--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/adminnetworkpolicy/ovn-k-anp#:~:text=The%20spec.priority,is%20well%20defined.)
For best [practices](https://85972--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/adminnetworkpolicy/ovn-k-anp-recommended-practices#:~:text=You%20can%20create,is%20well%20defined.)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
