### PR TITLE
Test API docs build failure mode

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -6,6 +6,12 @@
 // * installing/installing_gcp/installing-gcp-network-customizations.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+
+
+
+// test
+
+
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Based on this, the API reference docs cannot be built any longer for the portal. I don't know why this is.

```
ERROR (objects/index.adoc): "xref:../operatorhub_apis/olm-operator-openshift-io-v1.adoc#olm-operator-openshift-io-v1[`array (OLM)`]" appears to try to reference a file not included in the "openshift-enterprise" distro
ERROR (objects/index.adoc): "xref:../operatorhub_apis/clustercatalog-olm-operatorframework-io-v1.adoc#clustercatalog-olm-operatorframework-io-v1[`array (ClusterCatalog)`]" appears to try to reference a file not included in the "openshift-enterprise" distro
ERROR (objects/index.adoc): "xref:../operatorhub_apis/clusterextension-olm-operatorframework-io-v1.adoc#clusterextension-olm-operatorframework-io-v1[`array (ClusterExtension)`]" appears to try to reference a file not included in the "openshift-enterprise" distro
```
