### PR TITLE
HCIDOCS-551: Update IPI installer docs with C-Series / X-Series updates

### DIFF
--- a/modules/ipi-install-bmc-addressing-for-cisco-cimc.adoc
+++ b/modules/ipi-install-bmc-addressing-for-cisco-cimc.adoc
@@ -22,7 +22,7 @@ platform:
 ----
 <1> The `address` configuration setting specifies the protocol.
 
-For Cisco UCS UCSX-210C-M6 hardware, Red Hat supports Cisco Integrated Management Controller (CIMC).
+For Cisco UCS C-Series and X-Series servers, Red Hat supports Cisco Integrated Management Controller (CIMC).
 
 .BMC address format for Cisco CIMC
 [width="100%", cols="1,3", options="header"]
@@ -31,7 +31,7 @@ For Cisco UCS UCSX-210C-M6 hardware, Red Hat supports Cisco Integrated Managemen
 |Redfish virtual media| `redfish-virtualmedia://<server_kvm_ip>/redfish/v1/Systems/<serial_number>`
 |====
 
-To enable Redfish virtual media for Cisco UCS UCSX-210C-M6 hardware, use `redfish-virtualmedia://` in the `address` setting. The following example demonstrates using Redfish virtual media within the `install-config.yaml` file.
+To enable Redfish virtual media for Cisco UCS C-Series and X-Series servers, use `redfish-virtualmedia://` in the `address` setting. The following example demonstrates using Redfish virtual media within the `install-config.yaml` file.
 
 [source,yaml]
 ----

--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -38,6 +38,7 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 [cols="1,1,1",options="header"]
 |====
 | Model | Management | Firmware versions
-| UCS UCSX-210C-M6 | CIMC | 5.2(2) or later
+| UCS X-Series servers footnote:[Installer-provisioned installation is supported for UCS M6 Platform and later.] | CIMC | 5.2(2) or later
+| UCS C-Series servers in UCS managed domain | CIMC | 4.3 or later
 
 |====


### PR DESCRIPTION
Updated CISCO CIMC docs.

Fixes: HCIDOCS-551

See https://issues.redhat.com/browse/HCIDOCS-551 for additional details.

Preview URL: https://85986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#bmc-addressing-for-cisco-cimc_ipi-install-installation-workflow and https://85986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites

For release(s): 4.18, 4.17
QE Review: 

- [x] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
