### PR TITLE
OSDOCS#50922: Fixing doc for setting up memory overcommit

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -265,18 +265,29 @@ $ oc label namespace wasp openshift.io/cluster-monitoring="true"
 . Enable memory overcommitment in {VirtProductName} by using the web console or the CLI.
 +
 --
-.Web console
-.. In the {product-title} web console, go to *Virtualization* -> *Overview* -> *Settings* -> *General settings* -> *Memory density*. 
-.. Set *Enable memory density* to on.
+* Web console
++
+. In the {product-title} web console, go to *Virtualization* -> *Overview* -> *Settings* -> *General settings* -> *Memory density*. 
+. Set *Enable memory density* to on.
 
-.CLI
-* Run the following command:
+* CLI
+** Configure your {VirtProductName} to enable higher memory density and set the overcommit rate:
 +
 [source,terminal]
 ----
-$ oc patch --type=merge \
-  -f <../manifests/openshift/hco-set-memory-overcommit.yaml> \
-  --patch-file <../manifests/openshift/hco-set-memory-overcommit.yaml>
+$ oc -n openshift-cnv patch HyperConverged/kubevirt-hyperconverged --type='json' -p='[ \
+  { \
+  "op": "replace", \
+  "path": "/spec/higherWorkloadDensity/memoryOvercommitPercentage", \
+  "value": 150 \
+  } \
+]'
+----
++
+.Successful output
+[source,terminal]
+----
+hyperconverged.hco.kubevirt.io/kubevirt-hyperconverged patched
 ----
 --
 
@@ -326,13 +337,13 @@ If swap is provisioned, an amount greater than zero is displayed in the `Swap:` 
 +
 [source,terminal]
 ----
-$ oc get -n openshift-cnv HyperConverged kubevirt-hyperconverged -o jsonpath="{.spec.higherWorkloadDensity.memoryOvercommitPercentage}"
+$ oc -n openshift-cnv get HyperConverged/kubevirt-hyperconverged -o jsonpath='{.spec.higherWorkloadDensity}{"\n"}'
 ----
 +
 .Example output
 [source,terminal]
 ----
-150
+{"memoryOvercommitPercentage":150}
 ----
 +
 The returned value must match the value you had previously configured.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16 and later

Issue:
https://issues.redhat.com/browse/CNV-50922

Link to docs preview:
https://85991--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->