### PR TITLE
OSDOCS-7561-413: Moving MCO info

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -44,14 +44,6 @@ include::modules/arch-platform-operators.adoc[leveloffset=+2]
 * xref:../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
 endif::[]
 
-include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-* For more information about detecting configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection].
-
-* For information about preventing the control plane machines from rebooting after the Machine Config Operator makes changes to the machine configuration, see xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling Machine Config Operator from automatically rebooting].
-
 include::modules/etcd-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -5,9 +5,9 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="machine-config-overview-{context}"]
-= Machine config overview
+= Machine Config overview
 
-The Machine Config Operator (MCO) manages updates to systemd, CRI-O and Kubelet, the kernel, Network Manager and other system features. It also offers a `MachineConfig` CRD that can write configuration files onto the host (see link:https://github.com/openshift/machine-config-operator#machine-config-operator[machine-config-operator]). Understanding what MCO does and how it interacts with other components is critical to making advanced, system-level changes to an {product-title} cluster. Here are some things you should know about MCO, machine configs, and how they are used:
+The Machine Config Operator (MCO) manages updates to systemd, CRI-O and Kubelet, the kernel, Network Manager and other system features. It also offers a `MachineConfig` CRD that can write configuration files onto the host (see link:https://github.com/openshift/machine-config-operator#machine-config-operator[machine-config-operator]). Understanding what the MCO does and how it interacts with other components is critical to making advanced, system-level changes to an {product-title} cluster. Here are some things you should know about the MCO, machine configs, and how they are used:
 
 * Machine configs are processed alphabetically, in lexicographically increasing order, of their name. The render controller uses the first machine config in the list as the base and appends the rest to the base machine config.
 

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * architecture/control-plane.adoc
+// * post_installation_configuration/machine-configuration-tasks.adoc
 :_mod-docs-content-type: CONCEPT
 [id="about-machine-config-operator_{context}"]
 = About the Machine Config Operator

--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -12,19 +12,10 @@ Aside from a few specialized features, most changes to operating systems on {pro
 
 Tasks in this section describe how to use features of the Machine Config Operator to configure operating system features on {product-title} nodes.
 
-[IMPORTANT]
-====
-NetworkManager stores new network configurations to `/etc/NetworkManager/system-connections/` in a key file format.
-
-Previously, NetworkManager stored new network configurations to `/etc/sysconfig/network-scripts/` in the ifcfg format. Starting with RHEL 9.0, RHEL stores new network configurations at `/etc/NetworkManager/system-connections/` in a key file format. The connections configurations stored to `/etc/sysconfig/network-scripts/` in the old format still work uninterrupted. Modifications in existing profiles continue updating the older files.
-====
-
 [id="understanding-the-machine-config-operator"]
-== Understanding the Machine Config Operator
 
-include::modules/machine-config-operator.adoc[leveloffset=+2]
+include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]
 include::modules/machine-config-overview.adoc[leveloffset=+2]
-
 include::modules/machine-config-node-drain.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -34,6 +25,12 @@ include::modules/machine-config-node-drain.adoc[leveloffset=+2]
 * xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling the Machine Config Operator from automatically rebooting]
 
 include::modules/machine-config-drift-detection.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling Machine Config Operator from automatically rebooting].
+
 include::modules/checking-mco-status.adoc[leveloffset=+2]
 
 [id="using-machineconfigs-to-change-machines"]
@@ -82,8 +79,6 @@ include::modules/rhcos-load-firmware-blobs.adoc[leveloffset=+2]
 
 * xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane]
 
-include::modules/core-user-password.adoc[leveloffset=+2]
-
 [id="configuring-machines-with-custom-resources"]
 == Configuring MCO-related custom resources
 
@@ -92,4 +87,5 @@ Besides managing `MachineConfig` objects, the MCO manages two custom resources (
 include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+2]
 include::modules/create-a-containerruntimeconfig-crd.adoc[leveloffset=+2]
 include::modules/set-the-default-max-container-root-partition-size-for-overlay-with-crio.adoc[leveloffset=+2]
-include::modules/create-crio-default-capabilities.adoc[leveloffset=+2]
+
+


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-7651](https://issues.redhat.com/browse/OSDOCS-7651)

Link to docs preview:
https://85995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/control-plane.html
https://85995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html

QE review:
- [x] SME approval

Additional information:
4.13 version of https://github.com/openshift/openshift-docs/pull/85977

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
