### PR TITLE
OSDOCS-7651-414: Moving MCO info

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -44,14 +44,6 @@ include::modules/arch-platform-operators.adoc[leveloffset=+2]
 * xref:../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
 endif::[]
 
-include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-* For more information about detecting configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection].
-
-* For information about preventing the control plane machines from rebooting after the Machine Config Operator makes changes to the machine configuration, see xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling Machine Config Operator from automatically rebooting].
-
 include::modules/etcd-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -5,9 +5,9 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="machine-config-overview-{context}"]
-= Machine config overview
+= Machine Config overview
 
-The Machine Config Operator (MCO) manages updates to systemd, CRI-O and Kubelet, the kernel, Network Manager and other system features. It also offers a `MachineConfig` CRD that can write configuration files onto the host (see link:https://github.com/openshift/machine-config-operator#machine-config-operator[machine-config-operator]). Understanding what MCO does and how it interacts with other components is critical to making advanced, system-level changes to an {product-title} cluster. Here are some things you should know about MCO, machine configs, and how they are used:
+The Machine Config Operator (MCO) manages updates to systemd, CRI-O and Kubelet, the kernel, Network Manager and other system features. It also offers a `MachineConfig` CRD that can write configuration files onto the host (see link:https://github.com/openshift/machine-config-operator#machine-config-operator[machine-config-operator]). Understanding what the MCO does and how it interacts with other components is critical to making advanced, system-level changes to an {product-title} cluster. Here are some things you should know about the MCO, machine configs, and how they are used:
 
 * Machine configs are processed alphabetically, in lexicographically increasing order, of their name. The render controller uses the first machine config in the list as the base and appends the rest to the base machine config.
 

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * architecture/control-plane.adoc
+// * post_installation_configuration/machine-configuration-tasks.adoc
 :_mod-docs-content-type: CONCEPT
 [id="about-machine-config-operator_{context}"]
 = About the Machine Config Operator

--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -20,18 +20,15 @@ Previously, NetworkManager stored new network configurations to `/etc/sysconfig/
 ====
 
 [id="understanding-the-machine-config-operator"]
-== Understanding the Machine Config Operator
 
-include::modules/machine-config-operator.adoc[leveloffset=+2]
+include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]
 include::modules/machine-config-overview.adoc[leveloffset=+2]
 
 include::modules/machine-config-node-drain.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
 
-* xref:../architecture/control-plane.adoc#about-machine-config-operator_control-plane[About the Machine Config Operator]
-* xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling the Machine Config Operator from automatically rebooting]
+* xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling Machine Config Operator from automatically rebooting].
 
 include::modules/machine-config-drift-detection.adoc[leveloffset=+2]
 include::modules/checking-mco-status.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-7651](https://issues.redhat.com/browse/OSDOCS-7651)

Link to docs preview:
https://86000--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/control-plane.html
https://86000--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html

QE review:
- [x] SME approval

Additional information:
4.14 version of https://github.com/openshift/openshift-docs/pull/85977

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
