### PR TITLE
OSDOCS#12852: Add the 4.16.26 z-stream RN text into the release notes section

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3338,6 +3338,44 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.26
+[id="ocp-4-16-26_{context}"]
+=== RHSA-2024:10823 - {product-title} {product-version}.26 bug fix and security update
+
+Issued: 12 December 2024
+
+{product-title} release {product-version}.26 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10823[RHSA-2024:10823] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10826[RHBA-2024:10826] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.26 --pullspecs
+----
+
+[id="ocp-4-16-26-enhancements_{context}"]
+==== Enhancements
+
+* Previously, ClusterTasks were listed on the *Pipelines builder* page and the *ClusterTask list* page in the *Tasks* navigation menu. Currently, the ClusterTasks are deprecated from Pipelines 1.17, and the ClusterTask dependency is removed from static plug-in. On the *Pipelines builder* page, you will only see the task that is present in the namespace and community tasks are displayed. (link:https://issues.redhat.com/browse/OCPBUGS-45015[*OCPBUGS-45015*])
+
+[id="ocp-4-16-26-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when you used the Agent-based Installer to install a cluster on a node that had an incorrect date, the cluster installation failed. With this release, a patch is applied to the Agent-based Installer live ISO time synchronization. The patch configures the `/etc/chrony.conf` file with the list of additional Network Time Protocol (NTP) servers, so that you can set any of these additional NTP servers in the `agent-config.yaml` without experiencing a cluster installation issue. (link:https://issues.redhat.com/browse/OCPBUGS-45181[*OOCPBUGS-45181*])
+
+* Previously, when you used a custom template, you could not enter multi-line parameters, such as private keys. With this release, you can switch between single-line and multi-line modes and you can complete the template fields with multi-line input. (link:https://issues.redhat.com/browse/OCPBUGS-45124[*OOCPBUGS-45124*])
+
+* Previously, up to {product-title} 4.15, you had the option to close the *Getting started with resources* section. After {product-title} 4.15, the *Getting started with resources* section converted to an expandable section, and you did not have a way to close the section. With this release, you can close the *Getting started with resources* section. (link:https://issues.redhat.com/browse/OCPBUGS-45181[*OOCPBUGS-45181*])
+
+* Previously in Red{nbsp}Hat {product-title}, when you selected the `start lastrun` option on the *Edit BuildConfig* page, an error prevented the `lastrun` operation from running. With this release, a fix ensures that the `start lastrun` option successfully completes. (link:https://issues.redhat.com/browse/OCPBUGS-44875[*OOCPBUGS-44875*])
+
+[id="ocp-4-16-26-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 //4.16.25
 [id="ocp-4-16-25_{context}"]
 === RHSA-2024:10528 - {product-title} {product-version}.25 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12852](https://issues.redhat.com//browse/OSDOCS-12852)

Link to docs preview:
[4.16.26](https://86010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-26_release-notes)

QE review:
- [ ] QE has approved this change.
n/a for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 12/12/24.

