### PR TITLE
OSDOCS-12877: Update heading in release note

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -84,8 +84,8 @@ With this release, you can see detailed explanations and example outputs to chec
 === Backup and restore
 
 [id="microshift-4-18-autorecovery-from-manual-backup_{context}"]
-==== Auto recovery from manual backups now documented
-With this release, you can automatically restore data from manual backups when {microshift-short} fails to start by using the `auto-recovery` feature. For more information, see xref:../microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc#microshift-auto-recover-manual-backup[Auto recovery from manual backups].
+==== Automated recovery from manual backups now documented
+With this release, you can automatically restore data from manual backups when {microshift-short} fails to start by using the `auto-recovery` feature. For more information, see xref:../microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc#microshift-auto-recover-manual-backup[Automated recovery from manual backups].
 
 //[id="microshift-4-18-doc-enhancements_{context}"]
 //=== Documentation enhancements


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12877](https://issues.redhat.com/browse/OSDOCS-12877)

Link to docs preview:
[Automated recovery from manual backups now documented](https://86023--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-backup_and_restore_release-notes)

QE review:
- [x] QE and SME has approved this change.

Additional information:
Refer to the PR https://github.com/openshift/openshift-docs/pull/85937 for approval from QE and SME on the feature updates. The same heading has been updated in the release notes in this PR.
