### PR TITLE
[enterprise-4.15] OCPBUGS-36911: Update PTP docs as per the Concious Language initiative

### DIFF
--- a/snippets/ztp_PtpConfigSlave.yaml
+++ b/snippets/ztp_PtpConfigSlave.yaml
@@ -1,12 +1,12 @@
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
-  name: slave
+  name: ordinary
   namespace: openshift-ptp
   annotations: {}
 spec:
   profile:
-    - name: "slave"
+    - name: "ordinary"
       # The interface name is hardware-specific
       interface: $interface
       ptp4lOpts: "-2 -s"
@@ -118,7 +118,7 @@ spec:
         userDescription ;
         timeSource 0xA0
   recommend:
-    - profile: "slave"
+    - profile: "ordinary"
       priority: 4
       match:
         - nodeLabel: "node-role.kubernetes.io/$mcp"


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-36911
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://86057--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu#ztp-sno-du-configuring-ptp_sno-configure-for-vdu
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Cherry-picked from https://github.com/openshift/openshift-docs/pull/85785#issuecomment-2528779757 after automatic cherry-pick failed.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
