### PR TITLE
OCPBUGS-44801-4.16:note in install docs about secure access

### DIFF
--- a/modules/microshift-creating-ostree-iso.adoc
+++ b/modules/microshift-creating-ostree-iso.adoc
@@ -21,7 +21,7 @@ Use the following procedure to create the ISO. The {op-system-ostree} Installer 
 +
 [source,terminal,subs="+quotes"]
 ----
-$ BUILDID=$(sudo composer-cli compose start-ostree --ref "rhel/{op-system-version-major}/$(uname -m)/edge" __<microshift_blueprint>__ edge-container | awk '{print $2}') <1>
+$ BUILDID=$(sudo composer-cli compose start-ostree --ref "rhel/{op-system-version-major}/$(uname -m)/edge" __<microshift_blueprint>__ edge-container | awk '/^Compose/ {print $2}') <1>
 ----
 <1> Replace _<microshift_blueprint>_ with the name of your blueprint.
 +


### PR DESCRIPTION
Version(s):
4.14, 4.15 and 4.16

Issue:
[OCPBUGS-44801](https://issues.redhat.com/browse/OCPBUGS-44801)

Link to docs preview:
[Creating the RHEL for Edge image - rpm ostree offline use](https://86058--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use.html#microshift-creating-ostree-iso_microshift-embed-rpm-ostree-offline-use)
[Creating the RHEL for Edge image - rpm ostree](https://86058--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#microshift-creating-ostree-iso_microshift-embed-in-rpm-ostree)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

