### PR TITLE
OSDOCS-12705-4.16:Copy edits in install section

### DIFF
--- a/modules/microshift-install-system-requirements.adoc
+++ b/modules/microshift-install-system-requirements.adoc
@@ -20,9 +20,9 @@ The following conditions must be met prior to installing {microshift-short}:
 ====
 These requirements are the minimum system requirements for {microshift-short} and {op-system-base-full}. Add the system requirements for the workload you plan to run.
 
-For example, if an IoT gateway solution requires 4 GB of RAM, your system needs to have at least 2GB for {op-system-base-full} and {microshift-short}, plus 4GB for the workloads. 6GB of RAM is required in total.
+For example, if an IoT gateway solution requires 4 GB of RAM, your system needs to have at least 2 GB for {op-system-base-full} and {microshift-short}, plus 4 GB for the workloads. 6 GB of RAM is required in total.
 
-It is recommended to allow for extra capacity for future needs if you are deploying physical devices in remote locations. If you are uncertain of the RAM required and if the budget permits, use the maximum RAM capacity the device can support.
+It is recommended to allow for extra capacity for future needs if you are deploying physical devices in remote locations. If you are uncertain of the RAM required and if the budget permits, use the maximum RAM capacity that the device can support.
 ====
 
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.16 only

Issue:
[OSDOCS-12705](https://issues.redhat.com/browse/OSDOCS-12705)

Link to docs preview:
[System requirements for installing MicroShift in RPM](https://86060--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html)
[System requirements for installing MicroShift in edge image](https://86060--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html)
[System requirements for installing MicroShift in offline use](https://86060--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use.html)


QE review:
- NA as only copy edits are made as suggested in the PR https://github.com/openshift/openshift-docs/pull/84816. No technical update is made.