### PR TITLE
Adds ovnk observ with ovs sampling to docs

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -28,6 +28,7 @@ The following Technology Preview features are enabled by this feature set:
 ** Dynamic Resource Allocation API. Enables a new API for requesting and sharing resources between pods and containers. This is an internal feature that most users do not need to interact with. (`DynamicResourceAllocation`)
 ** Pod security admission enforcement. Enables the restricted enforcement mode for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)
 ** StatefulSet pod availability upgrading limits. Enables users to define the maximum number of statefulset pods unavailable during updates which reduces application downtime. (`MaxUnavailableStatefulSet`)
+** `OVNObservability` resource allows you to verify expected network behavior. Supports the following network APIs: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinesdNetwork` isolation, multicast ACLs, and egress firewalls. When enabled, you can view network events in the terminal.
 ** `gcpLabelsTags`
 ** `vSphereStaticIPs`
 ** `routeExternalCertificate`
@@ -77,7 +78,6 @@ The following Technology Preview features are enabled by this feature set:
 ** `DNSNameResolver`
 ** `ManagedBootImagesAWS`
 ** `NetworkSegmentation`
-** `OVNObservability`
 ** `PersistentIPsForVirtualization`
 ** `ProcMountType`
 ** `RouteAdvertisements`

--- a/modules/nw-ovn-kubernetes-observability.adoc
+++ b/modules/nw-ovn-kubernetes-observability.adoc
@@ -1,0 +1,154 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ovn-kubernetes-observability_{context}"]
+= Checking OVN-Kubernetes network traffic with OVS sampling using the CLI
+:FeatureName: Checking OVN-Kubernetes network traffic with OVS sampling
+include::snippets/technology-preview.adoc[]
+
+OVN-Kubernetes network traffic can be viewed with OVS sampling via the CLI for the following network APIs: 
+
+* `NetworkPolicy`
+* `AdminNetworkPolicy`
+* `BaselineNetworkPolicy`
+* `UserDefinesdNetwork` isolation
+* `EgressFirewall`
+* Multicast ACLs. 
+
+Scripts for these networking events are found in the `/usr/bin/ovnkube-observ` path of each OVN-Kubernetes node.
+
+Although both the Network Observability Operator and checking OVN-Kubernetes network traffic with OVS sampling are good for debuggability, the Network Observability Operator is intended for observing network events. Alternatively, checking OVN-Kubernetes network traffic with OVS sampling using the CLI is intended to help with packet tracing; it can also be used while the Network Observability Operator is installed, however that is not a requirement.
+
+Administrators can add the `--add-ovs-collect` option to view network traffic across the node, or pass in additional flags to filter result for specific pods. Additional flags can be found in the "OVN-Kubernetes network traffic with OVS sampling flags" section.
+
+Use the following procedure to view OVN-Kubernetes network traffic using the CLI.
+
+.Prerequisites
+
+* You are logged in to the cluster as a user with `cluster-admin` privileges.
+* You have created a source pod and a destination pod and ran traffic between them.
+* You have created at least one of the following network APIs: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinesdNetwork` isolation, multicast, or egress firewalls.
+
+.Procedure
+
+. To enable the `OVNObservability` with OVS sampling feature, enable `TechPreviewNoUpgrade` feature set in the `FeatureGate` CR named `cluster` by entering the following command:
++
+[source,terminal]
+----
+$ oc patch --type=merge --patch '{"spec": {"featureSet": "TechPreviewNoUpgrade"}}' featuregate/cluster
+----
++
+.Example output
++
+[source,terminal]
+----
+featuregate.config.openshift.io/cluster patched
+----
+
+. Confirm that the `OVNObservability` feature is enabled by entering the following command:
++
+[source,terminal]
+----
+$ oc get featuregate cluster -o yaml
+----
++
+.Example output
++
+[source,yaml]
+----
+  featureGates:
+# ...
+    enabled:
+    - name: OVNObservability
+----
+
+. Obtain a list of the pods inside of the namespace in which you have created one of the relevant network APIs by entering the following command. Note the `NODE` name of the pods, as they are used in the following step.
++
+[source,terminal]
+----
+$ oc get pods -n <namespace> -o wide
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME              READY   STATUS    RESTARTS   AGE     IP            NODE                                       NOMINATED NODE   READINESS GATES
+destination-pod   1/1     Running   0          53s     10.131.0.23   ci-ln-1gqp7b2-72292-bb9dv-worker-a-gtmpc   <none>           <none>
+source-pod        1/1     Running   0          56s     10.131.0.22   ci-ln-1gqp7b2-72292-bb9dv-worker-a-gtmpc   <none>           <none>
+----
+
+. Obtain a list of OVN-Kubernetes pods and locate the pod that shares the same `NODE` as the pods from the previous step by entering the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes -o wide
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME        
+...                             READY   STATUS    RESTARTS      AGE   IP           NODE                                       NOMINATED NODE   
+ovnkube-node-jzn5b              8/8     Running   1 (34m ago)   37m   10.0.128.2   ci-ln-1gqp7b2-72292-bb9dv-worker-a-gtmpc   <none>          
+...
+----
+
+. Open a bash shell inside of the `ovnkube-node` pod by entering the following command:
++
+[source,terminal]
+----
+$ oc exec -it <pod_name> -n openshift-ovn-kubernetes -- bash
+----
+
+. While inside of the `ovnkube-node` pod, you can run the `ovnkube-observ -add-ovs-collector` script to show network events using the OVS collector. For example:
++
+[source,terminal]
+----
+# /usr/bin/ovnkube-observ -add-ovs-collector
+----
++
+.Example output
++
+[source,terminal]
+----
+...
+2024/12/02 19:41:41.327584 OVN-K message: Allowed by default allow from local node policy, direction ingress
+2024/12/02 19:41:41.327593 src=10.131.0.2, dst=10.131.0.6
+
+2024/12/02 19:41:41.327692 OVN-K message: Allowed by default allow from local node policy, direction ingress
+2024/12/02 19:41:41.327715 src=10.131.0.6, dst=10.131.0.2
+...
+----
+
+. You can filter the content by type, such as source pods, by entering the following command with the `-filter-src-ip` flag and your pod's IP address. For example:
++
+[source,terminal]
+----
+# /usr/bin/ovnkube-observ -add-ovs-collector -filter-src-ip <pod_ip_address>
+----
++
+.Example output
++
+[source,terminal]
+----
+...
+Found group packets, id 14
+2024/12/10 16:27:12.456473 OVN-K message: Allowed by admin network policy allow-egress-group1, direction Egress
+2024/12/10 16:27:12.456570 src=10.131.0.22, dst=10.131.0.23
+
+2024/12/10 16:27:14.484421 OVN-K message: Allowed by admin network policy allow-egress-group1, direction Egress
+2024/12/10 16:27:14.484428 src=10.131.0.22, dst=10.131.0.23
+
+2024/12/10 16:27:12.457222 OVN-K message: Allowed by network policy test:allow-ingress-from-specific-pod, direction Ingress
+2024/12/10 16:27:12.457228 src=10.131.0.22, dst=10.131.0.23
+
+2024/12/10 16:27:12.457288 OVN-K message: Allowed by network policy test:allow-ingress-from-specific-pod, direction Ingress
+2024/12/10 16:27:12.457299 src=10.131.0.22, dst=10.131.0.23
+...
+----
++
+For a full list of flags that can be passed in with `/usr/bin/ovnkube-observ`, see "OVN-Kubernetes network traffic with OVS sampling flags".

--- a/modules/observability-ovs-sampling-flags.adoc
+++ b/modules/observability-ovs-sampling-flags.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="observability-ovs-sampling-flags_{context}"]
+= OVN-Kubernetes network traffic with OVS sampling flags
+
+The following flags are available to view OVN-Kubernetes network traffic by using the CLI. Append these flags to the following syntax in your terminal after you have opened a bash shell inside of the `ovnkube-node` pod:
+
+.Command syntax
+[source,terminal]
+----
+# /usr/bin/ovnkube-observ <flag>
+----
+
+[options="header",cols="1,3"]
+|===
+| Flag | Description
+
+| `-h` | Returns a complete list flags that can be used with the `usr/bin/ovnkube-observ` command.
+`
+|`-add-ovs-collector` | Add OVS collector to enable sampling. Use with caution. Make sure no one else is using observability.
+
+|`-enable-enrichment` | Enrich samples with NBDB data. Defaults to `true`.
+
+|`-filter-dst-ip` | Filter only packets to a given destination IP.
+
+|`-filter-src-ip` | Filters only packets from a given source IP.
+
+|`-log-cookie` | Print raw sample cookie with psample group_id.
+
+|`-output-file` | Output file to write the samples to.
+
+|`-print-full-packet` | Print full received packet. When false, only source and destination IPs are printed with every sample.
+
+|===

--- a/networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc
+++ b/networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc
@@ -27,6 +27,9 @@ include::modules/nw-ovn-kubernetes-change-log-levels.adoc[leveloffset=+2]
 
 include::modules/nw-ovn-kubernetes-pod-connectivity-checks.adoc[leveloffset=+1]
 
+include::modules/nw-ovn-kubernetes-observability.adoc[leveloffset=+1]
+include::modules/observability-ovs-sampling-flags.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 [id="additional-resources_ovn-kubernetes-sources-of-troubleshooting-information"]
 == Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-11793

Link to docs preview:
https://86079--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.html#nw-ovn-kubernetes-observability_ovn-kubernetes-sources-of-troubleshooting-information

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
