### PR TITLE
OCPBUGS-44663: modules/understanding-update-channels: Drop obsolete "up to a day"

### DIFF
--- a/modules/understanding-update-channels.adoc
+++ b/modules/understanding-update-channels.adoc
@@ -130,5 +130,5 @@ Changing your channel might impact the supportability of your cluster. The follo
 
 * You can switch from the `candidate-{product-version}` channel to the `fast-{product-version}` channel if your current release is a general availability release.
 
-* You can always switch from the `fast-{product-version}` channel to the `stable-{product-version}` channel. There is a possible delay of up to a day for the release to be promoted to `stable-{product-version}` if the current release was recently promoted.
+* You can always switch from the `fast-{product-version}` channel to the `stable-{product-version}` channel. There is a possible delay for the release to be promoted to `stable-{product-version}` if the current release was recently promoted.
 endif::openshift-origin[]


### PR DESCRIPTION
The text was originally from 1c199f19e0 (#19088).  When it landed, the file also included 42c10066ed (#18944)'s "can range from several hours to a day" in the `stable-*` channel section.  3e702f16d3 (#22816) later removed the "several hours to a day" from the `stable-*` channel section.

a8d3109ebe (#47333) added the "Choosing the correct channel for your cluster" section, with its "generally ... within a week or two", but missed removing the "up to a day" I'm removing now. a8d3109ebe added:

> Since the time required to obtain a significant number of data points varies based on many factors, Service LeveL Objective (SLO) is not offered for the delay duration between fast and stable channels. For more information, please see "Choosing the correct channel for your cluster"

This commit follows the example set by 3e702f16d3 and the lack-of-SLO described in a8d3109ebe by removing the duration text from the channel-changing section.

Version(s): 4.12 through main.  Not worth patching older, end-of-life releases.  Possibly not even worth patching 4.12?

Issue: https://issues.redhat.com/browse/OCPBUGS-44663

Link to docs preview: https://86088--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/understanding_updates/understanding-update-channels-release.html#switching-between-channels_understanding-update-channels-releases

QE review:
- [ ] QE has approved this change.
