### PR TITLE
Update machineconfig-garbage-collect-removing.adoc

### DIFF
--- a/modules/machineconfig-garbage-collect-removing.adoc
+++ b/modules/machineconfig-garbage-collect-removing.adoc
@@ -44,7 +44,7 @@ where:
 
 `--count`:: Optional: Specifies the maximum number of unused rendered machine configs you want to delete, starting with the oldest.
 
-`--confirm`:: Optional: Specifies the maximum number of unused rendered machine configs you want to delete, starting with the oldest.
+`--confirm`:: Optional: Indicate that pruning should occur, instead of performing a dry-run.
 
 `--pool-name`:: Optional: Specifies the machine config pool from which you want to delete the machine. If not specified, all the pools are evaluated.
 


### PR DESCRIPTION
Created new PR against `main`. [Original PR](https://github.com/openshift/openshift-docs/pull/85934) is against `enterprise-4.16`.
*****
`confirm` description is currently just a duplicate of the `count` description. Borrow the description from the Pruning Objects page.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change. See https://github.com/openshift/openshift-docs/pull/85934
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
