### PR TITLE
CNF-13831 - TELCODOCS-1871 - Configuring RDMA CNI for SR-IOV

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1550,6 +1550,8 @@ Topics:
     File: configuring-sriov-net-attach
   - Name: Configuring an SR-IOV InfiniBand network attachment
     File: configuring-sriov-ib-attach
+  - Name: Configuring an RDMA subsytem for SR-IOV
+    File: configuring-sriov-rdma-cni
   - Name: Adding a pod to an SR-IOV network
     File: add-pod
   - Name: Configuring interface-level network sysctl settings and all-multicast mode for SR-IOV networks

--- a/modules/nw-configuring-sriov-rdma-cni.adoc
+++ b/modules/nw-configuring-sriov-rdma-cni.adoc
@@ -1,0 +1,164 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-rdma-cni.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-sriov-configuring-sriov-rdma-cni_{context}"]
+= Configuring SR-IOV RDMA CNI
+
+Configure an RDMA CNI on SR-IOV.
+
+[NOTE]
+====
+This procedure applies only to Mellanox devices.
+====
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the SR-IOV Network Operator.
+
+.Procedure
+
+. Create an `SriovNetworkPoolConfig` CR and save it as `sriov-nw-pool.yaml`, as shown in the following example:
++
+.Example `SriovNetworkPoolConfig` CR
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkPoolConfig
+metadata:
+  name: worker
+  namespace: openshift-sriov-network-operator
+spec:
+  maxUnavailable: 1 
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker: ""
+  rdmaMode: exclusive <1>
+----
+<1> Set RDMA network namespace mode to `exclusive`.
+
+. Create the `SriovNetworkPoolConfig` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-nw-pool.yaml
+----
+
+. Create an `SriovNetworkNodePolicy` CR and save it as `sriov-node-policy.yaml`, as shown in the following example: 
++
+.Example `SriovNetworkNodePolicy` CR
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: sriov-nic-pf1
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: netdevice
+  isRdma: true <1>
+  nicSelector:
+    pfNames: ["ens3f0np0"]
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  numVfs: 4
+  priority: 99
+  resourceName: sriov_nic_pf1
+----
+<1> Activate RDMA mode.
+
+. Create the `SriovNetworkNodePolicy` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-node-policy.yaml
+----
+
+. Create an `SriovNetwork` CR and save it as `sriov-network.yaml`, as shown in the following example: 
++
+.Example `SriovNetwork` CR
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-nic-pf1
+  namespace: openshift-sriov-network-operator
+spec:
+  networkNamespace: sriov-tests
+  resourceName: sriov_nic_pf1
+    ipam: |- 
+  metaPlugins: |
+    {
+      "type": "rdma" <1>
+    }
+----
+<1> Create the RDMA plugin.
+
+. Create the `SriovNetwork` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-network.yaml
+----
+
+.Verification
+
+. Create a  `Pod` CR and save it as `sriov-test-pod.yaml`, as shown in the following example: 
++
+.Example runtime configuration
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sample-pod
+  annotations:
+    k8s.v1.cni.cncf.io/networks: |-
+      [
+        {
+          "name": "net1",
+          "mac": "20:04:0f:f1:88:01",
+          "ips": ["192.168.10.1/24", "2001::1/64"]
+        }
+      ]
+spec:
+  containers:
+  - name: sample-container
+    image: <image>
+    imagePullPolicy: IfNotPresent
+    command: ["sleep", "infinity"]
+----
+
+. Create the test pod by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-test-pod.yaml
+----
+
+. Log in to the test pod by running the following command:
++
+[source,terminal]
+----
+$ oc rsh testpod1 -n sriov-tests
+----
+
+. Verify that the path to the `hw-counters` directory exists by running the following command:
++
+[source,terminal]
+----
+$ ls /sys/bus/pci/devices/${PCIDEVICE_OPENSHIFT_IO_SRIOV_NIC_PF1}/infiniband/*/ports/1/hw_counters/
+----
++
+.Example output
+[source,terminal]
+----
+duplicate_request       out_of_buffer req_cqe_flush_error           resp_cqe_flush_error        roce_adp_retrans        roce_slow_restart_trans
+implied_nak_seq_err     out_of_sequence req_remote_access_errors    resp_local_length_error     roce_adp_retrans_to     rx_atomic_requests
+lifespan                packet_seq_err req_remote_invalid_request   resp_remote_access_errors   roce_slow_restart       rx_read_requests
+local_ack_timeout_err  req_cqe_error resp_cqe_error                 rnr_nak_retry_err           roce_slow_restart_cnps  rx_write_requests
+----

--- a/networking/hardware_networks/configuring-sriov-rdma-cni.adoc
+++ b/networking/hardware_networks/configuring-sriov-rdma-cni.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-sriov-rdma-cni"]
+= Configuring an RDMA subsytem for SR-IOV
+include::_attributes/common-attributes.adoc[]
+:context: configuring-sriov-rdma-cni
+
+toc::[]
+
+Remote Direct Memory Access (RDMA) allows direct memory access between two systems without involving the operating system of either system.
+You can configure an RDMA Container Network Interface (CNI) on Single Root I/O Virtualization (SR-IOV) to enable high-performance, low-latency communication between containers.
+When you combine RDMA with SR-IOV, you provide a mechanism to expose hardware counters of Mellanox Ethernet devices for use inside  Data Plane Development Kit (DPDK)    applications.
+
+include::modules/nw-configuring-sriov-rdma-cni.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[CNF-13831](https://issues.redhat.com//browse/CNF-13831) - [TELCODOCS-1871](https://issues.redhat.com//browse/TELCODOCS-1871) - Configuring RDMA CNI for SR-IOV
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1871
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Configuring an RDMA CNI for SR-IOV](https://86101--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-rdma-cni.html) 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
