### PR TITLE
OSSM-6856: Operator API Reference Documentation

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -42,6 +42,8 @@
 :TempoShortName: distributed tracing platform (Tempo)
 :TempoOperator: Tempo Operator
 :TempoVersion: 2.1.1
+//sail 
+:sail-operator: Sail Operator
 //gitops
 :gitops-title: Red{nbsp}Hat OpenShift GitOps
 :gitops-shortname: GitOps

--- a/install/ossm-installing-openshift-service-mesh.adoc
+++ b/install/ossm-installing-openshift-service-mesh.adoc
@@ -11,6 +11,7 @@ Installing {ocp-short-name} {SMProductShortName} consists of three main tasks: i
 include::modules/ossm-about-deploying-istio-using-service-mesh-operator.adoc[leveloffset=+1]
 include::modules/ossm-about-deployment-and-update-strategies.adoc[leveloffset=+2]
 include::modules/ossm-installing-operator.adoc[leveloffset=+1]
+include::modules/ossm-about-service-mesh-custom-resource-definitions.adoc[leveloffset=+2]
 include::modules/ossm-about-istio-deployment.adoc[leveloffset=+1]
 include::modules/ossm-creating-istio-project-using-console.adoc[leveloffset=+2]
 include::modules/ossm-creating-istio-resource-using-console.adoc[leveloffset=+2]

--- a/modules/ossm-about-service-mesh-custom-resource-definitions.adoc
+++ b/modules/ossm-about-service-mesh-custom-resource-definitions.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+// * install/ossm-installing-openshift-service-mesh.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-about-service-mesh-custom-resource-definitions_{context}"]
+= About Service Mesh custom resource definitions
+
+Installing the {SMProductName} Operator also installs custom resource definitions (CRD) that administrators can use to configure {istio} for {SMProductShortName} installations. The {olm-first} installs two categories of CRDs: {sail-operator} CRDs and {istio} CRDs.
+
+{sail-operator} CRDs define custom resources for installing and maintaining the {istio} components required to operate a service mesh. These custom resources belong to the `sailoperator.io` API group and include the `Istio`, `IstioRevision`, `IstioCNI`, and `ZTunnel` resource kinds. For more information on how to configure these resources, see the `sailoperator.io` link:https://github.com/istio-ecosystem/sail-operator/blob/main/docs/api-reference/sailoperator.io.md[API reference] documentation.
+
+{istio} CRDs are associated with mesh configuration and service management. These CRDs define custom resources in several `istio.io` API groups, such as `networking.istio.io` and `security.istio.io`. The CRDs also include various resource kinds, such as `AuthorizationPolicy`, `DestinationRule`, and `VirtualService`, that administrators use to configure a service mesh.


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue:
https://issues.redhat.com/browse/OSSM-6856
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://86115--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#ossm-about-service-mesh-custom-resource-definitions_ossm-installing-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
