### PR TITLE
[enterprise-4.16] Cherry-pick of OBSDOCS-1317: Add docs for the OTLP JSON File Receiver

### DIFF
--- a/observability/otel/otel-collector/otel-collector-receivers.adoc
+++ b/observability/otel/otel-collector/otel-collector-receivers.adoc
@@ -352,6 +352,29 @@ include::snippets/technology-preview.adoc[]
 <3> The lnterval for scraping the metrics data. Accepts time units. The default value is `1m`.
 <4> The targets at which the metrics are exposed. This example scrapes the metrics from a `my-app` application in the `example` project.
 
+[id="otlpjsonfile-receiver_{context}"]
+== OTLP JSON File Receiver
+
+The OTLP JSON File Receiver extracts pipeline information from files containing data in the link:https://protobuf.dev/programming-guides/json/[ProtoJSON] format and conforming to the link:https://opentelemetry.io/docs/specs/otel/protocol/[OpenTelemetry Protocol] specification. The receiver watches a specified directory for changes such as created or modified files to process.
+
+:FeatureName: The OTLP JSON File Receiver
+include::snippets/technology-preview.adoc[]
+
+.OpenTelemetry Collector custom resource with the enabled OTLP JSON File Receiver
+[source,yaml]
+----
+# ...
+  config: |
+    otlpjsonfile:
+      include:
+        - "/var/log/*.log" # <1>
+      exclude:
+        - "/var/log/test.log" # <2>
+# ...
+----
+<1> The list of file path glob patterns to watch.
+<2> The list of file path glob patterns to ignore.
+
 [id="zipkin-receiver_{context}"]
 == Zipkin Receiver
 


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-docs/pull/84251

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1317
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: See https://github.com/openshift/openshift-docs/pull/84251.
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
