### PR TITLE
OCPBUGS-44063: Removing RHEL 9.2 update requirement 4.15+

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -242,7 +242,7 @@ For {product-title} version 4.18, RHCOS is based on RHEL version 9.4, which upda
 * IBM Power architecture requires Power 9 ISA
 * s390x architecture requires z14 ISA
 
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#architectures[RHEL Architectures].
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.2_release_notes/index#architectures[Architectures] ({op-system-base} documentation).
 ====
 
 ifdef::azure[]

--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -44,7 +44,7 @@ You must ensure that the time on your ESXi hosts is synchronized before you inst
 
 |CPU micro-architecture
 |x86-64-v2 or higher
-|OpenShift 4.13 and later are based on RHEL 9.2 host operating system which raised the microarchitecture requirements to x86-64-v2. See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#architectures[RHEL Microarchitecture requirements documentation]. You can verify compatibility by following the procedures outlined in link:https://access.redhat.com/solutions/7052996[this KCS article].
+|{product-title} version 4.13 and later are based on the {op-system-base} 9.2 host operating system, which raised the microarchitecture requirements to x86-64-v2. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.2_release_notes/index#architectures[Architectures] in the {op-system-base} documentation.
 |===
 
 [IMPORTANT]

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -14,16 +14,6 @@ To do: Remove this comment once 4.13 docs are EOL.
 
 Learn more about administrative tasks that cluster admins must perform to successfully initialize an update, as well as optional guidelines for ensuring a successful update.
 
-[id="rhel-micro-architecture-update-requirements"]
-== {op-system-base} 9.2 micro-architecture requirement change
-
-{product-title} is now based on the {op-system-base} 9.2 host operating system. The micro-architecture requirements are now increased to x86_64-v2, Power9, and Z14. See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#architectures[RHEL micro-architecture requirements documentation]. You can verify compatibility before updating by following the procedures outlined in this link:https://access.redhat.com/solutions/7052996[KCS article].
-
-[IMPORTANT]
-====
-Without the correct micro-architecture requirements, the update process will fail. Make sure you purchase the appropriate subscription for each architecture. For more information, see link:https://access.redhat.com/products/red-hat-enterprise-linux#addl-arch[Get Started with Red Hat Enterprise Linux - additional architectures]
-====
-
 [id="kube-api-removals_{context}"]
 == Kubernetes API removals
 


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OCPBUGS-44063](https://issues.redhat.com/browse/OCPBUGS-44063)

Link to docs preview:
https://86171--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html

https://86171--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations.html#installation-minimum-resource-requirements_installing-aws-customizations

https://86171--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html#installation-vsphere-infrastructure_upi-vsphere-installation-reqs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
