### PR TITLE
Updated the instructions to include gettext on MacOS

### DIFF
--- a/scripts/prow/README.adoc
+++ b/scripts/prow/README.adoc
@@ -5,11 +5,11 @@ The script uses the `./openshift-openshift-docs-BRANCH.yaml` template file to cr
 After you create the job config, you run the CI make jobs to create the Prow jobs.
 Then, open a pull request against the https://github.com/openshift/release repository to make the Prow job live for that branch.
 
-To add a new job to Prow CI, do the following:
+.Prerequisites
 
 . Install link:https://podman.io/docs/installation[Podman].
 
-. Fork and clone the https://github.com/openshift/release repository to `$HOME/release`.
+. Fork and clone the https://github.com/openshift/release repository to `$HOME/release` and create a new branch.
 +
 [NOTE]
 ====
@@ -27,9 +27,21 @@ git checkout <your_new_branch> <1>
 ----
 <1> Replace `<your_new_branch>` with an appropriate branch name.
 ====
+. On MacOS, you must install the `gettext` package.
++
+[source,terminal]
+----
+brew install gettext
+brew link --force gettext
+----
 
-. Create the new branch config by running the `add-new-prow-config.sh` script passing the `$VERSION`, `$BRANCH` and `$DISTROS` variables.
-Open a shell prompt in the `openshift-docs/` directory, and run the script passing in the required variables, for example:
+.Procedure
+
+To add a new job to Prow CI, run the following commands:
+
+. Switch to you `openshift-docs` directory.
+
+. Create the new branch config by running the `add-new-prow-config.sh` script passing the `$VERSION`, `$BRANCH` and `$DISTROS` variables, for example:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Script fails on MacOS with the message `./scripts/prow/add-new-prow-config.sh: line 35: envsubst: command not found`. The updated instructions include installation of `gettext` which includes `envsubst`.