### PR TITLE
OBSDOCS-1542 - Logging 5.6.27 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-6-27.adoc
+++ b/modules/logging-release-notes-5-6-27.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+// logging-5-6-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-6-27_{context}"]
+= Logging 5.6.27
+This release includes link:https://access.redhat.com/errata/RHBA-2024:10988[RHBA-2024:10988].
+
+[id="logging-release-notes-5-6-27-bug-fixes_{context}"]
+== Bug fixes
+None.
+
+[id="logging-release-notes-5-6-27-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2018-12699[CVE-2018-12699]
+* link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]
+* link:https://access.redhat.com/security/cve/CVE-2024-3596[CVE-2024-3596]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+* link:https://access.redhat.com/security/cve/CVE-2024-10041[CVE-2024-10041]
+* link:https://access.redhat.com/security/cve/CVE-2024-10963[CVE-2024-10963]
+* link:https://access.redhat.com/security/cve/CVE-2024-27043[CVE-2024-27043]
+* link:https://access.redhat.com/security/cve/CVE-2024-27399[CVE-2024-27399]
+* link:https://access.redhat.com/security/cve/CVE-2024-38564[CVE-2024-38564]
+* link:https://access.redhat.com/security/cve/CVE-2024-46858[CVE-2024-46858]
+* link:https://access.redhat.com/security/cve/CVE-2024-50602[CVE-2024-50602]

--- a/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-6-27.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-6-26.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-6-25.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging 5.6.27 Release Notes

Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1542

Fix Version: 4.13 and 4.12

Doc Preview: 
https://86190--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-6-release-notes.html
SME Review:
QE Review:
Peer Review: