### PR TITLE
OBSDOCS-1543 - Logging 5.8.16 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-8-16.adoc
+++ b/modules/logging-release-notes-5-8-16.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-16_{context}"]
+= Logging 5.8.16
+This release includes link:https://access.redhat.com/errata/RHBA-2024:10989[RHBA-2024:10989].
+
+[id="logging-release-notes-5-8-16-bug-fixes_{context}"]
+== Bug fixes
+None.
+
+[id="openshift-logging-5-8-16-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]
+* link:https://access.redhat.com/security/cve/CVE-2024-10041[CVE-2024-10041]
+* link:https://access.redhat.com/security/cve/CVE-2024-10963[CVE-2024-10963]
+* link:https://access.redhat.com/security/cve/CVE-2024-50602[CVE-2024-50602]


### PR DESCRIPTION
Change type: Doc update; Logging 5.8.16 Release Notes

Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1543

Fix Version: 4.12, 4.13, 4.14, 4.15

Doc Preview:
https://86191--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes
SME Review:
QE Review:
Peer Review: