### PR TITLE
Telcodocs 2141 416 Adding note for OCPBUGS-45983

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3280,6 +3280,8 @@ Until this limitation is addressed, T-GM does not support PTP clock holdover sta
 
 * When a worker node's Topology Manager policy is changed, the NUMA-aware secondary pod scheduler does not respect this change, which can result in incorrect scheduling decisions and unexpected topology affinity errors. As a workaround, restart the NUMA-aware scheduler by deleting the NUMA-aware scheduler pod. (link:https://issues.redhat.com/browse/OCPBUGS-34583[*OCPBUGS-34583*])
 
+* If you plan to deploy the NUMA Resources Operator, avoid using {product-title} versions 4.16.25 or 4.16.26. (link:https://issues.redhat.com/browse/OCPBUGS-45983[*OCPBUGS-45983*])
+
 * Due to an issue with Kubernetes, the CPU Manager is unable to return CPU resources from the last pod admitted to a node to the pool of available CPU resources. These resources are allocatable if a subsequent pod is admitted to the node. However, this pod then becomes the last pod, and again, the CPU manager cannot return this pod's resources to the available pool.
 +
 This issue affects CPU load balancing features, which depend on the CPU Manager releasing CPUs to the available pool. Consequently, non-guaranteed pods might run with a reduced number of CPUs. As a workaround, schedule a pod with a `best-effort` CPU Manager policy on the affected node. This pod will be the last admitted pod and this ensures the resources will be correctly released to the available pool. (link:https://issues.redhat.com/browse/OCPBUGS-17792[*OCPBUGS-17792*])


### PR DESCRIPTION
[OCPBUGS-45983]: RTE pods fail to start due to selinux issues

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-45983 tracking https://issues.redhat.com/browse/TELCODOCS-2141
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://86192--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
