### PR TITLE
Telcodocs 2141 417 Adding OCPBUGS-45639 

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2831,6 +2831,8 @@ As a temporary workaround, the image registry should not be configured as privat
 
 * Each node group must only match one `MachineConfigPool` object. In some cases, the NUMA Resources Operator can allow a configuration where a node group matches more than one `MachineConfigPool` object. This issue could lead to unexpected behavior in resource management. (link:https://issues.redhat.com/browse/OCPBUGS-42523[*OCPBUGS-42523*])
 
+* If you plan to deploy the NUMA Resources Operator, avoid using {product-title} versions 4.17.7 or 4.17.8. (link:https://issues.redhat.com/browse/OCPBUGS-45639[*OCPBUGS-45639*])
+
 * When the bond mode in the `NetworkNodeConfigurationPolicy` is changed from `balance-rr` to `active-backup` on kernel bonds that are attached to the `br-ex` interface, the change might fail on arbitrary nodes. As a workaround, create a `NetworkNodeConfigurationPolicy` object without specifying the bond port configuration. (link:https://issues.redhat.com/browse/OCPBUGS-42031[*OCPBUGS-42031*])
 
 [id="ocp-storage-core-4-17-known-issues_{context}"]


### PR DESCRIPTION
[OCPBUGS-45639]: RTE pods fail to start due to selinux issues

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-45639 tracking https://issues.redhat.com/browse/TELCODOCS-2141
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://86212--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->