### PR TITLE
OSDOCS-12570: CAS scaleup limitations

### DIFF
--- a/modules/cluster-autoscaler-about.adoc
+++ b/modules/cluster-autoscaler-about.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * nodes/nodes-about-autoscaling-nodes.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 // * machine_management/applying-autoscaling.adoc
 // * osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.adoc
 // * osd_cluster_admin/osd-cluster-autoscaling.adoc
@@ -29,6 +28,10 @@ on all nodes the cluster, even though it does not manage the control plane nodes
 Ensure that the `maxNodesTotal` value in the `ClusterAutoscaler` resource definition that you create is large enough to account for the total possible number of machines in your cluster. This value must encompass the number of control plane machines and the possible number of compute machines that you might scale to.
 ====
 
+[discrete]
+[id="cluster-autoscaler-scale-down_{context}"]
+== Automatic node removal
+
 Every 10 seconds, the cluster autoscaler checks which nodes are unnecessary in the cluster and removes them. The cluster autoscaler considers a node for removal if the following conditions apply:
 
 * The node utilization is less than the _node utilization level_ threshold for the cluster. The node utilization level is the sum of the requested resources divided by the allocated resources for the node. If you do not specify a value in the `ClusterAutoscaler` custom resource, the cluster autoscaler uses a default value of `0.5`, which corresponds to 50% utilization.
@@ -47,6 +50,10 @@ If the following types of pods are present on a node, the cluster autoscaler wil
 
 For example, you set the maximum CPU limit to 64 cores and configure the cluster autoscaler to only create machines that have 8 cores each. If your cluster starts with 30 cores, the cluster autoscaler can add up to 4 more nodes with 32 cores, for a total of 62.
 
+[discrete]
+[id="cluster-autoscaler-limitations_{context}"]
+== Limitations
+
 If you configure the cluster autoscaler, additional usage restrictions apply:
 
 * Do not modify the nodes that are in autoscaled node groups directly. All nodes within the same node group have the same capacity and labels and run the same system pods.
@@ -55,13 +62,21 @@ If you configure the cluster autoscaler, additional usage restrictions apply:
 * Confirm that your cloud provider quota is large enough to support the maximum node pools that you configure.
 * Do not run additional node group autoscalers, especially the ones offered by your cloud provider.
 
+[NOTE]
+====
+The cluster autoscaler only adds nodes in autoscaled node groups if doing so would result in a schedulable pod.
+If the available node types cannot meet the requirements for a pod request, or if the node groups that could meet these requirements are at their maximum size, the cluster autoscaler cannot scale up.
+====
+
+[discrete]
+[id="cluster-autoscaler-interaction_{context}"]
+== Interaction with other scheduling features
+
 The horizontal pod autoscaler (HPA) and the cluster autoscaler modify cluster resources in different ways. The HPA changes the deployment's or replica set's number of replicas based on the current CPU load. If the load increases, the HPA creates new replicas, regardless of the amount of resources available to the cluster. If there are not enough resources, the cluster autoscaler adds resources so that the HPA-created pods can run. If the load decreases, the HPA stops some replicas. If this action causes some nodes to be underutilized or completely empty, the cluster autoscaler deletes the unnecessary nodes.
 
 The cluster autoscaler takes pod priorities into account. The Pod Priority and Preemption feature enables scheduling pods based on priorities if the cluster does not have enough resources, but the cluster autoscaler ensures that the cluster has resources to run all pods. To honor the intention of both features, the cluster autoscaler includes a priority cutoff function. You can use this cutoff to schedule "best-effort" pods, which do not cause the cluster autoscaler to increase resources but instead run only when spare resources are available.
 
 Pods with priority lower than the cutoff value do not cause the cluster to scale up or prevent the cluster from scaling down. No new nodes are added to run the pods, and nodes running these pods might be deleted to free resources.
-
-Cluster autoscaling is supported for the platforms that have machine API available on it.
 
 ////
 Default priority cutoff is 0. It can be changed using `--expendable-pods-priority-cutoff` flag, but we discourage it. cluster autoscaler also doesn't trigger scale-up if an unschedulable Pod is already waiting for a lower priority Pod preemption.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-12570](https://issues.redhat.com//browse/OSDOCS-12570)

Link to docs preview:
[About the cluster autoscaler](https://86239--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#cluster-autoscaler-about_applying-autoscaling)

QE review:
- [x] QE has approved this change.

Additional information:
Added note per ticket, added subheadings to better organize the "About" section