### PR TITLE
OCPBUGS#44745 Adding missing untagResources aws permission

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -278,6 +278,12 @@ If you use an existing VPC, your account does not require these permissions to d
 * `iam:UntagRole`
 ====
 
+.Required permissions to delete a cluster with shared instance profiles
+[%collapsible]
+====
+* `tag:UntagResources`
+====
+
 .Additional IAM and S3 permissions that are required to create manifests
 [%collapsible]
 ====


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-44745

Link to docs preview:
https://86241--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions_installing-aws-account

QE review:
- [x] QE has approved this change.
