### PR TITLE
OSDOCS-12755 adding admonition to only use marketplace images for compute nodes

### DIFF
--- a/modules/installation-aws-marketplace-subscribe.adoc
+++ b/modules/installation-aws-marketplace-subscribe.adoc
@@ -27,6 +27,13 @@ endif::[]
 = Obtaining an AWS Marketplace image
 If you are deploying an {product-title} cluster using an AWS Marketplace image, you must first subscribe through AWS. Subscribing to the offer provides you with the AMI ID that the installation program uses to deploy compute nodes.
 
+:platform-abbreviation: an AWS
+:platform-abbreviation-short: AWS
+[NOTE]
+====
+include::snippets/installation-marketplace-note.adoc[]
+====
+
 .Prerequisites
 
 * You have an AWS account to purchase the offer. This account does not have to be the same account that is used to install the cluster.

--- a/modules/installation-azure-marketplace-subscribe.adoc
+++ b/modules/installation-azure-marketplace-subscribe.adoc
@@ -41,9 +41,14 @@ endif::mapi[]
 * The offer includes a `rh-ocp-worker` SKU and a `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker` SKU represents a Hyper-V generation version 2 VM image. The default instance types used in {product-title} are version 2 compatible. If you plan to use an instance type that is only version 1 compatible, use the image associated with the `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker-gen1` SKU represents a Hyper-V version 1 VM image.
 //What happens with control plane machines? "worker" SKU seems incorrect
 
+:platform-abbreviation: an Azure
+:platform-abbreviation-short: Azure
+
 [IMPORTANT]
 ====
 Installing images with the Azure marketplace is not supported on clusters with 64-bit ARM instances.
+
+include::snippets/installation-marketplace-note.adoc[]
 ====
 
 .Prerequisites

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1697,7 +1697,7 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
     defaultMachinePlatform:
       osImage:
         publisher:
-|Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane and compute machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for both types of machines.
+|Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane and compute machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for both types of machines. Control plane machines do not contribute to licensing costs when using the default image, but if you apply an Azure Marketplace image for a control plane machine, usage costs will apply.
 |String. The name of the image publisher.
 
 |platform:
@@ -1793,7 +1793,7 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
     azure:
       osImage:
         publisher:
-|Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for control plane machines only.
+|Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for control plane machines only. Control plane machines do not contribute to licensing costs when using the default image, but if you apply an Azure Marketplace image for a control plane machine, usage costs will apply.
 |String. The name of the image publisher.
 
 |controlPlane:
@@ -2133,7 +2133,7 @@ Additional GCP configuration parameters are described in the following table:
     gcp:
       osImage:
         project:
-|Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by specifying the location of a custom {op-system} image that the installation program is to use for control plane machines only.
+|Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by specifying the location of a custom {op-system} image that the installation program is to use for control plane machines only. Control plane machines do not contribute to licensing costs when using the default image, but if you apply a GCP Marketplace image for a control plane machine, usage costs will apply.
 |String. The name of GCP project where the image is located.
 
 |controlPlane:

--- a/modules/installation-gcp-marketplace.adoc
+++ b/modules/installation-gcp-marketplace.adoc
@@ -10,6 +10,14 @@ Using the GCP Marketplace offering lets you deploy an {product-title} cluster, w
 
 By default, the installation program downloads and installs the {op-system-first} image that is used to deploy compute machines. To deploy an {product-title} cluster using an {op-system} image from the GCP Marketplace, override the default behavior by modifying the `install-config.yaml` file to reference the location of GCP Marketplace offer.
 
+:platform-abbreviation: a GCP
+:platform-abbreviation-short: GCP
+
+[NOTE]
+====
+include::snippets/installation-marketplace-note.adoc[]
+====
+
 .Prerequisites
 
 * You have an existing `install-config.yaml` file.

--- a/snippets/installation-marketplace-note.adoc
+++ b/snippets/installation-marketplace-note.adoc
@@ -1,0 +1,12 @@
+// Text snippet included in the following modules:
+//
+// * modules/installation-aws-marketplace-subscribe.adoc
+// * modules/installation-azure-marketplace-subscribe.adoc
+// * modules/installation-gcp-marketplace.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+You should only modify the {op-system} image for compute machines to use {platform-abbreviation} Marketplace image. Control plane machines and infrastructure nodes do not require an {product-title} subscription and use the public RHCOS default image by default, which does not incur subscription costs on your {platform-abbreviation-short} bill. Therefore, you should not modify the cluster default boot image or the control plane boot images. Applying the {platform-abbreviation-short} Marketplace image to them will incur additional licensing costs that cannot be recovered.
+
+:!platform-abbreviation:
+:!platform-abbreviation-short:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-12755

Link to docs preview:
AWS: 
[Marketplace install content](https://86242--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations#installation-aws-marketplace-subscribe_installing-aws-customizations)
Azure: 
[Marketplace install content](https://86242--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-customizations#installation-azure-marketplace-subscribe_installing-azure-customizations)
[Install config parameters](https://86242--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure#installation-configuration-parameters-additional-azure_installation-config-parameters-azure)
GCP: 
[Marketplace install content](https://86242--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-gcp-marketplace_installing-gcp-customizations)
[Install config parameters](https://86242--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp)
QE review:
- [x] QE has approved this change.
