### PR TITLE
OSDOCS#12785: node adding enhancements

### DIFF
--- a/modules/adding-node-iso-configs.adoc
+++ b/modules/adding-node-iso-configs.adoc
@@ -68,15 +68,21 @@ For more information, see "Root device hints" in the "Setting up the environment
 The configuration must match the Host Network Management API defined in the link:https://nmstate.io/[nmstate documentation].
 |A dictionary of host network configuration objects.
 
-|cpuArchitecture
+|cpuArchitecture:
 |Optional.
 Specifies the architecture of the nodes you are adding.
 This parameter allows you to override the default value from the cluster when required.
 |String.
 
-|sshKey
+|sshKey:
 |Optional.
 The file containing the SSH key to authenticate access to your cluster machines.
+|String.
+
+|bootArtifactsBaseURL:
+|Optional.
+Specifies the URL of the server to upload Preboot Execution Environment (PXE) assets to when you are generating an iPXE script.
+You must also set the `--pxe` flag to generate PXE assets instead of an ISO image.
 |String.
 
 |====
@@ -112,12 +118,23 @@ This path is also used to store the generated artifacts.
 |The name of the generated output image.
 |String
 
+|`p`, `--pxe`
+|Generates Preboot Execution Environment (PXE) assets instead of a bootable ISO file.
+
+When this flag is set, you can also use the `bootArtifactsBaseURL` parameter in the `nodes-config.yaml` file to specify URL of the server you will upload PXE assets to.
+|Boolean
+
 |`-a`, `--registry-config`
 |The path to your registry credentials.
 Alternatively, you can specify the `REGISTRY_AUTH_FILE` environment variable.
 The default paths are `${XDG_RUNTIME_DIR}/containers/auth.json`, `/run/containers/${UID}/auth.json`, `${XDG_CONFIG_HOME}/containers/auth.json`, `${DOCKER_CONFIG}`, `~/.docker/config.json`, `~/.dockercfg.`
 The order can be changed through the deprecated `REGISTRY_AUTH_PREFERENCE` environment variable to a "docker" value, in order to prioritize Docker credentials over Podman.
 |String
+
+|`-r`, `--report`
+|Generates a report of the node creation process regardless of whether the process is successful or not.
+If you do not specify this flag, reports are generated only in cases of failure.
+|Boolean
 
 |`--skip-verification`
 |An option to skip verifying the integrity of the retrieved content.


### PR DESCRIPTION
[OSDOCS-12785](https://issues.redhat.com/browse/OSDOCS-12785)

Version(s): 4.18+

This PR adds enhancements to the node adding procedure introduced in 4.17


QE review:
- [x] QE has approved this change.

Preview: 

- [Command flag options](https://86243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso.html#adding-node-iso-flags-config_adding-node-iso)
- [YAML file parameters](https://86243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso.html#adding-node-iso-yaml-config_adding-node-iso)