### PR TITLE
OSDOCS-12822 Added Tag User role to GCP perms

### DIFF
--- a/modules/installation-gcp-permissions.adoc
+++ b/modules/installation-gcp-permissions.adoc
@@ -34,6 +34,7 @@ When you attach the `Owner` role to the service account that you create, you gra
 
 .Required roles for using the Cloud Credential Operator in passthrough mode
 * Compute Load Balancer Admin
+* Tag User
 
 ifdef::template[]
 .Required roles for user-provisioned GCP infrastructure


### PR DESCRIPTION
Version(s):
4.17+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-12822

Link to docs preview:
https://86244--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-permissions_installing-gcp-account

QE review:
- [x] QE has approved this change.
