### PR TITLE
OSDOCS-12904: Separate MAPI feature intros from procs

### DIFF
--- a/_unused_topics/machine-set-CLOUD-options-FEATURE.adoc
+++ b/_unused_topics/machine-set-CLOUD-options-FEATURE.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-CLOUD.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-CLOUD.adoc
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:mapi:
+endif::[]
+ifdef::mapi[]
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+endif::mapi[]
+
+ifeval::["{context}" == "capi-compute-config-options-CLOUD"]
+:capi:
+endif::[]
+ifdef::capi[]
+:machine-set: compute machine set
+:api-name: Cluster API
+:api-group: cluster.x-k8s.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-cluster-api
+endif::capi[]
+
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:cpmso:
+endif::[]
+ifdef::cpmso[]
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+endif::cpmso[]
+
+:_mod-docs-content-type: REFERENCE
+[id="machine-set-CLOUD-options-FEATURE_{context}"]
+= FEATURE configuration options
+
+The {machine-set} custom resource (CR) can include parameters for FEATURE.
+
+.FEATURE 
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {api-group}/{api-version}
+kind: {api-kind}
+# ...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          featureKey: <feature_value> # <1>
+# ...
+----
+<1> Specifies a FEATURE VALUE.
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:!mapi:
+endif::[]
+ifeval::["{context}" == "mcpi-compute-config-options-CLOUD"]
+:!capi:
+endif::[]
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:!cpmso:
+endif::[]

--- a/_unused_topics/machine-set-CLOUD-using-FEATURE.adoc
+++ b/_unused_topics/machine-set-CLOUD-using-FEATURE.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-CLOUD.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-CLOUD.adoc
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:mapi:
+endif::[]
+ifdef::mapi[]
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+endif::mapi[]
+
+ifeval::["{context}" == "capi-compute-config-options-CLOUD"]
+:capi:
+endif::[]
+ifdef::capi[]
+:machine-set: compute machine set
+:api-name: Cluster API
+:api-group: cluster.x-k8s.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-cluster-api
+endif::capi[]
+
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:cpmso:
+endif::[]
+ifdef::cpmso[]
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+endif::cpmso[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="machine-set-CLOUD-using-FEATURE_{context}"]
+= Using FEATURE
+
+You can configure a {machine-set} to FEATURE.
+
+.Prerequisites
+
+* Prereq
+
+.Procedure
+
+. Step 1
+
+.Verification
+
+* Verification
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:!mapi:
+endif::[]
+ifeval::["{context}" == "mcpi-compute-config-options-CLOUD"]
+:!capi:
+endif::[]
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:!cpmso:
+endif::[]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-aws.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-aws.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-aws"]
-= Control plane configuration options for Amazon Web Services
+= Compute configuration options for Amazon Web Services
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-aws
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-azure.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-azure.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-azure"]
-= Control plane configuration options for Microsoft Azure
+= Compute configuration options for Microsoft Azure
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-azure
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-gcp.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-gcp.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-gcp"]
-= Control plane configuration options for Google Cloud Platform
+= Compute configuration options for Google Cloud Platform
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-gcp
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-nutanix.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-nutanix.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-nutanix"]
-= Control plane configuration options for Nutanix
+= Compute configuration options for Nutanix
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-nutanix
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-openstack.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-openstack.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-openstack"]
-= Control plane configuration options for Red Hat OpenStack Platform
+= Compute configuration options for Red Hat OpenStack Platform
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-openstack
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-vsphere.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-vsphere.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-vsphere"]
-= Control plane configuration options for VMware vSphere
+= Compute configuration options for VMware vSphere
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-vsphere
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Assigning machines to placement groups by using machine sets
 include::modules/machineset-aws-existing-placement-group.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Enabling Azure boot diagnostics on compute machines
 include::modules/machineset-azure-boot-diagnostics.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Selecting an Azure Marketplace image
 include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
@@ -19,7 +19,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 // Mothballed - re-add when available
 // include::modules/machineset-osp-adding-bare-metal.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Configuring persistent disk types by using compute machine sets
 include::modules/machineset-gcp-pd-disk-types.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
@@ -22,4 +22,4 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]

--- a/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
@@ -22,4 +22,4 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]

--- a/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Failure domains for Nutanix clusters
 include::modules/mapi-failure-domain-nutanix.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-osp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-osp.adoc
@@ -28,7 +28,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 // Mothballed - re-add when available
 // include::modules/machineset-osp-adding-bare-metal.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -43,7 +43,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Adding tags to machines by using machine sets
 include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+1,tag=!controlplane]

--- a/modules/machineset-label-gpu-autoscaler.adoc
+++ b/modules/machineset-label-gpu-autoscaler.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/applying-autoscaling.adoc
+// * machine_management/compute_machine_management/applying-autoscaling.adoc
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
 // * machine_management/creating_machinesets/creating-machineset-azure.adoc
 // * machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -309,7 +309,7 @@ For information about moving {logging} resources, see:
 
 Applying autoscaling to an {product-title} cluster involves deploying a cluster autoscaler and then deploying machine autoscalers for each machine type in your cluster.
 
-For more information, see xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[Applying autoscaling to an {product-title} cluster].
+For more information, see xref:../machine_management/compute_machine_management/applying-autoscaling.adoc#applying-autoscaling[Applying autoscaling to an {product-title} cluster].
 
 include::modules/nodes-clusters-cgroups-2.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
N/A release branch

Issue:
[OSDOCS-12904](https://issues.redhat.com//browse/OSDOCS-12904)

Link to docs preview:
None of these changes build anything at this time.

QE review:
N/A

Additional information:
This adds some templates to `_unused_topics` and sets up some assemblies that are commented out of the TOC until I populate them. It's also set to merge into a release branch and not a normal branch. I'm not sure it really needs review but I put a label on it, so if you're like "what the heck is this?" that's what's up, and please feel free to send me questions :sweat_smile: 