### PR TITLE
OSDOCS-12919: Documented the 4.16.27 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3340,6 +3340,41 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.27
+[id="ocp-4-16-27_{context}"]
+=== RHBA-2024:10973 - {product-title} {product-version}.27 bug fix and security update
+
+Issued: 19 December 2024
+
+{product-title} release {product-version}.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:10973[RHBA-2024:10973] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10976[RHBA-2024:10976] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.27 --pullspecs
+----
+
+[id="ocp-4-16-27-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when `openshift-sdn` pods were deployed during the {product-title} upgrading process, the Open vSwitch (OVS) storage table was cleared. This issue occurred on {product-title} {product-version}.19 and later versions. Ports for existing pods had to be re-created and this caused disruption to numerous services. With this release, a fix ensures that the OVS tables do not get cleared and pods do not get disconnected during a cluster upgrade operation. (link:https://issues.redhat.com/browse/OCPBUGS-45806[*OCPBUGS-45806*])
+
+* Previously, you could not remove a finally pipeline task from the *edit Pipeline* form if you created a pipeline with only one finally task. With this release, you can remove the finally task from the *edit Pipeline* form and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-45229[*OCPBUGS-45229*])
+
+* Previously, the installation program did not validate the maximum transmission unit (MTU) for a custom IPv6 network on {op-system-first}. If you specified a low value for the MTU, installation of the cluster would fail. With this release, the minimum MTU value for IPv6 networks is set to `1380` octets, where `1280` octets is the minimum MTU for the IPv6 protocol and the remaining `100` octets is for the OVN-Kubernetes encapsulation overhead. With this release, the installation program now validates the MTU for a custom IPv6 network on {op-system-first} (link:https://issues.redhat.com/browse/OCPBUGS-41813[*OCPBUGS-41813*])
+
+* Previously, the `Display Admission Webhook` warning implementation presented issues with some incorrect code. With this update, the unnecessary warning message has been removed. (link:https://issues.redhat.com/browse/OCPBUGS-43750[*OCPBUGS-43750*])
+
+* Previously, deploying the NUMA Resources Operator on a cluster was not possible for {product-title} versions {product-version}.25, {product-version}.26, or potentially subsequent z-stream versions of {product-version}. With this release, deployment of the NUMA Resources Operator is now supported starting from {product-title} {product-version}.27 and later versions of {product-title}{product-version}. The issue remains unresolved for {product-version}.25 and {product-version}.26. (link:https://issues.redhat.com/browse/OCPBUGS-45983[*OCPBUGS-45983*])
+
+[id="ocp-4-16-27-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 //4.16.26
 [id="ocp-4-16-26_{context}"]
 === RHSA-2024:10823 - {product-title} {product-version}.26 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12919](https://issues.redhat.com/browse/OSDOCS-12919)

Link to docs preview:
* [4.16.27](https://86261--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-27_release-notes)


