### PR TITLE
OCPBUGS#46020: Fixed link in Location section of Proxy cert doc

### DIFF
--- a/modules/security-hardening-what.adoc
+++ b/modules/security-hardening-what.adoc
@@ -6,18 +6,13 @@
 
 = Choosing what to harden in {op-system}
 ifdef::openshift-origin[]
-The link:https://docs.fedoraproject.org/en-US/Fedora/19/html/Security_Guide/chap-Security_Guide-Basic_Hardening.html[{op-system-base} Security Hardening] guide describes how you should approach security for any
-{op-system-base} system.
+The link:https://docs.fedoraproject.org/en-US/Fedora/19/html/Security_Guide/chap-Security_Guide-Basic_Hardening.html[{op-system-base} Security Hardening] guide describes how you should approach security for any {op-system-base} system.
 endif::[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-aro[]
-The link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#scanning-container-and-container-images-for-vulnerabilities_scanning-the-system-for-security-compliance-and-vulnerabilities[{op-system-base} 8 Security Hardening] guide describes how you should approach security for any
-{op-system-base} system.
+The link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/security_hardening/index#scanning-container-and-container-images-for-vulnerabilities_scanning-the-system-for-security-compliance-and-vulnerabilities[{op-system-base} 9 Security Hardening] guide describes how you should approach security for any {op-system-base} system.
 endif::[]
 
-Use this guide to learn how to approach cryptography, evaluate
-vulnerabilities, and assess threats to various services.
-Likewise, you can learn how to scan for compliance standards, check file
-integrity, perform auditing, and encrypt storage devices.
+Use this guide to learn how to approach cryptography, evaluate vulnerabilities, and assess threats to various services.
+Likewise, you can learn how to scan for compliance standards, check file integrity, perform auditing, and encrypt storage devices.
 
-With the knowledge of what features you want to harden, you can then
-decide how to harden them in {op-system}.
+With the knowledge of what features you want to harden, you can then decide how to harden them in {op-system}.

--- a/security/certificate_types_descriptions/proxy-certificates.adoc
+++ b/security/certificate_types_descriptions/proxy-certificates.adoc
@@ -64,9 +64,7 @@ The user-provided trust bundle is represented as a config map. The config map is
 
 Complete proxy support means connecting to the specified proxy and trusting any signatures it has generated. Therefore, it is necessary to let the user specify a trusted root, such that any certificate chain connected to that trusted root is also trusted.
 
-If using the RHCOS trust bundle, place CA certificates in `/etc/pki/ca-trust/source/anchors`.
-
-See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-shared-system-certificates_security-hardening[Using shared system certificates] in the Red Hat Enterprise Linux documentation for more information.
+If you use the {op-system} trust bundle, place CA certificates in `/etc/pki/ca-trust/source/anchors`. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/securing_networks/using-shared-system-certificates_securing-networks[Using shared system certificates] in the {op-system-base-full} _Securing networks_ document.
 
 == Expiration
 


### PR DESCRIPTION
Version(s):
4.13+

> for Y in $(seq 12 17); do echo -n "4.${Y} "; oc adm release info "quay.io/openshift-release-dev/ocp-release:4.${Y}.0-x86_64" | grep 'Red Hat Enterprise Linux CoreOS'; done

![Screenshot from 2024-12-16 10-58-39](https://github.com/user-attachments/assets/4af72db6-00db-4d24-b2c4-ee0463efc59e)

*Note:* OCP 4.12 support on RHEL does not yet extend beyond RHEL 8.6:

```
oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.12.0-x86_64 | grep 'Red Hat Enterprise Linux CoreOS'
  machine-os 412.86.202301061548-0 Red Hat Enterprise Linux CoreOS
```

Issue:
[OCPBUGS-46020](https://issues.redhat.com/browse/OCPBUGS-46020)

Link to docs preview:
* [Location doc](https://86268--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/proxy-certificates.html#location)
* [Security hardening](https://86268--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/container_security/security-hardening.html)

- [x] SME has approved this change (Trevor King).
- [x] QE has approved this change (Ke Wang).
