### PR TITLE
OCPBUGS-41971-rn: Added OCP core RN note for the Ingress capability f…

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3257,16 +3257,9 @@ In the following tables, features are marked with the following statuses:
 
 * {product-title} version {product-version} disconnected installation fails on {ibm-power-name} Virtual Server. (link:https://issues.redhat.com/browse/OCPBUGS-36250[*OCPBUGS-36250*])
 
-* In {hcp} for {product-title}, if you disable the xref:../installing/overview/cluster-capabilities.adoc#ingress-operator_cluster-capabilities[Ingress capability], the Console Operator returns the following error message:
-+
-[source,text]
-----
-RouteHealthAvailable: failed to GET route.
-----
-+
-To avoid this error, do not disable the `Ingress` capability in an {product-title} managed cluster. (link:https://issues.redhat.com/browse/OCPBUGS-33788[*OCPBUGS-33788*])
-
 * If you have IPsec enabled on the cluster, on the node hosting the north-south IPsec connection, restarting the `ipsec.service` systemd unit or restarting the `ovn-ipsec-host` pod causes a loss of the IPsec connection. (link:https://issues.redhat.com/browse/RHEL-26878[*RHEL-26878*])
+
+* If you set the `baselineCapabilitySet` field to `None`, you must explicitly enable the Ingress Capability, because the installation of a cluster fails if the Ingress Capability is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-33794[*OCPBUGS-33794*])
 
 [id="ocp-telco-ran-4-16-known-issues_{context}"]
 


### PR DESCRIPTION
**Note:** CM sent. See email "**[Notice of change] 4.16 Release Notes addition for Ingress capability**"

Version(s):
4.16

Issue:
[OCPBUGS-43908](https://issues.redhat.com/browse/OCPBUGS-43908)

Link to docs preview:
* [Search for baselineCapabilitySet](https://86269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-known-issues_release-notes)

- [x] SME has approved this change (Trevor King).
- [x] QE has approved this change. (Jinyun Ma)

Additional info.:

* [HCP note](https://github.com/openshift/openshift-docs/pull/82879/files#diff-60dd4ed43d374d795a3409a865f96d35477d6b869d75641e2a9e9477d1f2f7bdL103-L111) removed as per PMs (Adel Zaalouk) approval. PR adds a known issue note to the core OCP docs.
