### PR TITLE
OSDOCS-12813: adds 4.16.27 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -378,3 +378,12 @@ Issued: 12 December 2024
 {product-title} release 4.16.26 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10825[RHBA-2024:10825] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10823[RHSA-2024:10823] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-27-dp_{context}"]
+=== RHBA-2024:10975 - {microshift-short} 4.16.27 bug fix and enhancement advisory
+
+Issued: 18 December 2024
+
+{product-title} release 4.16.27 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10975[RHBA-2024:10975] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10973[RHBA-2024:10973] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12813](https://issues.redhat.com/browse/OSDOCS-12813)

Link to docs preview:
[microshift-4-16-27-dp_release-notes](https://86281--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-27-dp_release-notes)

QE review:
- N/A, stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
