### PR TITLE
OSDOCS-10893: Enabling the dynamic configuration manager

### DIFF
--- a/modules/nw-ne-dynamic-config-manager.adoc
+++ b/modules/nw-ne-dynamic-config-manager.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * networking/routes/route-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ne-dynamic-config-manager_{context}"]
+= Enabling the dynamic configuration manager
+
+You can enable the dynamic configuration manager for your template routers (like HAProxy).
+
+.Procedure
+
+. Enable the HAProxy Config Manager.
++
+Set the UseHAProxyConfigManager flag to true in your TemplateRouterConfigManager.
+
+. Set the Commit Interval.
++
+Define the interval at which the router commits changes using the CommitInterval option. The default value is set to 60 * 60 seconds (1 hour).
+
+. Configure Dynamic Servers Pool.
++
+Adjust the size of the dynamic servers pool using the MaxDynamicServers option or the ROUTER_MAX_DYNAMIC_SERVERS environment variable.
+
+. Pre-allocate the blueprint pool of routes.
++
+Define a pool of routes (known as blueprints) using the BlueprintRoutePoolSize option or the ROUTER_BLUEPRINT_ROUTE_POOL_SIZE environment variable.
++
+. Customize blueprints (optional).
++
+Set the BlueprintRouteNamespace and BlueprintRouteLabelSelector options to select routes from a specific namespace matching certain labels.
+
+For example, enable the dynamic configuration manager in your router deployment or ConfigMap by setting these options as follows:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-router-config
+data:
+  useHAProxyConfigManager: "true" <1>
+  commitInterval: "3600" <2>
+  maxDynamicServers: "20" <3>
+  blueprintRoutePoolSize: "10" <4>
+  blueprintRouteNamespace: "my-namespace" <5>
+  blueprintRouteLabelSelector: "my-label=my-value" <6>
+----
+<1> Enable the UseHAProxyConfigManager.
+<2> Set the commit interval.
+<3> Configure the dynamic servers pool.
+<4> Pre-allocate the blueprints pool of routes.
+<5> Customize blueprint namespace (optional).
+<6> Customize blueprint label selector (optional). 
+
+Alternatively, you can set these values using environment variables in your router deployment:
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-router
+spec:
+  template:
+    spec:
+      containers:
+      - name: router
+        env:
+        - name: USE_HAPROXY_CONFIG_MANAGER <1>
+          value: "true"
+        - name: COMMIT_INTERVAL <2>
+          value: "3600"
+        - name: ROUTER_MAX_DYNAMIC_SERVERS <3>
+          value: "20"
+        - name: ROUTER_BLUEPRINT_ROUTE_POOL_SIZE <4>
+          value: "10"
+----
+<1> Enable the UseHAProxyConfigManager.
+<2> Set the commit interval.
+<3> Configure the dynamic servers pool.
+<4> Pre-allocate the blueprints pool of routes.

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-dynamic-configuration-manager.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-dynamic-configuration-manager.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-ingress-cluster-traffic-ingress-controller"]
+= Configuring ingress cluster traffic using an Ingress Controller
+include::_attributes/common-attributes.adoc[]
+:context: configuring-ingress-cluster-traffic-ingress-controller
+
+toc::[]
+
+By default, the router uses a dynamic configuration manager to propagate endpoint changes using dynamic HAPRoxy API. This approach allows the router to adapt to changes efficiently reducing the number of reloads needed and hence the memory footprint. The dynamic configuration manager uses the HAProxy dynamic API to modify the operational state of HAProxy backends. Endpoint changes, such as scaling up and down, are managed by provisioning each backend with a pool of dynamic servers.
+
+//Enabling the dynamic configuration manager
+include::modules/nw-ne-dynamic-config-manager.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10893](https://issues.redhat.com//browse/OSDOCS-10893)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://86283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-ne-dynamic-config-manager_route-configuration
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
