### PR TITLE
(enterprise-4.12) Indentation fault in Configuring CPU and memory limits for logging components

### DIFF
--- a/modules/cluster-logging-cpu-memory.adoc
+++ b/modules/cluster-logging-cpu-memory.adoc
@@ -61,7 +61,7 @@ spec:
             cpu: 100m
             memory: 100Mi
       replicas: 2
-collection:
+  collection:
     resources: <3>
       limits:
         memory: 736Mi


### PR DESCRIPTION
- Indentation fault in Configuring CPU and memory limits for logging components in Documentation.

- Here is the documentation link: 
https://docs.openshift.com/container-platform/4.12/observability/logging/config/cluster-logging-memory.html#cluster-logging-memory-limits_cluster-logging-memory

- Here, `spec.collection` indentation is wrongly mentioned.

~~~
apiVersion: "logging.openshift.io/v1"
kind: "ClusterLogging"
metadata:
  name: "instance" 
  namespace: openshift-logging 
spec:
collection:  <<== collection indentation is wrongly mentioned
    resources: 
      limits:
        memory: 736Mi
      requests:
        cpu: 200m
        memory: 736Mi
    type: fluentd
~~~

- Due to this `spec.collection` will not get applied in the ClusterLogging instance CR.
- The correct configuration should look like the following:

~~~
apiVersion: "logging.openshift.io/v1"
kind: "ClusterLogging"
metadata:
  name: "instance" 
  namespace: openshift-logging 
spec:
  collection:                 <<== Here is the correct indentation
    resources: 
      limits:
        memory: 736Mi
      requests:
        cpu: 200m
        memory: 736Mi
    type: fluentd
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> RHOCP 4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/OBSDOCS-1522

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://86299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/config/cluster-logging-memory.html
https://86299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_visualization/logging-kibana.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
