### PR TITLE
OADP-5316-must-gather for 4.16-4.18

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -16,6 +16,7 @@
 :op-system-base: RHEL
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system-version: 9.x
+:op-system-version-9: 9
 ifdef::openshift-origin[]
 :op-system-first: Fedora CoreOS (FCOS)
 :op-system: FCOS

--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -7,7 +7,8 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :oadp-troubleshooting:
 :namespace: openshift-adp
 :local-product: OADP
-:must-gather: registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.1
+:must-gather-v1-3: registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3
+:must-gather-v1-4: registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.4
 
 toc::[]
 

--- a/modules/migration-combining-must-gather.adoc
+++ b/modules/migration-combining-must-gather.adoc
@@ -7,9 +7,9 @@
 
 Currently, it is not possible to combine must-gather scripts, for example specifying a timeout threshold while permitting insecure TLS connections. In some situations, you can get around this limitation by setting up internal variables on the must-gather command line, such as the following example:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3 -- skip_tls=true /usr/bin/gather_with_timeout <timeout_value_in_seconds>
+$ oc adm must-gather --image={must-gather-v1-4} -- skip_tls=true /usr/bin/gather_with_timeout <timeout_value_in_seconds>
 ----
 
 In this example, set the `skip_tls` variable before running the `gather_with_timeout` script. The result is a combination of `gather_with_timeout` and `gather_without_tls`.
@@ -21,7 +21,7 @@ The only other variables that you can specify this way are the following:
 
 If `DataProtectionApplication` custom resource (CR) is configured with `s3Url` and `insecureSkipTLS: true`, the CR does not collect the necessary logs because of a missing CA certificate. To collect those logs, run the `must-gather` command with the following option:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3 -- /usr/bin/gather_without_tls true
+$ oc adm must-gather --image={must-gather-v1-4} -- /usr/bin/gather_without_tls true
 ----

--- a/modules/migration-using-must-gather.adoc
+++ b/modules/migration-using-must-gather.adoc
@@ -30,8 +30,7 @@ endif::[]
 * You must have the OpenShift CLI (`oc`) installed.
 
 ifdef::oadp-troubleshooting[]
-* You must use {op-system-base-full} 8.x with OADP 1.2.
-* You must use {op-system-base-full} {op-system-version} with OADP 1.3.
+* You must use {op-system-base-full} {op-system-version-9} with {oadp-short} 1.4.
 endif::[]
 
 .Procedure
@@ -77,18 +76,10 @@ This operation can take a long time. This command saves the data as the `must-ga
 endif::[]
 ifdef::oadp-troubleshooting[]
 * Full `must-gather` data collection, including Prometheus metrics:
-.. For OADP 1.2, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
-----
-+
-.. For OADP 1.3, run the following command:
-+
-[source,terminal]
-----
-$ oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3
+$ oc adm must-gather --image={must-gather-v1-4}
 ----
 +
 The data is saved as `must-gather/must-gather.tar.gz`. You can upload this file to a support case on the link:https://access.redhat.com/[Red Hat Customer Portal].
@@ -97,7 +88,7 @@ The data is saved as `must-gather/must-gather.tar.gz`. You can upload this file 
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image={must-gather} \
+$ oc adm must-gather --image={must-gather-v1-4} \
   -- /usr/bin/gather_<time>_essential <1>
 ----
 <1> Specify the time in hours. Allowed values are `1h`, `6h`, `24h`, `72h`, or `all`, for example, `gather_1h_essential` or `gather_all_essential`.
@@ -106,24 +97,16 @@ $ oc adm must-gather --image={must-gather} \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image={must-gather} \
+$ oc adm must-gather --image={must-gather-v1-4} \
   -- /usr/bin/gather_with_timeout <timeout> <1>
 ----
 <1> Specify a timeout value in seconds.
 
 * Prometheus metrics data dump:
-
-.. For OADP 1.2, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2 -- /usr/bin/gather_metrics_dump
-----
-.. For OADP 1.3, run the following command:
-+
-[source,terminal]
-----
-$ oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3 -- /usr/bin/gather_metrics_dump
+$ oc adm must-gather --image={must-gather-v1-4} -- /usr/bin/gather_metrics_dump
 ----
 This operation can take a long time. The data is saved as `must-gather/metrics/prom_data.tar.gz`.
 endif::[]

--- a/modules/support-insecure-tls-connections.adoc
+++ b/modules/support-insecure-tls-connections.adoc
@@ -10,9 +10,9 @@ If a custom CA certificate is used, the `must-gather` pod fails to grab the outp
 .Procedure
 * Pass the `gather_without_tls` flag, with value set to `true`, to the `must-gather` tool by using the following command:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3 -- /usr/bin/gather_without_tls <true/false>
+$ oc adm must-gather --image={must-gather-v1-4} -- /usr/bin/gather_without_tls <true/false>
 ----
 
 By default, the flag value is set to `false`. Set the value to `true` to allow insecure TLS connections.


### PR DESCRIPTION
## Jira 

* [OADP-5316](https://issues.redhat.com/browse/OADP-5316)

updated must-gather image for OCP 4.16 , 4.17, and 4.18. I have used [OpenShift Operator Lifecycle doc](https://access.redhat.com/support/policy/updates/openshift_operators) to update the correct information. I have also attached the OADP screenshot.
![image](https://github.com/user-attachments/assets/65a9dc7b-9392-40bd-b793-ec1d12c389be)

##  Version

* OCP 4.16 , 4.17, and 4.18 only

## Preview

* [OADP must-gather 4.17, 4.16](https://86301--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#migration-using-must-gather_oadp-troubleshooting)

## QE Review

* [x] QE has approved this change.
