### PR TITLE
OCPBUGS#46020-12: Fixed link in Location section of Proxy cert doc

### DIFF
--- a/security/certificate_types_descriptions/proxy-certificates.adoc
+++ b/security/certificate_types_descriptions/proxy-certificates.adoc
@@ -64,9 +64,7 @@ The user-provided trust bundle is represented as a config map. The config map is
 
 Complete proxy support means connecting to the specified proxy and trusting any signatures it has generated. Therefore, it is necessary to let the user specify a trusted root, such that any certificate chain connected to that trusted root is also trusted.
 
-If using the RHCOS trust bundle, place CA certificates in `/etc/pki/ca-trust/source/anchors`.
-
-See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-shared-system-certificates_security-hardening[Using shared system certificates] in the Red Hat Enterprise Linux documentation for more information.
+If you use the {op-system} trust bundle, place CA certificates in `/etc/pki/ca-trust/source/anchors`. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/securing_networks/using-shared-system-certificates_securing-networks[Using shared system certificates] in the {op-system-base-full} _Securing networks_ document.
 
 == Expiration
 


### PR DESCRIPTION
Version(s):
4.12

*Note:* OCP 4.12 support on RHEL does not yet extend beyond RHEL 8.6:

```
oc adm release info --commits quay.io/openshift-release-dev/ocp-release:4.12.0-x86_64 | grep 'Red Hat Enterprise Linux CoreOS'
  machine-os 412.86.202301061548-0 Red Hat Enterprise Linux CoreOS
```

Issue:
[OCPBUGS-46020](https://issues.redhat.com/browse/OCPBUGS-46020)

Link to docs preview:
* [Location doc](https://86307--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/proxy-certificates.html#locationn)


- [x] SME has approved this change (Trevor King).
- [x] QE has approved this change (Ke Wang).
