### PR TITLE
RHDEVDOCS-6234: Fixing publishing errors in the GitOps 1.15 release build

### DIFF
--- a/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
+++ b/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To use Argo Rollouts and manage progressive delivery, after you install the {gitops-titel} Operator on the cluster, you can create and configure a `RolloutManager` custom resource (CR) instance in the namespace of your choice. You can scope the `RolloutManager` CR for single or multiple namespaces. 
+To use Argo Rollouts and manage progressive delivery, after you install the {gitops-title} Operator on the cluster, you can create and configure a `RolloutManager` custom resource (CR) instance in the namespace of your choice. You can scope the `RolloutManager` CR for single or multiple namespaces. 
 
 [id="prerequisites_{context}"]
 == Prerequisites

--- a/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.adoc
+++ b/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.adoc
@@ -2,7 +2,7 @@
 include::_attributes/common-attributes.adoc[]
 [id="using-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources"]
 = Using a cluster-scoped Argo Rollouts instance to manage rollout resources
-context: using-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources
+:context: using-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources
 
 toc::[]
 

--- a/argocd_application_sets/managing-app-sets-in-non-control-plane-namespaces.adoc
+++ b/argocd_application_sets/managing-app-sets-in-non-control-plane-namespaces.adoc
@@ -35,8 +35,8 @@ include::modules/gitops-allowing-scm-providers.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 
-* link:https://argo-cd.readthedocs.io/en/release-2.10/operator-manual/applicationset/#the-applicationset-resource[The `ApplicationSet` resource]
-* link:https://argo-cd.readthedocs.io/en/release-2.10/operator-manual/applicationset/Appset-Any-Namespace/[ApplicationSet in any namespace]
+* link:https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/#the-applicationset-resource[The `ApplicationSet` resource]
+* link:https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Appset-Any-Namespace/[ApplicationSet in any namespace]
 * xref:../argocd_instance/argo-cd-cr-component-properties.adoc#argo-cd-cr-component-properties[Argo CD custom resource and component properties]
-* link:https://argo-cd.readthedocs.io/en/release-2.10/operator-manual/applicationset/Generators-SCM-Provider[SCM Provider Generator]
-* link:https://argo-cd.readthedocs.io/en/release-2.10/operator-manual/applicationset/Generators-Pull-Request[Pull Request Generator]
+* link:https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-SCM-Provider/[SCM Provider Generator]
+* link:https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Pull-Request/[Pull Request Generator]

--- a/gitops_cli_argocd/argocd-gitops-cli-reference.adoc
+++ b/gitops_cli_argocd/argocd-gitops-cli-reference.adoc
@@ -29,5 +29,5 @@ include::modules/gitops-argocd-cli-utility-commands.adoc[leveloffset=+1]
 * xref:../gitops_cli_argocd/configuring-argocd-gitops-cli.adoc#configuring-argocd-gitops-cli[Configuring the {gitops-shortname} CLI]
 * xref:../gitops_cli_argocd/logging-in-to-argocd-server-in-default-mode.adoc#logging-in-to-argocd-server-in-default-mode[Logging in to the Argo CD server in the default mode]
 * link:https://github.com/redhat-developer/gitops-operator/blob/7ac4b2ce179c167b39be259b8d9be37dc280f689/docs/OpenShift%20GitOps%20CLI%20User%20Guide.md#login-related-commands[OpenShift {gitops-shortname} CLI User Guide]
-* link:https://argo-cd.readthedocs.io/en/release-{upstream-ver}/user-guide/commands/argocd/[`argocd` command reference]
+* link:https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd/[`argocd` Command Reference]
 //update the upstream version attribute value for every release

--- a/installing_gitops/installing-openshift-gitops.adoc
+++ b/installing_gitops/installing-openshift-gitops.adoc
@@ -14,7 +14,7 @@ toc::[]
 * You have access to the {OCP} web console.
 * You are logged in as a user with the `cluster-admin` role.
 * You are logged in to the {OCP} cluster as an administrator.
-* Your cluster has the link:https://docs.openshift.com/container-platform/latest/installing/cluster-capabilities.html#marketplace-operator_cluster-capabilities[Marketplace capability] enabled or the Red Hat Operator catalog source configured manually.
+* Your cluster has the link:https://docs.openshift.com/container-platform/latest/installing/overview/cluster-capabilities.html#marketplace-operator_cluster-capabilities[Marketplace capability] enabled or the Red Hat Operator catalog source configured manually.
 
 [WARNING]
 ====

--- a/modules/gitops-creating-a-new-client-using-keycloak.adoc
+++ b/modules/gitops-creating-a-new-client-using-keycloak.adoc
@@ -73,7 +73,7 @@ spec:
       rootCA: ""
 ----
 
-* Optional: Customize the `spec.sso.keycloak` field to add the route name for the `keycloak` provider in the `ArgoCD` CR. Use this feature to support advanced routing use cases, such as balancing incoming traffic load among multiple link:https://docs.openshift.com/container-platform/latest/networking/ingress-sharding.html#nw-ingress-sharding_ingress-sharding[Ingress Controller shards].
+* Optional: Customize the `spec.sso.keycloak` field to add the route name for the `keycloak` provider in the `ArgoCD` CR. Use this feature to support advanced routing use cases, such as balancing incoming traffic load among multiple link:https://docs.openshift.com/container-platform/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#nw-ingress-sharding_configuring-ingress-cluster-traffic-ingress-controller[Ingress Controller sharding].
 +
 ** Add a `host` parameter in the `ArgoCD` CR by using the following example YAML:
 +
@@ -146,7 +146,7 @@ status:
 ----
 <1> Specifies the name of the route.
 <2> Specifies the name of the host key.
-
++
 [NOTE]
 ====
 The Keycloak instance takes 2-3 minutes to install and run.

--- a/observability/logging/viewing-argo-cd-logs.adoc
+++ b/observability/logging/viewing-argo-cd-logs.adoc
@@ -14,4 +14,4 @@ include::modules/gitops-storing-and-retrieving-argo-cd-logs.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* link:https://docs.openshift.com/container-platform/latest/observability/logging/cluster-logging-deploying.html#cluster-logging-deploy-console_cluster-logging-deploying[Installing the {logging-title} using the web console]
+* link:https://docs.openshift.com/container-platform/4.16/observability/logging/cluster-logging-deploying.html#logging-loki-gui-install_cluster-logging-deploying[Installing the {logging-title} using the web console]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.16, gitops-docs-main

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6234

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

The following changes are made to the content:

- In the [Configuring a new client in Keycloak](https://86314--ocpdocs-pr.netlify.app/openshift-gitops/latest/accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak#gitops-creating-a-new-client-in-keycloak_configuring-sso-for-argo-cd-using-keycloak) section, fixed the **Ingress Controller shards** hyperlink and added a + sign to the note to improve the formatting.

- Fixed the hyperlinks for **The `ApplicationSet` resource**, **ApplicationSet in any namespace**, **SCM Provider Generator,** and **Pull Request Generator** in the Additional Resources section for 
[Managing the application set resources in non-control plane namespaces](https://86314--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_application_sets/managing-app-sets-in-non-control-plane-namespaces.html)

- Fixed an incorrectly spelled attribute **{gitops-titel}** in the [Using Argo Rollouts for progressive deployment delivery](https://86314--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.html)

- Fixed an incorrect ID in the metadata for the [Using a cluster-scoped Argo Rollouts instance to manage rollout resources](https://86314--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.html) section

- Fixed the hyperlink for **argocd command reference** in the Additional Resources section for [GitOps argocd CLI reference](https://86314--ocpdocs-pr.netlify.app/openshift-gitops/latest/gitops_cli_argocd/argocd-gitops-cli-reference)

- Fixed the hyperlink for **Marketplace capability** in the [Installing Red Hat OpenShift GitOps](https://86314--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/installing-openshift-gitops.html#additional-resources_installing-openshift-gitops) section.

- Fixed the hyperlink for **Installing the logging subsystem for Red Hat OpenShift** using the web console in the [Storing and retrieving Argo CD logs](https://86314--ocpdocs-pr.netlify.app/openshift-gitops/latest/observability/logging/viewing-argo-cd-logs.html) section.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @svghadi 
QE review: @varshab1210 
Peer review: @sr1kar99 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
