### PR TITLE
OSSM-8615: Document multi-primary single-network mesh topology

### DIFF
--- a/install/ossm-multi-cluster-topologies.adoc
+++ b/install/ossm-multi-cluster-topologies.adoc
@@ -29,3 +29,5 @@ include::modules/ossm-installing-kiali-multi-cluster-mesh.adoc[leveloffset=+1]
 * xref:../install/ossm-multi-cluster-topologies.adoc#ossm-verifying-multi-cluster-topology_ossm-multi-cluster-topologies[Verifying a multi-cluster topology]
 
 * xref:../install/ossm-multi-cluster-topologies.adoc#ossm-removing-multi-cluster-installation-from-development-environment_ossm-multi-cluster-topologies[Removing a multi-cluster topology from a development environment]
+
+include::modules/ossm-installing-multi-primary-single-network.adoc[leveloffset=+1]

--- a/modules/ossm-installing-multi-primary-single-network.adoc
+++ b/modules/ossm-installing-multi-primary-single-network.adoc
@@ -14,6 +14,8 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 
 .Prerequisites
 
+* You have installed all of the clusters on the same network, and there must be direct connectivity between the pods in all clusters.
+
 * You have installed the {SMProduct} Operator on all of the clusters that comprise the mesh.
 
 * You have completed "Creating certificates for a multi-cluster mesh". 
@@ -30,7 +32,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 +
 [source,terminal]
 ----
-$ export ISTIO_VERSION=1.24.0 
+$ export ISTIO_VERSION=1.24.1 
 ----
 
 . Install {istio} on the East cluster:

--- a/modules/ossm-installing-multi-primary-single-network.adoc
+++ b/modules/ossm-installing-multi-primary-single-network.adoc
@@ -35,11 +35,11 @@ $ export ISTIO_VERSION=1.24.0
 
 . Install {istio} on the East cluster:
 
-.. Create a YAML file named `istio-east.yaml` that defines an `Istio` resource on the East cluster by running the following command:
+.. Create an `Istio` resource on the East cluster by running the following command:
 +
 [source,terminal]
 ----
-$ cat <<EOF > istio-east.yaml
+$ cat <<EOF | oc --context "${CTX_CLUSTER1}" apply -f -
 apiVersion: sailoperator.io/v1alpha1
 kind: Istio
 metadata:
@@ -56,13 +56,6 @@ spec:
 EOF
 ----
 
-.. Apply the YAML file by running the following command:
-+
-[source,terminal]
-----
-$ oc apply -f istio-east.yaml
-----
-
 .. Wait for the control plane to return the "Ready" status condition by running the following command:
 +
 [source,terminal]
@@ -72,11 +65,11 @@ $ oc --context "${CTX_CLUSTER1}" wait --for condition=Ready istio/default --time
 
 . Install {istio} on the West cluster:
 
-.. Create a YAML file named `istio-west.yaml` that defines an `Istio` resource on the West cluster by running the following command:
+.. Create an `Istio` resource on the West cluster by running the following command:
 +
 [source,terminal]
 ----
-$ cat <<EOF > istio-west.yaml
+$ cat <<EOF | oc --context "${CTX_CLUSTER2}" apply -f -
 apiVersion: sailoperator.io/v1alpha1
 kind: Istio
 metadata:
@@ -93,13 +86,6 @@ spec:
 EOF
 ----
 
-.. Apply the YAML file by running the following command:
-+
-[source,terminal]
-----
-oc --context "${CTX_CLUSTER2}" apply -f istio-west.yaml
-----
-
 .. Wait for the control plane to return the "Ready" status condition by running the following command:
 +
 [source,terminal]
@@ -113,8 +99,7 @@ $ oc --context "${CTX_CLUSTER2}" wait --for condition=Ready istio/default --time
 ----
 $ istioctl create-remote-secret \
   --context="${CTX_CLUSTER2}" \
-  --name=cluster2 \
-  --create-service-account=false | \
+  --name=cluster2 | \
   oc --context="${CTX_CLUSTER1}" apply -f -
 ----
 

--- a/modules/ossm-installing-multi-primary-single-network.adoc
+++ b/modules/ossm-installing-multi-primary-single-network.adoc
@@ -14,7 +14,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 
 .Prerequisites
 
-* You have installed all of the clusters on the same network, and there must be direct connectivity between the pods in all clusters.
+* You have installed all of the clusters on the same network, and there is direct connectivity between the pods in all of the clusters.
 
 * You have installed the {SMProduct} Operator on all of the clusters that comprise the mesh.
 

--- a/modules/ossm-installing-multi-primary-single-network.adoc
+++ b/modules/ossm-installing-multi-primary-single-network.adoc
@@ -76,7 +76,7 @@ $ oc --context "${CTX_CLUSTER1}" wait --for condition=Ready istio/default --time
 +
 [source,terminal]
 ----
-$ cat <<EOF > istio-east.yaml
+$ cat <<EOF > istio-west.yaml
 apiVersion: sailoperator.io/v1alpha1
 kind: Istio
 metadata:

--- a/modules/ossm-installing-multi-primary-single-network.adoc
+++ b/modules/ossm-installing-multi-primary-single-network.adoc
@@ -1,0 +1,280 @@
+:_mod-docs-content-type: Procedure
+[id="ossm-installing-multi-primary-single-network-mesh_{context}"]
+= Installing a multi-primary single-network mesh 
+:context: ossm-installing-multi-primary-single-network-mesh
+
+Install {istio} in the multi-primary single-network topology on two {ocp-product-title} clusters. 
+
+[NOTE]
+====
+In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster. 
+====
+
+You can adapt these instructions for a mesh spanning more than two clusters.
+
+.Prerequisites
+
+* You have installed the {SMProduct} Operator on all of the clusters that comprise the mesh.
+
+* You have completed "Creating certificates for a multi-cluster mesh". 
+
+* You have completed "Applying certificates to a multi-cluster topology".
+
+* You have created an {istio} Container Network Interface (CNI) resource.
+
+* You have `istioctl` installed on the laptop you will use to run these instructions.
+
+.Procedure
+
+. Create an `ISTIO_VERSION` environment variable that defines the {istio} version to install by running the following command:
++
+[source,terminal]
+----
+$ export ISTIO_VERSION=1.24.0 
+----
+
+. Install {istio} on the East cluster:
+
+.. Create a YAML file named `istio-east.yaml` that defines an `Istio` resource on the East cluster.
++
+.Example resource file
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: sailoperator.io/v1alpha1
+kind: Istio
+metadata:
+  name: default
+spec:
+  version: v${ISTIO_VERSION}
+  namespace: istio-system
+  values:
+    global:
+      meshID: mesh1
+      multiCluster:
+        clusterName: cluster1
+      network: network1
+----
+
+.. Apply the YAML file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f istio-east.yaml
+----
+
+.. Wait for the control plane to return the "Ready" status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" wait --for condition=Ready istio/default --timeout=3m
+----
+
+. Install {istio} on the West cluster:
+
+.. Create a YAML file named `istio-west.yaml` that defines an `Istio` resource on the West cluster.
++
+.Example resource file
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: sailoperator.io/v1alpha1
+kind: Istio
+metadata:
+  name: default
+spec:
+  version: v${ISTIO_VERSION}
+  namespace: istio-system
+  values:
+    global:
+      meshID: mesh1
+      multiCluster:
+        clusterName: cluster2
+      network: network1
+----
+
+.. Apply the YAML file by running the following command:
++
+[source,terminal]
+----
+oc --context "${CTX_CLUSTER2}" apply -f istio-west.yaml
+----
+
+.. Wait for the control plane to return the "Ready" status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER2}" wait --for condition=Ready istio/default --timeout=3m
+----
+
+. Install a remote secret on the East cluster that provides access to the API server on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ istioctl create-remote-secret \
+  --context="${CTX_CLUSTER2}" \
+  --name=cluster2 | \
+  oc --context="${CTX_CLUSTER1}" apply -f -
+----
+
+. Install a remote secret on the West cluster that provides access to the API server on the East cluster by running the following command:
++
+[source,terminal]
+----
+$ istioctl create-remote-secret \
+  --context="${CTX_CLUSTER1}" \
+  --name=cluster1 | \
+  oc --context="${CTX_CLUSTER2}" apply -f -
+----
+
+
+
+
+
+CREATE VERIFICATION PROCEDURE UED FOR ALL TOPOLOGY
+
+. Deploy sample applications on the East cluster:
+
+.. Create a sample application namespace on the East cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" get project sample || oc --context="${CTX_CLUSTER1}" new-project sample
+----
+
+.. Label the application namespace to support sidecar injection by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" label namespace sample istio-injection=enabled
+----
+
+.. Deploy the `helloworld` application:
+
+... Create the `helloworld` service by running the following command:
++
+[source,terminal]
+----
+oc --context="${CTX_CLUSTER1}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -l service=helloworld -n sample
+----
+
+... Create the `helloworld-v1` deployment by running the following command:
++
+[source,terminal]
+----
+oc --context="${CTX_CLUSTER1}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -l version=v1 -n sample
+----
+
+.. Deploy the `sleep` application by running the following command:
++
+[source,terminal]
+----
+oc --context="${CTX_CLUSTER1}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/sleep/sleep.yaml -n sample
+----
+
+. Wait for the sample applications on the East cluster to return the "Ready" status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" wait --for condition=available -n sample deployment/helloworld-v1
+$ oc --context="${CTX_CLUSTER1}" wait --for condition=available -n sample deployment/sleep
+----
+
+. Deploy the sample applications on the West cluster:
+
+.. Create a sample application namespace on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER2}" get project sample || oc --context="${CTX_CLUSTER2}" new-project sample
+----
+
+.. Label the application namespace to support sidecar injection by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" label namespace sample istio-injection=enabled
+----
+
+.. Deploy the `helloworld` application:
+
+... Create the `helloworld` service by running the following command:
++
+[source,terminal]
+----
+oc --context="${CTX_CLUSTER2}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -l service=helloworld -n sample
+----
+
+... Create the `helloworld-v2` deployment by running the following command:
++
+[source,terminal]
+----
+oc --context="${CTX_CLUSTER2}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -l version=v2 -n sample
+----
+
+.. Deploy the `sleep` application by running the following command:
++
+[source,terminal]
+----
+oc --context="${CTX_CLUSTER2}" apply \
+  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/sleep/sleep.yaml -n sample
+----
+
+. Wait for the sample applications on the West cluster to return the "Ready" status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" wait --for condition=available -n sample deployment/helloworld-v2
+$ oc --context="${CTX_CLUSTER2}" wait --for condition=available -n sample deployment/sleep
+----
+
+.Verifying traffic flows between clusters
+
+. For the East cluster, send 10 requests to the `helloworld` service by running the following command:
++
+[source,terminal]
+----
+for i in {0..9}; do
+  oc --context="${CTX_CLUSTER1}" exec -n sample deploy/sleep -c sleep -- curl -sS helloworld.sample:5000/hello;
+done
+----
++
+Verify that you see responses from both clusters. This means you will see version 1 and version 2 of the service in the responses. 
+
+. For the West cluster, send 10 requests to the `helloworld` service:
++
+[source,terminal]
+----
+for i in {0..9}; do
+  oc --context="${CTX_CLUSTER2}" exec -n sample deploy/sleep -c sleep -- curl -sS helloworld.sample:5000/hello;
+done
+----
++
+Verify that you see responses from both clusters. This means you will see version 1 and version 2 of the service in the responses. 
+
+
+====== END ======
+
+.Cleanup
+
+. Optional: Remove the cluster1 from a development environment by running the following command:
++
+[source,terminal]
+----
+oc --context="${CTX_CLUSTER1}" delete istio/default ns/istio-system ns/sample ns/istio-cni
+----
+
+. 
+. Optional: Remove the cluster2 from a development environment by running the following command:
++
+[source,terminal]
+----
+oc --context="${CTX_CLUSTER2}" delete istio/default ns/istio-system ns/sample ns/istio-cni
+----

--- a/modules/ossm-installing-multi-primary-single-network.adoc
+++ b/modules/ossm-installing-multi-primary-single-network.adoc
@@ -7,7 +7,7 @@ Install {istio} in the multi-primary single-network topology on two {ocp-product
 
 [NOTE]
 ====
-In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster. 
+In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster. The East cluster is the primary cluster and the West cluster is the remote cluster.
 ====
 
 You can adapt these instructions for a mesh spanning more than two clusters.

--- a/modules/ossm-installing-multi-primary-single-network.adoc
+++ b/modules/ossm-installing-multi-primary-single-network.adoc
@@ -35,11 +35,11 @@ $ export ISTIO_VERSION=1.24.0
 
 . Install {istio} on the East cluster:
 
-.. Create a YAML file named `istio-east.yaml` that defines an `Istio` resource on the East cluster.
+.. Create a YAML file named `istio-east.yaml` that defines an `Istio` resource on the East cluster by running the following command:
 +
-.Example resource file
-[source,yaml,subs="attributes,verbatim"]
+[source,terminal]
 ----
+$ cat <<EOF > istio-east.yaml
 apiVersion: sailoperator.io/v1alpha1
 kind: Istio
 metadata:
@@ -53,6 +53,7 @@ spec:
       multiCluster:
         clusterName: cluster1
       network: network1
+EOF
 ----
 
 .. Apply the YAML file by running the following command:
@@ -71,11 +72,11 @@ $ oc --context "${CTX_CLUSTER1}" wait --for condition=Ready istio/default --time
 
 . Install {istio} on the West cluster:
 
-.. Create a YAML file named `istio-west.yaml` that defines an `Istio` resource on the West cluster.
+.. Create a YAML file named `istio-west.yaml` that defines an `Istio` resource on the West cluster by running the following command:
 +
-.Example resource file
-[source,yaml,subs="attributes,verbatim"]
+[source,terminal]
 ----
+$ cat <<EOF > istio-east.yaml
 apiVersion: sailoperator.io/v1alpha1
 kind: Istio
 metadata:
@@ -89,6 +90,7 @@ spec:
       multiCluster:
         clusterName: cluster2
       network: network1
+EOF
 ----
 
 .. Apply the YAML file by running the following command:
@@ -111,7 +113,8 @@ $ oc --context "${CTX_CLUSTER2}" wait --for condition=Ready istio/default --time
 ----
 $ istioctl create-remote-secret \
   --context="${CTX_CLUSTER2}" \
-  --name=cluster2 | \
+  --name=cluster2 \
+  --create-service-account=false | \
   oc --context="${CTX_CLUSTER1}" apply -f -
 ----
 
@@ -123,158 +126,4 @@ $ istioctl create-remote-secret \
   --context="${CTX_CLUSTER1}" \
   --name=cluster1 | \
   oc --context="${CTX_CLUSTER2}" apply -f -
-----
-
-
-
-
-
-CREATE VERIFICATION PROCEDURE UED FOR ALL TOPOLOGY
-
-. Deploy sample applications on the East cluster:
-
-.. Create a sample application namespace on the East cluster by running the following command:
-+
-[source,terminal]
-----
-$ oc --context "${CTX_CLUSTER1}" get project sample || oc --context="${CTX_CLUSTER1}" new-project sample
-----
-
-.. Label the application namespace to support sidecar injection by running the following command:
-+
-[source,terminal]
-----
-$ oc --context="${CTX_CLUSTER1}" label namespace sample istio-injection=enabled
-----
-
-.. Deploy the `helloworld` application:
-
-... Create the `helloworld` service by running the following command:
-+
-[source,terminal]
-----
-oc --context="${CTX_CLUSTER1}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
-  -l service=helloworld -n sample
-----
-
-... Create the `helloworld-v1` deployment by running the following command:
-+
-[source,terminal]
-----
-oc --context="${CTX_CLUSTER1}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
-  -l version=v1 -n sample
-----
-
-.. Deploy the `sleep` application by running the following command:
-+
-[source,terminal]
-----
-oc --context="${CTX_CLUSTER1}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/sleep/sleep.yaml -n sample
-----
-
-. Wait for the sample applications on the East cluster to return the "Ready" status condition by running the following command:
-+
-[source,terminal]
-----
-$ oc --context="${CTX_CLUSTER1}" wait --for condition=available -n sample deployment/helloworld-v1
-$ oc --context="${CTX_CLUSTER1}" wait --for condition=available -n sample deployment/sleep
-----
-
-. Deploy the sample applications on the West cluster:
-
-.. Create a sample application namespace on the West cluster by running the following command:
-+
-[source,terminal]
-----
-$ oc --context "${CTX_CLUSTER2}" get project sample || oc --context="${CTX_CLUSTER2}" new-project sample
-----
-
-.. Label the application namespace to support sidecar injection by running the following command:
-+
-[source,terminal]
-----
-$ oc --context="${CTX_CLUSTER2}" label namespace sample istio-injection=enabled
-----
-
-.. Deploy the `helloworld` application:
-
-... Create the `helloworld` service by running the following command:
-+
-[source,terminal]
-----
-oc --context="${CTX_CLUSTER2}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
-  -l service=helloworld -n sample
-----
-
-... Create the `helloworld-v2` deployment by running the following command:
-+
-[source,terminal]
-----
-oc --context="${CTX_CLUSTER2}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
-  -l version=v2 -n sample
-----
-
-.. Deploy the `sleep` application by running the following command:
-+
-[source,terminal]
-----
-oc --context="${CTX_CLUSTER2}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/sleep/sleep.yaml -n sample
-----
-
-. Wait for the sample applications on the West cluster to return the "Ready" status condition by running the following command:
-+
-[source,terminal]
-----
-$ oc --context="${CTX_CLUSTER2}" wait --for condition=available -n sample deployment/helloworld-v2
-$ oc --context="${CTX_CLUSTER2}" wait --for condition=available -n sample deployment/sleep
-----
-
-.Verifying traffic flows between clusters
-
-. For the East cluster, send 10 requests to the `helloworld` service by running the following command:
-+
-[source,terminal]
-----
-for i in {0..9}; do
-  oc --context="${CTX_CLUSTER1}" exec -n sample deploy/sleep -c sleep -- curl -sS helloworld.sample:5000/hello;
-done
-----
-+
-Verify that you see responses from both clusters. This means you will see version 1 and version 2 of the service in the responses. 
-
-. For the West cluster, send 10 requests to the `helloworld` service:
-+
-[source,terminal]
-----
-for i in {0..9}; do
-  oc --context="${CTX_CLUSTER2}" exec -n sample deploy/sleep -c sleep -- curl -sS helloworld.sample:5000/hello;
-done
-----
-+
-Verify that you see responses from both clusters. This means you will see version 1 and version 2 of the service in the responses. 
-
-
-====== END ======
-
-.Cleanup
-
-. Optional: Remove the cluster1 from a development environment by running the following command:
-+
-[source,terminal]
-----
-oc --context="${CTX_CLUSTER1}" delete istio/default ns/istio-system ns/sample ns/istio-cni
-----
-
-. 
-. Optional: Remove the cluster2 from a development environment by running the following command:
-+
-[source,terminal]
-----
-oc --context="${CTX_CLUSTER2}" delete istio/default ns/istio-system ns/sample ns/istio-cni
 ----


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OSSM-8615
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
https://86315--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html#ossm-installing-multi-primary-single-network-mesh_ossm-multi-cluster-topologies

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
