### PR TITLE
OSDOCS#12586: Bumping Kube version throughout doc set to 1.31

### DIFF
--- a/metering/configuring_metering/metering-common-config-options.adoc
+++ b/metering/configuring_metering/metering-common-config-options.adoc
@@ -156,12 +156,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS   ROLES    AGE   VERSION
-ip-10-0-147-106.us-east-2.compute.internal   Ready    master   14h   v1.30.3
-ip-10-0-150-175.us-east-2.compute.internal   Ready    worker   14h   v1.30.3
-ip-10-0-175-23.us-east-2.compute.internal    Ready    master   14h   v1.30.3
-ip-10-0-189-6.us-east-2.compute.internal     Ready    worker   14h   v1.30.3
-ip-10-0-205-158.us-east-2.compute.internal   Ready    master   14h   v1.30.3
-ip-10-0-210-167.us-east-2.compute.internal   Ready    worker   14h   v1.30.3
+ip-10-0-147-106.us-east-2.compute.internal   Ready    master   14h   v1.31.3
+ip-10-0-150-175.us-east-2.compute.internal   Ready    worker   14h   v1.31.3
+ip-10-0-175-23.us-east-2.compute.internal    Ready    master   14h   v1.31.3
+ip-10-0-189-6.us-east-2.compute.internal     Ready    worker   14h   v1.31.3
+ip-10-0-205-158.us-east-2.compute.internal   Ready    master   14h   v1.31.3
+ip-10-0-210-167.us-east-2.compute.internal   Ready    worker   14h   v1.31.3
 ----
 --
 

--- a/modules/ai-adding-worker-nodes-to-cluster.adoc
+++ b/modules/ai-adding-worker-nodes-to-cluster.adoc
@@ -315,6 +315,6 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES           AGE   VERSION
-control-plane-1.example.com    Ready    master,worker   56m   v1.30.3
-compute-1.example.com          Ready    worker          11m   v1.30.3
+control-plane-1.example.com    Ready    master,worker   56m   v1.31.3
+compute-1.example.com          Ready    worker          11m   v1.31.3
 ----

--- a/modules/aws-outposts-load-balancer-clb.adoc
+++ b/modules/aws-outposts-load-balancer-clb.adoc
@@ -64,9 +64,9 @@ $ oc get nodes -l <key_name>=<value>
 [source,terminal]
 ----
 NAME                   STATUS    ROLES     AGE       VERSION
-node1.example.com      Ready     worker    7h        v1.30.3
-node2.example.com      Ready     worker    7h        v1.30.3
-node3.example.com      Ready     worker    7h        v1.30.3
+node1.example.com      Ready     worker    7h        v1.31.3
+node2.example.com      Ready     worker    7h        v1.31.3
+node3.example.com      Ready     worker    7h        v1.31.3
 ----
 
 . Configure the Classic Load Balancer service by adding the cloud-based subnet information to the `annotations` field of the `Service` manifest:

--- a/modules/cleaning-crio-storage.adoc
+++ b/modules/cleaning-crio-storage.adoc
@@ -122,7 +122,7 @@ $ oc get nodes
 +
 ----
 NAME				    STATUS	                ROLES    AGE    VERSION
-ci-ln-tkbxyft-f76d1-nvwhr-master-1  Ready, SchedulingDisabled   master	 133m   v1.30.3
+ci-ln-tkbxyft-f76d1-nvwhr-master-1  Ready, SchedulingDisabled   master	 133m   v1.31.3
 ----
 +
 . Mark the node schedulable. You will know that the scheduling is enabled when `SchedulingDisabled` is no longer in status:
@@ -137,5 +137,5 @@ $ oc adm uncordon <node_name>
 +
 ----
 NAME				     STATUS	      ROLES    AGE    VERSION
-ci-ln-tkbxyft-f76d1-nvwhr-master-1   Ready            master   133m   v1.30.3
+ci-ln-tkbxyft-f76d1-nvwhr-master-1   Ready            master   133m   v1.31.3
 ----

--- a/modules/compliance-apply-remediation-for-customized-mcp.adoc
+++ b/modules/compliance-apply-remediation-for-customized-mcp.adoc
@@ -23,11 +23,11 @@ $ oc get nodes -n openshift-compliance
 [source,terminal]
 ----
 NAME                                       STATUS  ROLES  AGE    VERSION
-ip-10-0-128-92.us-east-2.compute.internal  Ready   master 5h21m  v1.30.3
-ip-10-0-158-32.us-east-2.compute.internal  Ready   worker 5h17m  v1.30.3
-ip-10-0-166-81.us-east-2.compute.internal  Ready   worker 5h17m  v1.30.3
-ip-10-0-171-170.us-east-2.compute.internal Ready   master 5h21m  v1.30.3
-ip-10-0-197-35.us-east-2.compute.internal  Ready   master 5h22m  v1.30.3
+ip-10-0-128-92.us-east-2.compute.internal  Ready   master 5h21m  v1.31.3
+ip-10-0-158-32.us-east-2.compute.internal  Ready   worker 5h17m  v1.31.3
+ip-10-0-166-81.us-east-2.compute.internal  Ready   worker 5h17m  v1.31.3
+ip-10-0-171-170.us-east-2.compute.internal Ready   master 5h21m  v1.31.3
+ip-10-0-197-35.us-east-2.compute.internal  Ready   master 5h22m  v1.31.3
 ----
 
 . Add a label to nodes.

--- a/modules/connected-to-disconnected-verify.adoc
+++ b/modules/connected-to-disconnected-verify.adoc
@@ -44,10 +44,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-47ltxtb-f76d1-mrffg-master-0         Ready    master   42m   v1.30.3
-ci-ln-47ltxtb-f76d1-mrffg-master-1         Ready    master   42m   v1.30.3
-ci-ln-47ltxtb-f76d1-mrffg-master-2         Ready    master   42m   v1.30.3
-ci-ln-47ltxtb-f76d1-mrffg-worker-a-gsxbz   Ready    worker   35m   v1.30.3
-ci-ln-47ltxtb-f76d1-mrffg-worker-b-5qqdx   Ready    worker   35m   v1.30.3
-ci-ln-47ltxtb-f76d1-mrffg-worker-c-rjkpq   Ready    worker   34m   v1.30.3
+ci-ln-47ltxtb-f76d1-mrffg-master-0         Ready    master   42m   v1.31.3
+ci-ln-47ltxtb-f76d1-mrffg-master-1         Ready    master   42m   v1.31.3
+ci-ln-47ltxtb-f76d1-mrffg-master-2         Ready    master   42m   v1.31.3
+ci-ln-47ltxtb-f76d1-mrffg-worker-a-gsxbz   Ready    worker   35m   v1.31.3
+ci-ln-47ltxtb-f76d1-mrffg-worker-b-5qqdx   Ready    worker   35m   v1.31.3
+ci-ln-47ltxtb-f76d1-mrffg-worker-c-rjkpq   Ready    worker   34m   v1.31.3
 ----

--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -163,12 +163,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS                     ROLES                  AGE   VERSION
-ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.30.3
-ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.30.3
-ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.30.3
-ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.30.3
-ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.30.3
-ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.30.3
+ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.31.3
+ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.31.3
+ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.31.3
+ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.31.3
+ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.31.3
+ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.31.3
 ----
 
 . When the node is back in the `Ready` state, check that the node is using the custom layered image:

--- a/modules/coreos-layering-removing.adoc
+++ b/modules/coreos-layering-removing.adoc
@@ -52,12 +52,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS                     ROLES                  AGE   VERSION
-ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.30.3
-ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.30.3
-ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.30.3
-ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.30.3
-ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.30.3
-ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.30.3
+ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.31.3
+ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.31.3
+ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.31.3
+ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.31.3
+ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.31.3
+ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.31.3
 ----
 
 . When the node is back in the `Ready` state, check that the node is using the base image:

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -241,14 +241,14 @@ $ oc get nodes -w
 [source,terminal]
 ----
 NAME                STATUS  ROLES          AGE     VERSION
-host-172-25-75-28   Ready   master         3d20h   v1.30.3
-host-172-25-75-38   Ready   infra,worker   3d20h   v1.30.3
-host-172-25-75-40   Ready   master         3d20h   v1.30.3
-host-172-25-75-65   Ready   master         3d20h   v1.30.3
-host-172-25-75-74   Ready   infra,worker   3d20h   v1.30.3
-host-172-25-75-79   Ready   worker         3d20h   v1.30.3
-host-172-25-75-86   Ready   worker         3d20h   v1.30.3
-host-172-25-75-98   Ready   infra,worker   3d20h   v1.30.3
+host-172-25-75-28   Ready   master         3d20h   v1.31.3
+host-172-25-75-38   Ready   infra,worker   3d20h   v1.31.3
+host-172-25-75-40   Ready   master         3d20h   v1.31.3
+host-172-25-75-65   Ready   master         3d20h   v1.31.3
+host-172-25-75-74   Ready   infra,worker   3d20h   v1.31.3
+host-172-25-75-79   Ready   worker         3d20h   v1.31.3
+host-172-25-75-86   Ready   worker         3d20h   v1.31.3
+host-172-25-75-98   Ready   infra,worker   3d20h   v1.31.3
 ----
 +
 It can take several minutes for all nodes to report their state.

--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -35,9 +35,9 @@ The control plane nodes are ready if the status is `Ready`, as shown in the foll
 [source,terminal]
 ----
 NAME                           STATUS   ROLES                  AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    control-plane,master   75m   v1.30.3
-ip-10-0-170-223.ec2.internal   Ready    control-plane,master   75m   v1.30.3
-ip-10-0-211-16.ec2.internal    Ready    control-plane,master   75m   v1.30.3
+ip-10-0-168-251.ec2.internal   Ready    control-plane,master   75m   v1.31.3
+ip-10-0-170-223.ec2.internal   Ready    control-plane,master   75m   v1.31.3
+ip-10-0-211-16.ec2.internal    Ready    control-plane,master   75m   v1.31.3
 ----
 
 . If the control plane nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -76,9 +76,9 @@ The worker nodes are ready if the status is `Ready`, as shown in the following o
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.30.3
-ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.30.3
-ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.30.3
+ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.31.3
+ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.31.3
+ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.31.3
 ----
 
 . If the worker nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -150,12 +150,12 @@ Check that the status for all nodes is `Ready`.
 [source,terminal]
 ----
 NAME                           STATUS   ROLES                  AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    control-plane,master   82m   v1.30.3
-ip-10-0-170-223.ec2.internal   Ready    control-plane.master   82m   v1.30.3
-ip-10-0-179-95.ec2.internal    Ready    worker                 70m   v1.30.3
-ip-10-0-182-134.ec2.internal   Ready    worker                 70m   v1.30.3
-ip-10-0-211-16.ec2.internal    Ready    control-plane,master   82m   v1.30.3
-ip-10-0-250-100.ec2.internal   Ready    worker                 69m   v1.30.3
+ip-10-0-168-251.ec2.internal   Ready    control-plane,master   82m   v1.31.3
+ip-10-0-170-223.ec2.internal   Ready    control-plane.master   82m   v1.31.3
+ip-10-0-179-95.ec2.internal    Ready    worker                 70m   v1.31.3
+ip-10-0-182-134.ec2.internal   Ready    worker                 70m   v1.31.3
+ip-10-0-211-16.ec2.internal    Ready    control-plane,master   82m   v1.31.3
+ip-10-0-250-100.ec2.internal   Ready    worker                 69m   v1.31.3
 ----
 +
 If the cluster did not start properly, you might need to restore your cluster using an etcd backup.

--- a/modules/ibi-create-standalone-config-iso.adoc
+++ b/modules/ibi-create-standalone-config-iso.adoc
@@ -230,5 +230,5 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS   ROLES                  AGE     VERSION
-node/sno-cluster-name.host.example.com       Ready    control-plane,master   5h15m   v1.30.3
+node/sno-cluster-name.host.example.com       Ready    control-plane,master   5h15m   v1.31.3
 ----

--- a/modules/images-configuration-file.adoc
+++ b/modules/images-configuration-file.adoc
@@ -85,10 +85,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS                     ROLES                  AGE   VERSION
-ip-10-0-137-182.us-east-2.compute.internal   Ready,SchedulingDisabled   worker                 65m   v1.30.3
-ip-10-0-139-120.us-east-2.compute.internal   Ready,SchedulingDisabled   control-plane          74m   v1.30.3
-ip-10-0-176-102.us-east-2.compute.internal   Ready                      control-plane          75m   v1.30.3
-ip-10-0-188-96.us-east-2.compute.internal    Ready                      worker                 65m   v1.30.3
-ip-10-0-200-59.us-east-2.compute.internal    Ready                      worker                 63m   v1.30.3
-ip-10-0-223-123.us-east-2.compute.internal   Ready                      control-plane          73m   v1.30.3
+ip-10-0-137-182.us-east-2.compute.internal   Ready,SchedulingDisabled   worker                 65m   v1.31.3
+ip-10-0-139-120.us-east-2.compute.internal   Ready,SchedulingDisabled   control-plane          74m   v1.31.3
+ip-10-0-176-102.us-east-2.compute.internal   Ready                      control-plane          75m   v1.31.3
+ip-10-0-188-96.us-east-2.compute.internal    Ready                      worker                 65m   v1.31.3
+ip-10-0-200-59.us-east-2.compute.internal    Ready                      worker                 63m   v1.31.3
+ip-10-0-223-123.us-east-2.compute.internal   Ready                      control-plane          73m   v1.31.3
 ----

--- a/modules/images-configuration-image-registry-settings-hcp.adoc
+++ b/modules/images-configuration-image-registry-settings-hcp.adoc
@@ -127,7 +127,7 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS                     ROLES                  AGE   VERSION
-ip-10-0-137-182.us-east-2.compute.internal   Ready,SchedulingDisabled   worker                 65m   v1.30.3
-ip-10-0-188-96.us-east-2.compute.internal    Ready                      worker                 65m   v1.30.3
-ip-10-0-200-59.us-east-2.compute.internal    Ready                      worker                 63m   v1.30.3
+ip-10-0-137-182.us-east-2.compute.internal   Ready,SchedulingDisabled   worker                 65m   v1.31.3
+ip-10-0-188-96.us-east-2.compute.internal    Ready                      worker                 65m   v1.31.3
+ip-10-0-200-59.us-east-2.compute.internal    Ready                      worker                 63m   v1.31.3
 ----

--- a/modules/images-configuration-registry-mirror-configuring.adoc
+++ b/modules/images-configuration-registry-mirror-configuring.adoc
@@ -207,12 +207,12 @@ $ oc get node
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE  VERSION
-ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.30.3
-ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.30.3
-ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.30.3
-ip-10-0-147-35.ec2.internal    Ready                      worker   7m   v1.30.3
-ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.30.3
-ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.30.3
+ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.31.3
+ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.31.3
+ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.31.3
+ip-10-0-147-35.ec2.internal    Ready                      worker   7m   v1.31.3
+ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.31.3
+ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.31.3
 ----
 
 .. Start the debugging process to access the node:

--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -104,7 +104,7 @@ $ oc get node <node_name> <1>
 [source,terminal]
 ----
 NAME                          STATUS  ROLES         AGE   VERSION
-ip-10-0-217-226.ec2.internal  Ready   infra,worker  17h   v1.30.3
+ip-10-0-217-226.ec2.internal  Ready   infra,worker  17h   v1.31.3
 ----
 +
 Because the role list includes `infra`, the pod is running on the correct node.

--- a/modules/install-sno-monitoring-the-installation-manually.adoc
+++ b/modules/install-sno-monitoring-the-installation-manually.adoc
@@ -66,7 +66,7 @@ ifndef::openshift-origin[]
 [source,terminal]
 ----
 NAME                         STATUS   ROLES           AGE     VERSION
-control-plane.example.com    Ready    master,worker   10m     v1.30.3
+control-plane.example.com    Ready    master,worker   10m     v1.31.3
 ----
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -65,9 +65,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  63m  v1.30.3
-master-1  Ready     master  63m  v1.30.3
-master-2  Ready     master  64m  v1.30.3
+master-0  Ready     master  63m  v1.31.3
+master-1  Ready     master  63m  v1.31.3
+master-2  Ready     master  64m  v1.31.3
 ----
 +
 The output lists all of the machines that you created.
@@ -193,21 +193,21 @@ endif::ibm-power[]
 ----
 ifndef::ibm-power[]
 NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  73m  v1.30.3
-master-1  Ready     master  73m  v1.30.3
-master-2  Ready     master  74m  v1.30.3
-worker-0  Ready     worker  11m  v1.30.3
-worker-1  Ready     worker  11m  v1.30.3
+master-0  Ready     master  73m  v1.31.3
+master-1  Ready     master  73m  v1.31.3
+master-2  Ready     master  74m  v1.31.3
+worker-0  Ready     worker  11m  v1.31.3
+worker-1  Ready     worker  11m  v1.31.3
 endif::ibm-power[]
 ifdef::ibm-power[]
 NAME               STATUS   ROLES                  AGE   VERSION   INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                  CONTAINER-RUNTIME
-worker-0-ppc64le   Ready    worker                 42d   v1.30.3   192.168.200.21   <none>        Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.ppc64le   cri-o://1.30.3-3.rhaos4.15.gitb36169e.el9
-worker-1-ppc64le   Ready    worker                 42d   v1.30.3   192.168.200.20   <none>        Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.ppc64le   cri-o://1.30.3-3.rhaos4.15.gitb36169e.el9
-master-0-x86       Ready    control-plane,master   75d   v1.30.3   10.248.0.38      10.248.0.38   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.30.3-3.rhaos4.15.gitb36169e.el9
-master-1-x86       Ready    control-plane,master   75d   v1.30.3   10.248.0.39      10.248.0.39   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.30.3-3.rhaos4.15.gitb36169e.el9
-master-2-x86       Ready    control-plane,master   75d   v1.30.3   10.248.0.40      10.248.0.40   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.30.3-3.rhaos4.15.gitb36169e.el9
-worker-0-x86       Ready    worker                 75d   v1.30.3   10.248.0.43      10.248.0.43   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.30.3-3.rhaos4.15.gitb36169e.el9
-worker-1-x86       Ready    worker                 75d   v1.30.3   10.248.0.44      10.248.0.44   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.30.3-3.rhaos4.15.gitb36169e.el9
+worker-0-ppc64le   Ready    worker                 42d   v1.31.3   192.168.200.21   <none>        Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.ppc64le   cri-o://1.31.3-3.rhaos4.15.gitb36169e.el9
+worker-1-ppc64le   Ready    worker                 42d   v1.31.3   192.168.200.20   <none>        Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.ppc64le   cri-o://1.31.3-3.rhaos4.15.gitb36169e.el9
+master-0-x86       Ready    control-plane,master   75d   v1.31.3   10.248.0.38      10.248.0.38   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.31.3-3.rhaos4.15.gitb36169e.el9
+master-1-x86       Ready    control-plane,master   75d   v1.31.3   10.248.0.39      10.248.0.39   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.31.3-3.rhaos4.15.gitb36169e.el9
+master-2-x86       Ready    control-plane,master   75d   v1.31.3   10.248.0.40      10.248.0.40   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.31.3-3.rhaos4.15.gitb36169e.el9
+worker-0-x86       Ready    worker                 75d   v1.31.3   10.248.0.43      10.248.0.43   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.31.3-3.rhaos4.15.gitb36169e.el9
+worker-1-x86       Ready    worker                 75d   v1.31.3   10.248.0.44      10.248.0.44   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.31.3-3.rhaos4.15.gitb36169e.el9
 endif::ibm-power[]
 ----
 +

--- a/modules/installation-aws-user-infra-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-bootstrap.adoc
@@ -40,7 +40,7 @@ stored the installation files in.
 [source,terminal]
 ----
 INFO Waiting up to 20m0s for the Kubernetes API at https://api.mycluster.example.com:6443...
-INFO API v1.30.3 up
+INFO API v1.31.3 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 INFO It is now safe to remove the bootstrap resources
 INFO Time elapsed: 1s

--- a/modules/installation-installing-bare-metal.adoc
+++ b/modules/installation-installing-bare-metal.adoc
@@ -62,7 +62,7 @@ $ ./openshift-install --dir <installation_directory> wait-for bootstrap-complete
 [source,terminal]
 ----
 INFO Waiting up to 30m0s for the Kubernetes API at https://api.test.example.com:6443...
-INFO API v1.30.3 up
+INFO API v1.31.3 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 INFO It is now safe to remove the bootstrap resources
 ----

--- a/modules/installation-osp-creating-control-plane.adoc
+++ b/modules/installation-osp-creating-control-plane.adoc
@@ -40,7 +40,7 @@ You will see messages that confirm that the control plane machines are running a
 +
 [source,terminal]
 ----
-INFO API v1.30.3 up
+INFO API v1.31.3 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 ...
 INFO It is now safe to remove the bootstrap resources

--- a/modules/installation-special-config-rtkernel.adoc
+++ b/modules/installation-special-config-rtkernel.adoc
@@ -92,12 +92,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.30.3
-ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.30.3
-ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.30.3
-ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.30.3
-ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.30.3
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.30.3
+ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.31.3
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.31.3
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.31.3
+ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.31.3
+ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.31.3
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.31.3
 ----
 +
 [source,terminal]

--- a/modules/ipi-install-provisioning-the-bare-metal-node.adoc
+++ b/modules/ipi-install-provisioning-the-bare-metal-node.adoc
@@ -35,11 +35,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                                STATUS   ROLES           AGE     VERSION
-openshift-master-1.openshift.example.com            Ready    master          30h     v1.30.3
-openshift-master-2.openshift.example.com            Ready    master          30h     v1.30.3
-openshift-master-3.openshift.example.com            Ready    master          30h     v1.30.3
-openshift-worker-0.openshift.example.com            Ready    worker          30h     v1.30.3
-openshift-worker-1.openshift.example.com            Ready    worker          30h     v1.30.3
+openshift-master-1.openshift.example.com            Ready    master          30h     v1.31.3
+openshift-master-2.openshift.example.com            Ready    master          30h     v1.31.3
+openshift-master-3.openshift.example.com            Ready    master          30h     v1.31.3
+openshift-worker-0.openshift.example.com            Ready    worker          30h     v1.31.3
+openshift-worker-1.openshift.example.com            Ready    worker          30h     v1.31.3
 ----
 
 . Get the compute machine set.
@@ -99,12 +99,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                          STATUS   ROLES   AGE     VERSION
-openshift-master-1.openshift.example.com      Ready    master  30h     v1.30.3
-openshift-master-2.openshift.example.com      Ready    master  30h     v1.30.3
-openshift-master-3.openshift.example.com      Ready    master  30h     v1.30.3
-openshift-worker-0.openshift.example.com      Ready    worker  30h     v1.30.3
-openshift-worker-1.openshift.example.com      Ready    worker  30h     v1.30.3
-openshift-worker-<num>.openshift.example.com  Ready    worker  3m27s   v1.30.3
+openshift-master-1.openshift.example.com      Ready    master  30h     v1.31.3
+openshift-master-2.openshift.example.com      Ready    master  30h     v1.31.3
+openshift-master-3.openshift.example.com      Ready    master  30h     v1.31.3
+openshift-worker-0.openshift.example.com      Ready    worker  30h     v1.31.3
+openshift-worker-1.openshift.example.com      Ready    worker  30h     v1.31.3
+openshift-worker-<num>.openshift.example.com  Ready    worker  3m27s   v1.31.3
 ----
 +
 You can also check the kubelet.

--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -178,11 +178,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS      ROLES     AGE   VERSION
-control-plane-1.example.com    available   master    4m2s  v1.30.3
-control-plane-2.example.com    available   master    141m  v1.30.3
-control-plane-3.example.com    available   master    141m  v1.30.3
-compute-1.example.com          available   worker    87m   v1.30.3
-compute-2.example.com          available   worker    87m   v1.30.3
+control-plane-1.example.com    available   master    4m2s  v1.31.3
+control-plane-2.example.com    available   master    141m  v1.31.3
+control-plane-3.example.com    available   master    141m  v1.31.3
+compute-1.example.com          available   worker    87m   v1.31.3
+compute-2.example.com          available   worker    87m   v1.31.3
 ----
 +
 [NOTE]

--- a/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
+++ b/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
@@ -21,10 +21,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                         STATUS   ROLES    AGE   VERSION
-master-0.cloud.example.com   Ready    master   145m   v1.30.3
-master-1.cloud.example.com   Ready    master   135m   v1.30.3
-master-2.cloud.example.com   Ready    master   145m   v1.30.3
-worker-2.cloud.example.com   Ready    worker   100m   v1.30.3
+master-0.cloud.example.com   Ready    master   145m   v1.31.3
+master-1.cloud.example.com   Ready    master   135m   v1.31.3
+master-2.cloud.example.com   Ready    master   145m   v1.31.3
+worker-2.cloud.example.com   Ready    worker   100m   v1.31.3
 ----
 
 . Check for inconsistent timing delays due to clock drift. For example:

--- a/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
+++ b/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
@@ -21,9 +21,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS   ROLES           AGE  VERSION
-master-0.example.com   Ready    master,worker   4h   v1.30.3
-master-1.example.com   Ready    master,worker   4h   v1.30.3
-master-2.example.com   Ready    master,worker   4h   v1.30.3
+master-0.example.com   Ready    master,worker   4h   v1.31.3
+master-1.example.com   Ready    master,worker   4h   v1.31.3
+master-2.example.com   Ready    master,worker   4h   v1.31.3
 ----
 
 . Confirm the installation program deployed all pods successfully. The following command

--- a/modules/machine-node-custom-partition.adoc
+++ b/modules/machine-node-custom-partition.adoc
@@ -236,13 +236,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE     VERSION
-ip-10-0-128-78.ec2.internal    Ready    worker   117m    v1.30.3
-ip-10-0-146-113.ec2.internal   Ready    master   127m    v1.30.3
-ip-10-0-153-35.ec2.internal    Ready    worker   118m    v1.30.3
-ip-10-0-176-58.ec2.internal    Ready    master   126m    v1.30.3
-ip-10-0-217-135.ec2.internal   Ready    worker   2m57s   v1.30.3 <1>
-ip-10-0-225-248.ec2.internal   Ready    master   127m    v1.30.3
-ip-10-0-245-59.ec2.internal    Ready    worker   116m    v1.30.3
+ip-10-0-128-78.ec2.internal    Ready    worker   117m    v1.31.3
+ip-10-0-146-113.ec2.internal   Ready    master   127m    v1.31.3
+ip-10-0-153-35.ec2.internal    Ready    worker   118m    v1.31.3
+ip-10-0-176-58.ec2.internal    Ready    master   126m    v1.31.3
+ip-10-0-217-135.ec2.internal   Ready    worker   2m57s   v1.31.3 <1>
+ip-10-0-225-248.ec2.internal   Ready    master   127m    v1.31.3
+ip-10-0-245-59.ec2.internal    Ready    worker   116m    v1.31.3
 ----
 <1> This is new new node.
 

--- a/modules/microshift-custom-ca-proc.adoc
+++ b/modules/microshift-custom-ca-proc.adoc
@@ -75,7 +75,7 @@ $ oc --certificate-authority ~/certs/ca.ca get node
 ----
 oc get node
 NAME                             STATUS   ROLES                         AGE   VERSION
-dhcp-1-235-195.arm.example.com   Ready    control-plane,master,worker   76m   v1.30.3
+dhcp-1-235-195.arm.example.com   Ready    control-plane,master,worker   76m   v1.31.3
 ----
 
 .. Add the new CA file to the $KUBECONFIG environment variable by running the following command:

--- a/modules/nodes-cluster-resource-override-move-infra.adoc
+++ b/modules/nodes-cluster-resource-override-move-infra.adoc
@@ -32,15 +32,15 @@ clusterresourceoverride-operator-6b8b8b656b-lvr62   1/1     Running   0         
 [source,terminal]
 ----
 NAME                                        STATUS   ROLES                  AGE   VERSION
-ip-10-0-14-183.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.30.4
-ip-10-0-2-39.us-west-2.compute.internal     Ready    worker                 58m   v1.30.4
-ip-10-0-20-140.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.30.4
-ip-10-0-23-244.us-west-2.compute.internal   Ready    infra                  55m   v1.30.4
-ip-10-0-77-153.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.30.4
-ip-10-0-99-108.us-west-2.compute.internal   Ready    worker                 24m   v1.30.4
-ip-10-0-24-233.us-west-2.compute.internal   Ready    infra                  55m   v1.30.4
-ip-10-0-88-109.us-west-2.compute.internal   Ready    worker                 24m   v1.30.4
-ip-10-0-67-453.us-west-2.compute.internal   Ready    infra                  55m   v1.30.4
+ip-10-0-14-183.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.31.3
+ip-10-0-2-39.us-west-2.compute.internal     Ready    worker                 58m   v1.31.3
+ip-10-0-20-140.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.31.3
+ip-10-0-23-244.us-west-2.compute.internal   Ready    infra                  55m   v1.31.3
+ip-10-0-77-153.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.31.3
+ip-10-0-99-108.us-west-2.compute.internal   Ready    worker                 24m   v1.31.3
+ip-10-0-24-233.us-west-2.compute.internal   Ready    infra                  55m   v1.31.3
+ip-10-0-88-109.us-west-2.compute.internal   Ready    worker                 24m   v1.31.3
+ip-10-0-67-453.us-west-2.compute.internal   Ready    infra                  55m   v1.31.3
 ----
 
 .Procedure

--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -203,12 +203,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                       STATUS                     ROLES    AGE   VERSION
-ci-ln-fm1qnwt-72292-99kt6-master-0         Ready,SchedulingDisabled   master   58m   v1.30.3
-ci-ln-fm1qnwt-72292-99kt6-master-1         Ready                      master   58m   v1.30.3
-ci-ln-fm1qnwt-72292-99kt6-master-2         Ready                      master   58m   v1.30.3
-ci-ln-fm1qnwt-72292-99kt6-worker-a-h5gt4   Ready,SchedulingDisabled   worker   48m   v1.30.3
-ci-ln-fm1qnwt-72292-99kt6-worker-b-7vtmd   Ready                      worker   48m   v1.30.3
-ci-ln-fm1qnwt-72292-99kt6-worker-c-rhzkv   Ready                      worker   48m   v1.30.3
+ci-ln-fm1qnwt-72292-99kt6-master-0         Ready,SchedulingDisabled   master   58m   v1.31.3
+ci-ln-fm1qnwt-72292-99kt6-master-1         Ready                      master   58m   v1.31.3
+ci-ln-fm1qnwt-72292-99kt6-master-2         Ready                      master   58m   v1.31.3
+ci-ln-fm1qnwt-72292-99kt6-worker-a-h5gt4   Ready,SchedulingDisabled   worker   48m   v1.31.3
+ci-ln-fm1qnwt-72292-99kt6-worker-b-7vtmd   Ready                      worker   48m   v1.31.3
+ci-ln-fm1qnwt-72292-99kt6-worker-c-rhzkv   Ready                      worker   48m   v1.31.3
 ----
 
 . After a node returns to the `Ready` state, start a debug session for that node:

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -187,12 +187,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.30.3
-ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.30.3
-ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.30.3
-ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.30.3
-ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.30.3
-ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.30.3
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.31.3
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.31.3
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.31.3
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.31.3
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.31.3
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.31.3
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/nodes-nodes-rtkernel-arguments.adoc
+++ b/modules/nodes-nodes-rtkernel-arguments.adoc
@@ -58,9 +58,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.30.3
-ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.30.3
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.30.3
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.31.3
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.31.3
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.31.3
 ----
 +
 [source,terminal]

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -26,9 +26,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS    ROLES     AGE       VERSION
-master.example.com     Ready     master    7h        v1.30.3
-node1.example.com      Ready     worker    7h        v1.30.3
-node2.example.com      Ready     worker    7h        v1.30.3
+master.example.com     Ready     master    7h        v1.31.3
+node1.example.com      Ready     worker    7h        v1.31.3
+node2.example.com      Ready     worker    7h        v1.31.3
 ----
 +
 The following example is a cluster with one unhealthy node:
@@ -42,9 +42,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS                      ROLES     AGE       VERSION
-master.example.com     Ready                       master    7h        v1.30.3
-node1.example.com      NotReady,SchedulingDisabled worker    7h        v1.30.3
-node2.example.com      Ready                       worker    7h        v1.30.3
+master.example.com     Ready                       master    7h        v1.31.3
+node1.example.com      NotReady,SchedulingDisabled worker    7h        v1.31.3
+node2.example.com      Ready                       worker    7h        v1.31.3
 ----
 +
 The conditions that trigger a `NotReady` status are shown later in this section.
@@ -60,9 +60,9 @@ $ oc get nodes -o wide
 [source,terminal]
 ----
 NAME                STATUS   ROLES    AGE    VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                 CONTAINER-RUNTIME
-master.example.com  Ready    master   171m   v1.30.3   10.0.129.108   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.30.3-30.rhaos4.10.gitf2f339d.el8-dev
-node1.example.com   Ready    worker   72m    v1.30.3   10.0.129.222   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.30.3-30.rhaos4.10.gitf2f339d.el8-dev
-node2.example.com   Ready    worker   164m   v1.30.3   10.0.142.150   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.30.3-30.rhaos4.10.gitf2f339d.el8-dev
+master.example.com  Ready    master   171m   v1.31.3   10.0.129.108   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.31.3-30.rhaos4.10.gitf2f339d.el8-dev
+node1.example.com   Ready    worker   72m    v1.31.3   10.0.129.222   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.31.3-30.rhaos4.10.gitf2f339d.el8-dev
+node2.example.com   Ready    worker   164m   v1.31.3   10.0.142.150   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.31.3-30.rhaos4.10.gitf2f339d.el8-dev
 ----
 
 * The following command lists information about a single node:
@@ -83,7 +83,7 @@ $ oc get node node1.example.com
 [source,terminal]
 ----
 NAME                   STATUS    ROLES     AGE       VERSION
-node1.example.com      Ready     worker    7h        v1.30.3
+node1.example.com      Ready     worker    7h        v1.31.3
 ----
 
 * The following command provides more detailed information about a specific node, including the reason for
@@ -161,9 +161,9 @@ System Info:    <9>
  OS Image:                                Red Hat Enterprise Linux CoreOS 410.8.20190520.0 (Ootpa)
  Operating System:                        linux
  Architecture:                            amd64
- Container Runtime Version:               cri-o://1.30.3-0.6.dev.rhaos4.3.git9ad059b.el8-rc2
- Kubelet Version:                         v1.30.3
- Kube-Proxy Version:                      v1.30.3
+ Container Runtime Version:               cri-o://1.31.3-0.6.dev.rhaos4.3.git9ad059b.el8-rc2
+ Kubelet Version:                         v1.31.3
+ Kube-Proxy Version:                      v1.31.3
 PodCIDR:                                  10.128.4.0/24
 ProviderID:                               aws:///us-east-2a/i-04e87b31dc6b3e171
 Non-terminated Pods:                      (12 in total)  <10>

--- a/modules/nodes-nodes-working-evacuating.adoc
+++ b/modules/nodes-nodes-working-evacuating.adoc
@@ -44,7 +44,7 @@ $ oc get node <node1>
 [source,terminal]
 ----
 NAME        STATUS                     ROLES     AGE       VERSION
-<node1>     Ready,SchedulingDisabled   worker    1d        v1.30.3
+<node1>     Ready,SchedulingDisabled   worker    1d        v1.31.3
 ----
 
 . Evacuate the pods using one of the following methods:

--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -145,7 +145,7 @@ $ oc get nodes -l type=user-node
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.30.3
+ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.31.3
 ----
 
 * Add labels directly to a node:
@@ -198,5 +198,5 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.30.3
+ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.31.3
 ----

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -180,7 +180,7 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                          STATUS   ROLES    AGE   VERSION
-ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.30.3
+ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.31.3
 ----
 
 . Add the matching node selector to a pod:

--- a/modules/nodes-scheduler-node-selectors-project.adoc
+++ b/modules/nodes-scheduler-node-selectors-project.adoc
@@ -161,7 +161,7 @@ $ oc get nodes -l type=user-node
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.30.3
+ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.31.3
 ----
 
 * Add labels directly to a node:
@@ -214,5 +214,5 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.30.3
+ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.31.3
 ----

--- a/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
@@ -28,12 +28,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS   ROLES                  AGE     VERSION
-ip-10-0-52-50.us-east-2.compute.internal    Ready    worker                 3d17h   v1.30.3
-ip-10-0-58-24.us-east-2.compute.internal    Ready    control-plane,master   3d17h   v1.30.3
-ip-10-0-68-148.us-east-2.compute.internal   Ready    worker                 3d17h   v1.30.3
-ip-10-0-68-68.us-east-2.compute.internal    Ready    control-plane,master   3d17h   v1.30.3
-ip-10-0-72-170.us-east-2.compute.internal   Ready    control-plane,master   3d17h   v1.30.3
-ip-10-0-74-50.us-east-2.compute.internal    Ready    worker                 3d17h   v1.30.3
+ip-10-0-52-50.us-east-2.compute.internal    Ready    worker                 3d17h   v1.31.3
+ip-10-0-58-24.us-east-2.compute.internal    Ready    control-plane,master   3d17h   v1.31.3
+ip-10-0-68-148.us-east-2.compute.internal   Ready    worker                 3d17h   v1.31.3
+ip-10-0-68-68.us-east-2.compute.internal    Ready    control-plane,master   3d17h   v1.31.3
+ip-10-0-72-170.us-east-2.compute.internal   Ready    control-plane,master   3d17h   v1.31.3
+ip-10-0-74-50.us-east-2.compute.internal    Ready    worker                 3d17h   v1.31.3
 ----
 
 . View the machines and machine sets that exist in the `openshift-machine-api` namespace by running the following command. Each compute machine set is associated with a different availability zone within the AWS region. The installer automatically load balances compute machines across availability zones.

--- a/modules/nvidia-gpu-azure-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-azure-adding-a-gpu-node.adoc
@@ -346,13 +346,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                                STATUS   ROLES                  AGE     VERSION
-myclustername-master-0                              Ready    control-plane,master   6h39m   v1.30.3
-myclustername-master-1                              Ready    control-plane,master   6h41m   v1.30.3
-myclustername-master-2                              Ready    control-plane,master   6h39m   v1.30.3
-myclustername-nc4ast4-gpu-worker-centralus1-w9bqn   Ready    worker                 14m     v1.30.3
-myclustername-worker-centralus1-rbh6b               Ready    worker                 6h29m   v1.30.3
-myclustername-worker-centralus2-dbz7w               Ready    worker                 6h29m   v1.30.3
-myclustername-worker-centralus3-p9b8c               Ready    worker                 6h31m   v1.30.3
+myclustername-master-0                              Ready    control-plane,master   6h39m   v1.31.3
+myclustername-master-1                              Ready    control-plane,master   6h41m   v1.31.3
+myclustername-master-2                              Ready    control-plane,master   6h39m   v1.31.3
+myclustername-nc4ast4-gpu-worker-centralus1-w9bqn   Ready    worker                 14m     v1.31.3
+myclustername-worker-centralus1-rbh6b               Ready    worker                 6h29m   v1.31.3
+myclustername-worker-centralus2-dbz7w               Ready    worker                 6h29m   v1.31.3
+myclustername-worker-centralus3-p9b8c               Ready    worker                 6h31m   v1.31.3
 ----
 
 . View the list of compute machine sets:

--- a/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
@@ -156,13 +156,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                                             STATUS     ROLES                  AGE     VERSION
-myclustername-2pt9p-master-0.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.30.3
-myclustername-2pt9p-master-1.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.30.3
-myclustername-2pt9p-master-2.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.30.3
-myclustername-2pt9p-worker-a-mxtnz.c.openshift-qe.internal       Ready      worker                 8h      v1.30.3
-myclustername-2pt9p-worker-b-9pzzn.c.openshift-qe.internal       Ready      worker                 8h      v1.30.3
-myclustername-2pt9p-worker-c-6pbg6.c.openshift-qe.internal       Ready      worker                 8h      v1.30.3
-myclustername-2pt9p-worker-gpu-a-wxcr6.c.openshift-qe.internal   Ready      worker                 4h35m   v1.30.3
+myclustername-2pt9p-master-0.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.31.3
+myclustername-2pt9p-master-1.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.31.3
+myclustername-2pt9p-master-2.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.31.3
+myclustername-2pt9p-worker-a-mxtnz.c.openshift-qe.internal       Ready      worker                 8h      v1.31.3
+myclustername-2pt9p-worker-b-9pzzn.c.openshift-qe.internal       Ready      worker                 8h      v1.31.3
+myclustername-2pt9p-worker-c-6pbg6.c.openshift-qe.internal       Ready      worker                 8h      v1.31.3
+myclustername-2pt9p-worker-gpu-a-wxcr6.c.openshift-qe.internal   Ready      worker                 4h35m   v1.31.3
 ----
 
 . View the machines and machine sets that exist in the `openshift-machine-api` namespace by running the following command. Each compute machine set is associated with a different availability zone within the GCP region. The installer automatically load balances compute machines across availability zones.

--- a/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
+++ b/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
@@ -61,13 +61,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME       STATUS   ROLES                   AGE   VERSION
-master-0   Ready    master                  2d    v1.30.3
-master-1   Ready    master                  2d    v1.30.3
-master-2   Ready    master                  2d    v1.30.3
-worker-0   Ready    worker                  2d    v1.30.3
-worker-1   Ready    worker                  2d    v1.30.3
-worker-2   Ready    mcp-offloading,worker   47h   v1.30.3
-worker-3   Ready    mcp-offloading,worker   47h   v1.30.3
+master-0   Ready    master                  2d    v1.31.3
+master-1   Ready    master                  2d    v1.31.3
+master-2   Ready    master                  2d    v1.31.3
+worker-0   Ready    worker                  2d    v1.31.3
+worker-1   Ready    worker                  2d    v1.31.3
+worker-2   Ready    mcp-offloading,worker   47h   v1.31.3
+worker-3   Ready    mcp-offloading,worker   47h   v1.31.3
 ----
 --
 

--- a/modules/olm-catalogsource-image-template.adoc
+++ b/modules/olm-catalogsource-image-template.adoc
@@ -14,18 +14,18 @@ endif::[]
 
 Operator compatibility with the underlying cluster can be expressed by a catalog source in various ways. One way, which is used for the default Red Hat-provided catalog sources, is to identify image tags for index images that are specifically created for a particular platform release, for example {product-title} {product-version}.
 
-During a cluster upgrade, the index image tag for the default Red Hat-provided catalog sources are updated automatically by the Cluster Version Operator (CVO) so that Operator Lifecycle Manager (OLM) pulls the updated version of the catalog. For example during an upgrade from {product-title} 4.16 to 4.17, the `spec.image` field in the `CatalogSource` object for the `redhat-operators` catalog is updated from:
+During a cluster upgrade, the index image tag for the default Red Hat-provided catalog sources are updated automatically by the Cluster Version Operator (CVO) so that Operator Lifecycle Manager (OLM) pulls the updated version of the catalog. For example during an upgrade from {product-title} 4.17 to 4.18, the `spec.image` field in the `CatalogSource` object for the `redhat-operators` catalog is updated from:
 
 [source,terminal]
 ----
-registry.redhat.io/redhat/redhat-operator-index:v4.16
+registry.redhat.io/redhat/redhat-operator-index:v4.17
 ----
 
 to:
 
 [source,terminal]
 ----
-registry.redhat.io/redhat/redhat-operator-index:v4.17
+registry.redhat.io/redhat/redhat-operator-index:v4.18
 ----
 
 However, the CVO does not automatically update image tags for custom catalogs. To ensure users are left with a compatible and supported Operator installation after a cluster upgrade, custom catalogs should also be kept updated to reference an updated index image.
@@ -64,7 +64,7 @@ metadata:
       "quay.io/example-org/example-catalog:v{kube_major_version}.{kube_minor_version}"
 spec:
   displayName: Example Catalog
-  image: quay.io/example-org/example-catalog:v1.30
+  image: quay.io/example-org/example-catalog:v1.31
   priority: -400
   publisher: Example Org
 ----
@@ -77,11 +77,11 @@ If the `spec.image` field and the `olm.catalogImageTemplate` annotation are both
 If the `spec.image` field is not set and the annotation does not resolve to a usable pull spec, OLM stops reconciliation of the catalog source and sets it into a human-readable error condition.
 ====
 
-For an {product-title} {product-version} cluster, which uses Kubernetes 1.30, the `olm.catalogImageTemplate` annotation in the preceding example resolves to the following image reference:
+For an {product-title} {product-version} cluster, which uses Kubernetes 1.31, the `olm.catalogImageTemplate` annotation in the preceding example resolves to the following image reference:
 
 [source,terminal]
 ----
-quay.io/example-org/example-catalog:v1.30
+quay.io/example-org/example-catalog:v1.31
 ----
 
 For future releases of {product-title}, you can create updated index images for your custom catalogs that target the later Kubernetes version that is used by the later {product-title} version. With the `olm.catalogImageTemplate` annotation set before the upgrade, upgrading the cluster to the later {product-title} version would then automatically update the catalog's index image as well.

--- a/modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc
+++ b/modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc
@@ -26,12 +26,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                          STATUS   ROLES    AGE   VERSION
-compute-1.example.com         Ready    worker   33m   v1.30.3
-control-plane-1.example.com   Ready    master   41m   v1.30.3
-control-plane-2.example.com   Ready    master   45m   v1.30.3
-compute-2.example.com         Ready    worker   38m   v1.30.3
-compute-3.example.com         Ready    worker   33m   v1.30.3
-control-plane-3.example.com   Ready    master   41m   v1.30.3
+compute-1.example.com         Ready    worker   33m   v1.31.3
+control-plane-1.example.com   Ready    master   41m   v1.31.3
+control-plane-2.example.com   Ready    master   45m   v1.31.3
+compute-2.example.com         Ready    worker   38m   v1.31.3
+compute-3.example.com         Ready    worker   33m   v1.31.3
+control-plane-3.example.com   Ready    master   41m   v1.31.3
 ----
 
 . Review CPU and memory resource availability for each cluster node:

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -71,7 +71,7 @@ $ oc get nodes -l node-role.kubernetes.io/master | grep "NotReady"
 .Example output
 [source,terminal]
 ----
-ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.30.3 <1>
+ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.31.3 <1>
 ----
 <1> If the node is listed as `NotReady`, then the *node is not ready*.
 
@@ -95,9 +95,9 @@ $ oc get nodes -l node-role.kubernetes.io/master
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE     VERSION
-ip-10-0-131-183.ec2.internal   Ready    master   6h13m   v1.30.3
-ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.30.3
-ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.30.3
+ip-10-0-131-183.ec2.internal   Ready    master   6h13m   v1.31.3
+ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.31.3
+ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.31.3
 ----
 
 .. Check whether the status of an etcd pod is either `Error` or `CrashloopBackoff`:

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -284,10 +284,10 @@ examplecluster-compute-1          Running                          165m    opens
 $ oc get nodes
 
 NAME                     STATUS ROLES   AGE   VERSION
-openshift-control-plane-0 Ready master 3h24m v1.30.3
-openshift-control-plane-1 Ready master 3h24m v1.30.3
-openshift-compute-0       Ready worker 176m v1.30.3
-openshift-compute-1       Ready worker 176m v1.30.3
+openshift-control-plane-0 Ready master 3h24m v1.31.3
+openshift-control-plane-1 Ready master 3h24m v1.31.3
+openshift-compute-0       Ready worker 176m v1.31.3
+openshift-compute-1       Ready worker 176m v1.31.3
 ----
 
 . Create the new `BareMetalHost` object and the secret to store the BMC credentials:
@@ -412,11 +412,11 @@ $ oc get nodes
 ----
 $ oc get nodes
 NAME                     STATUS ROLES   AGE   VERSION
-openshift-control-plane-0 Ready master 4h26m v1.30.3
-openshift-control-plane-1 Ready master 4h26m v1.30.3
-openshift-control-plane-2 Ready master 12m   v1.30.3
-openshift-compute-0       Ready worker 3h58m v1.30.3
-openshift-compute-1       Ready worker 3h58m v1.30.3
+openshift-control-plane-0 Ready master 4h26m v1.31.3
+openshift-control-plane-1 Ready master 4h26m v1.31.3
+openshift-control-plane-2 Ready master 12m   v1.31.3
+openshift-compute-0       Ready worker 3h58m v1.31.3
+openshift-compute-1       Ready worker 3h58m v1.31.3
 ----
 
 . Turn the quorum guard back on by entering the following command:

--- a/modules/rhcos-add-extensions.adoc
+++ b/modules/rhcos-add-extensions.adoc
@@ -94,7 +94,7 @@ $ oc get node | grep worker
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.30.3
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.31.3
 ----
 +
 [source,terminal]

--- a/modules/rhcos-enabling-multipath-day-2.adoc
+++ b/modules/rhcos-enabling-multipath-day-2.adoc
@@ -111,12 +111,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.30.3
-ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.30.3
-ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.30.3
-ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.30.3
-ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.30.3
-ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.30.3
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.31.3
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.31.3
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.31.3
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.31.3
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.31.3
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.31.3
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -125,13 +125,13 @@ The `upgrade` playbook only updates the {product-title} packages. It does not up
 [source,terminal]
 ----
 NAME                        STATUS                        ROLES    AGE    VERSION
-mycluster-control-plane-0   Ready                         master   145m   v1.30.3
-mycluster-control-plane-1   Ready                         master   145m   v1.30.3
-mycluster-control-plane-2   Ready                         master   145m   v1.30.3
-mycluster-rhel8-0           Ready                         worker   98m    v1.30.3
-mycluster-rhel8-1           Ready                         worker   98m    v1.30.3
-mycluster-rhel8-2           Ready                         worker   98m    v1.30.3
-mycluster-rhel8-3           Ready                         worker   98m    v1.30.3
+mycluster-control-plane-0   Ready                         master   145m   v1.31.3
+mycluster-control-plane-1   Ready                         master   145m   v1.31.3
+mycluster-control-plane-2   Ready                         master   145m   v1.31.3
+mycluster-rhel8-0           Ready                         worker   98m    v1.31.3
+mycluster-rhel8-1           Ready                         worker   98m    v1.31.3
+mycluster-rhel8-2           Ready                         worker   98m    v1.31.3
+mycluster-rhel8-3           Ready                         worker   98m    v1.31.3
 ----
 
 . Optional: Update the operating system packages that were not updated by the `upgrade` playbook. To update packages that are not on {product-version}, use the following command:

--- a/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
+++ b/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
@@ -214,6 +214,6 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES           AGE   VERSION
-control-plane-1.example.com    Ready    master,worker   56m   v1.30.3
-compute-1.example.com          Ready    worker          11m   v1.30.3
+control-plane-1.example.com    Ready    master,worker   56m   v1.31.3
+compute-1.example.com          Ready    worker          11m   v1.31.3
 ----

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -190,11 +190,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.30.3
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.30.3
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.30.3
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.30.3
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.30.3
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.30.3
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.31.3
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.31.3
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.31.3
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.31.3
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.31.3
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.31.3
 ----
 

--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -31,9 +31,9 @@ $ oc get nodes -l node-role.kubernetes.io/worker
 [source,terminal]
 ----
 NAME              STATUS   ROLES    AGE   VERSION
-compute-node-0    Ready    worker   30m   v1.30.3
-compute-node-1    Ready    worker   30m   v1.30.3
-compute-node-2    Ready    worker   30m   v1.30.3
+compute-node-0    Ready    worker   30m   v1.31.3
+compute-node-1    Ready    worker   30m   v1.31.3
+compute-node-2    Ready    worker   30m   v1.31.3
 ----
 +
 Note the names of your compute nodes.

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -26,9 +26,9 @@ $ oc get nodes -l node-role.kubernetes.io/master
 [source,terminal]
 ----
 NAME                    STATUS   ROLES    AGE   VERSION
-control-plane-node-0    Ready    master   75m   v1.30.3
-control-plane-node-1    Ready    master   75m   v1.30.3
-control-plane-node-2    Ready    master   75m   v1.30.3
+control-plane-node-0    Ready    master   75m   v1.31.3
+control-plane-node-1    Ready    master   75m   v1.31.3
+control-plane-node-2    Ready    master   75m   v1.31.3
 ----
 +
 Note the names of your control plane nodes.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-12586

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

This is the only link that has changes other than the normal find/replace:

* https://86328--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/understanding/olm/olm-understanding-olm.html#olm-catalogsource-image-template_olm-understanding-olm

Full list of links:

- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-restart.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/connected-to-disconnected.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/updating/disconnected-update.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install-standalone.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-outposts.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/upi/installing-azure-stack-hub-user-infra.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/upi/installing-azure-user-infra.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-expanding-the-cluster.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-troubleshooting.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-restricted-networks-ibm-power.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-lpar.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-lpar.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-user.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere-network-customizations.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/validation_and_troubleshooting/validating-an-installation.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/more-rhel-compute.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-aws-compute-user-infra.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-bare-metal-compute-user-infra.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-vsphere-compute-user-infra.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-hardware-offloading.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-viewing.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-working.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-sno-worker-nodes.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-node-selectors.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-olm.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-power.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-lpar.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-remediation.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-crio-issues.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-rhel-compute.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.html
- https://86328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is the Kube bump we do every release - it's out of scope of this PR to make changes outside of the bump.