### PR TITLE
OSDOCS-10453:Added JIT paragraph to SRE access to cloud infrastructure accounts

### DIFF
--- a/modules/policy-identity-access-management.adoc
+++ b/modules/policy-identity-access-management.adoc
@@ -50,6 +50,8 @@ Each of these access types has different levels of access to components:
 == SRE access to cloud infrastructure accounts
 Red Hat personnel do not access cloud infrastructure accounts in the course of routine {product-title} operations. For emergency troubleshooting purposes, Red Hat SRE have well-defined and auditable procedures to access cloud infrastructure accounts.
 
+In the isolated backplane flow, SREs request access to a customer's support role. This request is just-in-time (JIT) processed by the backplane API which dynamically updates the organization role's permissions to a specific SRE personnel's account. This SRE's account is given access to a specific Red Hat customer's environment. SRE access to a Red Hat customer's environment is a temporary, short-lived access that is only established at the time of the access request.
+
 In AWS, SREs generate a short-lived AWS access token for the `BYOCAdminAccess` user using the AWS Security Token Service (STS). Access to the STS token is audit logged and traceable back to individual users. The `BYOCAdminAccess` has the `AdministratorAccess` IAM policy attached.
 
 In Google Cloud, SREs access resources after being authenticated against a Red Hat SAML identity provider (IDP). The IDP authorizes tokens that have time-to-live expirations. The issuance of the token is auditable by corporate Red Hat IT and linked back to an individual user.


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-10453

Link to docs preview:
[SRE access to cloud infrastructure accounts](https://86345--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-sre-access.html#sre-access-cloud-infra_osd-sre-access)

QE review:
- [ ] QE has approved this change.

Peer reviewer:
- [ ] Peer reviewer has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
