### PR TITLE
OSDOCS-12918:Corrected links to create cluster guides in Getting started section

### DIFF
--- a/modules/understanding-clusters.adoc
+++ b/modules/understanding-clusters.adoc
@@ -15,7 +15,7 @@ Alternatively, you can install {product-title} in a cloud account that is owned 
 [id="osd-deployment-option-ccs_{context}"]
 == Deploying clusters using the Customer Cloud Subscription (CCS) model
 
-The Customer Cloud Subscription (CCS) model enables you to deploy Red Hat managed {product-title} clusters in an existing AWS or GCP account that you own. Red Hat requires several prerequisites be met in order to provide this service, and this service is supported by Red Hat Site Reliability Engineers (SRE).
+The Customer Cloud Subscription (CCS) model enables you to deploy Red Hat managed {product-title} clusters in an existing {AWS} or {GCP} account that you own. Red Hat requires several prerequisites be met in order to provide this service, and this service is supported by Red Hat Site Reliability Engineers (SRE).
 
 In the CCS model, the customer pays the cloud infrastructure provider directly for cloud costs, and the cloud infrastructure account is part of an organization owned by the customer, with specific access granted to Red Hat. In this model, the customer pays Red Hat for the CCS subscription and pays the cloud provider for the cloud costs.
 

--- a/osd_getting_started/osd-getting-started.adoc
+++ b/osd_getting_started/osd-getting-started.adoc
@@ -22,29 +22,35 @@ You can install {product-title} in your own cloud provider account through the C
 
 Choose from one of the following methods to deploy your cluster.
 
-[id="osd-getting-started-create-cluster-ccs"]
-=== Creating a cluster using the CCS model
+[id="osd-getting-started-create-cluster-gcp-ccs"]
+=== Creating a cluster on GCP using the CCS model
 
-Complete the steps in one of the following sections to deploy {product-title} in a cloud account that you own:
+You can install {product-title} in your own {GCP} account by using the CCS model. Complete the steps in one of the following sections to deploy {product-title} in your own {GCP} account.
 
-* *xref:../osd_install_access_delete_cluster/creating-an-aws-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws[Creating a cluster on AWS with CCS]*: You can install {product-title} in your own {AWS} account by using the CCS model.
+* Red Hat recommends using GCP Workload Identity Federation (WIF) as the authentication type for installing and interacting with the {product-title} cluster deployed on {GCP} because it provides enhanced security. For more information, see xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc[Creating a cluster on GCP with Workload Identity Federation].
 
-* *Creating a cluster on GCP with CCS*: You can install {product-title} in your own {GCP} account by using the CCS model.
+* Red Hat also recommends creating an {product-title} cluster deployed on {GCP} in Private cluster mode with Private Service Connect (PSC) to manage and monitor a cluster to avoid all public ingress network traffic. For more information, see xref:../osd_install_access_delete_cluster/creating-a-gcp-psc-enabled-private-cluster.adoc#creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview].
 
-** Red Hat recommends using GCP Workload Identity Federation (WIF) as the authentication type for installing and interacting with the {product-title} cluster deployed on {GCP} because it provides enhanced security. For more information, see xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc[Creating a cluster on GCP with Workload Identity Federation].
+* For installing and interacting with the {product-title} cluster deployed on the {GCP} using the Service Account authentication type, see xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp[Creating a cluster on GCP with Service Account authentication].
 
-** Red Hat also recommends creating an {product-title} cluster deployed on {GCP} in Private cluster mode with Private Service Connect (PSC) to manage and monitor a cluster to avoid all public ingress network traffic. For more information, see xref:../osd_install_access_delete_cluster/creating-a-gcp-psc-enabled-private-cluster.adoc#creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview].
+// Update link with new title when new SA auth guide goes live.
 
-** For installing and interacting with the {product-title} cluster deployed on the {GCP} using the Service Account authentication type, see xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp[Creating a cluster on GCP].
+[id="osd-getting-started-create-cluster-aws-ccs"]
+=== Creating a cluster on AWS using the CCS model
+
+You can install {product-title} in your own {AWS} account by using the CCS model.
+
+* xref:../osd_install_access_delete_cluster/creating-an-aws-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws[Creating a cluster on AWS]
 
 [id="osd-getting-started-create-cluster-red-hat-cloud-account"]
 === Creating a cluster using a Red Hat cloud account
 
 Complete the steps in one of the following sections to deploy {product-title} in a cloud account that is owned by Red Hat:
 
-* *xref:../osd_install_access_delete_cluster/creating-an-aws-cluster.adoc#osd-create-aws-cluster-red-hat-account_osd-creating-a-cluster-on-aws[Creating a cluster on AWS with a Red Hat cloud account]*: You can install {product-title} in an AWS account that is owned by Red Hat.
+* xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-gcp[Creating a cluster on GCP with a Red Hat cloud account]: You can install {product-title} in an GCP account that is owned by Red Hat.
 
-* *xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-gcp[Creating a cluster on GCP with a Red Hat cloud account]*: You can install {product-title} in an GCP account that is owned by Red Hat.
+* xref:../osd_install_access_delete_cluster/creating-an-aws-cluster.adoc#osd-create-aws-cluster-red-hat-account_osd-creating-a-cluster-on-aws[Creating a cluster on AWS]: You can install {product-title} in an AWS account that is owned by Red Hat.
+// Update link when OSDOCS-12950 goes live.
 
 include::modules/config-idp.adoc[leveloffset=+1]
 

--- a/osd_getting_started/osd-understanding-your-cloud-deployment-options.adoc
+++ b/osd_getting_started/osd-understanding-your-cloud-deployment-options.adoc
@@ -14,5 +14,12 @@ include::modules/understanding-clusters.adoc[leveloffset=+1]
 [id="next-steps_{context}"]
 == Next steps
 
-* xref:../osd_install_access_delete_cluster/creating-an-aws-cluster.adoc#osd-creating-a-cluster-on-aws[Creating a cluster on AWS]
-* xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc#osd-creating-a-cluster-on-gcp[Creating a cluster on GCP]
+* xref:../osd_getting_started/osd-getting-started.adoc#osd-getting-started-create-cluster[Creating an {product-title} cluster]
+
+[id="additional-resources-cloud-deploy_{context}"]
+== Additional resources
+
+* For more information about using Customer Cloud Subscriptions on GCP, see xref:../osd_planning/gcp-ccs.adoc#ccs-gcp-understand[Understanding Customer Cloud Subscriptions on GCP].
+
+* For more information about using Customer Cloud Subscriptions on AWS, see xref:../osd_planning/aws-ccs.adoc#ccs-aws-understand[Understanding Customer Cloud Subscriptions on AWS].
+


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12918

Link to docs preview:
[Getting started with OpenShift Dedicated](https://86353--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_getting_started/osd-getting-started.html)

Peer reviewer:
- [x] Peer reviewer has approved this change.

QE review:
- [ ] QE has approved this change.
**QE approval not needed as this is only amending links.**

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
