### PR TITLE
[RHACS] fix additional resources ordering

### DIFF
--- a/integration/integrate-with-image-registries.adoc
+++ b/integration/integrate-with-image-registries.adoc
@@ -70,12 +70,11 @@ include::modules/manual-configuration-image-registry-jfrog.adoc[leveloffset=+2]
 
 include::modules/manual-configuration-image-registry-qcr.adoc[leveloffset=+2]
 
-include::modules/manual-configuration-image-registry-ghcr.adoc[leveloffset=+2]
-
 [role="_additional-resources"]
-[id="additional-resources_integrating-quay-scanner"]
-== Additional resources
+.Additional resources
 * xref:../integration/integrate-with-image-vulnerability-scanners.adoc#integrate-with-qcr-scanner_integrate-with-image-vulnerability-scanners[Integrating with Quay Container Registry to scan images]
+
+include::modules/manual-configuration-image-registry-ghcr.adoc[leveloffset=+2]
 
 include::modules/manual-configuration-image-registry-ibm.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version: 4.7

issue: none

[link to doc preview
](https://86368--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-image-registries.html)
Additional information:

- Fix issue with additional resources section in assembly
- Fix issue introduced in #86008 with Quay reference not being next to the module it provides information for
