### PR TITLE
OSDOCS-12851-41: 4.15.40 skipped and moved to 4.15.41

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2775,13 +2775,13 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
-//4.15.40
-[id="ocp-4-15-40_{context}"]
-=== RHSA-2024:10839 - {product-title} 4.15.40 bug fix and security update
+//4.15.41
+[id="ocp-4-15-41_{context}"]
+=== RHSA-2024:10839 - {product-title} 4.15.41 bug fix and security update
 
 Issued: 12 December 2024
 
-{product-title} release 4.15.40, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10839[RHSA-2024:10839] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10842[RHBA-2024:10842] advisory.
+{product-title} release 4.15.41, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10839[RHSA-2024:10839] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10842[RHBA-2024:10842] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -2789,10 +2789,10 @@ You can view the container images in this release by running the following comma
 
 [source,terminal]
 ----
-$ oc adm release info 4.15.40 --pullspecs
+$ oc adm release info 4.15.41 --pullspecs
 ----
 
-[id="ocp-4-15-40-bug-fixes_{context}"]
+[id="ocp-4-15-41-bug-fixes_{context}"]
 ==== Bug fixes
 
 * Previously, the Single-Root I/O Virtualization (SR-IOV) Operator did not expire the acquired lease during the Operator's shutdown. This impacted a new instance of the Operator, because the new instance had to wait for the lease to expire before the new instance could work. With this release, an update to the Operator shutdown logic ensures that the Operator expires the lease when the Operator is shutting down. (link:https://issues.redhat.com/browse/OCPBUGS-43361[*OCPBUGS-43361*])
@@ -2803,10 +2803,9 @@ $ oc adm release info 4.15.40 --pullspecs
 
 * Previously, the Messaging Application Programming Interface (MAPI) for {ibm-cloud-title} currently checked the first group of subnets (50) when searching for subnet details by name. With this release, the search provides pagination support to search all subnets. (link:https://issues.redhat.com/browse/OCPBUGS-43675[*OCPBUGS-43675*])
 
-[id="ocp-4-15-40-updating_{context}"]
+[id="ocp-4-15-41-updating_{context}"]
 ==== Updating
 To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
-
 
 //4.15.39
 [id="ocp-4-15-39_{context}"]


### PR DESCRIPTION
4.15.40 was skipped. Notification was received today so the 4.15.40 notes need to be updated to now state "4.15.41".


Version(s):
4.15

Issue:
[OSDOCS-12851](https://issues.redhat.com/browse/OSDOCS-12851)

Link to docs preview:
* [4.15.41](https://86371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-41_release-notes)


