### PR TITLE
Agent 4.18 release notes

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -519,6 +519,26 @@ For more information, see xref:../installing/installing_nutanix/installing-nutan
 
 For an existing Nutanix cluster, you can add multiple subnets by using machine sets. For more information, see xref:../installing/installing_nutanix/nutanix-failure-domains.adoc#post-installation-configuring-nutanix-failure-domains_nutanix-failure-domains[Adding failure domains to the Infrastructure CR].
 
+[id="ocp-release-notes-agent-5-node-control-plane_{context}"]
+==== Configuring 4 and 5 node control planes with the Agent-based Installer
+With this release, if you are using the Agent-based Installer, you can now configure your cluster to be installed with either 4 or 5 nodes in the control plane. This feature is enabled by setting the `controlPlane.replicas` parameter to either `4` or `5` in the `install-config.yaml` file.
+
+For more information, see xref:../installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc#installation-configuration-parameters-optional_installation-config-parameters-agent[Optional configuration parameters] for the Agent-based Installer.
+
+[id="ocp-release-notes-agent-minimal-iso_{context}"]
+==== Minimal ISO image support for the Agent-based Installer
+With this release, the Agent-based Installer supports creating a minimal ISO image on all supported platforms. Previously, minimal ISO images were supported only on the `external` platform.
+
+This feature is enabled using the `minimalISO` parameter in the `agent-config.yaml` file.
+
+For more information, see xref:../installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc#agent-configuration-parameters-optional_installation-config-parameters-agent[Optional configuration parameters] for the Agent-based Installer.
+
+[id="ocp-release-notes-agent-iscsi_{context}"]
+==== Internet Small Computer System Interface (iSCSI) boot support for the Agent-based Installer
+With this release, the Agent-based Installer supports creating assets that can be used to boot an {product-title} cluster from an iSCSI target.
+
+For more information, see xref:../installing/installing_with_agent_based_installer/installing-using-iscsi.adoc#installing-using-iscsi[Preparing installation assets for iSCSI booting].
+
 [id="ocp-release-notes-olm_{context}"]
 === Operator lifecycle
 
@@ -654,6 +674,11 @@ After updating from {product-title} 4.17.z to {product-title} {product-version},
 
 Available as a Technology Preview, you can use the sigstore project with {product-title} to improve supply chain security. You can create signature policies at the cluster-wide level or for a specific namespace. For more information, see xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-using[Manage secure signatures with sigstore].
 
+[id="ocp-release-notes-nodes-adding-enhancements_{context}"]
+==== Enhancements to process for adding nodes
+Enhancements have been added to the process for xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[adding worker nodes to an on-premise cluster] that was introduced in {product-title} 4.17.
+With this release, you can now generate Preboot Execution Environment (PXE) assets instead of an ISO image file, and you can configure reports to be generated regardless of whether the node creation process fails or not.
+
 [id="ocp-release-notes-postinstallation-configuration_{context}"]
 === Postinstallation configuration
 
@@ -704,7 +729,7 @@ For more information, see xref:../scalability_and_performance/using-node-tuning-
 [id="ocp-release-notes-scalability-and-performance-nrop-policy_{context}"]
 ==== NUMA Resources Operator now uses default SELinux policy
 
-With this release, the NUMA Resources Operator no longer creates a custom SELinux policy to enable the installation of Operator components on a target node. Instead, the Operator uses a built-in container SELinux policy. This change removes the additional node reboot that was previously required when applying a custom SELinux policy during an installation. 
+With this release, the NUMA Resources Operator no longer creates a custom SELinux policy to enable the installation of Operator components on a target node. Instead, the Operator uses a built-in container SELinux policy. This change removes the additional node reboot that was previously required when applying a custom SELinux policy during an installation.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Version(s): 4.18

This PR adds release notes for Agent 4.18 features

QE review:
- [x] QE has approved this change.

Previews:

- [Agent RNs](https://86377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-agent-5-node-control-plane_release-notes)
- [Node adding RN](https://86377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-nodes-adding-enhancements_release-notes) 