### PR TITLE
OSDOCS11063: Make crun the default runtime for OpenShift

### DIFF
--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -50,11 +50,11 @@ In a Kubernetes cluster, worker nodes run and manage the actual workloads reques
 * CRI-O, which is the container engine.
 * kubelet, which is the service that accepts and fulfills requests for running and stopping container workloads.
 * A service proxy, which manages communication for pods across workers.
-* The runC or crun low-level container runtime, which creates and runs containers.
+* The crun or runC low-level container runtime, which creates and runs containers.
 
 [NOTE]
 ====
-For information about how to enable crun instead of the default runC, see the documentation for creating a `ContainerRuntimeConfig` CR.
+For information about how to enable runC instead of the default crun, see the documentation for creating a `ContainerRuntimeConfig` CR.
 ====
 
 In {product-title}, compute machine sets control the compute machines, which are assigned the `worker` machine role. Machines with the `worker` role drive compute workloads that are governed by a specific machine pool that autoscales them. Because {product-title} has the capacity to support multiple machine types, the machines with the `worker` role are classed as _compute_ machines. In this release, the terms _worker machine_ and _compute machine_ are used interchangeably because the only default type of compute machine is the worker machine. In future versions of {product-title}, different types of compute machines, such as infrastructure machines, might be used by default.

--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -25,7 +25,7 @@ The CRI-O flag is applied on the cgroup of the container, while the Kubelet flag
 * **Log level**: The `logLevel` parameter sets the CRI-O `log_level` parameter, which is the level of verbosity for log messages. The default is `info` (`log_level = info`). Other options include `fatal`, `panic`, `error`, `warn`, `debug`, and `trace`.
 * **Overlay size**: The `overlaySize` parameter sets the CRI-O Overlay storage driver `size` parameter, which is the maximum size of a container image.
 * **Maximum log size**: Setting the maximum log size in the `ContainerRuntimeConfig` is expected to be deprecated. If a maximum log size is required, it is recommended to use the `containerLogMaxSize` field in the `KubeletConfig` CR instead.
-* **Container runtime**: The `defaultRuntime` parameter sets the container runtime to either `runc` or `crun`. The default is `runc`.
+* **Container runtime**: The `defaultRuntime` parameter sets the container runtime to either `crun` or `runc`. The default is `crun`.
 
 You should have one `ContainerRuntimeConfig` CR for each machine config pool with all the config changes you want for that pool. If you are applying the same content to all the pools, you only need one `ContainerRuntimeConfig` CR for all the pools.
 
@@ -74,7 +74,7 @@ $ oc get mc | grep container
 ...
 ----
 
-The following example sets the `log_level` field to `debug` and sets the overlay size to 8 GB:
+The following example sets the `log_level` field to `debug`, sets the overlay size to 8 GB, and configures runC as the container runtime:
 
 .Example `ContainerRuntimeConfig` CR
 [source,yaml]
@@ -90,12 +90,12 @@ spec:
  containerRuntimeConfig:
    logLevel: debug <2>
    overlaySize: 8G <3>
-   defaultRuntime: "crun" <4>
+   defaultRuntime: "runc" <4>
 ----
 <1> Specifies the machine config pool label. For a container runtime config, the role must match the name of the associated machine config pool.
 <2> Optional: Specifies the level of verbosity for log messages.
 <3> Optional: Specifies the maximum size of a container image.
-<4> Optional: Specifies the container runtime to deploy to new containers. The default value is `runc`.
+<4> Optional: Specifies the container runtime to deploy to new containers, either `crun` or `runc`. The default value is `crun`.
 
 .Procedure
 
@@ -116,6 +116,7 @@ spec:
  containerRuntimeConfig: <2>
    logLevel: debug
    overlaySize: 8G
+   defaultRuntime: "runc"
 ----
 <1> Specify a label for the machine config pool that you want you want to modify.
 <2> Set the parameters as needed.
@@ -197,7 +198,7 @@ sh-4.4# crio config | grep 'log_level'
 log_level = "debug"
 ----
 
-.. Verify the changes in the `storage.conf`file:
+.. Verify the changes in the `storage.conf` file:
 +
 [source,terminal]
 ----
@@ -205,7 +206,7 @@ sh-4.4# head -n 7 /etc/containers/storage.conf
 ----
 +
 .Example output
-+
+[source,terminal]
 ----
 [storage]
   driver = "overlay"
@@ -214,4 +215,19 @@ sh-4.4# head -n 7 /etc/containers/storage.conf
   [storage.options]
     additionalimagestores = []
     size = "8G"
+----
+
+.. Verify the changes in the `crio/crio.conf.d/01-ctrcfg-defaultRuntime` file:
++
+[source,terminal]
+----
+sh-5.1# cat /etc/crio/crio.conf.d/01-ctrcfg-defaultRuntime
+----
++
+.Example output
+[source,terminal]
+----
+[crio]
+  [crio.runtime]
+    default_runtime = "runc"
 ----

--- a/modules/nodes-pods-user-namespaces-configuring.adoc
+++ b/modules/nodes-pods-user-namespaces-configuring.adoc
@@ -35,7 +35,7 @@ Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
 
-* You enabled the crun container runtime on the worker nodes. crun is currently the only released OCI runtime with support for user namespaces.
+* The crun container runtime is present on the worker nodes. crun is currently the only OCI runtime packaged with {product-title} that supports user namespaces. crun is active by default.
 +
 [source,yaml]
 ----
@@ -50,7 +50,7 @@ spec:
  containerRuntimeConfig:
    defaultRuntime: crun <2>
 ----
-<1> Specifies the machine config pool label. 
+<1> Specifies the machine config pool label.
 <2> Specifies the container runtime to deploy.
 
 .Procedure

--- a/modules/rhcos-about.adoc
+++ b/modules/rhcos-about.adoc
@@ -25,7 +25,7 @@ The following list describes key features of the {op-system} operating system:
 
 * **CRI-O container runtime**: Although {op-system} contains features for running the OCI- and libcontainer-formatted containers that Docker requires, it incorporates the CRI-O container engine instead of the Docker container engine. By focusing on features needed by Kubernetes platforms, such as {product-title}, CRI-O can offer specific compatibility with different Kubernetes versions. CRI-O also offers a smaller footprint and reduced attack surface than is possible with container engines that offer a larger feature set. At the moment, CRI-O is the only engine available within {product-title} clusters.
 +
-CRI-O can use either the runC or crun container runtime to start and manage containers. For information about how to enable crun, see the documentation for creating a `ContainerRuntimeConfig` CR.
+CRI-O can use either the crun or runC container runtime to start and manage containers. crun is the default. For information about how to enable runC, see the documentation for creating a `ContainerRuntimeConfig` CR.
 
 * **Set of container tools**: For tasks such as building, copying, and otherwise managing containers, {op-system} replaces the Docker CLI tool with a compatible set of container tools. The podman CLI tool supports many container runtime features, such as running, starting, stopping, listing, and removing containers and container images. The skopeo CLI tool can copy, authenticate, and sign images. You can use the `crictl` CLI tool to work with containers and pods from the CRI-O container engine. While direct use of these tools in {op-system} is discouraged, you can use them for debugging purposes.
 

--- a/nodes/containers/nodes-containers-using.adoc
+++ b/nodes/containers/nodes-containers-using.adoc
@@ -50,11 +50,11 @@ The {product-title} documentation uses the term _container runtime_ to refer to 
 ====
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-{product-title} uses CRI-O as the container engine and runC or crun as the container runtime. The default container runtime is runC. Both container runtimes adhere to the link:https://www.opencontainers.org/[Open Container Initiative (OCI)] runtime specifications.
+{product-title} uses CRI-O as the container engine and runC or crun as the container runtime. The default container runtime is crun. Both container runtimes adhere to the link:https://www.opencontainers.org/[Open Container Initiative (OCI)] runtime specifications.
 
 include::snippets/about-crio-snippet.adoc[]
 
-runC, developed by Docker and maintained by the Open Container Project, is a lightweight, portable container runtime written in Go. crun, developed by Red Hat, is a fast and low-memory container runtime fully written in C. As of {product-title} {product-version}, you can select between the two.
+crun, developed by Red Hat, is a fast and low-memory container runtime fully written in C. runC, developed by Docker and maintained by the Open Container Project, is a lightweight, portable container runtime written in Go.
 
 crun has several improvements over runC, including:
 
@@ -74,5 +74,5 @@ For information on setting which container runtime to use, see xref:../../machin
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-{product-title} uses CRI-O as the container engine and runC or crun as the container runtime. The default container runtime is runC.
+{product-title} uses CRI-O as the container engine and crun or runC as the container runtime. The default container runtime is crun.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-11063  Make crun default, change the procedure to update runc to crun.

Version(s):
4.18+

Link to docs preview:
Architecture -> Control plane architecture -> [Cluster workers](https://86378--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/control-plane#defining-workers_control-plane) - Updated third bullet and note
Machine configuration -> Configuring MCO-related custom resources -> [Creating a ContainerRuntimeConfig CR to edit CRI-O parameters](https://86378--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-custom.html#create-a-containerruntimeconfig_machine-configs-custom) - Updated bullet 5, Example ContainerRuntimeConfig CR, Step 1 example. Added step 6d.
Nodes -> Working with pods -> Running pods in Linux user namespaces -> [Configuring Linux user namespace support](https://86378--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-user-namespaces) - Updated second prereq.
Architecture -> Red Hat Enterprise Linux CoreOS -> [Key RHCOS features](https://86378--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/architecture-rhcos#rhcos-key-features_architecture-rhcos) - Updated second paragraph in _CRI-O container runtime_ bullet.
Nodes -> Working with containers -> Understanding containers -> [About the container engine and container runtime](https://86378--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-using#nodes-containers-runtimes) - Updated paragraphs 2 and 4.
ROSA  [About the container engine and container runtime](https://86378--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/containers/nodes-containers-using.html#nodes-containers-runtimes) - Updated paragraphs 2.
Dedicated [About the container engine and container runtime](https://86378--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/containers/nodes-containers-using.html#nodes-containers-runtimes) - Updated paragraphs 2.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

NOTE: There are multiple references to runC/crun in the Telco docs that will be addressed separately as needed by the Telco writers.