### PR TITLE
OSDOCS-12946: machine set feature REF bare metal

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2378,9 +2378,9 @@ Topics:
       File: modifying-machineset
   # - Name: Compute machine set configuration
   #   File: mapi-compute-configuration
-  # - Name: Configuration options for compute machines
-  #   Dir: mapi_compute_provider_configurations
-  #   Topics:
+  - Name: Configuration options for compute machines
+    Dir: mapi_compute_provider_configurations
+    Topics:
   #   - Name: Compute configuration options for Amazon Web Services
   #     File: mapi-compute-config-options-aws
   #   - Name: Compute configuration options for Microsoft Azure
@@ -2393,6 +2393,8 @@ Topics:
   #     File: mapi-compute-config-options-openstack
   #   - Name: Compute configuration options for VMware vSphere
   #     File: mapi-compute-config-options-vsphere
+    - Name: Compute configuration options for bare metal
+      File: mapi-compute-config-options-bare-metal
   - Name: Applying autoscaling to a cluster
     File: applying-autoscaling
   # - Name: Compute resiliency and recovery

--- a/_unused_topics/machine-set-CLOUD-options-FEATURE.adoc
+++ b/_unused_topics/machine-set-CLOUD-options-FEATURE.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-CLOUD.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-CLOUD.adoc
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:mapi:
+endif::[]
+ifdef::mapi[]
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+endif::mapi[]
+
+ifeval::["{context}" == "capi-compute-config-options-CLOUD"]
+:capi:
+endif::[]
+ifdef::capi[]
+:machine-set: compute machine set
+:api-name: Cluster API
+:api-group: cluster.x-k8s.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-cluster-api
+endif::capi[]
+
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:cpmso:
+endif::[]
+ifdef::cpmso[]
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+endif::cpmso[]
+
+:_mod-docs-content-type: REFERENCE
+[id="machine-set-CLOUD-options-FEATURE_{context}"]
+= FEATURE configuration options
+
+The {machine-set} custom resource (CR) can include parameters for FEATURE.
+
+.FEATURE 
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {api-group}/{api-version}
+kind: {api-kind}
+# ...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          featureKey: <feature_value> # <1>
+# ...
+----
+<1> Specifies a FEATURE VALUE.
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:!mapi:
+endif::[]
+ifeval::["{context}" == "mcpi-compute-config-options-CLOUD"]
+:!capi:
+endif::[]
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:!cpmso:
+endif::[]

--- a/_unused_topics/machine-set-CLOUD-options-FEATURE.adoc
+++ b/_unused_topics/machine-set-CLOUD-options-FEATURE.adoc
@@ -3,41 +3,7 @@
 // * machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-CLOUD.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-CLOUD.adoc
 
-ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
-:mapi:
-endif::[]
-ifdef::mapi[]
-:machine-set: compute machine set
-:api-name: Machine API
-:api-group: machine.openshift.io
-:api-version: v1beta1
-:api-kind: MachineSet
-:namespace: openshift-machine-api
-endif::mapi[]
-
-ifeval::["{context}" == "capi-compute-config-options-CLOUD"]
-:capi:
-endif::[]
-ifdef::capi[]
-:machine-set: compute machine set
-:api-name: Cluster API
-:api-group: cluster.x-k8s.io
-:api-version: v1beta1
-:api-kind: MachineSet
-:namespace: openshift-cluster-api
-endif::capi[]
-
-ifeval::["{context}" == "cpmso-config-options-CLOUD"]
-:cpmso:
-endif::[]
-ifdef::cpmso[]
-:machine-set: control plane machine set
-:api-name: Machine API
-:api-group: machine.openshift.io
-:api-version: v1
-:api-kind: ControlPlaneMachineSet
-:namespace: openshift-machine-api
-endif::cpmso[]
+include::snippets/machine-set-ifeval-open.adoc[]
 
 :_mod-docs-content-type: REFERENCE
 [id="machine-set-CLOUD-options-FEATURE_{context}"]
@@ -61,12 +27,4 @@ spec:
 ----
 <1> Specifies a FEATURE VALUE.
 
-ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
-:!mapi:
-endif::[]
-ifeval::["{context}" == "mcpi-compute-config-options-CLOUD"]
-:!capi:
-endif::[]
-ifeval::["{context}" == "cpmso-config-options-CLOUD"]
-:!cpmso:
-endif::[]
+include::snippets/machine-set-ifeval-close.adoc[]

--- a/_unused_topics/machine-set-CLOUD-using-FEATURE.adoc
+++ b/_unused_topics/machine-set-CLOUD-using-FEATURE.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-CLOUD.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-CLOUD.adoc
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:mapi:
+endif::[]
+ifdef::mapi[]
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+endif::mapi[]
+
+ifeval::["{context}" == "capi-compute-config-options-CLOUD"]
+:capi:
+endif::[]
+ifdef::capi[]
+:machine-set: compute machine set
+:api-name: Cluster API
+:api-group: cluster.x-k8s.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-cluster-api
+endif::capi[]
+
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:cpmso:
+endif::[]
+ifdef::cpmso[]
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+endif::cpmso[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="machine-set-CLOUD-using-FEATURE_{context}"]
+= Using FEATURE
+
+You can configure a {machine-set} to FEATURE.
+
+.Prerequisites
+
+* Prereq
+
+.Procedure
+
+. Step 1
+
+.Verification
+
+* Verification
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:!mapi:
+endif::[]
+ifeval::["{context}" == "mcpi-compute-config-options-CLOUD"]
+:!capi:
+endif::[]
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:!cpmso:
+endif::[]

--- a/_unused_topics/machine-set-CLOUD-using-FEATURE.adoc
+++ b/_unused_topics/machine-set-CLOUD-using-FEATURE.adoc
@@ -3,41 +3,7 @@
 // * machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-CLOUD.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-CLOUD.adoc
 
-ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
-:mapi:
-endif::[]
-ifdef::mapi[]
-:machine-set: compute machine set
-:api-name: Machine API
-:api-group: machine.openshift.io
-:api-version: v1beta1
-:api-kind: MachineSet
-:namespace: openshift-machine-api
-endif::mapi[]
-
-ifeval::["{context}" == "capi-compute-config-options-CLOUD"]
-:capi:
-endif::[]
-ifdef::capi[]
-:machine-set: compute machine set
-:api-name: Cluster API
-:api-group: cluster.x-k8s.io
-:api-version: v1beta1
-:api-kind: MachineSet
-:namespace: openshift-cluster-api
-endif::capi[]
-
-ifeval::["{context}" == "cpmso-config-options-CLOUD"]
-:cpmso:
-endif::[]
-ifdef::cpmso[]
-:machine-set: control plane machine set
-:api-name: Machine API
-:api-group: machine.openshift.io
-:api-version: v1
-:api-kind: ControlPlaneMachineSet
-:namespace: openshift-machine-api
-endif::cpmso[]
+include::snippets/machine-set-ifeval-open.adoc[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="machine-set-CLOUD-using-FEATURE_{context}"]
@@ -57,12 +23,4 @@ You can configure a {machine-set} to FEATURE.
 
 * Verification
 
-ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
-:!mapi:
-endif::[]
-ifeval::["{context}" == "mcpi-compute-config-options-CLOUD"]
-:!capi:
-endif::[]
-ifeval::["{context}" == "cpmso-config-options-CLOUD"]
-:!cpmso:
-endif::[]
+include::snippets/machine-set-ifeval-close.adoc[]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-aws.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-aws.adoc
@@ -9,10 +9,10 @@ toc::[]
 This assembly needs an intro.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //[template] FEATURE configuration options
-include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+//include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
 
 //[template] Using FEATURE
-include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]
+//include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-aws.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-aws.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-aws"]
-= Control plane configuration options for Amazon Web Services
+= Compute configuration options for Amazon Web Services
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-aws
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-azure.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-azure.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-azure"]
-= Control plane configuration options for Microsoft Azure
+= Compute configuration options for Microsoft Azure
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-azure
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-azure.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-azure.adoc
@@ -9,10 +9,10 @@ toc::[]
 This assembly needs an intro.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //[template] FEATURE configuration options
-include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+//include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
 
 //[template] Using FEATURE
-include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]
+//include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-bare-metal.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-bare-metal.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="mapi-compute-config-options-bare-metal"]
+= Compute configuration options for bare metal
+include::_attributes/common-attributes.adoc[]
+:context: mapi-compute-config-options-bare-metal
+
+toc::[]
+
+You can configure compute machine sets to create compute machines that serve specific purposes in your {product-title} cluster.
+
+<Stuff about editing and creating>
+
+For more information, see <creating a machine set> and xref:../../../machine_management/compute_machine_management/mapi_compute_managing_machines/modifying-machineset.adoc#machineset-modifying_modifying-machineset[Modifying a compute machine set by using the CLI].
+
+//[IMPORTANT] admonition for UPI
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//Sample bare metal provider specification
+include::modules/machine-set-yaml-bare-metal.adoc[leveloffset=+1]
+
+[id="mapi-compute-supported-features-bare-metal_{context}"]
+== Enabling features for bare-metal compute machines
+
+You can enable features by updating values in the compute machine set custom resource (CR).
+
+//Cluster autoscaler GPU labeling options
+include::modules/machine-set-agnostic-options-label-gpu-autoscaler.adoc[leveloffset=+2]
+
+//Labeling GPU machine sets for the cluster autoscaler
+include::modules/machine-set-agnostic-using-label-gpu-autoscaler.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-gcp.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-gcp.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-gcp"]
-= Control plane configuration options for Google Cloud Platform
+= Compute configuration options for Google Cloud Platform
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-gcp
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-gcp.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-gcp.adoc
@@ -9,10 +9,10 @@ toc::[]
 This assembly needs an intro.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //[template] FEATURE configuration options
-include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+//include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
 
 //[template] Using FEATURE
-include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]
+//include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-nutanix.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-nutanix.adoc
@@ -9,10 +9,10 @@ toc::[]
 This assembly needs an intro.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //[template] FEATURE configuration options
-include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+//include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
 
 //[template] Using FEATURE
-include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]
+//include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-nutanix.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-nutanix.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-nutanix"]
-= Control plane configuration options for Nutanix
+= Compute configuration options for Nutanix
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-nutanix
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-openstack.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-openstack.adoc
@@ -9,10 +9,10 @@ toc::[]
 This assembly needs an intro.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //[template] FEATURE configuration options
-include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+//include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
 
 //[template] Using FEATURE
-include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]
+//include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-openstack.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-openstack.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-openstack"]
-= Control plane configuration options for Red Hat OpenStack Platform
+= Compute configuration options for Red Hat OpenStack Platform
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-openstack
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-vsphere.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-vsphere.adoc
@@ -9,10 +9,10 @@ toc::[]
 This assembly needs an intro.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //[template] FEATURE configuration options
-include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+//include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
 
 //[template] Using FEATURE
-include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]
+//include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-vsphere.adoc
+++ b/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-vsphere.adoc
@@ -1,9 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mapi-compute-config-options-vsphere"]
-= Control plane configuration options for VMware vSphere
+= Compute configuration options for VMware vSphere
 include::_attributes/common-attributes.adoc[]
 :context: mapi-compute-config-options-vsphere
 
 toc::[]
 
-Placeholder assembly.
+This assembly needs an intro.
+
+//[IMPORTANT] admonition for UPI
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+//[template] FEATURE configuration options
+include::../../../_unused_topics/machine-set-CLOUD-options-FEATURE.adoc[leveloffset=+1]
+
+//[template] Using FEATURE
+include::../../../_unused_topics/machine-set-CLOUD-using-FEATURE.adoc[leveloffset=+2]

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Assigning machines to placement groups by using machine sets
 include::modules/machineset-aws-existing-placement-group.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Enabling Azure boot diagnostics on compute machines
 include::modules/machineset-azure-boot-diagnostics.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Selecting an Azure Marketplace image
 include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
@@ -10,7 +10,7 @@ You can create a different compute machine set to serve a specific purpose in yo
 
 include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
-include::modules/machineset-yaml-baremetal.adoc[leveloffset=+1]
+include::modules/machine-set-yaml-bare-metal.adoc[leveloffset=+1]
 
 include::modules/machineset-creating.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
@@ -19,7 +19,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 // Mothballed - re-add when available
 // include::modules/machineset-osp-adding-bare-metal.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Configuring persistent disk types by using compute machine sets
 include::modules/machineset-gcp-pd-disk-types.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
@@ -22,4 +22,4 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]

--- a/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
@@ -22,4 +22,4 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]

--- a/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
@@ -22,7 +22,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Failure domains for Nutanix clusters
 include::modules/mapi-failure-domain-nutanix.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-osp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-osp.adoc
@@ -28,7 +28,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 // Mothballed - re-add when available
 // include::modules/machineset-osp-adding-bare-metal.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -43,7 +43,7 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
+* xref:../../machine_management/compute_machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Adding tags to machines by using machine sets
 include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+1,tag=!controlplane]

--- a/modules/machine-set-agnostic-options-label-gpu-autoscaler.adoc
+++ b/modules/machine-set-agnostic-options-label-gpu-autoscaler.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-bare-metal.adoc
+
+include::snippets/machine-set-ifeval-open.adoc[]
+
+:_mod-docs-content-type: REFERENCE
+[id="machine-set-agnostic-options-label-gpu-autoscaler_{context}"]
+= Cluster autoscaler GPU labels
+
+The {machine-set} custom resource (CR) can include parameters to indicate which machines the cluster autoscaler can use to deploy GPU-enabled nodes.
+You must also specify the value of this label for the `spec.resourceLimits.gpus.type` parameter in your `ClusterAutoscaler` CR.
+For more information, see "Cluster autoscaler resource definition".
+
+.Sample cluster autoscaler GPU label
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {api-group}/{api-version}
+kind: {api-kind}
+# ...
+spec:
+  template:
+    spec:
+      metadata:
+        labels:
+          cluster-api/accelerator: <gpu_type> # <1>
+# ...
+----
+<1> Specifies a label that consists of alphanumeric characters, `-`, `_`, or `.` and starts and ends with an alphanumeric character.
+For example, this value might be `nvidia-t4` to represent Nvidia T4 GPUs, or `nvidia-a10g` for A10G GPUs.
+
+include::snippets/machine-set-ifeval-close.adoc[]

--- a/modules/machine-set-agnostic-using-label-gpu-autoscaler.adoc
+++ b/modules/machine-set-agnostic-using-label-gpu-autoscaler.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-bare-metal.adoc
+
+include::snippets/machine-set-ifeval-open.adoc[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="machine-set-agnostic-using-label-gpu-autoscaler_{context}"]
+= Labeling GPU machine sets for the cluster autoscaler
+
+You can configure a {api-name} {machine-set} to indicate which machines the cluster autoscaler can use to deploy GPU-enabled nodes.
+
+.Prerequisites
+
+* You have reviewed the process "Modifying a compute machine set by using the CLI".
+* Your cluster uses a cluster autoscaler.
+
+.Procedure
+
+. Identify the machine set you want to modify.
+For more information, see "Modifying a compute machine set by using the CLI".
+
+. Add a `cluster-api/accelerator` label to a {api-name} {machine-set} by running the following command:
++
+--
+[source,terminal,subs="attributes+"]
+----
+$ oc patch {api-kind}.{api-group} <machine_set_name> \// <1>
+  --namespace {namespace} \
+  --patch '{"spec":{"template":{"spec":{"metadata":{"labels":"cluster-api/accelerator:<gpu_type>"}}}}}' <2>
+----
+<1> Specify the name of the machine set that you want to create machines for the cluster autoscaler to use to deploy GPU-enabled nodes.
+<2> Specify a label of your choice that consists of alphanumeric characters, `-`, `_`, or `.` and starts and ends with an alphanumeric character.
+For example, you might use `nvidia-t4` to represent Nvidia T4 GPUs, or `nvidia-a10g` for A10G GPUs.
++
+[NOTE]
+====
+You must specify the value of this label for the `spec.resourceLimits.gpus.type` parameter in your `ClusterAutoscaler` CR.
+For more information, see "Cluster autoscaler resource definition".
+====
+--
+
+. If you do not need to make any further modifications, create replacement machines with the new configuration.
+For more information, see "Modifying a compute machine set by using the CLI".
+
+.Next steps
+
+* Specify the value of this label for the `spec.resourceLimits.gpus.type` parameter in your `ClusterAutoscaler` CR.
+For more information, see "Cluster autoscaler resource definition".
+
+include::snippets/machine-set-ifeval-close.adoc[]

--- a/modules/machine-set-yaml-bare-metal.adoc
+++ b/modules/machine-set-yaml-bare-metal.adoc
@@ -8,8 +8,8 @@ ifeval::["{context}" == "creating-infrastructure-machinesets"]
 endif::[]
 
 :_mod-docs-content-type: REFERENCE
-[id="machineset-yaml-vsphere_{context}"]
-= Sample YAML for a compute machine set custom resource on bare metal
+[id="machine-set-yaml-bare-metal_{context}"]
+= Sample base YAML for a compute machine set custom resource on bare metal
 
 This sample YAML defines a compute machine set that runs on bare metal and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
@@ -19,6 +19,10 @@ In this sample, `<infrastructure_id>` is the infrastructure ID label that is bas
 ifndef::infra[`<role>`]
 ifdef::infra[`<infra>`]
 is the node label to add.
+
+#This needs to be reduced to the most simple base config#
+
+#Less relevant for bare metal, but can the YAML be repurposed to any degree across MAPI/CAPI/CPMS?#
 
 [source,yaml]
 ----

--- a/modules/machineset-label-gpu-autoscaler.adoc
+++ b/modules/machineset-label-gpu-autoscaler.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/applying-autoscaling.adoc
+// * machine_management/compute_machine_management/applying-autoscaling.adoc
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
 // * machine_management/creating_machinesets/creating-machineset-azure.adoc
 // * machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -309,7 +309,7 @@ For information about moving {logging} resources, see:
 
 Applying autoscaling to an {product-title} cluster involves deploying a cluster autoscaler and then deploying machine autoscalers for each machine type in your cluster.
 
-For more information, see xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[Applying autoscaling to an {product-title} cluster].
+For more information, see xref:../machine_management/compute_machine_management/applying-autoscaling.adoc#applying-autoscaling[Applying autoscaling to an {product-title} cluster].
 
 include::modules/nodes-clusters-cgroups-2.adoc[leveloffset=+1]
 

--- a/snippets/machine-set-ifeval-close.adoc
+++ b/snippets/machine-set-ifeval-close.adoc
@@ -1,0 +1,228 @@
+// Text snippet included in the following modules:
+//
+// *
+
+:_mod-docs-content-type: SNIPPET
+
+// README
+//
+// Closes the ifeval directives that are opened by snippets/machine-set-ifeval-open.adoc
+// You must include both snippets in any module that uses them.
+//
+// Use: 
+//
+//  -----------------------------------------------------
+//  ¦ // Module included in the following assemblies:   ¦
+//  ¦ //                                                ¦
+//  ¦ // * path/to/assembly.adoc                        ¦
+//  ¦                                                   ¦
+//  ¦ include::snippets/machine-set-ifeval-open.adoc[]  ¦
+//  ¦                                                   ¦
+//  ¦ :_mod-docs-content-type: MODULE_TYPE              ¦
+//  ¦ [id="MODULE-ID_{context}"]                        ¦
+//  ¦ = MODULE TITLE                                    ¦
+//  ¦                                                   ¦
+//  ¦ <BODY OF MODULE>                                  ¦
+//  ¦                                                   ¦
+//  ¦ include::snippets/machine-set-ifeval-close.adoc[] ¦
+//  -----------------------------------------------------
+
+// #######################################################
+// # Unsetting temporary attributes                      #
+// #######################################################
+
+:!provider-name:
+:!machine-set:
+:!api-name:
+:!api-group:
+:!api-version:
+:!api-kind:
+:!namespace:
+:!platform:
+:!providerspec-path:
+:!providerspec-api-version:
+:!spec-path:
+:!template-api-group:
+:!template-api-version:
+:!template-kind:
+:!spec-path:
+
+// #######################################################
+// # Control plane machine set closing ifeval directives #
+// #######################################################
+
+// Agnostic
+// Adding a section to evaluate whether this would be helpful for the base specs.
+
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:!cpmso:
+endif::[]
+
+// Amazon Web Services (AWS)
+
+ifeval::["{context}" == "cpmso-config-options-aws"]
+:!cpmso:
+endif::[]
+
+// Microsoft Azure
+
+ifeval::["{context}" == "cpmso-config-options-azure"]
+:!cpmso:
+endif::[]
+
+// Microsoft Azure Stack Hub
+// Not supported.
+
+// Google Cloud Platform
+
+ifeval::["{context}" == "cpmso-config-options-gcp"]
+:!cpmso:
+endif::[]
+
+// IBM Cloud
+// Not supported.
+
+// IBM Power VS
+// Not supported.
+
+// Nutanix
+
+ifeval::["{context}" == "cpmso-config-options-nutanix"]
+:!cpmso:
+endif::[]
+
+// OpenStack
+
+ifeval::["{context}" == "cpmso-config-options-openstack"]
+:!cpmso:
+endif::[]
+
+// VMware vSphere
+
+ifeval::["{context}" == "cpmso-config-options-vsphere"]
+:!cpmso:
+endif::[]
+
+// bare metal
+// Not supported.
+
+// #############################################################
+// # Machine API compute machine set closing ifeval directives #
+// #############################################################
+
+// Agnostic
+// Adding a section to evaluate whether this would be helpful for the base specs.
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:!mapi:
+endif::[]
+
+// Amazon Web Services (AWS)
+
+ifeval::["{context}" == "mapi-compute-config-options-aws"]
+:!mapi:
+endif::[]
+
+// Microsoft Azure
+
+ifeval::["{context}" == "mapi-compute-config-options-azure"]
+:!mapi:
+endif::[]
+
+// Microsoft Azure Stack Hub
+
+ifeval::["{context}" == "mapi-compute-config-options-azure-stack-hub"]
+:!mapi:
+endif::[]
+
+// Google Cloud Platform
+
+ifeval::["{context}" == "mapi-compute-config-options-gcp"]
+:!mapi:
+endif::[]
+
+// IBM Cloud
+
+ifeval::["{context}" == "mapi-compute-config-options-ibm-cloud"]
+:!mapi:
+endif::[]
+
+// IBM Power VS
+
+ifeval::["{context}" == "mapi-compute-config-options-ibm-power-vs"]
+:!mapi:
+endif::[]
+
+// Nutanix
+
+ifeval::["{context}" == "mapi-compute-config-options-nutanix"]
+:!mapi:
+endif::[]
+
+// OpenStack
+
+ifeval::["{context}" == "mapi-compute-config-options-openstack"]
+:!mapi:
+endif::[]
+
+// VMware vSphere
+
+ifeval::["{context}" == "mapi-compute-config-options-vsphere"]
+:!mapi:
+endif::[]
+
+// bare metal
+
+ifeval::["{context}" == "mapi-compute-config-options-bare-metal"]
+:!mapi:
+endif::[]
+
+// #############################################################
+// # Cluster API compute machine set closing ifeval directives #
+// #############################################################
+
+// Agnostic
+// Adding a section to evaluate whether this would be helpful for the base specs.
+
+ifeval::["{context}" == "capi-compute-config-options-CLOUD"]
+:!capi:
+endif::[]
+
+// Amazon Web Services (AWS)
+
+ifeval::["{context}" == "capi-compute-config-options-aws"]
+:!capi:
+endif::[]
+
+// Microsoft Azure
+// Not supported.
+
+// Microsoft Azure Stack Hub
+// Not supported.
+
+// Google Cloud Platform
+
+ifeval::["{context}" == "capi-compute-config-options-gcp"]
+:!capi:
+endif::[]
+
+// IBM Cloud
+// Not supported.
+
+// IBM Power VS
+// Not supported.
+
+// Nutanix
+// Not supported.
+
+// OpenStack
+// Not supported.
+
+// VMware vSphere
+
+ifeval::["{context}" == "capi-compute-config-options-vsphere"]
+:!capi:
+endif::[]
+
+// bare metal
+// Not supported.

--- a/snippets/machine-set-ifeval-open.adoc
+++ b/snippets/machine-set-ifeval-open.adoc
@@ -1,0 +1,474 @@
+// Text snippet included in the following modules:
+//
+// *
+
+:_mod-docs-content-type: SNIPPET
+
+// README
+//
+// These ifeval directives are closed in snippets/machine-set-ifeval-close.adoc
+// You must include both snippets in any module that uses them.
+//
+// Use: 
+//
+//  -----------------------------------------------------
+//  ¦ // Module included in the following assemblies:   ¦
+//  ¦ //                                                ¦
+//  ¦ // * path/to/assembly.adoc                        ¦
+//  ¦                                                   ¦
+//  ¦ include::snippets/machine-set-ifeval-open.adoc[]  ¦
+//  ¦                                                   ¦
+//  ¦ :_mod-docs-content-type: MODULE_TYPE              ¦
+//  ¦ [id="MODULE-ID_{context}"]                        ¦
+//  ¦ = MODULE TITLE                                    ¦
+//  ¦                                                   ¦
+//  ¦ <BODY OF MODULE>                                  ¦
+//  ¦                                                   ¦
+//  ¦ include::snippets/machine-set-ifeval-close.adoc[] ¦
+//  -----------------------------------------------------
+
+// #######################################################
+// # Control plane machine set opening ifeval directives #
+// #######################################################
+
+// Agnostic
+// Adding a section to evaluate whether this would be helpful for the base specs.
+
+ifeval::["{context}" == "cpmso-config-options-CLOUD"]
+:cpmso:
+endif::[]
+
+ifdef::cpmso[]
+:provider-name: <provider_name>
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+:platform: <platform_value>
+:providerspec-path: spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value
+:providerspec-api-version: <varies>
+endif::cpmso[]
+
+// Amazon Web Services (AWS)
+
+ifeval::["{context}" == "cpmso-config-options-aws"]
+:cpmso:
+endif::[]
+
+ifdef::cpmso[]
+:provider-name: AWS
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+:platform: AWS
+:providerspec-path: spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value
+:providerspec-api-version: v1beta1
+endif::cpmso[]
+
+// Microsoft Azure
+
+ifeval::["{context}" == "cpmso-config-options-azure"]
+:cpmso:
+endif::[]
+
+ifdef::cpmso[]
+:provider-name: Azure
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+:platform: Azure
+:providerspec-path: spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value
+:providerspec-api-version: v1beta1
+endif::cpmso[]
+
+// Microsoft Azure Stack Hub
+// Not supported.
+
+// Google Cloud Platform
+
+ifeval::["{context}" == "cpmso-config-options-gcp"]
+:cpmso:
+endif::[]
+
+ifdef::cpmso[]
+:provider-name: GCP
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+:platform: GCP
+:providerspec-path: spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value
+:providerspec-api-version: v1beta1
+endif::cpmso[]
+
+// IBM Cloud
+// Not supported.
+
+// IBM Power VS
+// Not supported.
+
+// Nutanix
+
+ifeval::["{context}" == "cpmso-config-options-nutanix"]
+:cpmso:
+endif::[]
+
+ifdef::cpmso[]
+:provider-name: Nutanix
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+:platform: Nutanix
+:providerspec-path: spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value
+:providerspec-api-version: v1
+endif::cpmso[]
+
+// OpenStack
+
+ifeval::["{context}" == "cpmso-config-options-openstack"]
+:cpmso:
+endif::[]
+
+ifdef::cpmso[]
+:provider-name: RHOSP
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+:platform: OpenStack
+:providerspec-path: spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value
+:providerspec-api-version: v1alpha1
+endif::cpmso[]
+
+// VMware vSphere
+
+ifeval::["{context}" == "cpmso-config-options-vsphere"]
+:cpmso:
+endif::[]
+
+ifdef::cpmso[]
+:provider-name: vSphere
+:machine-set: control plane machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1
+:api-kind: ControlPlaneMachineSet
+:namespace: openshift-machine-api
+:platform: VSphere
+:providerspec-path: spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value
+:providerspec-api-version: v1beta1
+endif::cpmso[]
+
+// bare metal
+// Not supported.
+
+// #############################################################
+// # Machine API compute machine set opening ifeval directives #
+// #############################################################
+
+// Agnostic
+// Adding a section to evaluate whether this would be helpful for the base specs.
+
+ifeval::["{context}" == "mapi-compute-config-options-CLOUD"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: <provider_name>
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// Amazon Web Services (AWS)
+
+ifeval::["{context}" == "mapi-compute-config-options-aws"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: AWS
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// Microsoft Azure
+
+ifeval::["{context}" == "mapi-compute-config-options-azure"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: Azure
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// Microsoft Azure Stack Hub
+
+ifeval::["{context}" == "mapi-compute-config-options-azure-stack-hub"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: Azure Stack Hub
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// Google Cloud Platform
+
+ifeval::["{context}" == "mapi-compute-config-options-gcp"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: GCP
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// IBM Cloud
+
+ifeval::["{context}" == "mapi-compute-config-options-ibm-cloud"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: IBM Cloud
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// IBM Power VS
+
+ifeval::["{context}" == "mapi-compute-config-options-ibm-power-vs"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: IBM Power VS
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// Nutanix
+
+ifeval::["{context}" == "mapi-compute-config-options-nutanix"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: Nutanix
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// OpenStack
+
+ifeval::["{context}" == "mapi-compute-config-options-openstack"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: RHOSP
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// VMware vSphere
+
+ifeval::["{context}" == "mapi-compute-config-options-vsphere"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: vSphere
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// bare metal
+
+ifeval::["{context}" == "mapi-compute-config-options-bare-metal"]
+:mapi:
+endif::[]
+
+ifdef::mapi[]
+:provider-name: bare metal
+:machine-set: compute machine set
+:api-name: Machine API
+:api-group: machine.openshift.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-machine-api
+:providerspec-path: spec.template.spec.providerSpec.value
+endif::mapi[]
+
+// #############################################################
+// # Cluster API compute machine set opening ifeval directives #
+// #############################################################
+
+// Agnostic
+// Adding a section to evaluate whether this would be helpful for the base specs.
+
+ifeval::["{context}" == "capi-compute-config-options-CLOUD"]
+:capi:
+endif::[]
+
+ifdef::capi[]
+:provider-name: <provider_name>
+:machine-set: compute machine set
+:api-name: Cluster API
+:api-group: cluster.x-k8s.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-cluster-api
+:spec-path: spec.template.spec
+// CAPI machine template and machine set spec paths are identical
+endif::capi[]
+
+// Amazon Web Services (AWS)
+
+ifeval::["{context}" == "capi-compute-config-options-aws"]
+:capi:
+endif::[]
+
+ifdef::capi[]
+:template-api-group: infrastructure.cluster.x-k8s.io
+:template-api-version: v1beta2
+:template-kind: AWSMachineTemplate
+:spec-path: spec.template.spec
+// CAPI machine template and machine set spec paths are identical
+:machine-set: compute machine set
+:api-name: Cluster API
+:api-group: cluster.x-k8s.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-cluster-api
+endif::capi[]
+
+// Microsoft Azure
+// Not supported.
+
+// Microsoft Azure Stack Hub
+// Not supported.
+
+// Google Cloud Platform
+
+ifeval::["{context}" == "capi-compute-config-options-gcp"]
+:capi:
+endif::[]
+
+ifdef::capi[]
+:template-api-group: infrastructure.cluster.x-k8s.io
+:template-api-version: v1beta1
+:template-kind: GCPMachineTemplate
+:spec-path: spec.template.spec
+// CAPI machine template and machine set spec paths are identical
+:machine-set: compute machine set
+:api-name: Cluster API
+:api-group: cluster.x-k8s.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-cluster-api
+endif::capi[]
+
+// IBM Cloud
+// Not supported.
+
+// IBM Power VS
+// Not supported.
+
+// Nutanix
+// Not supported.
+
+// OpenStack
+// Not supported.
+
+// VMware vSphere
+
+ifeval::["{context}" == "capi-compute-config-options-vsphere"]
+:capi:
+endif::[]
+
+ifdef::capi[]
+:template-api-group: infrastructure.cluster.x-k8s.io
+:template-api-version: v1beta1
+:template-kind: VSphereMachineTemplate
+:spec-path: spec.template.spec
+// CAPI machine template and machine set spec paths are identical
+:machine-set: compute machine set
+:api-name: Cluster API
+:api-group: cluster.x-k8s.io
+:api-version: v1beta1
+:api-kind: MachineSet
+:namespace: openshift-cluster-api
+endif::capi[]
+
+// bare metal
+// Not supported.


### PR DESCRIPTION
Merged this by mistake, reverted in ~~#86690~~ #86769, continued in #86773

Version(s):
N/A (release branch merge will have a target version)

Issue:
[OSDOCS-12946](https://issues.redhat.com//browse/OSDOCS-12946)

Link to docs preview:
[Compute configuration options for bare metal](https://86400--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/compute_machine_management/mapi_compute_provider_configurations/mapi-compute-config-options-bare-metal)

QE review:
- [ ] QE has approved this change.

Additional information: