### PR TITLE
OSDOCS#12931: Update the 4.17.9 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2874,6 +2874,55 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.9
+[id="ocp-4-17-9_{context}"]
+=== RHBA-2024:11010 - {product-title} {product-version}.9 bug fix, and security update advisory
+
+Issued: 19 December 2024
+
+{product-title} release {product-version}.9 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:11010[RHBA-2024:11010] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:11013[RHBA-2024:11013] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.9 --pullspecs
+----
+
+[id="ocp-4-17-9-known-issues_{context}"]
+==== Known issues
+
+* If you plan to deploy the NUMA Resources Operator, avoid using {product-title}  versions 4.17.7 or 4.17.8. (link:https://issues.redhat.com/browse/OCPBUGS-45639[*OCPBUGS-45639*]) 
+
+[id="ocp-4-17-9-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the {gcp-first} *Project Number input* field was incorrectly labeled as *GCP Pool ID*. With this release, the {gcp-short} *Project Number input* field is correctly labeled. (link:https://issues.redhat.com/browse/OCPBUGS-46000[*OCPBUGS-46000*])
+
+* Previously, there was a maximum bulk delete limit of 10. This limit caused an issue with the `PreferNoSchedule` taint. With this release, the maximum bulk delete rate is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-45929[*OCPBUGS-45929*])
+
+* Previously, users wanted to configure their {aws-full} DHCP option set with a custom domain name that contained a trailing period. When the hostname of EC2 instances were converted to Kubelet node names, the trailing period was not removed. Trailing periods are not allowed in a Kubernetes object name. With this release, trailing periods are allowed in a domain name in a DHCP option set. (link:https://issues.redhat.com/browse/OCPBUGS-45918[*OCPBUGS-45918*])
+
+* Previously, when a long string of individual CPUs were in the Performance Profile, the machine configurations were not processed. With this release, the user input process is updated to use a sequence of numbers or a range of numbers on the kernel command line. (link:https://issues.redhat.com/browse/OCPBUGS-45627[*OCPBUGS-45627*])
+
+* Previously, when accessing the image from the release payload to run the `oc adm node-image` command, the command failed. With this release, a retry mechanism is added to correct the temporary failures when the image is accessed. (link:https://issues.redhat.com/browse/OCPBUGS-45517[*OCPBUGS-45517*])
+
+* Previously, the first reboot failed while running Agent-based Installer using FCP or NVME storage devices for multiple images on s390x hardware. With this release, this issue is resolved and the reboot completes. (link:https://issues.redhat.com/browse/OCPBUGS-44904[*OCPBUGS-44904*])
+
+* Previously, a missing permission caused cluster deprovision to fail when using a custom identity and access management (IAM) profile. With this release, the list of required permissions includes `tag:UntagResource` and the cluster deprovision completes. (link:https://issues.redhat.com/browse/OCPBUGS-44848[*OCPBUGS-44848*])
+
+* Previously, when you created a hosted cluster by using a shared VPC where the private DNS hosted zones existed in the cluster creator account, the private link controller failed to create the `route53` DNS records in the local zone. With this release, the ingress shared role adds records to the private link controller. The VPC endpoint is used to share the role to create the VPC endpoint in the VPC owner account. A hosted cluster is created in a shared VPC configuration, where the private hosted zones exist in the cluster creator account. (link:https://issues.redhat.com/browse/OCPBUGS-44630[*OCPBUGS-44630*])
+
+* Previously, the `kdump initramfs` stopped responding when opening a local encrypted disk, even when the kdump destination was a remote machine that did not need to access the local machine. With this release, this issue is fixed and the `kdump initranfs` successfully opens a local encrypted disk. (link:https://issues.redhat.com/browse/OCPBUGS-43079[*OCPBUGS-43079*])
+
+* Previously, the Cluster Version Operator (CVO) did not filter internal errors that were propogated to the `ClusterVersion Failing condition` message. As a result, errors that did not negatively impact the update were shown for the `ClusterVersion Failing condition` message. With this release, the errors that are propogated to the `ClusterVersion Failing condition` message are filtered. (link:https://issues.redhat.com/browse/OCPBUGS-39558[*OCPBUGS-39558*])
+
+[id="ocp-4-17-9-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.8
 [id="ocp-4-17-8_{context}"]
 === RHSA-2024:10818 - {product-title} {product-version}.8 bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12931](https://issues.redhat.com/browse/OSDOCS-12931)

Link to docs preview:
[4.17.9](https://86405--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-9_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.
