### PR TITLE
fix: add ScannerV4 PVC size and storageClassName options

### DIFF
--- a/modules/central-configuration-options-operator.adoc
+++ b/modules/central-configuration-options-operator.adoc
@@ -202,8 +202,14 @@ Ensure that this value does not exceed the maximum number of connections support
 | Use this parameter to override the default resource requests for Scanner V4 DB.
 
 | `scannerV4.db.persistence.persistentVolumeClaim.claimName`
-|The name of the PVC to manage persistent data for Scanner V4.
+| The name of the PVC to manage persistent data for Scanner V4.
 If no PVC with the given name exists, it is created. The default value is `scanner-v4-db` if not set. To prevent data loss, the PVC is not removed automatically when Central is deleted.
+
+| `scannerV4.db.persistence.persistentVolumeClaim.size`
+| The size of the PVC to manage persistent data for Scanner V4.
+
+| `scannerV4.db.persistence.persistentVolumeClaim.storageClassName`
+| The name of the storage class to use for the PVC. If your cluster is not configured with a default storage class, you must provide a value for this parameter.
 
 | `scannerV4.indexer.nodeSelector`
 | If you want this component to only run on specific nodes, you can use this parameter to configure a node selector.

--- a/modules/central-services-public-config.adoc
+++ b/modules/central-services-public-config.adoc
@@ -330,8 +330,14 @@ The following table lists the configurable parameters for Scanner V4.
 | Parameter | Description
 
 | `scannerV4.db.persistence.persistentVolumeClaim.claimName`
-|The name of the PVC to manage persistent data for Scanner V4.
+| The name of the PVC to manage persistent data for Scanner V4.
 If no PVC with the given name exists, it is created. The default value is `scanner-v4-db` if not set. To prevent data loss, the PVC is not removed automatically when Central is deleted.
+
+| `scannerV4.db.persistence.persistentVolumeClaim.size`
+| The size of the PVC to manage persistent data for Scanner V4.
+
+| `scannerV4.db.persistence.persistentVolumeClaim.storageClassName`
+| The name of the storage class to use for the PVC. If your cluster is not configured with a default storage class, you must provide a value for this parameter.
 
 | `scannerV4.disable`
 | Use `false` to enable Scanner V4. When setting this parameter, the StackRox Scanner must also be enabled by setting `scanner.disable=false`. Until feature parity between the StackRox Scanner and Scanner V4 is reached, Scanner V4 can only be used in combination with the StackRox Scanner. Enabling Scanner V4 without also enabling the StackRox Scanner is not supported. When you set this parameter to `true` with the `helm upgrade` command, Helm removes the existing Scanner V4 deployment.

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -164,8 +164,14 @@ Use Scanner configuration settings to modify the local cluster scanner for the i
 | Use this parameter to override the default resource requests for Scanner V4 DB.
 
 | `scannerV4.db.persistence.persistentVolumeClaim.claimName`
-|The name of the PVC to manage persistent data for Scanner V4.
+| The name of the PVC to manage persistent data for Scanner V4.
 If no PVC with the given name exists, it is created. The default value is `scanner-v4-db` if not set. To prevent data loss, the PVC is not removed automatically when Central is deleted.
+
+| `scannerV4.db.persistence.persistentVolumeClaim.size`
+| The size of the PVC to manage persistent data for Scanner V4.
+
+| `scannerV4.db.persistence.persistentVolumeClaim.storageClassName`
+| The name of the storage class to use for the PVC. If your cluster is not configured with a default storage class, you must provide a value for this parameter.
 
 | `scannerV4.indexer.nodeSelector`
 | If you want this component to only run on specific nodes, you can use this parameter to configure a node selector.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: add ScannerV4 PVC size and storageClassName options --->
The `size` and `storageClassName` field for Scanner V4 PVC configuration are missing. This PR adds documentation for those fields.


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
`>=4.4`

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
No issue created, fix created due to a internal slack conversion.
https://redhat-internal.slack.com/archives/C01R0E7CVMX/p1734503268808559

Links to docs previews:

[86409--ocpdocs-pr.netlify.app](https://86409--ocpdocs-pr.netlify.app/)
[86409--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp.html](https://86409--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp.html)
[86409--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html](https://86409--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html)
[86409--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html](https://86409--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html)
[86409--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-central-other.html](https://86409--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-central-other.html)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
