### PR TITLE
OSSM-8630: Documentation for primary-remote multi-network topology

### DIFF
--- a/install/ossm-multi-cluster-topologies.adoc
+++ b/install/ossm-multi-cluster-topologies.adoc
@@ -15,4 +15,9 @@ include::modules/ossm-applying-certificates-to-a-multi-cluster-topology.adoc[lev
 include::modules/ossm-installing-multi-primary-multi-network-mesh.adoc[leveloffset=+1]
 include::modules/ossm-verifying-multi-cluster-topology.adoc[leveloffset=+2]
 include::modules/ossm-removing-multi-cluster-installation-from-development-environment.adoc[leveloffset=+2]
+include::modules/ossm-installing-primary-remote-multi-network-mesh.adoc[leveloffset=+1]
+[role="_next-steps"]
+.Next steps
+* xref:../install/ossm-multi-cluster-topologies.adoc#ossm-verifying-multi-cluster-topology_ossm-multi-cluster-topologies[Verifying a multi-cluster topology]
 
+* xref:../install/ossm-multi-cluster-topologies.adoc#ossm-removing-multi-cluster-installation-from-development-environment_ossm-multi-cluster-topologies[Removing a multi-cluster topology from a development environment]

--- a/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
+++ b/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
@@ -1,0 +1,171 @@
+// This procedure is used in the following assembly:
+// * install/ossm-multi-cluster-topologies.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-installing-primary-remote-multi-network-mesh_{context}"]
+= Installing a primary-remote multi-network mesh 
+
+Install {istio} in a primary-remote multi-network topology on two {ocp-product-title} clusters. 
+
+[NOTE]
+====
+In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster. The East cluster is the primary cluster and the West cluster is the remote cluster.
+====
+
+You can adapt these instructions for a mesh spanning more than two clusters.
+
+.Prerequisites
+
+* You have installed the {SMProduct} 3 Operator on all of the clusters that comprise the mesh.
+
+* You have completed "Creating certificates for a multi-cluster mesh". 
+
+* You have completed "Applying certificates to a multi-cluster topology".
+
+* You have created an {istio} Container Network Interface (CNI) resource.
+
+* You have `istioctl` installed on the laptop you will use to run these instructions.
+
+.Procedure
+
+. Create an `ISTIO_VERSION` environment variable that defines the {istio} version to install by running the following command:
++
+[source,terminal]
+----
+$ export ISTIO_VERSION=1.24.1 
+----
+
+. Install {istio} on the East cluster:
+
+.. Set the default network for the East cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" label namespace istio-system topology.istio.io/network=network1
+----
+
+.. Create an `Istio` resource on the East cluster by running the following command:
++
+[source,terminal]
+----
+$ cat <<EOF | oc --context "${CTX_CLUSTER1}" apply -f -
+apiVersion: sailoperator.io/v1alpha1
+kind: Istio
+metadata:
+  name: default
+spec:
+  version: v${ISTIO_VERSION}
+  namespace: istio-system
+  values:
+    global:
+      meshID: mesh1
+      multiCluster:
+        clusterName: cluster1
+      network: network1
+      externalIstiod: true <1>
+EOF      
+----
+<1> This enables the control plane installed on the East cluster to serve as an external control plane for other remote clusters.
+
+.. Wait for the control plane to return the "Ready" status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" wait --for condition=Ready istio/default --timeout=3m
+----
+
+.. Create an East-West gateway on the East cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/east-west-gateway-net1.yaml
+----
+
+.. Expose the control plane through the gateway so that services in the West cluster can access the control plane by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/expose-istiod.yaml
+----
+
+.. Expose the application services through the gateway by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/expose-services.yaml
+----
+
+. Install {istio} on the West cluster:
+
+.. Save the IP address of the East-West gateway running in the East cluster by running the following command:
++
+[source,terminal]
+----
+$ export DISCOVERY_ADDRESS=$(oc --context="${CTX_CLUSTER1}" \
+    -n istio-system get svc istio-eastwestgateway \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+----
+
+.. Create an `Istio` resource on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ cat <<EOF | oc --context "${CTX_CLUSTER2}" apply -f -
+apiVersion: sailoperator.io/v1alpha1
+kind: Istio
+metadata:
+  name: default
+spec:
+  version: v${ISTIO_VERSION}
+  namespace: istio-system
+  profile: remote
+  values:
+    istiodRemote: 
+      injectionPath: /inject/cluster/cluster2/net/network2
+    global:
+      remotePilotAddress: ${DISCOVERY_ADDRESS}
+EOF      
+----
+
+.. Annotate the `istio-system` namespace in the West cluster so that it is managed by the control plane in the East cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" annotate namespace istio-system topology.istio.io/controlPlaneClusters=cluster1
+----
+
+.. Set the default network for the West cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" label namespace istio-system topology.istio.io/network=network2
+----
+
+.. Install a remote secret on the East cluster that provides access to the API server on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ istioctl create-remote-secret \
+  --context="${CTX_CLUSTER2}" \
+  --name=cluster2 | \
+  oc --context="${CTX_CLUSTER1}" apply -f -
+----
+
+.. Wait for the `Istio` resource to return the "Ready" status condition by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER2}" wait --for condition=Ready istio/default --timeout=3m
+----
+
+.. Create an East-West gateway on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context "${CTX_CLUSTER2}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/east-west-gateway-net2.yaml
+----
++
+[NOTE]
+====
+Since the West cluster is installed with a remote profile, exposing the application services on the East cluster exposes them on the East-West gateways of both clusters.
+====


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OSSM-8630
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://86419--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html#ossm-installing-primary-remote-multi-network-mesh_ossm-multi-cluster-topologies
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
