### PR TITLE
OSDOCS#12967: Add OLMv1 to "Cluster Operators reference", update OLMv0 entry

### DIFF
--- a/modules/olm-architecture.adoc
+++ b/modules/olm-architecture.adoc
@@ -11,9 +11,11 @@ ifeval::["{context}" == "cluster-operators-ref"]
 = CRDs
 endif::[]
 
+ifeval::["{context}" != "cluster-operators-ref"]
 Operator Lifecycle Manager (OLM) is composed of two Operators: the OLM Operator and the Catalog Operator.
+endif::[]
 
-Each of these Operators is responsible for managing the custom resource definitions (CRDs) that are the basis for the OLM framework:
+The OLM and Catalog Operators are responsible for managing the custom resource definitions (CRDs) that are the basis for the OLM framework:
 
 .CRDs managed by OLM and Catalog Operators
 [cols="2a,1a,1a,8a",options="header"]

--- a/modules/olmv1-clusterextension-api.adoc
+++ b/modules/olmv1-clusterextension-api.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: CONCEPT
 
-[id="olmv1-clusterextension-api"]
+[id="olmv1-clusterextension-api_{context}"]
 = ClusterExtension API
 
 Operator Controller provides a new `ClusterExtension` API object that is a single resource representing an instance of an installed extension, which includes Operators via the `registry+v1` bundle format. This `clusterextension.olm.operatorframework.io` API streamlines management of installed extensions by consolidating user-facing APIs into a single object.

--- a/modules/olmv1-clusteroperator.adoc
+++ b/modules/olmv1-clusteroperator.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * operators/operator-reference.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cluster-operators-ref-olmv1_{context}"]
+= {olmv1-first} Operator
+
+[discrete]
+== Purpose
+
+Starting in {product-title} 4.18, {olmv1-first} is enabled by default alongside the {olmv0}. This next-generation iteration provides an updated framework that evolves many of the {olmv0} concepts that enable cluster administrators to extend capabilities for their users.
+
+{olmv1} manages the lifecycle of the new `ClusterExtension` object, which includes Operators via the `registry+v1` bundle format, and controls installation, upgrade, and role-based access control (RBAC) of extensions within a cluster.
+
+In {product-title}, {olmv1} is provided by the `olm` cluster Operator.
+
+[NOTE]
+====
+The `olm` cluster Operator informs cluster administrators if there are any installed extensions blocking cluster upgrade, based on their `olm.maxOpenShiftVersion` properties. For more information, see "Compatibility with {product-title} versions".
+====
+
+[discrete]
+== Components
+
+{olmv1-first} comprises the following component projects:
+
+Operator Controller:: The central component of {olmv1} that extends Kubernetes with an API through which users can install and manage the lifecycle of Operators and extensions. It consumes information from catalogd.
+
+Catalogd:: A Kubernetes extension that unpacks file-based catalog (FBC) content packaged and shipped in container images for consumption by on-cluster clients. As a component of the {olmv1} microservices architecture, catalogd hosts metadata for Kubernetes extensions packaged by the authors of the extensions, and as a result helps users discover installable content.
+
+[discrete]
+== CRDs
+
+* `clusterextension.olm.operatorframework.io`
+** Scope: Cluster
+** CR: `ClusterExtension`
+
+* `clustercatalog.olm.operatorframework.io`
+** Scope: Cluster
+** CR: `ClusterCatalog`
+
+[discrete]
+== Project
+
+* link:https://github.com/operator-framework/operator-controller[operator-framework/operator-controller]
+* link:https://github.com/operator-framework/catalogd[operator-framework/catalogd]

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -102,7 +102,7 @@ include::modules/insights-operator.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../installing/overview/cluster-capabilities.adoc#insights-operator_cluster-capabilities[Insights capability]
-* See xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for details about Insights Operator and Telemetry.
+* xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
 include::modules/kube-apiserver-operator.adoc[leveloffset=+1]
 
@@ -135,23 +135,48 @@ include::modules/openshift-apiserver-operator.adoc[leveloffset=+1]
 include::modules/cluster-openshift-controller-manager-operators.adoc[leveloffset=+1]
 
 [id="cluster-operators-ref-olm"]
-== Operator Lifecycle Manager Operators
+== Operator Lifecycle Manager (OLM) Operators
+
+[NOTE]
+====
+The following sections pertain to the {olmv0-first} that has been included with {product-title} 4 since its initial release. For {olmv1}, see xref:../operators/operator-reference.adoc#cluster-operators-ref-olmv1_cluster-operators-ref[{olmv1-first} Operators].
+====
+
 [discrete]
 include::modules/olm-overview.adoc[leveloffset=+2]
-[discrete]
-include::modules/olm-architecture.adoc[leveloffset=+2]
 [discrete]
 include::modules/olm-arch-olm-operator.adoc[leveloffset=+2]
 [discrete]
 include::modules/olm-arch-catalog-operator.adoc[leveloffset=+2]
 [discrete]
 include::modules/olm-arch-catalog-registry.adoc[leveloffset=+2]
+[discrete]
+include::modules/olm-architecture.adoc[leveloffset=+2]
+
+[discrete]
+=== Cluster Operators
+
+In {product-title}, OLM functionality is provided across a set of cluster Operators:
+
+`operator-lifecycle-manager`:: Provides the OLM Operator. Also informs cluster administrators if there are any installed Operators blocking cluster upgrade, based on their `olm.maxOpenShiftVersion` properties. For more information, see "Controlling Operator compatibility with {product-title} versions".
+`operator-lifecycle-manager-catalog`:: Provides the Catalog Operator.
+`operator-lifecycle-manager-packageserver`:: Represents an API extension server responsible for collecting metadata from all catalogs on the cluster and serves the user-facing `PackageManifest` API.
 
 [role="_additional-resources"]
 [discrete]
 [id="cluster-operators-ref-olm-addtl-resources"]
 === Additional resources
-* For more information, see the sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[understanding Operator Lifecycle Manager (OLM)].
+* xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Understanding Operator Lifecycle Manager (OLM)]
+* xref:../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-control-compat_osdk-working-bundle-images[Controlling Operator compatibility with {product-title} versions]
+
+include::modules/olmv1-clusteroperator.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[discrete]
+[id="cluster-operators-ref-olmv1-addtl-resources"]
+=== Additional resources
+* xref:../extensions/index.adoc#extensions-overview[Extensions overview]
+* xref:../extensions/ce/upgrade-edges.adoc#upgrade-edges[Compatibility with {product-title} versions]
 
 include::modules/openshift-service-ca-operator.adoc[leveloffset=+1]
 
@@ -159,4 +184,4 @@ include::modules/vsphere-problem-detector-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* For more details, see xref:../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#using-vsphere-problem-detector-operator[Using the vSphere Problem Detector Operator].
+* xref:../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#using-vsphere-problem-detector-operator[Using the vSphere Problem Detector Operator]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-12967

4.18+

Update the OLMv0 entry in "Cluster Operators reference" to mention its related cluster Operator names:

* `operator-lifecycle-manager`
* `operator-lifecycle-manager-catalog`
* `operator-lifecycle-manager-packageserver`

And add an entry for OLMv1 overall, including its CO name:

* `olm`

Preview:

* [OLMv0 entry](https://86434--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-operators-ref-olm)
* [OLMv1 entry](https://86434--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-operators-ref-olmv1_cluster-operators-ref)