### PR TITLE
OSDOCS-12932: 4.14.43 RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3392,6 +3392,35 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.43
+[id="ocp-4-14-43_{context}"]
+=== RHSA-2024:11031 - {product-title} 4.14.43 bug fix and security update
+
+Issued: 18 December 2024
+
+{product-title} release 4.14.43, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:11031[RHSA-2024:11031] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:11034[RHBA-2024:11034] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.43 --pullspecs
+----
+
+[id="ocp-4-14-43-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, a trailing period was not permitted in a Kubernetes object name per the DNS 1123 sub-domain name standard. If you configured your AWS DHCP option set with a custom domain name containing a trailing period, the logic for extracting the hostname of EC2 instances and turning it into Kubelet node names would not trim the hostnames for trailing periods. With this release, the logic is updated to trim trailing periods, and trailing periods are permitted within the domain name in the DHCP option set. (link:https://issues.redhat.com/browse/OCPBUGS-46057[*OCPBUGS-46057*])
+
+* Previously, {hcp}-based clusters were unable to authenticate through the `oc login` command. The web browser displayed an error when it attepted to retrieve the the token after selecting *Display Token*. With this release, `cloud.ibm.com` and other cloud-based endpoints are no longer proxied and authentication is successful. (link:https://issues.redhat.com/browse/OCPBUGS-44279[*OCPBUGS-44279*])
+
+[id="ocp-4-14-43-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.42
 [id="ocp-4-14-42_{context}"]
 === RHSA-2024:10523 - {product-title} 4.14.42 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-12932

Link to docs preview:
https://86435--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-43_release-notes

QE review:
N/A

Additional information:
Errata links will return 404 until errata are shipped live (12/18)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
