### PR TITLE
OSDOCS-11772.1 (12965): Upgrade ROSA with HCP cluster through Openshift Cluster manager console with xref links

### DIFF
--- a/modules/rosa-red-hat-support-access.adoc
+++ b/modules/rosa-red-hat-support-access.adoc
@@ -29,7 +29,7 @@ Write: None
 
 Write: None
 
-|OpenShift SRE - Elevated Access ^[2]^ (Gated by link:https://docs.openshift.com/rosa/support/approved-access.html[Approved Access])| Read: All
+|OpenShift SRE - Elevated Access ^[2]^ (Gated by link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/support/approved-access[Approved Access])| Read: All
 
 Write: All
 
@@ -111,6 +111,6 @@ Write: None
 |===
 --
 1. Limited to addressing common use cases such as failing deployments, upgrading a cluster, and replacing bad worker nodes.
-2. Elevated access gives SRE the access levels of a cluster-admin role. See link:https://docs.openshift.com/container-platform/4.17/authentication/using-rbac.html#default-roles_using-rbac[cluster roles] for more information.
+2. Elevated access gives SRE the access levels of a cluster-admin role and is gated by Approved Access. For more information, see "Default cluster roles" and "Approved Access".
 3. Limited to what is granted through RBAC by the Customer Administrator and namespaces created by the user.
 --

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -31,7 +31,7 @@ include::modules/rosa-sdpolicy-instance-types.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-For a detailed listing of supported instance types, see 
+For a detailed listing of supported instance types, see
 ifdef::openshift-rosa-hcp[]
 xref:../rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-instance-types[{product-title} instance types].
 endif::openshift-rosa-hcp[]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
@@ -16,15 +16,21 @@ For a list of the available subprocessors, see the link:https://access.redhat.co
 
 include::modules/sre-cluster-access.adoc[leveloffset=+1]
 include::modules/rosa-red-hat-support-access.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/support/approved-access[Approved Access].
+
+* For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/authentication_and_authorization/using-rbac#default-roles_using-rbac[Default cluster roles]
+
 include::modules/rosa-customer-access.adoc[leveloffset=+1]
 include::modules/rosa-access-approval-review.adoc[leveloffset=+1]
 include::modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the AWS IAM roles used by the cluster Operators, see xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-operator-roles_rosa-sts-about-iam-resources[Cluster-specific Operator IAM role reference].
+* For more information about the AWS IAM roles used by the cluster Operators, see https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-sts-about-iam-resources#rosa-sts-operator-roles_rosa-sts-about-iam-resources[Cluster-specific Operator IAM role reference].
 
-* For more information about the policies and permissions that the cluster Operators require, see xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation].
-endif::openshift-rosa-hcp[]
+* For more information about the policies and permissions that the cluster Operators require, see https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/rosa-sts-about-iam-resources#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation].
+
+* For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/support/approved-access[Approved Access].


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-12965

Link to docs preview:
https://86442--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.html

https://86442--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.html

QE review:
QE approval is not required to merge this PR as the changes from a link to an xref does not impact the meaning of the docs.
