### PR TITLE
[enterprise-4.13] OCPBUGS#44420: Added a warning about the change in disk ordering behavior

### DIFF
--- a/modules/lvms-creating-logical-volume-manager-cluster.adoc
+++ b/modules/lvms-creating-logical-volume-manager-cluster.adoc
@@ -41,6 +41,7 @@ You also can perform the same task by using the {product-title} web console.
 You can only create a single instance of the `LVMCluster` custom resource (CR) on an {product-title} cluster.
 =====
 +
+--
 .. Save the following YAML in the `lvmcluster.yaml` file:
 +
 [source,yaml]
@@ -78,6 +79,16 @@ When configuring multiple device classes, you must specify the device path for e
 If you are upgrading the `LVMCluster` resource from a previous version, you must specify a single default device class.
 <3> Optional: To control what worker nodes the `LVMCluster` CR is applied to, specify a set of node selector labels.
 The specified labels must be present on the node in order for the `LVMCluster` to be scheduled on that node.
+--
++
+[WARNING]
+====
+It is recommended to avoid referencing disks using symbolic naming, such as `/dev/sdX`, as these names may change across reboots within RHCOS. Instead, you must use stable naming schemes, such as `/dev/disk/by-path/` or `/dev/disk/by-id/`, to ensure consistent disk identification.
+
+With this change, you might need to adjust existing automation workflows in the cases where monitoring collects information about the install device for each node.
+
+For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_file_systems/assembly_overview-of-persistent-naming-attributes_managing-file-systems[{op-system-base} documentation].
+====
 
 .. Create the `LVMCluster` CR:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-44420](https://issues.redhat.com/browse/OCPBUGS-44420)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Creating a Logical Volume Manager cluster on a {sno} worker node](url)

Note to the merge reviewer: The content added in this PR has been verified in https://github.com/openshift/openshift-docs/pull/85369. Created this PR as cherry-pick to 4.13 failed due to the section updated in main branch is missing in 4.13.