### PR TITLE
removing xrefs to nonexistent pages

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
@@ -37,8 +37,6 @@ include::modules/oadp-storage-class-mapping-oadp.adoc[leveloffset=+3]
 
 * xref:../../backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc#oadp-different-kubernetes-api-versions[Working with different Kubernetes API versions on the same cluster].
 
-* xref:../../backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc#backing-up-applications[Using Data Mover for CSI snapshots].
-
 * xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic].
 
 * xref:../../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-converting-storage-classes_advanced-migration-options-mtc[Migration converting storage classes].

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -77,8 +77,6 @@ include::modules/live-migration-metrics-information.adoc[leveloffset=+3]
 * xref:../../networking/changing-cluster-network-mtu.adoc#nw-cluster-mtu-change_changing-cluster-network-mtu[Changing the cluster MTU]
 * xref:../../networking/changing-cluster-network-mtu.adoc#mtu-value-selection_changing-cluster-network-mtu[MTU value selection]
 
-* xref:../../networking/network_security/network_policy/about-network-policy.adoc#nw-networkpolicy-optimize-ovn_about-network-policy[About network policy]
-
 * xref:../../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc#converting-to-dual-stack[Converting to IPv4/IPv6 dual-stack networking]
 
 * OVN-Kubernetes capabilities


### PR DESCRIPTION
Removing xrefs that cause 4.15 builds to fail because they point to files that are not included in the topic map