### PR TITLE
removing xrefs to nonexistent pages, 4.14

### DIFF
--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -11,7 +11,7 @@ As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 
 [WARNING]
-==== 
+====
 Do not automate the migration from OpenShift SDN to OVN-Kubernetes with a script or another tool like Red Hat Ansible Automation Platform. This might cause outages or crash your {product-title} cluster.
 ====
 
@@ -21,7 +21,7 @@ include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-release[Understanding update channels and releases] 
+* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-release[Understanding update channels and releases]
 * xref:../../release_notes/ocp-4-14-release-notes.adoc#ocp-4-14-asynchronous-errata-updates_release-notes[Asynchronous errata updates]
 
 // How the migration process works
@@ -40,8 +40,6 @@ include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
 * xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
 * xref:../../networking/changing-cluster-network-mtu.adoc#nw-cluster-mtu-change_changing-cluster-network-mtu[Changing the cluster MTU]
 * xref:../../networking/changing-cluster-network-mtu.adoc#mtu-value-selection_changing-cluster-network-mtu[MTU value selection]
-
-* xref:../../networking/network_security/network_policy/about-network-policy.adoc#nw-networkpolicy-optimize-ovn_about-network-policy[About network policy]
 
 * xref:../../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc#converting-to-dual-stack[Converting to IPv4/IPv6 dual-stack networking]
 


### PR DESCRIPTION
Removing an xref that caused 4.14 builds to fail because they point to a file that is not included in the topic map