### PR TITLE
Changing restricted to disconnected terminology in titles

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -198,7 +198,7 @@ Topics:
       File: installing-aws-customizations
     - Name: Installing a cluster with network customizations
       File: installing-aws-network-customizations
-    - Name: Installing a cluster in a restricted network
+    - Name: Installing a cluster in a disconnected environment
       File: installing-restricted-networks-aws-installer-provisioned
     - Name: Installing a cluster into an existing VPC
       File: installing-aws-vpc
@@ -228,7 +228,7 @@ Topics:
       File: upi-aws-installation-reqs
     - Name: Installing a cluster using CloudFormation templates
       File: installing-aws-user-infra
-    - Name: Installing a cluster in a restricted network with user-provisioned infrastructure
+    - Name: Installing a cluster in a disconnected environment with user-provisioned infrastructure
       File: installing-restricted-networks-aws
     - Name: Installing an AWS cluster with the support for configuring multi-architecture compute machines
       File: installing-aws-multiarch-support-upi
@@ -261,7 +261,7 @@ Topics:
       File: installing-azure-customizations
     - Name: Installing a cluster with network customizations
       File: installing-azure-network-customizations
-    - Name: Installing a cluster in a restricted network
+    - Name: Installing a cluster in a disconnected environment
       File: installing-restricted-networks-azure-installer-provisioned
     - Name: Installing a cluster into an existing VNet
       File: installing-azure-vnet
@@ -275,7 +275,7 @@ Topics:
     Topics:
     - Name: Preparing to install a cluster
       File: installing-azure-preparing-upi
-    - Name: Installing a cluster in a restricted network with user-provisioned infrastructure
+    - Name: Installing a cluster in a disconnected environment with user-provisioned infrastructure
       File: installing-restricted-networks-azure-user-provisioned
     - Name: Installing a cluster using ARM templates
       File: installing-azure-user-infra
@@ -329,7 +329,7 @@ Topics:
     File: installing-gcp-customizations
   - Name: Installing a cluster on GCP with network customizations
     File: installing-gcp-network-customizations
-  - Name: Installing a cluster on GCP in a restricted network
+  - Name: Installing a cluster on GCP in a disconnected environment
     File: installing-restricted-networks-gcp-installer-provisioned
   - Name: Installing a cluster on GCP into an existing VPC
     File: installing-gcp-vpc
@@ -341,7 +341,7 @@ Topics:
     File: installing-gcp-user-infra
   - Name: Installing a cluster into a shared VPC on GCP using Deployment Manager templates
     File: installing-gcp-user-infra-vpc
-  - Name: Installing a cluster on GCP in a restricted network with user-provisioned infrastructure
+  - Name: Installing a cluster on GCP in a disconnected environment with user-provisioned infrastructure
     File: installing-restricted-networks-gcp
   - Name: Installing a three-node cluster on GCP
     File: installing-gcp-three-node
@@ -371,7 +371,7 @@ Topics:
     File: installing-ibm-cloud-vpc
   - Name: Installing a private cluster on IBM Cloud
     File: installing-ibm-cloud-private
-  - Name: Installing a cluster on IBM Cloud in a restricted network
+  - Name: Installing a cluster on IBM Cloud in a disconnected environment
     File: installing-ibm-cloud-restricted
   - Name: Installation configuration parameters for IBM Cloud
     File: installation-config-parameters-ibm-cloud-vpc
@@ -387,7 +387,7 @@ Topics:
     File: nutanix-failure-domains
   - Name: Installing a cluster on Nutanix
     File: installing-nutanix-installer-provisioned
-  - Name: Installing a cluster on Nutanix in a restricted network
+  - Name: Installing a cluster on Nutanix in a disconnected environment
     File: installing-restricted-networks-nutanix-installer-provisioned
   - Name: Installing a three-node cluster on Nutanix
     File: installing-nutanix-three-node
@@ -439,7 +439,7 @@ Topics:
       File: installing-bare-metal
     - Name: Installing a user-provisioned bare metal cluster with network customizations
       File: installing-bare-metal-network-customizations
-    - Name: Installing a user-provisioned bare metal cluster on a restricted network
+    - Name: Installing a user-provisioned bare metal cluster on a disconnected environment
       File: installing-restricted-networks-bare-metal
     - Name: Scaling a user-provisioned installation with the bare metal operator
       File: scaling-a-user-provisioned-cluster-with-the-bare-metal-operator
@@ -509,7 +509,7 @@ Topics:
     File: preparing-to-install-on-ibm-power
   - Name: Installing a cluster on IBM Power
     File: installing-ibm-power
-  - Name: Restricted network IBM Power installation
+  - Name: Installing a cluster on IBM Power in a disconnected environment
     File: installing-restricted-networks-ibm-power
   - Name: Installation configuration parameters for IBM Power
     File: installation-config-parameters-ibm-power
@@ -529,7 +529,7 @@ Topics:
     File: installing-ibm-powervs-vpc
   - Name: Installing a private cluster on IBM Power Virtual Server
     File: installing-ibm-power-vs-private-cluster
-  - Name: Installing a cluster on IBM Power Virtual Server in a restricted network
+  - Name: Installing a cluster on IBM Power Virtual Server in a disconnected environment
     File: installing-restricted-networks-ibm-power-vs
   - Name: Uninstalling a cluster on IBM Power Virtual Server
     File: uninstalling-cluster-ibm-power-vs
@@ -549,7 +549,7 @@ Topics:
     File: installing-openstack-installer-custom
   - Name: Installing a cluster on OpenStack on your own infrastructure
     File: installing-openstack-user
-  - Name: Installing a cluster on OpenStack in a restricted network
+  - Name: Installing a cluster on OpenStack in a disconnected environment
     File: installing-openstack-installer-restricted
   - Name: Installing a three-node cluster on OpenStack
     File: installing-openstack-three-node
@@ -595,7 +595,7 @@ Topics:
       File: installing-vsphere-installer-provisioned-customizations
     - Name: Installing a cluster with network customizations
       File: installing-vsphere-installer-provisioned-network-customizations
-    - Name: Installing a cluster in a restricted network
+    - Name: Installing a cluster in a disconnected environment
       File: installing-restricted-networks-installer-provisioned-vsphere
   - Name: User-provisioned infrastructure
     Dir: upi
@@ -609,7 +609,7 @@ Topics:
       File: installing-vsphere
     - Name: Installing a cluster with network customizations
       File: installing-vsphere-network-customizations
-    - Name: Installing a cluster in a restricted network
+    - Name: Installing a cluster in a disconnected environment
       File: installing-restricted-networks-vsphere
   - Name: Assisted Installer
     Distros: openshift-enterprise
@@ -813,7 +813,7 @@ Topics:
     File: using-insights-to-identify-issues-with-your-cluster
   - Name: Using the Insights Operator
     File: using-insights-operator
-  - Name: Using remote health reporting in a restricted network
+  - Name: Using remote health reporting in a disconnected environment
     File: remote-health-reporting-from-restricted-network
   - Name: Importing simple content access entitlements with Insights Operator
     File: insights-operator-simple-access
@@ -3681,7 +3681,7 @@ Topics:
   File: about-mtc-3-4
 - Name: Installing MTC
   File: installing-3-4
-- Name: Installing MTC in a restricted network environment
+- Name: Installing MTC in a disconnected environment
   File: installing-restricted-3-4
 - Name: Upgrading MTC
   File: upgrading-3-4
@@ -3713,7 +3713,7 @@ Topics:
     File: mtc-release-notes-1-5
 - Name: Installing MTC
   File: installing-mtc
-- Name: Installing MTC in a restricted network environment
+- Name: Installing MTC in a disconnected environment
   File: installing-mtc-restricted
 - Name: Upgrading MTC
   File: upgrading-mtc

--- a/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-aws-installer-provisioned"]
-= Installing a cluster on AWS in a restricted network
+= Installing a cluster on AWS in a disconnected environment
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-aws-installer-provisioned
 

--- a/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-aws"]
-= Installing a cluster on AWS in a restricted network with user-provisioned infrastructure
+= Installing a cluster on AWS in a disconnected environment with user-provisioned infrastructure
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-aws
 

--- a/installing/installing_azure/ipi/installing-restricted-networks-azure-installer-provisioned.adoc
+++ b/installing/installing_azure/ipi/installing-restricted-networks-azure-installer-provisioned.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-azure-installer-provisioned"]
-= Installing a cluster on Azure in a restricted network
+= Installing a cluster on Azure in a disconnected environment
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-azure-installer-provisioned
 

--- a/installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned.adoc
+++ b/installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-azure-user-provisioned"]
-= Installing a cluster on Azure in a restricted network with user-provisioned infrastructure
+= Installing a cluster on Azure in a disconnected environment with user-provisioned infrastructure
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-azure-user-provisioned
 

--- a/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-bare-metal"]
-= Installing a user-provisioned bare metal cluster on a restricted network
+= Installing a user-provisioned bare metal cluster on a disconnected environment
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-bare-metal
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-gcp-installer-provisioned"]
-= Installing a cluster on GCP in a restricted network
+= Installing a cluster on GCP in a disconnected environment
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-gcp-installer-provisioned
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-gcp"]
-= Installing a cluster on GCP in a restricted network with user-provisioned infrastructure
+= Installing a cluster on GCP in a disconnected environment with user-provisioned infrastructure
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-gcp
 

--- a/installing/installing_ibm_cloud/installing-ibm-cloud-restricted.adoc
+++ b/installing/installing_ibm_cloud/installing-ibm-cloud-restricted.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-cloud-restricted"]
-= Installing a cluster on {ibm-cloud-title} in a restricted network
+= Installing a cluster on {ibm-cloud-title} in a disconnected environment
 :context: installing-ibm-cloud-restricted
 
 toc::[]

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="installing-restricted-networks-ibm-power"]
-= Installing a cluster on {ibm-power-title} in a restricted network
+= Installing a cluster on {ibm-power-title} in a disconnected environment
 :context: installing-restricted-networks-ibm-power
 
 toc::[]

--- a/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="installing-restricted-networks-ibm-power-vs"]
-= Installing a cluster on {ibm-power-server-title} in a restricted network
+= Installing a cluster on {ibm-power-server-title} in a disconnected environment
 :context: installing-restricted-networks-ibm-power-vs
 
 toc::[]

--- a/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-nutanix-installer-provisioned"]
-= Installing a cluster on Nutanix in a restricted network
+= Installing a cluster on Nutanix in a disconnected environment
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-nutanix-installer-provisioned
 

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-openstack-installer-restricted"]
-= Installing a cluster on OpenStack in a restricted network
+= Installing a cluster on OpenStack in a disconnected environment
 include::_attributes/common-attributes.adoc[]
 :context: installing-openstack-installer-restricted
 

--- a/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-vmc-user-infra"]
-= Installing a cluster on VMC in a restricted network with user-provisioned infrastructure
+= Installing a cluster on VMC in a disconnected environment with user-provisioned infrastructure
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-vmc-user-infra
 

--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-installer-provisioned-vsphere"]
-= Installing a cluster on vSphere in a restricted network
+= Installing a cluster on vSphere in a disconnected environment
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-installer-provisioned-vsphere
 

--- a/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-vsphere"]
-= Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure
+= Installing a cluster on vSphere in a disconnected environment with user-provisioned infrastructure
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-vsphere
 


### PR DESCRIPTION
Updating titles and topic map from "restricted network" to "disconnected environment" per https://issues.redhat.com/browse/OSDOCS-11846

Versions: 4.18

As each file's changes are a single line, I will not list all preview links here. 