### PR TITLE
OSDOCS-12496-1: adds 4.17.9 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -178,3 +178,12 @@ Issued: 11 December 2024
 {product-title} release 4.17.8 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:10820[RHBA-2024:10820] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:10818[RHSA-2024:10818] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-9-dp_{context}"]
+=== RHBA-2024:11012 - {microshift-short} 4.17.9 bug fix and enhancement advisory
+
+Issued: 19 December 2024
+
+{product-title} release 4.17.9 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:11012[RHBA-2024:11012] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:11010[RHBA-2024:11010] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12496](https://issues.redhat.com/browse/OSDOCS-12496)

Link to docs preview:
[microshift-4-17-9-dp_release-notes](https://86484--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-9-dp_release-notes)

QE review:
- N/A stock text

Additional information:
This is a new PR created to update the release date. Refer the old PR https://github.com/openshift/openshift-docs/pull/86280 for the peer review approval.