### PR TITLE
Fixing the attributes and links for GitOps 1.15 published docs build …

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -14,8 +14,8 @@
 //gitops
 :gitops-title: Red Hat OpenShift GitOps
 :gitops-shortname: GitOps
-:gitops-ver: 1.14
-:upstream-ver: 2.12
+:gitops-ver: 1.15
+:upstream-ver: 2.13
 :rh-app-icon: image:red-hat-applications-menu-icon.jpg[title="Red Hat applications"]
 
 // IBM Power

--- a/gitops_cli_argocd/argocd-gitops-cli-reference.adoc
+++ b/gitops_cli_argocd/argocd-gitops-cli-reference.adoc
@@ -29,5 +29,5 @@ include::modules/gitops-argocd-cli-utility-commands.adoc[leveloffset=+1]
 * xref:../gitops_cli_argocd/configuring-argocd-gitops-cli.adoc#configuring-argocd-gitops-cli[Configuring the {gitops-shortname} CLI]
 * xref:../gitops_cli_argocd/logging-in-to-argocd-server-in-default-mode.adoc#logging-in-to-argocd-server-in-default-mode[Logging in to the Argo CD server in the default mode]
 * link:https://github.com/redhat-developer/gitops-operator/blob/7ac4b2ce179c167b39be259b8d9be37dc280f689/docs/OpenShift%20GitOps%20CLI%20User%20Guide.md#login-related-commands[OpenShift {gitops-shortname} CLI User Guide]
-* link:https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd/[`argocd` Command Reference]
+* link:https://argo-cd.readthedocs.io/en/release-{upstream-ver}/user-guide/commands/argocd/[`argocd` Command Reference]
 //update the upstream version attribute value for every release


### PR DESCRIPTION
Version(s):

CP to GitOps 1.15

Issue:

https://issues.redhat.com/browse/RHDEVDOCS-6234

Link to docs preview:

The following changes are made to the content:

Fixed the hyperlink for argocd command reference in the Additional Resources section for [GitOps argocd CLI reference](https://86487--ocpdocs-pr.netlify.app/openshift-gitops/latest/gitops_cli_argocd/argocd-gitops-cli-reference.html)

Fixed the example command sections for GitOps release versions in the [Installing the Red Hat OpenShift GitOps CLI on Linux using an RPM](https://86487--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/installing-argocd-gitops-cli#gitops-installing-argocd-cli-on-linux-using-rpm) section.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

- SME and QE review not required.

This PR is an addendum to the approach suggested by @Srivaralakshmi in this [comment](https://issues.redhat.com/browse/RHDEVDOCS-6234?focusedId=26307289&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26307289). As per the feedback in the comment, I have made similar changes in this PR and I request to merge this PR in the gitops-docs-1.15 branch.

CC: @Dhruv-Soni11  
