### PR TITLE
vroc: fix typos in mdadm commands

### DIFF
--- a/modules/installation-special-config-raid-intel-vroc.adoc
+++ b/modules/installation-special-config-raid-intel-vroc.adoc
@@ -31,7 +31,7 @@ $ mdadm -CR /dev/md/imsm0 -e \
 +
 [source,terminal]
 ----
-$ mdadm -CR /dev/md/dummy -l0 -n2 /dev/imsm0 -z10m --assume-clean
+$ mdadm -CR /dev/md/dummy -l0 -n2 /dev/imsm0 -z10M --assume-clean
 ----
 
 .. Create the real RAID1 array by running the following command:
@@ -63,7 +63,7 @@ $ mdadm -A /dev/md/coreos /dev/md/imsm0
 +
 [source,terminal]
 ----
-$ mdadm --details --export /dev/md/imsm0
+$ mdadm --detail --export /dev/md/imsm0
 ----
 
 .. Install {op-system} and include the `rd.md.uuid` kernel argument by running the following command:


### PR DESCRIPTION
I'm guessing this didn't show up before because users have been correcting it themselves after getting an error and didn't file a bug.

Compare with e.g.
https://github.com/openshift/os/blob/master/docs/faq.md#fake-raidhybrid-raidintel-vroc

Version(s):

I think this needs to go all the way back to 4.14...

Issue:

None. Noticed by inspection.

Link to docs preview:

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
