### PR TITLE
[OSDOCS-12971]Document command line verification of WIF resources

### DIFF
--- a/modules/create-wif-cluster-cli.adoc
+++ b/modules/create-wif-cluster-cli.adoc
@@ -186,6 +186,22 @@ $ ocm create cluster <cluster_name> \ <1>
 <12> Optional: Maximum number of compute nodes.
 <13> Optional: Secure Boot enables the use of Shielded VMs in the Google Cloud Platform.
 
+[id="ocm-cli-list-wif-commands_{context}"]
+== Listing WIF clusters
+
+To list all of your {product-title} clusters that have been deployed using the WIF authentication type, run the following command:
+
+[source,terminal]
+----
+$ ocm list clusters --parameter search="gcp.authentication.wif_config_id != ''"
+----
+To list all of your {product-title} clusters that have been deployed using a specific wif-config, run the following command:
+[source,terminal]
+----
+$ ocm list clusters --parameter search="gcp.authentication.wif_config_id = '<wif_config_id>'" <1>
+----
+<1> Replace `<wif_config_id>` with the ID of the WIF configuration.
+
 [id="wif-configuration-update_{context}"]
 == Updating a WIF configuration
 
@@ -205,18 +221,32 @@ ocm gcp update wif-config --version <version> \ <1>
 <1> Replace `<version>` with the {product-title} y-stream version you plan to update the cluster to.
 <2> Replace `<wif_name>` with the name of the WIF configuration you want to update.
 
-[id="ocm-cli-list-wif-commands_{context}"]
-== List WIF clusters
+[id="ocm-cli-verify-wif-commands_{context}"]
+== Verifying a WIF configuration
+You can verify that the configuration of resources associated with a WIF configuration are correct by running the `ocm gcp verify wif-config` command. If a misconfiguration is found, the output provides details about the misconfiguration and recommends that you update the WIF configuration.
 
-To list all of your {product-title} clusters that have been deployed using the WIF authentication type, run the following command:
+You need the name and ID of the WIF configuration you want to verify before verification.
+To obtain the name and ID of your active WIF configurations, run the following command:
 
 [source,terminal]
 ----
-$ ocm list clusters --parameter search="gcp.authentication.wif_config_id != ''"
+$ ocm gcp list wif-configs
 ----
-To list all of your {product-title} clusters that have been deployed using a specific wif-config, run the following command:
+
+To determine if the WIF configuration you want to verify is configured correctly, run the following command:
+
 [source,terminal]
 ----
-$ ocm list clusters --parameter search="gcp.authentication.wif_config_id = '<wif_config_id>'" <1>
+$ ocm gcp verify wif-config <wif_config_name>|<wif_config_id> <1>
 ----
-<1> Replace `<wif_config_id>` with the ID of the WIF configuration to list the clusters that have been deployed using that WIF configuration.
+<1> Replace `<wif_config_name>` and `<wif_config_id>` with the name and ID of your WIF configuration, respectively.
+
+--
+.Example output
+[source,terminal]
+----
+Error: verification failed with error: missing role 'compute.storageAdmin'.
+Running 'ocm gcp update wif-config' may fix errors related to cloud resource misconfiguration.
+exit status 1.
+----
+--


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.17+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-12971
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://86516--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.html#ocm-cli-verify-wif-commands_osd-creating-a-cluster-on-gcp-with-workload-identity-federation
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
