### PR TITLE
Incorrect indentation of storageClassName parameter in the Lokistack CR under Logging 6.0 documentation

### DIFF
--- a/observability/logging/logging-6.0/log6x-about.adoc
+++ b/observability/logging/logging-6.0/log6x-about.adoc
@@ -62,7 +62,7 @@ spec:
     secret:
       name: logging-loki-s3
       type: s3
-    storageClassName: gp3-csi
+  storageClassName: gp3-csi
   tenants:
     mode: openshift-logging
 ----


### PR DESCRIPTION
- Inside `About Logging 6.0` [1]  section in `Quick Start` [2] , the step number 2, Create a LokiStack custom resource (CR) in the openshift-logging namespace: `storageClassName` is wrongly mentioned.

[1] https://docs.openshift.com/container-platform/4.16/observability/logging/logging-6.0/log6x-about.html
[2] https://docs.openshift.com/container-platform/4.16/observability/logging/logging-6.0/log6x-about.html#quick-start

- Here is the current configuration: 
~~~
apiVersion: loki.grafana.com/v1
kind: LokiStack
metadata:
  name: logging-loki
  namespace: openshift-logging
spec:
  managementState: Managed
  size: 1x.extra-small
  storage:
    schemas:
    - effectiveDate: '2022-06-01'
      version: v13
    secret:
      name: logging-loki-s3
      type: s3
    storageClassName: gp3-csi       <<=== Wrong indentation
  tenants:
    mode: openshift-logging 
~~~

- `storageClassName` parameter indentation is wrong here.

- Here is the correct configuration: 
~~~
apiVersion: loki.grafana.com/v1
kind: LokiStack
metadata:
  name: logging-loki
  namespace: openshift-logging
spec:
  managementState: Managed
  size: 1x.extra-small
  storage:
    schemas:
    - effectiveDate: '2022-06-01'
      version: v13
    secret:
      name: logging-loki-s3
      type: s3
  storageClassName: gp3-csi            <<== Correct indentation
  tenants:
    mode: openshift-logging
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP-4.18, RHOCP-4.17, RHOCP-4.16, RHOCP-4.15, RHOCP-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1346

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://86527--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-about.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
