### PR TITLE
Fixes UPI Machine API admonition snippet

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 You can use infrastructure machine sets to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
 

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on Amazon Web Services (AWS). For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //Sample YAML for a compute machine set custom resource on AWS
 include::modules/machineset-yaml-aws.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on Microsoft Azure Stack Hub. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //Sample YAML for a compute machine set custom resource on Azure Stack Hub
 include::modules/machineset-yaml-azure-stack-hub.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on Microsoft Azure. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //Sample YAML for a compute machine set custom resource on Azure
 include::modules/machineset-yaml-azure.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on bare metal. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machineset-yaml-baremetal.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on Google Cloud Platform (GCP). For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //Sample YAML for a compute machine set custom resource on GCP
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on {ibm-cloud-name}. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //Sample YAML for a machine set custom resource on {ibm-cloud-title}
 include::modules/machineset-yaml-ibm-cloud.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on {ibm-power-server-name}. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //Sample YAML for a machine set custom resource on {ibm-cloud-title}
 include::modules/machineset-yaml-ibm-power-vs.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on Nutanix. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //Sample YAML for a compute machine set custom resource on Nutanix
 include::modules/machineset-yaml-nutanix.adoc[leveloffset=+1]

--- a/machine_management/creating_machinesets/creating-machineset-osp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-osp.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on {rh-openstack-first}. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machineset-yaml-osp.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on VMware vSphere. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 //Sample YAML for a compute machine set custom resource on vSphere
 include::modules/machineset-yaml-vsphere.adoc[leveloffset=+1]

--- a/machine_management/deploying-machine-health-checks.adoc
+++ b/machine_management/deploying-machine-health-checks.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 You can configure and deploy a machine health check to automatically repair damaged machines in a machine pool.
 
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machine-health-checks-about.adoc[leveloffset=+1]
 [role="_additional-resources"]

--- a/machine_management/manually-scaling-machineset.adoc
+++ b/machine_management/manually-scaling-machineset.adoc
@@ -17,7 +17,7 @@ If you need to modify aspects of a compute machine set outside of scaling, see x
 
 * If you enabled the cluster-wide proxy and scale up compute machines not included in `networking.machineNetwork[].cidr` from the installation configuration, you must xref:../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[add the compute machines to the Proxy object's `noProxy` field] to prevent connection issues.
 
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machineset-manually-scaling.adoc[leveloffset=+1]
 

--- a/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
+++ b/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 
 You can use infrastructure machine sets to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -62,7 +62,7 @@ include::modules/machine-node-custom-partition.adoc[leveloffset=+2]
 
 Understand and deploy machine health checks.
 
-include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+2]
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+2]
 include::modules/machine-health-checks-about.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources

--- a/snippets/machine-user-provisioned-limitations.adoc
+++ b/snippets/machine-user-provisioned-limitations.adoc
@@ -12,6 +12,8 @@
 // * post_installation_configuration/node-tasks.adoc
 // * nodes-nodes-creating-infrastructure-nodes.adoc
 
+:_mod-docs-content-type: SNIPPET
+
 [IMPORTANT]
 ====
 You can use the advanced machine management and scaling capabilities only in clusters where the Machine API is operational. Clusters with user-provisioned infrastructure require additional validation and configuration to use the Machine API.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
N/A

Link to docs preview:
(samples)
[Creating a compute machine set on AWS](https://86530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws)
[Deploying machine health checks](https://86530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks#post-installation-config-deploying-machine-health-checks)

QE review:
N/A

Additional information:
Moved `machine-user-provisioned-limitations.adoc` from `modules` to `snippets`, added its missing content type tag, and updated refs in all assemblies that use it