### PR TITLE
logging-collector-logs-writer clusterrole is not required to be created manually

### DIFF
--- a/observability/logging/logging-6.0/log6x-about.adoc
+++ b/observability/logging/logging-6.0/log6x-about.adoc
@@ -74,27 +74,6 @@ spec:
 $ oc create sa collector -n openshift-logging
 ----
 
-. Create a `ClusterRole` for the collector:
-+
-[source,yaml]
-----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: logging-collector-logs-writer
-rules:
-- apiGroups:
-  - loki.grafana.com
-  resourceNames:
-  - logs
-  resources:
-  - application
-  - audit
-  - infrastructure
-  verbs:
-  - create
-----
-
 . Bind the `ClusterRole` to the service account:
 +
 [source,shell]


### PR DESCRIPTION
- Inside `About Logging 6.0` [1]  section in `Quick Start` [2] , the step number: 4, Create a ClusterRole for the collector: is not required.

[1] https://docs.openshift.com/container-platform/4.16/observability/logging/logging-6.0/log6x-about.html
[2] https://docs.openshift.com/container-platform/4.16/observability/logging/logging-6.0/log6x-about.html#quick-start

- In step 4, it has been mentioned that the user needs to create the ClusterRole `logging-collector-logs-writer` 
- But this `ClusterRole` is created automatically by the Loki operator and it is not required to create it manually.

- This ClusterRole was also made available with the `Loki Operator 5.9` version.
- Here is jira [3] for reference: 

[3] https://issues.redhat.com/browse/LOG-5967 

- Hence step 4 needs to be omitted from documentation:

------
4. Create a ClusterRole for the collector: 
~~~
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: logging-collector-logs-writer
rules:
- apiGroups:
  - loki.grafana.com
  resourceNames:
  - logs
  resources:
  - application
  - audit
  - infrastructure
  verbs:
  - create
~~~
------

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP-4.18, RHOCP-4.17, RHOCP-4.16, RHOCP-4.15, RHOCP-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1341

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://86531--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-about.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
