### PR TITLE
OCPBUGS42766 Typo in title over documentation QoS section

### DIFF
--- a/modules/nodes-cluster-overcommit-qos-about.adoc
+++ b/modules/nodes-cluster-overcommit-qos-about.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nodes-cluster-overcommit-qos-about_{context}"]
-= Understanding overcomitment and quality of service classes
+= Understanding overcommitment and quality of service classes
 
 A node is _overcommitted_ when it has a pod scheduled that makes no request, or
 when the sum of limits across all pods on that node exceeds available machine


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-42766

4.12+

Preview:
Nodes -> Working with clusters -> Configuring your cluster to place pods on overcommited nodes -> [Understanding overcommitment and quality of service classes](https://86551--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-overcommit-qos-about_nodes-cluster-overcommit)
Post-install -> Node tasks -> [Understanding overcommitment and quality of service classes](https://86551--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#nodes-cluster-overcommit-qos-about_post-install-node-tasks)

No QE