### PR TITLE
OCPBUGS44591: The link of 'Understanding ephemeral storage' is not right

### DIFF
--- a/nodes/pods/nodes-pods-using.adoc
+++ b/nodes/pods/nodes-pods-using.adoc
@@ -24,5 +24,5 @@ ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on pods and storage see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage] and xref:../../storage/understanding-persistent-storage.adoc#understanding-ephemeral-storage[Understanding ephemeral storage].
+* For more information on pods and storage see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage] and xref:../../storage/understanding-ephemeral-storage.adoc#understanding-ephemeral-storage[Understanding ephemeral storage].
 endif::openshift-rosa-hcp[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-44591

4.12+

Preview
Nodes -> Pods -> About pods -> [Additional resources](https://86552--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-using.html#additional-resources)

No QE