### PR TITLE
Adds OVS sampling using the cli to release notes

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -451,6 +451,22 @@ Updated boot images has been promoted to GA for Amazon Web Services (AWS) cluste
 === Updated terminology for whitelist and blacklist annotations
 The terminology for the `ip_whitelist` and `ip_blacklist` annotations have been updated to `ip_allowlist` and `ip_denylist`, respectively. Currently, {product-title} still supports the `ip_whitelist` and `ip_blacklist` annotations. However, these annotations are planned for removal in a future release.
 
+[id="ocp-release-notes-networking-ovn-kubernetes-observability_{context}"]
+=== Checking OVN-Kubernetes network traffic with OVS sampling using the CLI
+
+OVN-Kubernetes network traffic can be viewed with OVS sampling via the CLI for the following network APIs: 
+
+* `NetworkPolicy`
+* `AdminNetworkPolicy`
+* `BaselineNetworkPolicy`
+* `UserDefinesdNetwork` isolation
+* `EgressFirewall`
+* Multicast ACLs. 
+
+Checking OVN-Kubernetes network traffic with OVS sampling using the CLI is intended to help with packet tracing. It can also be used while the Network Observability Operator is installed.
+
+For more information, see xref:../networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc#nw-ovn-kubernetes-observability_ovn-kubernetes-sources-of-troubleshooting-information[Checking OVN-Kubernetes network traffic with OVS sampling using the CLI].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 


### PR DESCRIPTION
Release note for https://github.com/openshift/openshift-docs/pull/86079. 

Version(s):
4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://86553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-networking-ovn-kubernetes-observability_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
