### PR TITLE
OCPBUGS41925: Wrong queries in the documentation

### DIFF
--- a/modules/nodes-nodes-viewing-listing-pods.adoc
+++ b/modules/nodes-nodes-viewing-listing-pods.adoc
@@ -10,42 +10,28 @@ You can list all the pods on a specific node.
 
 .Procedure
 
-* To list all or selected pods on one or more nodes:
-+
-[source,terminal]
-----
-$ oc describe node <node1> <node2>
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc describe node ip-10-0-128-218.ec2.internal
-----
-
 * To list all or selected pods on selected nodes:
 +
 [source,terminal]
 ----
-$ oc describe node --selector=<node_selector>
+$ oc get pod --selector=<nodeSelector>
 ----
 +
 [source,terminal]
 ----
-$ oc describe node --selector=kubernetes.io/os
+$ oc get pod --selector=kubernetes.io/os
 ----
 +
 Or:
 +
 [source,terminal]
 ----
-$ oc describe node -l=<pod_selector>
+$ oc get pod -l=<nodeSelector>
 ----
 +
 [source,terminal]
 ----
-$ oc describe node -l node-role.kubernetes.io/worker
+$ oc get pod -l kubernetes.io/os=linux
 ----
 
 * To list all pods on a specific node, including terminated pods:

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -101,9 +101,10 @@ For example:
 $ oc describe node node1.example.com
 ----
 +
-
+--
 include::snippets/osd-aws-example-only.adoc[]
-
+--
++
 .Example output
 [source,text]
 ----
@@ -210,14 +211,12 @@ Events:     <11>
 <9> Information about the node host.
 <10> The pods on the node.
 <11> The events reported by the node.
-
++
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-
 [NOTE]
 ====
 The control plane label is not automatically added to newly created or updated master nodes. If you want to use the control plane label for your nodes, you can manually configure the label. For more information, see _Understanding how to update labels on nodes_ in the _Additional resources_ section.
 ====
-
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 Among the information shown for nodes, the following node conditions appear in the output of the commands shown in this section:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-41925

Preview
[About listing all the nodes in a cluster](https://86567--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/nodes/nodes-nodes-viewing.html)

*PEER REVIEW*  Because the scale of these changes is so low, I am comfortable in not wasting a QE engineer's time. Let me know if you disagree.
