### PR TITLE
[enterprise-4.16] OCPBUGS44591: The link of 'Understanding ephemeral storage' is not right

### DIFF
--- a/nodes/pods/nodes-pods-using.adoc
+++ b/nodes/pods/nodes-pods-using.adoc
@@ -22,4 +22,4 @@ include::modules/nodes-pods-using-example.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on pods and storage see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage] and xref:../../storage/understanding-persistent-storage.adoc#understanding-ephemeral-storage[Understanding ephemeral storage].
+* For more information on pods and storage see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage] and xref:../../storage/understanding-ephemeral-storage.adoc#understanding-ephemeral-storage[Understanding ephemeral storage].


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/86552