### PR TITLE
Update builds-restricting-build-strategy-globally.adoc

### DIFF
--- a/modules/builds-restricting-build-strategy-globally.adoc
+++ b/modules/builds-restricting-build-strategy-globally.adoc
@@ -9,10 +9,6 @@
 
 You can allow a set of specific users to create builds with a particular strategy.
 
-.Prerequisites
-
-* Disable global access to the build strategy.
-
 .Procedure
 
 * Assign the role that corresponds to the build strategy to a specific user. For


### PR DESCRIPTION
Removed the pre-requisite as that was not required.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->. Incorrect Pre-requisite steps for restricting users to access to a build strategy

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> 4.17+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> 
https://issues.redhat.com/browse/OSDOCS-13018

Link to docs preview:
https://86625--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cicd/builds/securing-builds-by-strategy.html#builds-restricting-build-strategy-globally_securing-builds-by-strategy

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
