### PR TITLE
OSDOCS-12162: adds 4.15.42 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -514,3 +514,12 @@ Issued: 12 December 2024
 {product-title} release 4.15.41 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10841[RHSA-2024:10841] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10839[RHSA-2024:10839] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-42-dp_{context}"]
+=== RHBA-2024:11564 - {microshift-short} 4.15.42 bug fix and enhancement advisory
+
+Issued: 2 January 2025
+
+{product-title} release 4.15.42 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:11564[RHBA-2024:11564] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:11562[RHSA-2024:11562] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12162](https://issues.redhat.com/browse/OSDOCS-12162)

Link to docs preview:
[4-15-42-dp_release-notes](https://86630--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-42-dp_release-notes)

QE review:
- NA. Stock text update. No other changes.