### PR TITLE
OSDOCS-12814: adds 4.16.28 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -387,3 +387,12 @@ Issued: 19 December 2024
 {product-title} release 4.16.27 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10975[RHBA-2024:10975] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10973[RHBA-2024:10973] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-28-dp_{context}"]
+=== RHBA-2024:11504 - {microshift-short} 4.16.28 bug fix and enhancement advisory
+
+Issued: 2 January 2025
+
+{product-title} release 4.16.28 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:11504[RHBA-2024:11504] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:11502[RHBA-2024:11502] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12814](https://issues.redhat.com/browse/OSDOCS-12814)

Link to docs preview:
[4-16-28-dp_release-notes](https://86631--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-28-dp_release-notes)

QE review:
- NA. Stock text update. No other changes.