### PR TITLE
OSDOCS-12497: adds 4.17.10 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -187,3 +187,12 @@ Issued: 19 December 2024
 {product-title} release 4.17.9 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:11012[RHBA-2024:11012] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:11010[RHBA-2024:11010] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-10-dp_{context}"]
+=== RHBA-2024:11524 - {microshift-short} 4.17.10 bug fix and enhancement advisory
+
+Issued: 2 January 2024
+
+{product-title} release 4.17.10 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:11524[RHBA-2024:11524] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:11522[RHBA-2024:11522] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12497](https://issues.redhat.com/browse/OSDOCS-12497)

Link to docs preview:
[4-17-10-dp_release-notes](https://86632--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-10-dp_release-notes)

QE review:
- NA. Stock text update. No other changes.

