### PR TITLE
OSDOCS#12975: Update relnotes for 4.16.28 z-stream 

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3322,6 +3322,8 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 (link:https://issues.redhat.com/browse/OCPBUGS-34022[*OCPBUGS-34022*])
 
 [id="ocp-4-16-asynchronous-errata-updates_{context}"]
+
+
 == Asynchronous errata updates
 
 Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
@@ -3339,6 +3341,56 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+//4.16.28
+[id="ocp-4-16-28_{context}"]
+=== RHBA-2024:11502 - {product-title} {product-version}.28 bug fix and security update
+
+Issued: 02 January 2025
+
+{product-title} release {product-version}.28 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:11502[RHBA-2024:11502] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:11505[RHBA-2024:11505] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.28 --pullspecs
+----
+
+[id="ocp-4-16-28-known-issues_{context}"]
+==== Known issues
+
+* A regression in the behavior of `libreswan` caused some IPsec-enabled nodes to lose communication with pods on other nodes in the same cluster. To resolve this issue, disable IPsec for your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-43715[*OCPBUGS-43715*])
+
+[id="ocp-4-16-28-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when the webhook token authenticator was enabled and had the authorization type set to `None`, the {product-title} web console would consistently crash. With this release, a bug fix ensures that this configuration does not cause the {product-title} web console to crash. (link:https://issues.redhat.com/browse/OCPBUGS-46481[*OCPBUGS-46481*])
+
+* Previously, when you attempted to use {olm-first} to upgrade an Operator, the upgrade was blocked and an `error validating existing CRs against new CRD's schema` message was generated. An issue existed with {olm}, where {olm} erroneously identified incompatibility issues validating existing custom resources (CRs) against the new Operator version custom resource definitions (CRDs). With this release, the validation is corrected so that Operator upgrades are no longer blocked.  (link:https://issues.redhat.com/browse/OCPBUGS-46434[*OCPBUGS-46434*])
+
+* Previously, when a long string of individual CPUs were in the Performance Profile, the machine configurations were not processed. With this release, the user input process is updated to use a sequence of numbers or a range of numbers on the kernel command line. (link:https://issues.redhat.com/browse/OCPBUGS-46074[*OCPBUGS-46074*])
+
+* Previously, when users wanted to configure their {aws-first} DHCP option set with a custom domain name that contained a trailing period and the hostname of EC2 instances were converted to Kubelet node names, the trailing period was not removed. Trailing periods are not allowed in a Kubernetes object name. With this release, trailing periods are allowed in a domain name in a DHCP option set. (link:https://issues.redhat.com/browse/OCPBUGS-45974[*OCPBUGS-45974*])
+
+* Previously, the kdump `initramfs` stopped responding when opening a local encrypted disk, even when the kdump destination was a remote machine that did not need to access the local machine. With this release, this issue is fixed and the kdump `initramfs` successfully opens a local encrypted disk. (link:https://issues.redhat.com/browse/OCPBUGS-45837[*OCPBUGS-45837*])
+
+* Previously, the `aws-sdk-go-v2` software development kit (SDK) failed to authenticate an `AssumeRoleWithWebIdentity` API operation on an {aws-first} {sts-first} cluster. With this release, `pod-identity-webhook` now includes a default region so that this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-45939[*OCPBUGS-45939*])
+
+* Previously, an ingress rule was created for a security group in an {aws-short} cluster that allowed a `0.0.0.0/0` Classless Inter-Domain Routing (CIDR) address access to a node port in the `30000-32767` range. With this release, the rule is removed during {aws-short} cluster installation. (link:https://issues.redhat.com/browse/OCPBUGS-45669[*OCPBUGS-45669*])
+
+* Previously, the build controller looked for secrets that were linked for general use, not specifically for the image pull. With this release, when searching for default image pull secrets, the builds use `ImagePullSecrets` that are linked to the service account. (link:https://issues.redhat.com/browse/OCPBUGS-31213[*OCPBUGS-31213*])
+
+* Previously, the Maximum Transmission Unit (MTU) migration phase of the SDN-OVN live migration could run many times if one machine config pool (MCP) was paused. This prevented the live migration from ending successfully. After this release, this should no longer happen. (link:https://issues.redhat.com/browse/OCPBUGS-44338[*OCPBUGS-44338*])
+
+* Previously, after upgrading from {product-title} 4.12 to 4.14, the customer reported that the pods could not reach their service when a `NetworkAttachmentDefinition` was set. With this release, the pods can reach their service after the upgrade. (link:https://issues.redhat.com/browse/OCPBUGS-44457[*OCPBUGS-44457*])
+
+[id="ocp-4-16-28-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
 
 //4.16.27
 [id="ocp-4-16-27_{context}"]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12975](https://issues.redhat.com//browse/OSDOCS-12975)

Link to docs preview:
[4.16.28](https://86633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-28_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RN.
