### PR TITLE
Indentation Fault in Viewing Logging status Documentation

### DIFF
--- a/modules/cluster-logging-clo-status.adoc
+++ b/modules/cluster-logging-clo-status.adoc
@@ -89,7 +89,7 @@ status:  <1>
           notReady:
           ready:
           - elasticsearch-cdm-mkkdys93-1-7f7c6-mjm7c
-visualization:  <4>
+  visualization:  <4>
     kibanaStatus:
     - deployment: kibana
       pods:


### PR DESCRIPTION
- There is one indentation fault in Viewing Logging status Documentation.
- Here is the documentation link: https://docs.openshift.com/container-platform/4.16/observability/logging/troubleshooting/cluster-logging-cluster-status.html#cluster-logging-clo-status_cluster-logging-cluster-status

- Here, the `status.visualization` indentation is wrongly mentioned.
~~~
apiVersion: logging.openshift.io/v1
kind: ClusterLogging
# ...
status:
visualization:    <<== visualization indentation is wrongly mentioned
    kibanaStatus:
    - deployment: kibana
      pods:
        failed: []
        notReady: []
        ready:
        - kibana-7fb4fd4cc9-f2nls
      replicaSets:
      - kibana-7fb4fd4cc9
      replicas: 1
~~~

- The correct configuration should look like the following: 
~~~
apiVersion: logging.openshift.io/v1
kind: ClusterLogging
# ...
status:
  visualization:      <<== Correct indentation
    kibanaStatus:
    - deployment: kibana
      pods:
        failed: []
        notReady: []
        ready:
        - kibana-7fb4fd4cc9-f2nls
      replicaSets:
      - kibana-7fb4fd4cc9
      replicas: 1
~~~

- We need to  perform this change in our standard documentation.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13, RHOCP 4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1589

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://86637--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/troubleshooting/cluster-logging-cluster-status.html
https://86637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/troubleshooting/cluster-logging-cluster-status.html
https://86637--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/troubleshooting/cluster-logging-cluster-status.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
