### PR TITLE
OCPBUGS-41344-412: Remove extra 4.12 reference

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy OpenShift clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.6 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version} 4.12.
+{product-title} {product-version} is supported on {op-system-base-full} 8.6 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
INTERNAL REVIEW TO REMOVE AND EXTRA "4.12" REFERENCE


Version(s):
4.12

Issue:
[OCPBUGS-41344](https://issues.redhat.com/browse/OCPBUGS-41344)

Link to docs preview:
[About this release](https://86644--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-about-this-release_release-notes)


