### PR TITLE
OSDOCS-12974: 4.15.42 RN

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2775,6 +2775,53 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.15.42
+[id="ocp-4-15-42_{context}"]
+=== RHSA-2024:11562 - {product-title} 4.15.42 bug fix and security update
+
+Issued: 02 January 2025
+
+{product-title} release 4.15.42, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:11562[RHSA-2024:11562] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2024:11565[RHBA-2024:11565] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.42 --pullspecs
+----
+
+[id="ocp-4-15-42-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when the webhook token authenticator was enabled and had the authorization type set to `None`, the {product-title} web console would consistently crash. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-46482[*OCPBUGS-46482*])
+
+* Previously, when you attempted to use the Operator Lifecycle Manager (OLM) to upgrade an Operator, the upgrade was blocked and an `error validating existing CRs against new CRD's schema` message was generated. An issue existed with OLM, whereby OLM erroneously identified incompatibility issues validating existing custom resources (CRs) against the new Operator version's custom resource definitions (CRDs). With this release, the validation is corrected so that Operator upgrades are no longer blocked. (link:https://issues.redhat.com/browse/OCPBUGS-46479[*OCPBUGS-46479*])
+
+* Previously, the images for custom OS layering were not present when the OS was on Red Hat Enterprise Linux CoreOS (RHCOS) 4.15, preventing some customers from upgrading from RHCOS 4.15 to RHCOS 4.16. This release adds Azure Container Registry (ACR) and Google Container Registry (GCR) image credential provider RPMs to RHCOS 4.15. (link:https://issues.redhat.com/browse/OCPBUGS-46063[*OCPBUGS-46063*])
+
+* Previously, you could not configure your Amazon Web Services DHCP option set with a custom domain name containing a period (`.`) as the final character, as trailing periods were not allowed in a Kubernetes object name. With this release, trailing periods are allowed in a domain name in a DHCP option set. (link:https://issues.redhat.com/browse/OCPBUGS-46034[*OCPBUGS-46034*])
+
+* Previously, when `openshift-sdn` pods were deployed during the {product-title} upgrading process, the Open vSwitch (OVS) storage table was cleared. This issue occurred on {product-title} {product-version}.19 and later versions. Ports for existing pods had to be re-created and this disrupted numerous services. With this release, a fix ensures that the OVS tables do not get cleared and pods do not get disconnected during a cluster upgrade operation. (link:https://issues.redhat.com/browse/OCPBUGS-45955[*OCPBUGS-45955*])
+
+* Previously, you could not remove a `finally` pipeline task from the *edit Pipeline* form if you created a pipeline with only one `finally` task. With this release, you can remove the `finally` task from the *edit Pipeline* form and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-45950[*OCPBUGS-45950*])
+
+* Previously, the `aws-sdk-go-v2` software development kit (SDK) failed to authenticate an `AssumeRoleWithWebIdentity` API operation on an {aws-short} {sts-first} cluster. With this release, the pod identity webhook now includes a default region, and this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-45940[*OCPBUGS-45940*])
+
+* Previously, the installation program populated the `network.devices`, `template` and `workspace` fields in the `spec.template.spec.providerSpec.value` section of the {vmw-full} control plane machine set custom resource (CR).
+These fields should be set in the {vmw-short} failure domain, and the installation program populating them caused unintended behaviors.
+Updating these fields did not trigger an update to the control plane machines, and these fields were cleared when the control plane machine set was deleted.
+With this release, the installation program is updated to no longer populate values that are included in the failure domain configuration.
+If these values are not defined in a failure domain configuration, for instance on a cluster that is updated to {product-title} {product-version} from an earlier version, the values defined by the installation program are used.
+(link:https://issues.redhat.com/browse/OCPBUGS-45839[*OCPBUGS-45839*], link:https://issues.redhat.com/browse/OCPBUGS-37064[*OCPBUGS-37064*])
+
+* Previously, the ClusterTasks were listed on the *Pipelines builder* and *ClusterTask list* pages in the *Tasks* navigation menu. With this release, the `ClusterTask` functionality is deprecated from Pipelines 1.17 and the `ClusterTask` dependency is removed from static plug-in. On the Pipelines builder page, you will only see the present task in the Namespace and Community tasks. (link:https://issues.redhat.com/browse/OCPBUGS-45248[*OCPBUGS-45248*])
+
+[id="ocp-4-15-42-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 //4.15.41
 [id="ocp-4-15-41_{context}"]
 === RHSA-2024:10839 - {product-title} 4.15.41 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-12974

Link to docs preview:
https://86646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-42_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until they are shipped live (01/02/25)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
