### PR TITLE
OCPBUGS-45011#rearrange step order

### DIFF
--- a/modules/private-clusters-setting-api-private.adoc
+++ b/modules/private-clusters-setting-api-private.adoc
@@ -31,48 +31,6 @@ you can reconfigure the API server to use only the private zone.
 
 .Procedure
 
-. In the web portal or console for your cloud provider, take the following actions:
-
-.. Locate and delete the appropriate load balancer component:
-ifndef::cpmso-using-azure[]
-*** For AWS, delete the external load balancer. The API DNS entry in the private zone already points to the internal load balancer, which uses an identical configuration, so you do not need to modify the internal load balancer.
-endif::cpmso-using-azure[]
-ifndef::cpmso-using-aws[]
-*** For Azure, delete the `api-internal-v4` rule for the public load balancer.
-
-.. For Azure, configure the Ingress Controller endpoint publishing scope to `Internal`.
-For more information, see "Configuring the Ingress Controller endpoint publishing scope to Internal".
-
-.. For the Azure public load balancer, if you configure the Ingress Controller endpoint publishing scope to `Internal` and there are no existing inbound rules in the public load balancer, you must create an outbound rule explicitly to provide outbound traffic for the backend address pool.
-For more information, see the Microsoft Azure documentation about adding outbound rules.
-endif::cpmso-using-aws[]
-
-.. Delete the
-ifdef::cpmso-using-aws[`api.$clustername.$yourdomain`]
-ifdef::post-install[`api.$clustername.$yourdomain` or]
-ifndef::cpmso-using-aws[`api.$clustername`]
-DNS entry in the public zone.
-
-ifdef::cpmso-using-aws[]
-. Remove the external load balancers by deleting the following indicated lines in the control plane machine set custom resource:
-+
-[source,yaml]
-----
-# ...
-providerSpec:
-  value:
-# ...
-    loadBalancers:
-    - name: lk4pj-ext # <1>
-      type: network # <2>
-    - name: lk4pj-int
-      type: network
-# ...
-----
-<1> Delete the `name` value for the external load balancer, which ends in `-ext`.
-<2> Delete the `type` value for the external load balancer.
-endif::cpmso-using-aws[]
-
 ifdef::post-install[]
 . AWS clusters: Remove the external load balancers:
 +
@@ -154,6 +112,48 @@ providerSpec:
 
 .... Repeat this process for each of the control plane machines.
 endif::post-install[]
+
+. In the web portal or console for your cloud provider, take the following actions:
+
+.. Locate and delete the appropriate load balancer component:
+ifndef::cpmso-using-azure[]
+*** For AWS, delete the external load balancer. The API DNS entry in the private zone already points to the internal load balancer, which uses an identical configuration, so you do not need to modify the internal load balancer.
+endif::cpmso-using-azure[]
+ifndef::cpmso-using-aws[]
+*** For Azure, delete the `api-internal-v4` rule for the public load balancer.
+
+.. For Azure, configure the Ingress Controller endpoint publishing scope to `Internal`.
+For more information, see "Configuring the Ingress Controller endpoint publishing scope to Internal".
+
+.. For the Azure public load balancer, if you configure the Ingress Controller endpoint publishing scope to `Internal` and there are no existing inbound rules in the public load balancer, you must create an outbound rule explicitly to provide outbound traffic for the backend address pool.
+For more information, see the Microsoft Azure documentation about adding outbound rules.
+endif::cpmso-using-aws[]
+
+.. Delete the
+ifdef::cpmso-using-aws[`api.$clustername.$yourdomain`]
+ifdef::post-install[`api.$clustername.$yourdomain` or]
+ifndef::cpmso-using-aws[`api.$clustername`]
+DNS entry in the public zone.
+
+ifdef::cpmso-using-aws[]
+. Remove the external load balancers by deleting the following indicated lines in the control plane machine set custom resource:
++
+[source,yaml]
+----
+# ...
+providerSpec:
+  value:
+# ...
+    loadBalancers:
+    - name: lk4pj-ext # <1>
+      type: network # <2>
+    - name: lk4pj-int
+      type: network
+# ...
+----
+<1> Delete the `name` value for the external load balancer, which ends in `-ext`.
+<2> Delete the `type` value for the external load balancer.
+endif::cpmso-using-aws[]
 
 ifeval::["{context}" == "configuring-private-cluster"]
 :!post-install:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-45011

Link to docs preview:
The update is reflected in these pages: 
- [Restricting the API server to private](https://86647--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.html#private-clusters-setting-api-private_cpmso-config-options-aws) (Control plane configuration options for Amazon Web Services)
- [Restricting the API server to private](https://86647--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html#private-clusters-setting-api-private_cpmso-config-options-azure) (Control plane configuration options for Microsoft Azure) 
- [Restricting the API server to private](https://86647--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-private-cluster.html#private-clusters-setting-api-private_configuring-private-cluster) (Configuring a private cluster) 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
From what I understand, the Vale messages below aren't valid. It is suggesting the ifdef statement requires an endif, but that's not required here.  

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
