### PR TITLE
OSDOCS-9210-4.18 adding GCP Custom DNS param

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2174,6 +2174,12 @@ Additional GCP configuration parameters are described in the following table:
 
 |platform:
   gcp:
+    userProvisionedDNS:
+|Enables user-provisioned DNS instead of the default cluster-provisioned DNS solution. If you use this feature, you must provide your own DNS solution that includes records for `api.<cluster_name>.<base_domain>` and `*.apps.<cluster_name>.<base_domain>`.
+|`Enabled` or `Disabled`. The default value is `Disabled`.
+
+|platform:
+  gcp:
     region:
 |The name of the GCP region that hosts your cluster.
 |Any valid region name, such as `us-central1`.

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -95,6 +95,7 @@ The following Technology Preview features are enabled by this feature set:
 ** `VSphereMultiVCenters`
 ** `VSphereStaticIPs`
 ** `ValidatingAdmissionPolicy`
+** `userProvisionedDNS`
 --
 
 ////

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -28,7 +28,7 @@ For more information about the features activated by the `TechPreviewNoUpgrade` 
 
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
 
-** xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement].
+** xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement]
 
 include::modules/nodes-cluster-enabling-features-install.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-9210

Link to docs preview:
https://86655--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp

QE review:
- [ ] QE has approved this change.
