### PR TITLE
OSDOCS#8067: Update Backup and restore files from OCP to ROSA topic map

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1254,9 +1254,8 @@ Topics:
   File: graceful-cluster-shutdown
 - Name: Restarting a cluster gracefully
   File: graceful-cluster-restart
-  Topics:
-  - Name: Backing up applications
-    File: backing-up-applications
+- Name: Backing up applications
+  File: backing-up-applications
 ---
 Name: Nodes
 Dir: nodes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1250,10 +1250,10 @@ Distros: openshift-rosa
 Topics:
 - Name: Backing up applications
   File: backing-up-applications
-- Name: Shutting down a cluster gracefully
-  File: graceful-cluster-shutdown
-- Name: Restarting a cluster gracefully
-  File: graceful-cluster-restart
+#- Name: Shutting down a cluster gracefully
+#  File: graceful-cluster-shutdown
+#- Name: Restarting a cluster gracefully
+#  File: graceful-cluster-restart
 ---
 Name: Nodes
 Dir: nodes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1250,8 +1250,8 @@ Distros: openshift-rosa
 Topics:
 - Name: Backing up applications
   File: backing-up-applications
-#- Name: Shutting down a cluster gracefully
-#  File: graceful-cluster-shutdown
+- Name: Shutting down a cluster gracefully
+  File: graceful-cluster-shutdown
 #- Name: Restarting a cluster gracefully
 #  File: graceful-cluster-restart
 ---

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1248,14 +1248,12 @@ Name: Backing up and restoring applications
 Dir: rosa_backing_up_and_restoring_applications
 Distros: openshift-rosa
 Topics:
-- Name: Overview of backup and restore operations
-  File: index
+- Name: Backing up applications
+  File: backing-up-applications
 - Name: Shutting down a cluster gracefully
   File: graceful-cluster-shutdown
 - Name: Restarting a cluster gracefully
   File: graceful-cluster-restart
-- Name: Backing up applications
-  File: backing-up-applications
 ---
 Name: Nodes
 Dir: nodes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1248,8 +1248,15 @@ Name: Backing up and restoring applications
 Dir: rosa_backing_up_and_restoring_applications
 Distros: openshift-rosa
 Topics:
-- Name: Backing up applications
-  File: backing-up-applications
+- Name: Overview of backup and restore operations
+  File: index
+- Name: Shutting down a cluster gracefully
+  File: graceful-cluster-shutdown
+- Name: Restarting a cluster gracefully
+  File: graceful-cluster-restart
+  Topics:
+  - Name: Backing up applications
+    File: backing-up-applications
 ---
 Name: Nodes
 Dir: nodes


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-8067](https://issues.redhat.com//browse/OSDOCS-8067)

Link to docs preview:
Backing up and restoring

QE review:
- [ ] QE has approved this change.


Additional information:
This PR is a part of the OCP to ROSA Classic porting process.
