### PR TITLE
OSDOCS#12698: Multiple NIC support for vSphere

### DIFF
--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -61,6 +61,14 @@ include::modules/ipi-install-modifying-install-config-for-dual-stack-network.ado
 
 include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
+// Specifying multiple NICS
+include::modules/installation-vsphere-multiple-nics.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../installing/installing_vsphere/installation-config-parameters-vsphere.adoc#installation-configuration-parameters-network_installation-config-parameters-vsphere[Network configuration parameters]
+
 // Network configuration phases
 include::modules/nw-network-config.adoc[leveloffset=+1]
 

--- a/modules/installation-vsphere-multiple-nics.adoc
+++ b/modules/installation-vsphere-multiple-nics.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-vsphere-installer-provisioned-network-customizations.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-vsphere-multiple-nics_{context}"]
+= Configuring multiple NICs
+
+For scenarios requiring multiple network interface controller (NIC), you can configure multiple network adapters per node. 
+
+:FeatureName: Configuring multiple NICs
+include::snippets/technology-preview.adoc[]
+
+.Procedure
+
+. Specify the network adapter names in the networks section of `platform.vsphere.failureDomains[*].topology` as shown in the following `install-config.yaml` file:
++
+[source,yaml]
+----
+platform:
+  vsphere:
+    vcenters:
+      ...
+    failureDomains:
+    - name: <failure_domain_name>
+      region: <default_region_name>
+      zone: <default_zone_name>
+      server: <fully_qualified_domain_name>
+      topology:
+        datacenter: <data_center>
+        computeCluster: "/<data_center>/host/<cluster>"
+        networks: # <1>
+        - <VM_network1_name>
+        - <VM_network2_name>
+        - ...
+        - <VM_network10_name>
+----
+<1> Specifies the list of network adapters. You can specify up to 10 network adapters.
+
+. Specify at least one of the following configurations in the `install-config.yaml` file:
+
+** `networking.machineNetwork`
++
+.Example configuration
++
+[source,yaml]
+----
+networking:
+  ...
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+  ...
+----
++
+[NOTE]
+====
+The `networking.machineNetwork.cidr` field must correspond to an address on the first adapter defined in `topology.networks`.
+====
+
+** Add a `nodeNetworking` object to the `install-config.yaml` file and specify internal and external network subnet CIDR implementations for the object.
++
+.Example configuration
++
+[source,yaml]
+----
+platform:
+  vsphere:
+    nodeNetworking:
+     external:
+       networkSubnetCidr:
+       - <machine_network_cidr_ipv4>
+       - <machine_network_cidr_ipv6>
+     internal:
+       networkSubnetCidr:
+       - <machine_network_cidr_ipv4>
+       - <machine_network_cidr_ipv6>
+    failureDomains:
+    - name: <failure_domain_name>
+      region: <default_region_name>
+----

--- a/modules/nw-network-config.adoc
+++ b/modules/nw-network-config.adoc
@@ -24,6 +24,7 @@ Phase 1:: You can customize the following network-related fields in the `install
 * `networking.clusterNetwork`
 * `networking.serviceNetwork`
 * `networking.machineNetwork`
+* `nodeNetworking`
 +
 For more information, see "Installation configuration parameters".
 +


### PR DESCRIPTION
Version(s): 4.18+

Issue: https://issues.redhat.com/browse/OSDOCS-12698 

Link to docs preview: https://86662--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.html#installation-vsphere-multiple-nics_installing-vsphere-installer-provisioned-network-customizations

Review:
- [x] QE has approved this change.
- [x] SME has approved this change
