### PR TITLE
outputRefs value is missing in Forwarding logs over HTTP documentation

### DIFF
--- a/modules/logging-http-forward.adoc
+++ b/modules/logging-http-forward.adoc
@@ -40,7 +40,7 @@ spec:
       inputRefs:
         - application
       outputRefs:
-        - <8>
+        - httpout-app <8>
 ----
 <1> In legacy implementations, the CR name must be `instance`. In multi log forwarder implementations, you can use any name.
 <2> In legacy implementations, the CR namespace must be `openshift-logging`. In multi log forwarder implementations, you can use any namespace.


### PR DESCRIPTION
- `outputRefs` value is missing in Forwarding logs over HTTP documentation.
- Here is the documentation link: https://docs.openshift.com/container-platform/4.16/observability/logging/log_collection_forwarding/configuring-log-forwarding.html#logging-http-forward_configuring-log-forwarding
- This `outputRefs` value should be the same as the output name.
- It is missing here.
- Here is the current configuration: 
~~~
apiVersion: logging.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  name: <log_forwarder_name> 
  namespace: <log_forwarder_namespace> 
spec:
  serviceAccountName: <service_account_name> 
  outputs:
    - name: httpout-app
      type: http
      url: 
      http:
        headers: 
          h1: v1
          h2: v2
        method: POST
      secret:
        name: 
      tls:
        insecureSkipVerify: 
  pipelines:
    - name:
      inputRefs:
        - application
      outputRefs:
        -                          <<=== Value is missing 
~~~
- Hence we need to add the `outputRefs` value here.
- Here is the correct configuration: 
~~~
apiVersion: logging.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  name: <log_forwarder_name> 
  namespace: <log_forwarder_namespace> 
spec:
  serviceAccountName: <service_account_name> 
  outputs:
    - name: httpout-app
      type: http
      url: 
      http:
        headers: 
          h1: v1
          h2: v2
        method: POST
      secret:
        name: 
      tls:
        insecureSkipVerify: 
  pipelines:
    - name:
      inputRefs:
        - application
      outputRefs:
        - httpout-app              <<=== Need to add this value here
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.12+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1590

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://86670--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/log_collection_forwarding/configuring-log-forwarding.html

https://86670--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_collection_forwarding/configuring-log-forwarding.html

https://86670--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/log_collection_forwarding/configuring-log-forwarding.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
