### PR TITLE
[enterprise-4.16] OSDOCS#50922: Improving docs for setting up memory overcommit

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -236,29 +236,35 @@ spec:
       labels:
         severity: critical
 ----
-. Configure {VirtProductName} to use memory overcommit either by using the {product-title} web console or by editing the HyperConverged custom resource (CR) file as shown in the following example.
+. Configure {VirtProductName} to use memory overcommit either by using the {product-title} web console or by editing the HyperConverged custom resource (CR) file in the CLI.
 +
-Example:
+--
+* Web console
 +
-[source,yaml]
-----
-apiVersion: hco.kubevirt.io/v1beta1
-kind: HyperConverged
-metadata:
-  name: kubevirt-hyperconverged
-  namespace: openshift-cnv
-spec:
-  higherWorkloadDensity:
-    memoryOvercommitPercentage: 150
-----
-. Apply all the configurations to compute nodes in your cluster by entering the following command:
+. In the {product-title} web console, go to *Virtualization* -> *Overview* -> *Settings* -> *General settings* -> *Memory density*. 
+. Set *Enable memory density* to on.
+
+
+* CLI
+** Configure your {VirtProductName} to enable higher memory density and set the overcommit rate:
 +
 [source,terminal]
 ----
-$ oc patch --type=merge \
-  -f <../manifests/hco-set-memory-overcommit.yaml> \
-  --patch-file <../manifests/hco-set-memory-overcommit.yaml>
+$ oc -n openshift-cnv patch HyperConverged/kubevirt-hyperconverged --type='json' -p='[ \
+  { \
+  "op": "replace", \
+  "path": "/spec/higherWorkloadDensity/memoryOvercommitPercentage", \
+  "value": 150 \
+  } \
+]'
 ----
++
+.Successful output
+[source,terminal]
+----
+hyperconverged.hco.kubevirt.io/kubevirt-hyperconverged patched
+----
+--
 +
 [NOTE]
 ====
@@ -308,11 +314,16 @@ If swap is provisioned correctly, an amount greater than zero is displayed, simi
 +
 [source,terminal]
 ----
-$ oc get -n openshift-cnv HyperConverged kubevirt-hyperconverged -o jsonpath="{.spec.higherWorkloadDensity.memoryOvercommitPercentage}"
-150
+$ oc -n openshift-cnv get HyperConverged/kubevirt-hyperconverged -o jsonpath='{.spec.higherWorkloadDensity}{"\n"}'
 ----
 +
-The returned value, for example `150`, must match the value you had previously configured.
+.Example output
+[source,terminal]
+----
+{"memoryOvercommitPercentage":150}
+----
++
+The returned value must match the value you had previously configured.
 
 
 


### PR DESCRIPTION
Cherrypicked from b4a87e58f6e9890443cf30906596e6e5fcdba8b7 xref: #85991

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

<!--- Version(s):
4.16

Issue:
https://issues.redhat.com/browse/CNV-50922

Link to docs preview:
https://86671--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html --->

<!--- QE review:
- [x] QE has approved this change. --->
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information:
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/85991 --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
