### PR TITLE
Incorrect configuration of namespace object for the Red Hat OpenShift Logging Operator

### DIFF
--- a/modules/logging-loki-cli-install.adoc
+++ b/modules/logging-loki-cli-install.adoc
@@ -80,9 +80,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-logging # <1>
-annotations:
+  annotations:
     openshift.io/node-selector: ""
-labels:
+  labels:
     openshift.io/cluster-logging: "true"
     openshift.io/cluster-monitoring: "true" # <2>
 ----


### PR DESCRIPTION
- Incorrect indentation mentioned in the step5 "namespace object for the Red Hat OpenShift Logging Operator"  [2] of "Installing Logging and the Loki Operator using the CLI" documentation  [1].
- Also Incorrect indentation mentioned in the step5 of  "Installing Logging and the Loki Operator using the CLI" [3] 

- Here are the documentation links: 
[1] https://docs.openshift.com/container-platform/4.14/observability/logging/log_storage/installing-log-storage.html#logging-loki-cli-install_installing-log-storage
[2] https://docs.openshift.com/container-platform/4.14/observability/logging/log_storage/installing-log-storage.html#logging-loki-cli-install_installing-log-storage:~:text=Create%20a%20namespace%20object%20for%20the%20Red%20Hat%20OpenShift%20Logging%20Operator%3A
[3] https://docs.openshift.com/container-platform/4.16/observability/logging/cluster-logging-deploying.html#logging-loki-cli-install_cluster-logging-deploying

- Here is the Step5: 
~~~
apiVersion: v1
kind: Namespace
metadata:
  name: openshift-logging 
annotations:                                     <<== Incorrect Indentation
    openshift.io/node-selector: ""
labels:                                          <<== Incorrect Indentation
    openshift.io/cluster-logging: "true"
    openshift.io/cluster-monitoring: "true" 
~~~

- `annotations`, and `labels` should be indented under the `metadata` field and inline with `name`.
- Here is the correct configuration of Step5:
~~~
apiVersion: v1
kind: Namespace
metadata:
  name: openshift-logging 
  annotations:                                   <<== Correct Indentation
    openshift.io/node-selector: ""
  labels:                                        <<== Correct Indentation
    openshift.io/cluster-logging: "true"
    openshift.io/cluster-monitoring: "true" 
~~~

- We need to perform this change under our standard documentation.
- Please refer Step1 from the same documentation for reference. 
--------
1. Create a Namespace object for Loki Operator: 

Example Namespace object
~~~
apiVersion: v1
kind: Namespace
metadata:
  name: openshift-operators-redhat 
  annotations:
    openshift.io/node-selector: ""
  labels:
    openshift.io/cluster-monitoring: "true" 
~~~
--------------

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.14+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1591

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://86672--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/cluster-logging-deploying.html

https://86672--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/log_storage/installing-log-storage.html

https://86672--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/cluster-logging-deploying.html

https://86672--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_storage/installing-log-storage.html

https://86672--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/cluster-logging-deploying.html

https://86672--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/log_storage/installing-log-storage.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
