### PR TITLE
Update logging-input-spec-filter-namespace-container.adoc

### DIFF
--- a/modules/logging-input-spec-filter-namespace-container.adoc
+++ b/modules/logging-input-spec-filter-namespace-container.adoc
@@ -36,6 +36,7 @@ spec:
         excludes: 
           - container: "other-container*" # <3>
             namespace: "other-namespace" # <4>
+      type: application 
 # ...
 ----
 <1> Specifies that the logs are only collected from these namespaces.


### PR DESCRIPTION
- The `type` field is missing in Filtering application logs by including and excluding documentation.
- Here is the documentation link: https://docs.openshift.com/container-platform/4.16/observability/logging/performance_reliability/logging-input-spec-filtering.html#logging-input-spec-filter-namespace-container_logging-input-spec-filtering
- `type` field is required while configuring ClusterLogForwarder with the inputs section.
- `spec.inputs.type` is required.
- Without the `type` field, ClusterLogForwarder will not be applied.
- Here is the current configuration: 
~~~
apiVersion: "logging.openshift.io/v1"
kind: ClusterLogForwarder
# ...
spec:
  inputs:
    - name: mylogs
      application:
        includes:
          - namespace: "my-project" 
            container: "my-container" 
        excludes:
          - container: "other-container*" 
            namespace: "other-namespace" 
# ...
~~~

- `type` should be `application` here in the above configuration.
- Here is the correct configuration: 
~~~
apiVersion: "logging.openshift.io/v1"
kind: ClusterLogForwarder
# ...
spec:
  inputs:
    - name: mylogs
      application:
        includes:
          - namespace: "my-project" 
            container: "my-container" 
        excludes:
          - container: "other-container*" 
            namespace: "other-namespace" 
      type: application                 <<=== Need to add this line
# ...
~~~

- We need to perform the above changes in our standard documentation.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1592


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://86678--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/performance_reliability/logging-input-spec-filtering.html

https://86678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/performance_reliability/logging-input-spec-filtering.html

https://86678--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/performance_reliability/logging-input-spec-filtering.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
