### PR TITLE
OCPBUGS-44384#updating ipsecConfig alignment

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -384,8 +384,8 @@ defaultNetwork:
   ovnKubernetesConfig:
     mtu: 1400
     genevePort: 6081
-      ipsecConfig:
-        mode: Full
+    ipsecConfig:
+      mode: Full
 ----
 
 ifdef::operator[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.15+

Issue:
https://issues.redhat.com/browse/OCPBUGS-44384

Link to docs preview:
[Cluster Network Operator configuration object](https://86679--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations#nw-operator-cr-cno-object_installing-vsphere-installer-provisioned-network-customizations)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
