### PR TITLE
NE-1809: adding release notes for AWS Load Balancer Operator v1.2

### DIFF
--- a/networking/networking_operators/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
+++ b/networking/networking_operators/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
@@ -23,10 +23,23 @@ For an overview of the AWS Load Balancer Operator, see xref:../../../networking/
 AWS Load Balancer Operator currently does not support AWS GovCloud.
 ====
 
+[id="aws-load-balancer-operator-release-notes-1.2"]
+== AWS Load Balancer Operator 1.2.0
+
+The following advisory is available for the AWS Load Balancer Operator version 1.2.0:
+
+* link:https://access.redhat.com/errata/RHEA-2025:0034[RHEA-2025:0034 Release of AWS Load Balancer Operator 1.2.z on OperatorHub]
+
+[id="aws-load-balancer-operator-1.2.0-notable-changes"]
+=== Notable changes
+
+* This release supports the AWS Load Balancer Controller version 2.8.2.
+* With this release, the platform tags defined in the `Infrastructure` resource will now be added to all AWS objects created by the controller.
+
 [id="aws-load-balancer-operator-release-notes-1.1.1"]
 == AWS Load Balancer Operator 1.1.1
 
-The following advisory is available for the AWS Load Balancer Operator version 1.1.1: 
+The following advisory is available for the AWS Load Balancer Operator version 1.1.1:
 
 * link:https://access.redhat.com/errata/RHEA-2024:0555[RHEA-2024:0555 Release of AWS Load Balancer Operator 1.1.z on OperatorHub]
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com//browse/NE-1809
https://issues.redhat.com/browse/OSDOCS-12483

Preview Build:
https://86682--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.html

QE review:
- [x] QE has approved this change.