### PR TITLE
MIG-1673: Release notes for MTC 1.7.18

### DIFF
--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.adoc
@@ -17,6 +17,7 @@ You can migrate from xref:../../migrating_from_ocp_3_to_4/about-migrating-from-3
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-7-18.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-17.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-16.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-15.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-7-17.adoc
+++ b/modules/migration-mtc-release-notes-1-7-17.adoc
@@ -6,4 +6,4 @@
 [id="migration-mtc-release-notes-1-7-17_{context}"]
 = {mtc-full} 1.7.17 release notes
 
-{mtc-first} 1.7.17 is a Container Grade Only (CGO) release, released to refresh the health grades of the containers, with no changes to any code in the product itself compared to that of {mtc-short} 1.7.16.
+{mtc-first} 1.7.17 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {mtc-short} 1.7.16.

--- a/modules/migration-mtc-release-notes-1-7-18.adoc
+++ b/modules/migration-mtc-release-notes-1-7-18.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes-1-7.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-18_{context}"]
+= {mtc-full} 1.7.18 release notes
+
+{mtc-first} 1.7.18 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {mtc-short} 1.7.17.
+
+[id="technical-changes-1-7.18_{context}"]
+== Technical changes
+
+{mtc-first} 1.7.18 has the following technical changes:
+
+.Federal Information Processing Standard (FIPS)
+
+FIPS is a set of computer security standards developed by the United States federal government in accordance with the Federal Information Security Management Act (FISMA).
+
+Starting with version 1.7.18, {mtc-short} is designed for FIPS compliance.


### PR DESCRIPTION
### JIRA

* [MIG-1673](https://issues.redhat.com/browse/MIG-1673)

### Version(s):

* OCP 4.14, 
* OCP 4.15, 
* OCP 4.16

### Link to docs preview:

* [MTC 1.7.18 release notes](https://86689--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.html#migration-mtc-release-notes-1-7-18_mtc-release-notes)

### QE review:
- [ X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/86689#issuecomment-2590895264).
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
