### PR TITLE
Change Role to ClusterRole for allowing unauthenticated webhooks

### DIFF
--- a/modules/unauthenticated-users-system-webhook.adoc
+++ b/modules/unauthenticated-users-system-webhook.adoc
@@ -37,7 +37,7 @@ metadata:
   namespace: <namespace> <1>
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: "system:webhook"
 subjects:
   - apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
system:webook is a ClusterRole not a Role and the RoleBinding should match this.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
My understanding is that it applies to 4.16 and above but I've only tested with OKD 4.17.0-okd-scos.0

Issue:
N/A

Link to docs preview:
I don't think I have a preview build? but it's this file here https://github.com/fmo183/openshift-docs/blob/main/modules/unauthenticated-users-system-webhook.adoc

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The provided example for allowing unauthenticated webhooks doesn't seem to work. It references a Role `system:webhook` but no such Role exists - there is a ClusterRole by that name. This is basically a typo fix.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
