### PR TITLE
Adds OMR version 2.0.4 to OCP docs

### DIFF
--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -12,7 +12,18 @@ These release notes track the development of the _mirror registry for Red{nbsp}H
 [id="mirror-registry-release-notes-2-0_{context}"]
 == Mirror registry for Red{nbsp}Hat OpenShift 2.0 release notes
 
-The following sections provide details for each 2.0 release of the mirror registry for Red{nbsp}Hat OpenShift
+The following sections provide details for each 2.0 release of the mirror registry for Red{nbsp}Hat OpenShift.
+
+[id="mirror-registry-for-openshift-2-0-4_{context}"]
+=== Mirror registry for Red{nbsp}Hat OpenShift 2.0.4
+
+Issued: 06 January 2025
+
+_Mirror registry for Red{nbsp}Hat OpenShift_ is now available with Red{nbsp}Hat Quay 3.12.4.
+
+The following advisory is available for the _mirror registry for Red{nbsp}Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2025:0033[RHBA-2025:0033 - mirror registry for Red{nbsp}Hat OpenShift 2.0.4]
 
 [id="mirror-registry-for-openshift-2-0-3_{context}"]
 === Mirror registry for Red{nbsp}Hat OpenShift 2.0.3
@@ -23,7 +34,7 @@ _Mirror registry for Red{nbsp}Hat OpenShift_ is now available with Red{nbsp}Hat 
 
 The following advisory is available for the _mirror registry for Red{nbsp}Hat OpenShift_:
 
-* link:https://access.redhat.com/errata/RHBA-2024:10181[RHBA-2024:10181 - mirror registry for Red{nbsp}Hat OpenShift 2.0.2]
+* link:https://access.redhat.com/errata/RHBA-2024:10181[RHBA-2024:10181 - mirror registry for Red{nbsp}Hat OpenShift 2.0.3]
 
 [id="mirror-registry-for-openshift-2-0-2_{context}"]
 === Mirror registry for Red{nbsp}Hat OpenShift 2.0.2


### PR DESCRIPTION
Only to be merged if https://errata.devel.redhat.com/advisory/143409 is marked as "Shipped". 

Version(s):
4.12+

Issue:
N/A. Release notes

Link to docs preview:
https://86692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-creating-registry.html

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
