### PR TITLE
OADP-5176: Support custom RBAC OADP to multi-tenancy

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -2,6 +2,7 @@
 [id="about-installing-oadp"]
 = About installing OADP
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: about-installing-oadp
 
 toc::[]

--- a/modules/about-installing-oadp-on-multiple-namespaces.adoc
+++ b/modules/about-installing-oadp-on-multiple-namespaces.adoc
@@ -5,16 +5,14 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="about-installing-oadp-on-multiple-namespaces_{context}"]
-= Installation of OADP on multiple namespaces
+= Installation of {oadp-short} on multiple namespaces
 
-You can install OpenShift API for Data Protection (OADP) into multiple namespaces on the same cluster so that multiple project owners can manage their own OADP instance. This use case has been validated with File System Backup (FSB) and Container Storage Interface (CSI).
+You can install {oadp-full} into multiple namespaces on the same cluster so that multiple project owners can manage their own {oadp-short} instance. This use case has been validated with File System Backup (FSB) and Container Storage Interface (CSI).
 
-You install each instance of OADP as specified by the per-platform procedures contained in this document with the following additional requirements:
+You install each instance of {oadp-short} as specified by the per-platform procedures contained in this document with the following additional requirements:
 
-* All deployments of OADP on the same cluster must be the same version, for example, 1.1.4. Installing different versions of OADP on the same cluster is *not* supported.
-* Each individual deployment of OADP must have a unique set of credentials and at least one `BackupStorageLocation` configuration. You can also use multiple `BackupStorageLocation` configurations within the same namespace.
-* By default, each OADP deployment has cluster-level access across namespaces. {product-title} administrators need to review security and RBAC settings carefully and make any necessary changes to them to ensure that each OADP instance has the correct permissions.
+* All deployments of {oadp-short} on the same cluster must be the same version, for example, 1.4.0. Installing different versions of {oadp-short} on the same cluster is *not* supported.
 
+* Each individual deployment of {oadp-short} must have a unique set of credentials and at least one `BackupStorageLocation` configuration. You can also use multiple `BackupStorageLocation` configurations within the same namespace.
 
-
-
+* By default, each {oadp-short} deployment has cluster-level access across namespaces. {OCP} administrators need to carefully review potential impacts, such as not backing up and restoring to and from the same namespace concurrently.


### PR DESCRIPTION
### JIRA

* [OADP-5176](https://issues.redhat.com/browse/OADP-5176)

### Version(s):

* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18



### Link to docs preview:

* [Installation of OADP on multiple namespaces](https://86706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#about-installing-oadp-on-multiple-namespaces_about-installing-oadp)

QE review:
- [ X] QE and DEV has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
