### PR TITLE
OSDOCS-12949: adds 4.14.44 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -675,3 +675,12 @@ Issued: 19 December 2024
 {product-title} release 4.14.43 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:11033[RHBA-2024:11033] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:11031[RHSA-2024:11031] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-44-dp_{context}"]
+=== RHBA-2025:0031 - {microshift-short} 4.14.44 bug fix and security update advisory
+
+Issued: 9 January 2025
+
+{product-title} release 4.14.44 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:0031[RHBA-2025:0031] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0029[RHSA-2025:0029] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-12949](https://issues.redhat.com/browse/OSDOCS-12949)

Link to docs preview:
[4-14-44-dp_release-notes](https://86709--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-44-dp_release-notes)

QE review:
- NA. Stock text update. No other changes.