### PR TITLE
OSDOCS-12498: adds 4.17.11 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -196,3 +196,12 @@ Issued: 2 January 2024
 {product-title} release 4.17.10 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:11524[RHBA-2024:11524] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:11522[RHBA-2024:11522] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-11-dp_{context}"]
+=== RHBA-2025:0025 - {microshift-short} 4.17.11 bug fix and enhancement advisory
+
+Issued: 8 January 2024
+
+{product-title} release 4.17.11 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0025[RHBA-2025:0025] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:0023[RHBA-2025:0023] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12498](https://issues.redhat.com/browse/OSDOCS-12498)

Link to docs preview:
[4-17-11-dp_release-notes](https://86711--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-11-dp_release-notes)

QE review:
- NA. Stock text update. No other changes.