### PR TITLE
OSDOCS-12815: adds 4.16.29 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -396,3 +396,12 @@ Issued: 2 January 2025
 {product-title} release 4.16.28 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:11504[RHBA-2024:11504] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:11502[RHBA-2024:11502] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-29-dp_{context}"]
+=== RHBA-2025:0020 - {microshift-short} 4.16.29 bug fix and enhancement advisory
+
+Issued: 9 January 2025
+
+{product-title} release 4.16.29 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0020[RHBA-2025:0020] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0018[RHBA-2025:0018] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12815](https://issues.redhat.com/browse/OSDOCS-12815)

Link to docs preview:
[4-16-29-dp_release-notes](https://86712--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-29-dp_release-notes)

QE review:
- NA. Stock text update. No other changes.