### PR TITLE
TELCODOCS-1828: Clarify supported format for osImages.openshiftVersion in ZTP docs

### DIFF
--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -54,6 +54,7 @@ data:
 <3> The configuration file for the mirror registry. The mirror registry configuration adds mirror information to the `/etc/containers/registries.conf` file in the discovery image. The mirror information is stored in the `imageContentSources` section of the `install-config.yaml` file when the information is passed to the installation program. The Assisted Service pod that runs on the hub cluster fetches the container images from the configured mirror registry.
 <4> The URL of the mirror registry. You must use the URL from the `imageContentSources` section by running the `oc adm release mirror` command when you configure the mirror registry. For more information, see the _Mirroring the OpenShift Container Platform image repository_ section.
 <5> The registries defined in the `registries.conf` file must be scoped by repository, not by registry. In this example, both the `quay.io/example-repository` and the `mirror1.registry.corp.com:5000/example-repository` repositories are scoped by the `example-repository` repository.
+
 +
 This updates `mirrorRegistryRef` in the `AgentServiceConfig` custom resource, as shown below:
 +
@@ -84,12 +85,13 @@ spec:
   mirrorRegistryRef:
     name: assisted-installer-mirror-config <2>
   osImages:
-    - openshiftVersion: <ocp_version>
-      url: <iso_url> <3>
+    - openshiftVersion: <ocp_version> <3>
+      url: <iso_url> <4>
 ----
-<1> Set the `AgentServiceConfig` namespace to `multicluster-engine` to match the `ConfigMap` namespace
-<2> Set `mirrorRegistryRef.name` to match the definition specified in the related `ConfigMap` CR
-<3> Set the URL for the ISO hosted on the `httpd` server
+<1> Set the `AgentServiceConfig` namespace to `multicluster-engine` to match the `ConfigMap` namespace.
+<2> Set `mirrorRegistryRef.name` to match the definition specified in the related `ConfigMap` CR.
+<3> Set the {product-title} version to either the x.y or x.y.z format.
+<4> Set the URL for the ISO hosted on the `httpd` server.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.15, 4.16, 4.17, 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1828
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://86715--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-preparing-the-hub-cluster.html#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-preparing-the-hub-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
