### PR TITLE
OADP-1986: OADP ROSA needs uninstallation steps

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
@@ -23,3 +23,5 @@ The OADP Operator installs link:https://{velero-domain}/docs/v{velero-version}/[
 . Click *Operators* -> *Installed Operators* to verify the installation.
 
 include::modules/velero-oadp-version-relationship.adoc[leveloffset=+1]
+
+include::snippets/operator-additional-resources.adoc[]

--- a/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
@@ -6,9 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can install the OpenShift API for Data Protection (OADP) Operator on {product-title} {product-version} by using Operator Lifecycle Manager (OLM).
+You can install the {oadp-first} Operator on {product-title} {product-version} by using Operator Lifecycle Manager (OLM).
 
-The OADP Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
+The {oadp-short} Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
 
 .Prerequisites
 
@@ -24,4 +24,8 @@ The OADP Operator installs link:https://{velero-domain}/docs/v{velero-version}/[
 
 include::modules/velero-oadp-version-relationship.adoc[leveloffset=+1]
 
+For information about uninstalling {oadp-short}, see xref:../../../backup_and_restore/application_backup_and_restore/installing/uninstalling-oadp.adoc#uninstalling-oadp[Uninstalling the OpenShift API for Data Protection].
+
+[role="_additional-resources"]
+.Additional resources
 include::snippets/operator-additional-resources.adoc[]

--- a/backup_and_restore/application_backup_and_restore/installing/uninstalling-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/uninstalling-oadp.adoc
@@ -7,3 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 You uninstall the OpenShift API for Data Protection (OADP) by deleting the OADP Operator. See xref:../../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-cluster[Deleting Operators from a cluster] for details.
+
+[role="_additional-resources"]
+.Additional resources
+
+include::snippets/operator-additional-resources.adoc[]

--- a/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
@@ -41,3 +41,7 @@ include::modules/installing-oadp-rosa-sts.adoc[leveloffset=+1]
 include::modules/performing-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]
 
 include::modules/cleanup-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]
+
+include::snippets/operator-additional-resources.adoc[]
+
+:oadp-rosa-backing-up-applications!:

--- a/snippets/operator-additional-resources.adoc
+++ b/snippets/operator-additional-resources.adoc
@@ -1,0 +1,24 @@
+// Snippets included in the following assemblies and modules:
+//
+// * /backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+// * /backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
+// * /backup_and_restore/application_backup_and_restore/installing/uninstalling-oadp.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+* xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-adding-operators-to-a-cluster[Updating installed Operators]
+* xref:../../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]
+* xref:../../applications/pruning-objects.adoc#pruning-objects[Pruning objects to reclaim resources]
+* xref:../../../operators/admin/olm-troubleshooting-operator-issues.adoc#olm-troubleshooting-operator-issues[Troubleshooting Operator issues]
+*
+// docs not in OCP enterprise so using links
+
+ifdef::oadp-rosa-backing-up-applications[]
+* link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-deleting-access-cluster.html[Deleting access to a ROSA cluster]
+* link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-deleting-cluster.html[Deleting a ROSA cluster]
+* link:https://docs.openshift.com/rosa/rosa_backing_up_and_restoring_applications/backing-up-applications.html#cleanup-a-backup-oadp-rosa-sts_rosa-backing-up-applications[Cleaning up a cluster after a backup with OADP and ROSA STS]
+endif::[]

--- a/snippets/operator-additional-resources.adoc
+++ b/snippets/operator-additional-resources.adoc
@@ -12,7 +12,7 @@
 * xref:../../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-adding-operators-to-a-cluster[Updating installed Operators]
 * xref:../../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]
-* xref:../../applications/pruning-objects.adoc#pruning-objects[Pruning objects to reclaim resources]
+* xref:../../../applications/pruning-objects.adoc#pruning-objects[Pruning objects to reclaim resources]
 * xref:../../../operators/admin/olm-troubleshooting-operator-issues.adoc#olm-troubleshooting-operator-issues[Troubleshooting Operator issues]
 *
 // docs not in OCP enterprise so using links


### PR DESCRIPTION
### JIRA

* [OADP-1986](https://issues.redhat.com/browse/OADP-1986)

### Version(s):

* OCP 4.12 and later

### Link to docs preview:

* [ Installing the OADP Operator ](https://86717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.html)

* [Uninstalling OADP](https://86717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/uninstalling-oadp.html)

* [Cleaning up a cluster after a backup with OADP and ROSA STS](https://86717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html#cleanup-a-backup-oadp-rosa-sts_oadp-rosa-backing-up-applications)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
