### PR TITLE
OSSM-8362 Update sentence in multicluster and mulitenant

### DIFF
--- a/modules/ossm-running-v2-v3-cluster-wide-deployment-model.adoc
+++ b/modules/ossm-running-v2-v3-cluster-wide-deployment-model.adoc
@@ -73,7 +73,7 @@ spec:
 
 . Create an `IstioCNI` resource in the `istio-cni` namespace.
 
-. Create an `Istio` resource in a different namespace than the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6. In this example, `istio-system3` is being used:
+. Create an `Istio` resource in a different namespace than the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6. This example uses the `istio-system3` namespace:
 +
 .Example `Istio` resource with `istio-system3`
 [source, yaml]
@@ -95,7 +95,7 @@ spec:
   version: v1.23.0
 ----
 <1> Do not use `default` as the name.
-<2> Must be different from the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6.
+<2> Must be different from the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6. This example uses the `istio-system3` namespace.
 <3> To ignore {SMProduct} 2.6 namespaces, configure the `discoverySelectors` section as shown. All other namespaces will be part of the {SMProduct} 3.0 mesh.
 +
 

--- a/modules/ossm-running-v2-v3-multitenant-deployment-model.adoc
+++ b/modules/ossm-running-v2-v3-multitenant-deployment-model.adoc
@@ -45,7 +45,7 @@ If you are not running {SMProduct} 2.6, you must upgrade to 2.6 before following
 
 . Create an `IstioCNI` resource in the `istio-cni` namespace.
 
-. Create an `Istio` resource in a different namespace than the `namespace` used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6. In this example, `istio-system3` is being used:
+. Create an `Istio` resource in a different namespace than the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6. This example uses the `istio-system3` namespace:
 +
 .Example `Istio` resource with `istio-system3`
 [source, yaml]
@@ -67,7 +67,7 @@ spec:
   version: v1.23.0
 ----
 <1> Do not use `default` as the name.
-<2> Must be different from the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6.
+<2> Must be different from the namespace used in the `ServiceMeshControlPlane` resource in {SMProduct} 2.6. This example uses the `istio-system3` namespace.
 <3> To ignore {SMProduct} 2.6 namespaces, configure the `discoverySelectors` section as shown. All other namespaces will be part of the {SMProduct} 3.0 mesh.
 
 . Deploy your workloads and label the namespaces with `istio.io/rev=ossm3` label by running the following command:


### PR DESCRIPTION
**OSSM 3.0**

https://issues.redhat.com/browse/OSSM-8362 [OSSM-8362](https://issues.redhat.com//browse/OSSM-8362) Update sentence in multicluster and mulitenant #86729


**Merge to:** https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick** to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology Preview.

OSSM 3.0 is moving to stand alone format and will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8362

Link to docs preview:
https://86729--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-running-v2-same-cluster-as-v3-assembly.html

QE review:
QE and Dev review are not needed for this change. This is a style update from the review of the original PR for this content.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
