### PR TITLE
OCPBUGS-44475#updating advanced network config text

### DIFF
--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -14,6 +14,9 @@ ifeval::["{context}" == "installing-vsphere-network-customizations"]
 :ignition-config:
 :vsphere:
 endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vsphere-ipi:
+endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
 :ibm-cloud:
 endif::[]
@@ -47,7 +50,7 @@ $ ./openshift-install create manifests --dir <installation_directory> <1>
 
 . Create a stub manifest file for the advanced network configuration that is named `cluster-network-03-config.yml` in the `<installation_directory>/manifests/` directory:
 +
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
 kind: Network
@@ -78,8 +81,8 @@ spec:
 installation program consumes the `manifests/` directory when you create the
 Ignition config files.
 
-ifdef::vsphere[]
-. Remove the Kubernetes manifest files that define the control plane machines and compute machineSets:
+ifndef::vsphere-ipi[]
+. Remove the Kubernetes manifest files that define the control plane machines and compute `MachineSets`:
 +
 [source,terminal]
 ----
@@ -89,8 +92,8 @@ $ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_o
 Because you create and manage these resources yourself, you do not have
 to initialize them.
 +
-* You can preserve the MachineSet files to create compute machines by using the machine API, but you must update references to them to match your environment.
-endif::vsphere[]
+* You can preserve the `MachineSet` files to create compute machines by using the machine API, but you must update references to them to match your environment.
+endif::[]
 
 ifeval::["{context}" == "installing-bare-metal-network-customizations"]
 :!ignition-config:
@@ -98,6 +101,9 @@ endif::[]
 ifeval::["{context}" == "installing-vsphere-network-customizations"]
 :!ignition-config:
 :!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:!vsphere-ipi:
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
 :!ibm-cloud:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-44475

Link to docs preview:
- [Specifying advanced network configuration (IPI)](https://86730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.html#modifying-nwoperator-config-startup_installing-vsphere-installer-provisioned-network-customizations)
- [Specifying advanced network configuration (UPI)](https://86730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere-network-customizations#modifying-nwoperator-config-startup_installing-vsphere-network-customizations)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
