### PR TITLE
OSDOCS-13044 noting support for BYO private hosted zone for GCP XPN

### DIFF
--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -20,6 +20,7 @@ The installation program provisions the rest of the required infrastructure, whi
 * You have a GCP host project which contains a shared VPC network.
 * You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster. This project, known as the service project, must be attached to the host project. For more information, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#create-shared[Attaching service projects in the GCP documentation].
 * You have a GCP service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#minimum-required-permissions-ipi-gcp-xpn_installing-gcp-account[required GCP permissions] in both the host and service projects.
+* If you want to provide your own private hosted zone, you must have created one in the service project with the DNS pattern `cluster-name.baseDomain.`, for example `testCluster.example.com.`. The private hosted zone must be bound to the VPC in the host project. For more information about cross-project binding, see link:https://cloud.google.com/dns/docs/zones/cross-project-binding[Create a zone with cross-project binding] (Google documentation). If you do not provide a private hosted zone, the installation program will provision one automatically.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -26,6 +26,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 * If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[manually create and maintain long-term credentials].
+* If you want to provide your own private hosted zone, you must have created one in the service project with the DNS pattern `cluster-name.baseDomain.`, for example `testCluster.example.com.`. The private hosted zone must be bound to the VPC in the host project. For more information about cross-project binding, see link:https://cloud.google.com/dns/docs/zones/cross-project-binding[Create a zone with cross-project binding] (Google documentation). If you do not provide a private hosted zone, the installation program will provision one automatically.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-13044

Link to docs preview:
[IPI XPN install doc](https://86739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-shared-vpc.html#installation-gcp-shared-vpc-prerequisites_installing-gcp-shared-vpc)
[UPI XPN install doc](https://86739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#prerequisites)

QE review:
- [x] QE has approved this change.
