### PR TITLE
Incorrect structure of command in Configuring replication policy for the log store

### DIFF
--- a/modules/cluster-logging-elasticsearch-ha.adoc
+++ b/modules/cluster-logging-elasticsearch-ha.adoc
@@ -18,7 +18,7 @@ You can define how Elasticsearch shards are replicated across data nodes in the 
 +
 [source,terminal]
 ----
-$ oc edit clusterlogging instance
+$ oc edit -n openshift-logging ClusterLogging instance
 ----
 +
 [source,yaml]


### PR DESCRIPTION
- The structure of the command is incorrect in Configuring the replication policy for the log store documentation. 
- Here is the documentation Link: 
https://docs.openshift.com/container-platform/4.16/observability/logging/log_storage/logging-config-es-store.html#cluster-logging-elasticsearch-ha_logging-config-es-store 
- Here in Step1 under the procedure section, we could see the below command is mentioned: 
~~~
$ oc edit clusterlogging instance 
~~~

- But this is not the correct way.
- The correct way to mention `clusterlogging` in the Red Hat Standard Documentation is `ClusterLogging`. 
- We can verify this in the other part of our documentation. 
- In addition, Step1 is noted with "Edit the ClusterLogging custom resource (CR) in the openshift-logging project:" 
- However, the project name is not mentioned in the command. 
- It is necessary to mention the project name while executing that command. 

**Reason:**

1. Suppose the user is not a part of `openshift-logging` project, and he tries to run this command then this command will not work.
2. If the credentials are shared, and two people are using the same cluster at the same time, then, the second person could change to work in a different namespace.

- Hence it will be always beneficial to run the above command with the project name. 
- We need to perform these changes in our documentation. 
- Here is the correct structure of this command.
--------------------
1. Edit the ClusterLogging custom resource (CR) in the openshift-logging project:

~~~
$ oc edit -n openshift-logging ClusterLogging instance 
~~~
--------------------

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP-4.18, RHOCP-4.17, RHOCP-4.16, RHOCP-4.15, RHOCP-4.14, RHOCP-4.13, RHOCP-4.12


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1598

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://86740--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/log_storage/logging-config-es-store.html

https://86740--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_storage/logging-config-es-store.html

https://86740--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/log_storage/logging-config-es-store.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
