### PR TITLE
OSDOCS#13024: 4.17.11 z-stream RN

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2874,6 +2874,40 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.11
+[id="ocp-4-17-11_{context}"]
+=== RHBA-2025:0023 - {product-title} {product-version}.11 bug fix, and security update advisory
+
+Issued: 08 January 2024
+
+{product-title} release {product-version}.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:0023[RHBA-2025:0023] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0026[RHBA-2025:0026] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.11 --pullspecs
+----
+
+[id="ocp-4-17-11-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the certificate signing request (CSR) approver included certificates from other systems when it calculated if it should stop approving certificates when the system was overloaded. In larger clusters, where other subsystems used CSRs, the CSR approver determined that there were many unapproved CSRs and prevented additional approvals. With this release, the CSR approver prevents new approvals when there are many CSRs for the `signerName` values that it observes, but has not been able to approve. The CSR approver now only includes CSRs that it can approve, using the `signerName` property as a filter. (link:https://issues.redhat.com/browse/OCPBUGS-46429[*OCPBUGS-46429*])
+
+* Previously, a hard eviction of a pod in a node caused a pod to enter a termination grace period instead of instantly shutting down and deleted by the kubelet. Each pod that enters a termination grace period exhausts the node resources. With this release, a bug fix ensures that a pod enters a one-second termination grace period so the kubelet can shut down and then delete the pod. (link:https://issues.redhat.com/browse/OCPBUGS-46364[*OCPBUGS-46364*])
+
+* Previously, the permissions `ec2:AllocateAddress` and `ec2:AssociateAddress` were not verified when the `PublicIpv4Pool` feature was used, which resulted in permission failures during the installation. With this release, the required permissions are validated before the cluster is installed. (link:https://issues.redhat.com/browse/OCPBUGS-46360[*OCPBUGS-46360*])
+
+* Previously, users could enter an invalid string for any CPU set in the performance profile, resulting in a broken cluster. With this release, the fix ensures that only valid strings can be entered, eliminating the risk of cluster breakage. (link:https://issues.redhat.com/browse/OCPBUGS-45964[*OCPBUGS-45964*])
+
+* Previously, in certain scenarios, an event was missed by the informer watch stream. If an object was deleted while this disconnection occurred, the informer returned an unexpected type, which caused a stale state. As a result, the incorrect returned type caused a problem. With this release, the unexpected types are correctly handled, and the temporary disconnection possibilities are successful. (link:https://issues.redhat.com/browse/OCPBUGS-46039[*OCPBUGS-46039*])
+
+[id="ocp-4-17-11-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.10
 [id="ocp-4-17-10_{context}"]
 === RHBA-2024:11522 - {product-title} {product-version}.10 bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13024](https://issues.redhat.com/browse/OSDOCS-13024)

Link to docs preview:
[4.17.11](https://86742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html)

QE review:
- [ ] QE has approved this change.
N/A for z-stream release notes.

Additional information:
The errata URLs will return 404 until the go-live date of 01/08/25.