### PR TITLE
TELCODOCS-1891: release note

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -500,6 +500,17 @@ $ oc patch featuregates cluster -p '{"spec": {"featureSet": "TechPreviewNoUpgrad
 [id="ocp-release-notes-scalability-and-performance_{context}"]
 === Scalability and performance
 
+[id="ocp-release-notes-scalability-and-performance-cluster-compare_{context}"]
+==== Cluster validation with the cluster-compare plugin
+
+The `cluster-compare` plugin is an OpenShift CLI (`oc`) plugin that compares a cluster configuration with a target configuration. The plugin reports configuration differences while suppressing expected variations by using configurable validation rules and templates. 
+
+For example, the plugin can highlight unexpected differences, such as mismatched field values, missing resources, or version discrepancies, while ignoring expected differences, such as optional components or hardware-specific fields. This focused comparison makes it easier to assess cluster compliance with the target configuration.
+
+You can use the `cluster-compare` plugin in development, production, and support scenarios. 
+
+For more information about the `cluster-compare` plugin, see xref:../scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.adoc#cluster-compare-overview_understanding-cluster-compare[Overview of the cluster-compare plugin].
+
 [id="ocp-release-notes-etcd-certificates_{context}"]
 === Security
 


### PR DESCRIPTION
[TELCODOCS-1891](https://issues.redhat.com//browse/TELCODOCS-1891): Release note for cluster-compare plugin

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/CNF-12055

Link to docs preview:
https://86757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-scalability-and-performance-cluster-compare_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
