### PR TITLE
OBSDOCS-1552: Add assembly content for 'Accessing metrics' section

### DIFF
--- a/observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer.adoc
+++ b/observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer.adoc
@@ -6,8 +6,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-TBD
+You can access metrics to monitor the performance of your cluster workloads.
 
+//Querying metrics for user-defined projects with the OCP web console
+include::modules/monitoring-querying-metrics-for-user-defined-projects-with-mon-dashboard.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus (Prometheus documentation)]
+
+//Reviewing monitoring dashboards as a developer
+include::modules/monitoring-reviewing-monitoring-dashboards-developer.adoc[leveloffset=+1]
 
 
 

--- a/observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc
+++ b/observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc
@@ -6,8 +6,24 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-TBD
+You can access metrics to monitor the performance of cluster components and your workloads.
 
+//Viewing a list of available metrics
+include::modules/monitoring-viewing-a-list-of-available-metrics.adoc[leveloffset=+1]
+
+//Querying metrics for all projects with the OCP web console
+include::modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus (Prometheus documentation)]
+
+//Getting detailed information about a metrics target
+include::modules/monitoring-getting-detailed-information-about-a-target.adoc[leveloffset=+1]
+
+//Reviewing monitoring dashboards as a cluster administrator
+include::modules/monitoring-reviewing-monitoring-dashboards-admin.adoc[leveloffset=+1]
 
 
 

--- a/observability/monitoring/accessing-metrics/accessing-monitoring-apis-by-using-the-CLI.adoc
+++ b/observability/monitoring/accessing-metrics/accessing-monitoring-apis-by-using-the-CLI.adoc
@@ -6,7 +6,41 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-TBD
+In {product-title}, you can access web service APIs for some monitoring components from the command-line interface (CLI).
+
+[IMPORTANT]
+====
+In certain situations, accessing API endpoints can degrade the performance and scalability of your cluster, especially if you use endpoints to retrieve, send, or query large amounts of metrics data.
+
+To avoid these issues, consider the following recommendations:
+
+* Avoid querying endpoints frequently. Limit queries to a maximum of one every 30 seconds.
+* Do not retrieve all metrics data through the `/federate` endpoint for Prometheus. Query the endpoint only when you want to retrieve a limited, aggregated data set. For example, retrieving fewer than 1,000 samples for each request helps minimize the risk of performance degradation.
+====
+
+// About accessing monitoring web service APIs
+include::modules/monitoring-about-accessing-monitoring-web-service-apis.adoc[leveloffset=+1]
+
+// .Additional resources
+// * TBD
+
+// Accessing a monitoring web service API
+include::modules/monitoring-accessing-third-party-monitoring-web-service-apis.adoc[leveloffset=+1]
+
+// Querying metrics by using the federation endpoint for Prometheus
+include::modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc[leveloffset=+1]
+
+// Accessing metrics from outside the cluster for custom applications
+include::modules/accessing-metrics-outside-cluster.adoc[leveloffset=+1]
+
+// Resources reference for the Cluster Monitoring Operator
+include::modules/monitoring-resources-reference-for-the-cluster-monitoring-operator.adoc[leveloffset=+1]
+
+// [role="_additional-resources"]
+// [id="additional-resources_{context}"]
+// == Additional resources
+
+// * TBD
 
 
 

--- a/observability/monitoring/accessing-third-party-monitoring-apis.adoc
+++ b/observability/monitoring/accessing-third-party-monitoring-apis.adoc
@@ -33,7 +33,7 @@ include::modules/monitoring-querying-metrics-by-using-the-federation-endpoint-fo
 include::modules/accessing-metrics-outside-cluster.adoc[leveloffset=+1]
 
 // Resources reference for accessing API endpoints
-include::modules/monitoring-resources-reference-for-the-cluster-monitoring-operator.adoc[leveloffset=+1]
+//include::modules/monitoring-resources-reference-for-the-cluster-monitoring-operator.adoc[leveloffset=+1]
 
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s): `none for cherry-picking, only merge to monitoring-docs-restructure

Issue: [OBSDOCS-1552](https://issues.redhat.com/browse/OBSDOCS-1552)

Links to docs preview: 

* A[ccessing metrics as an administrator](https://86759--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator)
* [Accessing metrics as a developer](https://86759--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer)
* [Accessing monitoring APIs by using the CLI](https://86759--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-metrics/accessing-monitoring-apis-by-using-the-cli)

**QE review: not needed, just moving the existing content**

**Additional information:**
**The changes it this PR are not yet user-facing.**
This PR moves content from old to the new assemblies. The content in the original assembly is still there . The reason is to not lose any content while moving it around. There will be a separate issue that will make sure that all the content is transfered as needed.

Therefore, the main thing to check in this PR is to see if the structure in the linked chapters looks good and renders without issues.

**NOTE**: The links and xrefs will be filled in in a different PR, because the content from other assemblies still needs to be moved to the new place, which means that if I filled the links now, I would have to keep repairing them later. So I am keeping that for a separate PR.

Let me know if you have any additional questions, thank you!

The following are the sections that need review (you can find it under Observability -> Monitoring) :
![image](https://github.com/user-attachments/assets/10f1d618-c067-491a-b08e-39f017637b18)

