### PR TITLE
OSDOCS-13047: Updated 44644 for the 4.17.10 z-stream notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2922,7 +2922,9 @@ The Node Tuning Operator can now properly select kernel arguments and management
 
 * Previously, an {ibm-power-server-name} cluster installation failed on installer-provisioned infrastructure because the installation program used a random network type instead of using of the specified network type that was specified in the `install-config.yaml` configuration file. With this release, the installation program now uses the network type that is specified in the `install-config.yaml` so that this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-45484[*OCPBUGS-45484*])
 
-* Previously, the validation of Non-Uniform Memory Access (NUMA) node topologies expected equal core indices. This expectation caused the Performance Profile Creator (PPC) to report inaccurate information for compute nodes. With this release, the validation check no longer expects equal core indices so that the PPC now reports accurate information for compute nodes. (link:https://issues.redhat.com/browse/OCPBUGS-44644[*OCPBUGS-44644*])
+* Previously, the Performance Profile Creator (PPC) failed to build a performance profile for compute nodes that had different core ID numbering (core per socket) for their logical processors and the nodes existed under the same node pool. For example, the PPC failed in a situation for two compute nodes that have logical processors `2` and `18`, where one node groups them as core ID `2` and the other node groups them as core ID `9`.
++
+With this release, PPC no longer fails to create the performance profile because PPC can now build a performance profile for a cluster that has compute nodes that each have different core ID numbering for their logical processors. The PPC now outputs a warning message that indicates to use the generated performance profile with caution, because different core ID numbering might impact system optimization and isolated management of tasks. (link:https://issues.redhat.com/browse/OCPBUGS-44644[*OCPBUGS-44644*])
 
 [id="ocp-4-17-10-updating_{context}"]
 ==== Updating


### PR DESCRIPTION
[CM](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r6303390863281775594) raised on the 08th of January.

Version(s):
4.17

Issue:
[OSDOCS-13047](https://issues.redhat.com/browse/OSDOCS-13047)

Link to docs preview:
[4.17.10](https://86760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-10_release-notes)


[X] SME has approved this change.


