### PR TITLE
OSSM-8668 Update link to redirect to 3.x on docs.redhat

### DIFF
--- a/service_mesh/v3x/ossm-service-mesh-3-0-overview.adoc
+++ b/service_mesh/v3x/ossm-service-mesh-3-0-overview.adoc
@@ -10,5 +10,5 @@ toc::[]
 
 [NOTE]
 ====
-Because {SMProductName} 3.0 releases on a different cadence from {product-title}, the {SMProductShortName} documentation is available as a separate documentation set at link:https://docs.openshift.com/service-mesh/3.0.0tp1/about/ossm-about-openshift-service-mesh.html[About {SMProductName}].
+Because {SMProductName} 3.0 releases on a different cadence from {product-title}, the {SMProductShortName} documentation is available as a separate documentation set at link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh[{SMProductName}].
 ====


### PR DESCRIPTION
[OSSM-8668](https://issues.redhat.com//browse/OSSM-8668) Update link to redirect to 3.x on docs.redhat


Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSSM-8668

Link to docs preview:
https://86767--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v3x/ossm-service-mesh-3-0-overview.html

QE review:
QE and Dev review are not required as this is a Doc-specific change.

Additional information:
This is updating to redirect users to the 3.x stand alone content on docs.redhat. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
