### PR TITLE
[OSDOCS-13048]: Added link to AWS Windows LI on ROSA with HCP kb article

### DIFF
--- a/modules/creating-a-machine-pool-cli.adoc
+++ b/modules/creating-a-machine-pool-cli.adoc
@@ -195,6 +195,22 @@ endif::openshift-rosa-hcp[]
 I: To view all machine pools, run 'rosa list machinepools -c mycluster'
 ----
 
+//ifdef::openshift-rosa-hcp[] Uncomment this out once HCP split occurs
+* To add a Windows Licence Included enabled machine pool to a {hcp-title} cluster, see link:https://access.redhat.com/articles/7096903[AWS Windows License Included for ROSA with HCP].
++
+Windows Licence Included enabled machine pools can only be created when the following criteria is met:
+
+** The host cluster is a {hcp-title} cluster.
+** The instance type is bare metal EC2.
++
+[IMPORTANT]
+====
+AWS Windows License Included for {hcp-title} is a Technology Preview feature only. Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs) and might not be functionally complete. Red{nbsp}Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+//endif::openshift-rosa-hcp[] Uncomment this out once HCP split occurs
+
 .Verification
 
 You can list all machine pools on your cluster or describe individual machine pools.
@@ -219,9 +235,9 @@ ifdef::openshift-rosa-hcp[]
 .Example output
 [source,terminal]
 ----
-ID             AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS                  TAINTS    AVAILABILITY ZONE  SUBNET                    VERSION  AUTOREPAIR  
+ID             AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS                  TAINTS    AVAILABILITY ZONE  SUBNET                    VERSION  AUTOREPAIR
 Default        No           1/1       m5. xlarge                                       us-east-2c         subnet-00552ad67728a6ba3  4.14.34  Yes
-mymachinepool  Yes          3/3-6     m5.xlarge      app=db, tier=backend              us-east-2a         subnet-0cb56f5f41880c413  4.14.34  Yes         
+mymachinepool  Yes          3/3-6     m5.xlarge      app=db, tier=backend              us-east-2a         subnet-0cb56f5f41880c413  4.14.34  Yes
 ----
 endif::openshift-rosa-hcp[]
 


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-13048](https://issues.redhat.com/browse/OSDOCS-13048)

**Note to reviewers:**
This PR covers basic info of the enable Win LI feature in Tech preview only. A more complete update will be made before the feature goes GA.

Link to docs preview:

ROSA Classic (only to appear in this build until Classic/ HCP Docs split happens)
- [Creating a machine pool using the ROSA CLI](https://86770--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#creating_machine_pools_cli_rosa-managing-worker-nodes)

ROSA HCP
- [Creating a machine pool using the ROSA CLI](https://86770--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Peer review:
- [x] Peer reviewer has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
