### PR TITLE
[enterprise-4.12] OCPBUGS-46535: Fixed the link in the deployments-ab-testing-lb.adoc file

### DIFF
--- a/applications/deployments/route-based-deployment-strategies.adoc
+++ b/applications/deployments/route-based-deployment-strategies.adoc
@@ -33,3 +33,9 @@ include::modules/deployments-graceful-termination.adoc[leveloffset=+1]
 include::modules/deployments-blue-green.adoc[leveloffset=+1]
 include::modules/deployments-ab-testing.adoc[leveloffset=+1]
 include::modules/deployments-ab-testing-lb.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[Route-specific annotations].

--- a/modules/deployments-ab-testing-lb.adoc
+++ b/modules/deployments-ab-testing-lb.adoc
@@ -56,7 +56,7 @@ Browse to the application at `ab-example-a.<project>.<router_domain>` to verify 
 +
 [NOTE]
 ====
-When using `alternateBackends`, also use the `roundrobin` load-balancing strategy to ensure requests are distributed as expected to the services based on weight. `roundrobin` can be set for a route by using a link:https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration[route annotation].
+When using `alternateBackends`, also use the `roundrobin` load balancing strategy to ensure requests are distributed as expected to the services based on weight. `roundrobin` can be set for a route by using a route annotation. See the _Additional resources_ section for more information about route annotations.
 ====
 +
 Setting the `oc set route-backend` to `0` means the service does not participate in load-balancing, but continues to serve existing persistent connections.


### PR DESCRIPTION
Cherry-picked from #86687 with commit b0e87576e449643d05bcb1486554263962c0c1c8

Version(s):
4.12

Issue:
[OCPBUGS-46535](https://issues.redhat.com/browse/OCPBUGS-46535)

Link to docs preview:
