### PR TITLE
osdocs10264: validate cluster wide policies using sigstore

### DIFF
--- a/modules/nodes-sigstore-using-validation.adoc
+++ b/modules/nodes-sigstore-using-validation.adoc
@@ -1,0 +1,127 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-sigstore-using.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-sigstore-using-validation_{context}"]
+= Validate cluster-wide policies using sigstore
+
+The following procedure demonstrates how to validate cluster-wide policies using Sigstore in {product-title}.
+
+.Prerequisites
+
+* Ensure that the policy on OpenShift image repositories (quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev) allows deployment of OpenShift images required for cluster operation.
+
+.Procedure
+
+. Build and Push an Image for Signing:
++
+[source,sh]
+----
+podman login quay.io
+Enter the username and password as prompted:
+Username: qiwanredhat
+Password: <your-password>
+Login Succeeded!
+----
+
+. Build and push the image:
++
+[source,sh]
+----
+echo "FROM scratch" > Dockerfile
+podman build -t quay.io/qiwanredhat/test-sigstoresigned .
+podman push quay.io/qiwanredhat/test-sigstoresigned:latest
+----
+
+. Generate a key pair for cosign:
++
+[source,sh]
+----
+cosign generate-key-pair
+Enter a password for the private key when prompted. The keys will be saved as cosign.key and cosign.pub.
+Sign the Image Using Cosign:
+Sign the image using your private key and push the signature to the registry:
+sh
+cosign sign --key ./cosign.key --registry-username=<your-username> --registry-password=<your-password> quay.io/qiwanredhat/test-sigstoresigned:latest
+----
+
+. Launch OpenShift Cluster ClusterBot to enable the feature gate:
++
+[source,sh]
+----
+launch quay.io/openshift-release-dev/ocp-release:4.16.0-rc.3-x86_64 techpreview
+----
+
+. Enable CRI-O debug log level:
+.. Create a ContainerRuntimeConfig to set the log level to debug:
++
+[source,sh]
+----
+oc create -f - <<EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: set-loglevel
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+  containerRuntimeConfig:
+    logLevel: debug
+EOF
+----
+
+.. Verify the log level:
++
+[source,sh]
+----
+oc debug node/<node-name>
+chroot /host
+crio config | grep "log_level"
+----
+
+. Create a ClusterImagePolicy for signature verification:
++
+[source,sh]
+----
+oc create -f - <<EOF
+apiVersion: config.openshift.io/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: qisigned
+spec:
+  scopes:
+    - quay.io/qiwanredhat/test-sigstoresigned
+  policy:
+    rootOfTrust:
+      policyType: PublicKey
+      publicKey:
+        keyData: <base64-encoded-cosign.pub>
+    signedIdentity:
+      matchPolicy: MatchRepository
+EOF
+----
+
+. Verify configurations in /etc/containers/policy.json and /etc/containers/registries.d/:
++
+[source,sh]
+----
+oc debug node/<node-name>
+chroot /host
+cat /etc/containers/policy.json
+cat /etc/containers/registries.d/sigstore-registries.yaml
+----
+
+. Pull the signed image and check the CRI-O logs for verification:
++
+[source,sh]
+----
+crictl pull quay.io/qiwanredhat/test-sigstoresigned:latest
+journalctl -u crio --since="3 minutes ago"
+----
+
+[NOTE]
+====
+If multiple scopes match a given image, only the policy requirements for the most specific scope apply.
+====

--- a/nodes/nodes-sigstore-using.adoc
+++ b/nodes/nodes-sigstore-using.adoc
@@ -13,5 +13,8 @@ You can use the sigstore project with {product-title} to improve supply chain se
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-// AManage secure signatures with SigStore
+// Manage secure signatures with SigStore
 include::modules/nodes-sigstore-using-about.adoc[leveloffset=+1]
+
+// Validate cluster-wide policies using sigstore
+include::modules/nodes-sigstore-using-validation.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10264](https://issues.redhat.com//browse/OSDOCS-10264)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://86776--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-using-validation_nodes-sigstore-using
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
