### PR TITLE
OSDOCS-9444 changed 3 to F in installation-network-user-infra file

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -229,7 +229,7 @@ Identifier (OUI) allocation ranges:
 * `00:05:69:00:00:00` to `00:05:69:FF:FF:FF`
 * `00:0c:29:00:00:00` to `00:0c:29:FF:FF:FF`
 * `00:1c:14:00:00:00` to `00:1c:14:FF:FF:FF`
-* `00:50:56:00:00:00` to `00:50:56:3F:FF:FF`
+* `00:50:56:00:00:00` to `00:50:56:FF:FF:FF`
 
 If a MAC address outside the VMware OUI is used, the cluster installation will
 not succeed.


### PR DESCRIPTION
Version(s):
12+

Issue:
https://issues.redhat.com/browse/OSDOCS-9444

Link to docs preview:
https://86778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html
https://86778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/upi/installing-azure-stack-hub-user-infra.html
https://86778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/upi/installing-azure-user-infra.html
https://86778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html
https://86778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html
https://86778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html


QE review:
- [x] QE has approved this change.


