### PR TITLE
OADP-5354: Backup is failing on validation PartiallyFailed

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
@@ -160,11 +160,13 @@ $ cat <<EOF > ${SCRATCH}/credentials
 [default]
 role_arn = ${ROLE_ARN}
 web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+region=<aws_region> # <1>
 EOF
 $ oc -n openshift-adp create secret generic cloud-credentials \
  --from-file=${SCRATCH}/credentials
 ----
-
++
+<1> Replace `<aws_region>` with the AWS region to use for the {sts-first} endpoint.
 . Deploy the OADP Operator:
 +
 [NOTE]

--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -49,8 +49,7 @@ $ cat <<EOF > ${SCRATCH}/credentials
   region = <aws_region> <1>
 EOF
 ----
-<1> The AWS region in which the cloud resources have been created.
-
+<1> Replace `<aws_region>` with the AWS region to use for the {sts-short} endpoint.
 .. Create a namespace for OADP:
 +
 [source,terminal]
@@ -185,11 +184,14 @@ $ cat << EOF | oc create -f -
         - openshift
         - aws
         - csi
-      restic:
+      nodeAgent:  # <2>
         enable: false
+        uploaderType: kopia # <3>
 EOF
 ----
 <1> ROSA supports internal image backup. Set this field to `false` if you do not want to use image backup.
+<2> See the important note regarding the `nodeAgent` attribute.
+<3> The type of uploader. The possible values are `restic` or `kopia`. The built-in Data Mover uses Kopia as the default uploader mechanism regardless of the value of the `uploaderType` field.
 
 // . Create the `DataProtectionApplication` resource, which is used to configure the connection to the storage where the backups and volume snapshots are stored:
 
@@ -205,9 +207,6 @@ $ cat << EOF | oc create -f -
     namespace: openshift-adp
   spec:
     backupImages: true <1>
-    features:
-      dataMover:
-         enable: false
     backupLocations:
     - bucket:
         cloudStorageRef:


### PR DESCRIPTION
### JIRA 

* [OADP-5354](https://issues.redhat.com/browse/OADP-5354)

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18

OADP 1.3 is [still supported](https://access.redhat.com/support/policy/updates/openshift_operators), which is why 4.12 is required

### Link to docs preview:

* [Installing the OADP Operator and providing the IAM role](https://86780--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html#installing-oadp-rosa-sts_oadp-rosa-backing-up-applications)

* [Deploy OADP on the cluster](https://86780--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.html#deploy-oadp-on-cluster_cloud-experts-deploy-api-data-protection)

* [Installing the OADP Operator and providing the IAM role](https://86780--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_backing_up_and_restoring_applications/backing-up-applications.html#installing-oadp-rosa-sts_rosa-backing-up-applications)

### QE review:

- [X ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
