### PR TITLE
RHDEVDOCS 6332 fix docs.openshift.com redirect for Pipelines RN

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -445,7 +445,7 @@ AddType text/vtt                            vtt
     RewriteRule ^pipelines/1\.(10|11|12|13|14|15)/release_notes/op-release-notes-1-([0-9]+)\.html$ pipelines/1.$1/about/op-release-notes.html [L,R=302]
     RewriteRule ^pipelines/1\.16/release_notes/op-release-notes-1-16\.html$ - [L]
     RewriteRule ^pipelines/1\.17/release_notes/op-release-notes-1-17\.html$ - [L]
-    RewriteRule ^pipelines/1\.(16|17)/release_notes/op-release-notes?(.*)\.html$ pipelines/1.$1/release_notes/pipelines-release-notes-1-$1.html [L,R=302]
+    RewriteRule ^pipelines/1\.(16|17)/release_notes/op-release-notes?(.*)\.html$ pipelines/1.$1/release_notes/op-release-notes-1-$1.html [L,R=302]
 
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
main only 

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6332

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
n/a

QE review:
n/a
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This change fixes a redirect used when switching versions in docs.openshift.com when viewing release notes for Pipelines. Doc text is not affected in any way.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
