### PR TITLE
OSDOCS-12809 Monitoring config for managed OpenShift

### DIFF
--- a/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -18,8 +18,11 @@ toc::[]
 Parts of {product-title} cluster monitoring are configurable.
 The API is accessible by setting parameters defined in various config maps.
 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * To configure monitoring components, edit the `ConfigMap` object named `cluster-monitoring-config` in the `openshift-monitoring` namespace.
 These configurations are defined by link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration].
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+
 * To configure monitoring components that monitor user-defined projects, edit the `ConfigMap` object named `user-workload-monitoring-config` in the `openshift-user-workload-monitoring` namespace.
 These configurations are defined by link:#userworkloadconfiguration[UserWorkloadConfiguration].
 


### PR DESCRIPTION
Adding condition to remove unsupported monitoring config instruction from managed OpenShift.

Version(s): 4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12809

Link to docs preview:
- Unchanged for OCP: https://86795--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html
- Bullet omitted in OSD: https://86795--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html
- Bullet omitted in ROSA: https://86795--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html

QE review: N/A