### PR TITLE
OSDOCS#12803: Pausing the node health check in HCP during updates

### DIFF
--- a/modules/hcp-updates-hosted-cluster.adoc
+++ b/modules/hcp-updates-hosted-cluster.adoc
@@ -9,3 +9,12 @@
 The `spec.release` value dictates the version of the control plane. The `HostedCluster` object transmits the intended `spec.release` value to the `HostedControlPlane.spec.release` value and runs the appropriate Control Plane Operator version.
 
 The hosted control plane manages the rollout of the new version of the control plane components along with any {product-title} components through the new version of the Cluster Version Operator (CVO).
+
+[IMPORTANT]
+====
+In {hcp}, the `NodeHealthCheck` resource cannot detect the status of the CVO. A cluster administrator must manually pause the remediation triggered by `NodeHealthCheck`, before performing critical operations, such as updating the cluster, to prevent new remediation actions from interfering with cluster updates.
+
+To pause the remediation, enter the array of strings, for example, `pause-test-cluster`, as a value of the `pauseRequests` field in the `NodeHealthCheck` resource. For more information, see link:https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift/24.4/html/remediation_fencing_and_maintenance/node-health-check-operator#about-node-health-check-operator_node-health-check-operator[About the Node Health Check Operator].
+
+After the cluster update is complete, you can edit or delete the remediation. Navigate to the *Compute* -> *NodeHealthCheck* page, click your node health check, and then click *Actions*, which shows a drop-down list.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12803
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://86799--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-updating.html#hcp-updates-hosted-cluster_hcp-updating
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
