### PR TITLE
OBSDOCS-1561: Add assemblies to the 'About OpenShift Container Platfo…

### DIFF
--- a/modules/monitoring-common-terms.adoc
+++ b/modules/monitoring-common-terms.adoc
@@ -3,7 +3,7 @@
 // * observability/monitoring/monitoring-overview.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="openshift-monitoring-common-terms_{context}"]
+[id="monitoring-common-terms_{context}"]
 = Glossary of common terms for {product-title} monitoring
 
 This glossary defines common terms that are used in {product-title} architecture.

--- a/modules/monitoring-monitoring-stack-in-ha-clusters.adoc
+++ b/modules/monitoring-monitoring-stack-in-ha-clusters.adoc
@@ -3,8 +3,8 @@
 // * observability/monitoring/monitoring-overview.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="understanding-monitoring-stack-in-ha-clusters_{context}"]
-= Understanding the monitoring stack in high-availability clusters
+[id="monitoring-stack-in-ha-clusters_{context}"]
+= The monitoring stack in high-availability clusters
 
 By default, in multi-node clusters, the following components run in high-availability (HA) mode to prevent data loss and service interruption:
 

--- a/modules/monitoring-understanding-the-monitoring-stack.adoc
+++ b/modules/monitoring-understanding-the-monitoring-stack.adoc
@@ -11,11 +11,7 @@
 [id="understanding-the-monitoring-stack_{context}"]
 = Understanding the monitoring stack
 
-The {product-title}
-ifdef::openshift-rosa[]
-(ROSA)
-endif::openshift-rosa[]
-monitoring stack is based on the link:https://prometheus.io/[Prometheus] open source project and its wider ecosystem. The monitoring stack includes the following:
+The monitoring stack includes the following components:
 
 * *Default platform monitoring components*.
 ifndef::openshift-dedicated,openshift-rosa[]

--- a/observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc
+++ b/observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc
@@ -6,7 +6,20 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-TBD
+ifndef::openshift-dedicated,openshift-rosa[]
+{product-title} includes a preconfigured, preinstalled, and self-updating monitoring stack that provides monitoring for core platform components. You also have the option to xref:../../../observability/monitoring/configuring-user-workload-monitoring/before-you-begin-uwm.adoc#enabling-monitoring-for-user-defined-projects-uwm_before-you-begin-uwm[enable monitoring for user-defined projects].
+
+A cluster administrator can xref:../../../observability/monitoring/configuring-core-platform-monitoring/before-you-begin.adoc#before-you-begin[configure the monitoring stack] with the supported configurations. {product-title} delivers monitoring best practices out of the box.
+
+A set of alerts are included by default that immediately notify administrators about issues with a cluster. Default dashboards in the {product-title} web console include visual representations of cluster metrics to help you to quickly understand the state of your cluster. With the {product-title} web console, you can xref:../../../observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc#accessing-metrics-as-an-administrator[access metrics] and xref:../../../observability/monitoring/managing-alerts/managing-alerts-for-core-platform-monitoring.adoc#managing-alerts-for-core-platform-monitoring[manage alerts].
+
+After installing {product-title}, cluster administrators can optionally enable monitoring for user-defined projects. By using this feature, cluster administrators, developers, and other users can specify how services and pods are monitored in their own projects.
+As a cluster administrator, you can find answers to common problems such as user metrics unavailability and high consumption of disk space by Prometheus in xref:../../../observability/monitoring/troubleshooting-monitoring-issues.adoc#troubleshooting-monitoring-issues[Troubleshooting monitoring issues].
+endif::openshift-dedicated,openshift-rosa[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+In {product-title}, you can monitor your own projects in isolation from Red{nbsp}Hat Site Reliability Engineering (SRE) platform metrics. You can monitor your own projects without the need for an additional monitoring solution.
+endif::openshift-dedicated,openshift-rosa[]
 
 
 

--- a/observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture.adoc
+++ b/observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture.adoc
@@ -6,7 +6,41 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-TBD
+The {product-title}
+ifdef::openshift-rosa[]
+(ROSA)
+endif::openshift-rosa[]
+monitoring stack is based on the link:https://prometheus.io/[Prometheus] open source project and its wider ecosystem. The monitoring stack includes default monitoring components and components for monitoring user-defined projects.
+
+// Understanding the monitoring stack
+include::modules/monitoring-understanding-the-monitoring-stack.adoc[leveloffset=+1]
+ifndef::openshift-dedicated,openshift-rosa[]
+//Default monitoring components
+include::modules/monitoring-default-monitoring-components.adoc[leveloffset=+1]
+include::modules/monitoring-default-monitoring-targets.adoc[leveloffset=+2]
+// [role="_additional-resources"]
+// .Additional resources
+// * TBD
+endif::openshift-dedicated,openshift-rosa[]
+
+//Components for monitoring user-defined projects
+include::modules/monitoring-components-for-monitoring-user-defined-projects.adoc[leveloffset=+1]
+include::modules/monitoring-targets-for-user-defined-projects.adoc[leveloffset=+2]
+
+//The monitoring stack in high-availability clusters
+include::modules/monitoring-monitoring-stack-in-ha-clusters.adoc[leveloffset=+1]
+// [role="_additional-resources"]
+// .Additional resources
+// * TBD
+
+//Glossary of common terms for OCP monitoring
+include::modules/monitoring-common-terms.adoc[leveloffset=+1]
+
+// [role="_additional-resources"]
+// [id="additional-resources_monitoring-overview"]
+// == Additional resources
+
+// * TBD
 
 
 

--- a/observability/monitoring/monitoring-overview.adoc
+++ b/observability/monitoring/monitoring-overview.adoc
@@ -39,7 +39,7 @@ include::modules/monitoring-default-monitoring-targets.adoc[leveloffset=+2]
 
 include::modules/monitoring-components-for-monitoring-user-defined-projects.adoc[leveloffset=+2]
 include::modules/monitoring-targets-for-user-defined-projects.adoc[leveloffset=+2]
-include::modules/monitoring-understanding-monitoring-stack-in-ha-clusters.adoc[leveloffset=+2]
+include::modules/monitoring-monitoring-stack-in-ha-clusters.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../operators/operator_sdk/osdk-ha-sno.adoc#osdk-ha-sno[High-availability or single-node cluster detection and support]


### PR DESCRIPTION
Version(s): none for cherry-picking, only merge to monitoring-docs-restructure

Issue: [OBSDOCS-1561](https://issues.redhat.com/browse/OBSDOCS-1561)

Links to docs preview: 

* [About OpenShift Container Platform monitoring](https://86801--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.html)
* [Monitoring stack architecture](https://86801--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture)

QE review: not needed, just moving content around and fixing the xrefs in the about section.

**Additional information:**
The changes it this PR are not yet user-facing.
This PR moves content from old to the new assemblies. The content in the original assembly is still there . The reason is to not lose any content while moving it around. There will be a separate issue that will make sure that all the content is transfered as needed.

Therefore, the main thing to check in this PR is to see if the structure in the linked chapters looks good and renders without issues.

NOTE: The xrefs (additional resources) will be filled in in a different PR, because the content from other assemblies still needs to be moved to the new place, which means that if I filled the links now, I would have to keep repairing them later. So I am keeping that for a separate PR.

Let me know if you have any additional questions, thank you!

The following are the sections that need review (you can find it under Observability -> Monitoring) :
![image](https://github.com/user-attachments/assets/edbeab4a-c782-475e-b6b1-29cb00d3a2ba)
