### PR TITLE
RHDEVDOCS-6335: Enable building standalone doc for Builds 1.3

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -444,6 +444,9 @@ openshift-builds:
     build-docs-1.2:
       name: '1.2'
       dir: builds/1.2
+    build-docs-1.3:
+      name: '1.3'
+      dir: builds/1.3
 openshift-lightspeed:
   name: Red Hat OpenShift Lightspeed
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
Version(s): main only

Issue: https://issues.redhat.com/browse/RHDEVDOCS-6335

Link to docs preview: n/a

QE review: n/a

Additional information:

This PR enables building a new version of a standalone documentation set on docs.openshift.com. This PR does not alter any documentation content, so no documentation preview is available.