### PR TITLE
updating context values from content migration

### DIFF
--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -37,7 +37,7 @@
 // * installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
 
 //Postinstall  and update content
-ifeval::["{context}" == "post-install-cluster-tasks"]
+ifeval::["{context}" == "changing-cloud-credentials-configuration"]
 :postinstall:
 endif::[]
 ifeval::["{context}" == "preparing-manual-creds-update"]
@@ -401,7 +401,7 @@ Use "ccoctl [command] --help" for more information about a command.
 ----
 
 //Postinstall and update content
-ifeval::["{context}" == "post-install-cluster-tasks"]
+ifeval::["{context}" == "changing-cloud-credentials-configuration"]
 :!postinstall:
 endif::[]
 ifeval::["{context}" == "preparing-manual-creds-update"]

--- a/modules/manually-rotating-cloud-creds.adoc
+++ b/modules/manually-rotating-cloud-creds.adoc
@@ -4,7 +4,7 @@
 // * authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
 // * authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
 
-ifeval::["{context}" == "post-install-cluster-tasks"]
+ifeval::["{context}" == "changing-cloud-credentials-configuration"]
 :post-install:
 endif::[]
 ifeval::["{context}" == "cco-mode-mint"]
@@ -227,7 +227,7 @@ Where `<example-iam-username>` is the name of an IAM user on the cloud provider.
 .. For each IAM username, view the details for the user on the cloud provider. The credentials should show that they were created after being rotated on the cluster.
 ////
 
-ifeval::["{context}" == "post-install-cluster-tasks"]
+ifeval::["{context}" == "changing-cloud-credentials-configuration"]
 :!post-install:
 endif::[]
 ifeval::["{context}" == "cco-mode-mint"]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
N/A

Link to docs preview:
[Changing the cloud provider credentials configuration](https://86811--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration.html)

QE review:
N/A

Additional information:
Missed updating a context value when moving content in #77450, this fixes the issue