### PR TITLE
HCIDOCS-572: Changes to be made in "List of Redfish virtual media APIs" section of the BareMetal IPI installation OpenShift documentation

### DIFF
--- a/modules/ipi-install-verifying-support-for-redfish-apis.adoc
+++ b/modules/ipi-install-verifying-support-for-redfish-apis.adoc
@@ -47,14 +47,14 @@ $ curl -u $USER:$PASS -X POST -H'Content-Type: application/json' -H'Accept: appl
 +
 [source,terminal]
 ----
-$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "pxe", "BootSourceOverrideEnabled": "Once"}}
+$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" -H "If-Match: <ETAG>"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "pxe", "BootSourceOverrideEnabled": "Once"}}
 ----
 
-. Check the status of setting the BIOS boot mode that uses `Legacy` or `UEFI` by running the following command:
+. Check the status of setting the firmware boot mode that uses `Legacy` or `UEFI` by running the following command:
 +
 [source,terminal]
 ----
-$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideMode":"UEFI"}}
+$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" -H "If-Match: <ETAG>"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideMode":"UEFI"}}
 ----
 
 .List of Redfish virtual media APIs
@@ -63,19 +63,24 @@ $ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json"  https://$Ser
 +
 [source,terminal]
 ----
-$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "cd", "BootSourceOverrideEnabled": "Once"}}'
+$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" -H "If-Match: <ETAG>" https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "cd", "BootSourceOverrideEnabled": "Once"}}'
 ----
 
-. Check the ability to mount virtual media by running the following command:
+. Virtual media might use `POST` or `PATCH`, depending on your hardware. Check the ability to mount virtual media by running one of the following commands:
 +
 [source,terminal]
 ----
-$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" -H "If-Match: *" https://$Server/redfish/v1/Managers/$ManagerID/VirtualMedia/$VmediaId -d '{"Image": "https://example.com/test.iso", "TransferProtocolType": "HTTPS", "UserName": "", "Password":""}'
+$ curl -u $USER:$PASS -X POST -H "Content-Type: application/json" https://$Server/redfish/v1/Managers/$ManagerID/VirtualMedia/$VmediaId -d '{"Image": "https://example.com/test.iso", "TransferProtocolType": "HTTPS", "UserName": "", "Password":""}'
+----
++
+[source,terminal]
+----
+$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" -H "If-Match: <ETAG>" https://$Server/redfish/v1/Managers/$ManagerID/VirtualMedia/$VmediaId -d '{"Image": "https://example.com/test.iso", "TransferProtocolType": "HTTPS", "UserName": "", "Password":""}'
 ----
 
 [NOTE]
 ====
-The `PowerOn` and `PowerOff` commands for Redfish APIs are the same for the Redfish virtual media APIs.
+The `PowerOn` and `PowerOff` commands for Redfish APIs are the same for the Redfish virtual media APIs. In some hardware, you might only find the `VirtualMedia` resource under `Systems/$SystemID` instead of `Managers/$ManagerID`. For the `VirtualMedia` resource, the `UserName` and `Password` fields are optional.
 ====
 
 [IMPORTANT]


### PR DESCRIPTION
Fixes bugs reported in [HCIDOCS-572](https://issues.redhat.com//browse/HCIDOCS-572).

Fixes: [HCIDOCS-572](https://issues.redhat.com//browse/HCIDOCS-572)

See https://issues.redhat.com/browse/HCIDOCS-572 for additional details.

Preview URL: https://86819--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#verifying-support-for-redfish-apis_ipi-install-installation-workflow

For release(s): 4.16-4.18
QE Review: 

- [x] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
