### PR TITLE
OCPBUGS-48180: modules/containers-signature-verify-skopeo: security.access.redhat.com key source

### DIFF
--- a/modules/containers-signature-verify-skopeo.adoc
+++ b/modules/containers-signature-verify-skopeo.adoc
@@ -35,7 +35,7 @@ Pull From: quay.io/openshift-release-dev/ocp-release@sha256:e73ab4b33a9c3ff00c9f
 +
 [source,terminal]
 ----
-$ curl -o pub.key https://access.redhat.com/security/data/fd431d51.txt
+$ curl -Lo pub.key https://security.access.redhat.com/data/fd431d51.txt
 ----
 
 . Get the signature file for the specific release that you want to verify by running the following command:


### PR DESCRIPTION
Version(s): 4.12+

Issue: 
[OCPBUGS-48180](https://issues.redhat.com/browse/OCPBUGS-48180)

Link to docs preview:
[Using skopeo to verify signatures of Red Hat container images, step 2](https://86821--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/container_security/security-container-signature.html#containers-signature-verify-skopeo_security-container-signature)

QE review:
- [ ] QE has approved this change.