### PR TITLE
HCIDOCS-260: Clarification on configuring RAID with RHOCP 

### DIFF
--- a/modules/bmo-about-the-baremetalhost-resource.adoc
+++ b/modules/bmo-about-the-baremetalhost-resource.adoc
@@ -94,12 +94,12 @@ a|  (Optional) Contains the information about the RAID configuration for bare me
 
 [NOTE]
 ====
-{product-title} {product-version} supports hardware RAID for BMCs, including:
+{product-title} {product-version} supports hardware RAID on the installation drive for BMCs, including:
 
 * Fujitsu iRMC with support for RAID levels 0, 1, 5, 6, and 10
 * Dell iDRAC using the Redfish API with firmware version 6.10.30.20 or later and RAID levels 0, 1, and 5
 
-{product-title} {product-version} does not support software RAID.
+{product-title} {product-version} does not support software RAID on the installation drive.
 ====
 
 See the following configuration settings:
@@ -114,7 +114,7 @@ See the following configuration settings:
 ** `rotational`: If set to `true`, it will only select rotational disk drives. If set to `false`, it will only select solid-state and NVMe drives. If not set, it selects any drive types, which is the default behavior.
 ** `sizeGibibytes`: The size of the logical drive as an integer to create in GiB. If unspecified or set to `0`, it will use the maximum capacity of physical drive for the logical drive.
 
-* `softwareRAIDVolumes`: {product-title} {product-version} does not support software RAID. The following information is for reference only. This configuration contains the list of logical disks for software RAID. If you do not specify `rootDeviceHints`, the first volume is the root volume. If you set `HardwareRAIDVolumes`, this item will be invalid. Software RAIDs will always be deleted. The number of created software RAID devices must be `1` or `2`. If there is only one software RAID device, it must be `RAID-1`. If there are two RAID devices, the first device must be `RAID-1`, while the RAID level for the second device can be `0`, `1`, or `1+0`. The first RAID device will be the deployment device. Therefore, enforcing `RAID-1` reduces the risk of a non-booting node in case of a device failure. The `softwareRAIDVolume` field defines the desired configuration of the volume in the software RAID. The sub-fields are:
+* `softwareRAIDVolumes`: {product-title} {product-version} does not support software RAID on the installation drive. This configuration contains the list of logical disks for software RAID. If you do not specify `rootDeviceHints`, the first volume is the root volume. If you set `HardwareRAIDVolumes`, this item will be invalid. Software RAIDs will always be deleted. The number of created software RAID devices must be `1` or `2`. If there is only one software RAID device, it must be `RAID-1`. If there are two RAID devices, the first device must be `RAID-1`, while the RAID level for the second device can be `0`, `1`, or `1+0`. The first RAID device will be the deployment device, which cannot be a software RAID volume. Enforcing `RAID-1` reduces the risk of a non-booting node in case of a device failure. The `softwareRAIDVolume` field defines the desired configuration of the volume in the software RAID. The sub-fields are:
 
 ** `level`: The RAID level for the logical drive. The following levels are supported: `0`,`1`,`1+0`.
 ** `physicalDisks`: A list of device hints. The number of items should be greater than or equal to `2`.

--- a/modules/installation-special-config-raid.adoc
+++ b/modules/installation-special-config-raid.adoc
@@ -7,6 +7,11 @@
 
 You can enable software RAID partitioning to provide an external data volume. {product-title} supports RAID 0, RAID 1, RAID 4, RAID 5, RAID 6, and RAID 10 for data protection and fault tolerance. See "About disk mirroring" for more details.
 
+[NOTE]
+====
+{product-title} {product-version} does not support software RAIDs on the installation drive.
+====
+
 .Prerequisites
 
 * You have downloaded the {product-title} installation program on your installation node.


### PR DESCRIPTION
Clarifies that software RAID is not support on installation drives. It is supported for storage drives.

Fixes: [HCIDOCS-260](https://issues.redhat.com//browse/HCIDOCS-260)

See https://issues.redhat.com/browse/HCIDOCS-260 for additional details.

Preview URL: https://86823--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html and https://86823--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.html#bmo-about-the-baremetalhost-resource_ipi-install-post-installation-configuration

For release(s): 4.14-4.18
QE Review: 

- [x] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
