### PR TITLE
OSDOCS-12836:  Changing default value from 15 to 11.

### DIFF
--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -8,8 +8,15 @@
 
 By default, Prometheus retains metrics data for the following durations:
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * *Core platform monitoring*: 15 days
 * *Monitoring for user-defined projects*: 24 hours
+endif::openshift-dedicated,openshift-rosa[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+* *Core platform monitoring*: 11 days
+* *Monitoring for user-defined projects*: 24 hours
+endif::openshift-dedicated,openshift-rosa[]
 
 You can modify the retention time for
 ifndef::openshift-dedicated,openshift-rosa[]
@@ -26,12 +33,22 @@ Note the following behaviors of these data retention settings:
 * Data in the `/wal` and `/head_chunks` directories counts toward the retention size limit, but Prometheus never purges data from these directories based on size- or time-based retention policies.
 Thus, if you set a retention size limit lower than the maximum size set for the `/wal` and `/head_chunks` directories, you have configured the system not to retain any data blocks in the `/prometheus` data directories.
 * The size-based retention policy is applied only when Prometheus cuts a new data block, which occurs every two hours after the WAL contains at least three hours of data.
+ifndef::openshift-dedicated,openshift-rosa[]
 * If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 15 days for core platform monitoring and 24 hours for user-defined project monitoring. Retention size is not set.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 11 days for core platform monitoring and 24 hours for user-defined project monitoring. Retention size is not set.
+endif::openshift-dedicated,openshift-rosa[]
 * If you define values for both `retention` and `retentionSize`, both values apply.
 If any data blocks exceed the defined retention time or the defined size limit, Prometheus purges these data blocks.
 * If you define a value for `retentionSize` and do not define `retention`, only the `retentionSize` value applies.
 * If you do not define a value for `retentionSize` and only define a value for `retention`, only the `retention` value applies.
+ifndef::openshift-dedicated,openshift-rosa[]
 * If you set the `retentionSize` or `retention` value to `0`, the default settings apply. The default settings set retention time to 15 days for core platform monitoring and 24 hours for user-defined project monitoring. By default, retention size is not set.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* If you set the `retentionSize` or `retention` value to `0`, the default settings apply. The default settings set retention time to 11 days for core platform monitoring and 24 hours for user-defined project monitoring. By default, retention size is not set.
+endif::openshift-dedicated,openshift-rosa[]
 
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
enterprise-4.18+

Issue:
[OSDOCS-12836](https://issues.redhat.com/browse/OSDOCS-12836)

Link to docs preview:

- [ROSA: Modifying the retention time and size for Prometheus metrics data](https://86835--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/monitoring/configuring-the-monitoring-stack.html#modifying-retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack) - Says 11 days

- [OSD: Modifying the retention time and size for Prometheus metrics data](https://86835--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/monitoring/configuring-the-monitoring-stack.html#modifying-retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack) - Says 11 days

- [OCP: Modifying the retention time and size for Prometheus metrics data](https://86835--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#modifying-retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack) - Says 15 days


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
