### PR TITLE
Fixing OTEL Processor wrong snippet for memory_limiter

### DIFF
--- a/observability/otel/otel-collector/otel-collector-processors.adoc
+++ b/observability/otel/otel-collector/otel-collector-processors.adoc
@@ -76,9 +76,9 @@ The Memory Limiter Processor periodically checks the Collector's memory usage an
     service:
       pipelines:
         traces:
-          processors: [batch]
+          processors: [memory_limiter]
         metrics:
-          processors: [batch]
+          processors: [memory_limiter]
 # ...
 ----
 


### PR DESCRIPTION
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.13, 4.14, 4.15, 4.16, 4.17, 4.18

Issue:
N/A

Link to docs preview:
N/A

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Fixes minor copy/paste error - the memory_limiter processor is not used in the snippet because it references the batch processor instead.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
