### PR TITLE
OSDOCS#13013: Restarting components in hcp

### DIFF
--- a/modules/hosted-restart-hcp-components.adoc
+++ b/modules/hosted-restart-hcp-components.adoc
@@ -10,21 +10,26 @@ If you are an administrator for hosted control planes, you can use the `hypershi
 
 .Procedure
 
-To restart a control plane, annotate the `HostedCluster` resource by entering the following command:
-
+* To restart a control plane, annotate the `HostedCluster` resource by entering the following command:
++
 [source,terminal]
 ----
 $ oc annotate hostedcluster \
   -n <hosted_cluster_namespace> \
   <hosted_cluster_name> \
-  hypershift.openshift.io/restart-date=$(date --iso-8601=seconds)
+  hypershift.openshift.io/restart-date=$(date --iso-8601=seconds) <1>
 ----
+<1> The control plane is restarted whenever the value of the annotation changes. The `date` command serves as the source of a unique string. The annotation is treated as a string, not a timestamp.
+
 
 .Verification
 
-The control plane is restarted whenever the value of the anonotation changes. The `date` command in the example serves as the source of a unique string. The annotation is treated as a string, not a timestamp.
+After you restart a control plane, the following {hcp} components are typically restarted:
 
-The following components are restarted:
+[NOTE]
+====
+You might see some additional components restarting as a side effect of changes implemented by the other components.
+====
 
 * catalog-operator
 * certified-operators-catalog


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13013
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
https://86843--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting.html#hosted-restart-hcp-components_hcp-troubleshooting
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
