### PR TITLE
TELCODOCS-2152: adding note for character limit in IBI deployment with extra manifests

### DIFF
--- a/modules/ibi-extra-manifests-configmap.adoc
+++ b/modules/ibi-extra-manifests-configmap.adoc
@@ -17,6 +17,11 @@ You can use a `ConfigMap` resource to add extra manifests to the image-based dep
 
 The following example adds an single-root I/O virtualization (SR-IOV) network to the deployment.
 
+[NOTE]
+====
+Filenames for extra manifests must not exceed 30 characters. Longer filenames might cause deployment failures. 
+====
+
 .Prerequisites
 
 * You preinstalled a host with {sno} using an image-based installation.

--- a/modules/ibi-extra-manifests-standalone.adoc
+++ b/modules/ibi-extra-manifests-standalone.adoc
@@ -10,6 +10,11 @@ You can optionally define additional resources in an image-based deployment for 
 
 Create the additional resources in an `extra-manifests` folder in the same working directory that has the `install-config.yaml` and `image-based-config.yaml` manifests.
 
+[NOTE]
+====
+Filenames for additional resources in the `extra-manifests` directory must not exceed 30 characters. Longer filenames might cause deployment failures. 
+====
+
 == Creating a resource in the extra-manifests folder
 
 You can create a resource in the `extra-manifests` folder of your working directory to add extra manifests to the image-based deployment for {sno} clusters.


### PR DESCRIPTION
[TELCODOCS-2152](https://issues.redhat.com//browse/TELCODOCS-2152): adding note for character limit in IBI deployment with extra manifests

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2152

Link to docs preview:
- https://86844--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install-standalone.html#ibi-extra-manifest-standalone_ibi-edge-image-based-install
- https://86844--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install.html#ibi-create-extra-manifest-configmap_ibi-edge-image-based-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
