### PR TITLE
OSDOCS-13061: DOcumented the 4.17.12 z-stream notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1982,7 +1982,7 @@ metadata:
 
 * Previously, if your `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) is set to use the default spanning tree protocol (STP) implementation, the CR configuration file would show `stp.enabled: true`, but the {product-title} web console cleared the STP checkbox. With this release, the web console only clears the STEP checkbox after you define `stp.enabled: false` in the NNCP CR YAML file. (link:https://issues.redhat.com/browse/OCPBUGS-36238[*OCPBUGS-36238*])
 
-* Previously, the Ingress Controller status was incorrectly displayed as `Degraded=False` because of a migration time issue with the `CanaryRepetitiveFailures` condition. With this release, the Ingress Controller status is correctly marked as `Degraded=True` for the appropriate length of time that the `CanaryRepetitiveFailures` condition exists. (link:https://issues.redhat.com/browse/OCPBUGS-39220[*OCPBUGS-39220*])
+* Previously, the Ingress Controller status was incorrectly displayed as `Degraded=False` because of a timing update issue with the `CanaryRepetitiveFailures` condition. With this release, the Ingress Controller status is correctly marked as `Degraded=True` for the appropriate length of time that the `CanaryRepetitiveFailures` condition exists. (link:https://issues.redhat.com/browse/OCPBUGS-39220[*OCPBUGS-39220*])
 
 [discrete]
 [id="ocp-4-17-node-bug-fixes_{context}"]
@@ -2871,6 +2871,27 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+// 4.17.12
+[id="ocp-4-17-12_{context}"]
+=== RHSA-2025:0115 - {product-title} {product-version}.12 bug fix, and security update advisory
+
+Issued: 14 January 2025
+
+{product-title} release {product-version}.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0115[RHSA-2025:0115] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0118[RHBA-2025:0118] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.12 --pullspecs
+----
+
+[id="ocp-4-17-12-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.17.11
 [id="ocp-4-17-11_{context}"]


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13061](https://issues.redhat.com/browse/OSDOCS-13061)

Link to docs preview:
[4.17.12](https://86852--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-12_release-notes)
