### PR TITLE
OSDOCS-13025: Documented the 4.16.29 z-stream notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3342,6 +3342,47 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.29
+[id="ocp-4-16-29_{context}"]
+=== RHBA-2025:0018 - {product-title} {product-version}.29 bug fix and security update
+
+Issued: 09 January 2025
+
+{product-title} release {product-version}.29 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:0018[RHBA-2025:0018] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0021[RHBA-2025:0021] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.29 --pullspecs
+----
+
+[id="ocp-4-16-29-enhancements_{context}"]
+==== Enhancements
+
+[id="ocp-4-16-29-node-tuning-operator_{context}"]
+===== Node Tuning Operator architecture detection
+
+The Node Tuning Operator can now properly select kernel arguments and management options for Intel and AMD CPUs. (link:https://issues.redhat.com/browse/OCPBUGS-46496[*OCPBUGS-46496*]) 
+
+[id="ocp-4-16-29-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, if you deleted the default `sriovOperatorConfig` custom resource (CR), you could not recreate the default `sriovOperatorConfig` CR, because the `ValidatingWebhookConfiguration` was not initially deleted. With this release, the Single Root I/O Virtualization (SR-IOV) Network Operator removes validating webhooks when you delete the `sriovOperatorConfig` CR, so that you can create a new `sriovOperatorConfig` CR. (link:https://issues.redhat.com/browse/OCPBUGS-44727[*OCPBUGS-44727*])
+
+* Previously, users could enter an invalid string for any CPU set in the performance profile, resulting in a broken cluster. With this release, the fix ensures that only valid strings can be entered, eliminating the risk of cluster breakage. (link:https://issues.redhat.com/browse/OCPBUGS-47678[*OCPBUGS-47678*])
+
+* Previously, the installation of an {aws-full} cluster failed when the service control policy (SCP) had `false` specified for its `AssociatePublicIpAddress` parameter. With this release, a fix ensures that this SCP configuration no longer causes the installation of an {aws-short} cluster to fail. (link:https://issues.redhat.com/browse/OCPBUGS-46508[*OCPBUGS-46508*])
+
+* Previously, the IDs that were used to determine the number of rows in a Dashboard table were not unique, and some rows were combined if their IDs were the same. With this release, the ID uses more information to prevent duplicate IDs and the table can display each expected row. (link:https://issues.redhat.com/browse/OCPBUGS-45334[*OCPBUGS-45334*])
+
+[id="ocp-4-16-29-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 //4.16.28
 [id="ocp-4-16-28_{context}"]
 === RHBA-2024:11502 - {product-title} {product-version}.28 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-13025](https://issues.redhat.com/browse/OSDOCS-13025)

Link to docs preview:
[4.16.29](https://86860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-29_release-notes)

