### PR TITLE
OSDOCS-13027-year-fix

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5032,7 +5032,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-71_{context}"]
 === RHSA-2025:0014 - {product-title} 4.12.71 bug fix and security update
 
-Issued: 09 January 2024
+Issued: 09 January 2025
 
 {product-title} release 4.12.71 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0014[RHSA-2025:0014] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0016[RHBA-2025:0016] advisory.
 


### PR DESCRIPTION
FIXES THE WRONG YEAR STATED ON https://github.com/openshift/openshift-docs/pull/86680

Version(s):
4.12

Issue:
[OSDOCS-13027](https://issues.redhat.com/browse/OSDOCS-13027)

Link to docs preview:
[4.12.71](https://86861--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-71_release-notes)

