### PR TITLE
OSSM-8312: Wrong namespace in examples

### DIFF
--- a/modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc
@@ -1,14 +1,13 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-accessing-bookinfo-application-using-istio-gateway-injection_{context}"]
 = Accessing the Bookinfo application by using Istio gateway injection
-:context: ossm-accessing-bookinfo-application-using-istio-gateway-injection
 
 Gateway injection uses the same mechanisms as {istio} sidecar injection to create a gateway from a `Deployment` resource that is paired with a `Service` resource. The `Service` resource can be made accessible from outside an {ocp-product-title} cluster.
 
-.Prerequisties
+.Prerequisites
 
 * You are logged in to the {ocp-product-title} web console as `cluster-admin`.
 
@@ -18,7 +17,7 @@ Gateway injection uses the same mechanisms as {istio} sidecar injection to creat
 
 .Procedure
 
-. Create the `istio-ingressgateway` deployment and service by running the following command at the CLI:
+. Create the `istio-ingressgateway` deployment and service by running the following command:
 +
 [source,terminal]
 ----
@@ -30,7 +29,7 @@ $ oc apply -n bookinfo -f ingress-gateway.yaml
 This example uses a sample `ingress-gateway.yaml` https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/chart/samples/ingress-gateway.yaml[file] that is available in the Istio community repository. 
 ====
 
-. Configure the `bookinfo` application to use the new gateway by applying the gateway configuration: 
+. Configure the `bookinfo` application to use the new gateway. Apply the gateway configuration by running the following command: 
 +
 [source,terminal]
 ----
@@ -42,15 +41,16 @@ $ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.23/samples
 To configure gateway injection with the `bookinfo` application, this example uses a sample gateway configuration file that must be applied in the namespace where the application is installed.
 ====
 
-. Use a route to expose the gateway external to the cluster:
+. Use a route to expose the gateway external to the cluster by running the following command:
 +
 [source,terminal]
 ----
 $ oc expose service istio-ingressgateway -n bookinfo
 ----
 
-. Automatically scale the pod when ingress traffic increases. This example sets the minimum replicas to `2` and the maximum replicas to `5`. It also creates another replica when utilization reaches 80%.
+. Modify the YAML file to automatically scale the pod when ingress traffic increases.
 +
+.Example configuration
 [source,yaml]
 ----
 apiVersion: autoscaling/v2
@@ -60,9 +60,9 @@ metadata:
     istio: ingressgateway
     release: istio
   name: ingressgatewayhpa
-  namespace: istio-ingress
+  namespace: bookinfo
 spec:
-  maxReplicas: 5
+  maxReplicas: 5 <1>
   metrics:
   - resource:
       name: cpu
@@ -76,9 +76,11 @@ spec:
     kind: Deployment
     name: istio-ingressgateway
 ----
+<1> This example sets the the maximum replicas to `5` and the minimum replicas to `2`. It also creates another replica when utilization reaches 80%.
 
-. Specify the minimum number of pods that must be running on the node. This example ensures one replica is running if a pod gets restarted on a new node.
+. Specify the minimum number of pods that must be running on the node. 
 +
+.Example configuration
 [source,yaml]
 ----
 apiVersion: policy/v1
@@ -88,20 +90,25 @@ metadata:
     istio: ingressgateway
     release: istio
   name: ingressgatewaypdb
-  namespace: istio-ingress
+  namespace: bookinfo
 spec:
-  minAvailable: 1
+  minAvailable: 1 <1>
   selector:
     matchLabels:
       istio: ingressgateway
 ----
+<1> This example ensures one replica is running if a pod gets restarted on a new node.
 
-. Obtain the gateway host name and the URL for the product page:
+. Obtain the gateway host name and the URL for the product page by running the following command:
 +
 [source,terminal]
 ----
 $ HOST=$(oc get route istio-ingressgateway -n bookinfo -o jsonpath='{.spec.host}')
-$ echo productpage URL: http://$HOST/productpage 
 ----
 
-. Verify that the `productpage` is accessible from a web browser.
+. Verify that the `productpage` is accessible from a web browser by running the following command:
++
+[source,terminal]
+----
+$ echo productpage URL: http://$HOST/productpage 
+----


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OSSM-8312
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://86868--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#ossm-accessing-bookinfo-application-using-istio-gateway-injection_ossm-about-accessing-bookinfo-application-using-gateway
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
