### PR TITLE
[OCPBUGS-48114]: HCP doc fixes: node pool description and sizing guidance

### DIFF
--- a/hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Many factors, including hosted cluster workload and worker node count, affect how many hosted clusters can fit within a certain number of control-plane nodes. Use this sizing guide to help with hosted cluster capacity planning. This guidance assumes a highly available {hcp} topology. The load-based sizing examples were measured on a bare-metal cluster. Cloud-based instances might have different limiting factors, such as memory size.
+Many factors, including hosted cluster workload and worker node count, affect how many hosted control planes can fit within a certain number of worker nodes. Use this sizing guide to help with hosted cluster capacity planning. This guidance assumes a highly available {hcp} topology. The load-based sizing examples were measured on a bare-metal cluster. Cloud-based instances might have different limiting factors, such as memory size.
 
 You can override the following resource utilization sizing measurements and disable the metric service monitoring.
 

--- a/modules/hosted-control-planes-concepts-personas.adoc
+++ b/modules/hosted-control-planes-concepts-personas.adoc
@@ -27,7 +27,7 @@ management cluster:: An {product-title} cluster where the HyperShift Operator is
 
 management cluster infrastructure:: Network, compute, and storage resources of the management cluster.
 
-node pool:: A resource that contains the compute nodes. The control plane contains node pools. The compute nodes run applications and workloads.
+node pool:: A resource that manages a set of compute nodes that are associated with a hosted cluster. The compute nodes run applications and workloads within the hosted cluster. 
 
 [id="hosted-control-planes-personas_{context}"]
 == Personas


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-48114
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Sizing guidance: https://86869--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-sizing-guidance.html
- Concepts: https://86869--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/#hosted-control-planes-concepts_hcp-overview (see entry for "node pool")
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
