### PR TITLE
OSDOCS-6962#adding custom IPv4 support

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -407,6 +407,15 @@ endif::ibm-power-vs[]
 Set the `networking.machineNetwork` to match the CIDR that the preferred NIC resides in.
 ====
 
+|networking:
+  ovnKubernetesConfig:
+    ipv4:
+      internalJoinSubnet:
+|
+Configures the IPv4 join subnet that is used internally by `ovn-kubernetes`. This subnet must not overlap with any other subnet that {product-title} is using, including the node network. The size of the subnet must be larger than the number of nodes. You cannot change the value after installation.
+
+|An IP network block in CIDR notation. The default value is `100.64.0.0/16`.
+
 |====
 
 [id="installation-configuration-parameters-optional_{context}"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-6962

Link to docs preview:
[Network configuration parameters](https://86874--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-network_installation-config-parameters-aws)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
