### PR TITLE
OCPBUGS-37110: fix security group tag in MAPI docs

### DIFF
--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -59,49 +59,49 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id> 
 ifdef::edge[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
 ifndef::infra,edge[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> 
 endif::infra,edge[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> 
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id> 
 ifndef::infra,edge[]
         machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
+        machine.openshift.io/cluster-api-machine-type: <role> 
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> 
 endif::infra,edge[]
 ifdef::infra[]
         machine.openshift.io/cluster-api-machine-role: infra <3>
-        machine.openshift.io/cluster-api-machine-type: infra <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
+        machine.openshift.io/cluster-api-machine-type: infra 
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> 
 endif::infra[]
 ifdef::edge[]
         machine.openshift.io/cluster-api-machine-role: edge <3>
-        machine.openshift.io/cluster-api-machine-type: edge <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone> <2>
+        machine.openshift.io/cluster-api-machine-type: edge 
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone> 
 endif::edge[]
     spec:
       metadata:
         labels:
 ifndef::infra,edge[]
-          node-role.kubernetes.io/<role>: "" <3>
+          node-role.kubernetes.io/<role>: "" 
 endif::infra,edge[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <3>
+          node-role.kubernetes.io/infra: "" 
 endif::infra[]
 ifdef::edge[]
           machine.openshift.io/parent-zone-name: <value_of_ParentZoneName>
           machine.openshift.io/zone-group: <value_of_GroupName>
           machine.openshift.io/zone-type: <value_of_ZoneType>
-          node-role.kubernetes.io/edge: "" <3>
+          node-role.kubernetes.io/edge: "" 
 endif::edge[]
       providerSpec:
         value:
@@ -117,7 +117,7 @@ endif::edge[]
             name: aws-cloud-credentials
           deviceIndex: 0
           iamInstanceProfile:
-            id: <infrastructure_id>-worker-profile <1>
+            id: <infrastructure_id>-worker-profile 
           instanceType: m6i.large
           kind: AWSMachineProviderConfig
           placement:
@@ -127,7 +127,11 @@ endif::edge[]
             - filters:
                 - name: tag:Name
                   values:
-                    - <infrastructure_id>-worker-sg <1>
+                    - <infrastructure_id>-node
+            - filters:
+                - name: tag:Name
+                  values:
+                    - <infrastructure_id>-lb
           subnet:
 ifndef::edge[]
             filters:
@@ -140,10 +144,10 @@ ifdef::edge[]
           publicIp: true
 endif::edge[]
           tags:
-            - name: kubernetes.io/cluster/<infrastructure_id> <1>
+            - name: kubernetes.io/cluster/<infrastructure_id> 
               value: owned
             - name: <custom_tag_name> <5>
-              value: <custom_tag_value> <5>
+              value: <custom_tag_value> 
           userDataSecret:
             name: worker-user-data
 ifdef::infra,edge[]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
OCPBUGS-37110

Link to docs preview:
- [Sample YAML for a compute machine set custom resource on AWS](https://86879--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machineset-yaml-aws_creating-machineset-aws) (compute)
- [Sample YAML for a compute machine set custom resource on AWS](https://86879--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-aws_creating-infrastructure-machinesets) (infra)

QE review:
- [x] QE has approved this change.

Additional information:
Also deduplicated reused callouts since that formatting is not supported