### PR TITLE
OCPBUGS48047 As per the document it does not states that 'evictionPressureTransitionPeriod configuration' cannot be set to '0s'.

### DIFF
--- a/modules/microshift-low-latency-config-yaml.adoc
+++ b/modules/microshift-low-latency-config-yaml.adoc
@@ -44,7 +44,7 @@ kubelet: <1>
     memory.available: "100Mi" # <9>
     nodefs.available: "10%" # <10>
     nodefs.inodesFree: "5%" # <11>
-  evictionPressureTransitionPeriod: 0s
+  evictionPressureTransitionPeriod: 5m <12>
 # ...
 ----
 <1> If you change the CPU or memory managers in the kubelet configuration, you must remove files that cache the previous configuration. Restart the host to remove them automatically, or manually remove the `/var/lib/kubelet/cpu_manager_state` and `/var/lib/kubelet/memory_manager_state` files.
@@ -58,6 +58,7 @@ kubelet: <1>
 <9> In this example, the `evictionHard.memory.available` parameter means that the pods are evicted when the available memory of the node drops below 100MiB.
 <10> In this example, the `evictionHard.nodefs.available` parameter means that the pods are evicted when the main filesystem of the node has less than 10% available space.
 <11> In this example, the `evictionHard.nodefs.inodesFree` parameter means that the pods are evicted when more than 15% of the node's main filesystem's inodes are in use.
+<12> For container garbage collection: The duration to wait before transitioning out of an eviction pressure condition. Setting the `evictionPressureTransitionPeriod` parameter to `0` configures the default value of 5 minutes.
 
 .Verification
 

--- a/modules/microshift-low-latency-install-kernelrt-rhel-edge.adoc
+++ b/modules/microshift-low-latency-install-kernelrt-rhel-edge.adoc
@@ -60,7 +60,7 @@ kubelet:
     memory.available: 100Mi
     nodefs.available: 10%
     nodefs.inodesFree: 5%
-  evictionPressureTransitionPeriod: 0s
+  evictionPressureTransitionPeriod: 5m
 """
 
 [[customizations.files]]

--- a/modules/microshift-low-latency-rhel-edge-blueprint-rtk.adoc
+++ b/modules/microshift-low-latency-rhel-edge-blueprint-rtk.adoc
@@ -79,7 +79,7 @@ kubelet:
     memory.available: 100Mi
     nodefs.available: 10%
     nodefs.inodesFree: 5%
-  evictionPressureTransitionPeriod: 0s
+  evictionPressureTransitionPeriod: 5m
 """
 
 [[customizations.files]]

--- a/modules/nodes-nodes-garbage-collection-configuring.adoc
+++ b/modules/nodes-nodes-garbage-collection-configuring.adoc
@@ -102,7 +102,7 @@ spec:
       nodefs.inodesFree: "4%"
       imagefs.available: "10%"
       imagefs.inodesFree: "5%"
-    evictionPressureTransitionPeriod: 0s <7>
+    evictionPressureTransitionPeriod: 3m <7>
     imageMinimumGCAge: 5m <8>
     imageGCHighThresholdPercent: 80 <9>
     imageGCLowThresholdPercent: 75 <10>
@@ -115,7 +115,7 @@ spec:
 <5> For container garbage collection: Grace periods for the soft eviction. This parameter does not apply to `eviction-hard`.
 <6> For container garbage collection: Eviction thresholds based on a specific eviction trigger signal.
 For `evictionHard` you must specify all of these parameters.  If you do not specify all parameters, only the specified parameters are applied and the garbage collection will not function properly.
-<7> For container garbage collection: The duration to wait before transitioning out of an eviction pressure condition.
+<7> For container garbage collection: The duration to wait before transitioning out of an eviction pressure condition. Setting the `evictionPressureTransitionPeriod` parameter to `0` configures the default value of 5 minutes.
 <8> For image garbage collection: The minimum age for an unused image before the image is removed by garbage collection.
 <9> For image garbage collection: The percent of disk usage (expressed as an integer) that triggers image garbage collection.
 <10> For image garbage collection: The percent of disk usage (expressed as an integer) that image garbage collection attempts to free.

--- a/modules/nodes-nodes-garbage-collection-containers.adoc
+++ b/modules/nodes-nodes-garbage-collection-containers.adoc
@@ -41,4 +41,9 @@ For `evictionHard` you must specify all of these parameters.  If you do not spec
 
 If a node is oscillating above and below a soft eviction threshold, but not exceeding its associated grace period, the corresponding node would constantly oscillate between `true` and `false`. As a consequence, the scheduler could make poor scheduling decisions.
 
-To protect against this oscillation, use the `eviction-pressure-transition-period` flag to control how long {product-title} must wait before transitioning out of a pressure condition. {product-title} will not set an eviction threshold as being met for the specified pressure condition for the period specified before toggling the condition back to false.
+To protect against this oscillation, use the `evictionpressure-transition-period` flag to control how long {product-title} must wait before transitioning out of a pressure condition. {product-title} will not set an eviction threshold as being met for the specified pressure condition for the period specified before toggling the condition back to false.
+
+[NOTE]
+====
+Setting the `evictionPressureTransitionPeriod` parameter to `0` configures the default value of 5 minutes. You cannot set an eviction pressure transition period to zero seconds. 
+====


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-48047

Add note that setting `evictionPressureTransitionPeriod` to `0s` actually sets the parameter to the default `5m`.

Previews
* MicroShift ->Configuring low latency -> Configuring low latency -> [Configuration kubelet parameters and values in MicroShift](https://86885--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift_low_latency/microshift-low-latency.html#microshift-low-latency-config-yaml_microshift-low-latency) -- Added a call-out 12 for the procedure with a sentence about setting the parameter to 0s. Changed the parameter value from 0s to 5m.
* MicroShift ->Configuring low latency -> Configuring low latency -> [Installing the Red Hat Enterprise Linux for Real Time (real-time kernel) in a RHEL for Edge image](https://86885--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift_low_latency/microshift-low-latency.html#microshift-low-latency-install-kernelrt-rhel-edge_microshift-low-latency) -- Changed the parameter value from 0s to 5m.
* MicroShift ->Configuring low latency -> Configuring low latency -> [Reference blueprint for installing Red Hat Enterprise Linux for Real Time (real-time kernel) in a RHEL for Edge image ](https://86885--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift_low_latency/microshift-low-latency.html#microshift-low-latency-blueprint-rhel-edge-rtk_microshift-low-latency)-- Changed the parameter value from 0s to 5m 
* OCP -> Nodes -> Working with nodes -> Freeing node resources using garbage collection -> [Configuring garbage collection for containers and images](https://86885--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring) -- Changed the parameter value in callout 7 from 0s to 3m. Added a sentence about setting the parameter to 0s.
*  OCP -> Nodes -> Working with nodes -> Freeing node resources using garbage collection -> [Understanding how terminated containers are removed through garbage collection](https://86885--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#nodes-nodes-garbage-collection-containers_post-install-node-tasks) -- Added a note about setting the parameter to 0s. 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

