### PR TITLE
OSDOCS#13249: Convert OLM common terms to snippet

### DIFF
--- a/extensions/of-terms.adoc
+++ b/extensions/of-terms.adoc
@@ -8,4 +8,4 @@ toc::[]
 
 The following terms are related to the Operator Framework, including {olmv1-first}.
 
-include::modules/olm-terms.adoc[leveloffset=+1]
+include::snippets/of-terms-snippet.adoc[leveloffset=+0]

--- a/operators/understanding/olm-common-terms.adoc
+++ b/operators/understanding/olm-common-terms.adoc
@@ -8,4 +8,4 @@ toc::[]
 
 This topic provides a glossary of common terms related to the Operator Framework, including Operator Lifecycle Manager (OLM) and the Operator SDK.
 
-include::modules/olm-terms.adoc[leveloffset=+1]
+include::snippets/of-terms-snippet.adoc[leveloffset=+0]

--- a/snippets/of-terms-snippet.adoc
+++ b/snippets/of-terms-snippet.adoc
@@ -1,10 +1,9 @@
-// Module included in the following assemblies:
+// Text snippet included in the following assemblies:
 //
-// * operators/understanding/olm/olm-common-terms.adoc
+// * extensions/of-terms.adoc
+// * operators/understanding/olm-common-terms.adoc
 
-:_mod-docs-content-type: CONCEPT
-[id="olm-common-terms-glossary_{context}"]
-= Common Operator Framework terms
+:_mod-docs-content-type: SNIPPET
 
 [id="olm-common-terms-bundle_{context}"]
 == Bundle


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13249

Currently, the OLM common terms are shared as a module between two assemblies (one in the Extensions book for OLMv1, and one in the Operators book for OLMv0). On docs.redhat.com, this structure results in the right-nav not showing the entries in the TOC (because of module requirements to have exactly 1 `=` level heading, titled "Common Operator Framework terms" in this case).

Per content strategist request to improve the right-nav on docs.redhat.com, by converting the module into a snippet (which have fewer formatting restrictions compared to a module) and using a `leveloffset` of `+0` at the assembly-level instead of `+1`, the terms can still be re-used in both assemblies while omitting the "Common Operator Framework terms" heading and just starting each entry with `==` headings. This allows for the right-nav TOC to reveal the entries, and improves navigation.

Preview:

* [86888--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/of-terms.html ](https://86888--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/of-terms.html)
* [86888--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/olm-common-terms.html ](https://86888--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/olm-common-terms.html)

No QE needed.