### PR TITLE
OCPBUGS-48192: clarifying the role of the root cred in CCO mint mode

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
@@ -14,7 +14,11 @@ Mint mode is the default Cloud Credential Operator (CCO) credentials mode for {p
 For clusters that use the CCO in mint mode, the administrator-level credential is stored in the `kube-system` namespace. 
 The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
 
-With mint mode, each cluster component has only the specific permissions it requires. The automatic, continuous reconciliation of cloud credentials in mint mode allows actions that require additional credentials or permissions, such as minor version cluster updates, to proceed.
+With mint mode, each cluster component has only the specific permissions it requires.
+Cloud credential reconciliation is automatic and continuous so that components can perform actions that require additional credentials or permissions.
+
+For example, a minor version cluster update (such as updating from {product-version}.3 to {product-version}.4) might include an updated `CredentialsRequest` resource for a cluster component.
+The CCO, operating in mint mode, uses the `admin` credential to process the `CredentialsRequest` resource and create users with limited permissions to satisfy the updated authentication requirements.
 
 [NOTE]
 ====

--- a/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
@@ -17,7 +17,7 @@ The CCO uses the `admin` credential to process the `CredentialsRequest` objects 
 With mint mode, each cluster component has only the specific permissions it requires.
 Cloud credential reconciliation is automatic and continuous so that components can perform actions that require additional credentials or permissions.
 
-For example, a minor version cluster update (such as updating from {product-version}.3 to {product-version}.4) might include an updated `CredentialsRequest` resource for a cluster component.
+For example, a minor version cluster update (such as updating from {product-title} 4.16 to 4.17) might include an updated `CredentialsRequest` resource for a cluster component.
 The CCO, operating in mint mode, uses the `admin` credential to process the `CredentialsRequest` resource and create users with limited permissions to satisfy the updated authentication requirements.
 
 [NOTE]

--- a/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
@@ -11,9 +11,10 @@ Mint mode is the default Cloud Credential Operator (CCO) credentials mode for {p
 [id="mint-mode-about"]
 == Mint mode credentials management
 
-For clusters that use the CCO in mint mode, the administrator-level credential is stored in the `kube-system` namespace. The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
+For clusters that use the CCO in mint mode, the administrator-level credential is stored in the `kube-system` namespace. 
+The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
 
-With mint mode, each cluster component has only the specific permissions it requires. The automatic, continuous reconciliation of cloud credentials in mint mode allows actions that require additional credentials or permissions, such as upgrading, to proceed.
+With mint mode, each cluster component has only the specific permissions it requires. The automatic, continuous reconciliation of cloud credentials in mint mode allows actions that require additional credentials or permissions, such as minor version cluster updates, to proceed.
 
 [NOTE]
 ====

--- a/modules/manually-removing-cloud-creds.adoc
+++ b/modules/manually-removing-cloud-creds.adoc
@@ -14,7 +14,7 @@ The CCO only requires the administrator-level credential during changes that req
 
 [NOTE]
 ====
-Before performing a minor version cluster update (for example, updating from {product-version}.3 to {product-version}.4), you must reinstate the credential secret with the administrator-level credential. 
+Before performing a minor version cluster update (for example, updating from {product-title} 4.16 to 4.17), you must reinstate the credential secret with the administrator-level credential. 
 If the credential is not present, the update might be blocked.
 ====
 

--- a/modules/manually-removing-cloud-creds.adoc
+++ b/modules/manually-removing-cloud-creds.adoc
@@ -10,7 +10,7 @@ For clusters that use the Cloud Credential Operator (CCO) in mint mode, the admi
 The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
 
 After installing an {product-title} cluster with the CCO in mint mode, you can remove the administrator-level credential secret from the `kube-system` namespace in the cluster. 
-The CCO only requires the administrator-level credential during changes that require reconciling new or modified `CredentialsRequest` custom resources, such as minor version cluster updates.
+The CCO only requires the administrator-level credential during changes that require reconciling new or modified `CredentialsRequest` custom resources, such as minor cluster version updates.
 
 [NOTE]
 ====

--- a/modules/manually-removing-cloud-creds.adoc
+++ b/modules/manually-removing-cloud-creds.adoc
@@ -1,21 +1,27 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/cluster-tasks.adoc
+// * post_installation_configuration/changing-cloud-credentials-configuration.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="manually-removing-cloud-creds_{context}"]
 = Removing cloud provider credentials
 
-After installing an {product-title} cluster with the Cloud Credential Operator (CCO) in mint mode, you can remove the administrator-level credential secret from the `kube-system` namespace in the cluster. The administrator-level credential is required only during changes that require its elevated permissions, such as upgrades.
+For clusters that use the Cloud Credential Operator (CCO) in mint mode, the administrator-level credential is stored in the `kube-system` namespace. 
+The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
+
+After installing an {product-title} cluster with the CCO in mint mode, you can remove the administrator-level credential secret from the `kube-system` namespace in the cluster. 
+The CCO only requires the administrator-level credential during changes that require reconciling new or modified `CredentialsRequest` custom resources, such as minor version cluster updates.
 
 [NOTE]
 ====
-Prior to a non z-stream upgrade, you must reinstate the credential secret with the administrator-level credential. If the credential is not present, the upgrade might be blocked.
+Before performing a minor version cluster update (for example, updating from {product-version}.3 to {product-version}.4), you must reinstate the credential secret with the administrator-level credential. 
+If the credential is not present, the update might be blocked.
 ====
 
 .Prerequisites
 
-* Your cluster is installed on a platform that supports removing cloud credentials from the CCO. Supported platforms are AWS and GCP.
+* Your cluster is installed on a platform that supports removing cloud credentials from the CCO. 
+Supported platforms are AWS and GCP.
 
 .Procedure
 

--- a/post_installation_configuration/changing-cloud-credentials-configuration.adoc
+++ b/post_installation_configuration/changing-cloud-credentials-configuration.adoc
@@ -31,15 +31,16 @@ include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
+* xref:../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#cco-mode-mint[The Cloud Credential Operator in mint mode]
+* xref:../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.html#cco-mode-passthrough[The Cloud Credential Operator in passthrough mode]
 * xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere[vSphere CSI Driver Operator]
 
 //Removing cloud provider credentials manually
 include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]
 
-//These additional resources are for the "Rotating or removing cloud provider credentials" section, do not separate them from that content.
 [role="_additional-resources"]
 .Additional resources
-* xref:../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc#admin-credentials-root-secret-formats_cco-mode-passthrough[Admin credentials root secret format]
+* xref:../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#cco-mode-mint[The Cloud Credential Operator in mint mode]
 
 [id="post-install-enable-token-auth_{context}"]
 == Enabling token-based authentication


### PR DESCRIPTION
Version(s):
4.12+

Issue:
OCPBUGS-48192

Link to docs preview:
- [Removing cloud provider credentials](https://86900--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration.html#manually-removing-cloud-creds_changing-cloud-credentials-configuration)
- [Mint mode credentials management](https://86900--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-mint#mint-mode-about)

QE review:
- [x] QE has approved this change.

Additional information: