### PR TITLE
OCPBUGS-44422-15: Added KBase article for RHCOS versions to RN doc

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.8 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported on {op-system-first} {product-version}.
+{product-title} {product-version} is supported on {op-system-base-full} 8.8 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported on {op-system-first} {product-version}. To understand {op-system-base} versions used by {op-system}, see link:https://access.redhat.com/articles/6907891[{op-system-base} Versions Utilized by {op-system-first} and {product-title}] (Knowledgebase article).
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OCPBUGS-44422](https://issues.redhat.com/browse/OCPBUGS-44422) - 4.18 and 4.17
[OCPBUGS-41344](https://issues.redhat.com/browse/OCPBUGS-41344) - All the other versions

Link to docs preview:
* [About this release](https://86903--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html)

- [x] SME has approved this change (Eric Rich and Mark Russell). Approval on #86523

