### PR TITLE
OSDOCS-12499: adds 4.17.12 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -191,7 +191,7 @@ See the latest images included with {microshift-short} by xref:../microshift_upd
 [id="microshift-4-17-10-dp_{context}"]
 === RHBA-2024:11524 - {microshift-short} 4.17.10 bug fix and enhancement advisory
 
-Issued: 2 January 2024
+Issued: 2 January 2025
 
 {product-title} release 4.17.10 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:11524[RHBA-2024:11524] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:11522[RHBA-2024:11522] advisory.
 
@@ -200,8 +200,17 @@ See the latest images included with {microshift-short} by xref:../microshift_upd
 [id="microshift-4-17-11-dp_{context}"]
 === RHBA-2025:0025 - {microshift-short} 4.17.11 bug fix and enhancement advisory
 
-Issued: 8 January 2024
+Issued: 8 January 2025
 
 {product-title} release 4.17.11 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0025[RHBA-2025:0025] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:0023[RHBA-2025:0023] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-12-dp_{context}"]
+=== RHBA-2025:0117 - {microshift-short} 4.17.12 bug fix and enhancement advisory
+
+Issued: 14 January 2025
+
+{product-title} release 4.17.12 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0117[RHBA-2025:0117] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:0115[RHSA-2025:0115] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-12499](https://issues.redhat.com/browse/OSDOCS-12499)

Link to docs preview:
[microshift-4-17-12-dp_release-notes](https://86906--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-12-dp_release-notes)

Ack'd by QE on Slack (generic release note; ack is to confirm release)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
