### PR TITLE
OSDOCS-12922: adds 4.16.30 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -405,3 +405,12 @@ Issued: 9 January 2025
 {product-title} release 4.16.29 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0020[RHBA-2025:0020] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0018[RHBA-2025:0018] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-30-dp_{context}"]
+=== RHBA-2025:0142 - {microshift-short} 4.16.30 bug fix and enhancement advisory
+
+Issued: 15 January 2025
+
+{product-title} release 4.16.30 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0142[RHBA-2025:0142] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0140[RHSA-2025:0140] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12922](https://issues.redhat.com/browse/OSDOCS-12922)

Link to docs preview:
[microshift-4-16-30-dp_release-notes](https://86911--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-30-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
