### PR TITLE
[enterprise-4.17] OSDOCS#11510: HCP: The multi-architecture migration flag: `multiArch` 

### DIFF
--- a/modules/hcp-migrate-aws-single-to-multiarch.adoc
+++ b/modules/hcp-migrate-aws-single-to-multiarch.adoc
@@ -82,6 +82,20 @@ linux/arm64   sha256:7b046404572ac96202d82b6cb029b421dddd40e88c73bbf35f602ffc130
 
 . Transition the hosted cluster from single-architecture to multi-architecture:
 
+.. Set the `multiArch` flag to `true` on your hosted cluster so that the hosted cluster can create both 64-bit AMD and 64-bit ARM node pools. Run the following command:
++
+[source,terminal]
+----
+$ oc patch -n clusters hostedclusters/<hosted_cluster_name> -p '{"spec":{"platform":{"aws":{"multiArch":true}}}}' --type=merge
+----
+
+.. Confirm that the `multiArch` flag is set to `true` on your hosted cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get hostedcluster/<hosted_cluster_name> -o jsonpath='{.spec.platform.aws.multiArch}'
+----
+
 .. Set the multi-architecture {product-title} release image for the hosted cluster by ensuring that you use the same {product-title} version as the hosted cluster. Run the following command:
 +
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Context: [dev's review comment](https://github.com/openshift/openshift-docs/pull/86622#discussion_r1907726529):  
The `multiArch` flag is deprecated in 4.18 but it is **not** deprecated in 4.17. Therefore, this change[1] is **not** required in 4.18 but is required in 4.17. After merging the [main PR](https://github.com/openshift/openshift-docs/pull/86622) in 4.17 and 4.18, (with the removed step[1]) opening a follow-up PR just to add the step[1] in `enterprise-4.17`. 

[1] https://github.com/openshift/openshift-docs/pull/86931/files#diff-862ebee6ae4811edf5e6835d73dc5025b1b921e24fe3bb6711eb625b8ea7cc6eR85-R97 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12034
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://86931--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-aws.html#hcp-migrate-aws-single-to-multiarch_hcp-managing-aws)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE, SME, and peer reviews:
- [x] Available in the `main` PR: https://github.com/openshift/openshift-docs/pull/86622 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
