### PR TITLE
[SRVKS-1255] Deployment resource configuration

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -138,6 +138,8 @@ Topics:
     File: startup-probes-for-serving
   - Name: Resolving image tags to digests
     File: resolving-image-tags-to-digests
+  - Name: Configuring deployment resources
+    File: deployment-resources
   - Name: Configuring Kourier
     File: configuring-kourier
   - Name: Restrictive network policies

--- a/knative-serving/config-applications/deployment-resources.adoc
+++ b/knative-serving/config-applications/deployment-resources.adoc
@@ -1,0 +1,27 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="deployment-resources"]
+= Configuring deployment resources
+:context: deployment-resources
+
+toc::[]
+
+In Knative Serving, the `config-deployment` config map contains settings that determine how Kubernetes `Deployment` resources are configured for Knative services. In {ServerlessProductName} Serving, you can configure these settings in the `deployment` section of your `KnativeServing` custom resource (CR).
+
+You can use the `deployment` section to configure the following:
+
+* Tag resolution
+* Runtime environments
+* Progress deadlines
+
+//Skipping tag resolution
+include::modules/serverless-skipping-tag-resolution.adoc[leveloffset=+1]
+
+//Configuring selectable RuntimeClassName
+include::modules/serverless-configuring-runtimeclass-name.adoc[leveloffset=+1]
+
+//Progress deadline
+include::modules/serverless-progress-deadline.adoc[leveloffset=+1]
+
+//Configuring progress deadline
+include::modules/serverless-progress-deadline-config.adoc[leveloffset=+2]

--- a/modules/serverless-configuring-runtimeclass-name.adoc
+++ b/modules/serverless-configuring-runtimeclass-name.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/deployment-resources.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-configuring-runtimeclass-name_{context}"]
+= Configuring selectable RuntimeClassName 
+
+You can configure {ServerlessProductName} Serving to set a specific `RuntimeClassName` resource for Deployments by updating the `runtime-class-name` setting in your `KnativeServing` custom resource (CR).
+
+This setting interacts with service labels, applying either the default `RuntimeClassName` or the one that matches the most labels associated with the service.
+
+.Procedure
+
+* In your `KnativeServing` CR, configure the `runtime-class-name` setting:
++
+.Example of configured `runtime-class-name` setting
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    deployment:
+      runtime-class-name: |
+        kata: {}
+        gvisor:
+          selector:
+            my-label: selector
+----

--- a/modules/serverless-progress-deadline-config.adoc
+++ b/modules/serverless-progress-deadline-config.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/deployment-resources.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-progress-deadline-config_{context}"]
+= Configuring the progress deadline
+
+Configure progress deadline settings to set the maximum time allowed in seconds or minutes for deployment progress before the system reports a Knative Revision failure.
+
+By default, the progress deadline is set to 600 seconds. This value is specified as a Go `time.Duration` string and must be rounded to the nearest second.
+
+.Procedure
+
+Configure progress deadline by modifying your `KnativeServing` custom resource (CR).
+
+* In your `KnativeServing` CR, set the value of `progressDeadline`: 
++
+.Example of progress deadline set to 60 seconds
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    deployment:
+      progressDeadline: "60s"
+----

--- a/modules/serverless-progress-deadline.adoc
+++ b/modules/serverless-progress-deadline.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/deployment-resources.adoc
+
+:_content-type: CONCEPT
+[id="serverless-progress-deadline_{context}"]
+= Progress deadline
+
+By default, services have a progress deadline that defines the time limit for a service to complete its initial startup.
+
+Consider increasing the progress deadline if you encounter any of these conditions in your deployment:
+
+* The service image takes a long time to pull due to its size.
+* The service takes a long time to become `READY` because of initial cache priming.
+* The cluster relies on autoscaling to allocate resources for new pods.
+
+If the initial scale is not achieved within the specified time limit, the Knative Autoscaler component scales the revision to `0`, and the service enters a terminal `Failed` state.

--- a/modules/serverless-skipping-tag-resolution.adoc
+++ b/modules/serverless-skipping-tag-resolution.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/deployment-resources.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-skipping-tag-resolution_{context}"]
+= Skipping tag resolution
+
+Skipping tag resolution in {ServerlessProductName} Serving can speed up deployments by avoiding unnecessary queries to the container registry, reducing latency and dependency on registry availability.
+
+You can configure Serving to skip tag resolution by modifying the `registriesSkippingTagResolving` setting in your `KnativeServing` custom resource (CR).
+
+.Procedure
+
+* In your `KnativeServing` CR, modify the `registriesSkippingTagResolving` setting with the list of registries for which tag resoution will be skipped:
++
+.Example of configured tag resolution skipping
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    deployment:
+      registriesSkippingTagResolving: "registry.example.com, another.registry.com"
+----


### PR DESCRIPTION
Version(s):
serverless-docs-1.35+

Issue:
https://issues.redhat.com/browse/SRVKS-1255

Link to docs preview:
https://86932--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-applications/deployment-resources.html

QE review:
- [x] QE has approved this change.
