### PR TITLE
CNV-40898: Add a note about workload updates in 4.16

### DIFF
--- a/modules/virt-preventing-workload-updates-during-control-plane-only-update.adoc
+++ b/modules/virt-preventing-workload-updates-during-control-plane-only-update.adoc
@@ -203,6 +203,22 @@ hyperconverged.hco.kubevirt.io/kubevirt-hyperconverged patched
 ----
 $ oc get vmim -A
 ----
++
+[NOTE]
+====
+{product-title} v4.16 introduced a new Red Hat CoreOS version (9.4). Therefore, in a process of an upgrade of {product-title}
+over multiple minor versions, once upgraded to v4.16, workload updates in {VirtProductName} should be re-enabled in order to align
+the virt-launcher pods with the new underlying RHCOS minor version.
+
+Ensure that the value of `KubeVirt` custom resource at `.status.outdatedVirtualMachineInstanceWorkloads` is 0 before proceeding to
+further minor version upgrade of {product-title}.
+
+[source,terminal]
+----
+$ oc get kv kubevirt-kubevirt-hyperconverged -o json -n openshift-cnv | jq .status.outdatedVirtualMachineInstanceWorkloads
+0
+----
+====
 
 .Next steps
 


### PR DESCRIPTION
In OCP 4.16, RHCOS moved to a new minor version - 9.4. Due to that, in a process of a long EUS upgrade, customers should re-enable workload updates when upgraded the cluster to 4.16, in order to align all VirtualMachines to be based on the new RHCOS minor version. This is done to avoid a situation in which RHEL9.2-based VM will be running on an incompatible RHCOS (9.4 and 9.6 in future versions).

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/CNV-40898
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://86933--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
