### PR TITLE
OSDOCS-12163: adds 4.15.43 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -523,3 +523,12 @@ Issued: 2 January 2025
 {product-title} release 4.15.42 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:11564[RHBA-2024:11564] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:11562[RHSA-2024:11562] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-43-dp_{context}"]
+=== RHBA-2025:0123 - {microshift-short} 4.15.43 bug fix and enhancement advisory
+
+Issued: 15 January 2025
+
+{product-title} release 4.15.43 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:0123[RHBA-2025:0123] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0121[RHSA-2025:0121] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12163](https://issues.redhat.com/browse/OSDOCS-12163)

Link to docs preview:
[4-15-43-dp_release-notes](https://86935--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-43-dp_release-notes)

QE review:
- NA. Stock text update. No other changes.