### PR TITLE
OBSDOCS-1612: Move the alertmanager configuration modules under a new…

### DIFF
--- a/modules/monitoring-configuring-alert-routing-console.adoc
+++ b/modules/monitoring-configuring-alert-routing-console.adoc
@@ -4,10 +4,15 @@
 // * post_installation_configuration/configuring-alert-notifications.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="configuring-alert-receivers_{context}"]
-= Configuring alert receivers
+[id="configuring-alert-routing-console_{context}"]
+= Configuring alert routing with the {product-title} web console
 
-You can configure alert receivers to ensure that you learn about important issues with your cluster.
+You can configure alert routing through the {product-title} web console to ensure that you learn about important issues with your cluster. 
+
+[NOTE]
+====
+The {product-title} web console provides fewer settings to configure alert routing than the `alertmanager-main` secret. To configure alert routing with the access to more configuration settings, see "Configuring alert routing for default platform alerts".
+====
 
 .Prerequisites
 

--- a/modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc
+++ b/modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc
@@ -3,14 +3,14 @@
 // * observability/monitoring/managing-alerts.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="configuring-notifications-for-default-platform-alerts_{context}"]
-= Configuring notifications for default platform alerts
+[id="configuring-alert-routing-default-platform-alerts_{context}"]
+= Configuring alert routing for default platform alerts
 
 You can configure Alertmanager to send notifications. Customize where and how Alertmanager sends notifications about default platform alerts by editing the default configuration in the `alertmanager-main` secret in the `openshift-monitoring` namespace.
 
-[IMPORTANT]
+[NOTE]
 ====
-Alertmanager does not send notifications by default. It is recommended to configure Alertmanager to receive notifications by setting up notifications details in the `alertmanager-main` secret configuration file.
+All features of a supported version of upstream Alertmanager are also supported in an {product-title} Alertmanager configuration. To check all the configuration options of a supported version of upstream Alertmanager, see link:https://prometheus.io/docs/alerting/0.27/configuration/[Alertmanager configuration] (Prometheus documentation).
 ====
 
 .Prerequisites

--- a/modules/monitoring-configuring-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-configuring-alert-routing-for-user-defined-projects.adoc
@@ -3,10 +3,9 @@
 // * observability/monitoring/managing-alerts.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="creating-alert-routing-for-user-defined-projects_{context}"]
-= Creating alert routing for user-defined projects
+[id="configuring-alert-routing-for-user-defined-projects_{context}"]
+= Configuring alert routing for user-defined projects
 
-[role="_abstract"]
 If you are a non-administrator user who has been given the `alert-routing-edit` cluster role, you can create or edit alert routing for user-defined projects.
 
 .Prerequisites
@@ -43,13 +42,7 @@ spec:
     webhookConfigs:
     - url: https://example.org/post
 ----
-+
-[NOTE]
-====
-For user-defined alerting rules, user-defined routing is scoped to the namespace in which the resource is defined.
-For example, a routing configuration defined in the `AlertmanagerConfig` object for namespace `ns1` only applies to `PrometheusRules` resources in the same namespace.
-====
-+
+
 . Save the file.
 
 . Apply the resource to the cluster:

--- a/modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc
+++ b/modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc
@@ -3,18 +3,24 @@
 // * observability/monitoring/managing-alerts.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="configuring-notifications-for-user-defined-alerts_{context}"]
-= Configuring notifications for user-defined alerts
+[id="configuring-alert-routing-user-defined-alerts-secret_{context}"]
+= Configuring alert routing for user-defined projects with the Alertmanager secret
 
 If you have enabled a separate instance of Alertmanager that is dedicated to user-defined alert routing, you can customize where and how the instance sends notifications by editing the `alertmanager-user-workload` secret in the `openshift-user-workload-monitoring` namespace.
 
+[NOTE]
+====
+All features of a supported version of upstream Alertmanager are also supported in an {product-title} Alertmanager configuration. To check all the configuration options of a supported version of upstream Alertmanager, see link:https://prometheus.io/docs/alerting/0.27/configuration/[Alertmanager configuration] (Prometheus documentation).
+====
+
 .Prerequisites
 
+ifndef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have enabled a separate instance of Alertmanager for user-defined alert routing.
+endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::[]
-ifndef::openshift-rosa,openshift-dedicated[]
-* You have access to the cluster as a user with the `cluster-admin` cluster role.
 endif::[]
 * You have installed the OpenShift CLI (`oc`).
 

--- a/modules/monitoring-enabling-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-alert-routing-for-user-defined-projects.adoc
@@ -10,7 +10,9 @@ In {product-title}, an administrator can enable alert routing for user-defined p
 This process consists of the following steps:
 
 ifndef::openshift-dedicated,openshift-rosa[]
-* Enable alert routing for user-defined projects to use the default platform Alertmanager instance or, optionally, a separate Alertmanager instance only for user-defined projects.
+* Enable alert routing for user-defined projects:
+** Use the default platform Alertmanager instance.
+** Use a separate Alertmanager instance only for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * Enable alert routing for user-defined projects to use a separate Alertmanager instance.

--- a/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
@@ -6,7 +6,6 @@
 [id="granting-users-permission-to-configure-alert-routing-for-user-defined-projects_{context}"]
 = Granting users permission to configure alert routing for user-defined projects
 
-[role="_abstract"]
 You can grant users permission to configure alert routing for user-defined projects.
 
 .Prerequisites

--- a/modules/monitoring-understanding-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-understanding-alert-routing-for-user-defined-projects.adoc
@@ -13,7 +13,7 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 As a `dedicated-admin`, you can enable alert routing for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
-With this feature, you can allow users with the **alert-routing-edit** role to configure alert notification routing and receivers for user-defined projects.
+With this feature, you can allow users with the `alert-routing-edit` cluster role to configure alert notification routing and receivers for user-defined projects.
 ifndef::openshift-dedicated,openshift-rosa[]
 These notifications are routed by the default Alertmanager instance or, if enabled, an optional Alertmanager instance dedicated to user-defined monitoring.
 endif::openshift-dedicated,openshift-rosa[]
@@ -36,7 +36,7 @@ endif::openshift-dedicated,openshift-rosa[]
 
 [NOTE]
 ====
-The following are limitations of alert routing for user-defined projects:
+Review the following limitations of alert routing for user-defined projects:
 
 * For user-defined alerting rules, user-defined routing is scoped to the namespace in which the resource is defined. For example, a routing configuration in namespace `ns1` only applies to `PrometheusRules` resources in the same namespace.
 

--- a/observability/monitoring/common-monitoring-configuration-scenarios.adoc
+++ b/observability/monitoring/common-monitoring-configuration-scenarios.adoc
@@ -28,7 +28,7 @@ Any other configuration options listed here are optional.
 
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-the-monitoring-stack[Create the `cluster-monitoring-config` `ConfigMap` object] if it does not exist.
 * xref:../../observability/monitoring/managing-alerts.adoc#sending-notifications-to-external-systems_managing-alerts[Configure alert receivers] so that Alertmanager can send alerts to an external notification system such as email, Slack, or PagerDuty.
-* xref:../../observability/monitoring/managing-alerts.adoc#configuring-notifications-for-default-platform-alerts_managing-alerts[Configure notifications for default platform alerts].
+* xref:../../observability/monitoring/managing-alerts.adoc#configuring-alert-routing-default-platform-alerts_managing-alerts[Configure notifications for default platform alerts].
 * For shorter term data retention, xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-persistent-storage_configuring-the-monitoring-stack[configure persistent storage] for Prometheus and Alertmanager to store metrics and alert data.
 Specify the metrics data retention parameters for Prometheus and Thanos Ruler.
 +
@@ -73,14 +73,14 @@ Cluster administrators typically complete the following activities to configure 
 * xref:../../observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc#enabling-alert-routing-for-user-defined-projects[Enable alert routing for user-defined projects] so that developers and other users can configure custom alerts and alert routing for their projects.
 * If needed, configure alert routing for user-defined projects to xref:../../observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc#enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing_enabling-alert-routing-for-user-defined-projects[use an optional Alertmanager instance dedicated for use only by user-defined projects].
 * xref:../../observability/monitoring/managing-alerts.adoc#configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts_managing-alerts[Configure alert receivers] for user-defined projects.
-* xref:../../observability/monitoring/managing-alerts.adoc#configuring-notifications-for-user-defined-alerts_managing-alerts[Configure notifications for user-defined alerts].
+* xref:../../observability/monitoring/managing-alerts.adoc#configuring-alert-routing-user-defined-alerts-secret_managing-alerts[Configure notifications for user-defined alerts].
 
 After monitoring for user-defined projects is enabled and configured, developers and other non-administrator users can then perform the following activities to set up and use monitoring for their own projects:
 
 * xref:../../observability/monitoring/managing-metrics.adoc#setting-up-metrics-collection-for-user-defined-projects_managing-metrics[Deploy and monitor services].
 * xref:../../observability/monitoring/managing-alerts.adoc#creating-alerting-rules-for-user-defined-projects_managing-alerts[Create and manage alerting rules].
 * xref:../../observability/monitoring/managing-alerts.adoc#managing-alerts[Receive and manage alerts] for their projects.
-* If granted the `user-workload-monitoring-config-edit` role, xref:../../observability/monitoring/managing-alerts.adoc#creating-alert-routing-for-user-defined-projects_managing-alerts[configure alert routing].
+* If granted the `user-workload-monitoring-config-edit` role, xref:../../observability/monitoring/managing-alerts.adoc#configuring-alert-routing-for-user-defined-projects_managing-alerts[configure alert routing].
 * Use the {product-title} web console to xref:../../observability/monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards-developer_reviewing-monitoring-dashboards[view dashboards].
 * xref:../../observability/monitoring/managing-metrics.adoc#querying-metrics-for-user-defined-projects-with-mon-dashboard_managing-metrics[Query the collected metrics] by creating PromQL queries or using predefined queries.
 

--- a/observability/monitoring/configuring-core-platform-monitoring/configuring-alerts-and-notifications.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/configuring-alerts-and-notifications.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="configuring-alerts-and-notifications"]
-= Configuring alerts and notifications
+= Configuring alerts and notifications for core platform monitoring
 :context: configuring-alerts-and-notifications
 
 toc::[]
@@ -11,6 +11,14 @@ You can configure a local or external Alertmanager instance to route alerts from
 //Configuring external Alertmanager instances
 include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=1,tags=**;CPM;!UWM]
 
+// Disabling the local Alertmanager
+include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+2]
+
+// [role="_additional-resources"]
+// .Additional resources
+
+// * TBD
+
 //Configuring secrets for Alertmanager
 include::modules/monitoring-configuring-secrets-for-alertmanager.adoc[leveloffset=1]
 
@@ -19,15 +27,29 @@ include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.ad
 //Attaching additional labels to your time series and alerts
 include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1,tags=**;CPM;!UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
-// Disabling the local Alertmanager
-include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+1]
+[id="configuring-alert-notifications_{context}"]
+== Configuring alert notifications
 
-[role="_additional-resources"]
-.Additional resources
+In {product-title} {product-version}, you can view firing alerts in the Alerting UI. You can configure Alertmanager to send notifications about default platform alerts by configuring alert receivers.
 
-* TBD
+[IMPORTANT]
+====
+Alertmanager does not send notifications by default. It is strongly recommended to configure Alertmanager to receive notifications by configuring alert receivers through the web console or through the `alertmanager-main` secret.
+====
+
+include::modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc[leveloffset=+2]
+
+include::modules/monitoring-configuring-alert-routing-console.adoc[leveloffset=+2]
+
+include::modules/monitoring-configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts.adoc[leveloffset=+2]
+
+// [role="_additional-resources"]
+// [id="additional-resources_{context}"]
+// == Additional resources
+
+// * TBD

--- a/observability/monitoring/configuring-user-workload-monitoring/before-you-begin-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/before-you-begin-uwm.adoc
@@ -29,17 +29,36 @@ include::snippets/monitoring-custom-prometheus-note.adoc[]
 
 include::modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
+
+// Enabling alert routing for user-defined projects
+include::modules/monitoring-enabling-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
+
+// Enabling the platform Alertmanager instance for user-defined alert routing
+ifndef::openshift-dedicated,openshift-rosa[]
+include::modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc[leveloffset=+2]
+endif::openshift-dedicated,openshift-rosa[]
+
+// Enabling a separate Alertmanager instance for user-defined alert routing
+include::modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc[leveloffset=+2]
+
+// Granting users permission to configure alert routing for user-defined projects
+include::modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc[leveloffset=+2]
+
+// [role="_additional-resources"]
+// .Additional resources
+
+// * TBD
 
 // Granting users permissions for monitoring for user-defined projects
 include::modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* TBD
+// [role="_additional-resources"]
+// .Additional resources
+// * TBD
 
 include::modules/monitoring-granting-user-permissions-using-the-web-console.adoc[leveloffset=+2]
 include::modules/monitoring-granting-user-permissions-using-the-cli.adoc[leveloffset=+2]

--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="configuring-alerts-and-notifications-uwm"]
-= Configuring alerts and notifications
+= Configuring alerts and notifications for user workload monitoring
 :context: configuring-alerts-and-notifications-uwm
 
 toc::[]
@@ -19,8 +19,49 @@ include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.ad
 //Attaching additional labels to your time series and alerts
 include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
+[id="configuring-alert-notifications_{context}"]
+== Configuring alert notifications
+
+In {product-title}, an administrator can enable alert routing for user-defined projects with one of the following methods:
+
+* Use the default platform Alertmanager instance.
+* Use a separate Alertmanager instance only for user-defined projects.
+
+Developers and other users with the `alert-routing-edit` cluster role can configure custom alert notifications for their user-defined projects by configuring alert receivers.
+
+[NOTE]
+====
+Review the following limitations of alert routing for user-defined projects:
+
+* User-defined alert routing is scoped to the namespace in which the resource is defined. For example, a routing configuration in namespace `ns1` only applies to `PrometheusRules` resources in the same namespace.
+
+* When a namespace is excluded from user-defined monitoring, `AlertmanagerConfig` resources in the namespace cease to be part of the Alertmanager configuration.
+====
+
+include::modules/monitoring-configuring-alert-routing-for-user-defined-projects.adoc[leveloffset=+2]
+
+// [role="_additional-resources"]
+// .Additional resources
+
+// * TBD
+
+include::modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc[leveloffset=+2]
+
+// [role="_additional-resources"]
+// .Additional resources
+
+// * TBD
+
+//Configuring different alert receivers for default platform alerts and user-defined alerts
+include::modules/monitoring-configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts.adoc[leveloffset=+2]
+
+// [role="_additional-resources"]
+// [id="additional-resources_{context}"]
+// == Additional resources
+
+// * TBD

--- a/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
+++ b/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
@@ -43,4 +43,4 @@ include::modules/monitoring-granting-users-permission-to-configure-alert-routing
 ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user defined projects]
 endif::openshift-dedicated,openshift-rosa[]
-* xref:../../observability/monitoring/managing-alerts.adoc#creating-alert-routing-for-user-defined-projects_managing-alerts[Creating alert routing for user-defined projects]
+* xref:../../observability/monitoring/managing-alerts.adoc#configuring-alert-routing-for-user-defined-projects_managing-alerts[Configuring alert routing for user-defined projects]

--- a/observability/monitoring/managing-alerts.adoc
+++ b/observability/monitoring/managing-alerts.adoc
@@ -83,12 +83,12 @@ include::modules/monitoring-disabling-cross-project-alerting-rules-for-user-defi
 include::modules/monitoring-sending-notifications-to-external-systems.adoc[leveloffset=+1]
 // Configuring alert receivers
 ifndef::openshift-dedicated,openshift-rosa[]
-include::modules/monitoring-configuring-alert-receivers.adoc[leveloffset=+2]
+include::modules/monitoring-configuring-alert-routing-console.adoc[leveloffset=+2]
 endif::openshift-dedicated,openshift-rosa[]
 // Configuring different alert receivers for default platform alerts and user-defined alerts
 include::modules/monitoring-configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts.adoc[leveloffset=+2]
 // Creating alert routing for user-defined projects
-include::modules/monitoring-creating-alert-routing-for-user-defined-projects.adoc[leveloffset=+2]
+include::modules/monitoring-configuring-alert-routing-for-user-defined-projects.adoc[leveloffset=+2]
 
 [id="configuring-alertmanager-to-send-notifications"]
 == Configuring Alertmanager to send notifications
@@ -106,11 +106,11 @@ All features of a supported version of upstream Alertmanager are also supported 
 
 // Configuring notifications for default platform alerts
 ifndef::openshift-dedicated,openshift-rosa[]
-include::modules/monitoring-configuring-notifications-for-default-platform-alerts.adoc[leveloffset=+2]
+include::modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc[leveloffset=+2]
 endif::openshift-dedicated,openshift-rosa[]
 
 // Configuring notifications for user-defined alerts
-include::modules/monitoring-configuring-notifications-for-user-defined-alerts.adoc[leveloffset=+2]
+include::modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_configuring-alertmanager-to-send-notifications"]


### PR DESCRIPTION
Version(s): none for cherry-picking, `monitoring-docs-restruce` only

Issue: [OBSDOCS-1612](https://issues.redhat.com/browse/OBSDOCS-1612)

Links to docs preview: 

* [Before you begin](https://86941--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/before-you-begin-uwm)
* [Configuring alerts and notifications for core platform monitoring](https://86941--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/configuring-alerts-and-notifications)
* [Configuring alerts and notifications for user workload monitoring](https://86941--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm)

QE review:
- [x] QE has approved this change.

**Additional information:**
**The changes it this PR are not yet user-facing.**
This PR adds an existing content to about alert configurations to the new assembly.

 The content in the original assembly is still there . The reason is to not lose any content while moving it around. There will be a separate issue that will make sure that all the content is transfered as needed.
 
 Therefore, the main thing to check in this PR is to see if the structure in the linked chapters looks good and renders without issues.
 
 This PR also makes small changes to naming of procedures to mitigate the confusion about using multiple terms for the same configuration.

**NOTE**: The links and xrefs will be filled in in a different PR, because the content from other assemblies still needs to be moved to the new place, which means that if I filled the links now, I would have to keep repairing them later. So I am keeping that for a separate PR. 