### PR TITLE
OSDOCS13124 Add version information to the output oc get machineconfignodes/Add MCP column to MCN output

### DIFF
--- a/machine_configuration/index.adoc
+++ b/machine_configuration/index.adoc
@@ -44,6 +44,7 @@ include::modules/machine-config-drift-detection.adoc[leveloffset=+1]
 
 include::modules/checking-mco-status.adoc[leveloffset=+1]
 include::modules/checking-mco-node-status.adoc[leveloffset=+1]
+include::modules/checking-mco-node-status-configuring.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/checking-mco-node-status-configuring.adoc
+++ b/modules/checking-mco-node-status-configuring.adoc
@@ -1,0 +1,139 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="checking-mco-node-status-congifuring_{context}"]
+= Checking machine config node status
+
+During the update of a machine config pool (MCP), you can monitor the progress of all control plane and worker nodes in your cluster by using the `oc get machineconfignodes` and `oc describe machineconfignodes` commands. These commands provide information that can be helpful if issues arise during the update and you need to troubleshoot a node.
+
+You cannot use these commands with custom machine config pools.
+
+For more information on the meaning of these fields, see "About checking machine config node status."
+
+.Prerequisites
+
+* You enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`:
++
+[source,terminal]
+----
+$ oc edit featuregate cluster
+----
++
+.Example `FeatureGate` CR
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade
+----
++
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
+====
++
+After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
+
+.Procedure
+
+* View the update status of all nodes in the cluster, including the current and desired machine configurations, by running the following command:
++
+[source,terminal]
+----
+$ oc get machineconfignodes
+----
++
+.Example output
+[source,text]
+----
+NAME                                       POOLNAME   DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED
+ci-ln-mdb23yt-72292-kzdsg-master-0         master     rendered-master-f21b093d20f68a7c06f922ed3ea5fbc8   rendered-master-1abc053eec29e6c945670f39d6dc8afa   False
+ci-ln-mdb23yt-72292-kzdsg-master-1         master     rendered-master-1abc053eec29e6c945670f39d6dc8afa   rendered-master-1abc053eec29e6c945670f39d6dc8afa   True
+ci-ln-mdb23yt-72292-kzdsg-master-2         master     rendered-master-1abc053eec29e6c945670f39d6dc8afa   rendered-master-1abc053eec29e6c945670f39d6dc8afa   True
+ci-ln-mdb23yt-72292-kzdsg-worker-a-gfqjr   worker     rendered-worker-d0130cd74e9e576d7ba78ce166272bfb   rendered-worker-8f61bf839898a4487c3b5263a430e94a   False
+ci-ln-mdb23yt-72292-kzdsg-worker-b-gknq4   worker     rendered-worker-8f61bf839898a4487c3b5263a430e94a   rendered-worker-8f61bf839898a4487c3b5263a430e94a   True
+ci-ln-mdb23yt-72292-kzdsg-worker-c-mffrx   worker     rendered-worker-8f61bf839898a4487c3b5263a430e94a   rendered-worker-8f61bf839898a4487c3b5263a430e94a   True
+----
+
+* View of all machine config node status fields for the nodes in your cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get machineconfignodes -o wide
+----
++
+.Example output
+[source,text]
+----
+NAME                                       POOLNAME   DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED   UPDATEPREPARED   UPDATEEXECUTED   UPDATEPOSTACTIONCOMPLETE   UPDATECOMPLETE   RESUMED   UPDATECOMPATIBLE   UPDATEDFILESANDOS   CORDONEDNODE   DRAINEDNODE   REBOOTEDNODE   RELOADEDCRIO   UNCORDONEDNODE
+ci-ln-g6dr34b-72292-g9btv-master-0         master     rendered-master-d4e122320b351cdbe1df59ddb63ddcfc   rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   False     True             Unknown          False                      False            False     True               Unknown             False          False         False          False          False
+ci-ln-g6dr34b-72292-g9btv-master-1         master     rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   True      False            False            False                      False            False     False              False               False          False         False          False          False
+ci-ln-g6dr34b-72292-g9btv-master-2         master     rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   True      False            False            False                      False            False     False              False               False          False         False          False          False
+ci-ln-g6dr34b-72292-g9btv-worker-a-sjh5r   worker     rendered-worker-671b88c8c569fa3f60dc1a27cf9c91f2   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   False     True             Unknown          False                      False            False     True               Unknown             False          False         False          False          False
+ci-ln-g6dr34b-72292-g9btv-worker-b-xthbz   worker     rendered-worker-d5534cb730e5e108905fc285c2a42b6c   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   True      False            False            False                      False            False     False              False               False          False         False          False          False
+ci-ln-g6dr34b-72292-g9btv-worker-c-gnpd6   worker     rendered-worker-d5534cb730e5e108905fc285c2a42b6c   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   True      False            False            False                      False            False     False              False               False          False         False          False          False
+----
+
+* Check the update status of nodes in a specific machine config pool by running the following command:
++
+[source,terminal]
+----
+$ oc get machineconfignodes $(oc get machineconfignodes -o json | jq -r '.items[]|select(.spec.pool.name=="<pool_name>")|.metadata.name') <1>
+----
++
+.Example output
+[source,text]
+----
+NAME                                       POOLNAME   DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED
+ci-ln-g6dr34b-72292-g9btv-worker-a-sjh5r   worker     rendered-worker-d5534cb730e5e108905fc285c2a42b6c   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   True
+ci-ln-g6dr34b-72292-g9btv-worker-b-xthbz   worker     rendered-worker-d5534cb730e5e108905fc285c2a42b6c   rendered-worker-faf6b50218a8bbce21f1370866283de5   False
+ci-ln-g6dr34b-72292-g9btv-worker-c-gnpd6   worker     rendered-worker-faf6b50218a8bbce21f1370866283de5   rendered-worker-faf6b50218a8bbce21f1370866283de5   True
+----
+
+* Check the update status of an individual node by running the following command:
++
+[source,terminal]
+----
+$ oc describe machineconfignode/<node_name>
+----
++
+.Example output
+[source,text]
+----
+Name:         <node_name>
+Namespace:
+Labels:       <none>
+Annotations:  <none>
+API Version:  machineconfiguration.openshift.io/v1alpha1
+Kind:         MachineConfigNode
+Metadata:
+  Creation Timestamp:  2023-10-17T13:08:58Z
+  Generation:          1
+  Resource Version:    49443
+  UID:                 4bd758ab-2187-413c-ac42-882e61761b1d
+Spec:
+  Node Ref:
+    Name:         <node_name>
+  Pool:
+    Name:         master
+  ConfigVersion:
+    Desired: rendered-worker-823ff8dc2b33bf444709ed7cd2b9855b
+Status:
+# ...
+    Message:               Drained node. The drain is complete as the desired drainer matches current drainer: drain-rendered-worker-01f27f752eb84eba917450e43636b210
+    Reason:                UpdateExecutedDrained
+    Status:                True
+    Type:                  Drained
+    Last Transition Time:  2025-01-14T15:45:55Z
+# ...  
+  Config Version:
+    Current:            rendered-master-8110974a5cea69dff5b263237b58abd8
+    Desired:            rendered-worker-823ff8dc2b33bf444709ed7cd2b9855b
+  Observed Generation:  6
+# ...  
+----

--- a/modules/checking-mco-node-status.adoc
+++ b/modules/checking-mco-node-status.adoc
@@ -2,83 +2,153 @@
 //
 // * post_installation_configuration/machine-configuration-tasks.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="checking-mco-node-status_{context}"]
-= Checking machine config node status
+= About checking machine config node status
 
-During updates you might want to monitor the progress of individual nodes in case issues arise and you need to troubleshoot a node.
+If you make changes to the default control plane or worker nodes in your cluster, for example by using a machine config or kubelet config, you can get detailed information about the progress of the node updates by using the machine config nodes custom resource. Any change that results in a new machine config triggers the node update process.
 
-To see the status of the Machine Config Operator (MCO) updates to your cluster, use the following `oc` commands:
+You can view this detailed information for nodes in the `control plane` and `worker` machine config pools that were created upon {product-title} installation. You cannot use custom machine config pools.
 
-:FeatureName: Improved MCO state reporting
+The `MachineConfigNode` custom resource allows you to monitor the progress of individual node updates as they move through the upgrade phases. This information can be helpful with troubleshooting if one of the nodes has an issue during the update. The custom resource reports where in the update process the node is at the moment, the phases that have completed, and the phases that are remaining.
+
+:FeatureName: The machine config node custom resource
 include::snippets/technology-preview.adoc[]
 
-.Prerequisites
-* You set `featureSet: TechPreviewNoUpgrade` in your `FeatureGate` custom resource (CR) to enable the feature set capability for your cluster.
+The node update process consists of the following phases and subphases that are tracked by the machine config node custom resource, explained with more detail later in this section:
 
-.Procedure
-. Get a summary of update statuses for all nodes in all machine config pools by running the following command:
-+
+* *Update Prepared*. The MCO stops the configuration drift monitoring process and verifies that the newly-created machine config can be applied to a node.
+** *UpdateCompatible*
+* *Update Executed*. The MCO cordons and drains the node and applies the new machine config to the node's files and operating system, as needed. It contains the following sub-phases:
+** *Cordoned*
+** *Drained*
+** *AppliedFilesAndOS*
+* *PinnedImageSetsProgressing* The MCO is performing the steps needed to pin and pre-load container images. 
+* *PinnedImageSetsDegraded* The pinned image process failed. You can view the reason for the failure by using the `oc describe machineconfignode` command, as described later in this section.
+* *Update Post update action*. The MCO reboots the node or reloads CRI-O, as needed.
+** *RebootedNode*
+** *ReloadedCRIO*
+* *Update Complete*. The MCO uncordons the nodes, updates the node state to the cluster, and resumes producing node metrics.
+** *Updated*
+** *Uncordoned*
+* *Resumed*. The MCO restarts the config drift monitor process and the node returns to operational state.
+
+As the update moves through these phases, you can query the `MachineConfigNode` custom resource, which reports one of the following conditions for each phase:
+
+* `True`. The phase is complete on that node or the MCO has started that phase on that node.
+* `False`.  The phase is either being executed or will not be executed on that node.
+* `Unknown`. The phase is either being executed on that node or has an error. If the phase has an error, you can use the `oc describe machineconfignodes` command for more information, as described later in this section.
+
+For example, consider a cluster with a newly-created machine config:
+
+[source,terminal]
+----
+$ oc get machineconfig
+----
+
+.Example output
+[source,text]
+----
+# ...
+rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   c00e2c941bc6e236b50e0bf3988e6c790cf2bbb2   3.4.0             6d15h
+rendered-master-a386c2d1550b927d274054124f58be68   c00e2c941bc6e236b50e0bf3988e6c790cf2bbb2   3.4.0             7m26s
+# ...
+rendered-worker-01f27f752eb84eba917450e43636b210   c00e2c941bc6e236b50e0bf3988e6c790cf2bbb2   3.4.0             6d15h <1>
+rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   c00e2c941bc6e236b50e0bf3988e6c790cf2bbb2   3.4.0             7m26s <2>
+# ...
+----
+<1> The current machine config for the control plane and worker nodes.
+<2> A newly-created machine config that is being applied to the control plane and worker nodes.
+
+You can watch as the nodes are updated with the new machine config:
+
 [source,terminal]
 ----
 $ oc get machineconfignodes
 ----
-+
+
 .Example output
 [source,text]
 ----
-NAME                          UPDATED   UPDATEPREPARED   UPDATEEXECUTED   UPDATEPOSTACTIONCOMPLETED   UPDATECOMPLETED   RESUMED
-ip-10-0-12-194.ec2.internal   True      False             False              False                    False              False
-ip-10-0-17-102.ec2.internal   False     True              False              False                    False              False
-ip-10-0-2-232.ec2.internal    False     False             True               False                    False              False
-ip-10-0-59-251.ec2.internal   False     False             False              True                     False              False
-ip-10-0-59-56.ec2.internal    False     False             False              False                    True               True
-ip-10-0-6-214.ec2.internal    False     False             Unknown            False                    False              False
+NAME                                       POOLNAME   DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED
+ci-ln-ds73n5t-72292-9xsm9-master-0         master     rendered-master-a386c2d1550b927d274054124f58be68   rendered-master-a386c2d1550b927d274054124f58be68   True
+ci-ln-ds73n5t-72292-9xsm9-master-1         master     rendered-master-a386c2d1550b927d274054124f58be68   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   False
+ci-ln-ds73n5t-72292-9xsm9-master-2         master     rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   True
+ci-ln-ds73n5t-72292-9xsm9-worker-a-2d8tz   worker     rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   True <1>
+ci-ln-ds73n5t-72292-9xsm9-worker-b-gw5sd   worker     rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-01f27f752eb84eba917450e43636b210   False <2>
+ci-ln-ds73n5t-72292-9xsm9-worker-c-t227w   worker     rendered-worker-01f27f752eb84eba917450e43636b210   rendered-worker-01f27f752eb84eba917450e43636b210   True <3>
 ----
-+
-where:
-+
-UPDATED:: The `True` status indicates that the MCO has applied the current machine config to that particular node. The `False` status indicates that the node is currently updating. The `Unknown` status means the operation is processing.
-UPDATEPREPARED:: The `False` status indicates that the MCO has not started reconciling the new machine configs to be distributed. The `True` status indicates that the MCO has completed this phase of the update. The `Unknown` status means the operation is processing.
-UPDATEEXECUTED:: The `False` status indicates that the MCO has not started cordoning and draining the node. It also indicates that the disk state and operating system have not started updating. The `True` status indicates that the MCO has completed this phase of the update. The `Unknown` status means the operation is processing.
-UPDATEPOSTACTIONCOMPLETED:: The `False` status indicates that the MCO has not started rebooting the node or closing the daemon. The `True` status indicates that the MCO has completed reboot and updating the node status. The `Unknown` status indicates either that an error has occurred during the update process at this phase, or that the MCO is currently applying the update.
-UPDATECOMPLETED:: The `False` status indicates that the MCO has not started uncordoning the node and updating the node state and metrics. The `True` status indicates that the MCO has finished updating the node state and available metrics.
-RESUMED:: The `False` status indicates that the MCO has not started the config drift monitor. The `True` status indicates that the node has resumed operation. The `Unknown` status means the operation is processing.
-+
-[NOTE]
-====
-Within the primary phases previously described, you can have secondary phases which you can use to see the update progression in more detail. You can get more information that includes secondary phases of updates by using the `-o wide` option of the preceding command. This provides the additional `UPDATECOMPATIBLE`, `UPDATEFILESANDOS`, `DRAINEDNODE`, `CORDONEDNODE`, `REBOOTNODE`, `RELOADEDCRIO` and `UNCORDONED` columns. These secondary phases do not always occur and depend on the type of update you want to apply.
-====
+<1> This node has been updated. The new machine config, `rendered-worker-f351f6947f15cd0380514f4b1c89f8f2`, is shown as the desired and current machine configs.
+<2> This node is currently being updated to the new machine config. The previous and new machine configs are shown as the desired and current machine configs, respectively.
+<3> This node has not yet been updated to the new machine config. The previous machine config is shown as the desired and current machine configs.
 
-. Check the update status of nodes in a specific machine config pool by running the following command:
-+
+.Basic machine config node fields
+[cols="1,4",options="header"]
+|===
+|Field |Meaning
+|`NAME` |The name of the node.
+|`POOLNAME` |The name of the machine config pool associated with that node.
+|`DESIREDCONFIG` |The name of the new machine config that the node updates to.
+|`CURRENTCONFIG` |The name of the current machine configuration on that node.
+|`UPDATED` a|Indicates if the node has been updated with one of the following conditions:
+
+* If `False`, the node is being updated to the new machine configuration shown in the `DESIREDCONFIG` field.
+* If `True`, and the `CURRENTCONFIG` matches the new machine configuration shown in the `DESIREDCONFIG` field, the node has been updated.
+* If `True`, and the `CURRENTCONFIG` matches the old machine configuration shown in the `DESIREDCONFIG` field, that node has not been updated yet.
+|===
+// Field definitions based on https://github.com/openshift/api/pull/1596
+
+You can use the `-o wide` flag to display additional information about the updates:
+
 [source,terminal]
 ----
-$ oc get machineconfignodes $(oc get machineconfignodes -o json | jq -r '.items[]|select(.spec.pool.name=="<pool_name>")|.metadata.name') <1>
-----
-<1> The name of the pool is the `MachineConfigPool` object name.
-+
-.Example output
-[source,text]
-----
-NAME                          UPDATED   UPDATEPREPARED   UPDATEEXECUTED   UPDATEPOSTACTIONCOMPLETE   UPDATECOMPLETE   RESUMED
-ip-10-0-48-226.ec2.internal   True      False            False            False                      False            False
-ip-10-0-5-241.ec2.internal    True      False            False            False                      False            False
-ip-10-0-74-108.ec2.internal   True      False            False            False                      False            False
+$ oc get machineconfignodes -o wide
 ----
 
-. Check the update status of an individual node by running the following command:
-+
-[source,terminal]
-----
-$ oc describe machineconfignode/<node_name> <1>
-----
-<1> The name of the node is the `MachineConfigNode` object name.
-+
 .Example output
 [source,text]
 ----
-Name:         <node_name>
+$ oc get machineconfignode -o wide
+NAME                                       POOLNAME   DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED   UPDATEPREPARED   UPDATEEXECUTED   UPDATEPOSTACTIONCOMPLETE   UPDATECOMPLETE   RESUMED   UPDATECOMPATIBLE   UPDATEDFILESANDOS   CORDONEDNODE   DRAINEDNODE   REBOOTEDNODE   RELOADEDCRIO   UNCORDONEDNODE
+ci-ln-ds73n5t-72292-9xsm9-master-0         master     rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   True      False            False            False                      False            False     False              False               False          False         False          False          False
+ci-ln-ds73n5t-72292-9xsm9-master-1         master     rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   True      False            False            False                      False            False     False              False               False          False         False          False          False
+ci-ln-ds73n5t-72292-9xsm9-master-2         master     rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   True      False            False            False                      False            False     False              False               False          False         False          False          False
+ci-ln-ds73n5t-72292-9xsm9-worker-a-2d8tz   worker     rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   True      False            False            False                      False            False     False              False               False          False         False          False          False
+ci-ln-ds73n5t-72292-9xsm9-worker-b-gw5sd   worker     rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-01f27f752eb84eba917450e43636b210   False     True             True             Unknown                    False            False     True               True                True           True          Unknown        False          False
+ci-ln-ds73n5t-72292-9xsm9-worker-c-t227w   worker     rendered-worker-01f27f752eb84eba917450e43636b210   rendered-worker-01f27f752eb84eba917450e43636b210   True      False            False            False                      False            False     False              False               False          False         False          False          False
+----
+
+In addition to the fields defined in the previous table, the `-o wide` output displays the following fields:
+
+.Machine config node fields in the `-o wide` output
+[cols="1,4",options="header"]
+|===
+|Phase Name |Definition
+|`UPDATEPREPARED` |Indicates if the MCO is preparing to update the node.
+|`UPDATEEXECUTED` |Indicates if the MCO has completed the body of the update on the node.
+|`UPDATEPOSTACTIONCOMPLETE` |Indicates if the MCO has executed the post-update actions on the node.
+|`UPDATECOMPLETE` |Indicates if the MCO has completed the update on the node.
+|`RESUMED` |Indicates if the node has resumed normal processes.
+|`UPDATECOMPATIBLE` |Indicates if the MCO has determined it can execute the update on the node.
+|`UPDATEDFILESANDOS` |Indicates if the MCO has updated the node files and operating system.
+|`CORDONEDNODE` |Indicates if the MCO has marked the node as not schedulable.
+|`DRAINEDNODE` |Indicates if the MCO has drained the node.
+|`REBOOTEDNODE` |Indicates if the MCO has restarted the node.
+|`RELOADEDCRIO` |Indicates if the MCO has restarted the CRI-O service.
+|`UNCORDONEDNODE` |Indicates if the MCO has marked the node as schedulable.
+|===
+
+For more details on the update status, you can use the `oc describe machineconfignode` command:
+
+[source,terminal]
+----
+$ oc describe machineconfignode/<machine_config_node_name> -o yaml
+----
+
+.Example output
+[source,text]
+----
+Name:         <machine_config_node_name> <1>
 Namespace:
 Labels:       <none>
 Annotations:  <none>
@@ -93,26 +163,92 @@ Spec:
   Node Ref:
     Name:         <node_name>
   Pool:
-    Name:         master
+    Name:         worker
   ConfigVersion:
-    Desired: rendered-worker-823ff8dc2b33bf444709ed7cd2b9855b <1>
+    Desired: rendered-worker-f351f6947f15cd0380514f4b1c89f8f2 <2>
 Status:
   Conditions:
-    Last Transition Time:  2023-10-17T13:09:02Z
-    Message:               Node has completed update to config rendered-master-cf99e619747ab19165f11e3546c71f1e
-    Reason:                NodeUpgradeComplete
-    Status:                True
+    Last Transition Time:  2025-01-14T17:01:16Z
+    Message:               Node ci-ln-ds73n5t-72292-9xsm9-worker-b-gw5sd needs an update
+    Reason:                Updated
+    Status:                False
     Type:                  Updated
-    Last Transition Time:  2023-10-17T13:09:02Z
-    Message:               This node has not yet entered the UpdatePreparing phase
+    Last Transition Time:  2025-01-14T17:01:18Z
+    Message:               Update is Compatible.
+    Reason:                UpdateCompatible
+    Status:                True
+    Type:                  UpdatePrepared
+    Last Transition Time:  2025-01-14T17:04:08Z
+    Message:               Updated the Files and OS on disk as a part of the in progress phase
+    Reason:                AppliedFilesAndOS
+    Status:                True
+    Type:                  UpdateExecuted
+    Last Transition Time:  2025-01-14T17:04:08Z
+    Message:               Node will reboot into config rendered-worker-db01b33f959e5645a721da50a6db1fbb
+    Reason:                RebootedNode
+    Status:                Unknown
+    Type:                  UpdatePostActionComplete
+    Last Transition Time:  2025-01-14T16:04:27Z
+    Message:               Action during update to rendered-worker-f351f6947f15cd0380514f4b1c89f8f2: UnCordoned Node as part of completing upgrade phase
+    Reason:                Uncordoned
+    Status:                False
+    Type:                  UpdateComplete
+    Last Transition Time:  2025-01-14T16:04:27Z
+    Message:               Action during update to rendered-worker-f351f6947f15cd0380514f4b1c89f8f2: In desired config rendered-worker-01f27f752eb84eba917450e43636b210. Resumed normal operations.
+    Reason:                Resumed
+    Status:                False
+    Type:                  Resumed
+    Last Transition Time:  2025-01-14T17:01:18Z
+    Message:               Update Compatible. Post Cfg Actions []: Drain Required: true
+    Reason:                UpdatePreparedUpdateCompatible
+    Status:                True
+    Type:                  UpdateCompatible
+    Last Transition Time:  2025-01-14T17:03:57Z
+    Message:               Drained node. The drain is complete as the desired drainer matches current drainer: drain-rendered-worker-db01b33f959e5645a721da50a6db1fbb
+    Reason:                UpdateExecutedDrained
+    Status:                True
+    Type:                  Drained
+    Last Transition Time:  2025-01-14T17:04:08Z
+    Message:               Applied files and new OS config to node. OS did not need an update. SSH Keys did not need an update
+    Reason:                UpdateExecutedAppliedFilesAndOS
+    Status:                True
+    Type:                  AppliedFilesAndOS
+    Last Transition Time:  2025-01-14T17:01:23Z
+    Message:               Cordoned node. The node is reporting Unschedulable = true
+    Reason:                UpdateExecutedCordoned
+    Status:                True
+    Type:                  Cordoned
+    Last Transition Time:  2025-01-14T17:04:08Z
+    Message:               Upgrade requires a reboot. Currently doing this as the post update action.
+    Reason:                UpdatePostActionCompleteRebootedNode
+    Status:                Unknown
+    Type:                  RebootedNode
+    Last Transition Time:  2025-01-14T15:30:57Z
+    Message:               This node has not yet entered the ReloadedCRIO phase
     Reason:                NotYetOccured
     Status:                False
+    Type:                  ReloadedCRIO
+    Last Transition Time:  2025-01-14T16:04:27Z
+    Message:               Action during update to rendered-worker-f351f6947f15cd0380514f4b1c89f8f2: UnCordoned node. The node is reporting Unschedulable = false
+    Reason:                UpdateCompleteUncordoned
+    Status:                False
+    Type:                  Uncordoned
+    Last Transition Time:  2025-01-14T16:04:07Z
+    Message:               All is good
+    Reason:                AsExpected
+    Status:                False
+    Type:                  PinnedImageSetsDegraded
+    Last Transition Time:  2025-01-14T16:04:07Z
+    Message:               All pinned image sets complete
+    Reason:                AsExpected
+    Status:                False
+    Type:                  PinnedImageSetsProgressing
   Config Version:
-    Current:            rendered-worker-823ff8dc2b33bf444709ed7cd2b9855b
-    Desired:            rendered-worker-823ff8dc2b33bf444709ed7cd2b9855b <2>
-  Health:               Healthy
-  Most Recent Error:
-  Observed Generation:  3
+    Current:            rendered-worker-01f27f752eb84eba917450e43636b210 <3>
+    Desired:            rendered-worker-f351f6947f15cd0380514f4b1c89f8f2
+  Observed Generation:  6
+# ...
 ----
-<1> The desired configuration specified in the `spec.configversion.desired` field updates immediately when a new configuration is detected on the node.
-<2> The desired configuration specified in the `status.configversion.desired` field updates only when the new configuration is validated by the Machine Config Daemon (MCD). The MCD performs validation by checking the current phase of the update. If the update successfully passes the `UPDATEPREPARED` phase, then the status adds the new configuration.
+<1> The `MachineConfigNode` object name.
+<2> The new machine configuration. This field updates after the MCO validates the machine config in the `UPDATEPREPARED` phase, then the status adds the new configuration.
+<3> The current machine config on the node.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13124

Previews:
Machine configuration -> Machine configuration overview -> [About checking machine config node status](https://86943--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#checking-mco-node-status_machine-config-overview) -- Updated module.
Machine configuration -> Machine configuration overview -> [Checking machine config node status](https://86943--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#checking-mco-node-status-congifuring_machine-config-overview) -- New module

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->