### PR TITLE
OCPBUGS-20395 replaced URLs in upstream section #6 in both the code a…

### DIFF
--- a/modules/configuring-dns-forwarding-with-tls.adoc
+++ b/modules/configuring-dns-forwarding-with-tls.adoc
@@ -48,8 +48,8 @@ spec:
           serverName: dnstls.example.com  <4>
       policy: Random <5>
       upstreams: <6>
-      - 192.0.2.1
-      - 192.0.2.2:5353
+      - 1.1.1.1
+      - 2.2.2.2:5353
   upstreamResolvers: <7>
     transportConfig:
       transport: TLS
@@ -67,7 +67,12 @@ spec:
 <3> When configuring TLS for forwarded DNS queries, set the `transport` field to have the value `TLS`.
 <4> When configuring TLS for forwarded DNS queries, this is a mandatory server name used as part of the server name indication (SNI) to validate the upstream TLS server certificate.
 <5> Defines the policy to select upstream resolvers. Default value is `Random`. You can also use the values `RoundRobin`, and `Sequential`.
-<6> Required. Use it to provide upstream resolvers. A maximum of 15 `upstreams` entries are allowed per `forwardPlugin` entry. These are IP addresses that you maintain/operate and are connected to your internal DNS servers. 
+<6> Required. Use it to provide upstream resolvers. A maximum of 15 `upstreams` entries are allowed per `forwardPlugin` entry.
++
+[NOTE]
+====
+All nameservers must be able to resolve the required DNS A-records for your domain.
+====
 <7> Optional. You can use it to override the default policy and forward DNS resolution to the specified DNS resolvers (upstream resolvers) for the default domain. If you do not provide any upstream resolvers, the DNS name queries go to the servers in `/etc/resolv.conf`.
 <8> Only the `Network` type is allowed when using TLS and you must provide an IP address. `Network` type indicates that this upstream resolver should handle forwarded requests separately from the upstream resolvers listed in `/etc/resolv.conf`.
 <9> The `address` field must be a valid IPv4 or IPv6 address.
@@ -94,7 +99,7 @@ apiVersion: v1
 data:
   Corefile: |
     example.com:5353 {
-        forward . 192.0.2.1 192.0.2.2:5353
+        forward . 1.1.1.1 2.2.2.2:5353
     }
     bar.com:5353 example.com:5353 {
         forward . 3.3.3.3 4.4.4.4:5454 <1>

--- a/modules/configuring-dns-forwarding-with-tls.adoc
+++ b/modules/configuring-dns-forwarding-with-tls.adoc
@@ -48,8 +48,8 @@ spec:
           serverName: dnstls.example.com  <4>
       policy: Random <5>
       upstreams: <6>
-      - 1.1.1.1
-      - 2.2.2.2:5353
+      - 192.0.2.1
+      - 192.0.2.2:5353
   upstreamResolvers: <7>
     transportConfig:
       transport: TLS
@@ -67,7 +67,7 @@ spec:
 <3> When configuring TLS for forwarded DNS queries, set the `transport` field to have the value `TLS`.
 <4> When configuring TLS for forwarded DNS queries, this is a mandatory server name used as part of the server name indication (SNI) to validate the upstream TLS server certificate.
 <5> Defines the policy to select upstream resolvers. Default value is `Random`. You can also use the values `RoundRobin`, and `Sequential`.
-<6> Required. Use it to provide upstream resolvers. A maximum of 15 `upstreams` entries are allowed per `forwardPlugin` entry.
+<6> Required. Use it to provide upstream resolvers. A maximum of 15 `upstreams` entries are allowed per `forwardPlugin` entry. These are IP addresses that you maintain/operate and are connected to your internal DNS servers. 
 <7> Optional. You can use it to override the default policy and forward DNS resolution to the specified DNS resolvers (upstream resolvers) for the default domain. If you do not provide any upstream resolvers, the DNS name queries go to the servers in `/etc/resolv.conf`.
 <8> Only the `Network` type is allowed when using TLS and you must provide an IP address. `Network` type indicates that this upstream resolver should handle forwarded requests separately from the upstream resolvers listed in `/etc/resolv.conf`.
 <9> The `address` field must be a valid IPv4 or IPv6 address.
@@ -94,7 +94,7 @@ apiVersion: v1
 data:
   Corefile: |
     example.com:5353 {
-        forward . 1.1.1.1 2.2.2.2:5353
+        forward . 192.0.2.1 192.0.2.2:5353
     }
     bar.com:5353 example.com:5353 {
         forward . 3.3.3.3 4.4.4.4:5454 <1>

--- a/modules/configuring-dns-forwarding-with-tls.adoc
+++ b/modules/configuring-dns-forwarding-with-tls.adoc
@@ -68,12 +68,11 @@ spec:
 <4> When configuring TLS for forwarded DNS queries, this is a mandatory server name used as part of the server name indication (SNI) to validate the upstream TLS server certificate.
 <5> Defines the policy to select upstream resolvers. Default value is `Random`. You can also use the values `RoundRobin`, and `Sequential`.
 <6> Required. Use it to provide upstream resolvers. A maximum of 15 `upstreams` entries are allowed per `forwardPlugin` entry.
-
++
 [NOTE]
 ====
 All nameservers must be able to resolve the required DNS A-records for your domain.
 ====
-
 <7> Optional. You can use it to override the default policy and forward DNS resolution to the specified DNS resolvers (upstream resolvers) for the default domain. If you do not provide any upstream resolvers, the DNS name queries go to the servers in `/etc/resolv.conf`.
 <8> Only the `Network` type is allowed when using TLS and you must provide an IP address. `Network` type indicates that this upstream resolver should handle forwarded requests separately from the upstream resolvers listed in `/etc/resolv.conf`.
 <9> The `address` field must be a valid IPv4 or IPv6 address.

--- a/modules/configuring-dns-forwarding-with-tls.adoc
+++ b/modules/configuring-dns-forwarding-with-tls.adoc
@@ -67,12 +67,7 @@ spec:
 <3> When configuring TLS for forwarded DNS queries, set the `transport` field to have the value `TLS`.
 <4> When configuring TLS for forwarded DNS queries, this is a mandatory server name used as part of the server name indication (SNI) to validate the upstream TLS server certificate.
 <5> Defines the policy to select upstream resolvers. Default value is `Random`. You can also use the values `RoundRobin`, and `Sequential`.
-<6> Required. Use it to provide upstream resolvers. A maximum of 15 `upstreams` entries are allowed per `forwardPlugin` entry.
-+
-[NOTE]
-====
-All nameservers must be able to resolve the required DNS A-records for your domain.
-====
+<6> Required. Use it to provide upstream resolvers. A maximum of 15 `upstreams` entries are allowed per `forwardPlugin` entry. All nameservers must be able to resolve the required DNS A-records for your domain.
 <7> Optional. You can use it to override the default policy and forward DNS resolution to the specified DNS resolvers (upstream resolvers) for the default domain. If you do not provide any upstream resolvers, the DNS name queries go to the servers in `/etc/resolv.conf`.
 <8> Only the `Network` type is allowed when using TLS and you must provide an IP address. `Network` type indicates that this upstream resolver should handle forwarded requests separately from the upstream resolvers listed in `/etc/resolv.conf`.
 <9> The `address` field must be a valid IPv4 or IPv6 address.

--- a/modules/configuring-dns-forwarding-with-tls.adoc
+++ b/modules/configuring-dns-forwarding-with-tls.adoc
@@ -68,11 +68,12 @@ spec:
 <4> When configuring TLS for forwarded DNS queries, this is a mandatory server name used as part of the server name indication (SNI) to validate the upstream TLS server certificate.
 <5> Defines the policy to select upstream resolvers. Default value is `Random`. You can also use the values `RoundRobin`, and `Sequential`.
 <6> Required. Use it to provide upstream resolvers. A maximum of 15 `upstreams` entries are allowed per `forwardPlugin` entry.
-+
+
 [NOTE]
 ====
 All nameservers must be able to resolve the required DNS A-records for your domain.
 ====
+
 <7> Optional. You can use it to override the default policy and forward DNS resolution to the specified DNS resolvers (upstream resolvers) for the default domain. If you do not provide any upstream resolvers, the DNS name queries go to the servers in `/etc/resolv.conf`.
 <8> Only the `Network` type is allowed when using TLS and you must provide an IP address. `Network` type indicates that this upstream resolver should handle forwarded requests separately from the upstream resolvers listed in `/etc/resolv.conf`.
 <9> The `address` field must be a valid IPv4 or IPv6 address.


### PR DESCRIPTION
Version(s):
12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-20395

Link to docs preview:
https://86946--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/dns-operator.html
https://86946--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/dns-operator.html
https://86946--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/dns-operator.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


