### PR TITLE
[RHACS] Fix error in RNs for API deprecation

### DIFF
--- a/release_notes/46-release-notes.adoc
+++ b/release_notes/46-release-notes.adoc
@@ -273,11 +273,6 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
-|`/v1/availableAuthProviders` endpoint
-|GA
-|DEP
-|DEP
-
 |`/v1/clustercves/suppress` APIs^[6,7]^
 |DEP
 |DEP
@@ -305,11 +300,6 @@ In the table, features are marked with the following statuses:
 
 |`/v1/summary/counts` endpoint
 |NA
-|DEP
-|DEP
-
-|`/v1/tls-challenge` endpoint
-|DEP
 |DEP
 |DEP
 


### PR DESCRIPTION
Version(s):

4.6+

Issue: none, see #86945 and #86944 

Link to docs preview: **ACS has no QE, approved by SME**
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
