### PR TITLE
HCIDOCS-373: Docs for OCPSTRAT-1425 Support additional NTP servers in install-config for bare metal (IPI)

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -6,10 +6,9 @@
 [id="additional-install-config-parameters_{context}"]
 = Additional `install-config` parameters
 
-See the following tables for the required parameters, the `hosts` parameter,
-and the `bmc` parameter for the `install-config.yaml` file.
+See the following tables for the required parameters, the `hosts` parameter, and the `bmc` parameter for the `install-config.yaml` file.
 
-[cols="2,1,5"]
+[cols="4,1,5"]
 [options="header"]
 .Required parameters
 |===
@@ -24,25 +23,40 @@ and the `bmc` parameter for the `install-config.yaml` file.
 | `UEFI`
 | The boot mode for a node. Options are `legacy`, `UEFI`, and `UEFISecureBoot`. If `bootMode` is not set, Ironic sets it while inspecting the node.
 
-| `bootstrapExternalStaticDNS`
+a| 
+----
+platform:
+  baremetal: 
+    bootstrapExternalStaticDNS
+----
 |
 | The static network DNS of the bootstrap node. You must set this value when deploying a cluster with static IP addresses when there is no Dynamic Host Configuration Protocol (DHCP) server on the bare-metal network. If you do not set this value, the installation program will use the value from `bootstrapExternalStaticGateway`, which causes problems when the IP address values of the gateway and DNS are different.
 
-| `bootstrapExternalStaticIP`
+a| 
+----
+platform:
+  baremetal:
+    bootstrapExternalStaticIP
+----
 |
 | The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
 
-| `bootstrapExternalStaticGateway`
+a| 
+----
+platform:
+  baremetal:
+    bootstrapExternalStaticGateway
+----
 |
 | The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
 
 | `sshKey`
 |
-| The `sshKey` configuration setting contains the key in the `~/.ssh/id_rsa.pub` file required to access the control plane nodes and compute nodes. Typically, this key is from the `provisioner` node.
+| The `sshKey` configuration setting has the key in the `~/.ssh/id_rsa.pub` file required to access the control plane nodes and compute nodes. Typically, this key is from the `provisioner` node.
 
 | `pullSecret`
 |
-| The `pullSecret` configuration setting contains a copy of the pull secret downloaded from the link:https://console.redhat.com/openshift/install/metal/user-provisioned[Install OpenShift on Bare Metal] page when preparing the provisioner node.
+| The `pullSecret` configuration setting has a copy of the pull secret downloaded from the link:https://console.redhat.com/openshift/install/metal/user-provisioned[Install OpenShift on Bare Metal] page when preparing the provisioner node.
 
 
 a|
@@ -51,7 +65,7 @@ metadata:
     name:
 ----
 |
-|The name to be given to the {product-title} cluster. For example, `openshift`.
+|The name of the {product-title} cluster. For example, `openshift`.
 
 
 a|
@@ -69,7 +83,7 @@ compute:
   - name: worker
 ----
 |
-|The {product-title} cluster requires a name be provided for compute nodes even if there are zero nodes.
+|The {product-title} cluster requires you to provide a name for compute nodes even if there are zero nodes.
 
 
 a|
@@ -105,7 +119,7 @@ a| `provisioningNetworkInterface` |  | The name of the network interface on node
 
 | `apiVIPs` | a| (Optional) The virtual IP address for Kubernetes API communication.
 
-This setting must either be provided in the `install-config.yaml` file as a reserved IP from the MachineNetwork or preconfigured in the DNS so that the default name resolves correctly. Use the virtual IP address and not the FQDN when adding a value to the `apiVIPs` configuration setting in the `install-config.yaml` file. The primary IP address must be from the IPv4 network when using dual stack networking. If not set, the installation program uses `api.<cluster_name>.<base_domain>` to derive the IP address from the DNS.
+You must either provide this setting in the `install-config.yaml` file as a reserved IP from the `MachineNetwork` parameter or preconfigured in the DNS so that the default name resolves correctly. Use the virtual IP address and not the FQDN when adding a value to the `apiVIPs` configuration setting in the `install-config.yaml` file. The primary IP address must be from the IPv4 network when using dual stack networking. If not set, the installation program uses `api.<cluster_name>.<base_domain>` to derive the IP address from the DNS.
 
 [NOTE]
 ====
@@ -117,7 +131,7 @@ Before {product-title} 4.12, the cluster installation program only accepted an I
 
 | `ingressVIPs` | a| (Optional) The virtual IP address for ingress traffic.
 
-This setting must either be provided in the `install-config.yaml` file as a reserved IP from the MachineNetwork or preconfigured in the DNS so that the default name resolves correctly. Use the virtual IP address and not the FQDN when adding a value to the `ingressVIPs` configuration setting in the `install-config.yaml` file. The primary IP address must be from the IPv4 network when using dual stack networking. If not set, the installation program uses `test.apps.<cluster_name>.<base_domain>` to derive the IP address from the DNS.
+You must either provide this setting in the `install-config.yaml` file as a reserved IP from the `MachineNetwork` parameter or preconfigured in the DNS so that the default name resolves correctly. Use the virtual IP address and not the FQDN when adding a value to the `ingressVIPs` configuration setting in the `install-config.yaml` file. The primary IP address must be from the IPv4 network when using dual stack networking. If not set, the installation program uses `test.apps.<cluster_name>.<base_domain>` to derive the IP address from the DNS.
 
 [NOTE]
 ====
@@ -134,13 +148,23 @@ Before {product-title} 4.12, the cluster installation program only accepted an I
 |Default
 |Description
 
+a|
+----
+platform:
+  baremetal:
+    additionalNTPServers:
+    - <ip_address_or_domain_name>
+----
+|
+| An optional list of additional NTP servers to add to each host. You can use an IP address or a domain name to specify each NTP server. Additional NTP servers are user-defined NTP servers that enable preinstallation clock synchronization when the cluster host clocks are out of synchronization.
+
 |`provisioningDHCPRange`
 |`172.22.0.10,172.22.0.100`
 |Defines the IP range for nodes on the provisioning network.
 
 a|`provisioningNetworkCIDR`
 |`172.22.0.0/24`
-|The CIDR for the network to use for provisioning. This option is required when not using the default address range on the provisioning network.
+|The CIDR for the network to use for provisioning. The installation program requires this option when not using the default address range on the provisioning network.
 
 |`clusterProvisioningIP`
 |The third IP address of the `provisioningNetworkCIDR`.
@@ -148,7 +172,7 @@ a|`provisioningNetworkCIDR`
 
 |`bootstrapProvisioningIP`
 |The second IP address of the `provisioningNetworkCIDR`.
-|The IP address on the bootstrap VM where the provisioning services run while the installer is deploying the control plane (master) nodes. Defaults to the second IP address of the provisioning subnet. For example, `172.22.0.2` or `2620:52:0:1307::2`.
+|The IP address on the bootstrap VM where the provisioning services run while the installation program is deploying the control plane (master) nodes. Defaults to the second IP address of the provisioning subnet. For example, `172.22.0.2` or `2620:52:0:1307::2`.
 
 | `externalBridge`
 | `baremetal`
@@ -175,7 +199,7 @@ a|`provisioningNetworkCIDR`
 |
 | The `provisioningNetwork` configuration setting determines whether the cluster uses the provisioning network. If it does, the configuration setting also determines if the cluster manages the network.
 
-`Disabled`: Set this parameter to `Disabled` to disable the requirement for a provisioning network. When set to `Disabled`, you must only use virtual media based provisioning, or bring up the cluster using the assisted installer. If `Disabled` and using power management, BMCs must be accessible from the bare-metal network. If `Disabled`, you must provide two IP addresses on the bare-metal network that are used for the provisioning services.
+`Disabled`: Set this parameter to `Disabled` to disable the requirement for a provisioning network. When set to `Disabled`, you must only use virtual media based provisioning, or start the cluster by using the {ai-full}. If set to `Disabled` and using power management, BMCs must be accessible from the bare-metal network. If set to `Disabled`, you must provide two IP addresses on the bare-metal network that the installation program uses for the provisioning services.
 
 `Managed`: Set this parameter to `Managed`, which is the default, to fully manage the provisioning network, including DHCP, TFTP, and so on.
 
@@ -211,7 +235,7 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 
 | `role`
 |
-| The role of the bare metal node. Either `master` (control plane node) or `worker` (compute node).
+| The role of the bare-metal node. Either `master` (control plane node) or `worker` (compute node).
 
 
 | `bmc`

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -36,24 +36,26 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
+    additionalNTPServers: <2>
+      - <ntp_domain_or_ip>
     apiVIPs:
       - <api_ip>
     ingressVIPs:
       - <wildcard_ip>
     provisioningNetworkCIDR: <CIDR>
-    bootstrapExternalStaticIP: <bootstrap_static_ip_address> <2>
-    bootstrapExternalStaticGateway: <bootstrap_static_gateway> <3>
-    bootstrapExternalStaticDNS: <bootstrap_static_dns> <4>
+    bootstrapExternalStaticIP: <bootstrap_static_ip_address> <3>
+    bootstrapExternalStaticGateway: <bootstrap_static_gateway> <4>
+    bootstrapExternalStaticDNS: <bootstrap_static_dns> <5>
     hosts:
       - name: openshift-master-0
         role: master
         bmc:
-          address: ipmi://<out_of_band_ip> <5>
+          address: ipmi://<out_of_band_ip> <6>
           username: <user>
           password: <password>
         bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
-         deviceName: "<installation_disk_drive_path>" <6>
+         deviceName: "<installation_disk_drive_path>" <7>
       - name: <openshift_master_1>
         role: master
         bmc:
@@ -94,11 +96,12 @@ sshKey: '<ssh_pub_key>'
 +
 --
 <1> Scale the compute machines based on the number of compute nodes that are part of the {product-title} cluster. Valid options for the `replicas` value are `0` and integers greater than or equal to `2`. Set the number of replicas to `0` to deploy a three-node cluster, which contains only three control plane machines. A three-node cluster is a smaller, more resource-efficient cluster that can be used for testing, development, and production. You cannot install the cluster with only one compute node.
-<2> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticIP` configuration setting to specify the static IP address of the bootstrap VM when there is no DHCP server on the bare-metal network.
-<3> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticGateway` configuration setting to specify the gateway IP address for the bootstrap VM when there is no DHCP server on the bare-metal network.
-<4> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticDNS` configuration setting to specify the DNS address for the bootstrap VM when there is no DHCP server on the bare-metal network.
-<5> See the BMC addressing sections for more options.
-<6> To set the path to the installation disk drive, enter the kernel name of the disk. For example, `/dev/sda`.
+<2> An optional list of additional NTP server domain names or IP addresses to add to each host configuration when the cluster host clocks are out of synchronization.
+<3> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticIP` configuration setting to specify the static IP address of the bootstrap VM when there is no DHCP server on the bare metal network.
+<4> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticGateway` configuration setting to specify the gateway IP address for the bootstrap VM when there is no DHCP server on the bare metal network.
+<5> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticDNS` configuration setting to specify the DNS address for the bootstrap VM when there is no DHCP server on the bare metal network.
+<6> See the BMC addressing sections for more options.
+<7> To set the path to the installation disk drive, enter the kernel name of the disk. For example, `/dev/sda`.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Added additionalNTPServers setting to install-config yaml config module, and to additional configuration settings module at line 26. The remaining changes are suggestions from the Vale linter.

Fixes: [HCIDOCS-373](https://issues.redhat.com//browse/HCIDOCS-373)

See https://issues.redhat.com/browse/HCIDOCS-373 for additional details.

Preview URL: https://86960--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-installation-workflow and https://86960--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#additional-install-config-parameters_ipi-install-installation-workflow

For release(s): 4.18
QE Review: 

- [x] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
