### PR TITLE
One step needs to be added to the Quick Start point of About Logging 6.0 documentation

### DIFF
--- a/observability/logging/logging-6.0/log6x-about.adoc
+++ b/observability/logging/logging-6.0/log6x-about.adoc
@@ -43,6 +43,20 @@ Logging includes extensive validation rules and default values to ensure a smoot
 
 . Install the `OpenShift Logging` and `Loki` Operators from OperatorHub.
 
+. Create a secret to access an existing object storage bucket: 
++
+.Example command for AWS
+[source,terminal,subs="+quotes"]
+----
+$ oc create secret generic logging-loki-s3 \
+  --from-literal=bucketnames="<bucket_name>" \
+  --from-literal=endpoint="<aws_bucket_endpoint>" \
+  --from-literal=access_key_id="<aws_access_key_id>" \
+  --from-literal=access_key_secret="<aws_access_key_secret>" \
+  --from-literal=region="<aws_region_of_your_bucket>" \
+  -n openshift-logging
+----
+
 . Create a `LokiStack` custom resource (CR) in the `openshift-logging` namespace:
 +
 [source,yaml]


### PR DESCRIPTION
- One step needs to be added to the Quick Start point of About Logging 6.0 documentation.
- Here is the documentation link: https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.0/log6x-about.html#quick-start
- Here Step 2 is mentioned as "Create a LokiStack custom resource (CR) in the openshift-logging namespace:"
- But before creating `LokiStack` custom resource (CR), it is necessary to create an `object storage secret`.
- Without creating a secret we can not create `Lokistack` customer resource.
- We need to mention that `object storage secret` name in the `LokiStack custom resource (CR)` under `spec.storage.secret.name` section.
- So it is required to add this step in our documentation.
- Hence adding Step 2 in the documentation:

-----------------
2.  Create a secret to access an existing object storage bucket: 
Example command for AWS
~~~
$ oc create secret generic logging-loki-s3 \
  --from-literal=bucketnames="<bucket_name>" \
  --from-literal=endpoint="<aws_bucket_endpoint>" \
  --from-literal=access_key_id="<aws_access_key_id>" \
  --from-literal=access_key_secret="<aws_access_key_secret>" \
  --from-literal=region="<aws_region_of_your_bucket>" \
  -n openshift-logging
~~~
------------------

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP-4.18, RHOCP-4.17, RHOCP-4.16, RHOCP-4.15, RHOCP-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1346
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://86970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-about.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
