### PR TITLE
TELCODOCS-2151: Clarifying versions must match between seed and openshift-install program

### DIFF
--- a/modules/ibi-create-iso-for-bmh.adoc
+++ b/modules/ibi-create-iso-for-bmh.adoc
@@ -15,7 +15,7 @@ For more information about the specification for the `image-based-installation-c
 
 .Prerequisites
 * You generated a seed image from a {sno} seed cluster.
-* You downloaded the latest version of the `openshift-install` program.
+* You downloaded the `openshift-install` program. The version of the `openshift-install` program must match the {product-title} version in your seed image.
 * The target host has network access to the seed image URL and all other installation artifacts.
 * If you require static networking, you must install the `nmstatectl` library on the host that creates the live installation ISO.
 


### PR DESCRIPTION
[TELCODOCS-2151](https://issues.redhat.com//browse/TELCODOCS-2151): Clarifying versions must match between seed and openshift-install program

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2151

Link to docs preview:
https://86974--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi-factory-image-based-install.html#ibi-create-iso-for-bmh_ibi-factory-image-based-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

