### PR TITLE
OBSDOCS-1492: Update the automatically generated resource file

### DIFF
--- a/modules/monitoring-resources-reference-for-the-cluster-monitoring-operator.adoc
+++ b/modules/monitoring-resources-reference-for-the-cluster-monitoring-operator.adoc
@@ -4,7 +4,7 @@
 // make edits or learn more about how this file is generated, read the docgen utility
 // instructions in the source code for the CMO.
 :_mod-docs-content-type: REFERENCE
-[id="resources-reference-for-the-cluster-monitoring-operator"]
+[id="resources-reference-for-the-cluster-monitoring-operator_{context}"]
 = Resources reference for the Cluster Monitoring Operator
 
 This document describes the following resources deployed and managed by the Cluster Monitoring Operator (CMO):
@@ -16,16 +16,13 @@ Use this information when you want to configure API endpoint connections to retr
 
 [IMPORTANT]
 ====
-In certain situations, accessing API endpoints can degrade the performance and scalability of your cluster, especially if you use endpoints to retrieve, send, or query large amounts of metrics data.
+In certain situations, accessing endpoints can degrade the performance and scalability of your cluster, especially if you use endpoints to retrieve, send, or query large amounts of metrics data.
 
 To avoid these issues, follow these recommendations:
 
 * Avoid querying endpoints frequently. Limit queries to a maximum of one every 30 seconds.
-* Do not try to retrieve all metrics data via the `/federate` endpoint for Prometheus.
-Query it only when you want to retrieve a limited, aggregated data set.
-For example, retrieving fewer than 1,000 samples for each request helps minimize the risk of performance degradation.
+* Do not try to retrieve all metrics data via the `/federate` endpoint. Query it only when you want to retrieve a limited, aggregated data set. For example, retrieving fewer than 1,000 samples for each request helps minimize the risk of performance degradation.
 ====
-
 [id="cmo-routes-resources"]
 == CMO routes resources
 
@@ -72,7 +69,8 @@ Expose the user-defined Alertmanager web server within the cluster on the follow
 
 Expose the Alertmanager web server within the cluster on the following ports:
 
-* Port 9094 provides access to all the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-view` role (for read-only operations) or the `monitoring-alertmanager-edit` role in the `openshift-monitoring` project.
+* Port 9094 provides access to all the Alertmanager endpoints. Granting access requires binding a user to the `monitoring-alertmanager-view` (for read-only operations) or `monitoring-alertmanager-edit` role in the `openshift-monitoring` project.
+
 * Port 9092 provides access to the Alertmanager endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit` cluster role or `monitoring-edit` cluster role in the project.
 * Port 9097 provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
 
@@ -107,7 +105,6 @@ Expose openshift-state-metrics `/metrics` endpoints within the cluster on the fo
 Expose the Prometheus web server within the cluster on the following ports:
 
 * Port 9091 provides access to all the Prometheus endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role.
-
 * Port 9092 provides access to the `/metrics` and `/federate` endpoints only. This port is for internal use, and no other usage is guaranteed.
 
 === openshift-user-workload-monitoring/prometheus-operator
@@ -137,7 +134,7 @@ Expose the Thanos Querier web server within the cluster on the following ports:
 
 * Port 9091 provides access to all the Thanos Querier endpoints. Granting access requires binding a user to the `cluster-monitoring-view` cluster role.
 * Port 9092 provides access to the `/api/v1/query`, `/api/v1/query_range/`, `/api/v1/labels`, `/api/v1/label/*/values`, and `/api/v1/series` endpoints restricted to a given project. Granting access requires binding a user to the `view` cluster role in the project.
-* Port 9093 provides access to the `/api/v1/alerts`, and `/api/v1/rules` endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit` cluster role, `monitoring-edit` cluster role or `monitoring-rules-view` cluster role in the project.
+* Port 9093 provides access to the `/api/v1/alerts`, and `/api/v1/rules` endpoints restricted to a given project. Granting access requires binding a user to the `monitoring-rules-edit`, `monitoring-edit`, or `monitoring-rules-view` cluster role in the project.
 * Port 9094 provides access to the `/metrics` endpoint only. This port is for internal use, and no other usage is guaranteed.
 
 === openshift-user-workload-monitoring/thanos-ruler
@@ -151,5 +148,5 @@ This also exposes the gRPC endpoints on port 10901. This port is for internal us
 
 === openshift-monitoring/cluster-monitoring-operator
 
-Expose the `/metrics` endpoint on port 8443. This port is for internal use, and no other usage is guaranteed.
+Expose the `/metrics` and `/validate-webhook` endpoints on port 8443. This port is for internal use, and no other usage is guaranteed.
 

--- a/observability/monitoring/accessing-third-party-monitoring-apis.adoc
+++ b/observability/monitoring/accessing-third-party-monitoring-apis.adoc
@@ -16,7 +16,7 @@ In certain situations, accessing API endpoints can degrade the performance and s
 To avoid these issues, follow these recommendations:
 
 * Avoid querying endpoints frequently. Limit queries to a maximum of one every 30 seconds.
-* Do not try to retrieve all metrics data via the `/federate` endpoint for Prometheus. Query it only when you want to retrieve a limited, aggregated data set. For example, retrieving fewer than 1,000 samples for each request helps minimize the risk of performance degradation.
+* Do not try to retrieve all metrics data through the `/federate` endpoint for Prometheus. Query it only when you want to retrieve a limited, aggregated data set. For example, retrieving fewer than 1,000 samples for each request helps minimize the risk of performance degradation.
 ====
 
 // Accessing service APIs for third-party monitoring components

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -82,7 +82,7 @@ include::modules/monitoring-granting-users-permissions-for-core-platform-monitor
 .Additional resources
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#granting-user-permissions-using-the-web-console_enabling-monitoring-for-user-defined-projects[Granting user permissions by using the web console] 
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#granting-user-permissions-using-the-cli_enabling-monitoring-for-user-defined-projects[Granting user permissions by using the CLI]
-* xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#resources-reference-for-the-cluster-monitoring-operator[Resources reference for the {cmo-full}]
+* xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#resources-reference-for-the-cluster-monitoring-operator_accessing-monitoring-apis-by-using-the-cli[Resources reference for the {cmo-full}]
 * xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#cmo-services-resources[CMO services resources]
 
 endif::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
Version(s): `enterprise-4.18` and `monitoring-docs-restructure`

NOTE: the creator of the PR will manually cherry pick this to older versions as this file needs to be adjusted for each OCP version.

Issue: [OBSDOCS-1492](https://issues.redhat.com/browse/OBSDOCS-1492)

Link to docs preview:  [Resources reference for the Cluster Monitoring Operator](https://86976--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-third-party-monitoring-apis.html#resources-reference-for-the-cluster-monitoring-operator_accessing-monitoring-apis-by-using-the-cli)

QE review:
- [X] QE has approved this change.

**Additional information:**
**This file is a copy of what we have in the `openshift/cluster-monitoring-operator` repository: [link](https://github.com/openshift/cluster-monitoring-operator/blob/master/Documentation/resources.adoc?plain=1)**

The actual content needs to be identical

**Edit:** I am removing the example commands based on SME comment and changes in the file: https://github.com/openshift/cluster-monitoring-operator/pull/2563/files#r1922521116
Everything stays the same otherwise, so the QE approval still stands.