### PR TITLE
CNV-45436: spec:running deprecated

### DIFF
--- a/modules/virt-accessing-rdp-console.adoc
+++ b/modules/virt-accessing-rdp-console.adoc
@@ -25,7 +25,7 @@ metadata:
   name: vm-ephemeral
   namespace: example-namespace
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc
+++ b/modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc
@@ -22,7 +22,7 @@ kind: VirtualMachine
 metadata:
   name: vm-server
 spec:
-  running: true
+  runStrategy: Always
   template:
     spec:
       domain:

--- a/modules/virt-configuring-downward-metrics.adoc
+++ b/modules/virt-configuring-downward-metrics.adoc
@@ -40,7 +40,7 @@ spec:
     name: u1.medium
   preference:
     name: fedora
-  running: true
+  runStrategy: Always
   template:
     metadata:
       labels:

--- a/modules/virt-configuring-runstrategy-vm.adoc
+++ b/modules/virt-configuring-runstrategy-vm.adoc
@@ -8,11 +8,6 @@
 
 You can configure a run strategy for a virtual machine (VM) by using the command line.
 
-[IMPORTANT]
-====
-The `spec.runStrategy` and `spec.running` keys are mutually exclusive. A VM configuration that contains values for both keys is invalid.
-====
-
 .Procedure
 
 * Edit the `VirtualMachine` resource by running the following command:

--- a/modules/virt-configuring-vm-real-time.adoc
+++ b/modules/virt-configuring-vm-real-time.adoc
@@ -23,7 +23,7 @@ kind: VirtualMachine
 metadata:
   name: realtime-vm
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       annotations:

--- a/modules/virt-connecting-vm-secondarynw-using-fqdn.adoc
+++ b/modules/virt-connecting-vm-secondarynw-using-fqdn.adoc
@@ -40,7 +40,7 @@ metadata:
   name: example-vm
   namespace: example-namespace
 spec:
-  running: true
+  runStrategy: Always
   template:
     spec:
       domain:

--- a/modules/virt-creating-new-vm-from-cloned-pvc-using-datavolumetemplate.adoc
+++ b/modules/virt-creating-new-vm-from-cloned-pvc-using-datavolumetemplate.adoc
@@ -47,7 +47,7 @@ metadata:
     kubevirt.io/vm: vm-dv-clone
   name: vm-dv-clone <1>
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/modules/virt-creating-service-cli.adoc
+++ b/modules/virt-creating-service-cli.adoc
@@ -25,7 +25,7 @@ metadata:
   name: example-vm
   namespace: example-namespace
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/modules/virt-creating-vm-cli.adoc
+++ b/modules/virt-creating-vm-cli.adoc
@@ -38,7 +38,7 @@ This example manifest does not configure VM authentication.
     name: u1.medium <3>
   preference:
     name: rhel.9 <4>
-  running: true
+  runStrategy: Always
   template:
     spec:
       domain:

--- a/modules/virt-creating-vm-cloned-pvc-data-volume-template.adoc
+++ b/modules/virt-creating-vm-cloned-pvc-data-volume-template.adoc
@@ -27,7 +27,7 @@ metadata:
     kubevirt.io/vm: vm-dv-clone
   name: vm-dv-clone <1>
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/modules/virt-defining-watchdog-device-vm.adoc
+++ b/modules/virt-defining-watchdog-device-vm.adoc
@@ -25,7 +25,7 @@ metadata:
     kubevirt.io/vm: vm2-rhel84-watchdog
   name: <vm-name>
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/modules/virt-runstrategies-vms.adoc
+++ b/modules/virt-runstrategies-vms.adoc
@@ -9,7 +9,7 @@
 The `spec.runStrategy` key has four possible values:
 
 `Always`::
-The virtual machine instance (VMI) is always present when a virtual machine (VM) is created on another node. A new VMI is created if the original stops for any reason. This is the same behavior as `running: true`.
+The virtual machine instance (VMI) is always present when a virtual machine (VM) is created on another node. A new VMI is created if the original stops for any reason.
 
 `RerunOnFailure`::
 The VMI is re-created on another node if the previous instance fails. The instance is not re-created if the VM stops successfully, such as when it is shut down.
@@ -18,7 +18,7 @@ The VMI is re-created on another node if the previous instance fails. The instan
 You control the VMI state manually with the `start`, `stop`, and `restart` virtctl client commands. The VM is not automatically restarted.
 
 `Halted`::
-No VMI is present when a VM is created. This is the same behavior as `running: false`.
+No VMI is present when a VM is created.
 
 Different combinations of the `virtctl start`, `stop` and `restart` commands affect the run strategy.
 

--- a/modules/virt-setting-resource-quota-limits-for-vms.adoc
+++ b/modules/virt-setting-resource-quota-limits-for-vms.adoc
@@ -19,7 +19,7 @@ kind: VirtualMachine
 metadata:
   name: with-limits
 spec:
-  running: false
+  runStrategy: Halted
   template:
     spec:
       domain:

--- a/modules/virt-vm-custom-scheduler.adoc
+++ b/modules/virt-vm-custom-scheduler.adoc
@@ -22,7 +22,7 @@ kind: VirtualMachine
 metadata:
   name: vm-fedora
 spec:
-  running: true
+  runStrategy: Always
   template:
     spec:
       schedulerName: my-scheduler <1>

--- a/snippets/virt-dynamic-key.yaml
+++ b/snippets/virt-dynamic-key.yaml
@@ -18,7 +18,7 @@ spec:
     name: u1.medium
   preference:
     name: rhel.9
-  running: true
+  runStrategy: Always
   template:
     spec:
       domain:

--- a/snippets/virt-static-key.yaml
+++ b/snippets/virt-static-key.yaml
@@ -18,7 +18,7 @@ spec:
     name: u1.medium
   preference:
     name: rhel.9
-  running: true
+  runStrategy: Always
   template:
     spec:
       domain:

--- a/virt/monitoring/virt-monitoring-vm-health.adoc
+++ b/virt/monitoring/virt-monitoring-vm-health.adoc
@@ -26,7 +26,7 @@ You can define a watchdog to monitor the health of the guest operating system by
 
 The watchdog device monitors the agent and performs one of the following actions if the guest operating system is unresponsive:
 
-* `poweroff`: The VM powers down immediately. If `spec.running` is set to `true` or `spec.runStrategy` is not set to `manual`, then the VM reboots.
+* `poweroff`: The VM powers down immediately. If `spec.runStrategy` is not set to `manual`, the VM reboots.
 * `reset`: The VM reboots in place and the guest operating system cannot react.
 +
 [NOTE]

--- a/virt/nodes/virt-node-maintenance.adoc
+++ b/virt/nodes/virt-node-maintenance.adoc
@@ -82,14 +82,7 @@ endif::openshift-rosa,openshift-dedicated[]
 [id="run-strategies"]
 == Run strategies
 
-A virtual machine (VM) configured with `spec.running: true` is immediately restarted. The `spec.runStrategy` key provides greater flexibility for determining how a VM behaves under certain conditions.
-
-[IMPORTANT]
-====
-The `spec.runStrategy` and `spec.running` keys are mutually exclusive. Only one of them can be used.
-
-A VM configuration with both keys is invalid.
-====
+The `spec.runStrategy` key determines how a VM behaves under certain conditions.
 
 include::modules/virt-runstrategies-vms.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-45436

OCP 4.18+
CNV 4.18

Preview:
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/creating_vms_cli/virt-creating-vms-by-cloning-pvcs.html#virt-creating-vm-cloning-pvc-data-volume-template_virt-creating-vms-by-cloning-pvcs
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/creating_vms_cli/virt-creating-vms-from-cli.html#virt-creating-vm-cli_virt-creating-vms-cli
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-schedule-vms.html#virt-vm-custom-scheduler_virt-schedule-vms
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-working-with-resource-quotas-for-vms.html#virt-setting-resource-quota-limits-for-vms_virt-working-with-resource-quotas-for-vms
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-accessing-vm-ssh.html#virt-adding-public-key-vm-cli_static-key
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-accessing-vm-ssh.html#virt-enabling-dynamic-key-injection-cli_dynamic-key
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-accessing-vm-ssh.html#virt-creating-service-cli_virt-accessing-vm-ssh
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-configuring-downward-metrics_virt-using-downward-metrics_virt-exposing-downward-metrics
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health.html#virt-defining-watchdog-device-vm
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-node-maintenance.html#run-strategies
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.html
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.html#virt-connecting-vm-secondarynw-fqdn_virt-accessing-vm-secondary-network-fqdn
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.html#virt-attaching-vm-to-ovn-secondary-nw-cli_virt-connecting-vm-to-ovn-secondary-network
https://86977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-exposing-vm-with-service.html#virt-creating-service-cli_virt-exposing-vm-with-service
