### PR TITLE
OCPBUGS-39252: Add step to change Argo CD default deletion behaviour

### DIFF
--- a/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
+++ b/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
@@ -41,3 +41,38 @@ You can configure the hub cluster with a set of ArgoCD applications that generat
 
 [start=2]
 include::snippets/ztp-patch-argocd-hub-cluster.adoc[]
+
+
+. Optional: If you have existing ArgoCD applications, verify that the `PrunePropagationPolicy=background` policy is set in the `Application` resource by running the following command:
++
+--
+[source,terminal]
+----
+$ oc -n openshift-gitops get applications.argoproj.io  \
+clusters -o jsonpath='{.spec.syncPolicy.syncOptions}' |jq
+----
+
+.Example output for an existing policy
+[source,terminal]
+----
+[
+  "CreateNamespace=true",
+  "PrunePropagationPolicy=background",
+  "RespectIgnoreDifferences=true"
+]
+----
+--
+
+.. If the `spec.syncPolicy.syncOption` field does not contain a `PrunePropagationPolicy` parameter or `PrunePropagationPolicy` is set to the `foreground` value, set the policy to `background` in the `Application` resource. See the following example:
++
+[source,yaml]
+----
+kind: Application
+spec:
+  syncPolicy:
+    syncOptions:
+    - PrunePropagationPolicy=background
+----
+
++
+Setting the `background` deletion policy ensures that the `ManagedCluster` CR and all its associated resources are deleted.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.15, 4.16, 4.17, 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-39252
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://86992--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-preparing-the-hub-cluster.html#ztp-configuring-hub-cluster-with-argocd_ztp-preparing-the-hub-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
