### PR TITLE
OSDOCS-13063: 4.15.43 RN

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2777,6 +2777,40 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.15.43
+[id="ocp-4-15-43_{context}"]
+=== RHSA-2025:0121 - {product-title} 4.15.43 bug fix and security update
+
+Issued: 15 January 2025
+
+{product-title} release 4.15.43, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0121[RHSA-2025:0121] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0125[RHBA-2025:0125] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.43 --pullspecs
+----
+
+[id="ocp-4-15-43-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, a machine controller failed to save the {vmw-full} task ID of an instance template clone operation. This caused the machine to go into the `Provisioning` state and to power off. With this release, the {vmw-full} machine controller can detect and recover from this state. (link:https://issues.redhat.com/browse/OCPBUGS-48105[*OCPBUGS-48105*])
+
+* Previously, the installation of an {aws-short} cluster failed when the service control policy (SCP) had `false` specified for its `AssociatePublicIpAddress` parameter. With this release, a fix ensures that this SCP configuration no longer causes the installation of an {aws-short} cluster to fail. (link:https://issues.redhat.com/browse/OCPBUGS-47680[*OCPBUGS-47680*])
+
+* Previously, the IDs used to determine the number of rows in a Dashboard table were not unique and some rows would be combined if their IDs were the same. With this release, the ID uses more information to prevent duplicate IDs and the table can display each expected row. (link:https://issues.redhat.com/browse/OCPBUGS-47646[*OCPBUGS-47646*])
+
+* Previously, the algorithm for calculating the priority of machine removal equated Machines over a specific age to Machines annotated as preferred for removal. With this release, the priority of unmarked Machines sorted by age is reduced to avoid conflict with those explicitly marked, and the algorithm has been updated to ensure age order is guaranteed for Machines up to ten years old. (link:https://issues.redhat.com/browse/OCPBUGS-46080[*OCPBUGS-46080*])
+
+* Previously, in managed services, audit logs are sent to a local webhook service. Control plane deployments sent traffic through `konnectivity` and attempted to send the audit webhook traffic through the `konnectivity` proxies - `openshift-apiserver` and `oauth-openshift`.  With this release, the audit-webhook is in the list of no_proxy hosts for the affected pods, and the audit log traffic that is sent to the audit-webhook is successfully sent. (link:https://issues.redhat.com/browse/OCPBUGS-46075[*OCPBUGS-46075*])
+
+[id="ocp-4-15-43-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 //4.15.42
 [id="ocp-4-15-42_{context}"]
 === RHSA-2024:11562 - {product-title} 4.15.42 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-13063](https://issues.redhat.com/browse/OSDOCS-13063)

Link to docs preview:
https://87000--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-43_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until Go-Live: 1/15/25

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
