### PR TITLE
OSDOCS-13113: Updated the 45186 note in 4.17.10

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2967,7 +2967,7 @@ The Node Tuning Operator can now properly select kernel arguments and management
 
 * Previously, the `aws-sdk-go-v2` software development kit (SDK) failed to authenticate an `AssumeRoleWithWebIdentity` API operation on an {aws-short} {sts-first} cluster. With this release, the pod identity webhook now includes a default region so that this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-45938[*OCPBUGS-45938*])
 
-* Previously, the installation of an {aws-short} cluster failed when the service control policy (SCP) had `false` specified for its `AssociatePublicIpAddress` parameter. With this release, a fix ensures that this SCP configuration no longer causes the installation of an {aws-short} cluster to fail. (link:https://issues.redhat.com/browse/OCPBUGS-45186[*OCPBUGS-45186*])
+* Previously, installation of an {aws-short} cluster failed in certain environments on existing subnets when the `publicIp` parameter of the `MachineSet` object was explicity set to `false`. With this release, a fix ensures that a configuration value set for `publicIp` no longer causes issues when the installation program provisions machines for your {aws-short} cluster in certain environments. (link:https://issues.redhat.com/browse/OCPBUGS-45186[*OCPBUGS-45186*])
 
 * Previously, an additional filtering property was passed into the component that is used to list operands on the *Operator details* page. The additional property caused the list to always be empty if it was extended by a dynamic plugin. With this release, the extra property has been removed so that available operands are listed as expected. (link:https://issues.redhat.com/browse/OCPBUGS-45667[*OCPBUGS-45667*])
 


### PR DESCRIPTION
Change management sent on the 15 Jan ([4.17 Release Notes doc, OCPBUGS-45186 note change](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-1777497669475061493)). 


Version(s):
4.17

Issue:
[OSDOCS-13113](https://issues.redhat.com/browse/OSDOCS-13113)

Link to docs preview:
[4.17.10: OCPBUGS-45186](https://87016--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-10_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.


