### PR TITLE
OSDOCS-13114: Update short-term creds note for Entra postinstall

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
@@ -10,7 +10,12 @@ During installation, you can configure the Cloud Credential Operator (CCO) to op
 
 [NOTE]
 ====
-This credentials strategy is supported for {aws-first}, {gcp-first}, and global {azure-full} only. The strategy must be configured during installation of a new {product-title} cluster. You cannot configure an existing cluster that uses a different credentials strategy to use this feature.
+This credentials strategy is supported for {aws-first}, {gcp-first}, and global {azure-full} only.
+
+For {aws-short} and {gcp-short} clusters, you must configure your cluster to use this strategy during installation of a new {product-title} cluster. 
+You cannot configure an existing {aws-short} or {gcp-short} cluster that uses a different credentials strategy to use this feature.
+
+If you did not configure your {azure-short} cluster to use {entra-first} during installation, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#post-install-enable-token-auth_changing-cloud-credentials-configuration[enable this authentication method on an existing cluster].
 ====
 
 //todo: Should provide some more info about the benefits of this here as well. Note: Azure is not yet limited-priv, but still gets the benefit of not storing root creds on the cluster and some sort of time-based rotation


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-13114

Link to docs preview:
[Manual mode with short-term credentials for components](https://87019--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-short-term-creds.html)

QE review:
- [x] QE has approved this change.

Additional information: