### PR TITLE
OSSM-8666: Wrong extensionProviders name in example

### DIFF
--- a/modules/ossm-config-otel.adoc
+++ b/modules/ossm-config-otel.adoc
@@ -70,7 +70,7 @@ spec:
     meshConfig:
       enableTracing: true
       extensionProviders:
-      - name: otel-tracing
+      - name: otel
         opentelemetry:
           port: 4317
           service: otel-collector.istio-system.svc.cluster.local # <1>
@@ -90,7 +90,7 @@ metadata:
 spec:
   tracing:
     - providers:
-        - name: otel-tracing
+        - name: otel
       randomSamplingPercentage: 100
 ----
 +


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OSSM-8666
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://87020--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/traces/ossm-distr-tracing-assembly.html#ossm-config-otel_ossm-traces-assembly

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
