### PR TITLE
OSDOCS-13043 updating oc-mirror in 4.18 RNs

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -454,14 +454,14 @@ The terminology for the `ip_whitelist` and `ip_blacklist` annotations have been 
 [id="ocp-release-notes-networking-ovn-kubernetes-observability_{context}"]
 === Checking OVN-Kubernetes network traffic with OVS sampling using the CLI
 
-OVN-Kubernetes network traffic can be viewed with OVS sampling via the CLI for the following network APIs: 
+OVN-Kubernetes network traffic can be viewed with OVS sampling via the CLI for the following network APIs:
 
 * `NetworkPolicy`
 * `AdminNetworkPolicy`
 * `BaselineNetworkPolicy`
 * `UserDefinesdNetwork` isolation
 * `EgressFirewall`
-* Multicast ACLs. 
+* Multicast ACLs.
 
 Checking OVN-Kubernetes network traffic with OVS sampling using the CLI is intended to help with packet tracing. It can also be used while the Network Observability Operator is installed.
 
@@ -470,7 +470,7 @@ For more information, see xref:../networking/ovn_kubernetes_network_provider/ovn
 [id="ocp-release-notes-networking-dynamic-config-manager_{context}"]
 === The dynamic configuration manager is enabled by default (Technology Preview)
 
-You can reduce your memory footprint by using the dynamic configuration manager on Ingress Controllers. The dynamic configuration manager propagates endpoint changes through a dynamic API. This process enables the underlying routers to adapt to changes (scale ups and scale downs) without reloads. 
+You can reduce your memory footprint by using the dynamic configuration manager on Ingress Controllers. The dynamic configuration manager propagates endpoint changes through a dynamic API. This process enables the underlying routers to adapt to changes (scale ups and scale downs) without reloads.
 
 To use the dynamic configuration manager, enable the `TechPreviewNoUpgrade` feature set by running the following command:
 
@@ -724,6 +724,10 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.16 |4.17 |4.18
 
+|oc-mirror plugin v1
+|General Availability
+|General Availability
+|Deprecated
 |====
 
 [discrete]
@@ -1204,7 +1208,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Node disruption policies
-|Technology Preview 
+|Technology Preview
 |General Availability
 |General Availability
 
@@ -1473,17 +1477,17 @@ In the following tables, features are marked with the following statuses:
 |oc-mirror plugin v2
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Enclave support
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Delete functionality
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |====
 


### PR DESCRIPTION
Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13043](https://issues.redhat.com/browse/OSDOCS-13043)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://87027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html 
ctrl+f for oc-mirror, changes are to the OpenShift CLI (oc) deprecated and removed features table and the OpenShift CLI (oc) Technology Preview features table.
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
