### PR TITLE
Edit two steps in quick start procedure of About Logging 6.0 documentation

### DIFF
--- a/observability/logging/logging-6.0/log6x-about.adoc
+++ b/observability/logging/logging-6.0/log6x-about.adoc
@@ -92,7 +92,7 @@ $ oc create sa collector -n openshift-logging
 +
 [source,shell]
 ----
-$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector
+$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector -n openshift-logging
 ----
 
 . Install the Cluster Observability Operator.
@@ -116,10 +116,9 @@ spec:
 +
 [source,shell]
 ----
-$ oc project openshift-logging
-$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector
-$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector
-$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector
+$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector -n openshift-logging
+$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector -n openshift-logging
+$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector -n openshift-logging
 ----
 
 . Create a `ClusterLogForwarder` CR to configure log forwarding:


### PR DESCRIPTION
- Need to edit 2 steps in the Quick Start point of About Logging 6.0 documentation.
- Here is the documentation link: https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.0/log6x-about.html#quick-start
- This is the last and important change in the Quick start process.
- In step 5 and step 8 changes are required: 
----
5. Bind the ClusterRole to the service account: 
~~~
$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector 
~~~

8. Add additional roles to the collector service account:
 ~~~
$ oc project openshift-logging
$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector 
$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector 
$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector 
~~~
----

- In these steps, commands are properly mentioned.
- However, the project name is not mentioned in the commands.
- So we need to mention project name in the above commands.


**Reason:**
1. If for any reason the user has changed the namespace in the middle, then, it will create the resource in the wrong namespace.
2. If the credentials are shared, and two people using the same cluster at the same time, then, the second person could change to work in a different namespace.

-Hence we need to explicitly mention the `-n openshift-logging` in the above commands.
-Here are the new required changes: 

----
5. Bind the ClusterRole to the service account: 
~~~
$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector -n openshift-logging 
~~~

8. Add additional roles to the collector service account: 
~~~
$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector -n openshift-logging 
$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector -n openshift-logging 
$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector -n openshift-logging 
~~~
----

-For more information, kindly check the documentation bug [2]
[2] https://issues.redhat.com/browse/OBSDOCS-1346

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP-4.18, RHOCP-4.17, RHOCP-4.16, RHOCP-4.15, RHOCP-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1346

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://87028--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-about.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
