### PR TITLE
OSDOCS-11542: CLI tools - Classic-HCP migration

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -237,6 +237,94 @@ Topics:
   File: creating-quick-start-tutorials
   Distros: openshift-rosa-hcp
 ---
+Name: CLI tools
+Dir: cli_reference
+Distros: openshift-rosa-hcp
+Topics:
+- Name: CLI tools overview
+  File: index
+- Name: OpenShift CLI (oc)
+  Dir: openshift_cli
+  Topics:
+  - Name: Getting started with the OpenShift CLI
+    File: getting-started-cli
+  - Name: Configuring the OpenShift CLI
+    File: configuring-cli
+  - Name: Usage of oc and kubectl commands
+    File: usage-oc-kubectl
+  - Name: Managing CLI profiles
+    File: managing-cli-profiles
+  - Name: Extending the OpenShift CLI with plugins
+    File: extending-cli-plugins
+ # - Name: Managing CLI plugins with Krew
+  #  File: managing-cli-plugins-krew
+  #  Distros: openshift-rosa-hcp
+  - Name: OpenShift CLI developer command reference
+    File: developer-cli-commands
+  - Name: OpenShift CLI administrator command reference
+    File: administrator-cli-commands
+    Distros: openshift-rosa-hcp
+- Name: Developer CLI (odo)
+  File: odo-important-update
+  # Dir: developer_cli_odo
+  Distros: openshift-rosa-hcp
+  # Topics:
+  # - Name: odo release notes
+  #  File: odo-release-notes
+  # - Name: Understanding odo
+  #  File: understanding-odo
+  # - Name: Installing odo
+  #  File: installing-odo
+  # - Name: Configuring the odo CLI
+  #  File: configuring-the-odo-cli
+  # - Name: odo CLI reference
+  #  File: odo-cli-reference
+- Name: Knative CLI (kn) for use with OpenShift Serverless
+  File: kn-cli-tools
+  Distros: openshift-rosa-hcp
+- Name: Pipelines CLI (tkn)
+  Dir: tkn_cli
+  Distros: openshift-rosa-hcp
+  Topics:
+  - Name: Installing tkn
+    File: installing-tkn
+  - Name: Configuring tkn
+    File: op-configuring-tkn
+  - Name: Basic tkn commands
+    File: op-tkn-reference
+- Name: opm CLI
+  Dir: opm
+  Distros: openshift-rosa-hcp
+  Topics:
+  - Name: Installing the opm CLI
+    File: cli-opm-install
+  - Name: opm CLI reference
+    File: cli-opm-ref
+- Name: Operator SDK
+  Dir: osdk
+  Distros: openshift-rosa-hcp
+  Topics:
+  - Name: Installing the Operator SDK CLI
+    File: cli-osdk-install
+  - Name: Operator SDK CLI reference
+    File: cli-osdk-ref
+- Name: ROSA CLI
+  Dir: rosa_cli
+  Distros: openshift-rosa-hcp
+  Topics:
+  # - Name: CLI and web console
+  #   File: rosa-cli-openshift-console
+  - Name: Getting started with the ROSA CLI
+    File: rosa-get-started-cli
+  - Name: Managing objects with the ROSA CLI
+    File: rosa-manage-objects-cli
+  - Name: Checking account and version information with the ROSA CLI
+    File: rosa-checking-acct-version-cli
+  - Name: Checking logs with the ROSA CLI
+    File: rosa-checking-logs-cli
+  - Name: Least privilege permissions for ROSA CLI commands
+    File: rosa-cli-permission-examples
+---
 Name: Red Hat OpenShift Cluster Manager
 Dir: ocm
 Distros: openshift-rosa-hcp
@@ -250,24 +338,6 @@ Topics:
 # OSDOCS-11789: Adding the minimum chapters of support and troubleshooting
 # docs needed to ensure that xrefs in "Planning your environment" work;
 # omit as required by further HCP migration work.
----
-# OSDOCS-11789: Adding the minimum chapters of CLI doc needed
-# to ensure that xrefs in "Planning your environment" work;
-# @BM feel free to alter as needed
-Name: CLI tools
-Dir: cli_reference
-Distros: openshift-rosa-hcp
-Topics:
-- Name: OpenShift CLI (oc)
-  Dir: openshift_cli
-  Topics:
-  - Name: Getting started with the OpenShift CLI
-    File: getting-started-cli
-- Name: ROSA CLI
-  Dir: rosa_cli
-  Topics:
-  - Name: Least privilege permissions for ROSA CLI commands
-    File: rosa-cli-permission-examples
 ---
 Name: Support
 Dir: support

--- a/cli_reference/openshift_cli/extending-cli-plugins.adoc
+++ b/cli_reference/openshift_cli/extending-cli-plugins.adoc
@@ -8,12 +8,12 @@ toc::[]
 
 You can write and install plugins to build on the default `oc` commands,
 allowing you to perform new and more complex tasks with the
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 {product-title}
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-rosa,openshift-dedicated[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 OpenShift
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 CLI.
 
 // Writing CLI plugins

--- a/cli_reference/openshift_cli/managing-cli-profiles.adoc
+++ b/cli_reference/openshift_cli/managing-cli-profiles.adoc
@@ -7,18 +7,18 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 A CLI configuration file allows you to configure different profiles, or contexts, for use with the xref:../../cli_reference/index.adoc#cli-tools-overview[CLI tools overview]. A context consists of
-ifndef::microshift,openshift-dedicated,openshift-rosa[]
+ifndef::microshift,openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 xref:../../authentication/understanding-authentication.adoc#understanding-authentication[user authentication]
-endif::microshift,openshift-dedicated,openshift-rosa[]
+endif::microshift,openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ifdef::microshift[]
 user authentication
 endif::[]
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 an {product-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 the {product-title} (ROSA)
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 server information associated with a _nickname_.
 
 include::modules/about-cli-profiles-switch.adoc[leveloffset=+1]

--- a/cli_reference/openshift_cli/usage-oc-kubectl.adoc
+++ b/cli_reference/openshift_cli/usage-oc-kubectl.adoc
@@ -5,53 +5,53 @@ include::_attributes/common-attributes.adoc[]
 :context: usage-oc-kubectl
 
 The Kubernetes command-line interface (CLI), `kubectl`, can be used to run commands against a Kubernetes cluster. Because {product-title}
-ifdef::openshift-rosa[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 (ROSA)
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 is a certified Kubernetes distribution, you can use the supported `kubectl` binaries that ship with
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 ROSA
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 , or you can gain extended functionality by using the `oc` binary.
 
 == The oc binary
 
 The `oc` binary offers the same capabilities as the `kubectl` binary, but it extends to natively support additional
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 ROSA
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 features, including:
 
 * **Full support for
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 ROSA
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 resources**
 +
 Resources such as `DeploymentConfig`, `BuildConfig`, `Route`, `ImageStream`, and `ImageStreamTag` objects are specific to
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 ROSA
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 distributions, and build upon standard Kubernetes primitives.
 +
 * **Authentication**
 +
-ifndef::microshift,openshift-rosa,openshift-dedicated[]
+ifndef::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 The `oc` binary offers a built-in `login` command for authentication and lets you work with projects, which map Kubernetes namespaces to authenticated users.
 Read xref:../../authentication/understanding-authentication.adoc#understanding-authentication[Understanding authentication] for more information.
-endif::microshift,openshift-rosa,openshift-dedicated[]
+endif::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 +
 ifdef::microshift[]
 The `oc` binary offers a built-in `login` command for authentication to {product-title}.
@@ -64,19 +64,19 @@ The additional command `oc new-app`, for example, makes it easier to get new app
 [IMPORTANT]
 ====
 If you installed an earlier version of the `oc` binary, you cannot use it to complete all of the commands in
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title} {product-version}
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 ROSA
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 . If you want the latest features, you must download and install the latest version of the `oc` binary corresponding to your
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 ROSA
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 server version.
 ====
 
@@ -109,19 +109,19 @@ image:redcircle-3.png[] `oc` client might provide options and features that migh
 == The kubectl binary
 
 The `kubectl` binary is provided as a means to support existing workflows and scripts for new
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 ROSA
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 users coming from a standard Kubernetes environment, or for those who prefer to use the `kubectl` CLI. Existing users of `kubectl` can continue to use the binary to interact with Kubernetes primitives, with no changes required to the
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 ROSA
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 cluster.
 
 You can install the supported `kubectl` binary by following the steps to xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-installing-cli_cli-developer-commands[Install the OpenShift CLI]. The `kubectl` binary is included in the archive if you download the binary, or is installed when you install the CLI by using an RPM.

--- a/cli_reference/opm/cli-opm-install.adoc
+++ b/cli_reference/opm/cli-opm-install.adoc
@@ -8,20 +8,20 @@ toc::[]
 
 include::modules/olm-about-opm.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
 * See xref:../../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Operator Framework packaging format] for more information about the bundle format.
 * To create a bundle image using the Operator SDK, see
 xref:../../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-working-bundle-images[Working with bundle images].
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/olm-installing-opm.adoc[leveloffset=+1]
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 [id="opm-addtl-resources"]
 == Additional resources
 
 * See xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs] for `opm` procedures including creating, updating, and pruning catalogs.
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/cli_reference/opm/cli-opm-ref.adoc
+++ b/cli_reference/opm/cli-opm-ref.adoc
@@ -38,14 +38,14 @@ include::snippets/deprecated-feature.adoc[]
 include::modules/opm-cli-ref-generate.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-index.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format]
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs]
-* xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
-endif::openshift-rosa,openshift-dedicated[]
+* xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/opm-cli-ref-init.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-migrate.adoc[leveloffset=+1]

--- a/cli_reference/osdk/cli-osdk-install.adoc
+++ b/cli_reference/osdk/cli-osdk-install.adoc
@@ -11,14 +11,14 @@ The Operator SDK provides a command-line interface (CLI) tool that Operator deve
 include::snippets/osdk-deprecation.adoc[]
 
 Operator authors with cluster administrator access to a Kubernetes-based cluster, such as {product-title}, can use the Operator SDK CLI to develop their own Operators based on Go, Ansible, Java, or Helm. link:https://kubebuilder.io/[Kubebuilder] is embedded into the Operator SDK as the scaffolding solution for Go-based Operators, which means existing Kubebuilder projects can be used as is with the Operator SDK and continue to work.
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 See xref:../../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operators] for full documentation on the Operator SDK.
 
 [NOTE]
 ====
 {product-title} {product-version} supports Operator SDK {osdk_ver}.
 ====
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/osdk-installing-cli-linux-macos.adoc[leveloffset=+1]
 

--- a/cli_reference/osdk/cli-osdk-ref.adoc
+++ b/cli_reference/osdk/cli-osdk-ref.adoc
@@ -15,9 +15,9 @@ include::snippets/osdk-deprecation.adoc[]
 ----
 $ operator-sdk <command> [<subcommand>] [<argument>] [<flags>]
 ----
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 See xref:../../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operators] for full documentation on the Operator SDK.
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/osdk-cli-ref-bundle.adoc[leveloffset=+1]
 include::modules/osdk-cli-ref-cleanup.adoc[leveloffset=+1]
@@ -26,31 +26,31 @@ include::modules/osdk-cli-ref-create.adoc[leveloffset=+1]
 include::modules/osdk-cli-ref-generate.adoc[leveloffset=+1]
 include::modules/osdk-cli-ref-generate-bundle.adoc[leveloffset=+2]
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
 * See xref:../../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-bundle-deploy-olm_osdk-working-bundle-images[Bundling an Operator and deploying with Operator Lifecycle Manager] for a full procedure that includes using the `make bundle` command to call the `generate bundle` subcommand.
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/osdk-cli-ref-generate-kustomize.adoc[leveloffset=+2]
 
 include::modules/osdk-cli-ref-init.adoc[leveloffset=+1]
 include::modules/osdk-cli-ref-run.adoc[leveloffset=+1]
 include::modules/osdk-cli-ref-run-bundle.adoc[leveloffset=+2]
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
 * See xref:../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-operatorgroups-membership_olm-understanding-operatorgroups[Operator group membership] for details on possible install modes.
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/osdk-cli-ref-run-bundle-upgrade.adoc[leveloffset=+2]
 include::modules/osdk-cli-ref-scorecard.adoc[leveloffset=+1]
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 [role="_additional-resources"]
 .Additional resources
 
 * See xref:../../operators/operator_sdk/osdk-scorecard.adoc#osdk-scorecard[Validating Operators using the scorecard tool] for details about running the scorecard tool.
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/cli_reference/rosa_cli/rosa-manage-objects-cli.adoc
+++ b/cli_reference/rosa_cli/rosa-manage-objects-cli.adoc
@@ -18,19 +18,25 @@ include::modules/rosa-common-commands.adoc[leveloffset=+1]
 include::modules/rosa-parent-commands.adoc[leveloffset=+1]
 include::modules/rosa-create-objects.adoc[leveloffset=+1]
 
+ifdef::openshift-rosa[]
 [role="_additional-resources"]
 == Additional resources
+
 * See xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-aws-instance-types_rosa-service-definition[AWS Instance types] for a list of supported instance types.
 * See xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference] for a list of IAM roles needed for cluster creation.
 * See xref:../../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-understanding-aws-account-association_rosa-sts-creating-a-cluster-with-customizations[Understanding AWS account association] for more information about the OCM role and user role.
 * See xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Additional custom security groups] for information about security group requirements.
+endif::openshift-rosa[]
 
 include::modules/rosa-edit-objects.adoc[leveloffset=+1]
 
 [role="_additional-resources_1"]
 == Additional resources
+ifdef::openshift-rosa[]
 * See xref:../../networking/networking_operators/ingress-operator.adoc#configuring-ingress-controller[Configuring the Ingress Controller] for information regarding editing non-default application routers.
-
+endif::openshift-rosa[]
+//Classic to HCP breakout. Remove ROSA-specific conditionals when networking is added to HCP. 
+ 
 include::modules/rosa-delete-objects.adoc[leveloffset=+1]
 include::modules/rosa-install-uninstall-addon.adoc[leveloffset=+1]
 include::modules/rosa-list-objects.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-11542
This PR replaces: https://github.com/openshift/openshift-docs/pull/80720

Link to docs preview:
https://87043--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
