### PR TITLE
OSDOCS-13064: Update 4.16.30 z-stream RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3341,6 +3341,41 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.30
+[id="ocp-4-16-30_{context}"]
+=== RHSA-2025:0140 - {product-title} {product-version}.30 bug fix and security update
+
+Issued: 15 January 2025
+
+{product-title} release {product-version}.30 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0140[RHSA-2025:0140] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0143[RHBA-2025:0143] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.30 --pullspecs
+----
+
+[id="ocp-4-16-30-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the Operator Lifecycle Manager (OLM)catalog registry pods were terminated by the kubelet with a `TerminationByKubelet` error, and the pods were not recreated by the catalog Operator. With this release, the registry pods are recreated without an error. (link:https://issues.redhat.com/browse/OCPBUGS-47738[*OCPBUGS-47738*])
+
+ * Previously, the certificate signing request (CSR) approver included certificates from other systems in its calculations to determine if it was congested. When this happened, the CSR approver stopped approving certificates. With this release, the CSR approver only includes CSRs that it can approve, using the `signerName` property as a filter. The CSR approver only prevents new approvals when there are a large number of CSRs, for the `signerName` values that it observes, and for certificates that it does not approve. (link:https://issues.redhat.com/browse/OCPBUGS-47704[*OCPBUGS-47704*])
+
+ * Previously, the Performance Profile Creator (PPC) failed to build a performance profile for compute nodes that had different core ID numbering (core per socket) for their logical processors and the nodes existed under the same node pool. With this release, the PPC does not fail to create the performance profile because the PPC can build a performance profile for a cluster that has compute nodes with different core ID numbering for their logical processors. The PPC produces a warning message to use the generated performance profile with caution, because different core ID numbering might impact the system optimization and isolated management of tasks. (link:https://issues.redhat.com/browse/OCPBUGS-47701[*OCPBUGS-47701*])
+
+ * Previously, an event was missed by the informer watch stream. If an object was deleted while this disconnection occurred, the informer resulted in a different type, reported that the state was invalid, and the object was deleted. With this release, the temporary disconnection possibilities are handled correctly. (link:https://issues.redhat.com/browse/OCPBUGS-47645[*OCPBUGS-47645*])
+
+ * Previously, when using the `SiteConfig` custom resource (CR) to delete a cluster or a node, the `BareMetalHost` CR was stuck in the `Deprovisioning` state. With this release, the order deletion is correct and the `SiteConfig` CR deletes a cluster or a node successfully. This fix requires version {gitops-title} 1.13 or later. (link:https://issues.redhat.com/browse/OCPBUGS-46524[*OCPBUGS-46524*])
+
+[id="ocp-4-16-30-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.16.29
 [id="ocp-4-16-29_{context}"]
 === RHBA-2025:0018 - {product-title} {product-version}.29 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-13064](https://issues.redhat.com//browse/OSDOCS-13064)

Link to docs preview:
[4.16.30](https://87044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-30_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream release notes.
