### PR TITLE
OSDOCS-10631: Updated the customized br-ex bridge section

### DIFF
--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -20,17 +20,11 @@ endif::[]
 == Creating a manifest object that includes a customized `br-ex` bridge
 
 ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
-As an alternative to using the `configure-ovs.sh` shell script to set a customized `br-ex` bridge on a bare-metal platform, you can create a `MachineConfig` object that includes a customized `br-ex` bridge network configuration.
-
-:FeatureName: Creating a `MachineConfig` object that includes a customized `br-ex` bridge
-include::snippets/technology-preview.adoc[]
+As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `MachineConfig` object that includes an NMState configuration file. The NMState configuration file creates a customized `br-ex` bridge network configuration on each node in your cluster.
 endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 
 ifdef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
-As an alternative to using the `configure-ovs.sh` shell script to set a customized `br-ex` bridge on a bare-metal platform, you can create a `NodeNetworkConfigurationPolicy` custom resource (CR) that includes a customized `br-ex` bridge network configuration.
-
-:FeatureName: Creating a `NodeNetworkConfigurationPolicy` CR that includes a customized `br-ex` bridge
-include::snippets/technology-preview.adoc[]
+As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `NodeNetworkConfigurationPolicy` custom resource (CR) that includes an NMState configuration file. The NMState configuration file creates a customized `br-ex` bridge network configuration on each node in your cluster.
 
 This feature supports the following tasks:
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-10631](https://issues.redhat.com/browse/OSDOCS-10631)

Link to docs preview:
* [Creating a manifest object that includes a customized br-ex bridge - IPI](https://87053--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow)
* [Creating a manifest object that includes a customized br-ex bridge - POSTINSTALL](https://87053--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.html#creating-manifest-file-customized-br-ex-bridge_ipi-install-post-installation-configuration)
* [Installing a user-provisioned cluster on bare metal - UPI](https://87053--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal)
* [Installing a user-provisioned bare metal cluster with network customizations - UPI](https://87053--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal-network-customizations)
* [Installing a user-provisioned bare metal cluster on a restricted network - UPI](https://87053--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#creating-manifest-file-customized-br-ex-bridge_installing-restricted-networks-bare-metal)



- [x] SME has approved this change.
- [x] QE has approved this change.
