### PR TITLE
OCPBUGS-10336: updated the Compliance Operator must-gather image

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -75,7 +75,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 |`registry.redhat.io/lvms4/lvms-must-gather-rhel9:v<installed_version_LVMS>`
 |Data collection for the LVM Operator.
 
-|`ghcr.io/complianceascode/must-gather-ocp`
+|`registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8:<digest-version>`
 |Data collection for the Compliance Operator.
 endif::openshift-rosa,openshift-dedicated[]
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-10336

Link to docs preview:
[Gathering data about specific features](https://87063--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data)

Additional information:
None