### PR TITLE
OSSM-8340: Prevent parameter expansion in example

### DIFF
--- a/modules/ossm-config-openshift-monitoring-only.adoc
+++ b/modules/ossm-config-openshift-monitoring-only.adoc
@@ -22,7 +22,7 @@ You can integrate {SMProductName} with user-workload monitoring.
 
 .Procedure
 
-. Apply a `ServiceMonitor` object to monitor the Istio control plane:
+. Create a YAML file named `servicemonitor.yml` to monitor the {istio} control plane:
 +
 .Example `ServiceMonitor` object
 [source,yaml]
@@ -43,7 +43,14 @@ spec:
     interval: 30s
 ----
 
-. Apply a `PodMonitor` object to collect metrics from Istio proxies:
+. Apply the YAML file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor.yml
+----
+
+. Create a YAML file named `podmonitor.yml` to collect metrics from the {istio} proxies:
 +
 .Example `PodMonitor` object
 [source,yaml]
@@ -87,9 +94,16 @@ spec:
       targetLabel: pod_name
 ----
 <1> Because {ocp-product-title} monitoring ignores the `namespaceSelector` spec in `ServiceMonitor` and `PodMonitor` objects, you must apply the `PodMonitor` object in all mesh namespaces, including the Istio control plane namespace.
-+
-. Go to the {ocp-short-name} Console -> **Observe** -> **Metrics**, and run the query `istio_requests_total`.
 
+. Apply the YAML file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f podmonitor.yml
+----
+
+. On the {ocp-short-name} Console go to **Observe** -> **Metrics**, and run the query `istio_requests_total`.
++
 [NOTE]
 ====
 The **Metrics** implementation can take a few minutes for the query to return results.


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue:https://issues.redhat.com/browse/OSSM-8340
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://87071--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/metrics/ossm-metrics-assembly.html#ossm-config-openshift-monitoring-only_ossm-metrics-assembly
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
