### PR TITLE
OSDOCS-13006-418: Updated the OCP Local link in add RN doc

### DIFF
--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -62,7 +62,7 @@ xref:../observability/distr_tracing/distr-tracing-rn.adoc#distr-tracing-rn[{DTPr
 {nbsp} +
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/#Get%20started[{gitops-title}] +
 {nbsp} +
-link:https://docs.redhat.com/en/documentation/red_hat_openshift_local/#Release%20Notes[{openshift-local-productname}] +
+link:https://crc.dev/docs/introducing/[{openshift-local-productname} (Upstream CRC documentation)] +
 {nbsp} +
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/#Getting%20Started[{pipelines-title}] +
 {nbsp} +


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13006](https://issues.redhat.com/browse/OSDOCS-13006)

Link to docs preview:
[Additional release notes](https://87087--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/addtl-release-notes.html)



