### PR TITLE
OSDOCS-13006-417: Updated the OCP Local link in add RN doc

### DIFF
--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -65,7 +65,7 @@ xref:../observability/distr_tracing/distr-tracing-rn.adoc#distr-tracing-rn[{DTPr
 {nbsp} +
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/#Get%20started[{gitops-title}] +
 {nbsp} +
-link:https://docs.redhat.com/en/documentation/red_hat_openshift_local/#Release%20Notes[{openshift-local-productname}] +
+link:https://crc.dev/docs/introducing/[{openshift-local-productname} (Upstream CRC documentation)] +
 {nbsp} +
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/#Getting%20Started[{pipelines-title}] +
 {nbsp} +


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13006](https://issues.redhat.com/browse/OSDOCS-13006)

Link to docs preview:
[Additional release notes](https://87088--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/addtl-release-notes.html)



