### PR TITLE
[enterprise-4.12] OCPBUGS-48192: clarifying the role of the root cred in CCO mint mode

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
@@ -10,9 +10,20 @@ Mint mode is supported for Amazon Web Services (AWS) and Google Cloud Platform (
 
 Mint mode is the default mode on the platforms for which it is supported. In this mode, the Cloud Credential Operator (CCO) uses the provided administrator-level cloud credential to create new credentials for components in the cluster with only the specific permissions that are required.
 
-If the credential is not removed after installation, it is stored and used by the CCO to process `CredentialsRequest` CRs for components in the cluster and create new credentials for each with only the specific permissions that are required. The continuous reconciliation of cloud credentials in mint mode allows actions that require additional credentials or permissions, such as upgrading, to proceed.
+For clusters that use the CCO in mint mode, the administrator-level credential is stored in the `kube-system` namespace. 
+The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
 
-Mint mode stores the administrator-level credential in the cluster `kube-system` namespace. If this approach does not meet the security requirements of your organization, see _Alternatives to storing administrator-level secrets in the kube-system project_ for xref:../../installing/installing_aws/manually-creating-iam.adoc#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-aws[AWS] or xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-gcp[GCP].
+With mint mode, each cluster component has only the specific permissions it requires.
+Cloud credential reconciliation is automatic and continuous so that components can perform actions that require additional credentials or permissions.
+
+For example, a minor version cluster update (such as updating from {product-title} 4.16 to 4.17) might include an updated `CredentialsRequest` resource for a cluster component.
+The CCO, operating in mint mode, uses the `admin` credential to process the `CredentialsRequest` resource and create users with limited permissions to satisfy the updated authentication requirements.
+
+[NOTE]
+====
+By default, mint mode requires storing the `admin` credential in the cluster `kube-system` namespace. 
+If this approach does not meet the security requirements of your organization, see _Alternatives to storing administrator-level secrets in the kube-system project_ for xref:../../installing/installing_aws/manually-creating-iam.adoc#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-aws[AWS] or xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-gcp[GCP].
+====
 
 [id="mint-mode-permissions"]
 == Mint mode permissions requirements

--- a/modules/manually-removing-cloud-creds.adoc
+++ b/modules/manually-removing-cloud-creds.adoc
@@ -6,16 +6,22 @@
 [id="manually-removing-cloud-creds_{context}"]
 = Removing cloud provider credentials
 
-After installing an {product-title} cluster with the Cloud Credential Operator (CCO) in mint mode, you can remove the administrator-level credential secret from the `kube-system` namespace in the cluster. The administrator-level credential is required only during changes that require its elevated permissions, such as upgrades.
+For clusters that use the Cloud Credential Operator (CCO) in mint mode, the administrator-level credential is stored in the `kube-system` namespace. 
+The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
+
+After installing an {product-title} cluster with the CCO in mint mode, you can remove the administrator-level credential secret from the `kube-system` namespace in the cluster. 
+The CCO only requires the administrator-level credential during changes that require reconciling new or modified `CredentialsRequest` custom resources, such as minor cluster version updates.
 
 [NOTE]
 ====
-Prior to a non z-stream upgrade, you must reinstate the credential secret with the administrator-level credential. If the credential is not present, the upgrade might be blocked.
+Before performing a minor version cluster update (for example, updating from {product-title} 4.16 to 4.17), you must reinstate the credential secret with the administrator-level credential. 
+If the credential is not present, the update might be blocked.
 ====
 
 .Prerequisites
 
-* Your cluster is installed on a platform that supports removing cloud credentials from the CCO. Supported platforms are AWS and GCP.
+* Your cluster is installed on a platform that supports removing cloud credentials from the CCO. 
+Supported platforms are AWS and GCP.
 
 .Procedure
 


### PR DESCRIPTION
Cherrypicked from aaa358d96b1e6b5761930c8ecbf2e2d96d6b9433 xref: #87091