### PR TITLE
ROX-24421: Add note about cloud services for shot-lived access

### DIFF
--- a/snippets/note-about-creating-tokens.adoc
+++ b/snippets/note-about-creating-tokens.adoc
@@ -10,4 +10,5 @@
 * To prevent privilege escalation, when you create a new token, your role's permissions limit the permission you can assign to that token. For example, if you only have `read` permission for the Integration resource, you cannot create a token with `write` permission.
 * If you want a custom role to create tokens for other users to use, you must assign the required permissions to that custom role.
 * Use short-lived tokens for machine-to-machine communication, such as CI/CD pipelines, scripts, and other automation. Also, use the `roxctl central login` command for human-to-machine communication, such as `roxctl` CLI or API access.
+* The majority of cloud service providers support OIDC identity tokens, for example, Microsoft Entra ID, Google Cloud Identity Platform, and AWS Cognito. OIDC identity tokens issued by these services can be used for {product-title-short} short-lived access.
 ====


### PR DESCRIPTION
This PR adds note/info that short-lived tokens can be integrated with existing auth services provided by cloud providers.

Version(s):
RHACS 4.7 (can also be ported to the current version 4.6 if needed)

Issue:
[ROX-24421](https://issues.redhat.com/browse/ROX-24421)

Link to docs preview:

[87148--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/using-the-roxctl-cli.html](https://87148--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/using-the-roxctl-cli.html)
[87148--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/configure-api-token.html](https://87148--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/configure-api-token.html)
[87148--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/configure-short-lived-access.html](https://87148--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/configure-short-lived-access.html)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The community guide for MS Entra ID is provided here: https://github.com/stackrox/contributions/blob/main/guides/cloud-provider-integrations/azure-service-principal-m2m-auth.md
