### PR TITLE
OLS-1346: Document the use of AdditionalCAConfigMapRef in CRD file

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -17,6 +17,7 @@ include::modules/ols-creating-the-credentials-secret-using-web-console.adoc[leve
 include::modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc[leveloffset=+1]
 include::modules/ols-creating-the-credentials-secret-using-cli.adoc[leveloffset=+1]
 include::modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc[leveloffset=+1]
+include::modules/ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm.adoc[leveloffset=+2]
 include::modules/ols-verifying-openshift-lightspeed-deployment.adoc[leveloffset=+1]
 include::modules/ols-about-lightspeed-and-role-based-access-control.adoc[leveloffset=+1]
 include::modules/ols-granting-access-to-individual-users.adoc[leveloffset=+2]

--- a/modules/ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm.adoc
+++ b/modules/ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm.adoc
@@ -1,0 +1,68 @@
+// This module is used in the following assemblies:
+
+// * configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm_{context}"]
+= Configuring {ols-long} with a trust provider certificate for the LLM 
+
+This procedure explains how to configure {ols-long} with a trust provider certificate for the Large Language Model (LLM) provider.
+
+[NOTE]
+====
+If the LLM provider you are using requires a trust certificate to authenticate the {ols-long} service you must perform this procedure. If the LLM provider does not require a trust certificate to authenticate the service, you should skip this procedure.
+====
+
+.Procedure
+
+. Copy the contents of the certificate file and paste it into a file called `caCertFileName`.
+
+. Create a `ConfigMap` object called `trusted-certs` by running the following command:
++
+[source,terminal]
+----
+$ oc create configmap trusted-certs --from-file=caCertFileName
+----
++
+.Example output
+[source,terminal]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: trusted-certs
+  namespace: openshift-lightspeed
+data:
+  caCertFileName: | <1>
+    -----BEGIN CERTIFICATE-----
+    .
+    .
+    .
+    -----END CERTIFICATE-----  
+----
+<1> Specify the CA certificates required to connect to your LLM provider. You can include one or more certificates.
+
+. Update the `OLSConfig` custom resource file to include the name of the `ConfigMap` object you just created.
++
+.Example {rhelai} CR file
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+spec:
+  ols:
+    defaultProvider: rhelai
+    defaultModel: models/granite-7b-redhat-lab
+    additionalCAConfigMapRef:
+      name: trusted-certs <1>
+----
+<1> Specifies the name of `ConfigMap` object.  
+
+ . Create the custom CR.
++
+[source,terminal]
+----
+$ oc apply -f <olfconfig_cr_filename> 
+----

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
@@ -6,7 +6,7 @@
 [id="ols-creating-lightspeed-custom-resource-file-using-cli_{context}"]
 = Creating the Lightspeed custom resource file using the CLI
 
-The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each LLM provider. Choose the configuration file that matches your LLM provider.
+The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each Large Language Model (LLM) provider. Choose the configuration file that matches your LLM provider.
 
 .Prerequisites
 
@@ -60,6 +60,8 @@ spec:
   ols:
     defaultProvider: rhelai
     defaultModel: models/granite-7b-redhat-lab
+    additionalCAConfigMapRef:
+      name: openshift-service-ca.crt
 ----
 <1> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`. 
 +

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
@@ -6,7 +6,7 @@
 [id="ols-creating-lightspeed-custom-resource-file-using-web-console_{context}"]
 = Creating the Lightspeed custom resource file using the web console
 
-The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each LLM provider. Choose the configuration file that matches your LLM provider.
+The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each Large Language Model (LLM) provider. Choose the configuration file that matches your LLM provider.
 
 .Prerequisites
 
@@ -80,7 +80,7 @@ spec:
       models:
       - name: granite-8b-code-instruct-128k
       name: red_hat_openshift_ai
-      type: rhoai_vllm
+      type: rhoai_vllm 
       url: <url> <1>
   ols:
     defaultProvider: red_hat_openshift_ai


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OLS-1346
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://87152--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm_ols-configuring-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
