### PR TITLE
Update cluster-logging-collector-tuning.adoc

### DIFF
--- a/modules/cluster-logging-collector-tuning.adoc
+++ b/modules/cluster-logging-collector-tuning.adoc
@@ -103,7 +103,7 @@ For more information on the Fluentd chunk lifecycle, see link:https://docs.fluen
 [source,terminal]
 +
 ----
-$ oc edit ClusterLogging instance
+$ oc -n openshift-logging edit ClusterLogging instance
 ----
 
 . Add or modify any of the following parameters:


### PR DESCRIPTION
- The structure of the command is incorrect in Edit the ClusterLogging custom resource (CR) step under "Advanced configuration for the Fluentd log forwarder" documentation.
- Here is the documentation link:   https://docs.openshift.com/container-platform/4.16/observability/logging/log_collection_forwarding/cluster-logging-collector.html#cluster-logging-collector-tuning_cluster-logging-collector
- Here in Step1 under the procedure section, we could see the below command is mentioned:   
~~~
$ oc edit ClusterLogging instance 
~~~

- Step1 is noted with "Edit the ClusterLogging custom resource (CR) in the openshift-logging project:" 
- However, the project name is not mentioned in the command. 
- It is necessary to mention the project name while executing that command. 

**Reason:**

1. Suppose the user is not a part of `openshift-logging` project, and he tries to run this command then this command will not work.
2. If the credentials are shared, and two people are using the same cluster at the same time, then, the second person could change to work in a different namespace.

- Hence it will be always beneficial to run the above command with the project name. 
- We need to perform these changes in our documentation. 
- Here is the correct structure of this command. 

--------------------
1. Edit the ClusterLogging custom resource (CR) in the openshift-logging project:

~~~
$ oc -n openshift-logging edit ClusterLogging instance   
~~~
--------------------

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP-4.18, RHOCP-4.17, RHOCP-4.16, RHOCP-4.15, RHOCP-4.14, RHOCP-4.13, RHOCP-4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1598

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://87169--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/log_collection_forwarding/cluster-logging-collector.html

https://87169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_collection_forwarding/cluster-logging-collector.html

https://87169--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/log_collection_forwarding/cluster-logging-collector.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
