### PR TITLE
OSDOCS-13099: adds bug fix and enhancement notes MicroShift 4.18

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -10,10 +10,9 @@ toc::[]
 
 {microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
-//TODO verify K8s version and another other relevant notes
 [id="microshift-4-18-about-this-release_{context}"]
 == About this release
-Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
 
@@ -101,19 +100,20 @@ Some features in this release are currently in Technology Preview. These experim
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
-//[id="microshift-4-18-rhel-image-mode_{context}"]
-//=== {op-system-base-full} image mode Technology Preview feature
-//* You can now install {microshift-short} using a `bootc` container image. Image mode for {op-system} is a technology preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
+[id="microshift-4-18-rhel-image-mode_{context}"]
+=== {op-system-base-full} image mode Technology Preview feature
+* You can install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
 
-//See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
+See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
 [id="microshift-4-18-bug-fixes_{context}"]
 == Bug fixes
 
-//[discrete]
-//[id="microshift-4-18-installation-bug-fixes"]
-//=== Installation
+[discrete]
+[id="microshift-4-18-installation-bug-fixes"]
+=== Installation
+Previously, the greenboot health check marked the Image mode for some healthy {op-system-base} systems as unhealthy due to a 300-second timeout, which was insufficient for systems with slow networks. Beginning in {product-title} 4.18, the default greenboot wait timeout has been extended to 600 seconds to provide more time to download images and ensure accurate system checks. (https://issues.redhat.com/browse/OCPBUGS-47463[OCPBUGS-47463])
 
 //[discrete]
 //[id="microshift-4-18-networking-bug-fixes"]


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13099](https://issues.redhat.com/browse/OSDOCS-13099)

Link to docs preview:
[microshift-4-18-bug-fixes_release-notes](https://87170--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-bug-fixes_release-notes)

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
