### PR TITLE
OLS-1354: List ability to attach a YAML file to a question in the release notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -32,7 +32,7 @@
 //LLM
 :openai: OpenAI
 :azure-openai: Microsoft Azure OpenAI
-:watsonx: IBM WatsonX
+:watsonx: IBM watsonx
 //Microsoft
 :azure-official: Microsoft Azure
 :entra-id: Microsoft Entra ID

--- a/modules/ols-0-2-1-release-notes.adoc
+++ b/modules/ols-0-2-1-release-notes.adoc
@@ -23,3 +23,5 @@ The following enhancements have been made with {ols-official} 0.2.1:
 * This release adds the ability for users to provide their own TLS certificates for communication between the {ols-long} console and the {ols-long} service.
 
 * With this release, the {ols-long} User Interface displays an email link that can be used to contact the {ols-official} Development Team.
+
+* This release introduces the ability to attach a YAML file to a question you ask on any page accessible from *Storage*, *Compute*, or *Builds* in the {ocp-product-title} web console.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Based on discussion with Kathryn, the CM process is not necessary for this content update to TP release notes that were previously published.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OLS-1354
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://87180--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-0-2-1-release-notes_ols-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
