### PR TITLE
OSDOCS 13097:Added a new section about override scheduling feature for cert-manager

### DIFF
--- a/modules/cert-manager-override-scheduling.adoc
+++ b/modules/cert-manager-override-scheduling.adoc
@@ -1,0 +1,105 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cert-manager-override-scheduling_{context}"]
+= Configuring scheduling overrides for cert-manager components
+
+You can configure the pod scheduling from the {cert-manager-operator} API for the {cert-manager-operator} components such as cert-manager controller, CA injector, and Webhook. 
+
+.Prerequisites
+
+* You have access to the {product-title} cluster as a user with the `cluster-admin` role.
+* You have installed version 1.15.0 or later of the {cert-manager-operator}.
+
+.Procedure
+
+* Update the `certmanager.operator` custom resource to configure pod scheduling overrides for the desired components by running the following command. Use the `overrideScheduling` field under the `controllerConfig`, `webhookConfig`, or `cainjectorConfig` sections to define `nodeSelector` and `tolerations` settings.
++
+[source,terminal]
+----
+$ oc patch certmanager.operator cluster --type=merge -p="
+spec:
+  controllerConfig:
+    overrideScheduling:
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: '' <1>
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule <2>
+  webhookConfig:
+    overrideScheduling:
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: '' <3>
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule <4>
+  cainjectorConfig:
+    overrideScheduling:
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: '' <5>
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule" <6>
+----
+<1> Defines the `nodeSelector` for the cert-manager controller deployment.
+<2> Defines the `tolerations` for the cert-manager controller deployment.
+<3> Defines the `nodeSelector` for the cert-manager webhook deployment.
+<4> Defines the `tolerations` for the cert-manager webhook deployment.
+<5> Defines the `nodeSelector` for the cert-manager cainjector deployment.
+<6> Defines the `tolerations` for the cert-manager cainjector deployment.
+
+
+.Verification
+
+. Verify pod scheduling settings for `cert-manager` pods:
+
+.. Check the deployments in the `cert-manager` namespace to confirm they have the correct `nodeSelector` and `tolerations` by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n cert-manager -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE   IP            NODE                         NOMINATED NODE   READINESS GATES
+cert-manager-58d9c69db4-78mzp              1/1     Running   0          10m   10.129.0.36   ip-10-0-1-106.ec2.internal   <none>           <none>
+cert-manager-cainjector-85b6987c66-rhzf7   1/1     Running   0          11m   10.128.0.39   ip-10-0-1-136.ec2.internal   <none>           <none>
+cert-manager-webhook-7f54b4b858-29bsp      1/1     Running   0          11m   10.129.0.35   ip-10-0-1-106.ec2.internal   <none>           <none>
+----
+
+.. Check the `nodeSelector` and `tolerations` settings applied to deployments by running the following command:
++
+[source,terminal]
+----
+$ oc get deployments -n cert-manager -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.spec.template.spec.nodeSelector}{"\n"}{.spec.template.spec.tolerations}{"\n\n"}{end}'
+----
++
+.Example output
+[source,terminal]
+----
+cert-manager
+{"kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}
+[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]
+
+cert-manager-cainjector
+{"kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}
+[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]
+
+cert-manager-webhook
+{"kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":""}
+[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]
+----
+
+. Verify pod scheduling events in the `cert-manager` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get events -n cert-manager --field-selector reason=Scheduled
+----

--- a/security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
+++ b/security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
@@ -20,3 +20,5 @@ include::modules/cert-manager-override-arguments.adoc[leveloffset=+1]
 include::modules/cert-manager-override-flag-controller.adoc[leveloffset=+1]
 
 include::modules/cert-manager-configure-cpu-memory.adoc[leveloffset=+1]
+
+include::modules/cert-manager-override-scheduling.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): cert-manager 1.15, 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13097
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://87192--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-customizing-api-fields.html#cert-manager-override-scheduling_cert-manager-customizing-api-fields
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
