### PR TITLE
[ROX-27311] Improve docs on enabling RHCOS node scanning V4

### DIFF
--- a/modules/rhcos-enable-node-scan-scannerv4.adoc
+++ b/modules/rhcos-enable-node-scan-scannerv4.adoc
@@ -9,9 +9,6 @@
 [role="_abstract"]
 If you use {ocp}, you can enable scanning of {op-system-first} nodes for vulnerabilities by using {rh-rhacs-first}.
 
-:FeatureName: RHCOS node scanning with Scanner V4
-include::snippets/technology-preview.adoc[]
-
 .Prerequisites
 * For scanning {op-system} node hosts of the secured cluster, you must have installed the following software:
 ** Secured Cluster services on {ocp} {ocp-supported-version} or later
@@ -23,18 +20,32 @@ For information about supported platforms and architecture, see the link:https:/
 
 To enable node indexing, also known as node scanning, by using Scanner V4:
 
-. In the Central pod, on the `central` container, set the `ROX_NODE_INDEX_ENABLED` variable to `true` by running the following command on the Central cluster:
+. Ensure that Scanner V4 is deployed in the Central cluster:
 +
 [source,terminal]
 ----
-$ kubectl -n stackrox set env deployment/central ROX_NODE_INDEX_ENABLED=true <1>
+$ kubectl -n stackrox get deployment scanner-v4-indexer scanner-v4-matcher scanner-v4-db<1>
 ----
 <1> For {ocp}, use `oc` instead of `kubectl`.
-. In the Collector Daemonset, in the `compliance` container, set the `ROX_NODE_INDEX_ENABLED` variable to `true` by running the following command on the secured cluster:
+. In the Central pod, on the `central` container, set the `ROX_NODE_INDEX_ENABLED` and the `ROX_SCANNER_V4` variables to `true` by running the following command on the Central cluster:
 +
 [source,terminal]
 ----
-$ kubectl -n stackrox set env daemonset/collector ROX_NODE_INDEX_ENABLED=true <1>
+$ kubectl -n stackrox set env deployment/central ROX_NODE_INDEX_ENABLED=true ROX_SCANNER_V4=true<1>
+----
+<1> For {ocp}, use `oc` instead of `kubectl`.
+. In the Sensor pod, on the `sensor` container, set the `ROX_NODE_INDEX_ENABLED` and the `ROX_SCANNER_V4` variables to `true` by running the following command on all secured clusters where you want to enable node scanning:
++
+[source,terminal]
+----
+$ kubectl -n stackrox set env deployment/sensor ROX_NODE_INDEX_ENABLED=true ROX_SCANNER_V4=true<1>
+----
+<1> For {ocp}, use `oc` instead of `kubectl`.
+. In the Collector Daemonset, in the `compliance` container, set the `ROX_NODE_INDEX_ENABLED` and the `ROX_SCANNER_V4` variables to `true` by running the following command on all secured clusters where you want to enable node scanning:
++
+[source,terminal]
+----
+$ kubectl -n stackrox set env daemonset/collector ROX_NODE_INDEX_ENABLED=true ROX_SCANNER_V4=true<1>
 ----
 <1> For {ocp}, use `oc` instead of `kubectl`.
 . To verify that node scanning is working, examine the Central logs for the following message:

--- a/modules/rhcos-enable-node-scan.adoc
+++ b/modules/rhcos-enable-node-scan.adoc
@@ -11,6 +11,8 @@ If you use {ocp}, you can enable scanning of {op-system-first} nodes for vulnera
 
 .Prerequisites
 * For scanning {op-system} node hosts of the secured cluster, you must have installed Secured Cluster services on {ocp} {ocp-supported-version} or later. For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+* This procedure describes how to enable node scanning for the first time.
+If you are reconfiguring {product-title} to use the StackRox Scanner instead of Scanner V4, follow the procedure in xref:../../operating/manage-vulnerabilities/scan-rhcos-node-host.html#rhcos-restore-node-scan-stackrox-scanner_{context}[Restoring {op-system} node scanning with the StackRox Scanner].
 
 .Procedure
 . Run one of the following commands to update the compliance container.

--- a/modules/rhcos-restore-node-scan-with-stackrox-scanner.adoc
+++ b/modules/rhcos-restore-node-scan-with-stackrox-scanner.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
+// * cloud_service/upgrading-cloud/upgrade-cloudsvc-roxctl.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rhcos-restore-node-scan-stackrox-scanner_{context}"]
+= Restoring {op-system} node scanning with the StackRox Scanner
+
+[role="_abstract"]
+If you use {ocp}, you can enable scanning of {op-system-first} nodes for vulnerabilities by using {rh-rhacs-first}.
+This feature is available with both the StackRox Scanner and Scanner V4.
+Follow this procedure if you want to use the StackRox Scanner to scan {op-system-first} nodes,
+but you want to keep using Scanner V4 to scan other nodes.
+
+.Prerequisites
+* For scanning {op-system} node hosts of the secured cluster, you must have installed Secured Cluster services on {ocp} {ocp-supported-version} or later. For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+
+.Procedure
+
+To enable node indexing, also known as node scanning, by using the StackRox Scanner:
+
+. Ensure that the StackRox Scanner is deployed in the Central cluster:
++
+[source,terminal]
+----
+$ kubectl -n stackrox get deployment scanner scanner-db<1>
+----
+<1> For {ocp}, use `oc` instead of `kubectl`.
+. In the Central pod, on the `central` container, set `ROX_NODE_INDEX_ENABLED` to `false` by running the following command on the Central cluster:
++
+[source,terminal]
+----
+$ kubectl -n stackrox set env deployment/central ROX_NODE_INDEX_ENABLED=false<1>
+----
+<1> For {ocp}, use `oc` instead of `kubectl`.
+. In the Collector Daemonset, in the `compliance` container, set `ROX_CALL_NODE_INVENTORY_ENABLED` to `true` by running the following command on all secured clusters where you want to enable node scanning:
++
+[source,terminal]
+----
+$ kubectl -n stackrox set env daemonset/collector ROX_CALL_NODE_INVENTORY_ENABLED=true<1>
+----
+<1> For {ocp}, use `oc` instead of `kubectl`.
+. To verify that node scanning is working, examine the Central logs for the following message:
++
+[source,text]
+----
+Scanned node inventory <node_name> (id: <node_id>) with <number> components.
+----
++
+where:
+
+<number>:: Specifies the number of discovered components.
+<node_name>:: Specifies the name of the node.
+<node_id>:: Specifies the internal ID of the node.
+

--- a/operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
+++ b/operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
@@ -30,6 +30,8 @@ include::modules/rhcos-enable-node-scan.adoc[leveloffset=+1]
 
 include::modules/rhcos-enable-node-scan-scannerv4.adoc[leveloffset=+1]
 
+include::modules/rhcos-restore-node-scan-with-stackrox-scanner.adoc[leveloffset=+1]
+
 include::modules/rhcos-analyse-detect.adoc[leveloffset=+1]
 
 include::modules/rhcos-match-vulnerability.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR improves the existing commands for enabling RHCOS node scanning using scanner V4. The previous state was missing one component and one env variable that may be required to enable this feature on some environments.

Version(s):
- 4.6 (Improving the commands and the text)
- 4.7 (the improvement above & removing the tech-preview note)

Issue:
https://issues.redhat.com/browse/ROX-27311

Link to docs preview:
- https://87199--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-vulnerabilities/scan-rhcos-node-host.html

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
