### PR TITLE
[enterprise-4.17] OSDOCS#13137: Correct hosted control planes name

### DIFF
--- a/modules/network-flow-matrix.adoc
+++ b/modules/network-flow-matrix.adoc
@@ -21,7 +21,7 @@ Additionally, consider the following dynamic port ranges when managing ingress t
 
 [NOTE]
 ====
-The network flow matrix describes ingress traffic flows for a base {product-title} installation. It does not describe network flows for additional components, such as optional Operators available from the Red Hat Marketplace. The matrix does not apply for Hosted-Control-Plane, MicroShift, or standalone clusters.
+The network flow matrix describes ingress traffic flows for a base {product-title} installation. It does not describe network flows for additional components, such as optional Operators available from the Red Hat Marketplace. The matrix does not apply for {hcp}, Red{nbsp}Hat build of MicroShift, or standalone clusters.
 ====
 
 .Network flow matrix


### PR DESCRIPTION
Manual CP of https://github.com/openshift/openshift-docs/pull/87189 cherry-picked from commit id: https://github.com/openshift/openshift-docs/commit/89300ff8ca03bbc1892318f3e8ac098803c05552