### PR TITLE
OSDOCS-13138: adds firewall rules for IPv6 listen address MicroShift

### DIFF
--- a/modules/microshift-firewall-allow-traffic.adoc
+++ b/modules/microshift-firewall-allow-traffic.adoc
@@ -32,3 +32,10 @@ $ sudo firewall-offline-cmd --permanent --zone=trusted --add-source=<custom IP r
 ----
 $ sudo firewall-offline-cmd --permanent --zone=trusted --add-source=169.254.169.1
 ----
+
+. If you are using a load balancer, allow the IPv6 traffic through the firewall by running the following command:
++
+[source,terminal]
+----
+$ sudo firewall-cmd --permanent --zone=trusted --add-source=fd01::/48
+----

--- a/modules/microshift-firewall-apply-settings.adoc
+++ b/modules/microshift-firewall-apply-settings.adoc
@@ -11,7 +11,7 @@ To apply firewall settings, use the following one-step procedure:
 .Procedure
 
 * After you have finished configuring network access through the firewall, run the following command to restart the firewall and apply the settings:
-
++
 [source,terminal]
 ----
 $ sudo firewall-cmd --reload


### PR DESCRIPTION
Version(s):
4.17, 4.18+

Issue:
[OSDOCS-13138](https://issues.redhat.com/browse/OSDOCS-13138)

Link to docs preview:
[allow-traffic_microshift-firewall](https://87201--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-firewall.html#microshift-firewall-allow-traffic_microshift-firewall)

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
