### PR TITLE
ROX-27514: Updates to RNs for patch release 4.5.6

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -55,7 +55,7 @@ endif::[]
 :osp: Red{nbsp}Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.5.5
+:rhacs-version: 4.5.6
 :ocp-supported-version: 4.11
 :ocp-latest-version: 4.17
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS

--- a/release_notes/45-release-notes.adoc
+++ b/release_notes/45-release-notes.adoc
@@ -21,6 +21,7 @@ toc::[]
 |`4.5.3` | 1 October 2024
 |`4.5.4` | 16 October 2024
 |`4.5.5` | 22 November 2024
+|`4.5.6` | 11 February 2025
 
 |====
 
@@ -471,5 +472,20 @@ Additionally, this release addresses the following security vulnerabilities:
 * link:https://access.redhat.com/security/cve/cve-2024-48910[CVE-2024-48910] (Tampering vulnerability in `DOMPurify` due to prototype pollution).
 * link:https://access.redhat.com/security/cve/cve-2024-24789[CVE-2024-24789] (Improper handling of certain ZIP files in the `archive/zip` package).
 * link:https://access.redhat.com/security/cve/cve-2024-24790[CVE-2024-24790] (Unexpected behavior in the `net/netip` package's Is methods for IPv4-mapped IPv6 addresses).
+
+[id="about-release-456_{context}"]
+== About release 4.5.6
+
+*Release date*: 11 February 2025
+
+This release of {product-title-short} includes the following bug fix:
+
+* Fixed an issue where the HTML code in column values was rendered in PDFs due to insufficient sanitization.
+
+This release also addresses the following security vulnerabilities:
+
+* link:https://access.redhat.com/security/cve/CVE-2025-21613[CVE-2025-21613]: An argument injection vulnerability was found in the `go-git` package
+* link:https://access.redhat.com/security/cve/CVE-2025-21614[CVE-2025-21614]: Vulnerability allows an attacker to perform denial of service attacks by providing specially crafted responses from a Git server in the `go-git` package
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]: Denial of service vulnerability in the `golang.org/x/net` package
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):

4.5

[Issue](https://issues.redhat.com/browse/ROX-27514)

[Link to docs preview
](https://87204--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/45-release-notes#about-release-456_release-notes-45)

QE review:
- [x] QE has approved this change. **ACS has no QE, approved by SME**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
