### PR TITLE
[RHACS] Added release notes for patch release 4.4.8

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -55,7 +55,7 @@ endif::[]
 :osp: Red{nbsp}Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.4.7
+:rhacs-version: 4.4.8
 :ocp-supported-version: 4.11
 :ocp-latest-version: 4.16
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS

--- a/release_notes/44-release-notes.adoc
+++ b/release_notes/44-release-notes.adoc
@@ -23,6 +23,7 @@ toc::[]
 |`4.4.5` | 29 August 2024
 |`4.4.6` | 13 November 2024
 |`4.4.7` | 02 December 2024
+|`4.4.8` | 29 January 2025
 
 |====
 
@@ -692,6 +693,18 @@ This release of {product-title-short} fixes the following security vulnerabiliti
 This release of {product-title-short} fixes the following security vulnerability:
 
 * link:https://access.redhat.com/security/cve/CVE-2024-21538[CVE-2024-21538]: Fixed a vulnerability in the cross-spawn package for `Node.js` that previously allowed attackers to crash programs through sending large, specially crafted strings that increased CPU usage.
+
+[id="resolved-in-version-448_{context}"]
+=== Resolved in version 4.4.8
+
+*Release date*: 29 January 2025
+
+This release of {product-title-short} fixes the following security vulnerabilities:
+
+* link:https://access.redhat.com/security/cve/CVE-2024-45337[CVE-2024-45337]: Fixed a vulnerability in the `golang.org/x/crypto` package that could cause authorization bypass through `ServerConfig.PublicKeyCallback` methods.
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]: Fixed a vulnerability in the `golang.org/x/net` package that could cause a denial of service through a crafted input to the `Parse` functions.
+* link:https://access.redhat.com/security/cve/CVE-2025-21613[CVE-2025-21613]: Fixed a vulnerability in the `go-git` library that could allow an attacker to set arbitrary values to git-upload-pack flags through argument injection by the URL field.
+* link:https://access.redhat.com/security/cve/CVE-2025-21614[CVE-2025-21614]: Fixed a vulnerability in the `go-git` library that could cause a denial of service through a crafted response from a Git server.
 
 [id="known-issues-440_{context}"]
 == Known issues


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-27730

Updated patch release notes and product version for 4.4.8 patch release.

No cherrypicks.


Preview: https://87238--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/44-release-notes.html#resolved-in-version-448_release-notes-44

---

<img src="https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWhqYnp2bzQyZnczdmVoeXIwZzRwazBibmVnMzVmeTF2cmE4NDN0biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/NWpTZunsRRaJor5KD1/giphy.gif"/>