### PR TITLE
OCPBUGS-43359-4-16: Removed the MTU statement to align with other ver…

### DIFF
--- a/modules/nw-cluster-mtu-change-about.adoc
+++ b/modules/nw-cluster-mtu-change-about.adoc
@@ -14,8 +14,6 @@ You might want to change the MTU of the cluster network for several reasons:
 * The MTU detected during cluster installation is not correct for your infrastructure.
 * Your cluster infrastructure now requires a different MTU, such as from the addition of nodes that need a different MTU for optimal performance.
 
-Only the OVN-Kubernetes cluster network plugin supports changing the MTU value.
-
 [id="service-interruption-considerations_{context}"]
 == Service interruption considerations
 

--- a/networking/changing-cluster-network-mtu.adoc
+++ b/networking/changing-cluster-network-mtu.adoc
@@ -7,9 +7,14 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-As a cluster administrator, you can change the MTU for the cluster network after cluster installation. This change is disruptive as cluster nodes must be rebooted to finalize the MTU change. You can change the MTU only for clusters using the OVN-Kubernetes or OpenShift SDN network plugins.
+As a cluster administrator, you can change the MTU for the cluster network after cluster installation. This change is disruptive as cluster nodes must be rebooted to finalize the MTU change.
 
+You can change the MTU only for clusters that use the OVN-Kubernetes plugin or the OpenShift SDN network plugin.
+
+// About the cluster MTU
 include::modules/nw-cluster-mtu-change-about.adoc[leveloffset=+1]
+
+// Changing the cluster network MTU or Changing the cluster network MTU to support AWS Outposts
 include::modules/nw-cluster-mtu-change.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.16 and 4.15

Issue:
[OCPBUGS-43359](https://issues.redhat.com/browse/OCPBUGS-43359)


Link to docs preview:
* [Changing the MTU for the cluster network](https://87257--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu.html)

- [x] SME has approved this change (Aniket).
- [x] QE has approved this change (Weliang).


