### PR TITLE
OBSDOCS-1628: Prepare the concept assembly in Monitoring Overview sec…

### DIFF
--- a/modules/monitoring-about-managing-alerts.adoc
+++ b/modules/monitoring-about-managing-alerts.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/managing-alerts.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-managing-alerts_{context}"]
+= Managing alerts
+
+In the {product-title}, the Alerting UI enables you to manage alerts, silences, and alerting rules.
+
+* *Alerting rules*. Alerting rules contain a set of conditions that outline a particular state within a cluster. Alerts are triggered when those conditions are true. An alerting rule can be assigned a severity that defines how the alerts are routed.
+* *Alerts*. An alert is fired when the conditions defined in an alerting rule are true. Alerts provide a notification that a set of circumstances are apparent within an {product-title} cluster.
+* *Silences*. A silence can be applied to an alert to prevent notifications from being sent when the conditions for an alert are true. You can mute an alert after the initial notification, while you work on resolving the issue.
+
+[NOTE]
+====
+The alerts, silences, and alerting rules that are available in the Alerting UI relate to the projects that you have access to. For example, if you are logged in as a user with the `cluster-admin` role, you can access all alerts, silences, and alerting rules.
+====

--- a/modules/monitoring-choosing-a-metrics-collection-profile.adoc
+++ b/modules/monitoring-choosing-a-metrics-collection-profile.adoc
@@ -6,6 +6,9 @@
 [id="choosing-a-metrics-collection-profile_{context}"]
 = Choosing a metrics collection profile
 
+:FeatureName: Metrics collection profile
+include::snippets/technology-preview.adoc[]
+
 To choose a metrics collection profile for core {product-title} monitoring components, edit the `cluster-monitoring-config` `ConfigMap` object.
 
 .Prerequisites

--- a/modules/monitoring-configuring-metrics-collection-profiles.adoc
+++ b/modules/monitoring-configuring-metrics-collection-profiles.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="configuring-metrics-collection-profiles_{context}"]
-= Configuring metrics collection profiles
+= About metrics collection profiles
 
 :FeatureName: Metrics collection profile
 include::snippets/technology-preview.adoc[]
@@ -18,9 +18,6 @@ However, you might want Prometheus to collect fewer metrics from a cluster in ce
 You can use a metrics collection profile to collect either the default amount of metrics data or a minimal amount of metrics data.
 When you collect minimal metrics data, basic monitoring features such as alerting continue to work.
 At the same time, the CPU and memory resources required by Prometheus decrease.
-
-[id="about-metrics-collection-profiles_{context}"]
-== About metrics collection profiles
 
 You can enable one of two metrics collection profiles:
 

--- a/modules/monitoring-maintenance-and-support.adoc
+++ b/modules/monitoring-maintenance-and-support.adoc
@@ -5,7 +5,7 @@
 [id="maintenance-and-support_{context}"]
 = Maintenance and support for monitoring
 
-Not all configuration options for the monitoring stack are exposed. The only supported way of configuring {product-title} monitoring is by configuring the {cmo-first} using the options described in the "Config map reference for the {cmo-short}". *Do not use other configurations, as they are unsupported.*
+Not all configuration options for the monitoring stack are exposed. The only supported way of configuring {product-title} monitoring is by configuring the {cmo-first} using the options described in the "Config map reference for the {cmo-short}". _Do not use other configurations, as they are unsupported._
 
 Configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use configurations other than those described in the "Config map reference for the {cmo-full}", your changes will disappear because the {cmo-short} automatically reconciles any differences and resets any unsupported changes back to the originally defined state by default and by design.
 

--- a/modules/monitoring-supported-remote-write-authentication-settings.adoc
+++ b/modules/monitoring-supported-remote-write-authentication-settings.adoc
@@ -3,7 +3,7 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="supported_remote_write_authentication_settings_{context}"]
+[id="supported-remote-write-authentication-settings_{context}"]
 = Supported remote write authentication settings
 
 You can use different methods to authenticate with a remote write endpoint. Currently supported authentication methods are AWS Signature Version 4, basic authentication, authorization, OAuth 2.0, and TLS client. The following table provides details about supported authentication methods for use with remote write.

--- a/modules/monitoring-using-node-selectors-to-move-monitoring-components.adoc
+++ b/modules/monitoring-using-node-selectors-to-move-monitoring-components.adoc
@@ -9,11 +9,10 @@
 By using the `nodeSelector` constraint with labeled nodes, you can move any of the monitoring stack components to specific nodes.
 By doing so, you can control the placement and distribution of the monitoring components across a cluster.
 
-By controlling placement and distribution of monitoring components, you can optimize system resource use, improve performance, and segregate workloads based on specific requirements or policies.
+By controlling placement and distribution of monitoring components, you can optimize system resource use, improve performance, and separate workloads based on specific requirements or policies.
 
-[id="how-node-selectors-work-with-other-constraints_{context}"]
+[discrete]
 == How node selectors work with other constraints
-
 
 If you move monitoring components by using node selector constraints, be aware that other constraints to control pod scheduling might exist for a cluster:
 

--- a/modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc
+++ b/modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc
@@ -4,9 +4,12 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="using-pod-topology-spread-constraints-for-monitoring_{context}"]
-= Using pod topology spread constraints for monitoring
+= About pod topology spread constraints for monitoring
 
 You can use pod topology spread constraints to control how the monitoring pods are spread across a network topology when {product-title} pods are deployed in multiple availability zones.
 
 Pod topology spread constraints are suitable for controlling pod scheduling within hierarchical topologies in which nodes are spread across different infrastructure levels, such as regions and zones within those regions.
 Additionally, by being able to schedule pods in different zones, you can improve network latency in certain scenarios.
+
+You can configure pod topology spread constraints for all the pods deployed by the {cmo-full} to control how pod replicas are scheduled to nodes across zones. This ensures that the pods are highly available and run more efficiently, because workloads are spread across nodes in different data centers or hierarchical infrastructure zones.
+

--- a/observability/monitoring/about-ocp-monitoring/key-concepts.adoc
+++ b/observability/monitoring/about-ocp-monitoring/key-concepts.adoc
@@ -6,8 +6,92 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-TBD
+Get familiar with the {product-title} monitoring concepts and terms. Learn about how you can improve performance and scale of your cluster, store and record data, manage metrics and alerts, and more.
 
+[id="about-performance-and-scalability_{context}"]
+== About performance and scalability
+
+You can optimize the performance and scale of your clusters.
+You can configure the default monitoring stack by performing any of the following actions:
+
+* Control the placement and distribution of monitoring components:
+** Use node selectors to move components to specific nodes.
+** Assign tolerations to enable moving components to tainted nodes.
+* Use pod topology spread constraints.
+* Set the body size limit for metrics scraping.
+* Manage CPU and memory resources.
+* Use metrics collection profiles.
+
+include::modules/monitoring-using-node-selectors-to-move-monitoring-components.adoc[leveloffset=+2]
+
+// [role="_additional-resources"]
+// .Additional resources
+
+// * TBD
+
+include::modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc[leveloffset=+2]
+
+include::modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;CPM;!UWM]
+
+include::modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;!CPM;UWM]
+
+include::modules/monitoring-configuring-metrics-collection-profiles.adoc[leveloffset=+2]
+
+// [role="_additional-resources"]
+// .Additional resources
+
+// * TBD
+
+[id="about-storing-and-recording-data_{context}"]
+== About storing and recording data
+
+You can store and record data to help you protect the data and use them for troubleshooting.
+You can configure the default monitoring stack by performing any of the following actions:
+
+* Configure persistent storage:
+** Protect your metrics and alerting data from data loss by storing them in a persistent volume (PV). As a result, they can survive pods being restarted or recreated.
+** Avoid getting duplicate notifications and losing silences for alerts when the Alertmanager pods are restarted.
+* Modify the retention time and size for Prometheus and Thanos Ruler metrics data.
+* Configure logging to help you troubleshoot issues with your cluster:
+** Configure audit logs for Metrics Server.
+** Set log levels for monitoring.
+** Enable the query logging for Prometheus and Thanos Querier.
+
+include::modules/monitoring-retention-time-and-size-for-prometheus-metrics-data.adoc[leveloffset=+2]
+
+// Understanding metrics
+include::modules/monitoring-understanding-metrics.adoc[leveloffset=+1]
+
+include::modules/monitoring-controlling-the-impact-of-unbound-attributes-in-user-defined-projects.adoc[leveloffset=+2]
+
+include::modules/monitoring-adding-cluster-id-labels-to-metrics.adoc[leveloffset=+2]
+
+// [role="_additional-resources"]
+// .Additional resources
+
+// * TBD
+
+
+//About monitoring dashboards
+include::modules/monitoring-about-monitoring-dashboards.adoc[leveloffset=+1]
+
+//Managing alerts
+include::modules/monitoring-about-managing-alerts.adoc[leveloffset=+1]
+
+include::modules/monitoring-managing-silences.adoc[leveloffset=+2]
+
+include::modules/monitoring-managing-core-platform-alerting-rules.adoc[leveloffset=+2]
+include::modules/monitoring-tips-for-optimizing-alerting-rules-for-core-platform-monitoring.adoc[leveloffset=+2]
+
+include::modules/monitoring-about-creating-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
+include::modules/monitoring-managing-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
+include::modules/monitoring-optimizing-alerting-for-user-defined-projects.adoc[leveloffset=+2]
+
+include::modules/monitoring-searching-alerts-silences-and-alerting-rules.adoc[leveloffset=+2]
+
+
+// Overview of setting up alert routing for user-defined projects
+include::modules/monitoring-understanding-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
 
 
 

--- a/observability/monitoring/configuring-core-platform-monitoring/configuring-metrics.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/configuring-metrics.adoc
@@ -19,17 +19,15 @@ include::modules/monitoring-example-remote-write-authentication-settings.adoc[le
 
 include::modules/monitoring-example-remote-write-queue-configuration.adoc[leveloffset=+2,tags=**;CPM;!UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
-// Adding cluster ID labels to metrics
-include::modules/monitoring-adding-cluster-id-labels-to-metrics.adoc[leveloffset=+1]
+//Creating cluster ID labels for metrics for core platform monitoring
+include::modules/monitoring-creating-cluster-id-labels-for-metrics.adoc[leveloffset=+1,tags=**;CPM;!UWM]
 
-include::modules/monitoring-creating-cluster-id-labels-for-metrics.adoc[leveloffset=+2,tags=**;CPM;!UWM]
+// [role="_additional-resources"]
+// .Additional resources
 
-[role="_additional-resources"]
-.Additional resources
-
-* TBD
+// * TBD

--- a/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
@@ -8,14 +8,17 @@ toc::[]
 
 You can configure the monitoring stack to optimize the performance and scale of your clusters. The following documentation provides information about how to distribute the monitoring components and control the impact of the monitoring stack on CPU and memory resources.
 
-// Using node selectors to move monitoring components
+[id="controlling-placement-and-distribution-of-monitoing-components_{context}"]
+== Controlling the placement and distribution of monitoring components
 
-include::modules/monitoring-using-node-selectors-to-move-monitoring-components.adoc[leveloffset=+1]]
+You can move the monitoring stack components to specific nodes:
 
-[role="_additional-resources"]
-.Additional resources
+* Use the `nodeSelector` constraint with labeled nodes to move any of the monitoring stack components to specific nodes.
+* Assign tolerations to enable moving components to tainted nodes.
 
-* TBD
+By doing so, you control the placement and distribution of the monitoring components across a cluster.
+
+By controlling placement and distribution of monitoring components, you can optimize system resource use, improve performance, and separate workloads based on specific requirements or policies.
 
 include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc[leveloffset=+2,tags=**;CPM;!UWM]
 
@@ -46,27 +49,17 @@ You can ensure that the containers that run monitoring components have enough CP
 
 You can configure these limits and requests for core platform monitoring components in the `openshift-monitoring` namespace.
 
-include::modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;CPM;!UWM]
-
 include::modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;CPM;!UWM]
 
-// Configuring metrics collection profiles
-include::modules/monitoring-configuring-metrics-collection-profiles.adoc[leveloffset=+1]
-include::modules/monitoring-choosing-a-metrics-collection-profile.adoc[leveloffset=+2]
+// Choosing a metrics collection profile
+include::modules/monitoring-choosing-a-metrics-collection-profile.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
-// Using pod topology spread constraints for monitoring components
-include::modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc[leveloffset=1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* TBD
-
-include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=2,tags=**;CPM;!UWM]
+//Configuring pod topology spread constraints for core platform monitoring
+include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=1,tags=**;CPM;!UWM]
 
 

--- a/observability/monitoring/configuring-core-platform-monitoring/storing-and-recording-data.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/storing-and-recording-data.adoc
@@ -13,23 +13,21 @@ include::modules/monitoring-configuring-persistent-storage.adoc[leveloffset=+1]
 
 include::modules/monitoring-configuring-a-persistent-volume-claim.adoc[leveloffset=+2,tags=**;CPM;!UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
 include::modules/monitoring-resizing-a-persistent-volume.adoc[leveloffset=+2,tags=**;CPM;!UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
 // Modifying the retention time and size for Prometheus metrics data
 
 include::modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc[leveloffset=+1,tags=**;CPM;!UWM]
-
-include::modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc[leveloffset=+2]
 
 // Configuring audit logs for Metrics Server
 include::modules/monitoring-configuring-audit-logs-for-metrics-server.adoc[leveloffset=+1]
@@ -40,16 +38,11 @@ include::modules/monitoring-setting-log-levels-for-monitoring-components.adoc[le
 // Enabling the query log file for Prometheus
 include::modules/monitoring-setting-query-log-file-for-prometheus.adoc[leveloffset=+1,tags=**;CPM;!UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
 // Enabling query logging for Thanos Querier
 include::modules/monitoring-enabling-query-logging-for-thanos-querier.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* TBD
 

--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc
@@ -19,20 +19,18 @@ include::modules/monitoring-example-remote-write-authentication-settings.adoc[le
 
 include::modules/monitoring-example-remote-write-queue-configuration.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
-// Adding cluster ID labels to metrics
-include::modules/monitoring-adding-cluster-id-labels-to-metrics.adoc[leveloffset=+1]
+// Creating cluster ID labels for metrics for monitoring of user-defined projects
+include::modules/monitoring-creating-cluster-id-labels-for-metrics.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
-include::modules/monitoring-creating-cluster-id-labels-for-metrics.adoc[leveloffset=+2,tags=**;!CPM;UWM]
+// [role="_additional-resources"]
+// .Additional resources
 
-[role="_additional-resources"]
-.Additional resources
-
-* TBD
+// * TBD
 
 // Setting up metrics collection for user-defined projects
 
@@ -44,7 +42,7 @@ include::modules/monitoring-specifying-how-a-service-is-monitored.adoc[leveloffs
 
 include::modules/monitoring-example-service-endpoint-authentication-settings.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD

--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
@@ -8,28 +8,36 @@ toc::[]
 
 You can configure the monitoring stack to optimize the performance and scale of your clusters. The following documentation provides information about how to distribute the monitoring components and control the impact of the monitoring stack on CPU and memory resources.
 
-// Using node selectors to move monitoring components
+[id="controlling-placement-and-distribution-of-monitoing-components_{context}"]
+== Controlling the placement and distribution of monitoring components
 
-include::modules/monitoring-using-node-selectors-to-move-monitoring-components.adoc[leveloffset=+1]]
+You can move the monitoring stack components to specific nodes:
 
-[role="_additional-resources"]
-.Additional resources
+* Use the `nodeSelector` constraint with labeled nodes to move any of the monitoring stack components to specific nodes.
+* Assign tolerations to enable moving components to tainted nodes.
 
-* TBD
+By doing so, you control the placement and distribution of the monitoring components across a cluster.
+
+By controlling placement and distribution of monitoring components, you can optimize system resource use, improve performance, and separate workloads based on specific requirements or policies.
+
+// [role="_additional-resources"]
+// .Additional resources
+
+// * TBD
 
 include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
-include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[leveloffset=+1,tags=**;!CPM;UWM]
+include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
 [id="managing-cpu-and-memory-resources-for-monitoring-components_{context}"]
 == Managing CPU and memory resources for monitoring components
@@ -38,28 +46,45 @@ You can ensure that the containers that run monitoring components have enough CP
 
 You can configure these limits and requests for monitoring components that monitor user-defined projects in the `openshift-user-workload-monitoring` namespace.
 
-include::modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;!CPM;UWM]
-
 include::modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
-// Controlling the impact of unbound metrics attributes in user-defined projects
-include::modules/monitoring-controlling-the-impact-of-unbound-attributes-in-user-defined-projects.adoc[leveloffset=+1]
+[id="controlling-the-impact-of-unbound-attributes-in-user-defined-projects_{context}"]
+== Controlling the impact of unbound metrics attributes in user-defined projects
+
+ifndef::openshift-dedicated,openshift-rosa[]
+Cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+A `dedicated-admin`
+endif::openshift-dedicated,openshift-rosa[]
+can use the following measures to control the impact of unbound metrics attributes in user-defined projects:
+
+* Limit the number of samples that can be accepted per target scrape in user-defined projects
+* Limit the number of scraped labels, the length of label names, and the length of label values
+* Configure the intervals between consecutive scrapes and between Prometheus rule evaluations
+* Create alerts that fire when a scrape sample threshold is reached or when the target cannot be scraped
+
+[NOTE]
+====
+Limiting scrape samples can help prevent the issues caused by adding many unbound attributes to labels. Developers can also prevent the underlying cause by limiting the number of unbound attributes that they define for metrics. Using attributes that are bound to a limited set of possible values reduces the number of potential key-value pair combinations.
+====
+
 include::modules/monitoring-setting-scrape-and-evaluation-intervals-limits-for-user-defined-projects.adoc[leveloffset=+2]
 ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/monitoring-creating-scrape-sample-alerts.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 endif::openshift-dedicated,openshift-rosa[]
 
 // Using topology spread constraints for monitoring components
 include::modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc[leveloffset=1]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
 include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=2,tags=**;!CPM;UWM]

--- a/observability/monitoring/configuring-user-workload-monitoring/storing-and-recording-data-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/storing-and-recording-data-uwm.adoc
@@ -13,23 +13,23 @@ include::modules/monitoring-configuring-persistent-storage.adoc[leveloffset=+1]
 
 include::modules/monitoring-configuring-a-persistent-volume-claim.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
 include::modules/monitoring-resizing-a-persistent-volume.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
-// Modifying the retention time and size for Prometheus metrics data
+// Modifying the retention time and size 
 
 include::modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
-include::modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc[leveloffset=+2]
+include::modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc[leveloffset=+1]
 
 // Setting log levels for monitoring components
 include::modules/monitoring-setting-log-levels-for-monitoring-components.adoc[leveloffset=+1,tags=**;!CPM;UWM]
@@ -37,10 +37,10 @@ include::modules/monitoring-setting-log-levels-for-monitoring-components.adoc[le
 // Enabling the query log file for Prometheus
 include::modules/monitoring-setting-query-log-file-for-prometheus.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* TBD
+// * TBD
 
 
 

--- a/observability/monitoring/getting-started/maintenance-and-support-for-monitoring.adoc
+++ b/observability/monitoring/getting-started/maintenance-and-support-for-monitoring.adoc
@@ -6,7 +6,23 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-TBD
+Not all configuration options for the monitoring stack are exposed. The only supported way of configuring {product-title} monitoring is by configuring the {cmo-first} using the options described in the xref:../../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}]. *Do not use other configurations, as they are unsupported.*
+
+Configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use configurations other than those described in the xref:../../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}], your changes will disappear because the {cmo-short} automatically reconciles any differences and resets any unsupported changes back to the originally defined state by default and by design.
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[IMPORTANT]
+====
+Installing another Prometheus instance is not supported by the Red Hat Site Reliability Engineers (SRE).
+====
+endif::openshift-dedicated,openshift-rosa[]
+
+include::modules/monitoring-support-considerations.adoc[leveloffset=+1]
+ifndef::openshift-dedicated,openshift-rosa[]
+include::modules/monitoring-support-policy-for-monitoring-operators.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
+
+include::modules/monitoring-support-version-matrix-for-monitoring-components.adoc[leveloffset=+1]
 
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): none for CP, `monitoring-docs-restructure` only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1628
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

QE review:
- [X] QE has approved this change.

$${\color{red}Additional \space information:}$$
**The changes in the PR are not yet user-facing** 

This PR moves content from old to the new assemblies. The content in the original assembly is still there . The reason is to not lose any content while moving it around. There will be a separate issue that will make sure that all the content is transfered as needed.

Therefore, the main thing to check in this PR is to see if the structure in the linked chapters looks good and renders without issues.

I also included some small fixes for the other already transfered sections.
\
\
$${\color{red}Links \space to \space docs \space preview \space (with \space an \space explanation \space of \space what \space was \space changed:}$$
* [Understanding the monitoring stack - key concepts](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/about-ocp-monitoring/key-concepts)
    * Added this whole new section based on existing concept modules (no new content, just moved the existing modules to this assembly)

* [Maintenance and support for monitoring](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/getting-started/maintenance-and-support-for-monitoring)
    * Added the existing content from the [configuring the mon stack section](https://docs.openshift.com/container-platform/4.17/observability/monitoring/configuring-the-monitoring-stack.html#maintenance-and-support_configuring-the-monitoring-stack) to its standalone assembly.

------------------------The assemblies above are the main changes---------------------

------------------------The following are minor inmprovements---------------------

* [Creating cluster ID labels for metrics for core platform monitoring](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/configuring-metrics#creating-cluster-id-labels-for-metrics-cpm_configuring-metrics)
*  [Creating cluster ID labels for metrics for monitoring of user-defined projects](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm#creating-cluster-id-labels-for-metrics-uwm_configuring-metrics-uwm)
    * Removed the introductory concept and moved it to the Key concepts section. Moved this procedural module up one level.

* [Controling the placement and distribution of monitoring components](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability#controling-placement-and-distribution-of-monitoing-components_configuring-performance-and-scalability)
* [Controling the placement and distribution of monitoring components-uwm](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm#controling-placement-and-distribution-of-monitoing-components_configuring-performance-and-scalability-uwm)
    * Changed the heading and introductory sentences to include both node selector and toleration procedures (the introduction wrongly included only the introduction to node selectors)

* [Choosing a metrics collection profile](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability#choosing-a-metrics-collection-profile_configuring-performance-and-scalability)
* [Configuring pod topology spread constraints for core platform monitoring](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability#configuring-pod-topology-spread-constraints-cpm_configuring-performance-and-scalability)
    * Removed the introductory concept  and moved it to the Key concepts section. Moved this procedural module up one level.

* [Controlling the impact of unbound metrics attributes in user-defined projects](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm#controlling-the-impact-of-unbound-attributes-in-user-defined-projects_configuring-performance-and-scalability-uwm)
    * Removed the conceptual content and moved that content to the Key concepts section.

* [Modifying the retention time for Thanos Ruler metrics data](https://87259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/storing-and-recording-data-uwm#modifying-the-retention-time-for-thanos-ruler-metrics-data_storing-and-recording-data-uwm)
    * Moved up one level (was incorrectly nested under the previous module)



<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->


<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->