### PR TITLE
RHDEVDOCS-6359: Changing the Argo Rollouts value in the Compatibility matrix table for GitOps 1.15

### DIFF
--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -27,7 +27,7 @@ In the table, features are marked with the following statuses:
 
 s|Version s|kam  s|Argo CD CLI  s|Helm  s|Kustomize s|Argo CD s|Argo Rollouts s|Dex     s|RH SSO |
 
-|1.15.0 |NA  |2.13.1 TP |3.15.4 GA |5.4.3 GA |2.13.1 GA |1.7.2 TP |2.41.1 GA |7.6.0 GA |4.14-4.17
+|1.15.0 |NA  |2.13.1 TP |3.15.4 GA |5.4.3 GA |2.13.1 GA |1.7.2 GA |2.41.1 GA |7.6.0 GA |4.14-4.17
 
 |1.14.0 |0.0.51 TP |2.12.3 TP |3.15.2 GA |5.4.2 GA |2.12.3 GA |1.7.1 GA |2.39.1 GA |7.6.0 GA |4.12-4.17
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.15 and GitOps 1.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6359

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Edited the value of the Argo Rollouts to 1.72 GA in the [Compatibility and matrix table](https://87261--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-15.html#GitOps-compatibility-support-matrix_gitops-release-notes) for the GitOps 1.15 release.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @jgwest @judexzhu 
QE review: @varshab1210 
Peer review: @xenolinux 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
