### PR TITLE
[GH#87271] Add information about the openshift-service-ca.crt ConfigMap

### DIFF
--- a/modules/customize-certificates-access-default-service-serving-configmap.adoc
+++ b/modules/customize-certificates-access-default-service-serving-configmap.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * security/certificates/service-serving-certificate.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="access-default-service-serving-configmap_{context}"]
+= Access the service CA bundle in the default config map
+
+A pod can access the service CA certificate by mounting the default
+`ConfigMap` object that exists in every namespace (project). The service CA
+certificate is in the `service-ca.crt` key of the `openshift-service-ca.crt`
+config map. Access to this CA certificate allows TLS clients to verify
+connections to services using service serving certificates.
+
+.Procedure
+
+. View the default config map:
++
+[source,terminal]
+----
+$ oc get configmap openshift-service-ca.crt -o yaml
+----
++
+The CA bundle is displayed as the value of the `service-ca.crt` key in the YAML output:
++
+[source,terminal]
+----
+apiVersion: v1
+data:
+  service-ca.crt: |
+    -----BEGIN CERTIFICATE-----
+...
+----
+
+. Mount the config map as a volume to each container that exists in a pod by configuring your `Deployment` object.
++
+.Example Deployment object that defines the volume for the mounted config map
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-example-custom-ca-deployment
+  namespace: my-example-custom-ca-ns
+spec:
+  ...
+    spec:
+      ...
+      containers:
+        - name: my-container-that-needs-custom-ca
+          volumeMounts:
+          - name: trusted-ca
+            mountPath: /etc/pki/ca-trust/extracted/pem
+            readOnly: true
+      volumes:
+      - name: trusted-ca
+        configMap:
+          name: openshift-service-ca.crt <1>
+          items:
+            - key: ca-bundle.crt <2>
+              path: tls-ca-bundle.pem <3>
+# ...
+----
+<1> `openshift-service-ca.crt` is the name of the default config map.
+<2> `ca-bundle.crt` is required as the ConfigMap key.
+<3> `tls-ca-bundle.pem` is required as the ConfigMap path.

--- a/modules/customize-certificates-access-default-service-serving-configmap.adoc
+++ b/modules/customize-certificates-access-default-service-serving-configmap.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * security/certificates/service-serving-certificate.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="access-default-service-serving-configmap_{context}"]
+= Access the service CA bundle in the default config map
+
+[role="_abstract"]
+A pod can access the service CA certificate by mounting the default `ConfigMap` object that exists in every namespace (project).
+The service CA certificate is in the `service-ca.crt` key of the `openshift-service-ca.crt` config map.
+Access to this CA certificate allows TLS clients to verify connections to services by using service serving certificates.
+
+.Procedure
+
+. View the default config map:
++
+[source,terminal]
+----
+$ oc get configmap openshift-service-ca.crt -o yaml
+----
++
+The CA bundle is displayed as the value of the `service-ca.crt` key in the YAML output:
++
+[source,terminal]
+----
+apiVersion: v1
+data:
+  service-ca.crt: |
+    -----BEGIN CERTIFICATE-----
+...
+----
+
+. Mount the config map as a volume to each container that exists in a pod by configuring your `Deployment` object.
++
+.Example Deployment object that defines the volume for the mounted config map
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-example-custom-ca-deployment
+  namespace: my-example-custom-ca-ns
+spec:
+  ...
+    spec:
+      ...
+      containers:
+        - name: my-container-that-needs-custom-ca
+          volumeMounts:
+          - name: trusted-ca
+            mountPath: /etc/pki/ca-trust/extracted/pem
+            readOnly: true
+      volumes:
+      - name: trusted-ca
+        configMap:
+          name: openshift-service-ca.crt
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+# ...
+----

--- a/security/certificates/service-serving-certificate.adoc
+++ b/security/certificates/service-serving-certificate.adoc
@@ -17,6 +17,8 @@ include::modules/customize-certificates-add-service-serving.adoc[leveloffset=+1]
 .Additional resources
 * You can use a service certificate to configure a secure route using reencrypt TLS termination. For more information, see xref:../../networking/ingress_load_balancing/routes/creating-advanced-routes.adoc#nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate_secured-routes[Creating a re-encrypt route with a custom certificate].
 
+include::modules/customize-certificates-access-default-service-serving-configmap.adoc[leveloffset=+1]
+
 include::modules/customize-certificates-add-service-serving-configmap.adoc[leveloffset=+1]
 
 include::modules/customize-certificates-add-service-serving-apiservice.adoc[leveloffset=+1]

--- a/security/certificates/service-serving-certificate.adoc
+++ b/security/certificates/service-serving-certificate.adoc
@@ -17,6 +17,8 @@ include::modules/customize-certificates-add-service-serving.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../networking/ingress_load_balancing/routes/creating-advanced-routes.adoc#nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate_secured-routes[Creating a re-encrypt route with a custom certificate]
 
+include::modules/customize-certificates-access-default-service-serving-configmap.adoc[leveloffset=+1]
+
 include::modules/customize-certificates-add-service-serving-configmap.adoc[leveloffset=+1]
 
 include::modules/customize-certificates-add-service-serving-apiservice.adoc[leveloffset=+1]


### PR DESCRIPTION
The openshift kube-controller-manager maintains a ConfigMap in every namespace that publishes the service serving certifcate CA. Adding it to the documentation for users.

Version(s):
This functionality has existed since OpenShift 4.12.

Issue:
#87271 

Link to docs preview:
https://87272--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/service-serving-certificate.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
