### PR TITLE
WMCO EUS to EUS upgrade

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2871,7 +2871,7 @@ Topics:
     File: creating-windows-machineset-vsphere
 - Name: Scheduling Windows container workloads
   File: scheduling-windows-workloads
-- Name: Windows node upgrades
+- Name: Windows node updates
   File: windows-node-upgrades
 - Name: Using Bring-Your-Own-Host Windows instances as nodes
   File: byoh-windows-instance

--- a/modules/windows-upgrades-eus.adoc
+++ b/modules/windows-upgrades-eus.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/windows-node-upgrades.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="wmco-upgrades-eus_{context}"]
+= Windows Machine Config Operator Control Plane Only update
+
+{product-title} and Windows Machine Config Operator (WMCO) support updating from one EUS version to another EUS version of {product-title}, in a process called a *Control Plane Only* update. After upgrading the cluster, the Windows nodes are updated from the starting EUS version to the new EUS version while keeping the Windows workloads in a healthy state with no disruptions.
+
+[IMPORTANT]
+====
+This update was previously known as an *EUS-to-EUS* update and is now referred to as a *Control Plane Only* update. These updates are only viable between *even-numbered minor versions* of {product-title}.
+====

--- a/modules/wmco-upgrades-eus-using-cli.adoc
+++ b/modules/wmco-upgrades-eus-using-cli.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/windows-node-upgrades.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="wmco-upgrades-eus-using-cli_{context}"]
+= WMCO Control Plane Only update by using the CLI
+
+You can use the {oc-first} to perform a Control Plane Only update of the Windows Machine Config Operator (WMCO).
+
+.Prerequisites
+* The cluster must be running on a supported EUS version of {product-title}.
+* All Windows nodes must be in a healthy state.
+* All Windows nodes must be running on the same version of the WMCO.
+* All the of the prerequisites of the Control Plane Only update are met, as described in "Performing a Control Plane Only update."
+
+.Procedure
+
+. Uninstall the WMCO Operator from the cluster by following the steps in "Deleting Operators from a cluster using the CLI."
++
+[IMPORTANT]
+====
+Delete the Operator only. Do not delete the Windows namespace or any Windows workloads.
+====
+
+. Update {product-title} by following the steps in "Performing a Control Plane Only update."
+
+. Install the new WMCO version by following the steps in "Installing the Windows Machine Config Operator using the CLI."
+
+.Verification 
+
+* On the Verify that the *Status* shows *Succeeded* to confirm successful installation of the WMCO.
+

--- a/modules/wmco-upgrades-eus-using-web-console.adoc
+++ b/modules/wmco-upgrades-eus-using-web-console.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/windows-node-upgrades.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="wmco-upgrades-eus-using-web-console_{context}"]
+= WMCO Control Plane Only update by using the web console
+
+You can use the {product-title} web console to perform a Control Plane Only update of the Windows Machine Config Operator (WMCO).
+
+.Prerequisites
+* The cluster must be running on a supported EUS version of {product-title}.
+* All Windows nodes must be in a healthy state.
+* All Windows nodes must be running on the same version of the WMCO.
+* All the of the prerequisites of the Control Plane Only update are met, as described in "Performing a Control Plane Only update."
+
+.Procedure
+
+. Uninstall WMCO operator by using the following the steps:
++
+[IMPORTANT]
+====
+Delete the Operator only. Do not delete the Windows namespace or any Windows workloads.
+====
++
+.. Log in to the {product-title} web console.
+.. Navigate to *Operators -> OperatorHub*.
+.. Use the *Filter by keyword* box to search for `Red Hat Windows Machine Config Operator`.
+.. Click the *Red Hat Windows Machine Config Operator* tile. The Operator tile indicates it is installed.
+.. In the *Windows Machine Config Operator* descriptor page, click *Uninstall*.
+
+. Update {product-title} by following the steps in "Performing a Control Plane Only update."
+
+. Install the new WMCO version by following the steps in "Installing the Windows Machine Config Operator using the web console."

--- a/modules/wmco-upgrades.adoc
+++ b/modules/wmco-upgrades.adoc
@@ -3,16 +3,16 @@
 // * windows_containers/windows-node-upgrades.adoc
 
 [id="wmco-upgrades_{context}"]
-= Windows Machine Config Operator upgrades
+= Windows Machine Config Operator updates
 
-When a new version of the Windows Machine Config Operator (WMCO) is released that is compatible with the current cluster version, the Operator is upgraded based on the upgrade channel and subscription approval strategy it was installed with when using the Operator Lifecycle Manager (OLM). The WMCO upgrade results in the Kubernetes components in the Windows machine being upgraded.
+When a new version of the Windows Machine Config Operator (WMCO) is released that is compatible with the current cluster version, the Operator is updated based on the update channel and subscription approval strategy it was installed with when using the Operator Lifecycle Manager (OLM). The WMCO update results in the Kubernetes components in the Windows machine being updated.
 
 [NOTE]
 ====
-If you are upgrading to a new version of the WMCO and want to use cluster monitoring, you must have the `openshift.io/cluster-monitoring=true` label present in the WMCO namespace. If you add the label to a pre-existing WMCO namespace, and there are already Windows nodes configured, restart the WMCO pod to allow monitoring graphs to display.
+If you are updating to a new version of the WMCO and want to use cluster monitoring, you must have the `openshift.io/cluster-monitoring=true` label present in the WMCO namespace. If you add the label to a pre-existing WMCO namespace, and there are already Windows nodes configured, restart the WMCO pod to allow monitoring graphs to display.
 ====
 
-For a non-disruptive upgrade, the WMCO terminates the Windows machines configured by the previous version of the WMCO and recreates them using the current version. This is done by deleting the `Machine` object, which results in the drain and deletion of the Windows node. To facilitate an upgrade, the WMCO adds a version annotation to all the configured nodes. During an upgrade, a mismatch in version annotation results in the deletion and recreation of a Windows machine. To have minimal service disruptions during an upgrade, the WMCO only updates one Windows machine at a time.
+For a non-disruptive update, the WMCO terminates the Windows machines configured by the previous version of the WMCO and recreates them using the current version. This is done by deleting the `Machine` object, which results in the drain and deletion of the Windows node. To facilitate an update, the WMCO adds a version annotation to all the configured nodes. During an update, a mismatch in version annotation results in the deletion and recreation of a Windows machine. To have minimal service disruptions during an update, the WMCO only updates one Windows machine at a time.
 
 After the update, it is recommended that you set the `spec.os.name.windows` parameter in your workload pods. The WMCO uses this field to authoritatively identify the pod operating system for validation and is used to enforce Windows-specific pod security context constraints (SCCs).
 

--- a/windows_containers/windows-node-upgrades.adoc
+++ b/windows_containers/windows-node-upgrades.adoc
@@ -1,13 +1,37 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="windows-node-upgrades"]
-= Windows node upgrades
+= Windows node updates
 include::_attributes/common-attributes.adoc[]
 :context: windows-node-upgrades
 
 toc::[]
 
-You can ensure your Windows nodes have the latest updates by upgrading the Windows Machine Config Operator (WMCO).
+You can ensure your Windows nodes have the latest updates by updating the Windows Machine Config Operator (WMCO).
+
+You can update the WMCO in any of the following scenarios:
+
+* Within the current version. for example, from <10.y.z> to <10.y.z+1>.
+* To a new, contiguous version. For example, from <10.y> to <10.y+1>.
+* From an EUS version to another EUS version by using a Control Plane Only update. For example, from <10.y> to <10.y+2>.
 
 include::modules/wmco-upgrades.adoc[leveloffset=+1]
 
-For more information on Operator upgrades using the Operator Lifecycle Manager (OLM), see xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators].
+[role="_additional-resources"]
+.Additional resources
+* xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators].
+
+include::modules/windows-upgrades-eus.adoc[leveloffset=+1]
+include::modules/wmco-upgrades-eus-using-web-console.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../updating/updating_a_cluster/control-plane-only-update.adoc#control-plane-only-update[Performing a Control Plane Only update]
+* xref:../windows_containers/enabling-windows-container-workloads.adoc#installing-wmco-using-web-console_enabling-windows-container-workloads[Installing the Windows Machine Config Operator using the web console]
+
+include::modules/wmco-upgrades-eus-using-cli.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operator-from-a-cluster-using-cli_olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster using the CLI]
+* xref:../updating/updating_a_cluster/control-plane-only-update.adoc#control-plane-only-update[Performing a Control Plane Only update]
+* xref:../windows_containers/enabling-windows-container-workloads.adoc#installing-wmco-using-cli_enabling-windows-container-workloads[Installing the Windows Machine Config Operator using the CLI]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13164

[Windows node upgrades](https://87273--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-node-upgrades.html) -- New second paragraph and list
[Windows Machine Config Operator Control Plane Only upgrade](https://87273--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-node-upgrades.html#wmco-upgrades-eus_windows-node-upgrades) -- New module
[WMCO Control Plane Only upgrade by using the web console](https://87273--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-node-upgrades.html#wmco-upgrades-eus-using-web-console_windows-node-upgrades) -- New module
[WMCO Control Plane Only upgrade by using the CLI](https://87273--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-node-upgrades.html#wmco-upgrades-eus-using-cli_windows-node-upgrades) -- New module
