### PR TITLE
EUS channel support update 4.12

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -33,6 +33,11 @@ In addition to the stable channel, all even-numbered minor versions of {product-
 Both standard and non-EUS subscribers can access all EUS repositories and necessary RPMs (`rhel-*-eus-rpms`) to be able to support critical purposes such as debugging and building drivers.
 ====
 
+[IMPORTANT]
+====
+EUS channels are the only channels that receive additional z-streams while a release is in the EUS phase.
+====
+
 [id="candidate-version-channel_{context}"]
 == candidate-{product-version} channel
 


### PR DESCRIPTION
Version(s):
4.12

Issue:
N/A

Link to docs preview:
https://87275--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html#eus-4y-channel_understanding-upgrade-channels-releases

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
4.13 and 4.14+ will follow

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
