### PR TITLE
OSDOCS-12746: Rotating OIDC bound keys (RN)

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -53,6 +53,15 @@ This release adds improvements related to the following components and concepts:
 [id="ocp-release-notes-auth_{context}"]
 === Authentication and authorization
 
+[id="ocp-release-notes-auth-ccoctl-rotation_{context}"]
+==== Rotating OIDC bound service account signer keys
+
+With this release, you can use the Cloud Credential Operator (CCO) utility (`ccoctl`) to rotate the OpenID Connect (OIDC) bound service account signer key for clusters installed on the following cloud providers:
+
+* xref:../post_installation_configuration/changing-cloud-credentials-configuration.adoc#rotating-bound-service-keys_key-rotation-aws[{aws-first} with {sts-first}]
+* xref:../post_installation_configuration/changing-cloud-credentials-configuration.adoc#rotating-bound-service-keys_key-rotation-gcp[{gcp-first} with {gcp-wid-short}]
+* xref:../post_installation_configuration/changing-cloud-credentials-configuration.adoc#rotating-bound-service-keys_key-rotation-azure[{azure-first} with {entra-short}]
+
 [id="ocp-release-notes-backup-restore_{context}"]
 === Backup and restore
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12746](https://issues.redhat.com//browse/OSDOCS-12746)

Link to docs preview:
[Rotating OIDC bound service account signer keys](https://87279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-auth-ccoctl-rotation_release-notes)

QE review:
- [ ] QE has approved this change.

Additional information:
Rel notes for OSDOCS-12745. 