### PR TITLE
OSDOCS-12464: Rel note for updates made in bootc install section

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -87,9 +87,12 @@ With this release, you can see detailed explanations and example outputs to chec
 ==== Automated recovery from manual backups now documented
 With this release, you can automatically restore data from manual backups when {microshift-short} fails to start by using the `auto-recovery` feature. For more information, see xref:../microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc#microshift-auto-recover-manual-backup[Automated recovery from manual backups].
 
-//[id="microshift-4-18-doc-enhancements_{context}"]
-//=== Documentation enhancements
-//Doc enhancements include additions for RFEs and other continuous improvement items that are substantial and are not tied to new features or bug fixes already listed here. These can also go under the relevant section as applicable.
+[id="microshift-4-18-doc-enhancements_{context}"]
+=== Documentation enhancements
+
+[id="microshift-4-18-install-with-rhel-image-mode_{context}"]
+==== Updating content in the {op-system-base} image mode section
+With this release, the contents of the "Installing with {op-system-base} image mode" section, which were previously developer-focused, are now updated to be {microshift-short} administrator-focused. For more information, see xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}].
 
 [id="microshift-4-18-tech-preview_{context}"]
 == Technology Preview features


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12464](https://issues.redhat.com/browse/OSDOCS-12464)

Link to docs preview:
[Updating content in the RHEL image mode section](https://87281--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-doc-enhancements_release-notes)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Additional information:
Refer to the PR https://github.com/openshift/openshift-docs/pull/87143 for approval from QE and SME on the updates. The has been updated in the release notes in this PR.
