### PR TITLE
OSDOCS-13081: Tutorials - Classic to HCP breakout

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -125,8 +125,26 @@ Topics:
   File: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
 - Name: ROSA with HCP private offer acceptance and sharing
   File: cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing
+- Name: Deploying ROSA with a Custom DNS Resolver
+  File: cloud-experts-custom-dns-resolver
+- Name: Using AWS WAF and Amazon CloudFront to protect ROSA workloads
+  File: cloud-experts-using-cloudfront-and-waf
+- Name: Using AWS WAF and AWS ALBs to protect ROSA workloads
+  File: cloud-experts-using-alb-and-waf
+- Name: Deploying OpenShift API for Data Protection on a ROSA cluster
+  File: cloud-experts-deploy-api-data-protection
+- Name: AWS Load Balancer Operator on ROSA
+  File: cloud-experts-aws-load-balancer-operator
 - Name: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
   File: cloud-experts-entra-id-idp
+- Name: Using AWS Secrets Manager CSI on ROSA with STS
+  File: cloud-experts-aws-secret-manager
+- Name: Using AWS Controllers for Kubernetes on ROSA
+  File: cloud-experts-using-aws-ack
+- Name: Dynamically issuing certificates using the cert-manager Operator on ROSA
+  File: cloud-experts-dynamic-certificate-custom-domain
+- Name: Assigning consistent egress IP for external traffic
+  File: cloud-experts-consistent-egress-ip
 # ---
 # Name: Getting started
 # Dir: rosa_getting_started

--- a/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
@@ -20,10 +20,18 @@ toc::[]
 
 include::snippets/mobb-support-statement.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa-hcp[]
 [TIP]
 ====
 Load Balancers created by the AWS Load Balancer Operator cannot be used for xref:../networking/routes/route-configuration.adoc#route-configuration[OpenShift Routes], and should only be used for individual services or ingress resources that do not need the full layer 7 capabilities of an OpenShift Route.
 ====
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+[TIP]
+====
+Load Balancers created by the AWS Load Balancer Operator cannot be used for link:https://docs.openshift.com/rosa/networking/routes/route-configuration.html[OpenShift Routes], and should only be used for individual services or ingress resources that do not need the full layer 7 capabilities of an OpenShift Route.
+====
+endif::openshift-rosa-hcp[]
 
 The link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/[AWS Load Balancer Controller] manages AWS Elastic Load Balancers for a {product-title} (ROSA) cluster. The controller provisions link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html[AWS Application Load Balancers (ALB)] when you create Kubernetes Ingress resources and link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html[AWS Network Load Balancers (NLB)] when implementing Kubernetes Service resources with a type of LoadBalancer.
 
@@ -44,7 +52,12 @@ The link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balanc
 AWS ALBs require a multi-AZ cluster, as well as three public subnets split across three AZs in the same VPC as the cluster. This makes ALBs unsuitable for many PrivateLink clusters. AWS NLBs do not have this restriction.
 ====
 
+ifndef::openshift-rosa-hcp[]
 * xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[A multi-AZ ROSA classic cluster]
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+* link:https://docs.openshift.com/rosa-hcp/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[A multi-AZ ROSA cluster]
+endif::openshift-rosa-hcp[]
 * BYO VPC cluster
 * AWS CLI
 * OC CLI

--- a/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
@@ -58,7 +58,13 @@ $ oc get authentication.config.openshift.io cluster -o json \
 "https://xxxxx.cloudfront.net/xxxxx"
 ----
 +
-If your output is different, do not proceed. See xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Red{nbsp}Hat documentation on creating an STS cluster] before continuing this process.
+If your output is different, do not proceed. 
+ifndef::openshift-rosa-hcp[]
+See xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Red{nbsp}Hat documentation on creating an STS cluster] before continuing this process.
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+See link:https://docs.openshift.com/rosa-hcp/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[Creating ROSA with HCP clusters using the default options] before continuing this process.
+endif::openshift-rosa-hcp[]
 
 . Set the `SecurityContextConstraints` permission to allow the CSI driver to run by running the following command:
 +

--- a/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
+++ b/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
@@ -21,7 +21,12 @@ You can assign a consistent IP address for traffic that leaves your cluster such
 
 By default, {product-title} (ROSA) uses the OVN-Kubernetes container network interface (CNI) to assign random IP addresses from a pool. This can make configuring security lockdowns unpredictable or open.
 
+ifndef::openshift-rosa-hcp[]
 See xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address] for more information.
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+See link:https://docs.openshift.com/rosa/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html[Configuring an egress IP address] for more information.
+endif::openshift-rosa-hcp[]
 
 .Objectives
 
@@ -30,9 +35,16 @@ See xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ov
 .Prerequisites
 
 * A ROSA cluster deployed with OVN-Kubernetes
+ifndef::openshift-rosa-hcp[]
 * The xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI] (`oc`)
 * The xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[ROSA CLI] (`rosa`)
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+* The link:https://docs.openshift.com/rosa/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI] (`oc`)
+* The link:https://docs.openshift.com/rosa/cli_reference/rosa_cli/rosa-get-started-cli.html[ROSA CLI] (`rosa`)
+endif::openshift-rosa-hcp[]
 * link:https://stedolan.github.io/jq/[`jq`]
+
 
 == Setting your environment variables
 

--- a/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.adoc
+++ b/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.adoc
@@ -124,8 +124,7 @@ $ aws route53resolver list-resolver-endpoint-ip-addresses \
 
 Use the following procedure to configure your DNS server to forward the necessary private hosted zones to your Amazon Route 53 Inbound Resolver. 
 
-=== ROSA with HCP
-
+ifdef::openshift-rosa-hcp[]
 ROSA with HCP clusters require you to configure DNS forwarding for two private hosted zones:
 
 * `<cluster-name>.hypershift.local`
@@ -151,7 +150,7 @@ zone "<cluster-name>.hypershift.local" { <1>
 <1> Replace `<cluster-name>` with your ROSA HCP cluster name.
 <2> Replace with the IP addresses of your inbound resolver endpoints collected above, ensuring that following each IP address there is a `;`.
 +
-. xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-account-wide-sts-roles-and-policies_rosa-hcp-sts-creating-a-cluster-quickly[Create your cluster].
+. link:https://docs.openshift.com/rosa/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[Create your cluster].
 +
 . Once your cluster has begun the creation process, locate the newly created private hosted zone:
 +
@@ -198,21 +197,18 @@ zone "rosa.<domain-prefix>.<unique-ID>.p3.openshiftapps.com" { <1>
 ----
 <1> Replace `<domain-prefix>` with your cluster domain prefix and `<unique-ID>` with your unique ID collected above.
 <2> Replace with the IP addresses of your inbound resolver endpoints collected above, ensuring that following each IP address there is a `;`.
+endif::openshift-rosa-hcp[]
 
-=== ROSA Classic
-
+ifdef::openshift-rosa[]
 ROSA Classic clusters require you to configure DNS forwarding for one private hosted zones:
 
 * `<domain-prefix>.<unique-ID>.p1.openshiftapps.com`
 
 This Amazon Route 53 private hosted zones is created during cluster creation. The `domain-prefix` is a customer-specified value, but the `unique-ID` is randomly generated during cluster creation and cannot be preselected. As such, you must wait for the cluster creation process to begin before configuring forwarding for the `p1.openshiftapps.com` private hosted zone. 
 
-ifdef::temp-ifdef[]
+ifndef::openshift-rosa-hcp[]
 . xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-account-wide-sts-roles-and-policies_rosa-sts-creating-a-cluster-quickly[Create your cluster].
-endif::[]
-ifdef::temp-ifdef[]
-* xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Create your cluster].
-endif::[]
+endif::openshift-rosa-hcp[]
 +
 . Once your cluster has begun the creation process, locate the newly created private hosted zone:
 +
@@ -258,3 +254,4 @@ zone "<domain-prefix>.<unique-ID>.p1.openshiftapps.com" { <1>
 ----
 <1> Replace `<domain-prefix>` with your cluster domain prefix and `<unique-ID>` with your unique ID collected above.
 <2> Replace with the IP addresses of your inbound resolver endpoints collected above, ensuring that following each IP address there is a `;`.
+endif::openshift-rosa[]

--- a/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
@@ -21,7 +21,12 @@ include::snippets/mobb-support-statement.adoc[leveloffset=+1]
 
 .Prerequisites
 
+ifndef::openshift-rosa-hcp[]
 * A xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[ROSA classic cluster]
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+* A link:https://docs.openshift.com/rosa-hcp/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[ROSA cluster]
+endif::openshift-rosa-hcp[]
 
 .Environment
 

--- a/cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc
+++ b/cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc
@@ -28,12 +28,10 @@ This tutorial guides you to complete the following tasks:
 . Configure the {product-title} cluster to use Entra ID as the identity provider.
 . Grant additional permissions to individual groups.
 
-[id="cloud-experts-entra-id-idp-prerequisites"]
 == Prerequisites
 
 * You created a set of security groups and assigned users by following link:https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/how-to-manage-groups[the Microsoft documentation].
 
-[id="cloud-experts-entra-id-idp-register-application"]
 == Registering a new application in Entra ID for authentication
 
 To register your application in Entra ID, first create the OAuth callback URL, then register your application.
@@ -50,7 +48,7 @@ Remember to save this callback URL; it will be required later in the process.
 [source,terminal]
 ----
 $ domain=$(rosa describe cluster -c <cluster_name> | grep "DNS" | grep -oE '\S+.openshiftapps.com')
-$ echo "OAuth callback URL: https://oauth-openshift.apps.$domain/oauth2callback/AAD"
+echo "OAuth callback URL: https://oauth.${domain}/oauth2callback/AAD"
 ----
 +
 The "AAD" directory at the end of the OAuth callback URL must match the OAuth identity provider name that you will set up later in this process.
@@ -82,15 +80,12 @@ image:azure-portal_add-a-client-secret-page.png[Azure Portal - Add a Client Secr
 +
 image:azure-portal_copy-client-secret-page.png[Azure Portal - Copy Client Secret page]
 
-[id="rosa-mobb-entra-id-configure-claims"]
 == Configuring the application registration in Entra ID to include optional and group claims
 
 So that {product-title} has enough information to create the user's account, you must configure Entra ID to give two optional claims: `email` and `preferred_username`. For more information about optional claims in Entra ID, see link:https://learn.microsoft.com/en-us/azure/active-directory/develop/optional-claims[the Microsoft documentation].
 
 In addition to individual user authentication, {product-title} provides group claim functionality. This functionality allows an OpenID Connect (OIDC) identity provider, such as Entra ID, to offer a user's group membership for use within {product-title}.
 
-[discrete]
-[id="rosa-mobb-entra-id-configure-optional-claims"]
 === Configuring optional claims
 
 You can configure the optional claims in Entra ID.
@@ -115,8 +110,6 @@ image:azure-portal_add-optional-preferred_username-claims-page.png[Azure Portal 
 +
 image:azure-portal_add-optional-claims-graph-permissions-prompt.png[Azure Portal - Add Optional Claims - Graph Permissions Prompt]
 
-[discrete]
-[id="rosa-mobb-entra-id-configure-group-claims"]
 === Configuring group claims (optional)
 
 Configure Entra ID to offer a groups claim.
@@ -135,7 +128,6 @@ In this example, the group claim includes all of the security groups that a user
 +
 image:azure-portal_edit-group-claims-page.png[Azure Portal - Edit Groups Claim Page]
 
-[id="cloud-experts-entra-id-idp-configure-cluster"]
 == Configuring the {product-title} cluster to use Entra ID as the identity provider
 
 You must configure {product-title} to use Entra ID as its identity provider.
@@ -201,15 +193,12 @@ $ rosa create idp \
 
 After a few minutes, the cluster authentication Operator reconciles your changes, and you can log in to the cluster by using Entra ID.
 
-[id="rosa-mobb-azure-oidc-grant-permissions"]
 == Granting additional permissions to individual users and groups
 
 When your first log in, you might notice that you have very limited permissions. By default, {product-title} only grants you the ability to create new projects, or namespaces, in the cluster. Other projects are restricted from view.
 
 You must grant these additional abilities to individual users and groups.
 
-[discrete]
-[id="rosa-mobb-azure-oidc-grant-permissions-users"]
 === Granting additional permissions to individual users
 
 {product-title} includes a significant number of preconfigured roles, including the `cluster-admin` role that grants full access and control over the cluster.
@@ -228,8 +217,6 @@ $ rosa grant user cluster-admin \
 <1> Provide the Entra ID username that you want to have cluster admin permissions.
 --
 
-[discrete]
-[id="cloud-experts-entra-id-idp-additional-permissions-groups"]
 === Granting additional permissions to individual groups
 
 If you opted to enable group claims, the cluster OAuth provider automatically creates or updates the user's group memberships by using the group ID. The cluster OAuth provider does not automatically create `RoleBindings` and `ClusterRoleBindings` for the groups that are created; you are responsible for creating those bindings by using your own processes.
@@ -252,7 +239,6 @@ $ oc create clusterrolebinding cluster-admin-group \
 +
 Now, any user in the specified group automatically receives `cluster-admin` access.
 
-[id="cloud-experts-entra-id-idp-additional-resources"]
 [role="_additional-resources"]
 == Additional resources
 

--- a/cloud_experts_tutorials/index.adoc
+++ b/cloud_experts_tutorials/index.adoc
@@ -4,6 +4,9 @@
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: tutorials-overview
 
-Step-by-step tutorials from Red{nbsp}Hat experts to help you get the most out of your Managed OpenShift cluster.
+Use the step-by-step tutorials from Red{nbsp}Hat experts to get the most out of your Managed OpenShift cluster.
 
-In an effort to make this Cloud Expert tutorial content available quickly, it may not yet be tested on every supported configuration.
+[IMPORTANT]
+====
+This content is authored by Red Hat experts but has not yet been tested on every supported configuration.
+====

--- a/cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
+++ b/cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-mobb-verify-permissions-sts-deployment"]
-= Tutorial: Verifying Permissions for a ROSA STS Deployment
+= Tutorial: Verifying permissions for a ROSA STS deployment
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-mobb-verify-permissions-sts-deployment
 
@@ -16,16 +16,27 @@ toc::[]
 // ---
 
 To proceed with the deployment of a ROSA cluster, an account must support the required roles and permissions.
-AWS Service Control Policies (SCPs) cannot block the API calls made by the installer or operator roles.
+AWS Service Control Policies (SCPs) cannot block the API calls made by the installer or Operator roles.
 
 Details about the IAM resources required for an STS-enabled installation of ROSA can be found here: xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources]
+ifndef::openshift-rosa-hcp[]
+Details about the IAM resources required for an STS-enabled installation of ROSA can be found here: xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for ROSA clusters that use STS]
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+Details about the IAM resources required for an STS-enabled installation of ROSA can be found here: link:https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html[About IAM resources for ROSA clusters]
+endif::openshift-rosa-hcp[]
 
 This guide is validated for ROSA v4.11.X.
 
 == Prerequisites
 
 * link:https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html[AWS CLI]
+ifndef::openshift-rosa-hcp[]
 * xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[ROSA CLI] v1.2.6
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+* link:https://docs.openshift.com/rosa/cli_reference/rosa_cli/rosa-get-started-cli.html[ROSA CLI] v1.2.6
+endif::openshift-rosa-hcp[]
 * link:https://stedolan.github.io/jq/[jq CLI]
 * link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html[AWS role with required permissions]
 


### PR DESCRIPTION
[OSDOCS-13081](https://issues.redhat.com//browse/OSDOCS-13081): Tutorials - Classic to HCP breakout

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-13081

Link to docs preview:

- Tutorial overview: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/
- Deploying ROSA with a Custom DNS Resolver: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-custom-dns-resolver
- Using AWS WAF and Amazon CloudFront to protect ROSA workloads: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf
- Using AWS WAF and AWS ALBs to protect ROSA workloads: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-using-alb-and-waf
- Deploying OpenShift API for Data Protection on a ROSA cluster: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection
- AWS Load Balancer Operator on ROSA: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator
- Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-entra-id-idp
- Using AWS Secrets Manager CSI on ROSA with STS: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-aws-secret-manager
- Using AWS Controllers for Kubernetes on ROSA: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-using-aws-ack
- Dynamically issuing certificates using the cert-manager Operator on ROSA: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain
- Assigning consistent egress IP for external traffic: https://87294--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-consistent-egress-ip

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
