### PR TITLE
OSDOCS-12566: Add Serverless to ROSA HCP

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -903,3 +903,13 @@ Topics:
 #  Topics:
 #  - Name: Adding worker nodes to single-node OpenShift clusters
 #    File: nodes-sno-worker-nodes
+---
+Name: Serverless
+Dir: serverless
+Distros: openshift-rosa-hcp
+Topics:
+- Name: About Serverless
+  Dir: about
+  Topics:
+  - Name: Serverless overview
+    File: about-serverless


### PR DESCRIPTION
Version(s):
- enterprise-4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-12566

Link to docs preview:
https://87302--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/serverless/about/about-serverless

QE review:
- N/A
