### PR TITLE
OSDOCS#13130: Update the 4.17.14 z-stream RN

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -330,7 +330,6 @@ endif::openshift-origin[]
 :gcp-wid-first: Google Cloud Platform Workload Identity
 :gcp-wid-short: GCP Workload Identity
 
-
 // Cluster API terminology
 // Cluster CAPI Operator
 :cluster-capi-operator: Cluster CAPI Operator

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2872,6 +2872,42 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.14
+[id="ocp-4-17-14_{context}"]
+=== RHSA-2025:0654 - {product-title} {product-version}.14 bug fix, and security update advisory
+
+Issued: 28 January 2025
+
+{product-title} release {product-version}.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0654[RHSA-2025:0654] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0656[RHSA-2025:0656] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.14 --pullspecs
+----
+
+[id="ocp-4-17-14-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, some cluster autoscaler metrics were not initialized and were unavailable. With this release, the cluster autoscaler metrics are initialized and available. (link:https://issues.redhat.com/browse/OCPBUGS-48606[*OCPBUGS-48606*])
+* Previously, installing an {aws-full} cluster in the Commercial Cloud Services (C2S) region or the Secret Commercial Cloud Services (SC2S) region failed because the installation program added unsupported security groups to the load balancer. With this release, the installation program does not add unsupported security groups to the load balancer for a cluster that needs to be installed in the C2S region or the SC2S region. (link:https://issues.redhat.com/browse/OCPBUGS-42763[*OCPBUGS-42763*])
+* Previously, you could not add a new worker by using the `oc adm node-image create` command if the node date or time was inaccurate. With this release, the issue is resolved by applying the same NTP configuration that is in the target cluster `machineconfig chrony` resource to the node ephemeral live environment. (link:https://issues.redhat.com/browse/OCPBUGS-45344[*OCPBUGS-45344*])
+* Previously, you could not use all available machine types in a zone because all zones in a region were assumed to have the same set of machine types. With this release, all machine types are available in all enabled zones. (link:https://issues.redhat.com/browse/OCPBUGS-46432[*OCPBUGS-46432*])
+* Previously, the installation program was not compliant with PCI-DSS/BAFIN regulations. With this release, the cross-tenant replication in {azure-first} is disabled, which reduces the chance of unauthorized data access and ensures strict adherence to data governance policies. (link:https://issues.redhat.com/browse/OCPBUGS-48119[*OCPBUGS-48119*])
+* Previously, when you clicked the *Don't show again* link in the Red Hat Ansible Lightspeed modal, it did not display the correct *General User Preference* tab when one of the other *User Preference* tabs was open. With this release, clicking the *Don't show again* link goes to the correct *General User Preference* tab. (link:https://issues.redhat.com/browse/OCPBUGS-48227[*OCPBUGS-48227*])
+* Previously, when a Google Cloud Platform (GCP) service account was created, the account would not always be immediately available. When the account was not available for updates, the installation program received failures when adding permissions to the account. According to link:https://cloud.google.com/iam/docs/retry-strategy[*Retry failed requests*], a service account might be created, but is not active for up to 60 seconds. With this release, the service account is updated on an exponential backoff to give the account enough time to update correctly. (link:https://issues.redhat.com/browse/OCPBUGS-48359[*OCPBUGS-48359*])
+* Previously, on RHEL 9 FIPS STIG compliant machines, The SHA-1 key caused the release signature verification to fail because of the restriction to use weak keys.
+With this release, the key used by the oc-mirror plugin for release signature verification is changed and release images are signed by a new SHA256 trusted-key that is different from the old SHA-1 key. (link:https://issues.redhat.com/browse/OCPBUGS-48363[*OCPBUGS-48363*])
+* Previously, the {olm-first} would sometimes concurrently resolve the same namespace in a cluster. This led to subscriptions reaching a terminal state of `ConstraintsNotSatisfiable`, because two concurrent processes interacted with a subscription and this caused a CSV file to become unassociated. With this release, {olm} can resolve concurrent namespaces for a subscription so no CSV remains unassociated. (link:https://issues.redhat.com/browse/OCPBUGS-45845[*OCPBUGS-45845*])
+* Previously, creating a hosted control planes (HCP) cluster using the HCP CLI failed on the release image check to verify that the release image was a multi-arch image. With this release, the HCP CLI does not fail to create a hosted cluster because the updated CLI code with the multi-arch release image check is available. (link:https://issues.redhat.com/browse/OCPBUGS-44927[*OCPBUGS-44927*])
+
+[id="ocp-4-17-14-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.12
 [id="ocp-4-17-12_{context}"]
 === RHSA-2025:0115 - {product-title} {product-version}.12 bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13130](https://issues.redhat.com/browse/OSDOCS-13130)

Link to docs preview:
[4.17.14](https://87303--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes#ocp-4-17-14_release-notes)

QE review:
- [ ] QE has approved this change.
z-stream RNs do not require QE approval.

Additional information: This PR was originally for the 4.17.13 z-stream advisories, but 2 of the advisories had to be reset, and the errata was Tombstoned. This 4.17.14 update replaces the 4.17.13 doc text that was peer reviewed.