### PR TITLE
[WIP] OSDOCS-13085: adds 4.17.13 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -214,3 +214,12 @@ Issued: 14 January 2025
 {product-title} release 4.17.12 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0117[RHBA-2025:0117] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:0115[RHSA-2025:0115] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-13-dp_{context}"]
+=== RHBA-2025:0353 - {microshift-short} 4.17.13 bug fix and enhancement advisory
+
+Issued: 21 January 2025
+
+{product-title} release 4.17.13 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0353[RHBA-2025:0353] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:0351[RHSA-2025:0351] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13085](https://issues.redhat.com/browse/OSDOCS-13085)

Link to docs preview:
[4-17-13-dp_release-notes](https://87307--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-13-dp_release-notes)

QE review:
- [x] QE has approved this change.
