### PR TITLE
OCPBUGS-48653: Fix log file name

### DIFF
--- a/modules/investigating-worker-node-installation-issues.adoc
+++ b/modules/investigating-worker-node-installation-issues.adoc
@@ -153,7 +153,7 @@ $ ssh core@<worker-node>.<cluster_name>.<base_domain> journalctl -b -f -u crio.s
 $ oc adm node-logs --role=worker --path=sssd
 ----
 +
-.. Inspect a specific log within a `/var/log/` subdirectory. The following example outputs `/var/log/sssd/audit.log` contents from all worker nodes:
+.. Inspect a specific log within a `/var/log/` subdirectory. The following example outputs `/var/log/sssd/sssd.log` contents from all worker nodes:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-48653](https://issues.redhat.com/browse/OCPBUGS-48653)

Link to docs preview:
[Investigating worker node installation issues](https://87308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-installations.html#investigating-worker-node-installation-issues_troubleshooting-installations)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
```
$ oc adm node-logs --role=worker --path=sssd
ip-10-0-134-39.ec2.internal sssd.log
ip-10-0-134-39.ec2.internal sssd_implicit_files.log
ip-10-0-134-39.ec2.internal sssd_implicit_files.log-20230917
ip-10-0-134-39.ec2.internal sssd_nss.log
ip-10-0-134-39.ec2.internal sssd_nss.log-20230917
```

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
