### PR TITLE
OADP-5482 ROSA STS RoleARN

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -47,6 +47,7 @@ endif::[]
 :oadp-version: 1.4.1
 :oadp-version-1-3: 1.3.3
 :oadp-version-1-4: 1.4.2
+:oadp-bsl-api: backupstoragelocations.velero.io
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
 :product-mirror-registry: Mirror registry for Red Hat OpenShift

--- a/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
@@ -36,6 +36,8 @@ include::modules/preparing-aws-credentials-for-oadp.adoc[leveloffset=+1]
 
 include::modules/installing-oadp-rosa-sts.adoc[leveloffset=+1]
 
+include::modules/updating-role-arn-oadp-rosa-sts.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 // This xref points to a topic that is not published in the ROSA docs.

--- a/modules/updating-role-arn-oadp-rosa-sts.adoc
+++ b/modules/updating-role-arn-oadp-rosa-sts.adoc
@@ -1,0 +1,163 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="updating-role-arn-oadp-rosa-sts_{context}"]
+= Updating the IAM role ARN in the {oadp-short} Operator subscription
+
+While installing the {oadp-short} Operator on a ROSA Security Token Service (STS) cluster, if you provide an incorrect IAM role Amazon Resource Name (ARN), the `openshift-adp-controller` pod gives an error. The credential requests that are generated contain the wrong IAM role ARN. To update the credential requests object with the correct IAM role ARN, you can edit the {oadp-short} Operator subscription and patch the IAM role ARN with the correct value. By editing the {oadp-short} Operator subscription, you do not have to uninstall and reinstall {oadp-short} to update the IAM role ARN.
+
+.Prerequisites
+
+ifdef::openshift-enterprise[]
+* You have a {product-rosa} STS cluster with the required access and tokens.
+endif::openshift-enterprise[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+* You have a {product-title} STS cluster with the required access and tokens.
+endif::openshift-rosa,openshift-rosa-hcp[]
+* You have installed {oadp-short} on the ROSA STS cluster.
+
+.Procedure
+
+. To verify that the {oadp-short} subscription has the wrong IAM role ARN environment variable set, run the following command:
++
+[source,terminal]
+----
+$ oc get sub -o yaml redhat-oadp-operator
+----
++
+.Example subscription 
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations:
+  creationTimestamp: "2025-01-15T07:18:31Z"
+  generation: 1
+  labels:
+    operators.coreos.com/redhat-oadp-operator.openshift-adp: ""
+  name: redhat-oadp-operator
+  namespace: openshift-adp
+  resourceVersion: "77363"
+  uid: 5ba00906-5ad2-4476-ae7b-ffa90986283d
+spec:
+  channel: stable-1.4
+  config:
+    env:
+    - name: ROLEARN
+      value: arn:aws:iam::11111111:role/wrong-role-arn # <1>
+  installPlanApproval: Manual
+  name: redhat-oadp-operator
+  source: prestage-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: oadp-operator.v1.4.2
+----
+<1> Verify the value of `ROLEARN` you want to update.
+
+. Update the `ROLEARN` field of the subscription with the correct role ARN by running the following command:
++
+[source,terminal]
+----
+$ oc patch subscription redhat-oadp-operator -p '{"spec": {"config": {"env": [{"name": "ROLEARN", "value": "<role_arn>"}]}}}' --type='merge'
+----
++
+where:
+
+`<role_arn>`:: Specifies the IAM role ARN to be updated. For example, `arn:aws:iam::160.....6956:role/oadprosa.....8wlf`.
+
+. Verify that the `secret` object is updated with correct role ARN value by running the following command:
++
+[source,terminal]
+----
+$ oc get secret cloud-credentials -o jsonpath='{.data.credentials}' | base64 -d
+----
++
+.Example output
++
+[source,terminal]
+----
+[default]
+sts_regional_endpoints = regional
+role_arn = arn:aws:iam::160.....6956:role/oadprosa.....8wlf
+web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+----
+
+. Configure the `DataProtectionApplication` custom resource (CR) manifest file as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: test-rosa-dpa
+  namespace: openshift-adp
+spec:
+  backupLocations:
+  - bucket:
+      config:
+        region: us-east-1
+      cloudStorageRef:
+        name: <cloud_storage> # <1>
+      credential:
+        name: cloud-credentials
+        key: credentials
+      prefix: velero
+      default: true
+  configuration:
+    velero:
+      defaultPlugins:
+      - aws
+      - openshift
+----
+<1> Specify the `CloudStorage` CR.
+
+. Create the `DataProtectionApplication` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <dpa_manifest_file>
+----
+
+. Verify that the `DataProtectionApplication` CR is reconciled and the `status` is set to `"True"` by running the following command:
++
+[source,terminal]
+----
+$  oc get dpa -n openshift-adp -o yaml
+----
++
+.Example `DataProtectionApplication`
++
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+...
+status:
+    conditions:
+    - lastTransitionTime: "2023-07-31T04:48:12Z"
+      message: Reconcile complete
+      reason: Complete
+      status: "True"
+      type: Reconciled
+----
+
+. Verify that the `BackupStorageLocation` CR is in an available state by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get {oadp-bsl-api} -n openshift-adp
+----
++
+.Example `BackupStorageLocation`
++
+[source,terminal]
+----
+NAME       PHASE       LAST VALIDATED   AGE   DEFAULT
+ts-dpa-1   Available   3s               6s    true
+----
+
+
+
+


### PR DESCRIPTION
## Jira 

* [OADP-5482](https://issues.redhat.com/browse/OADP-5482)

Added a section in ROSA doc to update the OADP subscription with correct IAM role ARN 

##  Version

* OCP 4.14 → OCP 4.17

## Preview

* [Updating the IAM role ARN in the OADP Operator subscription](https://87309--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html#updating-role-arn-oadp-rosa-sts_oadp-rosa-backing-up-applications)

## QE Review

* [x] QE has approved this change.
