### PR TITLE
Builds for OpenShift Release Notes 1.1.1

### DIFF
--- a/about/ob-release-notes.adoc
+++ b/about/ob-release-notes.adoc
@@ -28,4 +28,6 @@ include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+include::modules/ob-release-notes-1-1-1.adoc[leveloffset=+1]
+
 include::modules/ob-release-notes-1-1.adoc[leveloffset=+1]

--- a/modules/ob-release-notes-1-1-1.adoc
+++ b/modules/ob-release-notes-1-1-1.adoc
@@ -1,0 +1,17 @@
+// This module is included in the following assemblies:
+// * about/ob-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ob-release-notes-1-1-1_{context}"]
+= Release notes for {builds-shortname} General Availability 1.1.1
+
+With this update, {builds-shortname} 1.1.1 is now Generally Available (GA) on {ocp-product-title} 4.12, 4.13, 4.14, 4.15, and 4.16.
+
+[id="fixed-issues-1-1-1_{context}"]
+== Fixed issues
+
+The following section highlights fixed issues in {builds-shortname} 1.1.1.
+
+* With this update, the Shared Resource Container Storage Interface (CSI) Driver has the following permissions:
+** Create subject access reviews
+** Get, list, and watch Shared Resource objects

--- a/modules/ob-release-notes-1-1.adoc
+++ b/modules/ob-release-notes-1-1.adoc
@@ -5,7 +5,7 @@
 [id="ob-release-notes-1-1_{context}"]
 = Release notes for {builds-shortname} General Availability 1.1
 
-{builds-shortname} General Availability (GA) 1.1 is now available on {ocp-product-title} 4.16.
+With this update, {builds-shortname} 1.1 is now Generally Available (GA) on {ocp-product-title} 4.12, 4.13, 4.14, 4.15, and 4.16.
 
 [id="new-features-1-1_{context}"]
 == New features


### PR DESCRIPTION
Version(s): `build-docs-1.1` only

Issue: https://issues.redhat.com/browse/RHDEVDOCS-6334

Link to docs preview:  https://87311--ocpdocs-pr.netlify.app/openshift-builds/latest/about/ob-release-notes.html#ob-release-notes-1-1-1_ob-release-notes

QE review: @sayan-biswas @avinal 

- [X]  QE has approved this change.

Additional information: This is cherry-picked from https://github.com/openshift/openshift-docs/pull/87185