### PR TITLE
OBSDOCS-1431: Logging Infrastructure Definitions Logging 6.1

### DIFF
--- a/observability/logging/logging-6.1/log6x-clf-6.1.adoc
+++ b/observability/logging/logging-6.1/log6x-clf-6.1.adoc
@@ -62,9 +62,13 @@ Filters:: Transform or drop log messages in the pipeline. Users can define filte
 
 Inputs are configured in an array under `spec.inputs`. There are three built-in input types:
 
-application:: Selects logs from all application containers, excluding those in infrastructure namespaces such as `default`, `openshift`, or any namespace with the `kube-` or `openshift-` prefix.
+application:: Selects logs from all application containers, excluding those in infrastructure namespaces.
 
-infrastructure:: Selects logs from infrastructure components running in `default` and `openshift` namespaces and node logs.
+infrastructure:: Selects logs from nodes and from infrastructure components running in the following namespaces:
+** `default`
+** `kube`
+** `openshift`   
+** Containing the `kube-` or `openshift-` prefix
 
 audit:: Selects logs from the OpenShift API server audit logs, Kubernetes API server audit logs, ovn audit logs, and node audit logs from auditd.
 


### PR DESCRIPTION
Version(s): 4.15, 4.16, 4.17, 4.18

Issue: [OBSDOCS-1431](https://issues.redhat.com/browse/OBSDOCS-1431)

Link to docs preview: https://87312--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-clf-6.1.html#clf-inputs_6-1_logging-6x-6.1

QE review:
- :white_check_mark:  QE has approved this change.

Additional information: These changes are only for Logging 6.1. For Logging 6.0 changes, see https://github.com/openshift/openshift-docs/pull/87310

