### PR TITLE
Builds for OpenShift Release Notes 1.2.1

### DIFF
--- a/modules/ob-release-notes-1-2-1.adoc
+++ b/modules/ob-release-notes-1-2-1.adoc
@@ -1,0 +1,20 @@
+// This module is included in the following assemblies:
+// * about/ob-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ob-release-notes-1-2-1_{context}"]
+= Release notes for {builds-shortname} General Availability 1.2.1
+
+With this update, {builds-shortname} 1.2.1 is now Generally Available (GA) on {ocp-product-title} 4.12, 4.13, 4.14, 4.15, 4.16, and 4.17.
+
+[id="fixed-issues-1-2-1_{context}"]
+== Fixed issues
+
+The following section highlights fixed issues in {builds-shortname} 1.2.1.
+
+* Before this update, when you installed {builds-shortname} without installing OpenShift Pipelines, the {builds-shortname} attempted to deploy OpenShift Pipelines and enable Pipelines controllers. {builds-shortname} incorrectly configured OpenShift Pipelines and failed to deploy the controllers. With this update, {builds-shortname} creates a valid `TektonConfig` custom resource and correctly deploys the Pipelines controllers.
+
+* Before this update, when you tried to run builds using {builds-title} installed on ARM64, IBM Power(R), or IBM Z(R) worker node CPU architectures, the build would fail because images were based on AMD64 platform only. Now, the AMD64 images are replaced with a `multi-arch` image in `buildah` and `source-to-image` build strategies, therefore you can run builds on all the architectures.
+
+* Before this update, when you enabled cluster monitoring in the `openshift-builds` namespace, the `TargetDown` alert was received on the Shared Resources Container Storage Interface (CSI) Driver `ServiceMonitor` resource due to an incorrect server name address. With this update, the server name is updated to the correct address in the Shared Resources CSI Driver `ServiceMonitor` resource and the `TargetDown` alert is no longer triggered.
+

--- a/modules/ob-release-notes-1-2.adoc
+++ b/modules/ob-release-notes-1-2.adoc
@@ -5,7 +5,7 @@
 [id="ob-release-notes-1-2_{context}"]
 = Release notes for {builds-shortname} General Availability 1.2
 
-{builds-shortname} General Availability (GA) 1.2 is now available on {ocp-product-title} 4.12 and later versions.
+With this update, {builds-shortname} 1.2 is now Generally Available (GA) on {ocp-product-title} 4.12, 4.13, 4.14, 4.15, 4.16, and 4.17.
 
 [id="new-features-1-2_{context}"]
 == New features

--- a/release_notes/ob-release-notes.adoc
+++ b/release_notes/ob-release-notes.adoc
@@ -28,4 +28,6 @@ include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+include::modules/ob-release-notes-1-2-1.adoc[leveloffset=+1]
+
 include::modules/ob-release-notes-1-2.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): `build-docs-1.2` only

Issue: https://issues.redhat.com/browse/RHDEVDOCS-6333

Link to docs preview:  https://87313--ocpdocs-pr.netlify.app/openshift-builds/latest/release_notes/ob-release-notes.html#ob-release-notes-1-2-1_ob-release-notes

QE review: @sayan-biswas @adambkaplan

- [X]  QE has approved this change.
(1 approval also granted by @adambkaplan in the [cherry-picked PR](https://github.com/openshift/openshift-docs/pull/86938))


Additional information: This is cherry-picked from https://github.com/openshift/openshift-docs/pull/86938