### PR TITLE
TELCODOCS-2149 OCPBUGS-28647 tuned deferred updates

### DIFF
--- a/modules/defer-application-tuning-proc.adoc
+++ b/modules/defer-application-tuning-proc.adoc
@@ -1,0 +1,221 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/using-node-tuning-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="defer-application-of-tuning-changes-example_{context}"]
+= Deferring application of tuning changes: An example
+
+The following worked example describes how to defer the application of tuning changes by using the Node Tuning Operator.
+
+.Prerequisites
+* You have `cluster-admin` role access.
+* You have applied a performance profile to your cluster.
+* A `MachineConfigPool` resource, for example, `worker-cnf` is configured to ensure that the profile is only applied to the designated nodes.
+
+.Procedure
+
+. Check what profiles are currently applied to your cluster by running the following command: 
++
+[source,shell]
+----
+$ oc -n openshift-cluster-node-tuning-operator get tuned
+----
++
+.Example output
+[source,shell]
+----
+NAME                                     AGE
+default                                  63m
+openshift-node-performance-performance   21m
+----
+
+. Check the machine config pools in your cluster by running the following command:
++
+[source,shell]
+----
+$ oc get mcp
+----
++
+.Example output
+[source,shell]
+----
+NAME         CONFIG                                                 UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+master       rendered-master-79a26af9f78ced61fa8ccd309d3c859c       True      False      False      3              3                   3                     0                      157m
+worker       rendered-worker-d9352e91a1b14de7ef453fa54480ce0e       True      False      False      2              2                   2                     0                      157m
+worker-cnf   rendered-worker-cnf-f398fc4fcb2b20104a51e744b8247272   True      False      False      1              1                   1                     0                      92m
+----
+
+. Describe the current applied performance profile by running the following command:
++
+[source,shell]
+----
+$ oc describe performanceprofile performance | grep Tuned
+----
++
+.Example output
+[source,shell]
+----
+Tuned:                   openshift-cluster-node-tuning-operator/openshift-node-performance-performance
+----
+
+. Verify the existing value of the `kernel.shmmni` sysctl parameter:
+
+.. Run the following command to display the node names:
++
+[source,shell]
+----
+$ oc get nodes 
+----
++
+.Example output
+[source,shell]
+----
+NAME                          STATUS   ROLES                  AGE    VERSION
+ip-10-0-26-151.ec2.internal   Ready    worker,worker-cnf      116m   v1.30.6
+ip-10-0-46-60.ec2.internal    Ready    worker                 115m   v1.30.6
+ip-10-0-52-141.ec2.internal   Ready    control-plane,master   123m   v1.30.6
+ip-10-0-6-97.ec2.internal     Ready    control-plane,master   121m   v1.30.6
+ip-10-0-86-145.ec2.internal   Ready    worker                 117m   v1.30.6
+ip-10-0-92-228.ec2.internal   Ready    control-plane,master   123m   v1.30.6
+----
+
+.. Run the following command to display the current value of the `kernel.shmmni` sysctl parameters on the node `ip-10-0-32-74.ec2.internal`:
++
+[source,shell]
+----
+$ oc debug node/ip-10-0-26-151.ec2.internal  -q -- chroot host sysctl kernel.shmmni
+----
++
+.Example output
+[source,shell]
+----
+kernel.shmmni = 4096
+----
+
+. Create a profile patch, for example, `perf-patch.yaml` that changes the `kernel.shmmni` sysctl parameter to `8192`. Defer the application of the change to a new manual restart by using the `always` method by applying the following configuration:
++
+[source,yaml]
+----
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: performance-patch
+  namespace: openshift-cluster-node-tuning-operator
+  annotations:
+    tuned.openshift.io/deferred: "always"
+spec:
+  profile:
+    - name: performance-patch
+      data: |
+        [main]
+        summary=Configuration changes profile inherited from performance created tuned
+        include=openshift-node-performance-performance <1>
+        [sysctl]
+        kernel.shmmni=8192 <2> 
+  recommend:
+    - machineConfigLabels:
+        machineconfiguration.openshift.io/role: worker-cnf <3>
+      priority: 19
+      profile: performance-patch
+----
++
+<1> The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
+<2> The `kernel.shmmni` sysctl parameter is being changed to `8192`.
+<3> The `machineConfigLabels` field is used to target the `worker-cnf` role.
+
+. Apply the profile patch by running the following command:
++
+[source,shell]
+----
+$ oc apply -f perf-patch.yaml
+----
+
+. Run the following command to verify that the profile patch is waiting for the next node restart:
++
+[source,shell]
+----
+$ oc -n openshift-cluster-node-tuning-operator get profile
+----
++
+.Example output
+[source,shell]
+----
+NAME                          TUNED                     APPLIED   DEGRADED   MESSAGE                                                                            AGE
+ip-10-0-26-151.ec2.internal   performance-patch         False     True       The TuneD daemon profile is waiting for the next node restart: performance-patch   126m
+ip-10-0-46-60.ec2.internal    openshift-node            True      False      TuneD profile applied.                                                             125m
+ip-10-0-52-141.ec2.internal   openshift-control-plane   True      False      TuneD profile applied.                                                             130m
+ip-10-0-6-97.ec2.internal     openshift-control-plane   True      False      TuneD profile applied.                                                             130m
+ip-10-0-86-145.ec2.internal   openshift-node            True      False      TuneD profile applied.                                                             126m
+ip-10-0-92-228.ec2.internal   openshift-control-plane   True      False      TuneD profile applied.                                                             130m
+----
+
+. Confirm the value of the `kernel.shmmni` sysctl parameter remain unchanged before a restart:
+
+.. Run the following command to confirm that the application of the `performance-patch` change to the `kernel.shmmni` sysctl parameter on the node `ip-10-0-26-151.ec2.internal` is not applied:
++
+[source,shell]
+----
+$ oc debug node/ip-10-0-26-151.ec2.internal  -q -- chroot host sysctl kernel.shmmni
+----
++
+.Example output
+[source,shell]
+----
+kernel.shmmni = 4096
+----
+
+. Restart the node `ip-10-0-26-151.ec2.internal` to apply the required changes by running the following command:
++
+[source,shell]
+----
+$ oc debug node/ip-10-0-26-151.ec2.internal  -q -- chroot host reboot&
+----
+
+. In another terminal window, run the following command to verify that the node has restarted:
++
+[source,shell]
+----
+$ watch oc get nodes
+----
++
+Wait for the node `ip-10-0-26-151.ec2.internal` to transition back to the `Ready` state.
+
+. Run the following command to verify that the profile patch is waiting for the next node restart:
++
+[source,shell]
+----
+$ oc -n openshift-cluster-node-tuning-operator get profile
+----
++
+.Example output
+[source,shell]
+----
+NAME                          TUNED                     APPLIED   DEGRADED   MESSAGE                                                                            AGE
+ip-10-0-20-251.ec2.internal   performance-patch         True      False      TuneD profile applied.                                                             3h3m
+ip-10-0-30-148.ec2.internal   openshift-control-plane   True      False      TuneD profile applied.                                                             3h8m
+ip-10-0-32-74.ec2.internal    openshift-node            True      True       TuneD profile applied.                                                             179m
+ip-10-0-33-49.ec2.internal    openshift-control-plane   True      False      TuneD profile applied.                                                             3h8m
+ip-10-0-84-72.ec2.internal    openshift-control-plane   True      False      TuneD profile applied.                                                             3h8m
+ip-10-0-93-89.ec2.internal    openshift-node            True      False      TuneD profile applied.                                                             179m
+----
+
+. Check that the value of the `kernel.shmmni` sysctl parameter have changed after the restart:
+
+.. Run the following command to verify that the `kernel.shmmni` sysctl parameter change has been applied on the node `ip-10-0-32-74.ec2.internal`:
++
+[source,shell]
+----
+$ oc debug node/ip-10-0-32-74.ec2.internal  -q -- chroot host sysctl kernel.shmmni
+----
++
+.Example output
+[source,shell]
+----
+kernel.shmmni = 8192
+----
+
+[NOTE]
+====
+An additional restart results in the restoration of the original value of the `kernel.shmmni` sysctl parameter.
+====

--- a/modules/defer-applicaton-tuning-example.adoc
+++ b/modules/defer-applicaton-tuning-example.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/using-node-tuning-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="defer-application-of-tuning-changes_{context}"]
+= Deferring application of tuning changes
+
+As an administrator, use the Node Tuning Operator (NTO) to update custom resources (CRs) on a running system and make tuning changes. For example, they can update or add a sysctl parameter to the [sysctl] section of the tuned object. When administrators apply a tuning change, the NTO prompts TuneD to reprocess all configurations, causing the tuned process to roll back all tuning and then reapply it.
+
+Latency-sensitive applications may not tolerate the removal and reapplication of the tuned profile, as it can briefly disrupt performance. This is particularly critical for configurations that partition CPUs and manage process or interrupt affinity using the performance profile. To avoid this issue, {product-title} introduced new methods for applying tuning changes. Before {product-title} 4.17, the only available method, immediate, applied changes instantly, often triggering a tuned restart.
+
+The following additional methods are supported:
+ 
+ * `always`: Every change is applied at the next node restart.
+ * `update`: When a tuning change modifies a tuned profile, it is applied immediately by default and takes effect as soon as possible. When a tuning change does not cause a tuned profile to change and its values are modified in place, it is treated as always.
+
+Enable this feature by adding the annotation `tuned.openshift.io/deferred`. The following table summarizes the possible values for the annotation:
+
+[cols="3,3",options="header"]
+|===
+|Annotation value | Description 
+|missing          | The change is applied immediately. 
+|always           | The change is applied at the next node restart.
+|update           | The change is applied immediately if it causes a profile change, otherwise at the next node restart. 
+|===
+
+The following example demonstrates how to apply a change to the `kernel.shmmni` sysctl parameter by using the `always` method:
+
+.Example
+[source,yaml]
+----
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: performance-patch
+  namespace: openshift-cluster-node-tuning-operator
+  annotations:
+    tuned.openshift.io/deferred: "always"
+spec:
+  profile:
+    - name: performance-patch
+      data: |
+        [main]
+        summary=Configuration changes profile inherited from performance created tuned
+        include=openshift-node-performance-performance <1>
+        [sysctl]
+        kernel.shmmni=8192 <2>
+  recommend:
+    - machineConfigLabels:
+        machineconfiguration.openshift.io/role: worker-cnf <3>
+      priority: 19
+      profile: performance-patch
+----
+
+<1> The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
+<2> The `kernel.shmmni` sysctl parameter is being changed to `8192`.
+<3> The `machineConfigLabels` field is used to target the `worker-cnf` role. Configure a `MachineConfigPool` resource to ensure the profile is applied only to the correct nodes.

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -21,6 +21,10 @@ include::modules/custom-tuning-specification.adoc[leveloffset=+1]
 
 include::modules/custom-tuning-example.adoc[leveloffset=+1]
 
+include::modules/defer-applicaton-tuning-example.adoc[leveloffset=+1]
+
+include::modules/defer-application-tuning-proc.adoc[leveloffset=+2]
+
 include::modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc[leveloffset=+1]
 
 include::modules/node-tuning-hosted-cluster.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-2149]: OCPBUGS-28647 tuned deferred updates

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17 and 4.18 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2149
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://87314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
