### PR TITLE
SECENGSP-6323: Update, fix, and re-structure the NBDE Tang Server Operator release notes

### DIFF
--- a/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc
+++ b/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc
@@ -1,43 +1,19 @@
-//NBDE Tang Server Operator Release Notes
 :_mod-docs-content-type: ASSEMBLY
+
 [id="nbde-tang-server-operator-release-notes"]
 = NBDE Tang Server Operator release notes
+
 :context: nbde-tang-server-operator-release-notes
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following release notes track the development of the Security Profiles Operator in the OpenShift Container Platform.
+The following release notes track the development of the NBDE Tang Server Operator in {product-title}.
 
-* link:https://access.redhat.com/errata/RHEA-2023:7491[RHEA-2023:7491 - Release of the NBDE Tang Server Operator 1.0]
-* link:https://access.redhat.com/errata/RHEA-2024:0854[RHEA-2024:0854 - NBDE Tang Server Operator 1.0.1 has been moved from the "alpha" channel to the "stable" channel]
-
+link:https://access.redhat.com/errata/RHEA-2023:7491[RHEA-2023:7491]:: The NBDE Tang Server Operator 1.0 has been released in the Red{nbsp}Hat OpenShift Enterprise 4 catalog.
+link:https://access.redhat.com/errata/RHEA-2024:0854[RHEA-2024:0854]:: The NBDE Tang Server Operator 1.0.1 has been moved from the `alpha` channel to the `stable` channel.
+link:https://access.redhat.com/errata/RHBA-2024:8681[RHBA-2024:8681]:: The 1.0.2 update contains fixes that increase the Container Health Index of containers deployed with the NBDE Tang Server Operator to the highest grade.
+link:https://access.redhat.com/errata/RHEA-2024:10970[RHEA-2024:10970]:: The 1.0.3 update contains changes that re-increase the Container Health Index to the highest grade.
 ////
-A template for a future use
-
-[id="nbde-tang-server-operator-release-notes-1-0-0"]
-== NBDE Tang Server Operator 1.0.0
-
-The following advisory is available for the NBDE Tang Server Operator 1.0.0:
-
-* link:https://access.redhat.com/errata/RHBA-2023:XXXX[RHBA-2023:XXXX NBDE Tang Server Operator bug fix update]
-
-[id="nbde-tang-server-operator-1-0-0-new-features-and-enhancements"]
-=== New features and enhancements
-
-* Lorem ipsum. (link:https://issues.redhat.com/browse/OCPBUGS-XXXXX[*OCPBUGS-XXXXX*])
-
-
-[id="nbde-tang-server-operator-1-0-0-bug-fixes"]
-=== Bug fixes
-
-* Lorem ipsum. (link:https://issues.redhat.com/browse/OCPBUGS-XXXXX[*OCPBUGS-XXXXX*])
-
-////
-
-////
-[id="nbde-tang-server-operator-release-notes_additional-resources"]
-[role="_additional-resources"]
-== Additional resources
-xref:../../security/nbde_tang_server_operator/nbde-tang-server-operator-understanding.adoc#understanding-nbde-tang-server-operator[Understanding the NBDE Tang Server Operator]
+link:https://access.redhat.com/errata/[RHBA-2025:xxxx]:: With the NBDE Tang Server Operator 1.1, the `golang` package is provided in version 1.23.2 and the `golang.org/x/net/html` package has been updated to version 0.33.0. The updates increase the Container Health Index.
 ////


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/SECENGSP-6323

Link to docs preview:
https://87315--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
