### PR TITLE
OSDOCS-13059:Sanity check on links after OSDOCS-12950.

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -126,7 +126,7 @@ Topics:
 - Name: Creating a cluster on GCP with Workload Identity Federation authentication
   File: creating-a-gcp-cluster-with-workload-identity-federation
 - Name: Creating a cluster on GCP with Service Account authentication
-  File: creating-a-gcp-cluster
+  File: creating-a-gcp-cluster-sa
 - Name: Creating a cluster on GCP with a Red Hat cloud account
   File: creating-a-gcp-cluster-redhat-account
 

--- a/architecture/osd-architecture-models-gcp.adoc
+++ b/architecture/osd-architecture-models-gcp.adoc
@@ -23,4 +23,4 @@ include::modules/osd-public-architecture-model-gcp.adoc[leveloffset=+1]
 
 * xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on GCP with Workload Identity Federation authentication]
 
-* xref:../osd_gcp_clusters/creating-a-gcp-cluster.adoc#osd-creating-a-cluster-on-gcp[Creating a cluster on GCP with Service Account authentication]
+* xref:../osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc#osd-creating-a-cluster-on-gcp-sa[Creating a cluster on GCP with Service Account authentication]

--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -66,7 +66,7 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 ifdef::openshift-dedicated[]
 * xref:../osd_aws_clusters/creating-an-aws-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws[Creating a cluster on AWS]
-* xref:../osd_gcp_clusters/creating-a-gcp-cluster.adoc#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp[Creating a cluster on GCP]
+* xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on GCP with Workload Identity Federation authentication]
 endif::openshift-dedicated[]
 
 [id="configuring-a-proxy-after-installation_{context}"]

--- a/osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc
+++ b/osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="osd-creating-a-cluster-on-gcp"]
+[id="osd-creating-a-cluster-on-gcp-sa"]
 = Creating a cluster on GCP with Service Account authentication
 include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: osd-creating-a-cluster-on-gcp
+:context: osd-creating-a-cluster-on-gcp-sa
 
 toc::[]
 

--- a/osd_getting_started/osd-getting-started.adoc
+++ b/osd_getting_started/osd-getting-started.adoc
@@ -31,7 +31,7 @@ You can install {product-title} in your own {GCP} account by using the CCS model
 
 * Red Hat also recommends creating an {product-title} cluster deployed on {GCP} in Private cluster mode with Private Service Connect (PSC) to manage and monitor a cluster to avoid all public ingress network traffic. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc#creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview].
 
-* For installing and interacting with the {product-title} cluster deployed on the {GCP} using the Service Account authentication type, see xref:../osd_gcp_clusters/creating-a-gcp-cluster.adoc#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp[Creating a cluster on GCP with Service Account authentication].
+* For installing and interacting with the {product-title} cluster deployed on the {GCP} using the Service Account authentication type, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp-sa[Creating a cluster on GCP with Service Account authentication].
 ** Red Hat recommends using GCP Workload Identity Federation (WIF) as the authentication type for installing and interacting with the {product-title} cluster deployed on {GCP} because it provides enhanced security. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on GCP with Workload Identity Federation authentication].
 
 // Update link with new title when new SA auth guide goes live.
@@ -48,7 +48,7 @@ You can install {product-title} in your own {AWS} account by using the CCS model
 
 Complete the steps in one of the following sections to deploy {product-title} in a cloud account that is owned by Red Hat:
 
-* xref:../osd_gcp_clusters/creating-a-gcp-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-gcp[Creating a cluster on GCP with a Red Hat cloud account]: You can install {product-title} in an GCP account that is owned by Red Hat.
+* xref:../osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.adoc#creating-a-gcp-cluster-rh-account[Creating a cluster on GCP with a Red Hat cloud account]: You can install {product-title} in an GCP account that is owned by Red Hat.
 
 * xref:../osd_aws_clusters/creating-an-aws-cluster.adoc#osd-create-aws-cluster-red-hat-account_osd-creating-a-cluster-on-aws[Creating a cluster on AWS]: You can install {product-title} in an AWS account that is owned by Red Hat.
 // Update link when OSDOCS-12950 goes live.
@@ -94,9 +94,7 @@ include::modules/deleting-cluster.adoc[leveloffset=+1]
 
 * For more information about deploying {product-title} clusters on AWS, see xref:../osd_aws_clusters/creating-an-aws-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws[Creating a cluster on AWS].
 
-* For more information about deploying {product-title} clusters on GCP, see  xref:../osd_gcp_clusters/creating-a-gcp-cluster.adoc#osd-creating-a-cluster-on-gcp[Creating a cluster on GCP with Service Account authentication] and xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on GCP with Workload Identity Federation authentication].
+* For more information about deploying {product-title} clusters on GCP, see  xref:../osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc#osd-creating-a-cluster-on-gcp-sa[Creating a cluster on GCP with Service Account authentication] and xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on GCP with Workload Identity Federation authentication].
 
 * For documentation on upgrading your cluster, see xref:../upgrading/osd-upgrades.adoc#osd-upgrades[{product-title} cluster upgrades].
 
-
-xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on GCP with Workload Identity Federation authentication]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-13059](https://issues.redhat.com/browse/OSDOCS-13059)

Link to docs preview:
- https://87327--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_getting_started/osd-getting-started.html#additional-resources_osd-getting-started
- https://87327--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-sa

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
No QE review required as this is just a link check.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
