### PR TITLE
TELCODOCS-2149 RN: deferred tuned updates RN 418

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -584,6 +584,12 @@ For example, the plugin can highlight unexpected differences, such as mismatched
 You can use the `cluster-compare` plugin in development, production, and support scenarios.
 
 For more information about the `cluster-compare` plugin, see xref:../scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.adoc#cluster-compare-overview_understanding-cluster-compare[Overview of the cluster-compare plugin].
+[id="ocp-release-notes-node-tuning-operator-deferred-updates_{context}"]
+==== Node Tuning Operator: Deferred Tuning Updates
+
+In this release, the Node Tuning Operator introduces support for deferring tuning updates. Administrators can schedule updates to be applied during a maintenance window with this feature.
+
+For more information, see xref:../scalability_and_performance/using-node-tuning-operator.adoc#defer-application-of-tuning-changes_node-tuning-operator[Deferring application of tuning changes].
 
 [id="ocp-release-notes-etcd-certificates_{context}"]
 === Security


### PR DESCRIPTION
[TELCODOCS-2149]: OCPBUGS-28647 tuned deferred updates

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18 RN
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2149
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://87340--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-node-tuning-operator-deferred-updates_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

