### PR TITLE
OCPBUGS 43007: Removed the acme.cert-manager.io/http01-ingress-class annotation

### DIFF
--- a/modules/cert-manager-acme-http01.adoc
+++ b/modules/cert-manager-acme-http01.adoc
@@ -89,22 +89,21 @@ metadata:
   namespace: my-ingress-namespace                                <2>
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging          <3>
-    acme.cert-manager.io/http01-ingress-class: openshift-default <4>
 spec:
-  ingressClassName: openshift-default                            <5>
+  ingressClassName: openshift-default                            <4>
   tls:
   - hosts:
-    - <hostname>                                                 <6>
-    secretName: sample-tls                                       <7>
+    - <hostname>                                                 <5>
+    secretName: sample-tls                                       <6>
   rules:
-  - host: <hostname>                                             <8>
+  - host: <hostname>                                             <7>
     http:
       paths:
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: sample-workload                                <9>
+            name: sample-workload                                <8>
             port:
               number: 80
 ----
@@ -112,11 +111,10 @@ spec:
 <2> Specify the namespace that you created for the Ingress.
 <3> Specify the cluster issuer that you created.
 <4> Specify the Ingress class.
-<5> Specify the Ingress class.
-<6> Replace `<hostname>` with the Subject Alternative Name to be associated with the certificate. This name is used to add DNS names to the certificate.
-<7> Specify the secret to store the created certificate in.
-<8> Replace `<hostname>` with the hostname. You can use the `<host_name>.<cluster_ingress_domain>` syntax to take advantage of the `*.<cluster_ingress_domain>` wildcard DNS record and serving certificate for the cluster. For example, you might use `apps.<cluster_base_domain>`. Otherwise, you must ensure that a DNS record exists for the chosen hostname.
-<9> Specify the name of the service to expose. This example uses a service named `sample-workload`.
+<5> Replace `<hostname>` with the Subject Alternative Name (SAN) to be associated with the certificate. This name is used to add DNS names to the certificate.
+<6> Specify the secret that stores the certificate.
+<7> Replace `<hostname>` with the hostname. You can use the `<host_name>.<cluster_ingress_domain>` syntax to take advantage of the `*.<cluster_ingress_domain>` wildcard DNS record and serving certificate for the cluster. For example, you might use `apps.<cluster_base_domain>`. Otherwise, you must ensure that a DNS record exists for the chosen hostname.
+<8> Specify the name of the service to expose. This example uses a service named `sample-workload`.
 
 .. Create the `Ingress` object by running the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-43007
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
