### PR TITLE
4.14.45 z-stream RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3392,6 +3392,41 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.45
+[id="ocp-4-14-45_{context}"]
+=== RHSA-2025:0364 - {product-title} 4.14.45 bug fix and security update
+
+Issued: 22 January 2025
+
+{product-title} release 4.14.45, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0364[RHSA-2025:0364] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0367[RHBA-2025:0367] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.45 --pullspecs
+----
+
+[id="ocp-4-14-45-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when using the `SiteConfig` custom resource (CR) to delete a cluster or a node, the `BareMetalHost` CR could get stuck in the `Deprovisioning` state. This bug has been fixed to ensure that the order deletion is correct. The fix requires {gitops-title} 1.13 or later version. (link:https://issues.redhat.com/browse/OCPBUGS-48339[*OCPBUGS-48339*])
+
+* Previously, a machine controller failed to save the {vmw-full} task ID of an instance template clone operation. This caused the machine to go into the `Provisioning` state and to power off. With this release, the {vmw-full} machine controller can detect and recover from this state. (link:https://issues.redhat.com/browse/OCPBUGS-48245[*OCPBUGS-48245*])
+
+* Previously, during node reboots, especially during update operations, the node that interacts with the rebooting machine entered a `Ready=Unknown` state for a short amount of time. This situation caused the Control Plane Machine Set Operator to enter an `UnavailableReplicas` condition and then an `Available=false` state. The `Available=false` state triggers alerts that demand urgent action, but in this case, intervention was only required for a short period of time until the node rebooted. With this release, a grace period for node unreadiness is provided where if a node enters an unready state, the Control Plane Machine Set Operator does not instantly enter an `UnavailableReplicas` condition or an `Available=false` state. (link:https://issues.redhat.com/browse/OCPBUGS-48211[*OCPBUGS-48211*])
+
+* Previously the algorithm used to calculate the priority for machine removal equated machines over a certain age as equal priority to machines that were preferred for removal. With this release, the priority of unmarked machines sorted by age is reduced so that they never conflict with machines explicitly marked for removal. The algorithm is also updated to ensure that age ordering is guaranteed for machines up to ten years old. (link:https://issues.redhat.com/browse/OCPBUGS-47659[*OCPBUGS-47659*])
+
+* Previously, when you upgraded an {product-title} cluster from 4.14 to 4.15, the `vCenterCluster` parameter was not populated with a value in the `use-connection-form.ts` configuration file. As a result, the {vmw-full} GUI did not display {vmw-full} vCenter information. With this release, an update to the `Infrastructure` custom resource (CR) ensures it has that the GUI checks the `cloud-provider-config` config map for the `vCenterCluster` value. (link:https://issues.redhat.com/browse/OCPBUGS-45323[*OCPBUGS-45323*])
+
+[id="ocp-4-14-45-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.44
 [id="ocp-4-14-44_{context}"]
 === RHSA-2025:0029 - {product-title} 4.14.44 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-13136](https://issues.redhat.com/browse/OSDOCS-13136)

Link to docs preview:
https://87364--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-45_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (1/22/25)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
