### PR TITLE
OSSM-8706 Add v2 version attribute to _attributes file

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -18,6 +18,9 @@
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
 :SMProductVersion: 3.0
+//service mesh v2
+:SMv2Version: 2.5.6
+//SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version.
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat
 //Kiali Server
@@ -42,7 +45,7 @@
 :TempoShortName: distributed tracing platform (Tempo)
 :TempoOperator: Tempo Operator
 :TempoVersion: 2.1.1
-//sail 
+//sail
 :sail-operator: Sail Operator
 //gitops
 :gitops-title: Red{nbsp}Hat OpenShift GitOps


### PR DESCRIPTION
OSSM 3.0 

https://issues.redhat.com/browse/OSSM-8706

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology Preview.

OSSM 3.0 is moving to stand alone format so it will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8706

Link to docs preview:
There is no preview for common-attributes.adoc

QE review:
QE review is not required for this change. It is a docs-only change to add an attribute.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
