### PR TITLE
OSDOCS 13186 modify build_for_portal.py to detect images and not duplicate the entire image directory for every book

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -455,32 +455,39 @@ def reformat_for_drupal(info):
 
         ensure_directory(images_dir)
 
+        # ADDED 21 Jan 2025: selective processing of images
+        # the set of file names is to be stored in image_files
+        # The initial value includes images defined in attributes (to copy every time)
+        image_files = set()
+
         log.debug("Copying source files for " + book["Name"])
-        copy_files(book, book_src_dir, src_dir, dest_dir, info)
+        copy_files(book, book_src_dir, src_dir, dest_dir, info, image_files)
 
         log.debug("Copying images for " + book["Name"])
-        copy_images(book, src_dir, images_dir, distro)
+        copy_images(book, src_dir, images_dir, distro, image_files)
 
 
 
-def copy_images(node, src_path, dest_dir, distro):
+def copy_images(node, src_path, dest_dir, distro, image_files):
     """
     Copy images over to the destination directory and flatten all image directories into the one top level dir.
+
+    REWORKED 21 Jan 2025: we now assume that there is a single images directory and
+     that all other images subdirectories are simply symlinks into it. So we do not
+     iterate over the tree but simply copy the necessary files from that one images directory
     """
 
-    def dir_callback(dir_node, parent_dir, depth):
-        node_dir = os.path.join(parent_dir, dir_node["Dir"])
-        src = os.path.join(node_dir, "images")
-
-        if os.path.exists(src):
-            src_files = os.listdir(src)
-            for src_file in src_files:
-                shutil.copy(os.path.join(src, src_file), dest_dir)
-
-    iter_tree(node, distro, dir_callback, parent_dir=src_path)
+    images_source_dir = os.path.join(src_path, "images")
+    for image_file_name in image_files:
+        image_file_pathname = os.path.join(images_source_dir,image_file_name)
+        if os.path.exists(image_file_pathname):
+            shutil.copy(image_file_pathname, dest_dir)
+        # if an image file is not found, this is not an error, because it might
+        # have been picked up from a commented-out line. Actual missing images
+        # should be caught by the asciidoctor/asciibinder part of CI
 
 
-def copy_files(node, book_src_dir, src_dir, dest_dir, info):
+def copy_files(node, book_src_dir, src_dir, dest_dir, info, image_files):
     """
     Recursively copy files from the source directory to the destination directory, making sure to scrub the content, add id's where the
     content is referenced elsewhere and fix any links that should be cross references.
@@ -498,7 +505,7 @@ def copy_files(node, book_src_dir, src_dir, dest_dir, info):
         dest_file = os.path.join(node_dest_dir, topic_node["File"] + ".adoc")
 
         # Copy the file
-        copy_file(info, book_src_dir, src_file, dest_dir, dest_file)
+        copy_file(info, book_src_dir, src_file, dest_dir, dest_file, image_files)
 
     iter_tree(node, info["distro"], dir_callback, topic_callback)
 
@@ -509,6 +516,7 @@ def copy_file(
     src_file,
     dest_dir,
     dest_file,
+    image_files,
     include_check=True,
     tag=None,
     cwd=None,
@@ -529,7 +537,7 @@ def copy_file(
     # os.mknod(dest_file)
     open(dest_file, "w").close()
     # Scrub/fix the content
-    content = scrub_file(info, book_src_dir, src_file, tag=tag, cwd=cwd)
+    content = scrub_file(info, book_src_dir, src_file, image_files, tag=tag, cwd=cwd)
 
     # Check for any includes
     if include_check:
@@ -584,6 +592,7 @@ def copy_file(
                     include_file,
                     dest_dir,
                     dest_include_file,
+                    image_files,
                     tag=include_tag,
                     cwd=current_dir,
                 )
@@ -612,8 +621,21 @@ def copy_file(
     with open(dest_file, "w") as f:
         f.write(content)
 
+def detect_images(content, image_files):
+    """
+    Detects all image file names referenced in the content, which is a readlines() output
+    Adds the filenames to the image_files set
+    Does NOT control for false positives such as commented out content,
+        because "false negatives" are worse
 
-def scrub_file(info, book_src_dir, src_file, tag=None, cwd=None):
+    TEMPORARY: use both procedural and RE detection and report any misalignment
+    """
+    image_pattern = re.compile(r'image::?([^\s\[]+)\[.*?\]')
+
+    for content_str in content:
+        image_files.update({os.path.basename(f) for f in image_pattern.findall(content_str)})
+
+def scrub_file(info, book_src_dir, src_file, image_files, tag=None, cwd=None):
     """
     Scrubs a file and returns the cleaned file contents.
     """
@@ -656,6 +678,9 @@ def scrub_file(info, book_src_dir, src_file, tag=None, cwd=None):
     # Read in the source content
     with open(src_file, "r") as f:
         src_file_content = f.readlines()
+
+    # detect image references in the content
+    detect_images(src_file_content, image_files)
 
     # Scrub the content
     content = ""


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-13186

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16, 4.17, 4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
OSDOCS 13186

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
N/A

QE review:
N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This is a modification to the build_for_portal.py script, not to the documentation

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
