### PR TITLE
OSDOCS-11311 updating AWS AMIs for 4.18

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,97 +23,97 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-019b3e090bb062842`
+|`ami-04d5ff4e5b4cbd76c`
 
 |`ap-east-1`
-|`ami-0cb76d97f77cda0a1`
+|`ami-099d3a812b1ccdbd8`
 
 |`ap-northeast-1`
-|`ami-0d7d4b329e5403cfb`
+|`ami-0cf766d9afcd1a8fb`
 
 |`ap-northeast-2`
-|`ami-02d3789d532feb517`
+|`ami-0bf19d854a176ceae`
 
 |`ap-northeast-3`
-|`ami-08b82c4899109b707`
+|`ami-0bd18de43f345f6e7`
 
 |`ap-south-1`
-|`ami-0c184f8b5ad8af69d`
+|`ami-0a783ebe835229b5b`
 
 |`ap-south-2`
-|`ami-0b0525037b9a20e9a`
+|`ami-0ee4833b9957916cf`
 
 |`ap-southeast-1`
-|`ami-0dbee0006375139a7`
+|`ami-0c4f1b05bdf8095df`
 
 |`ap-southeast-2`
-|`ami-043072b1af91be72f`
+|`ami-0b9c21cf076063cf3`
 
 |`ap-southeast-3`
-|`ami-09d8bbf16b228139e`
+|`ami-01d230dad5b4fe7bd`
 
 |`ap-southeast-4`
-|`ami-01c6b29e9c57b434b`
+|`ami-0cfd0681912380ec0`
 
 |`ca-central-1`
-|`ami-06fda1fa0b65b864b`
+|`ami-06ad86c8cb56292b7`
 
 |`ca-west-1`
-|`ami-0141eea486b5e2c43`
+|`ami-065326a3da6e2d064`
 
 |`eu-central-1`
-|`ami-0f407de515454fdd0`
+|`ami-04b19d43c2f7940ae`
 
 |`eu-central-2`
-|`ami-062cfad83bc7b71b8`
+|`ami-0f75d79d939ede3e3`
 
 |`eu-north-1`
-|`ami-0af77aba6aebb5086`
+|`ami-0865b287be745da0a`
 
 |`eu-south-1`
-|`ami-04d9da83bc9f854fc`
+|`ami-03f66b67246b64d3c`
 
 |`eu-south-2`
-|`ami-035d487abf54f0af7`
+|`ami-095eee3ca36c343e3`
 
 |`eu-west-1`
-|`ami-043dd3b788dbaeb1c`
+|`ami-066fd2c60a9d450b1`
 
 |`eu-west-2`
-|`ami-0c7d0f90a4401b723`
+|`ami-021977d6feb19b2b1`
 
 |`eu-west-3`
-|`ami-039baa878e1def55f`
+|`ami-0d77374741562bdf3`
 
 |`il-central-1`
-|`ami-07d305bf03b2148de`
+|`ami-0d7b94c021522f50f`
 
 |`me-central-1`
-|`ami-0fc457e8897ccb41a`
+|`ami-0cf7856de20fa9552`
 
 |`me-south-1`
-|`ami-0af99a751cf682b90`
+|`ami-0c39fed6bcb5b6c07`
 
 |`sa-east-1`
-|`ami-04a7300f64ee01d68`
+|`ami-0b85ee49d409d9ada`
 
 |`us-east-1`
-|`ami-01b53f2824bf6d426`
+|`ami-02f3bcf1e55af21d2`
 
 |`us-east-2`
-|`ami-0565349610e27bd41`
+|`ami-071da668451fce4d0`
 
 |`us-gov-east-1`
-|`ami-0020504fa043fe41d`
+|`ami-096041aa344110617`
 
 |`us-gov-west-1`
-|`ami-036798bce4722d3c2`
+|`ami-00834d851fc0b4523`
 
 |`us-west-1`
-|`ami-0147c634ad692da52`
+|`ami-08a9f9068c2b54917`
 
 |`us-west-2`
-|`ami-0c65d71e89d43aa90`
+|`ami-04c69b57c0ede04d2`
 
 |===
 
@@ -126,97 +126,97 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-0e585ef53405bebf5`
+|`ami-0836aa261a6126375`
 
 |`ap-east-1`
-|`ami-05f32f1715bb51bda`
+|`ami-0f8beb91cb70365f9`
 
 |`ap-northeast-1`
-|`ami-05ecb62bab0c50e52`
+|`ami-0565bc03e0a809d95`
 
 |`ap-northeast-2`
-|`ami-0a3ffb2c07c9e4a8d`
+|`ami-03117f8cfc0f9bb7d`
 
 |`ap-northeast-3`
-|`ami-0ae6746ea17d1042c`
+|`ami-0c40f3aa48cdd890c`
 
 |`ap-south-1`
-|`ami-00deb5b08c86060b8`
+|`ami-04b09daf05f39d779`
 
 |`ap-south-2`
-|`ami-047a47d5049781e03`
+|`ami-0a6282871d9f5da78`
 
 |`ap-southeast-1`
-|`ami-09cb598f0d36fde4c`
+|`ami-0dfd3c8feaae9ec97`
 
 |`ap-southeast-2`
-|`ami-01fe8a7538500f24c`
+|`ami-0115f5ff97e5a90fd`
 
 |`ap-southeast-3`
-|`ami-051b3f67dd787d5e9`
+|`ami-019d8fdc40c34ee21`
 
 |`ap-southeast-4`
-|`ami-04d2e14a9eef40143`
+|`ami-0539020ffd761870e`
 
 |`ca-central-1`
-|`ami-0f66973ff12d09356`
+|`ami-0ffe8d7ad8405534c`
 
 |`ca-west-1`
-|`ami-0c9f3e2f0470d6d0b`
+|`ami-0fc0cc839cd990535`
 
 |`eu-central-1`
-|`ami-0a79af8849b425a8a`
+|`ami-0423fa4b88ae31f3f`
 
 |`eu-central-2`
-|`ami-0f9f66951c9709471`
+|`ami-0325afd3998a0ca9a`
 
 |`eu-north-1`
-|`ami-0670362aa7eb9032d`
+|`ami-0426e484515f3176f`
 
 |`eu-south-1`
-|`ami-031b24b970eae750b`
+|`ami-016b53f0b000f0d26`
 
 |`eu-south-2`
-|`ami-0734d2ed55c00a46c`
+|`ami-06c17fbce9d638288`
 
 |`eu-west-1`
-|`ami-0a9af75c2649471c0`
+|`ami-0f0a7f937c3016bac`
 
 |`eu-west-2`
-|`ami-0b84155a3672ac44e`
+|`ami-078dd031ff7c23414`
 
 |`eu-west-3`
-|`ami-02b51442c612818d4`
+|`ami-07def9b1e1e85a4b3`
 
 |`il-central-1`
-|`ami-0d2c47a297d483ce4`
+|`ami-080fc1c490d9e7859`
 
 |`me-central-1`
-|`ami-0ef3005246bd83b07`
+|`ami-0d0ba944f6562fcff`
 
 |`me-south-1`
-|`ami-0321ca1ee89015eda`
+|`ami-08b5f892f7fc7684b`
 
 |`sa-east-1`
-|`ami-0e63f1103dc71d8ae`
+|`ami-097d165e4b2c10f97`
 
 |`us-east-1`
-|`ami-0404da96615c73bec`
+|`ami-0a5f3df933f4f116b`
 
 |`us-east-2`
-|`ami-04c3bd7be936f728f`
+|`ami-07f2517c49aac0ea0`
 
 |`us-gov-east-1`
-|`ami-0d30bc0b99b153247`
+|`ami-0445140a17d5211f8`
 
 |`us-gov-west-1`
-|`ami-0ee006f84d6aa5045`
+|`ami-0bfda00bc2a9a29cf`
 
 |`us-west-1`
-|`ami-061bfd61d5cfd7aa6`
+|`ami-0462ce4084ad64095`
 
 |`us-west-2`
-|`ami-05ffb8f6f18b8e3f8`
+|`ami-01a318224d096c90d`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-11311

Link to docs preview:
[UPI install](https://87377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra)
[UPI restricted network install](https://87377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-user-infra-rhcos-ami_installing-restricted-networks-aws)

QE review:
- [x] QE has approved this change.