### PR TITLE
OCPBUGS#36933: Updated the "Adding a multi-architecture compute machine set to your AWS cluster" proc

### DIFF
--- a/modules/multi-architecture-modify-machine-set-aws.adoc
+++ b/modules/multi-architecture-modify-machine-set-aws.adoc
@@ -79,12 +79,12 @@ spec:
             - filters:
                 - name: tag:Name
                   values:
-                    - <infrastructure_id>-worker-sg <1>
+                    - <infrastructure_id>-node <1>
           subnet:
             filters:
               - name: tag:Name
                 values:
-                  - <infrastructure_id>-private-<zone>
+                  - <infrastructure_id>-subnet-private-<zone>
           tags:
             - name: kubernetes.io/cluster/<infrastructure_id> <1>
               value: owned
@@ -97,11 +97,11 @@ spec:
 +
 [source,terminal]
 ----
-$ oc get -o jsonpath=‘{.status.infrastructureName}{“\n”}’ infrastructure cluster
+$ oc get -o jsonpath="{.status.infrastructureName}{'\n'}" infrastructure cluster
 ----
 <2> Specify the infrastructure ID, role node label, and zone.
 <3> Specify the role node label to add.
-<4> Specify a Red{nbsp}Hat Enterprise Linux CoreOS (RHCOS) Amazon Machine Image (AMI) for your AWS zone for the nodes. The RHCOS AMI must be compatible with the machine architecture.
+<4> Specify a {op-system-first} Amazon Machine Image (AMI) for your AWS region for the nodes. The {op-system} AMI must be compatible with the machine architecture.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-36933](https://issues.redhat.com/browse/OCPBUGS-36933)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Adding a multi-architecture compute machine set to your AWS cluster](https://87379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws.html#multi-architecture-modify-machine-set-aws_creating-multi-arch-compute-nodes-aws)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->