### PR TITLE
OSDOCS-13201:Removed incorrect AWS info from GCP section of Getting started guide.

### DIFF
--- a/osd_getting_started/osd-getting-started.adoc
+++ b/osd_getting_started/osd-getting-started.adoc
@@ -25,16 +25,13 @@ Choose from one of the following methods to deploy your cluster.
 [id="osd-getting-started-create-cluster-gcp-ccs"]
 === Creating a cluster on GCP using the CCS model
 
-You can install {product-title} in your own {GCP} account by using the CCS model. Complete the steps in one of the following sections to deploy {product-title} in your own {GCP} account.
+You can install {product-title} in your own {GCP} account by using the CCS model. Complete the steps in one of the following sections to deploy {product-title} in your own GCP account.
 
-* *xref:../osd_aws_clusters/creating-an-aws-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws[Creating a cluster on AWS]*: You can install {product-title} in your own {AWS} account by using the CCS model.
+* Red Hat recommends using GCP Workload Identity Federation (WIF) as the authentication type for installing and interacting with the {product-title} cluster deployed on GCP because it provides enhanced security. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on GCP with Workload Identity Federation authentication].
 
-* Red Hat also recommends creating an {product-title} cluster deployed on {GCP} in Private cluster mode with Private Service Connect (PSC) to manage and monitor a cluster to avoid all public ingress network traffic. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc#creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview].
+* Red Hat also recommends creating an {product-title} cluster deployed on GCP in Private cluster mode with Private Service Connect (PSC) to manage and monitor a cluster to avoid all public ingress network traffic. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc#creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview].
 
-* For installing and interacting with the {product-title} cluster deployed on the {GCP} using the Service Account authentication type, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp-sa[Creating a cluster on GCP with Service Account authentication].
-** Red Hat recommends using GCP Workload Identity Federation (WIF) as the authentication type for installing and interacting with the {product-title} cluster deployed on {GCP} because it provides enhanced security. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on GCP with Workload Identity Federation authentication].
-
-// Update link with new title when new SA auth guide goes live.
+* For installing and interacting with the {product-title} cluster deployed on GCP by using the Service Account authentication type, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp-sa[Creating a cluster on GCP with Service Account authentication].
 
 [id="osd-getting-started-create-cluster-aws-ccs"]
 === Creating a cluster on AWS using the CCS model


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-13201

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
-No QE approval is required as this PR is removing incorrect information that is duplicated in the following section.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
