### PR TITLE
SECENGSP-6323: Add the URL of the last advisory and reveal the 1.1 release

### DIFF
--- a/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc
+++ b/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc
@@ -14,6 +14,4 @@ link:https://access.redhat.com/errata/RHEA-2023:7491[RHEA-2023:7491]:: The NBDE 
 link:https://access.redhat.com/errata/RHEA-2024:0854[RHEA-2024:0854]:: The NBDE Tang Server Operator 1.0.1 has been moved from the `alpha` channel to the `stable` channel.
 link:https://access.redhat.com/errata/RHBA-2024:8681[RHBA-2024:8681]:: The 1.0.2 update contains fixes that increase the Container Health Index of containers deployed with the NBDE Tang Server Operator to the highest grade.
 link:https://access.redhat.com/errata/RHEA-2024:10970[RHEA-2024:10970]:: The 1.0.3 update contains changes that re-increase the Container Health Index to the highest grade.
-////
-link:https://access.redhat.com/errata/[RHBA-2025:xxxx]:: With the NBDE Tang Server Operator 1.1, the `golang` package is provided in version 1.23.2 and the `golang.org/x/net/html` package has been updated to version 0.33.0. The updates increase the Container Health Index.
-////
+link:https://access.redhat.com/errata/RHBA-2025:0533[RHBA-2025:0533]:: With the NBDE Tang Server Operator 1.1, the `golang` package is provided in version 1.23.2 and the `golang.org/x/net/html` package has been updated to version 0.33.0. The updates increase the Container Health Index.


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/SECENGSP-6323

Preview:
https://87406--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.html

QE review:
- [x] QE has approved this change.
(reviewed by a QE within https://github.com/openshift/openshift-docs/pull/87315)

Additional information:
Only adding the URL (when it's known) and removing the comment-out markup from the part, which was hidden before the release.

