### PR TITLE
OCPBUGS-44421-fix

### DIFF
--- a/modules/node-network-configuration-policy-file.adoc
+++ b/modules/node-network-configuration-policy-file.adoc
@@ -2,8 +2,8 @@
 //
 // * networking/k8s_nmstate/k8s-observing-node-network-state.adoc
 
-:_mod-docs-content-type: PROCEDURE
-[id="node-network-configuration-policy-file.adoc_{context}"]
+:_mod-docs-content-type: CONCEPT
+[id="node-network-configuration-policy-file_{context}"]
 = The NodeNetworkConfigurationPolicy manifest file
 
 A `NodeNetworkConfigurationPolicy` (NNCP) manifest file defines policies that the Kubernetes NMState Operator uses to configure networking for nodes that exist in an {product-title} cluster. 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-44421](https://issues.redhat.com/browse/OCPBUGS-44421)

Link to docs preview:
* [The NodeNetworkConfigurationPolicy manifest file](https://87413--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#node-network-configuration-policy-file_k8s-nmstate-updating-node-network-config)
* [DNS](https://87413--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-IP-management-dns_k8s-nmstate-updating-node-network-config)

- [x] SME has approved this change (Mat K).
- [x] QE has approved this change (Gris G).

