### PR TITLE
OCPBUGS-44421-415: Added missing cherry-pick content

### DIFF
--- a/modules/node-network-configuration-policy-file.adoc
+++ b/modules/node-network-configuration-policy-file.adoc
@@ -2,8 +2,8 @@
 //
 // * networking/k8s_nmstate/k8s-observing-node-network-state.adoc
 
-:_mod-docs-content-type: PROCEDURE
-[id="node-network-configuration-policy-file.adoc_{context}"]
+:_mod-docs-content-type: CONCEPT
+[id="node-network-configuration-policy-file_{context}"]
 = The NodeNetworkConfigurationPolicy manifest file
 
 A `NodeNetworkConfigurationPolicy` (NNCP) manifest file defines policies that the Kubernetes NMState Operator uses to configure networking for nodes that exist in an {product-title} cluster. 

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -12,6 +12,16 @@ include::modules/virt-viewing-network-state-of-node.adoc[leveloffset=+1]
 
 include::modules/virt-viewing-network-state-of-node-console.adoc[leveloffset=+1]
 
+// The `NodeNetworkConfigurationPolicy` manifest file
+include::modules/node-network-configuration-policy-file.adoc[leveloffset=+1]
+
+[discrete]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-nmstate-example-policy-configurations_{context}[Example policy configurations for different interfaces]
+
+* xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-removing-interface-from-nodes_{context}[Removing an interface from nodes]
+
 include::modules/virt-node-network-config-console.adoc[leveloffset=+1]
 include::modules/virt-monitor-node-network-config-console.adoc[leveloffset=+2]
 include::modules/virt-create-node-network-config-console.adoc[leveloffset=+2]


### PR DESCRIPTION
The cherry pick PR dropped the most important part: the module include. See the [4.15 PR](https://github.com/openshift/openshift-docs/pull/87393) on https://github.com/openshift/openshift-docs/pull/85705


Version(s):
4.15

Issue:
[OCPBUGS-44421](https://issues.redhat.com/browse/OCPBUGS-44421)

Link to docs preview:
* [The NodeNetworkConfigurationPolicy manifest file](https://85705--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#node-network-configuration-policy-file.adoc_k8s-nmstate-updating-node-network-config)
* [DNS](https://85705--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-IP-management-dns_k8s-nmstate-updating-node-network-config)

