### PR TITLE
OCPBUGS#38212: Added missing OVN Infra Controller default range to 4.…

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1490,6 +1490,11 @@ Additionally, the `oc registry login` command now stores credentials in the Podm
 
 In {product-title} metrics, the pod `attach`, `exec`, `log`, `portforward`, and `proxy` requests are now recorded as `CONNECT` requests.
 
+[id="ocp-4-14-ovnic-default-range"]
+=== Open Virtual Network Infrastructure Controller default range
+
+With this update, the Controller uses `100.88.0.0/16` as the default IP address range for the transit switch subnet. Do not use this IP range in your production infrastructure network. (link:https://issues.redhat.com/browse/OCPBUGS-20261[*OCPBUGS-20261*])
+
 [id="ocp-4-14-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OCPBUGS-38212](https://issues.redhat.com/browse/OCPBUGS-38212)

Link to docs preview:
* [Open Virtual Network Infrastructure Controller default range](https://87422--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-notable-technical-changes)

- [x] SME has approved this change (Riccardo Ravaioli).
- [x] QE has approved this change (Anurag Saxena).

