### PR TITLE
OCPBUGS#45919: Updated the service account in STS

### DIFF
--- a/modules/aws-installing-an-aws-load-balancer-operator.adoc
+++ b/modules/aws-installing-an-aws-load-balancer-operator.adoc
@@ -15,7 +15,7 @@ You can install an AWS Load Balancer Operator and an AWS Load Balancer Controlle
 * You have access to modify the VPC and subnets of the created ROSA cluster.
 * You have installed the ROSA CLI (`rosa`).
 * You have installed the Amazon Web Services (AWS) CLI.
-* You are using OpenShift Container Platform 4.13 or later.
+* You are using {product-title} 4.13 or later.
 
 [IMPORTANT]
 ====
@@ -86,7 +86,7 @@ $ IDP_ARN="arn:aws:iam::{AWS_AccountNo}:oidc-provider/${IDP}" <1>
 .Example output
 [source,terminal,subs="quotes,verbatim"]
 ----
-$ cat EOF albo-operator-trusted-policy.json
+$ cat <<EOF > albo-operator-trusted-policy.json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -160,7 +160,7 @@ $ aws iam put-role-policy --role-name albo-operator --policy-name perms-policy-a
 ----
 $ IDP='{Cluster_OIDC_Endpoint}'
 $ IDP_ARN="arn:aws:iam::{AWS_AccountNo}:oidc-provider/${IDP}"
-$ cat <EOF> albo-controller-trusted-policy.json
+$ cat <<EOF > albo-controller-trusted-policy.json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -172,7 +172,7 @@ $ cat <EOF> albo-controller-trusted-policy.json
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "${IDP}:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-cluster"
+                    "${IDP}:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-operator-controller-manager"
                 }
             }
         }
@@ -196,7 +196,7 @@ $ echo $CONTROLLER_ROLE_ARN
 ROLE	arn:aws:iam::<aws_account_number>:role/albo-controller	2023-08-02T12:13:22Z
 ASSUMEROLEPOLICYDOCUMENT	2012-10-17
 STATEMENT	    sts:AssumeRoleWithWebIdentity	Allow
-STRINGEQUALS	system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-cluster
+STRINGEQUALS	system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-operator-controller-manager
 PRINCIPAL	    arn:aws:iam:<aws_account_number>:oidc-provider/<oidc_provider_id>
 ----
 +
@@ -243,7 +243,7 @@ ELBv2 resources (such as ALBs and NLBs) created by AWS Load Balancer Operator do
 +
 [source,terminal]
 ----
-$ cat EOF | oc apply -f -
+$ cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -258,7 +258,7 @@ EOF
 +
 [source,terminal]
 ----
-$ cat EOF | oc apply -f -
+$ cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/modules/using-aws-cli-create-iam-role-alb-controller.adoc
+++ b/modules/using-aws-cli-create-iam-role-alb-controller.adoc
@@ -30,7 +30,7 @@ $ cat <<EOF > albo-controller-trust-policy.json
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "<cluster_oidc_endpoint>:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-cluster" <2>
+                    "<cluster_oidc_endpoint>:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-operator-controller-manager" <2>
                 }
             }
         }
@@ -54,7 +54,7 @@ $ aws iam create-role --role-name albo-controller --assume-role-policy-document 
 ROLE	arn:aws:iam::<aws_account_number>:role/albo-controller	2023-08-02T12:13:22Z <1>
 ASSUMEROLEPOLICYDOCUMENT	2012-10-17
 STATEMENT	sts:AssumeRoleWithWebIdentity	Allow
-STRINGEQUALS	system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-cluster
+STRINGEQUALS	system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-operator-controller-manager
 PRINCIPAL	arn:aws:iam:<aws_account_number>:oidc-provider/<cluster_oidc_endpoint>
 ----
 <1> Note the ARN of an {aws-short} IAM role for the {aws-short} Load Balancer Controller, such as `arn:aws:iam::777777777777:role/albo-controller`.

--- a/modules/using-aws-cli-create-iam-role-alb-operator.adoc
+++ b/modules/using-aws-cli-create-iam-role-alb-operator.adoc
@@ -30,7 +30,7 @@ $ cat <<EOF > albo-operator-trust-policy.json
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
                 "StringEquals": {
-                    "<cluster_oidc_endpoint>:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-controller-cluster" <2>
+                    "<cluster_oidc_endpoint>:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-operator-controller-manager" <2>
                 }
             }
         }


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-45919](https://issues.redhat.com/browse/OCPBUGS-45919)

Link to docs preview:

* [Creating an AWS IAM role by using the AWS CLI](https://87443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/preparing-sts-cluster-for-albo.html)
* [Installing an AWS Load Balancer Operator](https://87443--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/aws-load-balancer-operator.html#aws-installing-an-aws-load-balancer-operator_aws-load-balancer-operator)

- [x] SME has approved this change (Dustin Row).
- [x] QE has approved this change (Melvin).

Additional information:

https://docs.openshift.com/container-platform/4.14/networking/aws_load_balancer_operator/installing-albo-sts-cluster.html#using-aws-cli-create-iam-role-alb-operator_albo-sts-cluster

