### PR TITLE
OADP-4832 - Release notes for OADP 1.4.2

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -14,6 +14,12 @@ The release notes for {oadp-first} describe new features and enhancements, depre
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
 ====
 
+include::modules/oadp-1-4-2-release-notes.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-deleting-backups.adoc#oadp-about-kopia-repo-maintenance_deleting-backups[About Kopia repository maintenance]
+
 include::modules/oadp-1-4-1-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]

--- a/modules/oadp-1-4-2-release-notes.adoc
+++ b/modules/oadp-1-4-2-release-notes.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-2-release-notes_{context}"]
+= {oadp-short} 1.4.2 release notes
+
+The {oadp-first} 1.4.2 release notes lists new features, resolved issues and bugs, and known issues.
+
+[id="new-features-1-4-2_{context}"]
+== New features
+
+.Backing up different volumes in the same namespace by using the VolumePolicy feature is now possible
+
+With this release, Velero provides resource policies to back up different volumes in the same namespace by using the `VolumePolicy` feature. The supported `VolumePolicy` feature to back up different volumes includes `skip`, `snapshot`, and `fs-backup` actions.
+link:https://issues.redhat.com/browse/OADP-1071[OADP-1071]
+
+.File system backup and data mover can now use short-term credentials
+
+File system backup and data mover can now use short-term credentials such as {aws-short} {sts-first} and {gcp-short} WIF. With this support, backup is successfully completed without any `PartiallyFailed` status.
+link:https://issues.redhat.com/browse/OADP-5095[OADP-5095]
+
+[id="resolved-issues-1-4-2_{context}"]
+== Resolved issues
+
+.DPA now reports errors if VSL contains an incorrect provider value 
+
+Previously, if the provider of a Volume Snapshot Location (VSL) spec was incorrect, the Data Protection Application (DPA) reconciled successfully. With this update, DPA reports errors and requests for a valid provider value.
+link:https://issues.redhat.com/browse/OADP-5044[OADP-5044]
+
+.Data Mover restore is successful irrespective of using different OADP namespaces for backup and restore
+
+Previously, when backup operation was executed by using {oadp-short} installed in one namespace but was restored by using {oadp-short} installed in a different namespace, the Data Mover restore failed. With this update, Data Mover restore is now successful.
+link:https://issues.redhat.com/browse/OADP-5460[OADP-5460]
+
+.SSE-C backup works with the calculated MD5 of the secret key
+
+Previously, backup failed with the following error:
+[source,terminal]
+----
+Requests specifying Server Side Encryption with Customer provided keys must provide the client calculated MD5 of the secret key.
+----
+With this update, missing Server-Side Encryption with Customer-Provided Keys (SSE-C) base64 and MD5 hash are now fixed. As a result, SSE-C backup works with the calculated MD5 of the secret key. In addition, incorrect `errorhandling` for the `customerKey` size is also fixed.
+link:https://issues.redhat.com/browse/OADP-5388[OADP-5388]
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12452476[OADP 1.4.2 resolved issues] in Jira.
+
+
+[id="known-issues-1-4-2_{context}"]
+== Known issues
+
+.The nodeSelector spec is not supported for the Data Mover restore action
+
+When a Data Protection Application (DPA) is created with the `nodeSelector` field set in the `nodeAgent` parameter, Data Mover restore partially fails instead of completing the restore operation. 
+link:https://issues.redhat.com/browse/OADP-5260[OADP-5260]
+
+.The S3 storage does not use proxy environment when TLS skip verify is specified
+
+In the image registry backup, the S3 storage does not use the proxy environment when the `insecureSkipTLSVerify` parameter is set to `true`.
+link:https://issues.redhat.com/browse/OADP-3143[OADP-3143]
+
+.Kopia does not delete artifacts after backup expiration
+
+Even after you delete a backup, Kopia does not delete the volume artifacts from the `${bucket_name}/kopia/${namespace}` on the S3 location after backup expired. For more information, see "About Kopia repository maintenance".
+link:https://issues.redhat.com/browse/OADP-5131[OADP-5131]


### PR DESCRIPTION
Version(s):
OCP 4.14 - 4.18

Issue:
[OADP-4832](https://issues.redhat.com/browse/OADP-4832)

Link to docs preview:
[OADP 1.4.2 release notes](https://87456--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html#oadp-1-4-2-release-notes_oadp-1-4-release-notes)


QE review:
- [x] QE has approved this change.


