### PR TITLE
OSSM-8511 Document how to delete OSSM 2.6 after upgrading to 3.0

### DIFF
--- a/migrating/done/ossm-migrating-complete-assembly.adoc
+++ b/migrating/done/ossm-migrating-complete-assembly.adoc
@@ -6,11 +6,30 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+At this stage, you have completed the migration process. It is safe to remove {SMProduct} {smv2version}.
+
+//need to add cleanup/delete 2.6 content
+
+Optionally, if you already have Kiali installed, before you delete {SMProduct} {SMv2Version}, you can verify that all data plane namespaces have been migrated by checking the Kiali **Mesh** page. To learn more about the Kiali **Mesh** page, see "Istio infrastructure status (Kiali.io)".
+
+//include::modules/ossm-migrating-done-network-policies.adoc[leveloffset=+1]
 include::modules/ossm-migrating-complete-multitant-cert-manager.adoc[leveloffset=+1]
 
 .Next steps
 
 * Remove {Smproduct} 2
 
-//exrefs handled by OSSM-8852
-//may not be necessary; will depend on all the other migrating complete content in other PRs
+//content taken from https://github.com/openshift-service-mesh/sail-operator/tree/main/docs/ossm/ossm2-migration#post-migration-checklist which is a new addition to the Premigration Checklist content as of 01/27/2025 even though it is post migration content. However, the engineering staging area, /docs/ossm/ doesn't have a post migration folder, so making note here for reference so whomever else is in this file doesn't have to go digging.
+
+//includes coming.
+
+include::modules/ossm-migrating-complete-remove-2-6-control-plane.adoc[leveloffset=+1]
+include::modules/ossm-migrating-complete-remove-2-6-operator-crds.adoc[leveloffset=+1]
+include::modules/ossm-migrating-complete-remove-maistra-labels.adoc[leveloffset=+1]
+
+
+[role="_additional-resources"]
+[id="addition-resource-complete_{context}"]
+== Additional Resources
+
+* link:https://kiali.io/docs/features/istio-component-status/#control-plane-namespace[Istio infrastructure status (Kiali.io)]

--- a/modules/ossm-migrating-complete-remove-2-6-control-plane.adoc
+++ b/modules/ossm-migrating-complete-remove-2-6-control-plane.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/done/ossm-migrating-complete-assembly
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-remove-2-6-control-plane_{context}"]
+= Remove the Service Mesh 2.6 control plane
+
+After you have migrated all your workloads and gateways, you can remove the {SMproduct} 2.x control plane.
+
+.Prerequisites
+
+* You have completed migrating your workloads.
+* You have completed migrating your gateways.
+* You are logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
+
+[NOTE]
+====
+Depending on how you created `ServiceMeshMember` and `ServiceMeshMemberRoll` resources, those resources might be removed automatically with removal of the `ServiceMeshControlPlane` resource.
+====
+
+.Procedure
+
+. Find all Service Mesh 2.6 resources by running the following command:
++
+[source,terminal]
+----
+$ oc get smcp,smm,smmr -A
+----
+
+. Remove all `ServiceMeshControlPlane` resources by running the following command:
++
+[source,terminal]
+----
+$ oc delete smcp --all -A
+----
+
+. Remove all `ServiceMeshMemberRoll` resources by running the following command:
++
+[source,terminal]
+----
+$ oc delete smmr --all -A
+----
+
+. Remove all `ServiceMeshMember` resources by running the following command:
++
+[source,terminal]
+----
+$ oc delete smm --all -A
+----
+
+. Verify that all resources were removed by running the following command:
++
+[source,terminal]
+----
+$ oc get smcp,smm,smmr -A
+----
++
+.Example output
+----
+No resources found
+----
+
+

--- a/modules/ossm-migrating-complete-remove-2-6-operator-crds.adoc
+++ b/modules/ossm-migrating-complete-remove-2-6-operator-crds.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/done/ossm-migrating-complete-assembly
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-complete-remove-2-6-operator-crds_{context}"]
+= Remove the Service Mesh 2.6 operator and custom resource definitions
+
+After you remove the {SMProductName} 2 `ServiceMeshControlplane` resource, and all other {SMProduct} 2 resources, you can remove the {SMproduct} 2.6 Operator and custom resource definitions (CRDs).
+
+.Prerequisites
+
+* You have completed migrating your workloads.
+* You have completed migrating your gateways.
+* You have removed the {SMProduct} 2 `ServiceMeshControlPlane` resource.
+* You have removed all other {SMProduct} 2 resources.
+* You are logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
+
+.Procedure
+
+. Check that there are no {SMPRoductName} 2.6 resources left by running the following command:
++
+[source,terminal]
+----
+$ oc get smcp,smm,smmr -A
+----
++
+.Example output
+----
+No resources found
+----
+
+. Remove the Operator by running the following commands:
+
+.. Find the Operator subscription:
++
+[source,terminal]
+----
+csv=$(oc get subscription servicemeshoperator -n openshift-operators -o yaml | grep currentCSV | cut -f 2 -d ':')
+----
+
+.. Delete the subscription:
++
+[source,terminal]
+----
+$ oc delete subscription servicemeshoperator -n openshift-operators
+----
+
+.. Delete the `clusterserviceversion` CSV:
++
+[source,terminal]
+----
+$ oc delete clusterserviceversion $csv -n openshift-operators
+----
+
+. Remove `maistra` CRDs by running the following command:
++
+[source,terminal]
+----
+$ oc get crds -o name | grep ".*\.maistra\.io" | xargs -r -n 1 oc delete
+----
+

--- a/modules/ossm-migrating-complete-remove-maistra-labels.adoc
+++ b/modules/ossm-migrating-complete-remove-maistra-labels.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/done/ossm-migrating-complete-assembly
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-complete-remove-maistra-labels_{context}"]
+= Remove the Maistra labels
+
+After you have removed all {SMProduct} 2 resources, removed the {SMProduct} 2 Operator, and {SMProduct} 2 custom resource definitions (CRDs), you can choose to remove namespace labels created during the migration.
+
+.Prerequisites
+
+* You have completed migrating your workloads.
+* You have completed migrating your gateways.
+* You have removed the {SMProduct} 2 `ServiceMeshControlPlane` resource.
+* You have removed all other {SMProduct} 2 resources.
+* You have removed the {SMProduct} 2 Operator.
+* You have removed the {SMProduct} 2 CRDs.
+* You are logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
+
+.Procedure
+
+. Verify that all {SMProduct} 2.6 resources have been removed by running the following command:
++
+[source,terminal]
+----
+$ oc get smcp,smm,smmr -A
+----
++
+.Example output
+----
+No resources found
+----
+
+. Find namespaces with the `maistra.io/ignore-namespace="true"` label by running the following command:
++
+[source,terminal]
+----
+$ oc get namespace -l maistra.io/ignore-namespace="true"
+----
++
+.Example output
+----
+NAME       STATUS   AGE
+bookinfo   Active   127m
+----
+
+. Remove the label by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace bookinfo maistra.io/ignore-namespace-
+----
++
+.Example output
+----
+namespace/bookinfo unlabeled
+----


### PR DESCRIPTION
**OSSM 3.0 GA** 

**Merge to:** https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick** to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

**01/22/2025** at time of PR creation, a new release branch for Red Hat Service Mesh product documentation has not been cut, so the cherry pick branch is unknown.

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):
OSSM 3.0 has moved to the stand alone format and will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8511

Link to docs preview:
https://87466--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/done/ossm-migrating-complete-assembly.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
