### PR TITLE
[enterprise-4.16] Added cert-manager operator 1.15 release note text.

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,6 +12,56 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1-15-0_{context}"]
+== {cert-manager-operator} 1.15.0
+
+Issued: 2025-01-22
+
+The following advisories are available for the {cert-manager-operator} 1.15.0:
+
+* link:https://access.redhat.com/errata/RHEA-2025:0487[RHEA-2025:0487]
+* link:https://access.redhat.com/errata/RHSA-2025:0535[RHSA-2025:0535]
+* link:https://access.redhat.com/errata/RHSA-2025:0536[RHSA-2025:0536]
+
+Version `1.15.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.15.4`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.15/#v1154[cert-manager project release notes for v1.15.4].
+
+[id="cert-manager-operator-1-15-0-features-enhancements_{context}"]
+=== New features and enhancements
+
+*Scheduling overrides for {cert-manager-operator}*
+
+With this release, you can configure scheduling overrides for {cert-manager-operator}, including the cert-manager controller, webhook, and CA injector.
+
+*Google CAS issuer*
+
+The {cert-manager-operator} now supports the Google Certificate Authority Service (CAS) issuer. The `google-cas-issuer` is an external issuer for cert-manager that automates certificate lifecycle management, including issuance and renewal, with CAS-managed private certificate authorities.
+
+[NOTE]
+====
+The Google CAS issuer is validated only with version 0.9.0 and {cert-manager-operator} version 1.15.0. These versions support tasks such as issuing, renewing, and managing certificates for the API server and ingress controller in {product-title} clusters.
+====
+
+*Default `installMode` updated to `AllNamespaces`*
+
+Starting from version 1.15.0, the default and recommended Operator Lifecycle Manager (OLM) `installMode` is `AllNamespaces`. Previously, the default was `SingleNamespace`. This change aligns with best practices for multi-namespace Operator management.
+For more information, see link:https://issues.redhat.com/browse/OCPBUGS-23406[OCPBUGS-23406].
+
+*Redundant `kube-rbac-proxy` sidecar removed*
+
+The Operator no longer includes the redundant `kube-rbac-proxy` sidecar container, reducing resource usage and complexity.
+For more information, see link:https://issues.redhat.com/browse/CM-436[CM-436].
+
+[id="cert-manager-operator-1-15-0-CVEs_{context}"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-35255[CVE-2024-35255]
+* link:https://access.redhat.com/security/cve/CVE-2024-28180[CVE-2024-28180]
+* link:https://access.redhat.com/security/cve/CVE-2024-24783[CVE-2024-24783]
+* link:https://access.redhat.com/security/cve/CVE-2024-6104[CVE-2024-6104]
+* link:https://access.redhat.com/security/cve/CVE-2023-45288[CVE-2023-45288]
+* link:https://access.redhat.com/security/cve/CVE-2024-45337[CVE-2024-45337]
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]
+
 [id="cert-manager-operator-release-notes-1-14-1_{context}"]
 == {cert-manager-operator} 1.14.1
 
@@ -28,7 +78,6 @@ Version `1.14.1` of the {cert-manager-operator} is based on the upstream cert-ma
 
 * link:https://access.redhat.com/security/cve/CVE-2024-33599[CVE-2024-33599]
 * link:https://access.redhat.com/security/cve/CVE-2024-2961[CVE-2024-2961]
-
 
 [id="cert-manager-operator-release-notes-1-14-0"]
 == {cert-manager-operator} 1.14.0


### PR DESCRIPTION
Manual CP of https://github.com/openshift/openshift-docs/pull/86686

https://github.com/openshift/openshift-docs/commit/7707ca596fa3b63ebde1d102cc388124da998f5f