### PR TITLE
OSDOCS11202: Clarifying and Adding Detail to "Controlling DNS pod placement” doc

### DIFF
--- a/modules/nw-controlling-dns-pod-placement.adoc
+++ b/modules/nw-controlling-dns-pod-placement.adoc
@@ -8,7 +8,12 @@
 
 The DNS Operator has two daemon sets: one for CoreDNS called `dns-default` and one for managing the `/etc/hosts` file called `node-resolver`.
 
-You might find a need to control which nodes have CoreDNS pods assigned and running, although this is not a common operation. For example, if the cluster administrator has configured security policies that can prohibit communication between pairs of nodes, that would necessitate restricting the set of nodes on which the daemonset for CoreDNS runs. If DNS pods are running on some nodes in the cluster and the nodes where DNS pods are not running have network connectivity to nodes where DNS pods are running, DNS service will be available to all pods.
+You can assign and run CoreDNS pods on specified nodes. For example, if the cluster administrator has configured security policies that prohibit communication between pairs of nodes, you can configure CoreDNS pods to run on a restricted set of nodes.
+
+DNS service is available to all pods if the following circumstances are true:
+
+* DNS pods are running on some nodes in the cluster.
+* The nodes on which DNS pods are not running have network connectivity to nodes on which DNS pods are running, 
 
 The `node-resolver` daemon set must run on every node host because it adds an entry for the cluster image registry to support pulling images. The `node-resolver` pods have only one job: to look up the `image-registry.openshift-image-registry.svc` service's cluster IP address and add it to `/etc/hosts` on the node host so that the container runtime can resolve the service name.
 
@@ -23,15 +28,24 @@ As a cluster administrator, you can use a custom node selector to configure the 
 .Procedure
 
 * To allow the daemon set for CoreDNS to run on certain nodes, configure a taint and toleration:
+
+. Set a taint on the nodes that you want to control DNS pod placement by entering the following command:
 +
-. Modify the DNS Operator object named `default`:
+[source,terminal]
+----
+$ oc adm taint nodes <node_name> dns-only=abc:NoExecute <1>
+----
++
+<1> Replace `<node_name>` with the actual name of the node.
+
+. Modify the DNS Operator object named `default` to include the corresponding toleration by entering the following command: 
 +
 [source,terminal]
 ----
 $ oc edit dns.operator/default
 ----
-+
-. Specify a taint key and a toleration for the taint:
+
+. Specify a taint key and a toleration for the taint. The following toleration matches the taint set on the nodes.
 +
 [source,yaml]
 ----
@@ -39,9 +53,24 @@ $ oc edit dns.operator/default
    nodePlacement:
      tolerations:
      - effect: NoExecute
-       key: "dns-only"
-       operators: Equal
+       key: "dns-only" <1>
+       operator: Equal
        value: abc
-       tolerationSeconds: 3600 <1>
+       tolerationSeconds: 3600 <2>
 ----
-<1> If the taint is `dns-only`, it can be tolerated indefinitely. You can omit `tolerationSeconds`.
+<1> If the `key` field is set to `dns-only`, it can be tolerated indefinitely.
+<2> The `tolerationSeconds` field is optional.
+
+. Optional: To specify node placement using a node selector, modify the default DNS Operator:
+
+.. Edit the DNS Operator object named `default` to include a node selector:
++
+[source,yaml]
+----
+ spec:
+   nodePlacement:
+     nodeSelector:    <1>
+       node-role.kubernetes.io/control-plane: ""
+----
++
+<1> This node selector ensures that the CoreDNS pods run only on control plane nodes.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11202](https://issues.redhat.com//browse/OSDOCS-11202)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://87491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/dns-operator.html#nw-controlling-dns-pod-placement_dns-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
