### PR TITLE
OCPBUGS#44353: Adds nodepool flag for the hcp CLI and small updates

### DIFF
--- a/modules/hcp-bm-hc.adoc
+++ b/modules/hcp-bm-hc.adoc
@@ -45,7 +45,8 @@ $ hcp create cluster agent \
     --ssh-key  <path_to_ssh_public_key> \// <7>
     --namespace <hosted_cluster_namespace> \// <8>
     --control-plane-availability-policy HighlyAvailable \// <9>
-    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image> <10>
+    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image> \// <10>
+    --node-pool-replicas <node_pool_replica_count> <11>
 ----
 +
 <1> Specify the name of your hosted cluster, for instance, `example`.
@@ -58,6 +59,7 @@ $ hcp create cluster agent \
 <8> Specify your hosted cluster namespace.
 <9> Specify the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
 <10> Specify the supported {product-title} version that you want to use, for example, `4.17.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see _Extracting the {product-title} release image digest_.
+<11> Specify the node pool replica count, for example, `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, no node pools are created.
 
 +
 . After a few moments, verify that your hosted control plane pods are up and running by entering the following command:

--- a/modules/hcp-dc-image-mirror.adoc
+++ b/modules/hcp-dc-image-mirror.adoc
@@ -38,8 +38,8 @@ mirror:
   platform:
     channels:
     - name: candidate-4.17
-      minVersion: 4.x.y-build  <2>
-      maxVersion: 4.x.y-build <2>
+      minVersion: <4.x.y-build>  <2>
+      maxVersion: <4.x.y-build> <2>
       type: ocp
     kubeVirtContainer: true <3>
     graph: true
@@ -68,7 +68,7 @@ mirror:
 ----
 +
 <1> Replace `<dns.base.domain.name>` with the DNS base domain name.
-<2> Replace `4.x.y-build` with the supported {product-title} version you want to use.
+<2> Replace `<4.x.y-build>` with the supported {product-title} version you want to use.
 <3> Set this optional flag to `true` if you want to also mirror the container disk image for the {op-system-first} boot image for the KubeVirt provider. This flag is available with oc-mirror v2 only.
 <4> For deployments that use the KubeVirt provider, include this line.
 
@@ -90,12 +90,12 @@ kind: ImageSetConfiguration
 mirror:
   platform:
     graph: true
-    release: registry.ci.openshift.org/ocp/release:4.x.y-build <1>
+    release: registry.ci.openshift.org/ocp/release:<4.x.y-build> <1>
     kubeVirtContainer: true <2>
 # ...
 ----
 +
-<1> Replace `4.x.y-build` with the supported {product-title} version you want to use.
+<1> Replace `<4.x.y-build>` with the supported {product-title} version you want to use.
 <2> Set this optional flag to `true` if you want to also mirror the container disk image for the {op-system-first} boot image for the KubeVirt provider. This flag is available with oc-mirror v2 only.
 
 . Apply the changes to the file by entering the following command:

--- a/modules/hcp-dc-mgmt-cluster.adoc
+++ b/modules/hcp-dc-mgmt-cluster.adoc
@@ -66,7 +66,7 @@ type: routed
 plan: hub-dual
 force: true
 version: stable
-tag: "4.x.y-x86_64" <1>
+tag: "<4.x.y>-x86_64" <1>
 cluster: "hub-dual"
 dualstack: true
 domain: dns.base.domain.name
@@ -133,7 +133,7 @@ vmrules:
       mac: aa:aa:aa:aa:10:03
 ----
 +
-<1> Replace `4.x.y` with the supported {product-title} version you want to use.
+<1> Replace `<4.x.y>` with the supported {product-title} version you want to use.
 
 . To provision the management cluster, enter the following command:
 +

--- a/modules/hcp-dc-scale-np.adoc
+++ b/modules/hcp-dc-scale-np.adoc
@@ -39,9 +39,9 @@ clusters-hosted   aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa0413   hosted    true       au
 [source,terminal]
 ----
 NAMESPACE   NAME     CLUSTER   DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION       UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
-clusters    hosted   hosted    3                               False         False        4.x.y-x86_64                                     Minimum availability requires 3 replicas, current 0 available
+clusters    hosted   hosted    3                               False         False        <4.x.y>-x86_64                                     Minimum availability requires 3 replicas, current 0 available
 ----
 +
-Replace `4.x.y` with the supported {product-title} version that you want to use.
+Replace `<4.x.y>` with the supported {product-title} version that you want to use.
 
 . Wait until the nodes join the cluster. During the process, the agents provide updates on their stage and status.

--- a/modules/hcp-hc-objects.adoc
+++ b/modules/hcp-hc-objects.adoc
@@ -154,7 +154,7 @@ spec:
   pullSecret:
     name: <hosted_cluster_name>-pull-secret <1>
   release:
-    image: registry.<dns.base.domain.name>:5000/openshift/release-images:4.x.y-x86_64 <4> <5>
+    image: registry.<dns.base.domain.name>:5000/openshift/release-images:<4.x.y>-x86_64 <4> <5>
   secretEncryption:
     aescbc:
       activeKey:
@@ -188,7 +188,7 @@ status:
 <2> Replace `<hosted_cluster_namespace>` with the name of your hosted cluster namespace.
 <3> The `imageContentSources` section contains mirror references for user workloads within the hosted cluster.
 <4> Replace `<dns.base.domain.name>` with the DNS base domain name.
-<5> Replace `4.x.y` with the supported {product-title} version you want to use.
+<5> Replace `<4.x.y>` with the supported {product-title} version you want to use.
 
 . Add an annotation in the `HostedCluster` object that points to the HyperShift Operator release in the {product-title} release:
 
@@ -196,10 +196,10 @@ status:
 +
 [source,terminal]
 ----
-$ oc adm release info registry.<dns.base.domain.name>:5000/openshift-release-dev/ocp-release:4.x.y-x86_64 | grep hypershift
+$ oc adm release info registry.<dns.base.domain.name>:5000/openshift-release-dev/ocp-release:<4.x.y>-x86_64 | grep hypershift
 ----
 +
-where `<dns.base.domain.name>` is the DNS base domain name and `4.x.y` is the supported {product-title} version you want to use.
+where `<dns.base.domain.name>` is the DNS base domain name and `<4.x.y>` is the supported {product-title} version you want to use.
 +
 .Example output
 [source,terminal]

--- a/modules/hcp-non-bm-hc.adoc
+++ b/modules/hcp-non-bm-hc.adoc
@@ -41,7 +41,8 @@ $ hcp create cluster agent \
   --ssh-key  <path_to_ssh_key> \// <7>
   --namespace <hosted_cluster_namespace> \// <8>
   --control-plane-availability-policy HighlyAvailable \// <9>
-  --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release> <10>
+  --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release> \// <10>
+  --node-pool-replicas <node_pool_replica_count> <11>
 ----
 +
 <1> Specify the name of your hosted cluster, for instance, `example`.
@@ -54,6 +55,7 @@ $ hcp create cluster agent \
 <8> Specify your hosted cluster namespace.
 <9> Specify the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
 <10> Specify the supported {product-title} version that you want to use, for example, `4.17.0-multi`.
+<11> Specify the node pool replica count, for example, `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, no node pools are created.
 
 .Verification
 

--- a/modules/hcp-virt-add-node.adoc
+++ b/modules/hcp-virt-add-node.adoc
@@ -40,11 +40,11 @@ $ oc get nodepools --namespace clusters
 [source,terminal]
 ----
 NAME                      CLUSTER         DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
-example                   example         5               5               False         False        4.x.0
+example                   example         5               5               False         False        <4.x.0>
 example-extra-cpu         example         2                               False         False                  True              True             Minimum availability requires 2 replicas, current 0 available
 ----
 +
-Replace `4.x.0` with the supported {product-title} version that you want to use.
+Replace `<4.x.0>` with the supported {product-title} version that you want to use.
 
 . After some time, you can check the status of the node pool by entering the following command:
 +
@@ -77,8 +77,8 @@ $ oc get nodepools --namespace clusters
 [source,terminal]
 ----
 NAME                      CLUSTER         DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
-example                   example         5               5               False         False        4.x.0
-example-extra-cpu         example         2               2               False         False        4.x.0
+example                   example         5               5               False         False        <4.x.0>
+example-extra-cpu         example         2               2               False         False        <4.x.0>
 ----
 +
-Replace `4.x.0` with the supported {product-title} version that you want to use.
+Replace `<4.x.0>` with the supported {product-title} version that you want to use.

--- a/modules/hcp-virt-create-hc-cli.adoc
+++ b/modules/hcp-virt-create-hc-cli.adoc
@@ -7,25 +7,25 @@
 [id="hcp-virt-create-hc-cli_{context}"]
 = Creating a hosted cluster with the KubeVirt platform by using the CLI
 
-To create a hosted cluster, you can use the hosted control plane command line interface, `hcp`.
+To create a hosted cluster, you can use the hosted control plane command-line interface, `hcp`.
 
 .Procedure
 
-. Enter the following command:
+. Create a hosted cluster with the KubeVirt platform by entering the following command:
 +
 [source,terminal]
 ----
 $ hcp create cluster kubevirt \
-  --name <hosted-cluster-name> \ <1>
-  --node-pool-replicas <worker-count> \ <2>
-  --pull-secret <path-to-pull-secret> \ <3>
-  --memory <value-for-memory> \ <4>
-  --cores <value-for-cpu> \ <5>
-  --etcd-storage-class=<etcd-storage-class> <6>
+  --name <hosted_cluster_name> \// <1>
+  --node-pool-replicas <node_pool_replica_count> \// <2>
+  --pull-secret <path_to_pull_secret> \// <3>
+  --memory <value_for_memory> \// <4>
+  --cores <value_for_cpu> \// <5>
+  --etcd-storage-class=<etcd_storage_class> <6>
 ----
 +
 <1> Specify the name of your hosted cluster, for instance, `example`.
-<2> Specify the worker count, for example, `2`.
+<2> Specify the node pool replica count, for example, `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, no node pools are created.
 <3> Specify the path to your pull secret, for example, `/user/name/pullsecret`.
 <4> Specify a value for memory, for example, `6Gi`.
 <5> Specify a value for CPU, for example, `2`.
@@ -72,7 +72,7 @@ See the following example output, which illustrates a fully provisioned `HostedC
 +
 ----
 NAMESPACE   NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
-clusters    example   4.x.0     example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
+clusters    example   <4.x.0>     example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
 ----
 +
-Replace `4.x.0` with the supported {product-title} version that you want to use.
+Replace `<4.x.0>` with the supported {product-title} version that you want to use.

--- a/modules/hcp-virt-hc-base-domain.adoc
+++ b/modules/hcp-virt-hc-base-domain.adoc
@@ -62,11 +62,11 @@ $ oc --kubeconfig <hosted_cluster_name>-kubeconfig get co
 [source,terminal]
 ----
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-console                                    4.x.0     False       False         False      30m     RouteHealthAvailable: failed to GET route (https://console-openshift-console.apps.example.hypershift.lab): Get "https://console-openshift-console.apps.example.hypershift.lab": dial tcp: lookup console-openshift-console.apps.example.hypershift.lab on 172.31.0.10:53: no such host
-ingress                                    4.x.0     True        False         True       28m     The "default" ingress controller reports Degraded=True: DegradedConditions: One or more other status conditions indicate a degraded state: CanaryChecksSucceeding=False (CanaryChecksRepetitiveFailures: Canary route checks for the default ingress controller are failing)
+console                                    <4.x.0>     False       False         False      30m     RouteHealthAvailable: failed to GET route (https://console-openshift-console.apps.example.hypershift.lab): Get "https://console-openshift-console.apps.example.hypershift.lab": dial tcp: lookup console-openshift-console.apps.example.hypershift.lab on 172.31.0.10:53: no such host
+ingress                                    <4.x.0>     True        False         True       28m     The "default" ingress controller reports Degraded=True: DegradedConditions: One or more other status conditions indicate a degraded state: CanaryChecksSucceeding=False (CanaryChecksRepetitiveFailures: Canary route checks for the default ingress controller are failing)
 ----
 +
-Replace `4.x.0` with the supported {product-title} version that you want to use.
+Replace `<4.x.0>` with the supported {product-title} version that you want to use.
 
 .Next steps
 

--- a/modules/hcp-virt-wildcard-dns.adoc
+++ b/modules/hcp-virt-wildcard-dns.adoc
@@ -51,7 +51,7 @@ $ oc get --namespace clusters hostedclusters
 [source,terminal]
 ----
 NAME            VERSION   KUBECONFIG                       PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
-example         4.x.0     example-admin-kubeconfig         Completed   True        False         The hosted control plane is available
+example         <4.x.0>     example-admin-kubeconfig         Completed   True        False         The hosted control plane is available
 ----
 +
-Replace `4.x.0` with the supported {product-title} version that you want to use.
+Replace `<4.x.0>` with the supported {product-title} version that you want to use.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-44353
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Creating a hosted cluster on bare metal](https://87497--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-bm.html#hcp-bm-hc_hcp-deploy-bm) -- step 2
- [Creating a hosted cluster on non-bare-metal agent machines](https://87497--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm#hcp-non-bm-hc_hcp-deploy-non-bm) -- step 2
- [Creating a hosted cluster with kubevirt ](https://87497--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-virt#hcp-virt-create-hc-cli_hcp-deploy-virt)-- step 1
- [Image mirroring for hcp in an disconnected env ](https://87497--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.html#hcp-dc-image-mirror_hcp-deploy-dc-virt) -- step 2 : callout 2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
