### PR TITLE
OCPBUGS#38212-15: Updated OVN default range RN

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1148,7 +1148,7 @@ For more information, see xref:../nodes/pods/nodes-pods-secrets.adoc#auto-genera
 [id="ocp-4-15-ovnic-default-range"]
 === Open Virtual Network Infrastructure Controller default range
 
-Previously, the IP address range `168.254.0.0/16` was the default IP address range that the Open Virtual Network Infrastructure Controller used for the transit switch subnet. With this update, the Controller uses `100.88.0.0/16` as the default IP address range. Do not use this IP range in your production infrastructure network. (link:https://issues.redhat.com/browse/OCPBUGS-20178[*OCPBUGS-20178*])
+With this update, the Controller uses `100.88.0.0/16` as the default IP address range for the transit switch subnet. Do not use this IP range in your production infrastructure network. (link:https://issues.redhat.com/browse/OCPBUGS-20178[*OCPBUGS-20178*])
 
 [discrete]
 [id="ocp-4-15-no-strict-limits-variable"]


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OCPBUGS-38212](https://issues.redhat.com/browse/OCPBUGS-38212)

Link to docs preview:
* [Open Virtual Network Infrastructure Controller default range](https://87499--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-notable-technical-changes)

- [x] SME has approved this change (Riccardo Ravaioli).
- [x] QE has approved this change (Anurag Saxena).

Change management

- [X] [Added a 4.15 release note for Open Virtual Network Infrastructure Controller default range](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-8361418702874815275)



