### PR TITLE
OCPBUGS#39006-15: Updated cidrSelector in Example EgressFirewall CR o…

### DIFF
--- a/modules/nw-egressnetworkpolicy-object.adoc
+++ b/modules/nw-egressnetworkpolicy-object.adoc
@@ -127,7 +127,7 @@ endif::openshift-sdn[]
 <1> A collection of egress firewall policy rule objects.
 
 ifdef::ovn[]
-The following example defines a policy rule that denies traffic to the host at the `172.16.1.1` IP address, if the traffic is using either the TCP protocol and destination port `80` or any protocol and destination port `443`.
+The following example defines a policy rule that denies traffic to the host at the `172.16.1.1/32` IP address, if the traffic is using either the TCP protocol and destination port `80` or any protocol and destination port `443`.
 
 [source,yaml,subs="attributes+"]
 ----
@@ -139,7 +139,7 @@ spec:
   egress:
   - type: Deny
     to:
-      cidrSelector: 172.16.1.1
+      cidrSelector: 172.16.1.1/32
     ports:
     - port: 80
       protocol: TCP


### PR DESCRIPTION
Version(s):
4.12 to 4.15

Issue:
[OCPBUGS-39006](https://issues.redhat.com/browse/OCPBUGS-39006)

Link to docs preview:
[Example EgressFirewall CR objects](https://87515--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.html#egressnetworkpolicy-example_configuring-egress-firewall-ovn)

- [x] SME has approved this change (Tim Rozet).
- [x] QE has approved this change (Huiran Wang).
