### PR TITLE
OCPBUGS#36807: Updated the nw-operator-cr file for internalMasquerade…

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -331,7 +331,7 @@ If you set this field to `true`, you do not receive the performance benefits of 
 |`internalMasqueradeSubnet`
 |`string`
 |
-The masquerade IPv4 addresses that are used internally to enable host to service traffic. The host is configured with these IP addresses as well as the shared gateway bridge interface. The default value is `169.254.169.0/29`.
+The masquerade IPv4 addresses that are used internally to enable host-to-service traffic. The host and the shared gateway bridge interface is configured with these IP addresses. The default value is `169.254.169.0/29`. If you change the value for the `internalMasqueradeSubnet`, you must reboot all the appropriate nodes in your cluster for the changes to take effect. 
 [IMPORTANT]
 ====
 For {product-title} 4.17 and later versions, clusters use `169.254.0.0/17` as the default masquerade subnet. For upgraded clusters, there is no change to the default masquerade subnet.
@@ -348,7 +348,7 @@ For {product-title} 4.17 and later versions, clusters use `169.254.0.0/17` as th
 |`internalMasqueradeSubnet`
 |`string`
 |
-The masquerade IPv6 addresses that are used internally to enable host to service traffic. The host is configured with these IP addresses as well as the shared gateway bridge interface. The default value is `fd69::/125`.
+The masquerade IPv6 addresses that are used internally to enable host to service traffic. The host is configured with these IP addresses as well as the shared gateway bridge interface. The default value is `fd69::/125`. If you change the value for the `internalMasqueradeSubnet`, you must reboot all the appropriate nodes in your cluster for the changes to take effect. 
 [IMPORTANT]
 ====
 For {product-title} 4.17 and later versions, clusters use `fd69::/112` as the default masquerade subnet. For upgraded clusters, there is no change to the default masquerade subnet.

--- a/modules/nw-ovn-k-day-2-masq-subnet.adoc
+++ b/modules/nw-ovn-k-day-2-masq-subnet.adoc
@@ -30,6 +30,11 @@ where:
 
 `ipv6_masquerade_subnet`:: Specifies an IP address to be used as the IPv6 masquerade subnet. This range cannot overlap with any other subnets used by {product-title} or on the host itself. The default value for IPv6 is `fd69::/125`.
 
+[NOTE]
+====
+If you change the value for the `internalMasqueradeSubnet`, you must reboot all the appropriate nodes in your cluster for the changes to take effect. 
+====
+
 ** For clusters using IPv4, run the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Many install doc platforms receiving by this change. Please see [artifacts/updated_preview_urls.txt](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_openshift-docs/87528/pull-ci-openshift-openshift-docs-main-validate-asciidoc/1882400185011671040/artifacts/validate-asciidoc/openshift-docs-preview-comment-pages/artifacts/updated_preview_urls.txt) for a complete list of files.


Version(s):
4.16+

Issue:
[OCPBUGS-36807](https://issues.redhat.com/browse/OCPBUGS-36807)

Link to docs preview:
[Cluster Network Operator configuration object - AWS](https://87528--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-network-customizations#nw-operator-cr-cno-object_installing-aws-network-customizations)

- [ ] SME has approved this change (Ying Huang: I asked for more clarification) .
- [ ] QE has approved this change (Arnab Gosh).

Add. resources

* https://issues.redhat.com/browse/OCPBUGS-36177

