### PR TITLE
OCPBUGS-33176:  Clarify the `spec.peers` field in BGPAdvertisments API specs

### DIFF
--- a/modules/nw-metallb-bgpadvertisement-cr.adoc
+++ b/modules/nw-metallb-bgpadvertisement-cr.adoc
@@ -70,5 +70,6 @@ This BGP attribute applies to BGP sessions within the Autonomous System.
 
 |`spec.peers`
 |`string`
-|Optional: Peers limits the BGP peer to advertise the IPs of the selected pools to. When empty, the load balancer IP is announced to all the BGP peers configured.
+|Optional: Use a list to specify the `metadata.name` values for each `BGPPeer` resource that receives advertisements for the MetalLB service IP address. The MetalLB service IP address is assigned from the IP address pool. By default, the MetalLB service IP address is advertised to all configured `BGPPeer` resources. Use this field to limit the advertisement to specific `BGPpeer` resources.
+
 |===


### PR DESCRIPTION
OCPBUGS-33176: Clarify the `spec.peers` field in BGPAdvertisments API specs

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-33176

Link to docs preview:
https://87534--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/about-advertising-ipaddresspool.html#nw-metallb-bgpadvertisement-cr_about-advertising-ip-address-pool

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

