### PR TITLE
OSSM-8737 Change 2.5.6 to 2.6.5 in _attributes for OSSM 3.0

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -19,7 +19,7 @@
 :SMProductShortName: Service Mesh
 :SMProductVersion: 3.0
 //service mesh v2
-:SMv2Version: 2.5.6
+:SMv2Version: 2.6.5
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version.
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat


### PR DESCRIPTION
**OSSM 3.0**

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick**: to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s):

Technology Preview

OSSM 3.0 is moving to stand alone format and will not be cherry-picked back to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-8737

Link to docs preview:
No preview for _attributes

QE review:
QE review is not required for this change. It is fixing a typo.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
