### PR TITLE
OSDOCS-12533: OCI GA follow up

### DIFF
--- a/modules/abi-oci-resources-services.adoc
+++ b/modules/abi-oci-resources-services.adoc
@@ -18,7 +18,7 @@ To ensure compatibility with {product-title}, you must set `A` as the record typ
 * `api-int.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer.
 * `*.apps.<cluster_name>.<base_domain>`, which targets the `ingressVIP` parameter of the Ingress load balancer.
 
-The `api.+*+` and `api-int.+*+` DNS records relate to control plane machines, so you must ensure that all nodes in your installed {product-title} cluster can access these DNS records.
+The `api.{asterisk}` and `api-int.{asterisk}` DNS records relate to control plane machines, so you must ensure that all nodes in your installed {product-title} cluster can access these DNS records.
 ====
 
 .Prerequisites
@@ -27,4 +27,8 @@ The `api.+*+` and `api-int.+*+` DNS records relate to control plane machines, so
 
 .Procedure
 
-* Create the required {oci} resources and services. See link:https://docs.oracle.com/iaas/Content/openshift-on-oci/agent-prereq.htm[{oci} Resources Needed for Using the Agent-based Installer (Oracle documentation)].
+* Create the required {oci} resources and services.
++
+For installations in a connected environment, see link:https://docs.oracle.com/en-us/iaas/Content/openshift-on-oci/agent-installer-using-stack.htm[Provisioning Cluster Infrastructure Using Terraform (Oracle documentation)].
++
+For installations in a disconnected environment, see link:https://docs.oracle.com/iaas/Content/openshift-on-oci/agent-prereq.htm[Provisioning OCI Resources for the Agent-based Installer in Disconnected Environments (Oracle documentation)].

--- a/modules/installing-oci-about-agent-based-installer.adoc
+++ b/modules/installing-oci-about-agent-based-installer.adoc
@@ -20,7 +20,7 @@ image::684_OpenShift_Installing_on_OCI_0624-connected.png[Image of a high-level 
 .Workflow for using the Agent-based installer in a disconnected environment to install a cluster on {oci}
 image::684_OpenShift_Installing_on_OCI_0624-disconnected.png[Image of a high-level workflow for using the Agent-based installer in a disconnected environment to install a cluster on {oci}]
 
-{oci} provides services that can meet your regulatory compliance, performance, and cost-effectiveness needs. {oci} supports 64-bit `x86` instances and 64-bit `ARM` instances. Additionally, {oci} provides an {ocvs} service where you can move VMware workloads to {oci} with minimal application re-architecture.
+{oci} provides services that can meet your regulatory compliance, performance, and cost-effectiveness needs. {oci} supports 64-bit `x86` instances and 64-bit `ARM` instances.
 
 [NOTE]
 ====
@@ -32,10 +32,6 @@ By running your {product-title} cluster on {oci}, you can access the following c
 * Compute flexible shapes, where you can customize the number of Oracle(R) CPUs (OCPUs) and memory resources for your VM. With access to this capability, a cluster’s workload can perform operations in a resource-balanced environment. You can find all RHEL-certified {oci} shapes by going to the Oracle page on the Red Hat Ecosystem Catalog portal.
 
 * Block Volume storage, where you can configure scaling and auto-tuning settings for your storage volume, so that the Block Volume service automatically adjusts the performance level to optimize performance.
-
-// Should I remove the reference below of ocvs? If so, what should the new phrasing be?
-
-* {ocvs-first}, where you can deploy a cluster in a public-cloud environment that operates on a VMware® vSphere software-defined data center (SDDC). You continue to retain full-administrative control over your VMware vSphere environment, but you can use {oci} services to improve your applications on flexible, scalable, and secure infrastructure.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
[OSDOCS-12533](https://issues.redhat.com/browse/OSDOCS-12533)

Versions: 4.17+

This PR follows up on the previous PR for the OCI via ABI GA, where references to Oracle® Cloud VMware Solution are being removed from the doc.

- [x] QE has approved this change.

Preview: [The Agent-based Installer and OCI overview](https://87546--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer.html#installing-oci-about-agent-based-installer_installing-oci-agent-based-installer)
