### PR TITLE
OCPBUGS-#10631-17: Updated the customized br-ex bridge section

### DIFF
--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -20,14 +20,14 @@ endif::[]
 == Creating a manifest object that includes a customized `br-ex` bridge
 
 ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
-As an alternative to using the `configure-ovs.sh` shell script to set a customized `br-ex` bridge on a bare-metal platform, you can create a `MachineConfig` object that includes a customized `br-ex` bridge network configuration.
+As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `MachineConfig` object that includes an NMState configuration file. The NMState configuration file creates a customized `br-ex` bridge network configuration on each node in your cluster.
 
 :FeatureName: Creating a `MachineConfig` object that includes a customized `br-ex` bridge
 include::snippets/technology-preview.adoc[]
 endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 
 ifdef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
-As an alternative to using the `configure-ovs.sh` shell script to set a customized `br-ex` bridge on a bare-metal platform, you can create a `NodeNetworkConfigurationPolicy` custom resource (CR) that includes a customized `br-ex` bridge network configuration.
+As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `NodeNetworkConfigurationPolicy` custom resource (CR) that includes an NMState configuration file. The NMState configuration file creates a customized `br-ex` bridge network configuration on each node in your cluster.
 
 :FeatureName: Creating a `NodeNetworkConfigurationPolicy` CR that includes a customized `br-ex` bridge
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
Like a cherry-pick of https://github.com/openshift/openshift-docs/pull/87053, but I need to keep the TP note for 4.17 and 4.16.

Version(s):
4.16+

Issue:
[OSDOCS-10631](https://issues.redhat.com/browse/OSDOCS-10631)

Link to docs preview:
* [Installing a user-provisioned cluster on bare metal](https://87588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal)
* [Installing a user-provisioned bare metal cluster with network customizations](https://87588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal-network-customizations)
* [Installing a user-provisioned bare metal cluster on a restricted network](https://87588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#creating-manifest-file-customized-br-ex-bridge_installing-restricted-networks-bare-metal)
* [Setting up the environment for an OpenShift installation](https://87588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow)
* [Installer-provisioned postinstallation configuration](https://87588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html#creating-manifest-file-customized-br-ex-bridge_ipi-install-post-installation-configuration)


- [x] SME has approved this change.
- [x] QE has approved this change.
