### PR TITLE
OSDOCS-12924: adds 4.16.32 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -414,3 +414,14 @@ Issued: 15 January 2025
 {product-title} release 4.16.30 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0142[RHBA-2025:0142] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0140[RHSA-2025:0140] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-32-dp_{context}"]
+=== RHBA-2025:0683 - {microshift-short} 4.16.32 bug fix and enhancement advisory
+
+Issued: 29 January 2025
+
+{product-title} release 4.16.32 is now available. With this release, {microshift-short} introduces a priority-based release cadence to provide the most important updates with the least disruption.
+
+The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0683[RHBA-2025:0683] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0652[RHBA-2025:0652] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12924](https://issues.redhat.com/browse/OSDOCS-12924)

Link to docs preview:
[microshift-4-16-32-dp_release-notes](https://87616--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-32-dp_release-notes)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
