### PR TITLE
TELCODOCS#2136: Deprecation of SiteConfig v1

### DIFF
--- a/edge_computing/ztp-advanced-install-ztp.adoc
+++ b/edge_computing/ztp-advanced-install-ztp.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 You can use `SiteConfig` custom resources (CRs) to deploy custom functionality and configurations in your managed clusters at installation time.
 
+include::snippets/siteconfig-deprecation-notice.adoc[]
+
 include::modules/ztp-customizing-the-install-extra-manifests.adoc[leveloffset=+1]
 
 include::modules/ztp-filtering-ai-crs-using-siteconfig.adoc[leveloffset=+1]

--- a/modules/ztp-creating-ztp-crs-for-multiple-managed-clusters.adoc
+++ b/modules/ztp-creating-ztp-crs-for-multiple-managed-clusters.adoc
@@ -15,3 +15,5 @@ You can provision single clusters manually or in batches with {ztp}:
 Provisioning a single cluster:: Create a single `SiteConfig` CR and related installation and configuration CRs for the cluster, and apply them in the hub cluster to begin cluster provisioning. This is a good way to test your CRs before deploying on a larger scale.
 
 Provisioning many clusters:: Install managed clusters in batches of up to 400 by defining `SiteConfig` and related CRs in a Git repository. ArgoCD uses the `SiteConfig` CRs to deploy the sites. The {rh-rhacm} policy generator creates the manifests and applies them to the hub cluster. This starts the cluster provisioning process.
+
+include::snippets/siteconfig-deprecation-notice.adoc[]

--- a/modules/ztp-deploying-a-site.adoc
+++ b/modules/ztp-deploying-a-site.adoc
@@ -8,6 +8,8 @@
 
 Use the following procedure to create a `SiteConfig` custom resource (CR) and related files and initiate the {ztp-first} cluster deployment.
 
+include::snippets/siteconfig-deprecation-notice.adoc[]
+
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).

--- a/modules/ztp-generating-install-and-config-crs-manually.adoc
+++ b/modules/ztp-generating-install-and-config-crs-manually.adoc
@@ -8,6 +8,8 @@
 
 Use the `generator` entrypoint for the `ztp-site-generate` container to generate the site installation and configuration custom resource (CRs) for a cluster based on `SiteConfig` and `{policy-gen-cr}` CRs.
 
+include::snippets/siteconfig-deprecation-notice.adoc[]
+
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).

--- a/modules/ztp-precaching-ztp-config.adoc
+++ b/modules/ztp-precaching-ztp-config.adoc
@@ -13,6 +13,8 @@ In the {ztp-first} provisioning workflow, the {factory-prestaging-tool} requires
 * `nodes.installerArgs`
 * `nodes.ignitionConfigOverride`
 
+include::snippets/siteconfig-deprecation-notice.adoc[]
+
 .Example SiteConfig with additional fields
 [source,yaml]
 ----

--- a/snippets/siteconfig-deprecation-notice.adoc
+++ b/snippets/siteconfig-deprecation-notice.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: SNIPPET
+[IMPORTANT]
+====
+SiteConfig v1 is deprecated starting with {product-title} version 4.18. Equivalent and improved functionality is now available through the SiteConfig Operator using the `ClusterInstance` custom resource. For more information, see link:https://access.redhat.com/articles/7105238[Procedure to transition from SiteConfig CRs to the ClusterInstance API].
+
+For more information about the SiteConfig Operator, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/multicluster_engine_operator_with_red_hat_advanced_cluster_management/index#siteconfig-intro[SiteConfig].
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2136](https://issues.redhat.com/browse/TELCODOCS-2136)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Installing managed clusters with SiteConfig resources and RHACM](https://87629--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-clusters-at-scale.html#ztp-creating-ztp-crs-for-multiple-managed-clusters_ztp-deploying-far-edge-clusters-at-scale)
- [Deploying a managed cluster with SiteConfig and  GitOps ZTP](https://87629--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-sites.html#ztp-deploying-a-site_ztp-deploying-far-edge-sites)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->