### PR TITLE
[OCPBUGS-49341] troubleshooting/operating-system: Fix incomplete note for kdump

### DIFF
--- a/modules/troubleshooting-enabling-kdump-day-one.adoc
+++ b/modules/troubleshooting-enabling-kdump-day-one.adoc
@@ -70,14 +70,15 @@ systemd:
 
 [NOTE]
 ====
-To export the dumps to NFS targets, the `nfs` kernel module must be explicitly added to the configuration file:
+To export the dumps to NFS targets, some kernel modules must be explicitly added to the configuration file:
 
 .Example `/etc/kdump.conf` file
 [source,text]
 ----
 nfs server.example.com:/export/cores
 core_collector makedumpfile -l --message-level 7 -d 31
-extra_modules nfs
+extra_bins /sbin/mount.nfs 
+extra_modules nfs nfsv3 nfs_layout_nfsv41_files blocklayoutdriver nfs_layout_flexfiles nfs_layout_nfsv41_files
 ----
 ====
 


### PR DESCRIPTION
fixes incorrect config for kdump over NFS

In 89a77acfc1b7a72106c6b9701b14b095ee73bfe9 [1] i updated the doc to add the required steps to enable kdump over NFS for OCP 4.16 and above, but I did not include all the necessary modules, resulting in a wrong documentation.

This is the complete and working solution, verified in [2]

Note that this will be obsoleted and can be removed once [3] is fixed.

[1]: https://github.com/openshift/openshift-docs/pull/78300
[2]: https://access.redhat.com/solutions/7063108
[3]: https://issues.redhat.com/browse/RHEL-74401


Version(s):
4.16 and above 

Issue: 

Link to docs preview:
https://87630--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operating-system-issues.html

QE review:
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
