### PR TITLE
[WIP] OSDOCS-12318: adding procedure for using image mode for RHEL

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -76,8 +76,12 @@ Name: Installing with RHEL image mode
 Dir: microshift_install_bootc
 Distros: microshift
 Topics:
-- Name: Installing with RHEL image mode
-  File: microshift-install-rhel-image-mode
+- Name: Understanding image mode for RHEL
+  File: microshift-about-rhel-image-mode
+- Name: Managing the bootc image
+  File: microshift-install-rhel-bootc-image
+- Name: Running the bootc image
+  File: microshift-install-running-bootc-image-in-VM
 ---
 Name: Updating
 Dir: microshift_updating

--- a/microshift_install_bootc/microshift-about-rhel-image-mode.adoc
+++ b/microshift_install_bootc/microshift-about-rhel-image-mode.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="microshift-install-rhel-image-mode"]
+[id="microshift-about-rhel-image-mode"]
 include::_attributes/attributes-microshift.adoc[]
-= Using image mode for RHEL with {microshift-short}
-:context: microshift-install-rhel-image-mode
+= Understanding image mode for RHEL with {microshift-short}
+:context: microshift-about-rhel-image-mode
 
 toc::[]
 
@@ -13,10 +13,6 @@ You can embed {microshift-short} into an operating system image using image mode
 include::snippets/technology-preview.adoc[]
 
 include::modules/microshift-install-rhel-image-mode-conc.adoc[leveloffset=+1]
-
-include::modules/microshift-install-rhel-image-mode-build-image.adoc[leveloffset=+1]
-
-include::modules/microshift-install-rhel-image-mode-publish-image.adoc[leveloffset=+1]
 
 [id="_additional-resources_microshift-install-rhel-image-mode_{context}"]
 == Additional resources

--- a/microshift_install_bootc/microshift-install-rhel-bootc-image.adoc
+++ b/microshift_install_bootc/microshift-install-rhel-bootc-image.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-install-rhel-bootc-image"]
+include::_attributes/attributes-microshift.adoc[]
+= Managing the bootc image
+:context: microshift-install-rhel-bootc-image
+
+toc::[]
+
+{microshift-short} is built and published as image mode containers. When installing a {op-system-base-full} bootable container image with {microshift-short}, use either a prebuilt bootable container image or build your own custom bootable container image.
+
+include::modules/microshift-install-rhel-obtain-published-bootc-image.adoc[leveloffset=+1]
+
+include::modules/microshift-install-rhel-image-mode-build-image.adoc[leveloffset=+1]
+
+include::modules/microshift-install-rhel-image-mode-publish-image.adoc[leveloffset=+2]

--- a/microshift_install_bootc/microshift-install-running-bootc-image-in-VM.adoc
+++ b/microshift_install_bootc/microshift-install-running-bootc-image-in-VM.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-install-running-bootc-image-in-VM"]
+include::_attributes/attributes-microshift.adoc[]
+= Running the bootc image
+:context: microshift-install-running-bootc-image-in-VM
+
+toc::[]
+
+Use the bootable container image as an installation source to set up a {op-system-base-full} system.
+
+include::modules/microshift-install-rhel-image-prepare-kickstart.adoc[leveloffset=+1]
+include::modules/microshift-install-rhel-image-creating-virtual-machine.adoc[leveloffset=+1]

--- a/modules/microshift-install-rhel-image-creating-virtual-machine.adoc
+++ b/modules/microshift-install-rhel-image-creating-virtual-machine.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// microshift_install_bootc/microshift-install-running-bootc-image-in-VM.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-install-rhel-image-creating-virtual-machine_{context}"]
+= Creating virtual machine
+
+You can create a virtual machine by using the following procedure.
+
+.Procedure
+
+. Download the {op-system-base-full} boot ISO image from the link:https://developers.redhat.com/products/rhel/download.
+
+. Copy the downloaded file to the `/var/lib/libvirt/images` directory.
+
+. Create a {op-system-base-full} virtual machine with 2 cores, 2GB of RAM and 20GB of storage by running the following command:
++
+[source,terminal]
+----
+$ VMNAME=microshift-4.17-bootc
+$ NETNAME=default
+
+$ sudo virt-install \
+    --name ${VMNAME} \
+    --vcpus 2 \
+    --memory 2048 \
+    --disk path=/var/lib/libvirt/images/${VMNAME}.qcow2,size=20 \
+    --network network=${NETNAME},model=virtio \
+    --events on_reboot=restart \
+    --location /var/lib/libvirt/images/rhel-9.4-$(uname -m)-boot.iso \
+    --initrd-inject kickstart.ks \
+    --extra-args "inst.ks=file://kickstart.ks" \
+    --wait
+----
++
+[NOTE]
+====
+The command uses the Kickstart file to pull a bootc image from the remote registry and install the {op-system-base-full} operating system.
+====
+
+. Log in to the virtual machine by using your `redhat` credentials.
+
+.Verification
+
+. Verify that all the {microshift-short} pods are running without error, by running the following command:
++
+[source,terminal]
+----
+$ watch sudo oc get pods -A \
+    --kubeconfig /var/lib/microshift/resources/kubeadmin/kubeconfig
+----
++
+.Example output
+[source,text]
+----
+NAMESPACE                  NAME                                       READY   STATUS    RESTARTS      AGE
+kube-system                csi-snapshot-controller-7cfb9df49c-kc9dx   1/1     Running   0             31s
+kube-system                csi-snapshot-webhook-5c6b978878-jzk5r      1/1     Running   0             28s
+openshift-dns              dns-default-rpnlt                          2/2     Running   0             14s
+openshift-dns              node-resolver-rxvdk                        1/1     Running   0             31s
+openshift-ingress          router-default-69cd7b5545-7zcw7            1/1     Running   0             29s
+openshift-ovn-kubernetes   ovnkube-master-c7hlh                       4/4     Running   1 (16s ago)   31s
+openshift-ovn-kubernetes   ovnkube-node-mkpht                         1/1     Running   1 (17s ago)   31s
+openshift-service-ca       service-ca-5d5d96459d-5pd5s                1/1     Running   0             28s
+openshift-storage          topolvm-controller-677cbfcdb9-28dqr        5/5     Running   0             31s
+openshift-storage          topolvm-node-6fzbl                         3/3     Running   0             14s
+----

--- a/modules/microshift-install-rhel-image-mode-build-image.adoc
+++ b/modules/microshift-install-rhel-image-mode-build-image.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// microshift_install_bootc/microshift-install-rhel-image-mode.adoc
+// microshift_install_bootc/microshift-install-rhel-bootc-image.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-rhel-image-mode-build-image_{context}"]

--- a/modules/microshift-install-rhel-image-mode-conc.adoc
+++ b/modules/microshift-install-rhel-image-mode-conc.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// microshift_install_bootc/microshift-install-rhel-image-mode.adoc
+// microshift_install_bootc/microshift-about-rhel-image-mode
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-rhel-image-mode-conc_{context}"]
-= Image mode for {op-system-base-full}
+= About image mode for {op-system-base-full}
 
 Image mode for {op-system-base-full} is a Technology Preview deployment method that uses a container-native approach to build, deploy, and manage the operating system as a bootc image. By using bootc, you can build, deploy, and manage the operating system as if it is any other container.
 
@@ -25,13 +25,13 @@ To use image mode for {op-system-base}, ensure that the following resources are 
 
 * A {op-system-base} 9.4 host with an active Red Hat subscription for building {microshift-short} bootc images.
 * A remote registry for storing and accessing bootc images.
-* You can use image mode for RHEL with a {microshift-short} cluster on AArch64 or x86_64 system architectures.
+* You can use image mode for RHEL with a {microshift-short} cluster on aarch64 or x86_64 system architectures.
 
 The workflow for using image mode with {microshift-short} includes the following steps:
 
-. Build the {microshift-short} bootc image.
-. Publish the image.
-. Run the image. This step includes configuring {microshift-short} networking and storage.
+. Find and use a prebuilt {microshift-short} container image to install {op-system-base-full}.
+. Build a custom {microshift-short} container image if the prebuilt {microshift-short} container image requires customization.
+. Run the container image.
 
 [IMPORTANT]
 ====

--- a/modules/microshift-install-rhel-image-mode-publish-image.adoc
+++ b/modules/microshift-install-rhel-image-mode-publish-image.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// microshift_install_bootc/microshift-install-rhel-image-mode.adoc
+// microshift_install_bootc/microshift-install-rhel-bootc-image.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-rhel-image-mode-publish-image_{context}"]

--- a/modules/microshift-install-rhel-image-prepare-kickstart.adoc
+++ b/modules/microshift-install-rhel-image-prepare-kickstart.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// microshift_install_bootc/microshift-install-running-bootc-image-in-VM.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-install-rhel-image-prepare-kickstart_{context}"]
+= Creating the Kickstart file
+
+You can create the Kickstart file to be used during installation by using the following procedure.
+
+.Prerequisites
+
+* You have root user access.
+* You are logged in to the physical hypervisor host.
+
+.Procedure
+
+. Set the variables to reference the secret files in the `kickstart.ks` file to authenticate private container registry access by running the following command:
++
+[source,terminal]
+----
+$ AUTH_CONFIG=~/.quay-auth.json
+----
+
+. Set the variables to reference the secret files in the `kickstart.ks` file to authenticate {OCP-short} registry access by running the following command:
++
+[source,terminal]
+----
+$ PULL_SECRET=~/.pull-secret.json
+----
+
+. Set the variable to reference the image mode container image to be used during installation by running the following command:
++
+[source,terminal]
+----
+$ IMAGE_REF="quay.io/<myorg>/<mypath>/microshift-4.17-bootc" <1>
+----
+<1> Replace _<myorg>_ with your remote registry organization name and _<mypath>_ with your remote registry organization path.
+
+. Create the `kickstart.ks` file to be used during installation by running the following command:
++
+[source,terminal]
+----
+$ cat > kickstart.ks <<EOFKS
+lang en_US.UTF-8
+keyboard us
+timezone UTC
+text
+reboot
+
+# Partition the disk with hardware-specific boot and swap partitions, adding an
+# LVM volume that contains a 10GB+ system root. The remainder of the volume will
+# be used by the CSI driver for storing data.
+zerombr
+clearpart --all --initlabel
+# Create boot and swap partitions as required by the current hardware platform
+reqpart --add-boot
+# Add an LVM volume group and allocate a system root logical volume
+part pv.01 --grow
+volgroup rhel pv.01
+logvol / --vgname=rhel --fstype=xfs --size=10240 --name=root
+
+# Lock root user account
+rootpw --lock
+
+# Configure network to use DHCP and activate on boot
+network --bootproto=dhcp --device=link --activate --onboot=on
+
+%pre-install --log=/dev/console --erroronfail
+
+# Create a 'bootc' image registry authentication file
+mkdir -p /etc/ostree
+cat > /etc/ostree/auth.json <<'EOF'
+$(cat "${AUTH_CONFIG}")
+EOF
+
+%end
+
+# Pull a 'bootc' image from a remote registry
+ostreecontainer --url "${IMAGE_REF}"
+
+%post --log=/dev/console --erroronfail
+
+# Create an OpenShift pull secret file
+cat > /etc/crio/openshift-pull-secret <<'EOF'
+$(cat "${PULL_SECRET}")
+EOF
+chmod 600 /etc/crio/openshift-pull-secret
+
+%end
+EOFKS
+----

--- a/modules/microshift-install-rhel-obtain-published-bootc-image.adoc
+++ b/modules/microshift-install-rhel-obtain-published-bootc-image.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// microshift_install_bootc/microshift-install-rhel-bootc-image.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-install-rhel-obtain-published-bootc-image_{context}"]
+= Obtaining the published bootc image
+
+Use the following procedure to find and use the {microshift-short} container images to install {op-system-base-full}.
+
+.Procedure
+
+. Navigate to the link link:https://catalog.redhat.com/[Red Hat Ecosystem Catalog].
+
+. Search for the {microshift-short} container image using the `MicroShift Bootc Image` keyword.
+
+. Open the container image page of the {microshift-short} container image.
+
+. View the `Overview` and `Technical Information` tabs, to get more details about the image.
+
+. Select the `Get this image` tab to view instructions for downloading the image.
+
+. Get access to the latest image on x86_64 and aarch64 platforms by running the following commands:
++
+[NOTE]
+====
+Only the x86_64 and aarch64 platforms are supported for {microshift-short}.
+====
++
+[source,terminal]
+----
+$ sudo podman login registry.redhat.io
+----
++
+[source,terminal]
+----
+$ sudo podman pull registry.redhat.io/microshift/microshift-bootc:4.18
+----


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-12318](https://issues.redhat.com/browse/OSDOCS-12318)

Link to docs preview:
[Understanding image mode for RHEL with MicroShift](https://87637--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-about-rhel-image-mode.html)
[Managing the bootc image](https://87637--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-rhel-bootc-image)
[Running the bootc image](https://87637--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-running-bootc-image-in-vm)


QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
