### PR TITLE
OSDOCS-12662-416: adds install concepts to 4.16

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -49,6 +49,8 @@ Name: Installing
 Dir: microshift_install
 Distros: microshift
 Topics:
+- Name: Getting ready to install
+  File: microshift-install-get-ready
 - Name: Installing from an RPM package
   File: microshift-install-rpm
 - Name: Using FIPS mode

--- a/microshift_configuring/microshift-using-config-tools.adoc
+++ b/microshift_configuring/microshift-using-config-tools.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes-microshift.adoc[]
 [id="microshift-using-config-tools"]
-= Using the {microshift-short} config.yaml
+= Using the {microshift-short} configuration file
 :context: microshift-configuring
 
 toc::[]

--- a/microshift_install/microshift-install-get-ready.adoc
+++ b/microshift_install/microshift-install-get-ready.adoc
@@ -1,0 +1,89 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes-microshift.adoc[]
+[id="microshift-install-get-ready"]
+= Getting ready to install {microshift-short}
+:context: microshift-install-get-ready
+
+toc::[]
+
+Plan for your {op-system-bundle} by planning your {op-system-base-full} installation type and your {microshift-short} configuration.
+
+include::modules/microshift-install-system-requirements.adoc[leveloffset=+1]
+
+[id="get-ready-install-rhde-compatibility-table_{context}"]
+== Compatibility table
+
+Plan to pair a supported version of {op-system-ostree} with the {microshift-short} version you are using as described in the following compatibility table.
+
+include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
+
+[id="microshift-get-ready-install-tools-intro_{context}"]
+== {microshift-short} installation tools
+
+To use {microshift-short}, you must already have or plan to install a {op-system-base} type, such as on bare metal, or as a virtual machine (VM) that you provision. Although each use case has different details, each installation of {op-system-bundle} uses {op-system-base} tools and the {oc-first}.
+
+You can use RPMs to install {microshift-short} on an existing {op-system-base} machine. See xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing from an RPM package] for more information. No other tools are required unless you are also installing an image-based {op-system-base} system or VM at the same time.
+
+[id="microshift-get-ready-install-rhel-types_{context}"]
+== {op-system-base} installation types
+
+Where you want to run your cluster and what your application needs to do determine the {op-system-base} installation type that you choose. For every installation target, you must configure both the operating system and {microshift-short}. Consider your application storage needs, networking for cluster or application access, and your authentication and security requirements.
+
+Understand the differences between the {op-system-base} installation types, including the support scope of each, and the tools used.
+
+[id="microshift-get-ready-install-rpm_{context}"]
+=== Using RPMs, or package-based installation
+
+This simple installation type uses a basic command to install {microshift-short} on an existing {op-system-base} machine. See xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing from an RPM package] for more information. No other tools are required unless you are also installing a {op-system-base} system or virtual machine (VM) at the same time.
+
+[id="microshift-get-ready-install-rhel-image-based_{context}"]
+=== {op-system-base} image-based installation
+
+Image-based installation types involve creating an `rpm-ostree`-based, immutable version of {op-system-base} that is optimized for edge deployment.
+
+* {op-system-ostree} can be deployed to the edge in production environments. This installation type can be used where network connections are present or completely offline, depending on the local environment.
+
+When choosing an image-based installation, consider whether the installation target is intended to be in an offline or networked state, where you plan to build system images, and how you plan to load your {op-system-bundle}. Use the following scenarios as general guidance:
+
+** If you build either a fully self-contained {op-system-ostree} ISO outside a disconnected environment, and then install the ISO locally on your edge devices, you likely do not need an RPM repository or a mirror registry.
+** If you build an ISO outside a disconnected environment that does not include the container images, but consists of only the RPMs, you need a mirror registry inside your disconnected environment. You use your mirror registry to pull container images.
+** If you build images inside a disconnected environment, or use package mode for installations, you need both a mirror registry and a local RPM mirror repository. You can use either the {op-system-base} reposync utility or Red{nbsp}Hat Satellite for advanced use cases. See link:https://access.redhat.com/solutions/7019225[How to create a local mirror of the latest update for Red{nbsp}Hat Enterprise Linux 8 and 9 without using Satellite Server] and link:https://www.redhat.com/en/technologies/management/satellite[Red{nbsp}Hat Satellite] for more information.
+
+[id="microshift-get-ready-install-rhel-tools-concepts_{context}"]
+== {op-system-base} installation tools and concepts
+
+Familiarize yourself with the following {op-system-base} tools and concepts:
+
+* A Kickstart file, which contains the configuration and instructions used during the installation of your specific operating system.
+
+* {op-system-base} image builder is a tool for creating deployment-ready customized system images. {op-system-base} image builder uses a blueprint that you create to make the ISO. {op-system-base} image builder is best installed on a {op-system-base} VM and is built with the `composer-cli` tool. To set up these tools and review the workflow, see the following {op-system-base} documentation links:
+** link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-command-line-interface_composing-a-customized-rhel-system-image#composer-command-line-interface_creating-system-images-with-composer-command-line-interface[Introducing the RHEL image builder command-line interface]
+** link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/installing-composer_composing-a-customized-rhel-system-image[Installing image builder]
+** link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-command-line-interface_composing-a-customized-rhel-system-image#creating-a-system-image-with-composer-in-the-command-line-interface_creating-system-images-with-composer-command-line-interface[Creating a system image with RHEL image builder in the command-line interface]
+
+* A blueprint file directs {op-system-base} image builder to the items to include in the ISO. An image blueprint provides a persistent definition of image customizations. You can create multiple builds from a single blueprint. You can also edit an existing blueprint to build a new ISO as requirements change. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-command-line-interface_composing-a-customized-rhel-system-image#creating-a-composer-blueprint-with-command-line-interface_creating-system-images-with-composer-command-line-interface[Creating a blueprint by using the command-line interface] in the {op-system-base} documentation.
+
+* An ISO, which is the bootable operating system on which {microshift-short} runs.
+** See link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/creating-a-boot-iso-installer-image-with-image-builder_composing-a-customized-rhel-system-image#creating-a-boot-iso-installer-image-with-image-builder-in-the-command-line-interface_creating-a-boot-iso-installer-image-with-image-builder[Creating a boot ISO installer image using the RHEL image builder CLI], link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/creating-a-boot-iso-installer-image-with-image-builder_composing-a-customized-rhel-system-image#installing-the-iso-to-a-bare-metal-system_creating-a-boot-iso-installer-image-with-image-builder[Installing a bootable ISO to a media and booting it], and xref:../microshift_install/microshift-embed-in-rpm-ostree.adoc#microshift-embed-in-rpm-ostree[Embedding in a {op-system-ostree} image using image builder].
+
+[id="microshift-get-ready-install-rhde-steps_{context}"]
+== {op-system-bundle} installation steps
+
+For most installation types, you must also take the following steps:
+
+* Download the link:https://console.redhat.com/openshift/install/pull-secret[pull secret] from the Red{nbsp}Hat Hybrid Cloud Console.
+
+* Be ready to configure {microshift-short} by adding parameters and values to the {microshift-short} YAML configuration file. See xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-configuring[Using the {microshift-short} configuration file] for more information.
+
+* Decide whether you need to configure storage for the application and tasks you are using in your {microshift-short} cluster, or disable the {microshift-short} storage plug-in completely.
+** For more information about creating volume groups and persistent volumes on {op-system-base}, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_logical_volumes/overview-of-logical-volume-management_configuring-and-managing-logical-volumes[Overview of logical volume management].
+** For more information about the {microshift-short} plug-in, see xref:../microshift_storage/microshift-storage-plugin-overview.adoc#microshift-storage-plugin-overview[Dynamic storage using the LVMS plugin].
+
+* Configure networking settings according to the access needs you plan for your {microshift-short} cluster and applications. Consider whether you want to use single or dual-stack networks, configure a firewall, or configure routes.
+** For more information about {microshift-short} networking options, see xref:../microshift_networking/microshift-networking-settings.adoc#microshift-networking[Understanding networking settings].
+
+* Install the {oc-first} to access your cluster, see xref:../microshift_cli_ref/microshift-oc-cli-install.adoc#microshift-oc-cli-install[Getting started with the OpenShift CLI].
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../microshift_install/microshift-deploy-with-mirror-registry.adoc#microshift-deployment-mirror[Mirroring container images for disconnected installations].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-12662](https://issues.redhat.com/browse/OSDOCS-12662)

Link to docs preview:
[microshift-install-get-ready](https://87659--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-get-ready.html)

Additional information:
Content was restructured in 4.17+, so this PR adds the assembly back to 4.16 in the original doc structure.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
