### PR TITLE
OCPBUGS#44579: prevent unintended unsupported sys config

### DIFF
--- a/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree.adoc
@@ -10,6 +10,8 @@ You can embed {microshift-short} into a {op-system-ostree-first} image. Use this
 
 include::modules/microshift-preparing-for-image-building.adoc[leveloffset=+1]
 
+include::modules/microshift-embed-ostree-enable-eus-repos.adoc[leveloffset=+1]
+
 include::modules/microshift-adding-repos-to-image-builder.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/microshift_troubleshooting/microshift-things-to-know.adoc
+++ b/microshift_troubleshooting/microshift-things-to-know.adoc
@@ -2,7 +2,7 @@
 [id="microshift-things-to-know"]
 = Responsive restarts and security certificates
 include::_attributes/attributes-microshift.adoc[]
-:context: microshift-configuring
+:context: microshift-things-to-know
 
 toc::[]
 

--- a/microshift_updating/microshift-update-options.adoc
+++ b/microshift_updating/microshift-update-options.adoc
@@ -14,6 +14,8 @@ You can update {op-system-ostree-first} images or {op-system-base-full} with or 
 
 include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 
+include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
+
 [id="microshift-update-options-standalone-updates_{context}"]
 == Standalone {microshift-short} updates
 Consider the following when planning to update {microshift-short}:
@@ -61,10 +63,7 @@ You can update {microshift-short} manually on a non-OSTree system such as {op-sy
 
 * xref:../microshift_updating/microshift-update-rpms-manually.adoc#microshift-update-rpms-manually[About updating MicroShift RPMs manually]
 
-[WARNING]
-====
-Keeping versions in a supported configuration of {op-system-bundle} can require updating {microshift-short} and {op-system-base} at the same time. Ensure that your version of {op-system-base} is compatible with the version of {microshift-short} you are updating to, especially if you are updating {microshift-short} across two minor versions. Otherwise, you can create an unsupported configuration, break your cluster, or both.
-====
+include::modules/microshift-updates-rhde-config-rhel-repos.adoc[leveloffset=+3]
 
 [id="microshift-update-options-standalone-rhel-updates_{context}"]
 == Standalone {op-system-ostree} updates
@@ -87,7 +86,7 @@ You can update {op-system-ostree} or {op-system-base} and update {microshift-sho
 //additional resources for updating RHEL and MicroShift
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[Managing RHEL for Edge images]
+* link:https://access.redhat.com/articles/rhel-eus#c5[How to Access EUS]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/index[Composing a customized RHEL system image]
 * xref:../microshift_updating/microshift-update-rpms-ostree.adoc#microshift-update-rpms-ostree[Applying updates on an OSTree system]
 * xref:../microshift_updating/microshift-update-rpms-manually.adoc#microshift-update-rpms-manually[Applying updates manually with RPMs]

--- a/modules/microshift-embed-ostree-enable-eus-repos.adoc
+++ b/modules/microshift-embed-ostree-enable-eus-repos.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * microshift_install_rpm_ostree/microshift-embed-into-rpm-ostree.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-enable-eus-repos_{context}"]
+= Enabling extended support repositories for image building
+
+If you have an extended support (EUS) release of {microshift-short}, you must enable the {op-system-base-full} EUS repositories for image builder to use. If you do not have an EUS version, you can skip these steps.
+
+.Prerequisites
+
+* You have an EUS version of {microshift-short} or are updating to one.
+* You have root-user access to your build host.
+* You reviewed the link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/getting_ready_to_install_microshift/microshift-install-get-ready#get-ready-install-rhde-compatibility-table_microshift-install-get-ready[{op-system-bundle} release compatibility matrix].
+
+include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
+
+.Procedure
+
+. Update the `baseos` source by modifying the `/etc/osbuild-composer/repositories/rhel-9.4.json` file with the following values:
++
+[source,terminal]
+----
+# ...
+"baseurl": "https://cdn.redhat.com/content/eus/rhel<9>/<9.4>//baseos/os", # <1>
+# ...
+----
+<1> Replace _<9>_ with the major {op-system-base} version you are using, and replace _<9.4>_ with the _<major.minor>_ version. Be certain that the {op-system-base} version you choose is compatible with the {microshift-short} version you are using.
+
+. Optional. Apply the `baseos` update by running the following command:
++
+[source,terminal]
+----
+$ sudo sed -i "s,dist/rhel<9>/<9.4>/$(uname -m)/baseos/,eus/rhel<9>/<9.4>/$(uname -m)/baseos/,g" \
+/etc/osbuild-composer/repositories/rhel-<9.4>.json # <1>
+----
+<1> Replace _<9>_ with the major {op-system-base} version you are using, and replace _<9.4>_ with the _<major.minor>_ version. Be certain that the {op-system-base} version you choose is compatible with the {microshift-short} version you are using.
+
+. Update the `appstream` source by modifying the `/etc/osbuild-composer/repositories/rhel-<major.minor>.json` file with the following values:
++
+[source,terminal]
+----
+# ...
+"baseurl": "https://cdn.redhat.com/content/eus/rhel<9>/<9.4>//appstream/os", # <1>
+# ...
+----
+<1> Replace _<9>_ with the major {op-system-base} version you are using, and replace _<9.4>_ with the _<major.minor>_ version. Be certain that the {op-system-base} version you choose is compatible with the {microshift-short} version you are using.
+
+. Optional. Apply the `appstream` update by running the following command:
++
+[source,terminal]
+----
+$ sudo sed -i "s,dist/rhel<9>/<9.4>/$(uname -m)/appstream/,eus/rhel<9>/<9.4>/$(uname -m)/appstream/,g" \
+/etc/osbuild-composer/repositories/rhel-<9.4>.json # <1>
+----
+<1> Replace _<9>_ with the major {op-system-base} version you are using, and replace _<9.4>_ with the _<major.minor>_ version. Be certain that the {op-system-base} version you choose is compatible with the {microshift-short} version you are using.
+
+.Verification
+
+You can verify the repositories by using the `composer-cli` tool to display information about the source.
+
+. Verify the `baseos` source by running the following command:
++
+[source,terminal]
+----
+$ sudo composer-cli sources info baseos | grep 'url ='
+----
+.Example output
++
+[source,text]
+----
+url = "https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os"
+----
+
+. Verify the `appstream` source by running the following command:
++
+[source,terminal]
+----
+$ sudo composer-cli sources info appstream | grep 'url ='
+----
+.Example output
++
+[source,text]
+----
+url = "https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os"
+----

--- a/modules/microshift-install-rpms.adoc
+++ b/modules/microshift-install-rpms.adoc
@@ -15,14 +15,35 @@ Use the following procedure to install {microshift-short} from an RPM package.
 
 .Procedure
 
-. As a root user, enable the {microshift-short} repositories by running the following command:
+. For all lifecycles, enable the repository for your release by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-{ocp-version}-for-{rhel-major}-$(uname -m)-rpms \
-    --enable fast-datapath-for-{rhel-major}-$(uname -m)-rpms
+    --enable rhocp-<4.18>-for-<9>-$(uname -m)-rpms \ # <1>
+    --enable fast-datapath-for-<9>-$(uname -m)-rpms # <2>
 ----
+<1> Replace _<4.18>_ and _<9>_ with the compatible versions of your {microshift-short} and {op-system-base-full}.
+<2> Replace  _<9>_ with the compatible version of {op-system-base}.
+
+. For extended support (EUS) releases, also enable the EUS repositories by running the following command:
++
+[source,terminal]
+----
+`$ sudo subscription-manager repos \
+    --enable rhel-<9>-for-x86_64-appstream-eus-rpms \ # <1>
+    --enable rhel-<9>-for-x86_64-baseos-eus-rpms` # <2>
+----
+<1> Replace _<9>_ with the compatible major version number of {op-system-base}.
+<2> Replace _<9>_ with the compatible major version number of {op-system-base}.
+
+. Avoid unintended future updates into an unsupported configuration by locking your operating system version with the following command:
++
+[source,terminal]
+----
+$ sudo subscription-manager release --set=<9.4> command. # <1>
+----
+<1> Replace _<9.4>_ with the major and minor version of your compatible {op-system-base} system.
 
 . Install {microshift-short} by running the following command:
 +

--- a/modules/microshift-updates-rhde-config-rhel-repos.adoc
+++ b/modules/microshift-updates-rhde-config-rhel-repos.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+//microshift_updating/microshift-update-options.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-updates-rhde-config-rhel-repos_{context}"]
+= Keeping {microshift-short} and {op-system-base} in a supported configuration
+
+When using RPM updates, avoid creating an unsupported configuration or breaking your cluster by carefully managing your {op-system-base} repositories.
+
+.Prerequisites
+
+* You understand the support status of the version of {microshift-short} you are using.
+* You have root-user access to your build host.
+* You reviewed the link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/getting_ready_to_install_microshift/microshift-install-get-ready#get-ready-install-rhde-compatibility-table_microshift-install-get-ready[{op-system-bundle} release compatibility matrix].
+
+.Procedure
+
+. Avoid unintended updates by locking your operating system version by running the following command:
++
+[source,terminal]
+----
+$ sudo subscription-manager release --set=<x.y> # <1>
+----
+<1> Replace _<x.y>_ with the major and minor version of your compatible {op-system-base} system. For example, _9.4_.
+
+. Update both {microshift-short} and {op-system-base} versions by running the following command:
++
+[source,terminal]
+----
+$ sudo subscription-manager release --set=<9.4> command. # <1>
+----
+<1> Replace _<9.4>_ with the major and minor version of your compatible {op-system-base} system.
+
+. If you are using an EUS {microshift-short} release, disable the {op-system-base} standard-support-scope repositories by running the following command:
++
+[source,terminal]
+----
+$ sudo subscription-manager repos \
+    --disable=rhel-<9>-for-x86_64-appstream-rpms \ # <1>
+    --disable=rhel-<9>-for-x86_64-baseos-rpms
+----
+<1> Replace _<9>_ with the major version of your compatible {op-system-base} system.
+
+. After you disable the standard-support repositories, enable the {op-system-base} EUS repos by running the following command:
++
+[source,terminal]
+----
+$ sudo subscription-manager repos \
+    --enable rhel-<9>-for-x86_64-appstream-eus-rpms \  # <1>
+    --enable rhel-<9>-for-x86_64-baseos-eus-rpms`
+----
+<1> Replace _<9>_ with the major version of your compatible {op-system-base} system.
+
+.Verification
+
+*  List the repositories you have enabled for {op-system-base} by running the following command:
++
+[source,terminal]
+----
+$ sudo subscription-manager repos --list-enabled
+----
++
+.Example output
++
+[source,terminal]
+----
++----------------------------------------------------------+
+    Available Repositories in /etc/yum.repos.d/redhat.repo
++----------------------------------------------------------+
+Repo ID:   rhel-9-for-x86_64-baseos-eus-rpms
+Repo Name: Red Hat Enterprise Linux 9 for x86_64 - BaseOS - Extended Update Support (RPMs)
+Repo URL:  https://cdn.redhat.com/content/eus/rhel9/$releasever/x86_64/baseos/os
+Enabled:   1
+Repo ID:   rhel-9-for-x86_64-appstream-eus-rpms
+Repo Name: Red Hat Enterprise Linux 9 for x86_64 - AppStream - Extended Update Support (RPMs)
+Repo URL:  https://cdn.redhat.com/content/eus/rhel9/$releasever/x86_64/appstream/os
+Enabled:   1
+----

--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -8,6 +8,8 @@
 
 Updating a {microshift-short} minor version on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to update from 4.16 to 4.18.
 
+include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
+
 .Prerequisites
 * The system requirements for installing {microshift-short} have been met.
 * You have root user access to the host.
@@ -22,14 +24,35 @@ You cannot downgrade {microshift-short} with this process. Downgrades are not su
 
 .Procedure
 
-. Enable the {microshift-short} repositories by running the following command:
+. For all lifecycles, enable the repository for your release by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-{ocp-version}-for-{rhel-major}-$(uname -m)-rpms \
-    --enable fast-datapath-for-{rhel-major}-$(uname -m)-rpms
+    --enable rhocp-<4.18>-for-<9>-$(uname -m)-rpms \ # <1>
+    --enable fast-datapath-for-<9>-$(uname -m)-rpms # <2>
 ----
+<1> Replace _<4.18>_ and _<9>_ with the compatible versions of your {microshift-short} and {op-system-base-full}.
+<2> Replace  _<9>_ with the compatible version of {op-system-base}.
+
+. For extended support (EUS) releases, also enable the EUS repositories by running the following command:
++
+[source,terminal]
+----
+`$ sudo subscription-manager repos \
+    --enable rhel-<9>-for-x86_64-appstream-eus-rpms \ # <1>
+    --enable rhel-<9>-for-x86_64-baseos-eus-rpms` # <2>
+----
+<1> Replace _<9>_ with the compatible major version number of {op-system-base}.
+<2> Replace _<9>_ with the compatible major version number of {op-system-base}.
+
+. Avoid unintended future updates into an unsupported configuration by locking your operating system version with the following command:
++
+[source,terminal]
+----
+$ sudo subscription-manager release --set=<9.4> command. # <1>
+----
+<1> Replace _<9.4>_ with the major and minor version of your compatible {op-system-base} system.
 
 . Update the {microshift-short} RPMs by running the following command:
 +

--- a/snippets/microshift-unsupported-config-warn.adoc
+++ b/snippets/microshift-unsupported-config-warn.adoc
@@ -1,0 +1,12 @@
+// Text snippet included in the following modules:
+//
+// * modules/microshift-updating-rpms-y.adoc
+// * modules/microshift-embed-ostree-enable-eus-repos.adoc
+// * assemblies/microshift-update-options.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[WARNING]
+====
+Keeping component versions in a supported configuration of {op-system-bundle} can require updating {microshift-short} and {op-system-base} at the same time. Ensure that your version of {op-system-base} is compatible with the version of {microshift-short} you are updating to, especially if you are updating {microshift-short} across two minor versions. Otherwise, you can create an unsupported configuration, break your cluster, or both. For more information, see the link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/getting_ready_to_install_microshift/microshift-install-get-ready#get-ready-install-rhde-compatibility-table_microshift-install-get-ready[Red Hat Device Edge release compatibility matrix].
+====


### PR DESCRIPTION
Version(s):
4.17, 4.18

Issue:
[OCPBUGS-44579](https://issues.redhat.com/browse/OCPBUGS-44579)

Link to docs preview:
[Installing from an RPM](https://87660--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm/microshift-install-rpm.html#installing-microshift-from-rpm-package_microshift-install-rpm)
[Enabling extended support repositories for image building](https://87660--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree.html#microshift-enable-eus-repos_microshift-embed-in-rpm-ostree)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This might backport all the way to 4.14., but will require manual backporting due to changes in content structure.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
