### PR TITLE
OSDOCS-13183: update CSI snapshot docs to remove webhook

### DIFF
--- a/microshift_networking/microshift_network_policy/microshift-network-policy-index.adoc
+++ b/microshift_networking/microshift_network_policy/microshift-network-policy-index.adoc
@@ -3,6 +3,7 @@
 = About network policies
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-network-policies
+
 toc::[]
 
 Learn how network policies work for {microshift-short} to restrict or allow network traffic to pods in your cluster.

--- a/microshift_storage/volume-snapshots-microshift.adoc
+++ b/microshift_storage/volume-snapshots-microshift.adoc
@@ -28,11 +28,11 @@ Only the logical volume manager storage (LVMS) plugin CSI driver is supported by
 
 * xref:../microshift_storage/understanding-persistent-storage-microshift.adoc#persistent-volumes_understanding-persistent-storage-microshift[Understanding persistent volumes]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/configuring_and_managing_logical_volumes/creating-and-managing-thin-provisioned-volumes_configuring-and-managing-logical-volumes[Configuring and managing logical volumes]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_logical_volumes/managing-lvm-volume-groups_configuring-and-managing-logical-volumes[Managing LVM volume groups] ({op-system-base} documentation)
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/storage/using-container-storage-interface-csi#persistent-storage-csi-snapshots[CSI snapshots: `VolumeSnapshot` APIs]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/storage/using-container-storage-interface-csi#persistent-storage-csi-snapshots[CSI snapshots: `VolumeSnapshot` APIs] ({OCP} documentation)
 
-* link:https://docs.openshift.com/container-platform/{ocp-version}/rest_api/storage_apis/volumesnapshot-snapshot-storage-k8s-io-v1.html[VolumeSnapshot API specification]
+* link:https://docs.openshift.com/container-platform/{ocp-version}/rest_api/storage_apis/volumesnapshot-snapshot-storage-k8s-io-v1.html[VolumeSnapshot API specification] ({OCP} documentation)
 
 include::modules/microshift-lvm-thin-volumes.adoc[leveloffset=+1]
 
@@ -40,11 +40,9 @@ include::modules/microshift-lvm-thin-volumes.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* To create a thin pool on the host, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/configuring_and_managing_logical_volumes/creating-and-managing-thin-provisioned-volumes_configuring-and-managing-logical-volumes[Creating and managing thin provisioned volumes]
+* To create a thin pool on the host, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_logical_volumes/basic-logical-volume-management_configuring-and-managing-logical-volumes#creating-thin-logical-volume_creating-logical-volumes[Creating a thin logical volume] ({op-system-base} documentation)
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/configuring_and_managing_logical_volumes/creating-and-managing-thin-provisioned-volumes_configuring-and-managing-logical-volumes#creating-thinly-provisioned-logical-volumes_creating-and-managing-thin-provisioned-volumes[Creating thinly provisioned logical volumes]
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/configuring_and_managing_logical_volumes/creating-and-managing-thin-provisioned-volumes_configuring-and-managing-logical-volumes[Configuring and managing thin provisioned volumes]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_logical_volumes/creating-and-managing-thin-provisioned-volumes_configuring-and-managing-logical-volumes[Configuring and managing thin provisioned volumes]
 
 * xref:../microshift_storage/volume-snapshots-microshift.adoc#microshift-storage-classes_volume-snapshots-microshift[Storage classes]
 
@@ -56,7 +54,7 @@ include::modules/microshift-storage-classes.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/storage/dynamic-provisioning#defining-storage-classes_dynamic-provisioning[Defining storage classes]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/storage/dynamic-provisioning#defining-storage-classes_dynamic-provisioning[Defining storage classes]
 
 * xref:../microshift_storage/microshift-storage-plugin-overview.adoc#microshift-storage-device-classes_microshift-storage-plugin-overview[Storage device classes]
 
@@ -66,7 +64,7 @@ include::modules/microshift-storage-vol-snapshot-class.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.openshift.com/container-platform/{ocp-version}/storage/container_storage_interface/persistent-storage-csi-snapshots.html#volume-snapshot-crds[OpenShift CSI volume snapshots]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/storage/using-container-storage-interface-csi#persistent-storage-csi-snapshots-overview_persistent-storage-csi-snapshots[OpenShift CSI volume snapshots]
 
 include::modules/microshift-storage-about-vol-snapshots.adoc[leveloffset=+1]
 
@@ -80,7 +78,7 @@ include::modules/microshift-storage-vol-snapshot-restore.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/storage/using-container-storage-interface-csi#persistent-storage-csi-snapshots-provision_persistent-storage-csi-snapshots[Restoring a volume snapshot]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/storage/using-container-storage-interface-csi#persistent-storage-csi-snapshots-restore_persistent-storage-csi-snapshots[Restoring a volume snapshot]
 
 //this module is reused from OCP; take care in editing for MicroShift
 include::modules/persistent-storage-csi-snapshots-delete.adoc[leveloffset=+2]
@@ -91,8 +89,9 @@ include::modules/microshift-storage-volume-cloning.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.openshift.com/container-platform/{ocp-version}/storage/container_storage_interface/persistent-storage-csi-cloning.html[CSI volume cloning]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/storage/using-container-storage-interface-csi#persistent-storage-csi-cloning[CSI volume cloning]
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/storage/configuring-persistent-storage#lvms-creating-volume-clones-in-single-node-openshift_logical-volume-manager-storage[LVMS volume cloning for Single-Node OpenShift]
+//* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/storage/configuring-persistent-storage#lvms-creating-volume-clones-in-single-node-openshift_logical-volume-manager-storage[LVMS volume cloning for Single-Node OpenShift]
+//cannot find new link
 
 * To configure the host to enable cloning, see xref:../microshift_storage/volume-snapshots-microshift.adoc#microshift-lvm-thin-volumes_volume-snapshots-microshift[About LVM thin volumes]

--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -259,5 +259,5 @@ container_memory_working_set_bytes{container=`router`,namespace=`openshift-ingre
 
 |`storage.optionalCsiComponents`
 |`array`
-|Default value is null or an empty array. A null or empty array defaults to deploying `snapshot-controller` and `snapshot-webhook`. Expected values are `csi-snapshot-controller`, `csi-snapshot-webhook`, or `none`. An entry of `none` is mutually exclusive with all other values.
+|Default value is null or an empty array. A null or empty array defaults to deploying `snapshot-controller`. Expected values are `csi-snapshot-controller` or `none`. A value of `none` is mutually exclusive with all other values.
 |===

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -90,4 +90,4 @@ storage:
 <1> Calculated based on the address of the service network.
 <2> The IP address of the default route.
 <3> Default null value deploys Logical Volume Managed Storage (LVMS).
-<4> Default null value deploys `snapshot-controller` and `snapshot-webhook`.
+<4> Default null value deploys `snapshot-controller`.

--- a/modules/microshift-deploying-a-load-balancer.adoc
+++ b/modules/microshift-deploying-a-load-balancer.adoc
@@ -29,7 +29,6 @@ $ oc get pods -A
 NAMESPACE                            NAME                                                     READY   STATUS   RESTARTS  AGE
 default                              i-06166fbb376f14a8bus-west-2computeinternal-debug-qtwcr  1/1     Running	   0		   46m
 kube-system                          csi-snapshot-controller-5c6586d546-lprv4                 1/1     Running	   0		   51m
-kube-system                          csi-snapshot-webhook-6bf8ddc7f5-kz6k9                    1/1     Running	   0		   51m
 openshift-dns                        dns-default-45jl7                                        2/2     Running	   0		   50m
 openshift-dns                        node-resolver-7wmzf                                      1/1     Running	   0		   51m
 openshift-ingress                    router-default-78b86fbf9d-qvj9s                          1/1     Running 	 0		   51m

--- a/modules/microshift-disabling-lvms-csi-snapshot.adoc
+++ b/modules/microshift-disabling-lvms-csi-snapshot.adoc
@@ -32,11 +32,11 @@ This procedure is for users who are defining the configuration file before insta
 <1> Accepted values are:
 * Not defining `optionalCsiComponents`.
 * Specifying `optionalCsiComponents` field with an empty value (`[]`) or a single empty string element (`[""]`).
-* Specifying `optionalCsiComponents` with one of the accepted values which are `snapshot-controller`, `snapshot-webhook`, or `none`. `none` is mutually exclusive with all other values.
+* Specifying `optionalCsiComponents` with one of the accepted values which are `snapshot-controller`, or `none`. A value of `none` is mutually exclusive with all other values.
 +
 [NOTE]
 ====
-If the `optionalCsiComponents` value is empty or null, {microshift-short} defaults to deploying snapshot-controller and snapshot-webhook.
+If the `optionalCsiComponents` value is empty or null, {microshift-short} defaults to deploying snapshot-controller.
 ====
 
 . After the `optionalCsiComponents` field is specified with a supported value in the `config.yaml`, start {microshift-short} by running the following command:

--- a/modules/microshift-disconnected-host-procedure.adoc
+++ b/modules/microshift-disconnected-host-procedure.adoc
@@ -95,7 +95,7 @@ $ sudo systemctl reboot <1>
 
 At this point, network access to the {microshift-short} host has been severed. If you have access to the host terminal, you can use the host CLI to verify that the cluster has started in a stable state.
 
-. Verify that the {microshift-short} cluster is running by entering the following command:
+. Verify that the {microshift-short} cluster is running by entering the following commands:
 +
 [source,terminal]
 ----
@@ -108,7 +108,6 @@ $ sudo -E oc get pods -A
 ----
 NAMESPACE                  NAME                                       READY   STATUS    RESTARTS      AGE
 kube-system                csi-snapshot-controller-74d566564f-66n2f   1/1     Running   0             1m
-kube-system                csi-snapshot-webhook-69bdff8879-xs6mb      1/1     Running   0             1m
 openshift-dns              dns-default-dxglm                          2/2     Running   0             1m
 openshift-dns              node-resolver-dbf5v                        1/1     Running   0             1m
 openshift-ingress          router-default-8575d888d8-xmq9p            1/1     Running   0             1m

--- a/modules/microshift-nw-ipv6-dual-stack-migrating-config.adoc
+++ b/modules/microshift-nw-ipv6-dual-stack-migrating-config.adoc
@@ -106,7 +106,6 @@ $ oc get pod -A -o wide
 ----
 NAMESPACE                  NAME                                      READY   STATUS    RESTARTS        AGE     IP                NODE           NOMINATED NODE   READINESS GATES
 kube-system                csi-snapshot-controller-bb7cb654b-7s5ql   1/1     Running   0               46m     10.42.0.6         microshift-9   <none>           <none>
-kube-system                csi-snapshot-webhook-95f475949-jrqv8      1/1     Running   0               46m     10.42.0.4         microshift-9   <none>           <none>
 openshift-dns              dns-default-zxkqn                         2/2     Running   0               46m     10.42.0.5         microshift-9   <none>           <none>
 openshift-dns              node-resolver-r2h5z                       1/1     Running   0               46m     192.168.113.117   microshift-9   <none>           <none>
 openshift-ingress          router-default-5b75594b4-228z7            1/1     Running   0               2m5s    10.42.0.3         microshift-9   <none>           <none>

--- a/modules/microshift-nw-ipv6-single-stack-config.adoc
+++ b/modules/microshift-nw-ipv6-single-stack-config.adoc
@@ -81,7 +81,6 @@ $ oc get pod -A -o wide
 ----
 NAMESPACE                  NAME                                      READY   STATUS    RESTARTS   AGE   IP                      NODE           NOMINATED NODE   READINESS GATES
 kube-system                csi-snapshot-controller-bb7cb654b-rqrt6   1/1     Running   0          65s   fd01:0:0:1::5           microshift-9   <none>           <none>
-kube-system                csi-snapshot-webhook-95f475949-nbz8x      1/1     Running   0          61s   fd01:0:0:1::6           microshift-9   <none>           <none>
 openshift-dns              dns-default-cjn66                         2/2     Running   0          62s   fd01:0:0:1::9           microshift-9   <none>           <none>
 openshift-dns              node-resolver-ppnjb                       1/1     Running   0          63s   2001:db9:ca7:ff::1db8   microshift-9   <none>           <none>
 openshift-ingress          router-default-6d97d7b8b6-wdtmg           1/1     Running   0          61s   fd01:0:0:1::8           microshift-9   <none>           <none>
@@ -100,11 +99,10 @@ $ oc get svc -A
 ----
 +
 .Example output
-[source,terminal]
+[source,text]
 ----
 NAMESPACE           NAME                            TYPE           CLUSTER-IP   EXTERNAL-IP                                             PORT(S)                      AGE
 default             kubernetes                      ClusterIP      fd02::1      <none>                                                  443/TCP                      3m42s
-kube-system         csi-snapshot-webhook            ClusterIP      fd02::4c4f   <none>                                                  443/TCP                      3m20s
 openshift-dns       dns-default                     ClusterIP      fd02::a      <none>                                                  53/UDP,53/TCP,9154/TCP       2m58s
 openshift-ingress   router-default                  LoadBalancer   fd02::f2e6   2001:db9:ca7:ff::1db8,fd01:0:0:1::2,fd02::1:0,fd69::2   80:31133/TCP,443:31996/TCP   2m58s
 openshift-ingress   router-internal-default         ClusterIP      fd02::c55e   <none>                                                  80/TCP,443/TCP,1936/TCP      2m58s

--- a/modules/microshift-storage-backup-volume-snapshots.adoc
+++ b/modules/microshift-storage-backup-volume-snapshots.adoc
@@ -21,22 +21,26 @@ To find specific snapshots and copy them, use the following procedure.
 +
 [source,terminal]
 ----
-$ oc get volumesnapshot -n <namespace> <snapshot_name> -o 'jsonpath={.status.volumeSnapshotContentName}'
+$ oc get volumesnapshot -n <namespace> <snapshot_name> -o 'jsonpath={.status.volumeSnapshotContentName}' # <1>
 ----
+<1> Replace _<namespace>_ and _<snapshot_name>_ with the namespace and snapshot name you used.
 
 . Get the unique identity of the volume created on the storage backend by using the following command and inserting the name retrieved in the previous step:
 +
 [source,terminal]
 ----
-$ oc get volumesnapshotcontent snapcontent-<retrieved_volume_identity> -o 'jsonpath={.status.snapshotHandle}'
+$ oc get volumesnapshotcontent snapcontent-<retrieved_volume_identity> -o 'jsonpath={.status.snapshotHandle}' # <1>
 ----
+<1> Replace _<retrieved_volume_identity>_ with the volume identity.
 
 . Display the snapshots by using the unique identity of the volume you retrieved in the previous step to determine which one you want to backup by running the following command:
 +
 [source,terminal]
 ----
-$ sudo lvdisplay <retrieved_snapshot_handle>
+$ sudo lvdisplay <retrieved_volume_identity> # <1>
 ----
+<1> Replace _<retrieved_volume_identity>_ with the volume identity.
+
 +
 .Example output
 [source,terminal]
@@ -73,12 +77,14 @@ $ sudo mkdir /mnt/snapshot
 +
 [source,terminal]
 ----
-$ sudo mount /dev/<retrieved_snapshot_handle> /mnt/snapshot
+$ sudo mount /dev/<retrieved_snapshot_handle> /mnt/snapshot # <1>
 ----
+<1> Replace _<retrieved_snapshot_handle>_ with the device name.
 
 . Copy the files from the mounted location and store them in a secure location by running the following command:
 +
 [source,terminal]
 ----
-$ sudo cp -r /mnt/snapshot <destination>
+$ sudo cp -r /mnt/snapshot <destination> # <1>
 ----
+<1> Replace _<destination>_ with the path to the secure location.

--- a/modules/microshift-uninstalling-lvms-csi-snapshot.adoc
+++ b/modules/microshift-uninstalling-lvms-csi-snapshot.adoc
@@ -11,7 +11,7 @@ To uninstall the installed CSI snapshot implementation, use the following proced
 .Prerequisites
 
 * {microshift-short} is installed and running.
-* The CSI snapshot implementation is deployed on the MicroShift cluster.
+* The CSI snapshot implementation is deployed on the {microshift-short} cluster.
 
 .Procedure
 
@@ -19,12 +19,11 @@ To uninstall the installed CSI snapshot implementation, use the following proced
 +
 [source,terminal]
 ----
-$ oc delete -n kube-system deployment.apps/snapshot-controller deployment.apps/snapshot-webhook
+$ oc delete -n kube-system deployment.apps/snapshot-controller
 ----
 +
 .Example output
 [source,terminal]
 ----
 deployment.apps "snapshot-controller" deleted
-deployment.apps "snapshot-webhook" deleted
 ----

--- a/modules/persistent-storage-csi-snapshots-delete.adoc
+++ b/modules/persistent-storage-csi-snapshots-delete.adoc
@@ -22,7 +22,7 @@ kind: VolumeSnapshotClass
 metadata:
   name: csi-hostpath-snap
 driver: hostpath.csi.k8s.io
-deletionPolicy: Delete <1>
+deletionPolicy: Delete # <1>
 ----
 [.small]
 <1> When deleting the volume snapshot, if the `Delete` value is set, the underlying snapshot is deleted along with the `VolumeSnapshotContent` object. If the `Retain` value is set, both the underlying snapshot and `VolumeSnapshotContent` object remain.
@@ -33,8 +33,9 @@ If the `Retain` value is set and the `VolumeSnapshot` object is deleted without 
 +
 [source,terminal]
 ----
-$ oc delete volumesnapshot <volumesnapshot_name>
+$ oc delete volumesnapshot <volumesnapshot_name> # <1>
 ----
+<1> Replace _<volumesnapshot_name>_ with the name of the volume snapshot you want to delete.
 +
 .Example output
 +
@@ -47,8 +48,9 @@ volumesnapshot.snapshot.storage.k8s.io "mysnapshot" deleted
 +
 [source,terminal]
 ----
-$ oc delete volumesnapshotcontent <volumesnapshotcontent_name>
+$ oc delete volumesnapshotcontent <volumesnapshotcontent_name> # <1>
 ----
+<1> Replace _<volumesnapshotcontent_name>_ with the content you want to delete.
 +
 . Optional: If the `VolumeSnapshot` object is not successfully deleted, enter the following command to remove any finalizers for the leftover resource so that the delete operation can continue:
 +

--- a/snippets/microshift-healthy-pods-snip.adoc
+++ b/snippets/microshift-healthy-pods-snip.adoc
@@ -14,7 +14,6 @@ $ oc get pods -A
 NAMESPACE                   NAME                                                     READY   STATUS   RESTARTS  AGE
 default                     i-06166fbb376f14a8bus-west-2computeinternal-debug-qtwcr  1/1     Running  0		    46m
 kube-system                 csi-snapshot-controller-5c6586d546-lprv4                 1/1     Running  0		    51m
-kube-system                 csi-snapshot-webhook-6bf8ddc7f5-kz6k9                    1/1     Running  0		    51m
 openshift-dns               dns-default-45jl7                                        2/2     Running  0		    50m
 openshift-dns               node-resolver-7wmzf                                      1/1     Running  0		    51m
 openshift-ingress           router-default-78b86fbf9d-qvj9s                          1/1     Running  0		    51m


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-13183](https://issues.redhat.com/browse/OSDOCS-13183)

Link to docs preview:
[Default settings; footnote 4](https://87662--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-yaml-default_microshift-configuring)
[Backing up a volume snapshot-add footnotes](https://87662--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/volume-snapshots-microshift.html#microshift-storage-backup-vol-snaps_volume-snapshots-microshift)
[Deploying a load balancer - healthy pod output](https://87662--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-networking-settings#microshift-deploying-a-load-balancer_microshift-networking)
[IPv6 config - healthy pod output](https://87662--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-nw-ipv6-config#microshift-configuring-ipv6-single-stack-config_microshift-nw-ipv6-config)
[In the NOTE text webhook is removed](https://87662--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot#microshift-disabling-lvms-csi-snapshot_microshift-disable-lvms-csi-provider-csi-snapshot)
[Healthy pods snippet example in Verification](https://87662--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-disconnected-network-config.html#microshift-disconnected-host-network-config_microshift-networking-disconnected-hosts)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
