### PR TITLE
OSDOCS-13235: ROSA-HCP - Image registry release notes

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 [id="rosa-q1-2025_{context}"]
 === Q1 2025
 
+* **Image configuration is now available for {product-title} with {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see /images/image-configuration-hcp#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {product-title} with {hcp-title}].
+
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]
 [IMPORTANT]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -17,7 +17,7 @@ toc::[]
 === Q1 2025
 
 ifndef::openshift-rosa-hcp[]
-* **Image configuration is now available for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
+* **Image configuration is now available for {hcp-title}.** You can filter registries within a cluster to exclude some registries or allow only a defined list. It also allows to expose additional trusted bundle for registries to pull from. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
 endif::openshift-rosa-hcp[]
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,7 +16,7 @@ toc::[]
 [id="rosa-q1-2025_{context}"]
 === Q1 2025
 
-* **Image configuration is now available for {product-title} with {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:../images/image-configuration-hcp#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {product-title} with {hcp-title}].
+* **Image configuration is now available for {product-title} for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:..openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {product-title} with {hcp-title}].
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -15,8 +15,14 @@ toc::[]
 
 [id="rosa-q1-2025_{context}"]
 === Q1 2025
+// These notes needed to be duplicated until the ROSA with HCP split out is completed.
 
+ifdef::openshift-rosa-hcp[]
 * **Image configuration is now available for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
+* **Image configuration is now available for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
+endif::openshift-rosa[]
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,7 +16,7 @@ toc::[]
 [id="rosa-q1-2025_{context}"]
 === Q1 2025
 
-* **Image configuration is now available for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:..openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
+* **Image configuration is now available for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -15,14 +15,10 @@ toc::[]
 
 [id="rosa-q1-2025_{context}"]
 === Q1 2025
-// These notes needed to be duplicated until the ROSA with HCP split out is completed.
 
-ifdef::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
 * **Image configuration is now available for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
 endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-* **Image configuration is now available for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
-endif::openshift-rosa[]
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -17,7 +17,7 @@ toc::[]
 === Q1 2025
 
 ifndef::openshift-rosa-hcp[]
-* **Image configuration is now available for {hcp-title}.** You can filter registries within a cluster to exclude some registries or allow only a defined list. It also allows to expose additional trusted bundle for registries to pull from. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
+* **Image configuration is now available for {hcp-title}.** You can configure registries within a cluster to exclude some registries or allow only a defined list. It also allows to expose additional trusted bundle for registries to pull from. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
 endif::openshift-rosa-hcp[]
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,7 +16,7 @@ toc::[]
 [id="rosa-q1-2025_{context}"]
 === Q1 2025
 
-* **Image configuration is now available for {product-title} for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:..openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {product-title} with {hcp-title}].
+* **Image configuration is now available for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:..openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -19,6 +19,7 @@ toc::[]
 * **Image configuration is now available for {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
+
 ifdef::openshift-rosa[]
 [IMPORTANT]
 ====

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,7 +16,7 @@ toc::[]
 [id="rosa-q1-2025_{context}"]
 === Q1 2025
 
-* **Image configuration is now available for {product-title} with {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see /images/image-configuration-hcp#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {product-title} with {hcp-title}].
+* **Image configuration is now available for {product-title} with {hcp-title}.** You can configure the `image` resource to block or allow specific registries. For more information, see xref:../images/image-configuration-hcp#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {product-title} with {hcp-title}].
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-13235

Link to docs preview:
https://87671--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html

QE review:
QE approval is NOT required to merge a PR as it is a release that should have been added in https://github.com/openshift/openshift-docs/pull/82728
