### PR TITLE
OCPBUGS-49380 WMCO install fix numbering

### DIFF
--- a/modules/installing-wmco-using-web-console.adoc
+++ b/modules/installing-wmco-using-web-console.adoc
@@ -36,9 +36,9 @@ Dual NIC is not supported on WMCO-managed Windows instances.
 * The *Automatic* strategy allows Operator Lifecycle Manager (OLM) to automatically update the Operator when a new version is available.
 +
 * The *Manual* strategy requires a user with appropriate credentials to approve the Operator update.
-
++
 //TODO add image of Installation page when official Operator is available.
-
++
 . Click *Install*. The WMCO is now listed on the *Installed Operators* page.
 +
 [NOTE]


### PR DESCRIPTION
The numbering in the [Installing the Windows Machine Config Operator using the web console](https://docs.openshift.com/container-platform/4.17/windows_containers/enabling-windows-container-workloads.html#installing-wmco-using-web-console_enabling-windows-container-workloads) procedure restarts after Step 4. 
https://issues.redhat.com/browse/OCPBUGS-49380

Link to docs preview:
[Installing the Windows Machine Config Operator using the web console](https://87674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html#installing-wmco-using-web-console_enabling-windows-container-workloads) -> See steps 4 and 5. 

QE review:
No QE