### PR TITLE
OSSM-8570: 2.6.5 (At Stage): [DOC] Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -186,7 +186,7 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.4
+:SMProductVersion: 2.6.5
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-4-14.adoc
+++ b/modules/ossm-release-2-4-14.adoc
@@ -1,0 +1,31 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-4-14_{context}"]
+= {SMProductName} version 2.4.14
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.5 and is supported on {product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+[id=ossm-release-2-4-14-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Kiali Server
+|1.65.19
+|===
+
+[id="ossm-fixed-issues-2-4-14_{context}"]
+== Fixed issues
+
+* https://issues.redhat.com/browse/OSSM-8608[OSSM-8608] Previously, terminating a Container Network Interface (CNI) pod during the installation phase while copying binaries could leave Istio-CNI temporary files on the node file system. Repeated occurrences could eventually fill up the node disk space. Now, while terminating a CNI pod during the installation phase, existing temporary files are deleted before copying the CNI binary, ensuring that only one temporary file per Istio version exists on the node file system.

--- a/modules/ossm-release-2-5-8.adoc
+++ b/modules/ossm-release-2-5-8.adoc
@@ -1,0 +1,31 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-5-8_{context}"]
+= {SMProductName} version 2.5.8
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.5 and is supported on {product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+[id=ossm-release-2-5-8-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.18.7
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali Server
+|1.73.18
+|===
+
+[id="ossm-fixed-issues-2-5-8_{context}"]
+== Fixed issues
+
+* https://issues.redhat.com/browse/OSSM-8608[OSSM-8608] Previously, terminating a Container Network Interface (CNI) pod during the installation phase while copying binaries could leave Istio-CNI temporary files on the node file system. Repeated occurrences could eventually fill up the node disk space. Now, while terminating a CNI pod during the installation phase, existing temporary files are deleted before copying the CNI binary, ensuring that only one temporary file per Istio version exists on the node file system.

--- a/modules/ossm-release-2-6-0.adoc
+++ b/modules/ossm-release-2-6-0.adoc
@@ -98,13 +98,6 @@ You can expose tracing data to the {TempoName} by appending a named element and 
 
 You can create a {OTELName} instance in a mesh namespace and configure it to send tracing data to a tracing platform backend service.
 
-//Still true for 2.6
-//Asked in forum-ocp-tracing channel 06/24/2024, verified 06/25/2024
-[NOTE]
-====
-{TempoName} Stack is not supported on {ibm-z-title}.
-====
-
 [id="jaeger-default-setting-change-ossm-2-6-0_{context}"]
 == {JaegerName} default setting change
 //also included in "Upgrading --> Upgrading 2.5 to 2.6" but added here for increased visibility.

--- a/modules/ossm-release-2-6-4.adoc
+++ b/modules/ossm-release-2-6-4.adoc
@@ -11,8 +11,6 @@ This release of {SMProductName} updates the {SMProductName} Operator version to 
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
 
-include::snippets/ossm-current-version-support-snippet.adoc[]
-
 The most current version of the {KialiProduct} can be used with all supported versions of {SMProductName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
 [id=ossm-release-2-6-4-components_{context}]

--- a/modules/ossm-release-2-6-5.adoc
+++ b/modules/ossm-release-2-6-5.adoc
@@ -1,0 +1,42 @@
+////
+Module included in the following assemblies:
+* service_mesh/v2x/servicemesh-release-notes.adoc
+////
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-5_{context}"]
+= {SMProductName} version 2.6.5
+
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.5, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.5, 2.5.8, and 2.4.14.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id=ossm-release-2-6-5-components_{context}]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.7
+
+|Kiali Server
+|1.73.18
+|===
+
+[id="ossm-new-features-2-6-5_{context}"]
+== New features
+
+* {TempoName} Stack is now supported on {ibm-z-title}.
+
+[id="ossm-fixed-issues-2-6-5_{context}"]
+== Fixed issues
+
+* https://issues.redhat.com/browse/OSSM-8608[OSSM-8608] Previously, terminating a Container Network Interface (CNI) pod during the installation phase while copying binaries could leave Istio-CNI temporary files on the node file system. Repeated occurrences could eventually fill up the node disk space. Now, while terminating a CNI pod during the installation phase, existing temporary files are deleted before copying the CNI binary, ensuring that only one temporary file per Istio version exists on the node file system.

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -10,6 +10,12 @@ toc::[]
 
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
+include::modules/ossm-release-2-6-5.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-5-8.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-4-14.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-4.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-5-7.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.5 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-8570

Fix Version: 4.14+

Doc Preview: https://87678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-5_ossm-release-notes

QE Review: @unsortedhashsets 
Peer Review: @GroceryBoyJr 