### PR TITLE
OADP-4882: Update velero and OCP atrributes for OADP 1.4.2 release

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -40,8 +40,8 @@ endif::[]
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
 :oadp-version: 1.4.1
-:oadp-version-1-4: 1.4.1
 :oadp-version-1-3: 1.3.3
+:oadp-version-1-4: 1.4.2
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
 :product-mirror-registry: Mirror registry for Red Hat OpenShift

--- a/modules/velero-oadp-version-relationship.adoc
+++ b/modules/velero-oadp-version-relationship.adoc
@@ -5,22 +5,22 @@
 [cols="3", options="header"]
 |===
 |OADP version |Velero version |{product-title} version
-| 1.1.0 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.9 and later
-| 1.1.1 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.9 and later
-| 1.1.2 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.9 and later
-| 1.1.3 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.9 and later
-| 1.1.4 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.9 and later
-| 1.1.5 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.9 and later
-| 1.1.6 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.11 and later
-| 1.1.7 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.11 and later
+| 1.1.0 | link:https://{velero-domain}/docs/v1.9/[1.9] | 4.9 and later
+| 1.1.1 | link:https://{velero-domain}/docs/v1.9/[1.9] | 4.9 and later
+| 1.1.2 | link:https://{velero-domain}/docs/v1.9/[1.9] | 4.9 and later
+| 1.1.3 | link:https://{velero-domain}/docs/v1.9/[1.9] | 4.9 and later
+| 1.1.4 | link:https://{velero-domain}/docs/v1.9/[1.9] | 4.9 and later
+| 1.1.5 | link:https://{velero-domain}/docs/v1.9/[1.9] | 4.9 and later
+| 1.1.6 | link:https://{velero-domain}/docs/v1.9/[1.9] | 4.11 and later
+| 1.1.7 | link:https://{velero-domain}/docs/v1.9/[1.9] | 4.11 and later
 | 1.2.0 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 | 1.2.1 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 | 1.2.2 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 | 1.2.3 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
-| 1.3.0 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
-| 1.3.1 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
-| 1.3.2 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
-| 1.3.3 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
-| 1.4.0 | link:https://{velero-domain}/docs/v1.14/[1.14] | 4.14 and later
-| 1.4.1 | link:https://{velero-domain}/docs/v1.14/[1.14] | 4.14 and later
+| 1.3.0 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10-4.15
+| 1.3.1 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10-4.15
+| 1.3.2 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10-4.15
+| 1.4.0 | link:https://{velero-domain}/docs/v1.14/[1.14] | 4.14-4.18
+| 1.4.1 | link:https://{velero-domain}/docs/v1.14/[1.14] | 4.14-4.18
+| 1.4.2 | link:https://{velero-domain}/docs/v1.14/[1.14] | 4.14-4.18
 |===


### PR DESCRIPTION
do not merge, I'm deleting this PR