### PR TITLE
OSDOCS-13245: corrects context tags in troubleshooting assemblies

### DIFF
--- a/microshift_troubleshooting/microshift-audit-logs.adoc
+++ b/microshift_troubleshooting/microshift-audit-logs.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="audit-logs-with-microshift"]
+[id="microshift-audit-logs"]
 = Checking audit logs
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-audit-logs

--- a/microshift_troubleshooting/microshift-things-to-know.adoc
+++ b/microshift_troubleshooting/microshift-things-to-know.adoc
@@ -2,11 +2,11 @@
 [id="microshift-things-to-know"]
 = Responsive restarts and security certificates
 include::_attributes/attributes-microshift.adoc[]
-:context: microshift-configuring
+:context: microshift-things-to-know
 
 toc::[]
 
-{product-title} responds to system configuration changes and restarts after alterations are detected, including IP address changes, clock adjustments, and security certificate age.
+{microshift-short} responds to system configuration changes and restarts after alterations are detected, including IP address changes, clock adjustments, and security certificate age.
 
 [id="microshift-ip-address-clock-changes_{context}"]
 == IP address changes or clock adjustments

--- a/microshift_troubleshooting/microshift-troubleshoot-backup-restore.adoc
+++ b/microshift_troubleshooting/microshift-troubleshoot-backup-restore.adoc
@@ -2,7 +2,7 @@
 [id="microshift-troubleshoot-backup-restore"]
 = Troubleshooting data backup and restore
 include::_attributes/attributes-microshift.adoc[]
-:context: microshift-troubleshoot-data-backup-and-restore
+:context: microshift-troubleshoot-backup-and-restore
 
 toc::[]
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-13245](https://issues.redhat.com/browse/OSDOCS-13245)

Link to docs preview:
N/A metadata/repo fixes

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
