### PR TITLE
HCIDOCS-573: Support for port numbers in NO_PROXY for IPv6

### DIFF
--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -102,7 +102,12 @@ spec:
 --
 <1> A proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be `http`.
 <2> A proxy URL to use for creating HTTPS connections outside the cluster. The URL scheme must be either `http` or `https`. Specify a URL for the proxy that supports the URL scheme. For example, most proxies will report an error if they are configured to use `https` but they only support `http`. This failure message may not propagate to the logs and can appear to be a network connection failure instead. If using a proxy that listens for `https` connections from the cluster, you may need to configure the cluster to accept the CAs and certificates that the proxy uses.
-<3> A comma-separated list of destination domain names, domains, IP addresses or other network CIDRs to exclude proxying.
+<3> A comma-separated list of destination domain names, domains, IP addresses (or other network CIDRs), and port numbers to exclude proxying.
++
+[NOTE]
+====
+Port numbers are only supported when configuring IPv6 addresses. Port numbers are not supported when configuring IPv4 addresses.
+====
 +
 Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
 If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.


### PR DESCRIPTION
**Fixes:** [HCIDOCS-573](https://issues.redhat.com/browse/HCIDOCS-573)

**For:** OCP 4.12 and later

[**Preview**](https://87728--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html)

**Approvals -** `/lgtm`:
- [x] SME
- [x] QE
- [x] Peer Review