### PR TITLE
MCO-1316 On-Cluster Layering GA - 4.18 upgrades and integrations

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -184,13 +184,30 @@ include::modules/coreos-layering-configuring-on.adoc[leveloffset=+1]
 
 .Additional resources
 * xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools]
+
+include::modules/coreos-layering-configuring-on-modifying.adoc[leveloffset=+2]
+
+.Additional resources
+* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools]
+
+include::modules/coreos-layering-configuring-on-extensions.adoc[leveloffset=+2]
+
+.Additional resources
+* xref:../machine_configuration/machine-configs-configure.html#rhcos-add-extensions_machine-configs-configure[Adding extensions to RHCOS]
+* xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools]
+
+// Not in 4.18; maybe 4.19
+// include::modules/coreos-layering-configuring-on-rebuild.adoc[leveloffset=+2] 
+
+include::modules/coreos-layering-configuring-on-revert.adoc[leveloffset=+2]
 
 include::modules/coreos-layering-configuring.adoc[leveloffset=+1]
 
 .Additional resources
 xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-updating_mco-coreos-layering[Updating with a {op-system} custom layered image]
 
-include::modules/coreos-layering-removing.adoc[leveloffset=+1]
+include::modules/coreos-layering-removing.adoc[leveloffset=+2]
 include::modules/coreos-layering-updating.adoc[leveloffset=+1]
 
 ////

--- a/modules/coreos-layering-configuring-on-extensions.adoc
+++ b/modules/coreos-layering-configuring-on-extensions.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/coreos-layering.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coreos-layering-configuring-on-extensions_{context}"]
+= Installing extensions into an on-cluster custom layered image
+
+You can install {op-system-first} extensions into your on-cluster custom layered image by creating a machine config that lists the extensions that you want to install. The Machine Config Operator (MCO) installs the extensions onto the nodes associated with a specific machine config pool (MCP).
+
+For a list of the currently supported extensions, see "Adding extensions to RHCOS."
+
+After you make the change, the MCO reboots the nodes associated with the specified machine config pool.
+
+[NOTE]
+====
+include::snippets/coreos-layering-configuring-on-pause.adoc[]
+====
+
+.Prerequisites
+
+* You have opted in to on-cluster layering by creating a `MachineOSConfig` object.
+
+.Procedure
+
+. Create a YAML file for the machine config similar to the following example: 
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1 <1>
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: layered <2>
+  name: 80-worker-extensions
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+  extensions: <3>
+    - usbguard
+    - kerberos
+----
+<1> Specifies the `machineconfiguration.openshift.io/v1` API that is required for `MachineConfig` CRs.
+<2> Specifies the machine config pool to apply the `MachineConfig` object to.
+<3> Lists the {op-system-first} extensions that you want to install.
+
+. Create the MCP object:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+
+.Verification
+
+. You can watch the build progress by using the following command:
++
+[source,terminal]
+----
+$ oc get machineosbuilds
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                       PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
+layered-f8ab2d03a2f87a2acd449177ceda805d   False      True       False       False         False <1>
+----
+<1> The value `True` in the `BUILDING` column indicates that the `MachineOSBuild` object is building. When the `SUCCEEDED` column reports `TRUE`, the build is complete. 
+
+. You can watch as the new machine config is rolled out to the nodes by using the following command:
++
+[source,terminal]
+----
+$ oc get machineconfigpools
+----
++
+.Example output
+[source,terminal]
+----
+NAME      CONFIG                                              UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+layered   rendered-layered-221507009cbcdec0eec8ab3ccd789d18   False     True       False      1              0                   0                     0                      167m <1>
+master    rendered-master-a0b404d061a6183cc36d302363422aba    True      False      False      3              3                   3                     0                      3h38m
+worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    True      False      False      2              2                   2                     0                      3h38m
+----
+<1> The value `FALSE` in the `UPDATED` column indicates that the `MachineOSBuild` object is building. When the `UPDATED` column reports `FALSE`, the new custom layered image has rolled out to the nodes.
+
+. When the associated machine config pool is updated, check that the extensions were installed:
+
+.. Open an `oc debug` session to the node by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+.. Set `/host` as the root directory within the debug shell by running the following command:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
+
+.. Use an appropriate command to verify that the extensions were installed. The following example shows that the usbguard extension was installed:
++
+[source,terminal]
+----
+sh-5.1# rpm -qa |grep usbguard
+----
++
+.Example output
+[source,terminal]
+----
+usbguard-selinux-1.0.0-15.el9.noarch
+usbguard-1.0.0-15.el9.x86_64
+----

--- a/modules/coreos-layering-configuring-on-modifying.adoc
+++ b/modules/coreos-layering-configuring-on-modifying.adoc
@@ -1,0 +1,139 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/coreos-layering.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coreos-layering-configuring-on-modifying_{context}"]
+= Modifying a custom layered image
+
+You can modify an on-cluster custom layered image, as needed. This allows you to install additional packages, remove existing packages, change the pull or push repositories, update secrets, or other similar changes. You can edit the `MachineOSConfig` object, apply changes to the YAML file that created the `MachineOSConfig` object, or create a new YAML file for that purpose.
+
+If you modify and apply the `MachineOSConfig` object YAML or create a new YAML file, the YAML overwrites any changes you made directly to the `MachineOSConfig` object itself.
+
+include::snippets//coreos-layering-configuring-on-pause.adoc[]
+
+.Prerequisites
+
+* You have opted in to on-cluster layering by creating a `MachineOSConfig` object.
+
+.Procedure
+
+* Modify an object to update the associated custom layered image:
+
+.. Edit the `MachineOSConfig` object to modify the custom layered image. The following example adds the `rngd` daemon to nodes that already have the tree package that was installed using a custom layered image.
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1alpha1
+kind: MachineOSConfig
+metadata:
+  name: layered-alpha1
+spec:
+  machineConfigPool:
+    name: layered
+  buildInputs:
+    containerFile:
+    - containerfileArch: noarch
+      content: |- <1>
+        FROM configs AS final
+
+        RUN rpm-ostree install rng-tools && \
+            systemctl enable rngd && \
+            rpm-ostree cleanup -m && \
+            ostree container commit
+
+        RUN rpm-ostree install tree && \
+            ostree container commit
+    imageBuilder:
+      imageBuilderType: PodImageBuilder
+    baseImagePullSecret:
+      name: global-pull-secret-copy <2>
+    renderedImagePushspec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-images:latest <3>
+    renderedImagePushSecret:  <4>
+      name: new-secret-name
+  buildOutputs:
+    currentImagePullSecret:
+      name: new-secret-name <5>
+----
+<1> Optional: Modify the Containerfile, for example to add or remove packages.
+<2> Optional: Update the secret needed to pull the base operating system image from the registry.
+<3> Optional: Modify the image registry to push the newly-built custom layered image to.
+<4> Optional: Update the secret needed to push the newly-built custom layered image to the registry.
+<5> Optional: Update the secret needed to pull the newly-built custom layered image from the registry.
++
+When you save the changes, the MCO drains, cordons, and reboots the nodes. After the reboot, the node uses the cluster base {op-system-first} image. If your changes modify a secret only, no new build is triggered and no reboot is performed.
+
+.Verification
+
+. Verify that the new `MachineOSBuild` object was created by using the following command:
++
+[source,terminal]
+----
+$ oc get machineosbuild
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                       PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
+layered-a5457b883f5239cdcb71b57e1a30b6ef   False      False      True        False         False
+layered-f91f0f5593dd337d89bf4d38c877590b   False      True       False       False         False <1>
+----
+<1> The value `True` in the `BUILDING` column indicates that the `MachineOSBuild` object is building. When the `SUCCEEDED` column reports `True`, the build is complete.
+
+. You can watch as the new machine config is rolled out to the nodes by using the following command:
++
+[source,terminal]
+----
+$ oc get machineconfigpools
+----
++
+.Example output
+[source,terminal]
+----
+NAME      CONFIG                                              UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+layered   rendered-layered-221507009cbcdec0eec8ab3ccd789d18   False     True       False      1              0                   0                     0                      167m <1>
+master    rendered-master-a0b404d061a6183cc36d302363422aba    True      False      False      3              3                   3                     0                      3h38m
+worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    True      False      False      2              2                   2                     0                      3h38m
+----
+<1> The value `FALSE` in the `UPDATED` column indicates that the `MachineOSBuild` object is building. When the `UPDATED` column reports `FALSE`, the new custom layered image has rolled out to the nodes.
+
+. When the node is back in the `Ready` state, check that the changes were applied:
+
+.. Open an `oc debug` session to the node by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+.. Set `/host` as the root directory within the debug shell by running the following command:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
+
+.. Use an appropriate command to verify that change was applied. The following examples shows that the `rngd` daemon was installed:
++
+[source,terminal]
+----
+sh-5.1# rpm -qa |grep rng-tools
+----
++
+.Example output
+[source,terminal]
+----
+rng-tools-6.17-3.fc41.x86_64
+----
++
+[source,terminal]
+----
+sh-5.1# rngd -v
+----
++
+.Example output
+[source,terminal]
+----
+rngd 6.16
+----

--- a/modules/coreos-layering-configuring-on-revert.adoc
+++ b/modules/coreos-layering-configuring-on-revert.adoc
@@ -1,0 +1,105 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/coreos-layering.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coreos-layering-configuring-on-revert_{context}"]
+= Reverting an on-cluster custom layered image
+
+You can revert an on-cluster custom layered image from nodes by removing the label for the machine config pool (MCP) that you specified in the `MachineOSConfig` object. After you remove the label, the Machine Config Operator (MCO) reboots the nodes in that MCP with the cluster base {op-system-first} image, along with any previously-made machine config changes, overriding the custom layered image. 
+
+[IMPORTANT]
+====
+If the node where the custom layered image is deployed uses a custom machine config pool, before you remove the label, make sure the node is associated with a second MCP.
+====
+
+You can reapply the custom layered image to the node by using the `oc label node/<node_name> 'node-role.kubernetes.io/<mcp_name>='` label.
+
+.Prerequisites
+
+* You have opted in to on-cluster layering by creating a `MachineOSConfig` object.
+
+.Procedure
+
+* Remove the label from the node by using the following command:
++
+[source,terminal]
+----
+$ oc label node/<node_name> node-role.kubernetes.io/<mcp_name>-
+----
++
+When you save the changes, the MCO drains, cordons, and reboots the nodes. After the reboot, the node uses the cluster base {op-system-first} image.
+
+.Verification
+
+You can verify that the custom layered image is removed by performing the following checks:
+
+. Check that the worker machine config pool is updating with the previous machine config:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+.Sample output
+[source,terminal]
+----
+NAME      CONFIG                                              UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+layered   rendered-layered-bde4e4206442c0a48b1a1fb35ba56e85   True      False      False      0              0                   0                     0                      4h46m
+master    rendered-master-8332482204e0b76002f15ecad15b6c2d    True      False      False      3              3                   3                     0                      5h26m
+worker    rendered-worker-bde4e4206442c0a48b1a1fb35ba56e85    False     True       False      3              2                   2                     0                      5h26m <1>
+----
+<1> The value `FALSE` in the `UPDATED` column indicates that the `MachineOSBuild` object is building. When the `UPDATED` column reports `FALSE`, the base image has rolled out to the nodes.
+
+. Check the nodes to see that scheduling on the nodes is disabled. This indicates that the change is being applied:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         STATUS                     ROLES                  AGE   VERSION
+ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.31.3
+ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.31.3
+ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.31.3
+ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.31.3
+ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.31.3
+ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.31.3
+----
+
+. When the node is back in the `Ready` state, check that the node is using the base image:
+
+.. Open an `oc debug` session to the node. For example:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+.. Set `/host` as the root directory within the debug shell:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
+
+.. Run an `rpm-ostree status` command to view that the base image is in use:
++
+[source,terminal]
+----
+sh-5.1# rpm-ostree status
+----
++
+.Example output
++
+[source,terminal]
+----
+State: idle
+Deployments:
+* ostree-unverified-image:containers-storage:quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:76721c875a2b79688be46b1dca654c2c6619a6be28b29a2822cd86c3f9d8e3c1
+                   Digest: sha256:76721c875a2b79688be46b1dca654c2c6619a6be28b29a2822cd86c3f9d8e3c1
+                  Version: 418.94.202501300706-0 (2025-01-30T07:10:58Z)
+----

--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -13,7 +13,21 @@ To apply a custom layered image to your cluster by using the on-cluster build pr
 * where the final image should be pushed and pulled from
 * the push and pull secrets to use
 
-When you create the object, the Machine Config Operator (MCO) creates a `MachineOSBuild` object and a `machine-os-builder` pod. The build process also creates transient objects, such as config maps, which are cleaned up after the build is complete.
+When you create the object, the Machine Config Operator (MCO) creates a `MachineOSBuild` object and a builder pod. The build process also creates transient objects, such as config maps, which are cleaned up after the build is complete. The `MachineOSBuild` object and the associated `builder-*` pod use the same naming scheme, `<MachineOSConfig_CR_name>-<hash>`, for example:
+
+.Example `MachineOSBuild` object
+[source,terminal]
+----
+NAME                                       PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
+layered-c8765e26ebc87e1e17a7d6e0a78e8bae   False      False      True        False         False
+----
+
+.Example builder pod
+[source,terminal]
+----
+NAME                                                READY   STATUS      RESTARTS        AGE
+build-layered-c8765e26ebc87e1e17a7d6e0a78e8bae      2/2     Running     0               11m
+----
 
 When the build is complete, the MCO pushes the new custom layered image to your repository for use when deploying new nodes. You can see the digested image pull spec for the new custom layered image in the `MachineOSBuild` object and `machine-os-builder` pod.
 
@@ -23,16 +37,47 @@ You need a separate `MachineOSConfig` CR for each machine config pool where you 
 
 :FeatureName: On-cluster image layering
 include::snippets/technology-preview.adoc[]
+include::snippets//coreos-layering-configuring-on-pause.adoc[]
+
+In the case of a build failure, for example due to network issues or an invalid secret, the MCO retries the build three additional times before the job fails. The MCO creates a different build pod for each build attempt. You can use the build pod logs to troubleshoot any build failures. However, the MCO automatically removes these build pods after a short period of time. 
+
+.Example failed `MachineOSBuild` object
+[source,terminal]
+----
+NAME                                       PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
+layered-c8765e26ebc87e1e17a7d6e0a78e8bae   False      False      False        False        True
+----
+
+// Not in 4.18; maybe 4.19
+// You can manually rebuild your custom layered image by either modifying your `MachineOSConfig` object or applying an annotation to the `MachineOSConfig` object as discussed in the following section.
+
+[discrete]
+[id="coreos-layering-configuring-on-limitations_{context}"]
+== On-cluster layering Technology Preview known limitations
+
+Note the following limitations when working with the on-cluster layering feature:
+
+* On-cluster layering is supported only for {product-title} clusters on the AMD64 architecture.
+* On-cluster layering is not supported on multi-architecture compute machines, {sno}, or disconnected clusters.
+* If you scale up a machine set that uses a custom layered image, the nodes reboot two times. The first, when the node is initially created with the base image and a second time when the custom layered image is applied.
+* Node disruption policies are not supported on nodes with a custom layered image. As a result the following configuration changes cause a node reboot:
+** Modifying the configuration files in the `/var` or `/etc` directory
+** Adding or modifying a systemd service
+** Changing SSH keys
+** Removing mirroring rules from `ICSP`, `ITMS`, and `IDMS` objects
+** Changing the trusted CA, by updating the `user-ca-bundle` configmap in the `openshift-config` namespace
+* The images used in creating custom layered images take up space in your push registry. Always be aware of the free space in your registry and prune the images as needed.
 
 .Prerequisites
 
-* You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates".
+* You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates". 
 
-* You have a copy of the global pull secret in the `openshift-machine-config-operator` namespace that the MCO needs in order to pull the base operating system image.
+* You have a copy of the pull secret in the `openshift-machine-config-operator` namespace that the MCO needs to pull the base operating system image. 
 
-* You have a copy of the `etc-pki-entitlement` secret in the `openshift-machine-api` namespace.
+// Not in 4.18; maybe in 4.19
+// If you are using the global pull secret, the MCO automatically creates a copy when you first create a `MachineOSconfig` object.
 
-* You have the push secret that the MCO needs in order to push the new custom layered image to your registry.
+* You have the push secret of the registry that the MCO needs to push the new custom layered image to.
 
 * You have a pull secret that your nodes need to pull the new custom layered image from your registry. This should be a different secret than the one used to push the image to the repository.
 
@@ -42,47 +87,48 @@ include::snippets/technology-preview.adoc[]
 
 .Procedure
 
-. Create a `machineOSconfig` object:
+. Create a `MachineOSconfig` object:
 
 .. Create a YAML file similar to the following:
 +
-[source,terminal]
+[source,yaml]
 ----
-apiVersion: machineconfiguration.openshift.io/v1alpha1
+apiVersion: machineconfiguration.openshift.io/v1aplha1 <1>
 kind: MachineOSConfig
 metadata:
-  name: layered
+  name: layered <2>
 spec:
   machineConfigPool:
-    name: <mcp_name> <1>
+    name: <mcp_name> <3>
   buildInputs:
-    containerFile: # <2>
-    - containerfileArch: noarch <3>
+    containerFile: <4>
+    - containerfileArch: noarch
       content: |-
-        FROM configs AS final <4>
-        RUN dnf install -y cowsay && \
-         dnf clean all && \
-         ostree container commit
-    imageBuilder: # <5>
+        FROM configs AS final
+        RUN rpm-ostree install tree && \
+            ostree container commit
+    imageBuilder: <5>
       imageBuilderType: PodImageBuilder
-    baseImagePullSecret: # <6>
+    baseImagePullSecret: <6>
       name: global-pull-secret-copy
-    renderedImagePushspec: image-registry.openshift-image-registry.svc:5000/openshift/os-image:latest  # <7>
-    renderedImagePushSecret: # <8>
+    renderedImagePushspec: image-registry.openshift-image-registry.svc:5000/openshift/os-image:latest <7>
+    renderedImagePushSecret: <8>
       name: builder-dockercfg-7lzwl
-  buildOutputs: # <9>
+  buildOutputs: <9>
     currentImagePullSecret:
       name: builder-dockercfg-7lzwl
 ----
-<1> Specifies the machine config pool to deploy the custom layered image.
-<2> Specifies the Containerfile to configure the custom layered image. You can specify multiple build stages in the Containerfile.
-<3> Specifies the architecture of the image to be built. You must set this parameter to `noarch`.
-<4> Specifies the build stage as final. This field is required and applies to the last image in the build.
-<5> Specifies the name of the image builder to use. You must set this parameter to `PodImageBuilder`.
+<1> Specifies the `machineconfiguration.openshift.io/v1` API that is required for `MachineConfig` CRs.
+<2> Specifies a name for the `MachineOSConfig` object. This name is used with other on-cluster layering resources. The examples in this documentation use the name `layered`. 
+<3> Specifies the name of the machine config pool associated with the nodes where you want to deploy the custom layered image.
+<4> Specifies the Containerfile to configure the custom layered image.
+<5> Specifies the name of the image builder to use. This must be `PodImageBuilder`.
 <6> Specifies the name of the pull secret that the MCO needs in order to pull the base operating system image from the registry.
 <7> Specifies the image registry to push the newly-built custom layered image to. This can be any registry that your cluster has access to. This example uses the internal {product-title} registry.
-<8> Specifies the name of the push secret that the MCO needs in order to push the newly-built custom layered image to the registry.
+<8> Specifies the name of the push secret that the MCO needs in order to push the newly-built custom layered image to that registry.
 <9> Specifies the secret required by the image registry that the nodes need in order to pull the newly-built custom layered image. This should be a different secret than the one used to push the image to your repository.
+// +
+// https://github.com/openshift/openshift-docs/pull/87486/files has the v1 api versions
 
 .. Create the `MachineOSConfig` object:
 +
@@ -103,8 +149,8 @@ $ oc get machineosbuild
 .Example output showing that the `MachineOSBuild` object is ready
 [source,terminal]
 ----
-NAME                                                                PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
-layered-rendered-layered-ad5a3cad36303c363cf458ab0524e7c0-builder   False      False      True        False         False
+NAME                                               PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
+layered-ad5a3cad36303c363cf458ab0524e7c0-builder   False      False      True        False         False
 ----
 
 .. Edit the nodes where you want to deploy the custom layered image by adding a label for the machine config pool you specified in the `MachineOSConfig` object:
@@ -135,14 +181,14 @@ $ oc get pods -n openshift-machine-config-operator
 [source,terminal]
 ----
 NAME                                                              READY   STATUS    RESTARTS   AGE
-build-rendered-layered-ad5a3cad36303c363cf458ab0524e7c0           2/2     Running   0          2m40s # <1>
+build-layered-ad5a3cad36303c363cf458ab0524e7c0-hxrws              2/2     Running   0          2m40s # <1>
 # ...
 machine-os-builder-6fb66cfb99-zcpvq                               1/1     Running   0          2m42s # <2>
 ----
-<1> This is the build pod where the custom layered image is building.
+<1> This is the build pod where the custom layered image is building, named in the `build-<MachineOSConfig_CR_name>-<hash>` format.
 <2> This pod can be used for troubleshooting.
 
-. Verify the current stage of your layered build by running the following command:
+. Verify that the `MachineOSConfig` object contains a reference to the new custom layered image by running the following command:
 +
 [source,terminal]
 ----
@@ -152,9 +198,10 @@ $ oc get machineosbuilds
 .Example output
 [source,terminal]
 ----
-NAME                                                                PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
-layered-rendered-layered-ef6460613affe503b530047a11b28710-builder   False      True       False       False         False
+NAME                                       PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
+layered-ad5a3cad36303c363cf458ab0524e7c0   False      True       False       False         False <1>
 ----
+<1> The `MachineOSBuild` is named in the `<MachineOSConfig_CR_name>-<hash>` format.
 
 . Verify that the `MachineOSBuild` object contains a reference to the new custom layered image by running the following command:
 +
@@ -166,25 +213,25 @@ $ oc describe machineosbuild <object_name>
 .Example output
 [source,yaml]
 ----
-apiVersion: machineconfiguration.openshift.io/v1alpha1
-kind: MachineOSBuild
-metadata:
-  name: layered-rendered-layered-ad5a3cad36303c363cf458ab0524e7c0-builder
-spec:
-  desiredConfig:
-    name: rendered-layered-ad5a3cad36303c363cf458ab0524e7c0
-  machineOSConfig:
-    name: layered
-  renderedImagePushspec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-image:latest
+Name:         layered-ad5a3cad36303c363cf458ab0524e7c0
 # ...
-status:
-  conditions:
-    - lastTransitionTime: "2024-05-21T20:25:06Z"
-      message: Build Ready
-      reason: Ready
-      status: "True"
-      type: Succeeded
-  finalImagePullspec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-image@sha256:f636fa5b504e92e6faa22ecd71a60b089dab72200f3d130c68dfec07148d11cd # <1>
+API Version:  machineconfiguration.openshift.io/v1alpha1
+Kind:         MachineOSBuild
+# ...
+Spec:
+  Config Generation:  1
+  Desired Config:
+    Name:  rendered-layered-ad5a3cad36303c363cf458ab0524e7c0
+  Machine OS Config:
+    Name:                   layered-alpha1
+  Rendered Image Pushspec:  image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-images:layered-ad5a3cad36303c363cf458ab0524e7c0
+# ...
+    Last Transition Time:  2025-02-12T19:21:28Z
+    Message:               Build Ready
+    Reason:                Ready
+    Status:                True
+    Type:                  Succeeded
+  Final Image Pullspec:    image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-images@sha256:312e48825e074b01a913deedd6de68abd44894ede50b2d14f99d722f13cda04b <1>
 ----
 <1> Digested image pull spec for the new custom layered image.
 
@@ -216,8 +263,8 @@ sh-5.1# rpm-ostree status
 ----
 # ...
 Deployments:
-* ostree-unverified-registry:quay.io/openshift-release-dev/os-image@sha256:f636fa5b504e92e6faa22ecd71a60b089dab72200f3d130c68dfec07148d11cd # <1>
-                   Digest: sha256:bcea2546295b2a55e0a9bf6dd4789433a9867e378661093b6fdee0031ed1e8a4
-                  Version: 416.94.202405141654-0 (2024-05-14T16:58:43Z)
+* ostree-unverified-registry:image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-images@sha256:312e48825e074b01a913deedd6de68abd44894ede50b2d14f99d722f13cda04b
+                   Digest: sha256:312e48825e074b01a913deedd6de68abd44894ede50b2d14f99d722f13cda04b <1>
+                  Version: 418.94.202502100215-0 (2025-02-12T19:20:44Z)
 ----
 <1> Digested image pull spec for the new custom layered image.

--- a/modules/coreos-layering-removing.adoc
+++ b/modules/coreos-layering-removing.adoc
@@ -4,15 +4,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="coreos-layering-removing_{context}"]
-= Removing a {op-system} custom layered image
+= Reverting an out-of-cluster node
 
-You can easily revert {op-system-first} image layering from the nodes in specific machine config pools. The Machine Config Operator (MCO) reboots those nodes with the cluster base {op-system-first} image, overriding the custom layered image.
+You can revert an out-of-cluster custom layered image from the nodes in specific machine config pools. The Machine Config Operator (MCO) reboots those nodes with the cluster base {op-system-first} image, overriding the custom layered image.
 
 To remove a {op-system-first} custom layered image from your cluster, you need to delete the machine config that applied the image.
 
 .Procedure
 
-. Delete the machine config that applied the custom layered image.
+* Delete the machine config that applied the custom layered image.
 +
 [source,terminal]
 ----
@@ -62,25 +62,25 @@ ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker  
 
 . When the node is back in the `Ready` state, check that the node is using the base image:
 
-.. Open an `oc debug` session to the node. For example:
+.. Open an `oc debug` session to the node by running the following command:
 +
 [source,terminal]
 ----
-$ oc debug node/ip-10-0-155-125.us-west-1.compute.internal
+$ oc debug node/<node_name>
 ----
 
-.. Set `/host` as the root directory within the debug shell:
+.. Set `/host` as the root directory within the debug shell by running the following command:
 +
 [source,terminal]
 ----
-sh-4.4# chroot /host
+sh-5.1# chroot /host
 ----
 
 .. Run the `rpm-ostree status` command to view that the custom layered image is in use:
 +
 [source,terminal]
 ----
-sh-4.4# sudo rpm-ostree status
+sh-5.1# sudo rpm-ostree status
 ----
 +
 .Example output

--- a/modules/rhcos-add-extensions.adoc
+++ b/modules/rhcos-add-extensions.adoc
@@ -6,15 +6,24 @@
 [id="rhcos-add-extensions_{context}"]
 
 = Adding extensions to {op-system}
-{op-system} is a minimal container-oriented RHEL operating system, designed to provide a common set of capabilities to {product-title} clusters across all platforms. While adding software packages to {op-system} systems is generally discouraged, the MCO provides an `extensions` feature you can use to add a minimal set of features to {op-system} nodes.
+
+{op-system} is a minimal container-oriented RHEL operating system, designed to provide a common set of capabilities to {product-title} clusters across all platforms. Although adding software packages to {op-system} systems is generally discouraged, the MCO provides an `extensions` feature you can use to add a minimal set of features to {op-system} nodes.
 
 Currently, the following extensions are available:
 
-* **usbguard**: Adding the `usbguard` extension protects {op-system} systems from attacks from intrusive USB devices. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#usbguard_protecting-systems-against-intrusive-usb-devices[USBGuard] for details.
+* **usbguard**: The `usbguard` extension protects {op-system} systems from attacks by intrusive USB devices. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#usbguard_protecting-systems-against-intrusive-usb-devices[USBGuard] for details.
 
-* **kerberos**: Adding the `kerberos` extension provides a mechanism that allows both users and machines to identify themselves to the network to receive defined, limited access to the areas and services that an administrator has configured. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/using_kerberos[Using Kerberos] for details, including how to set up a Kerberos client and mount a Kerberized NFS share.
+* **kerberos**: The `kerberos` extension provides a mechanism that allows both users and machines to identify themselves to the network to receive defined, limited access to the areas and services that an administrator has configured. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/using_kerberos[Using Kerberos] for details, including how to set up a Kerberos client and mount a Kerberized NFS share.
 
-* **sysstat**: Adding the `sysstat` extension provides additional performance monitoring for {product-title} nodes, including the system activity reporter (`sar`) command for collecting and reporting information. See link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/monitoring_and_managing_system_status_and_performance/index#proc_providing-feedback-on-red-hat-documentation_monitoring-and-managing-system-status-and-performance[Monitoring and managing system status and performance] for details.
+* **sandboxed-containers**: The `sandboxed-containers` extension contains RPMs for Kata, QEMU, and its dependencies. For more information, see https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/latest[OpenShift Sandboxed Containers].
+
+* **ipsec**: The `ipsec` extension contains RPMs for libreswan and NetworkManager-libreswan.
+
+* **wasm**: The `wasm` extension enables Developer Preview functionality in {product-title} for users who want to use WASM-supported workloads.   
+
+* **sysstat**: Adding the `sysstat` extension provides additional performance monitoring for {product-title} nodes, including the system activity reporter (`sar`) command for collecting and reporting information.
+
+* **kernel-devel**: The `kernel-devel` extension provides kernel headers and makefiles sufficient to build modules against the kernel package.
 
 The following procedure describes how to use a machine config to add one or more extensions to your {op-system} nodes.
 

--- a/snippets/coreos-layering-configuring-on-pause.adoc
+++ b/snippets/coreos-layering-configuring-on-pause.adoc
@@ -1,0 +1,22 @@
+// Text snippet included in the following modules:
+//
+// * modules/coreos-layering-configuring-on.adoc
+// * modules/coreos-layering-configuring-on-modifying.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+Making certain changes to a `MachineOSConfig` object triggers an automatic rebuild of the associated custom layered image. You can mitigate the effects of the rebuild by pausing the machine config pool where the custom layered image is applied as described in "Pausing the machine config pools." For example, if you want to remove and replace a `MachineOSCOnfig` object, pausing the machine config pools before making the change prevents the MCO from reverting the associated nodes to the base image, reducing the number of reboots needed. 
+
+When a machine config pool is paused, the `oc get machineconfigpools` reports the following status:
+
+.Example output
+[source,terminal]
+----
+NAME      CONFIG                                              UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+layered   rendered-layered-221507009cbcdec0eec8ab3ccd789d18   False     False      False      1              0                   0                     0                      3h23m <1>
+master    rendered-master-a0b404d061a6183cc36d302363422aba    True      False      False      3              3                   3                     0                      4h14m
+worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    True      False      False      2              2                   2                     0                      4h14m
+----
+<1> The `layered` machine config pool is paused, as indicated by the three `False` statuses and the `READYMACHINECOUNT` at `0`.
+
+After the changes have been rolled out, you can unpause the machine config pool.


### PR DESCRIPTION
https://issues.redhat.com/browse/MCO-1316

[Using on-cluster layering to apply a custom layered image](https://87730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on_mco-coreos-layering) -- Edits to existing text
[Modifying a custom layered image](https://87730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on-modifying_mco-coreos-layering) -- New module
[Installing extensions into an on-cluster custom layered image](https://87730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on-extensions_mco-coreos-layering) -- New module
[Reverting an on-cluster custom layered image](https://87730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on-revert_mco-coreos-layering) -- New module
[Reverting an out-of-cluster node](https://87730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-removing_mco-coreos-layering)  -- Minor edits to an existing module
[Adding extensions to RHCOS](https://87730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure.html#rhcos-add-extensions_machine-configs-configure) -- Replaced extensions list with snippet.

**PEER REVIEW**: No need to review "Rebuilding an on-cluster custom layered image" at this time. Feature planned to be added in 4.19.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
