### PR TITLE
OSDOCS-11795: Shared VPC doc updates.

### DIFF
--- a/modules/rosa-sharing-vpc-dns-and-roles.adoc
+++ b/modules/rosa-sharing-vpc-dns-and-roles.adoc
@@ -72,7 +72,7 @@ $ rosa create operator-roles --oidc-config-id <oidc-config-ID> <1>
 The Installer account role and the shared VPC role must have a one-to-one relationship. If you want to create multiple shared VPC roles, you should create one set of account roles per shared VPC role.
 ====
 
-. After you create the Operator roles, share the full domain name, which is created with `<intended_cluster_name>.<reserved_dns_domain>`, your _Ingress Operator Cloud Credentials_ role's ARN, and your _Installer_ role's ARN with the *VPC Owner* to continue configuration.
+. After you create the Operator roles, share the full domain name, which is created with `<intended_cluster_domain_prefix>.<reserved_dns_domain>`, your _Ingress Operator Cloud Credentials_ role's ARN, and your _Installer_ role's ARN with the *VPC Owner* to continue configuration.
 +
 The shared information resembles these examples:
 +

--- a/modules/rosa-sharing-vpc-hosted-zones.adoc
+++ b/modules/rosa-sharing-vpc-hosted-zones.adoc
@@ -39,7 +39,7 @@ image::372_OpenShift_on_AWS_persona_worflows_0923_3.png[]
   ]
 }
 ----
-. Create a private hosted zone in the link:https://us-east-1.console.aws.amazon.com/route53/v2/[Route 53 section of the AWS console]. In the hosted zone configuration, the domain name is `<cluster_name>.<reserved_dns_domain>`. The private hosted zone must be associated with the created VPC.
+. Create a private hosted zone in the link:https://us-east-1.console.aws.amazon.com/route53/v2/[Route 53 section of the AWS console]. In the hosted zone configuration, the domain name is `<cluster_domain_prefix>.<reserved_dns_domain>`. The private hosted zone must be associated with the created VPC.
 . After the hosted zone is created and associated with the VPC, provide the following to the *Cluster Creator* to continue configuration:
 * Hosted zone ID
 * AWS region


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
enterprise-4.17+

Issue:
[OSDOCS-11795](https://issues.redhat.com/browse/OSDOCS-11795)

Link to docs preview:
[Step Two - Cluster Creator: Reserving your DNS and creating cluster operator roles](https://87731--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config.html#rosa-sharing-vpc-dns-and-roles_rosa-shared-vpc-config) - See Step 4

[Step Three - VPC Owner: Updating the shared VPC role and creating hosted zones](https://87731--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config.html#rosa-sharing-vpc-hosted-zones_rosa-shared-vpc-config) - See Step 3

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
