### PR TITLE
OSDOCS-13238 RODOO admonition added

### DIFF
--- a/modules/rodoo-about.adoc
+++ b/modules/rodoo-about.adoc
@@ -13,3 +13,8 @@ Cluster administrators can use the {run-once-operator} to force a limit on the t
 To apply the run-once duration override from the {run-once-operator} to run-once pods, you must enable it on each applicable namespace.
 
 If both the run-once pod and the {run-once-operator} have their `activeDeadlineSeconds` value set, the lower of the two values is used.
+
+[NOTE]
+====
+You cannot install the {run-once-operator} on clusters managed by the HyperShift Operator.
+====


### PR DESCRIPTION
Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13238](https://issues.redhat.com/browse/OSDOCS-13238)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://87739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/index.html#run-once-about_run-once-duration-override-about)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
