### PR TITLE
OSDOCS#13249: Fix product-tile typo

### DIFF
--- a/snippets/of-terms-snippet.adoc
+++ b/snippets/of-terms-snippet.adoc
@@ -45,7 +45,7 @@ OLM resolves dependencies by ensuring that all specified versions of Operators a
 [id="olm-common-terms-extension_{context}"]
 == Extension
 
-Extensions enable cluster administrators to extend capabilities for users on their {product-tile} cluster. Extensions are managed by {olmv1-first}.
+Extensions enable cluster administrators to extend capabilities for users on their {product-title} cluster. Extensions are managed by {olmv1-first}.
 
 The `ClusterExtension` API streamlines management of installed extensions, which includes Operators via the `registry+v1` bundle format, by consolidating user-facing APIs into a single object. Administrators and SREs can use the API to automate processes and define desired states by using GitOps principles.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13249

Follow-up fix to https://github.com/openshift/openshift-docs/pull/86888.

Preview: https://87741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/of-terms.html

No QE needed.