### PR TITLE
OADP-5570: Improving DataMover Support

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-oadp-data-mover.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-oadp-data-mover.adoc
@@ -6,17 +6,35 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{oadp-short} includes a built-in Data Mover that you can use to move Container Storage Interface (CSI) volume snapshots to a remote object store. The built-in Data Mover allows you to restore stateful applications from the remote object store if a failure, accidental deletion, or corruption of the cluster occurs. It uses xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-about-kopia.adoc#oadp-about-kopia[Kopia] as the uploader mechanism to read the snapshot data and write to the unified repository.
+{oadp-first} includes a built-in Data Mover that you can use to move Container Storage Interface (CSI) volume snapshots to a remote object store. The built-in Data Mover allows you to restore stateful applications from the remote object store if a failure, accidental deletion, or corruption of the cluster occurs. It uses xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-about-kopia.adoc#oadp-about-kopia[Kopia] as the uploader mechanism to read the snapshot data and write to the unified repository.
 
 {oadp-short} supports CSI snapshots on the following:
 
 * {odf-full}
 * Any other cloud storage provider with the Container Storage Interface (CSI) driver that supports the Kubernetes Volume Snapshot API
 
-[IMPORTANT]
-====
+// ** suggest removing the admonition and replacing with a clear section **
+//
+// [IMPORTANT]
+// ====
+// The {oadp-short} built-in Data Mover, which was introduced in {oadp-short} 1.3 as a Technology Preview, is now fully supported for both containerized and virtual machine workloads.
+// ====
+
+[id="oadp-data-mover-support_{context}"]
+== Data Mover support
+
 The {oadp-short} built-in Data Mover, which was introduced in {oadp-short} 1.3 as a Technology Preview, is now fully supported for both containerized and virtual machine workloads.
-====
+
+.Supported
+
+The Data Mover backups taken with {oadp-short} 1.3 can be restored using {oadp-short} 1.3, 1.4, and later. This is supported.
+
+.Not supported
+
+Backups taken with {oadp-short} 1.1 or {oadp-short} 1.2 using the Data Mover feature cannot be restored using {oadp-short} 1.3 and later. Therefore, it is not supported.
+
+{oadp-short} 1.1 and {oadp-short} 1.2 are no longer supported. The DataMover feature in {oadp-short} 1.1 or {oadp-short} 1.2 was a Technology Preview and was never supported. DataMover backups taken with {oadp-short} 1.1 or {oadp-short} 1.2 cannot be restored on later versions of {oadp-short}.
+
 
 [id="enabling-oadp-data-mover_{context}"]
 == Enabling the built-in Data Mover


### PR DESCRIPTION
### JIRA

* [OADP-5570](https://issues.redhat.com/browse/OADP-5570)

### Version(s):

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18

### Link to docs preview:

* [Data Mover support](https://87746--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-oadp-data-mover.html#oadp-data-mover-support_about-oadp-data-mover)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
