### PR TITLE
OSDOCS-13237: Create metrics for network traffic flows fields

### DIFF
--- a/modules/network-observability-creating-metrics-network-events.adoc
+++ b/modules/network-observability-creating-metrics-network-events.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/mertics-alerts-dashboards.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-creating-metrics-network-events_{context}"]
+= Creating metrics from nested or array fields in the Traffic flows table
+
+:FeatureName: OVN Observability / Viewing `NetworkEvents`
+include::snippets/technology-preview.adoc[]
+[IMPORTANT]
+====
+OVN Observability and the ability to view and track network events is available only in {product-title} 4.17 and 4.18. 
+====
+You can create a `FlowMetric` resource to generate metrics for nested or array fields in the *Traffic flows* table, such as *Network events* or *Interfaces*. The following example shows how to generate metrics from the *Network events* field for network policy events. 
+
+.Prerequsities
+* Enable `NetworkEvents feature`. See the Additional resources for how to do this. 
+* A network policy specified. 
+
+.Procedure
+. In the web console, navigate to *Operators* -> *Installed Operators*.
+. In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
+. In the *Project*  dropdown list, select the project of the Network Observability Operator instance. 
+. Click *Create FlowMetric*.
+. Create `FlowMetric` resources to add the following configurations: 
++
+.Configuration counting network policy events per policy name and namespace
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: network-policy-events
+  namespace: netobserv
+spec:
+  metricName: network_policy_events_total
+  type: Counter
+  labels: [NetworkEvents>Type, NetworkEvents>Namespace, NetworkEvents>Name, NetworkEvents>Action, NetworkEvents>Direction]       <1>
+  filters:
+  - field: NetworkEvents>Feature
+    value: acl
+  flatten: [NetworkEvents]       <2>
+  remap:                         <3>
+    "NetworkEvents>Type": type
+    "NetworkEvents>Namespace": namespace
+    "NetworkEvents>Name": name
+    "NetworkEvents>Direction": direction
+----
+<1> These labels represent the nested fields for *Network Events* from the *Traffic flows* table. Each network event has a specific type, namespace, name, action, and direction. You can alternatively specify the `Interfaces` if `NetworkEvents` is unavailable in your {product-title} version.
+<2> Optional: You can choose to represent a field that contains a list of items as distinct items.
+<3> Optional: You can rename the fields in Prometheus.  
+
+.Verification
+. In the web console, navigate to *Observe* -> *Dashboards* and scroll down to see the *Network Policy* tab. 
+. You should begin seeing metrics filter in based on the metric you created along with the network policy specifications. 

--- a/modules/network-observability-metrics-names.adoc
+++ b/modules/network-observability-metrics-names.adoc
@@ -51,3 +51,8 @@ When the `FlowRTT` feature is enabled in `spec.agent.ebpf.features`, the followi
 * `namespace_rtt_seconds` *
 * `node_rtt_seconds`
 * `workload_rtt_seconds`
+
+Network events metrics names::
+When `NetworkEvents` feature is enabled, this metric is available by default:
+
+* `namespace_network_policy_events_total`

--- a/observability/network_observability/metrics-alerts-dashboards.adoc
+++ b/observability/network_observability/metrics-alerts-dashboards.adoc
@@ -14,10 +14,11 @@ include::modules/network-observability-metrics-names.adoc[leveloffset=+1]
 include::modules/network-observability-includelist-example.adoc[leveloffset=+1]
 include::modules/network-observability-custom-metrics.adoc[leveloffset=+1]
 include::modules/network-observability-configuring-custom-metrics.adoc[leveloffset=+1]
+include::modules/network-observability-creating-metrics-network-events.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====
-High cardinality can affect the memory usage of Prometheus. You can check whether specific labels have high cardinality in the xref:../../observability/network_observability/json-flows-format-reference.adocl#network-observability-flows-format_json_reference[Network Flows format reference].
+High cardinality can affect the memory usage of Prometheus. You can check whether specific labels have high cardinality in the xref:../../observability/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network Flows format reference].
 ====
 include::modules/network-observability-flowmetrics-charts.adoc[leveloffset=+1]
 include::modules/network-observability-tcp-flag-syn-flood.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Do not merge until 2/25, Network Observability GA. Only merge to 4.17, 4.18
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-13237
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://87747--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards.html#network-observability-creating-metrics-network-events_metrics-dashboards-alerts
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
