### PR TITLE
OSDOCS-13251: Remove NIST NTP servers from firewall prerequisites

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -120,28 +120,7 @@ endif::[]
 |`oidc.op1.openshiftapps.com`
 |443
 |Used by ROSA for STS implementation with managed OIDC configuration.
-
-ifdef::fedramp[]
-|`time-a-g.nist.gov`
-|123 ^[1]^
-|Allows NTP traffic for FedRAMP.
-
-|`time-a-wwv.nist.gov`
-|123 ^[1]^
-|Allows NTP traffic for FedRAMP.
-
-|`time-a-b.nist.gov`
-|123 ^[1]^
-|Allows NTP traffic for FedRAMP.
-endif::fedramp[]
 |===
-+
-[.small]
---
-ifdef::fedramp[]
-1. Both TCP and UDP ports.
-endif::fedramp[]
---
 +
 . Allowlist the following telemetry URLs:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): `enterprise-4.17`+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13251](https://issues.redhat.com/browse/OSDOCS-13251)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://87750--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs.html
- https://87750--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html
- https://87750--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] ~~QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Confirmed via Slack [here](https://redhat-internal.slack.com/archives/C027UG79RR9/p1738088960630389?thread_ts=1738083809.631399&cid=C027UG79RR9).
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
