### PR TITLE
OADP-4821 Added note for kopia repo config

### DIFF
--- a/modules/oadp-kopia-algorithms-benchmarking.adoc
+++ b/modules/oadp-kopia-algorithms-benchmarking.adoc
@@ -14,9 +14,11 @@ You can run Kopia commands to benchmark the hashing, encryption, and splitter al
 * You have an application with persistent volumes running in a separate namespace.
 * You have run a backup of the application with Container Storage Interface (CSI) snapshots.
 
+include::snippets/kopia-repo-config.adoc[]
+
 .Procedure
 
-. Configure a pod as shown in the following example. Make sure you are using the `oadp-mustgather` image for {oadp-short} version 1.3 and later.
+. Configure the `must-gather` pod as shown in the following example. Make sure you are using the `oadp-mustgather` image for {oadp-short} version 1.3 and later.
 +
 .Example pod configuration
 +

--- a/modules/oadp-kopia-configuring-algorithms.adoc
+++ b/modules/oadp-kopia-configuring-algorithms.adoc
@@ -17,6 +17,8 @@ You can use an {oadp-first} option to override the default Kopia algorithms for 
 * You have installed the {oadp-short} Operator.
 * You have created the secret by using the credentials provided by the cloud provider.
 
+include::snippets/kopia-repo-config.adoc[]
+
 .Procedure
 
 * Configure the DPA with the environment variables for hashing, encryption, and splitter as shown in the following example.

--- a/snippets/kopia-repo-config.adoc
+++ b/snippets/kopia-repo-config.adoc
@@ -1,0 +1,12 @@
+//This snippet appears in the following modules:
+//
+// * modules/oadp-kopia-algorithms-benchmarking.adoc
+// * modules/oadp-kopia-configuring-algorithms.adoc
+
+:_mod-docs-content-type: SNIPPET
+[NOTE]
+====
+The configuration of the Kopia algorithms for splitting, hashing, and encryption in the Data Protection Application (DPA) apply only during the initial Kopia repository creation, and cannot be changed later.
+
+To use different Kopia algorithms, ensure that the object storage does not contain any previous Kopia repositories of backups. Configure a new object storage in the Backup Storage Location (BSL) or specify a unique prefix for the object storage in the BSL configuration.
+====


### PR DESCRIPTION
## Jira 

* [OADP-4821](https://issues.redhat.com/browse/OADP-4821)

Added a note for kopia repo config

##  Version

* OCP 4.13 → OCP 4.18

## Preview

* [Note for Kopia repo configuration](https://87752--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/overriding-kopia-algorithms.html#oadp-kopia-configuring-algorithms_overriding-kopia-algorithms)

## QE Review

* [x] QE has approved this change.
