### PR TITLE
MULTIARCH#4560: Adding a new API field in images.config.openshift.io

### DIFF
--- a/modules/images-configuration-parameters.adoc
+++ b/modules/images-configuration-parameters.adoc
@@ -47,6 +47,35 @@ pods. For instance, whether or not to allow insecure access. It does not contain
 
 Either `blockedRegistries` or `allowedRegistries` can be set, but not both.
 
+ifndef::openshift-rosa,openshift-dedicated[]
+|`imageStreamImportMode`
+|Controls the import mode behavior of image streams.
+
+You must enable the `TechPreviewNoUpgrade` feature set in the `FeatureGate` custom resource (CR) to enable the `imageStreamImportMode` feature. 
+For more information about feature gates, see "Understanding feature gates".
+
+You can set the `imageStreamImportMode` field to either of the following values:
+
+* `Legacy`: Indicates that the legacy behavior must be used. The legacy behavior discards the manifest list and imports a single sub-manifest. In this case, the platform is chosen in the following order of priority: 
+. Tag annotations: Determining the platform by using the platform-specific annotations in the image tags.
+. Control plane architecture or the operating system: Selecting the platform based on the architecture or the operating system of the control plane.
+. `linux/amd64`: If no platform is selected by the preceeding methods, the `linux/amd64` platform is selected. 
+. The first manifest in the list is selected.
+
+* `PreserveOriginal`: Indicates that the original manifest is preserved. The manifest list and its sub-manifests are imported. 
+
+If you specify a value for this field, the value is applied to the newly created image stream tags that do not already have this value manually set. 
+
+If you do not configure this field, the behavior is decided based on the payload type advertised by the `ClusterVersion` status. In this case, the platform is chosen as follows:
+
+* The single architecture payload implies that the `Legacy` mode is applicable.
+* The multi payload implies that the `PreserveOriginal` mode is applicable.
+
+For information about importing manifest lists, see "Working with manifest lists".
+
+:FeatureName: `imageStreamImportMode`
+include::snippets/technology-preview.adoc[]
+endif::openshift-rosa,openshift-dedicated[]
 |===
 
 [WARNING]

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -28,6 +28,7 @@ The following Technology Preview features are enabled by this feature set:
 ** Dynamic Resource Allocation API. Enables a new API for requesting and sharing resources between pods and containers. This is an internal feature that most users do not need to interact with. (`DynamicResourceAllocation`)
 ** Pod security admission enforcement. Enables the restricted enforcement mode for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)
 ** StatefulSet pod availability upgrading limits. Enables users to define the maximum number of statefulset pods unavailable during updates which reduces application downtime. (`MaxUnavailableStatefulSet`)
+** Image mode behavior of image streams. Enables a new API for controlling the import mode behavior of image streams. (`imageStreamImportMode`)
 ** `OVNObservability` resource allows you to verify expected network behavior. Supports the following network APIs: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinesdNetwork` isolation, multicast ACLs, and egress firewalls. When enabled, you can view network events in the terminal.
 ** `gcpLabelsTags`
 ** `vSphereStaticIPs`

--- a/openshift_images/image-configuration.adoc
+++ b/openshift_images/image-configuration.adoc
@@ -10,6 +10,15 @@ Use the following procedure to configure image registries.
 
 include::modules/images-configuration-parameters.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../openshift_images/image-streams-manage.adoc#images-imagestream-import-import-mode_image-streams-managing[Working with manifest lists]
+
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates]
+endif::openshift-rosa,openshift-dedicated[]
+
 include::modules/images-configuration-file.adoc[leveloffset=+1]
 
 include::modules/images-configuration-allowed.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[MULTIARCH-4560](https://issues.redhat.com/browse/MULTIARCH-4560)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Image controller configuration parameters](https://87753--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-configuration.html#images-configuration-parameters_image-configuration)
- [Understanding feature gates](https://87753--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->