### PR TITLE
HCP proper node selector for infra nodes

### DIFF
--- a/modules/hcp-labels-taints.adoc
+++ b/modules/hcp-labels-taints.adoc
@@ -40,7 +40,7 @@ To enable a hosted cluster to require its pods to be scheduled into infrastructu
 ----
   spec:
     nodeSelector:
-      role.kubernetes.io/infra: ""
+      node-role.kubernetes.io/infra: ""
 ----
 
 This way, {hcp} for each hosted cluster are eligible infrastructure node workloads, and you do not need to entitle the underlying {product-title} nodes.


### PR DESCRIPTION
Just a few lines above, the docs say:
`node-role.kubernetes.io/infra`: Use this label to avoid having the control-plane workload count toward your subscription

The nodeSelector should match the label.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A - typo fix
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://87772--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.html#hcp-labels-taints_hcp-distribute-workloads
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: This PR fixes a typo. No QE review required.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
