### PR TITLE
OSDOCS-13211: 4.15.44 RN

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2777,6 +2777,34 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.15.44
+[id="ocp-4-15-44_{context}"]
+=== RHSA-2025:0646 - {product-title} 4.15.44 bug fix and security update
+
+Issued: 29 January 2025
+
+{product-title} release 4.15.44, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0646[RHSA-2025:0646] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0648[RHSA-2025:0648] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.44 --pullspecs
+----
+
+[id="ocp-4-15-44-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, East to West pod traffic over the Geneve overlay could stop working between one or multiple nodes, which prevented pods from reaching pods on other nodes. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-47799[*OCPBUGS-47799*])
+
+* Previously, when installing a cluster on {ibm-cloud-name} into an existing VPC, the installation program retrieved an unsupported VPC region. Attempting to install into a supported VPC region that follows the unsupported VPC region alphabetically caused the installation program to crash. With this release, the installation program is updated to ignore any VPC regions that are not fully available during resource lookups. (link:https://issues.redhat.com/browse/OCPBUGS-44259[*OCPBUGS-44259*])
+
+[id="ocp-4-15-44-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 //4.15.43
 [id="ocp-4-15-43_{context}"]
 === RHSA-2025:0121 - {product-title} 4.15.43 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-13211](https://issues.redhat.com/browse/OSDOCS-13211)

Link to docs preview:
https://87807--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-44_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (1/29)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
