### PR TITLE
OSDOCS-13235.1: ROSA-HCP - Image registry release notes dup of PR 87671

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,10 @@ toc::[]
 [id="rosa-q1-2025_{context}"]
 === Q1 2025
 
+ifndef::openshift-rosa-hcp[]
+* **Image configuration is now available for {hcp-title}.** You can configure registries within a cluster to exclude some registries or allow only a defined list. It also allows to expose additional trusted bundle for registries to pull from. For more information, see xref:../openshift_images/image-configuration-hcp.adoc#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {hcp-title}].
+endif::openshift-rosa-hcp[]
+
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-13235

Link to docs preview:
https://87810--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html

QE review:
not needed s SME review complete in PR 87671