### PR TITLE
OSDOCS-13182: release note removed feature MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -83,14 +83,14 @@ With this release, you can see detailed explanations and example outputs to chec
 === Backup and restore
 
 [id="microshift-4-18-autorecovery-from-manual-backup_{context}"]
-==== Automated recovery from manual backups now documented
+==== Automated recovery from manual backups
 With this release, you can automatically restore data from manual backups when {microshift-short} fails to start by using the `auto-recovery` feature. For more information, see xref:../microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc#microshift-auto-recover-manual-backup[Automated recovery from manual backups].
 
 [id="microshift-4-18-doc-enhancements_{context}"]
 === Documentation enhancements
 
 [id="microshift-4-18-install-with-rhel-image-mode_{context}"]
-==== Updating content in the {op-system-base} image mode section
+==== Updated content in the {op-system-base} image mode section
 With this release, the contents of the "Installing with {op-system-base} image mode" section, which were previously developer-focused, are now updated to be {microshift-short} administrator-focused. For more information, see xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}].
 
 [id="microshift-4-18-tech-preview_{context}"]
@@ -106,6 +106,10 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
 
+[id="microshift-4-18-deprecated-and-removed-features_{context}"]
+== Deprecated and removed features
+With this release, the CSI snapshot webhook feature available in previous releases is removed. The webhook is replaced by CEL validation rules for snapshot objects.
+
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
 [id="microshift-4-18-bug-fixes_{context}"]
 == Bug fixes
@@ -113,7 +117,7 @@ See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#mic
 [discrete]
 [id="microshift-4-18-installation-bug-fixes"]
 === Installation
-Previously, the greenboot health check marked the Image mode for some healthy {op-system-base} systems as unhealthy due to a 300-second timeout, which was insufficient for systems with slow networks. Beginning in {product-title} 4.18, the default greenboot wait timeout has been extended to 600 seconds to provide more time to download images and ensure accurate system checks. (https://issues.redhat.com/browse/OCPBUGS-47463[OCPBUGS-47463])
+Previously, the greenboot health check marked some healthy Image mode for {op-system-base} systems as unhealthy due to a 300-second timeout, which was insufficient for systems with slow networks. Beginning in {product-title} 4.18, the default greenboot wait timeout has been extended to 600 seconds to provide more time to download images and ensure accurate system checks. (https://issues.redhat.com/browse/OCPBUGS-47463[OCPBUGS-47463])
 
 //[discrete]
 //[id="microshift-4-18-networking-bug-fixes"]


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13182](https://issues.redhat.com/browse/OSDOCS-13182)

Link to docs preview:
[microshift-4-18-deprecated-and-removed-features_release-notes](https://87811--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-deprecated-and-removed-features_release-notes)

QE review:
- [x] QE has approved this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
