### PR TITLE
OSDOCS-13257: Added a note about the supported AWS regions for egress lockdown functionality

### DIFF
--- a/modules/rosa-hcp-vpc-terraform.adoc
+++ b/modules/rosa-hcp-vpc-terraform.adoc
@@ -64,6 +64,12 @@ $ terraform plan -out rosa-zero-egress.tfplan -var region=<aws_region> \ <1>
 +
 --
 <1> Enter your AWS region.
++
+[IMPORTANT]
+====
+You can only use egress lockdown on clusters that use the `us-west-1, us-west-2, us-east-1, us-east-2, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-north-1, eu-west-1, eu-west-2, eu-west-3`, and `sa-east-1` AWS regions.
+====
+
 <2> Enter the availability zones for the VPC. For example, for a VPC that uses `ap-southeast-1`, you would use the following as availability zones: `["ap-southeast-1a", "ap-southeast-1b", "ap-southeast-1c"]`.
 <3> Enter the CIDR block for your VPC.
 <4> Enter each of the subnets that are created for the VPC.

--- a/rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
+++ b/rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
@@ -6,7 +6,32 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 
-Creating a {product-title} cluster with egress lockdown provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the Internet. Your cluster will try to pull the images from Quay, but when they aren't reached, it will instead pull the images from the image registry in the local region. All public and private clusters with egress lockdown get their Red Hat container images from a registery that is located in the local region of the cluster instead of gathering these images from various endpoints and registeries on the Internet. You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster.
+Creating a {product-title} cluster with egress lockdown provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the Internet. Your cluster will try to pull the images from Quay, but when they aren't reached, it will instead pull the images from the image registry in the local region. 
+
+[IMPORTANT]
+====
+You can only use egress lockdown on clusters that use the following AWS regions:
+
+* `us-west-1` 
+* `us-west-2`
+* `us-east-1` 
+* `us-east-2`
+* `ap-northeast-1`
+* `ap-northeast-2`
+* `ap-northeast-3`
+* `ap-south-1`
+* `ap-southeast-1`
+* `ap-southeast-2`
+* `ca-central-1`
+* `eu-central-1`
+* `eu-north-1`
+* `eu-west-1`
+* `eu-west-2`
+* `eu-west-3`
+* `sa-east-1`
+====
+
+All public and private clusters with egress lockdown get their Red Hat container images from a registery that is located in the local region of the cluster instead of gathering these images from various endpoints and registeries on the Internet. You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster.
 
 :FeatureName: Egress lockdown
 include::snippets/technology-preview.adoc[]
@@ -36,7 +61,7 @@ You must have a Virtual Private Cloud (VPC) to create {hcp-title} clusters. You 
 
 [NOTE]
 ====
-The Terraform instructions are for testing and demonstration purposes. Your own installation requires modifications to the VPC for your specific needs and constraints. You should also ensure that when you use the following Terraform script it is in the same region that you intend to install your cluster. In the following examples, use `us-east-2`.
+The Terraform instructions are for testing and demonstration purposes. Your own installation requires modifications to the VPC for your specific needs and constraints. You should also ensure that when you use the following Terraform script it is in the same region that you intend to install your cluster.
 ====
 
 include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
`enterprise-4.17+`

Issue:
**[OSDOCS-13257](https://issues.redhat.com/browse/OSDOCS-13257)**

Link to docs preview:
- [Creating a cluster with egress lockdown](https://87819--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-egress-lockdown-install.html) - ROSA with HCP distro link
-  [Creating a cluster with egress lockdown](https://87819--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-egress-lockdown-install.html) - Live build using ROSA
- Two notes:
   ![image](https://github.com/user-attachments/assets/dcd1dde8-492a-4ffb-9e5c-4b385dea66fa)
   ![image](https://github.com/user-attachments/assets/09f176ff-57eb-4b9f-8732-2f1ebb109d0f)

Additional information:
I added a note in two places to point out the supported versions for egress lockdown.
