### PR TITLE
OLS-1199: Document OCP layered product coverage

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -99,3 +99,13 @@
 :TempoShortName: distributed tracing platform (Tempo)
 :TempoOperator: Tempo Operator
 :TempoVersion: 2.1.1
+//Product titles
+:pipelines-title: Red Hat OpenShift Pipelines
+:gitops-title: Red Hat OpenShift GitOps
+:builds-title: Builds for Red Hat OpenShift 
+:serverless-title: Red Hat OpenShift Serverless
+:ossm3-title: Red Hat OpenShift Service Mesh 3.x
+:cluster-security-title: Red Hat Advanced Cluster Security for Kubernetes
+:cluster-management-title: Red Hat Advanced Cluster Management for Kubernetes
+:codeready-title: Red Hat CodeReady Workspaces
+:quay-title: Red Hat Quay

--- a/about/ols-about-openshift-lightspeed.adoc
+++ b/about/ols-about-openshift-lightspeed.adoc
@@ -9,6 +9,7 @@ toc::[]
 The following topics provide an overview of {ols-official} and discuss functional requirements.
 
 include::modules/ols-openshift-lightspeed-overview.adoc[leveloffset=+1]
+include::modules/ols-about-product-coverage.adoc[leveloffset=+2]
 include::modules/ols-openshift-requirements.adoc[leveloffset=+1]
 include::modules/ols-large-language-model-requirements.adoc[leveloffset=+1]
 //Xavier wanted to remove vLLM until further testing is performed.

--- a/modules/ols-about-product-coverage.adoc
+++ b/modules/ols-about-product-coverage.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+// * about/ols-about-openshift-lightspeed
+
+:_mod-docs-content-type: CONCEPT
+[id="ols-about-product-coverage_{context}"]
+= About product coverage
+
+{ols-official} generates answers to questions based on the content in the official {ocp-product-title} product documentation. The documentation for the following products is not part of the {ocp-short-name} product documentation; therefore, {ols-short} has limited context for generating answers about these products:
+
+* {builds-title}
+* {cluster-security-title}
+* {cluster-management-title}
+* {codeready-title}
+* {gitops-title}
+* {pipelines-title}
+* {serverless-title}
+* {ossm3-title}
+* {quay-title}

--- a/modules/ols-openshift-lightspeed-overview.adoc
+++ b/modules/ols-openshift-lightspeed-overview.adoc
@@ -1,10 +1,12 @@
+// Module included in the following assemblies:
+// * about/ols-about-openshift-lightspeed
+
 :_mod-docs-content-type: CONCEPT
-[id="ols-openshift-lightspeed-overview"]
-= OpenShift Lightspeed Overview 
-:context: ols-openshift-lightspeed-overview
+[id="ols-openshift-lightspeed-overview_{context}"]
+= OpenShift Lightspeed overview 
 
-{ols-official} is a generative AI-powered virtual assistant for {ocp-product-title}. Lightspeed functionality uses a natural-language interface in the {ocp-short-name} web console.
+{ols-official} is a generative AI-powered virtual assistant for {ocp-product-title}. {ols-short} functionality uses a natural-language interface in the {ocp-short-name} web console to provide answers to questions that you ask about the product.
 
-This early access program exists so that customers can provide feedback on the user experience, features and capabilities, issues encountered, and any other aspects of the product so that Lightspeed can become more aligned with your needs when it is released and made generally available.
+This early access program exists so that customers can provide feedback on the user experience, features and capabilities, issues encountered, and any other aspects of the product so that {ols-short} can become more aligned with your needs when it is released and made generally available.
 
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-1199
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://87821--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/about/ols-about-openshift-lightspeed.html#ols-about-product-coverage_ols-about-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
