### PR TITLE
OSDOCS-13215: updating oc-mirror links

### DIFF
--- a/cli_reference/opm/cli-opm-ref.adoc
+++ b/cli_reference/opm/cli-opm-ref.adoc
@@ -44,7 +44,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 
 * xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format]
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs]
-* xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+* xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
 endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/opm-cli-ref-init.adoc[leveloffset=+1]

--- a/disconnected/about.adoc
+++ b/disconnected/about.adoc
@@ -54,7 +54,7 @@ However, some options provide a simpler and more convenient user experience for 
 
 Unless your organizational needs require you to choose another option, use the following methods for mirroring images, installing your cluster, and updating your cluster:
 
-* Mirror your images using the xref:../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[oc-mirror plugin].
+* Mirror your images using the xref:../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[oc-mirror plugin v2].
 
 * Install your cluster using the xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Agent-based Installer].
 

--- a/disconnected/mirroring/index.adoc
+++ b/disconnected/mirroring/index.adoc
@@ -19,4 +19,4 @@ If you already have a container image registry, such as Red Hat Quay, you can us
 You can use one of the following procedures to mirror your {product-title} image repository to your mirror registry:
 
 * xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation by using the oc adm command]
-* xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+* xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]

--- a/disconnected/updating/mirroring-image-repository.adoc
+++ b/disconnected/updating/mirroring-image-repository.adoc
@@ -52,7 +52,7 @@ Compared to using the `oc adm release mirror` command, the oc-mirror plugin has 
 
 You can use the oc-mirror OpenShift CLI (`oc`) plugin to mirror images to a mirror registry in your fully or partially disconnected environments. You must run oc-mirror from a system with internet connectivity to download the required images from the official Red{nbsp}Hat registries.
 
-See xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin] for additional details.
+See xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2] for additional details.
 
 [id="update-mirror-repository-adm-release-mirror_{context}"]
 == Mirroring images using the oc adm release mirror command

--- a/disconnected/using-olm.adoc
+++ b/disconnected/using-olm.adoc
@@ -61,7 +61,7 @@ As of {product-title} 4.11, the default Red{nbsp}Hat-provided Operator catalog r
 
 The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
 
-Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format], xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs], and xref:../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format], xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs], and xref:../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2].
 ====
 
 include::modules/olm-creating-catalog-from-index.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-disconnected/disconnected-install-ibmz-hcp.adoc
+++ b/hosted_control_planes/hcp-disconnected/disconnected-install-ibmz-hcp.adoc
@@ -24,7 +24,7 @@ include::modules/hcp-ibm-z-dc-prereqs.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../disconnected/mirroring/installing-mirroring-creating-registry.adoc#mirror-registry-introduction_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift]
-* xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+* xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
 
 
 include::modules/hcp-ibm-z-adding-credentials-registry.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
@@ -21,7 +21,7 @@ include::modules/hcp-dc-apply-objects.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+* xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2].
 
 [id="hcp-dc-mce-bm"]
 == Deploying {mce-short} for a disconnected installation of {hcp}

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
@@ -19,7 +19,7 @@ include::modules/hcp-dc-apply-objects.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+* xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2].
 
 [id="hcp-dc-mce-virt"]
 == Deploying {mce-short} for a disconnected installation of {hcp}

--- a/installing/installing_ibm_cloud/installing-ibm-cloud-restricted.adoc
+++ b/installing/installing_ibm_cloud/installing-ibm-cloud-restricted.adoc
@@ -13,7 +13,7 @@ In {product-title} {product-version}, you can install a cluster in a restricted 
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You xref:../../installing/installing_ibm_cloud/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an {ibm-cloud-title} account] to host the cluster.
-* You have a container image registry that is accessible to the internet and your restricted network. The container image registry should mirror the contents of the {product-registry} and contain the installation media. For more information, see xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+* You have a container image registry that is accessible to the internet and your restricted network. The container image registry should mirror the contents of the {product-registry} and contain the installation media. For more information, see xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2].
 * You have an existing VPC on {ibm-cloud-name} that meets the following requirements:
 ** The VPC contains the mirror registry or has firewall rules or a peering connection to access the mirror registry that is hosted elsewhere.
 ** The VPC can access {ibm-cloud-name} service endpoints using a public endpoint. If network restrictions limit access to public service endpoints, evaluate those services for alternate endpoints that might be available. For more information see xref:../../installing/installing_ibm_cloud/installing-ibm-cloud-restricted.adoc#access-to-ibm-service-endpoints_installing-ibm-cloud-restricted[Access to IBM service endpoints].
@@ -30,7 +30,7 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+* xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
 * xref:../../installing/installing_ibm_cloud/installation-config-parameters-ibm-cloud-vpc.adoc#installation-configuration-parameters-additional-ibm-cloud_installation-config-parameters-ibm-cloud-vpc[Additional {ibm-cloud-title} configuration parameters]
 
 include::modules/installation-custom-ibm-cloud-vpc.adoc[leveloffset=+1]

--- a/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
@@ -24,7 +24,7 @@ If your Nutanix environment uses an internal CA to issue certificates, you must 
 Use 2048-bit certificates. The installation fails if you use 4096-bit certificates with Prism Central 2022.x.
 ====
 * You have a container image registry, such as Red Hat Quay. If you do not already have a registry, you can create a mirror registry using  xref:../../disconnected/mirroring/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[_mirror registry for Red Hat OpenShift_].
-* You have used the xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[oc-mirror OpenShift CLI (oc) plugin] to mirror all of the required {product-title} content and other images, including the Nutanix CSI Operator, to your mirror registry.
+* You have used the xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[oc-mirror OpenShift CLI (oc) plugin] to mirror all of the required {product-title} content and other images, including the Nutanix CSI Operator, to your mirror registry.
 +
 [IMPORTANT]
 ====

--- a/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
+++ b/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
@@ -15,7 +15,7 @@ You can use a mirror registry for disconnected installations and to ensure that 
 You can use one of the following procedures to mirror your {product-title} image repository to your mirror registry:
 
 * xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
-* xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+* xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
 
 include::modules/agent-install-about-mirroring-for-disconnected-registry.adoc[leveloffset=+1]
 

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -44,7 +44,7 @@ The `opm` subcommands, flags, and functionality related to the SQLite database f
 
 Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format.
 ifndef::openshift-dedicated,openshift-rosa[]
-For more information about working with file-based catalogs, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format] and xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+For more information about working with file-based catalogs, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format] and xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2].
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 For more information about working with file-based catalogs, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format].

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -41,7 +41,7 @@ The `opm` subcommands, flags, and functionality related to the SQLite database f
 
 Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format.
 ifndef::openshift-dedicated,openshift-rosa[]
-For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs] and xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs] and xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2].
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs].

--- a/operators/understanding/olm-rh-catalogs.adoc
+++ b/operators/understanding/olm-rh-catalogs.adoc
@@ -17,7 +17,7 @@ The `opm` subcommands, flags, and functionality related to the SQLite database f
 Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format.
 ifndef::openshift-dedicated,openshift-rosa[]
 For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs],
-xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format], and xref:../../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format], and xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2].
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs], and

--- a/rosa_architecture/index.adoc
+++ b/rosa_architecture/index.adoc
@@ -120,7 +120,7 @@ xref:../installing/installing_vsphere/upi/installing-restricted-networks-vsphere
 xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[bare metal] and the cluster
 does not have full access to the internet, you must mirror the {product-title} installation images. To do this action, use one of the following methods, so that you can install a cluster in a restricted network.
 *** xref:../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
-*** xref:../disconnected/mirroring/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation by using the oc-mirror plug-in]
+*** xref:../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]

--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -33,9 +33,9 @@ include::modules/lvms-installing-logical-volume-manager-operator-disconnected-en
 
 * xref:../../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the OpenShift Container Platform image repository]
 
-* xref:../../../disconnected/mirroring/installing-mirroring-disconnected.adoc#oc-mirror-creating-image-set-config_installing-mirroring-disconnected[Creating the image set configuration]
+* xref:../../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#oc-mirror-building-image-set-config-v2_about-installing-oc-mirror-v2[Creating the image set configuration]
 
-* xref:../../../disconnected/mirroring/installing-mirroring-disconnected.adoc#mirroring-image-set[Mirroring an image set to a mirror registry]
+* xref:../../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#using-oc-mirror_about-installing-oc-mirror-v2[Mirroring an image set to a mirror registry]
 
 * xref:../../../openshift_images/image-configuration.adoc#images-configuration-registry-mirror_image-configuration[Configuring image registry repository mirroring]
 


### PR DESCRIPTION
[OSDOCS-13215](https://issues.redhat.com/browse/OSDOCS-13215)

Version(s): 4.18+ 

This PR updates links to the oc-mirror v1 doc, wherever appropriate, with links to the v2 doc.

QE review:
- [x] QE has approved this change.

Previews (only listing a few for examples):

- [HCP on BM](https://87822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm#:~:text=Additional%20resources)
- [Installing on Nutanix](https://87822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned#:~:text=Hat%20OpenShift.-,You%20have%20used,-the%20oc%2Dmirror)
- [Operators section](https://87822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs#olm-managing-custom-catalogs-fb)
- [Mirroring images for a disconnected installation](https://87822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/#mirroring-images-disconnected-install)