### PR TITLE
OSDOCS:12999 Misleading Example of Autoscaling for Image-Registry Deployment

### DIFF
--- a/modules/nodes-pods-autoscaling-about.adoc
+++ b/modules/nodes-pods-autoscaling-about.adoc
@@ -66,26 +66,26 @@ and ensure that your application meets these requirements before using
 memory-based autoscaling.
 ====
 
-The following example shows autoscaling for the `image-registry` `Deployment` object. The initial deployment requires 3 pods. The HPA object increases the minimum to 5. If CPU usage on the pods reaches 75%, the pods increase to 7:
+The following example shows autoscaling for the `hello-node` `Deployment` object. The initial deployment requires 3 pods. The HPA object increases the minimum to 5. If CPU usage on the pods reaches 75%, the pods increase to 7:
 
 [source,terminal]
 ----
-$ oc autoscale deployment/image-registry --min=5 --max=7 --cpu-percent=75
+$ oc autoscale deployment/hello-node --min=5 --max=7 --cpu-percent=75
 ----
 
 .Example output
 [source,terminal]
 ----
-horizontalpodautoscaler.autoscaling/image-registry autoscaled
+horizontalpodautoscaler.autoscaling/hello-node autoscaled
 ----
 
-.Sample HPA for the `image-registry` `Deployment` object with `minReplicas` set to 3
+.Sample YAML to create an HPA for the `hello-node` deployment object with `minReplicas` set to 3
 [source,yaml]
 ----
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: image-registry
+  name: hello-node
   namespace: default
 spec:
   maxReplicas: 7
@@ -93,25 +93,25 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: image-registry
+    name: hello-node
   targetCPUUtilizationPercentage: 75
 status:
   currentReplicas: 5
   desiredReplicas: 0
 ----
 
-. View the new state of the deployment:
-+
+After you create the HPA, you can view the new state of the deployment by running the following command:
+
 [source,terminal]
 ----
-$ oc get deployment image-registry
+$ oc get deployment hello-node
 ----
-+
+
 There are now 5 pods in the deployment:
-+
+
 .Example output
 [source,terminal]
 ----
-NAME             REVISION   DESIRED   CURRENT   TRIGGERED BY
-image-registry   1          5         5         config
+NAME         REVISION   DESIRED   CURRENT   TRIGGERED BY
+hello-node   1          5         5         config
 ----

--- a/modules/nodes-pods-autoscaling-creating-cpu.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu.adoc
@@ -76,11 +76,11 @@ $ oc autoscale <object_type>/<name> \// <1>
 <3> Specify the maximum number of replicas when scaling up.
 <4> Specify the target average CPU utilization over all the pods, represented as a percent of requested CPU. If not specified or negative, a default autoscaling policy is used.
 +
-For example, the following command shows autoscaling for the `image-registry` `Deployment` object. The initial deployment requires 3 pods. The HPA object increases the minimum to 5. If CPU usage on the pods reaches 75%, the pods will increase to 7:
+For example, the following command shows autoscaling for the `hello-node` deployment object. The initial deployment requires 3 pods. The HPA object increases the minimum to 5. If CPU usage on the pods reaches 75%, the pods will increase to 7:
 +
 [source,terminal]
 ----
-$ oc autoscale deployment/image-registry --min=5 --max=7 --cpu-percent=75
+$ oc autoscale deployment/hello-node --min=5 --max=7 --cpu-percent=75
 ----
 
 ** To scale for a specific CPU value, create a YAML file similar to the following for an existing object:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-12999

Previews
[Understanding horizontal pod autoscalers](https://87829--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling.html#nodes-pods-autoscaling-about_nodes-pods-autoscaling) -- Various edits, starting after the Metrics table and Important admonition
[Creating a horizontal pod autoscaler for CPU utilization by using the CLI](https://87829--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling.html#nodes-pods-autoscaling-creating-cpu_nodes-pods-autoscaling) -- Updated the deployment name in the example to `hello-node` in two places

QE reviewed