### PR TITLE
CNV-55143: Fix machine configuration and add explicit warning about usage of resources.requests.memory

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -13,6 +13,8 @@ The `wasp-agent` component facilitates memory overcommitment by assigning swap r
 Swap resources can be only assigned to virtual machine workloads (VM pods) of the `Burstable` Quality of Service (QoS) class. VM pods of the `Guaranteed` QoS class and pods of any QoS class that do not belong to VMs cannot swap resources.
 
 For descriptions of QoS classes, see link:https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/[Configure Quality of Service for Pods] (Kubernetes documentation).
+
+Using `spec.domain.resources.requests.memory` in the VM manifest disables the memory overcommit configuration. Use `spec.domain.memory.guest` instead.
 ====
 
 .Prerequisites
@@ -76,7 +78,8 @@ spec:
             [Unit]
             Description=Provision and enable swap
             ConditionFirstBoot=no
-            
+            ConditionPathExists=!/var/tmp/swapfile
+
             [Service]
             Type=oneshot
             Environment=SWAP_SIZE_MB=5000
@@ -84,13 +87,25 @@ spec:
             sudo chmod 600 /var/tmp/swapfile && \
             sudo mkswap /var/tmp/swapfile && \
             sudo swapon /var/tmp/swapfile && \
-            free -h && \
-            sudo systemctl set-property --runtime system.slice MemorySwapMax=0 IODeviceLatencyTargetSec=\"/ 50ms\""
-            
+            free -h"
+
             [Install]
             RequiredBy=kubelet-dependencies.target
           enabled: true
           name: swap-provision.service
+        - contents: |
+            [Unit]
+            Description=Restrict swap for system slice
+            ConditionFirstBoot=no
+
+            [Service]
+            Type=oneshot
+            ExecStart=/bin/sh -c "sudo systemctl set-property --runtime system.slice MemorySwapMax=0 IODeviceLatencyTargetSec=\"/ 50ms\""
+
+            [Install]
+            RequiredBy=kubelet-dependencies.target
+          enabled: true
+          name: cgroup-system-slice-config.service
 ----
 +
 To have enough swap space for the worst-case scenario, make sure to have at least as much swap space provisioned as overcommitted RAM. Calculate the amount of swap space to be provisioned on a node by using the following formula:
@@ -174,9 +189,9 @@ spec:
             - name: SWAP_UTILIZATION_THRESHOLD_FACTOR
               value: "0.8"
             - name: MAX_AVERAGE_SWAP_IN_PAGES_PER_SECOND
-              value: "1000"
+              value: "1000000000"
             - name: MAX_AVERAGE_SWAP_OUT_PAGES_PER_SECOND
-              value: "1000"
+              value: "1000000000"
             - name: AVERAGE_WINDOW_SIZE_SECONDS
               value: "30"
             - name: VERBOSITY


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-55143

OCP 4.17+
CNV 4.17+

Preview: https://87835--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html#virt-using-wasp-agent-to-configure-higher-vm-workload-density_virt-configuring-higher-vm-workload-density
