### PR TITLE
OCPBUGS#41970: Updated MTU data type in MACVLAN table

### DIFF
--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -5,9 +5,9 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="nw-multus-macvlan-object_{context}"]
-= Configuration for a macvlan additional network
+= Configuration for a MACVLAN additional network
 
-The following object describes the configuration parameters for the MACVLAN CNI plugin:
+The following object describes the configuration parameters for the MAC Virtual LAN (MACVLAN) Container Network Interface (CNI) plugin:
 
 .MACVLAN CNI plugin JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
@@ -39,7 +39,7 @@ The following object describes the configuration parameters for the MACVLAN CNI 
 |Optional: The host network interface to associate with the newly created macvlan interface. If a value is not specified, then the default route interface is used.
 
 |`mtu`
-|`string`
+|`integer`
 |Optional: The maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
 |`linkInContainer`


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-41970](https://issues.redhat.com/browse/OCPBUGS-41970)

Link to docs preview:

* [Configuration for a MACVLAN additional network (core)](https://87836--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.html#nw-multus-macvlan-config-example_configuring-additional-network-cni)
* [Configuration for a MACVLAN additional network (MicroShift)](https://87836--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus.html#nw-multus-macvlan-object_microshift-cni-multus)

[x] SME review (Marcelo Guerrero Viveros)
[x] QE review (Weibin Liang)

