### PR TITLE
OCPBUGS-34880: Clarifying flow for disconnected with different registries for seed and target

### DIFF
--- a/edge_computing/image_based_upgrade/cnf-image-based-upgrade-base.adoc
+++ b/edge_computing/image_based_upgrade/cnf-image-based-upgrade-base.adoc
@@ -18,6 +18,8 @@ include::modules/cnf-image-based-upgrade-prep.adoc[leveloffset=+1]
 
 * xref:../../edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-prep-resources.adoc#cnf-image-based-upgrade-prep-resources[Creating ConfigMap objects for the image-based upgrade with {lcao}]
 
+* xref:../../openshift_images/image-configuration.adoc#images-configuration-registry-mirror-configuring_image-configuration[Configuring image registry repository mirroring]
+
 include::modules/cnf-image-based-upgrade-with-backup.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/cnf-image-based-upgrade-prep.adoc
+++ b/modules/cnf-image-based-upgrade-prep.adoc
@@ -10,6 +10,18 @@ When you deploy the {lcao} on a cluster, an `ImageBasedUpgrade` custom resource 
 After you created all the resources that you need during the upgrade, you can move on to the `Prep` stage.
 For more information, see the "Creating ConfigMap objects for the image-based upgrade with {lcao}" section.
 
+[NOTE]
+====
+In a disconnected environment, if the seed cluster's release image registry is different from the target cluster's release image registry, you must create an `ImageDigestMirrorSet` (IDMS) resource to configure alternative mirrored repository locations. For more information, see "Configuring image registry repository mirroring". 
+
+You can retrieve the release registry used in the seed image by running the following command:
+
+[source,terminal]
+----
+$ skopeo inspect docker://<imagename> | jq -r '.Labels."com.openshift.lifecycle-agent.seed_cluster_info" | fromjson | .release_registry'
+----
+====
+
 .Prerequisites
 
 * You have created resources to back up and restore your clusters.


### PR DESCRIPTION
OCPBUGS-34880: Clarifying flow for disconnected with different registries for seed and target

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-34880

Link to docs preview:
- https://file.corp.redhat.com/rohennes/OCPBUGS-34880/edge_computing/image_based_upgrade/cnf-image-based-upgrade-base.html#ztp-image-based-upgrade-prep_cnf-non-gitops

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
