### PR TITLE
RHDEVDOCS-2108: Installing OpenShift Pipelines Operator Using CLI is unclear (copy)

### DIFF
--- a/modules/op-installing-pipelines-operator-using-the-cli.adoc
+++ b/modules/op-installing-pipelines-operator-using-the-cli.adoc
@@ -3,17 +3,16 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="op-installing-pipelines-operator-using-the-cli_{context}"]
-= Installing the {pipelines-shortname} Operator using the CLI
+= Installing the {pipelines-shortname} Operator by using the CLI
 
-You can install {pipelines-title} Operator from the OperatorHub using the CLI.
+You can install {pipelines-title} Operator from OperatorHub by using the command-line interface (CLI).
 
-[discrete]
 .Procedure
 
-. Create a Subscription object YAML file to subscribe a namespace to the {pipelines-title} Operator,
+. Create a `Subscription` object YAML file to subscribe a namespace to the {pipelines-title} Operator,
 for example, `sub.yaml`:
 +
-.Example Subscription
+.Example `Subscription` YAML
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -22,18 +21,19 @@ metadata:
   name: openshift-pipelines-operator
   namespace: openshift-operators
 spec:
-  channel:  <channel name> <1>
-  name: openshift-pipelines-operator-rh <2>
-  source: redhat-operators <3>
+  channel:  <channel_name> # <1>
+  name: openshift-pipelines-operator-rh # <2>
+  source: redhat-operators # <3>
   sourceNamespace: openshift-marketplace <4>
 ----
-<1> The channel name of the Operator. The `pipelines-<version>` channel is the default channel. For example, the default channel for {pipelines-title} Operator version `1.7` is `pipelines-1.7`. The `latest` channel enables installation of the most recent stable version of the {pipelines-title} Operator.
+<1> Name of the channel that you want to subscribe. The `pipelines-<version>` channel is the default channel. For example, the default channel for {pipelines-title} Operator version `1.7` is `pipelines-1.7`. The `latest` channel enables installation of the most recent stable version of the {pipelines-title} Operator.
 <2> Name of the Operator to subscribe to.
-<3> Name of the CatalogSource that provides the Operator.
-<4> Namespace of the CatalogSource. Use `openshift-marketplace` for the default OperatorHub CatalogSources.
+<3> Name of the `CatalogSource` object that provides the Operator.
+<4> Namespace of the `CatalogSource` object. Use `openshift-marketplace` for the default OperatorHub catalog sources.
 
-. Create the Subscription object:
+. Create the `Subscription` object by running the following command:
 +
+[source, terminal]
 ----
 $ oc apply -f sub.yaml
 ----


### PR DESCRIPTION
Clone of: https://github.com/openshift/openshift-docs/pull/83755

Versions for CP: `pipelines-docs-1.14`, `pipelines-docs-1.15`, `pipelines-docs-1.16`, `pipelines-docs-1.17` `pipelines-docs-1.18`