### PR TITLE
OBSDOCS-1520: Missing Release notes for Logging 5.8

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2918,32 +2918,6 @@ Topics:
   Dir: logging
   Distros: openshift-enterprise,openshift-origin
   Topics:
-#  - Name: Release notes
-#    Dir: logging_release_notes
-#    Topics:
-#    - Name: Logging 5.9
-#      File: logging-5-9-release-notes
-#    - Name: Logging 5.8
-#      File: logging-5-8-release-notes
-#    - Name: Logging 5.7
-#      File: logging-5-7-release-notes
-  - Name: Logging 6.0
-    Dir: logging-6.0
-    Topics:
-      - Name: Release notes
-        File: log6x-release-notes
-      - Name: About logging 6.0
-        File: log6x-about
-      - Name: Upgrading to Logging 6.0
-        File: log6x-upgrading-to-6
-      - Name: Configuring log forwarding
-        File: log6x-clf
-      - Name: Configuring LokiStack storage
-        File: log6x-loki
-      - Name: Visualization for logging
-        File: log6x-visual
-#      - Name: API reference 6.0
-#        File: log6x-api-reference
   - Name: Logging 6.1
     Dir: logging-6.1
     Topics:
@@ -2961,6 +2935,36 @@ Topics:
       File: log6x-opentelemetry-data-model-6.1
     - Name: Visualization for logging
       File: log6x-visual-6.1
+  - Name: Logging 6.0
+    Dir: logging-6.0
+    Topics:
+      - Name: Release notes
+        File: log6x-release-notes
+      - Name: About logging 6.0
+        File: log6x-about
+      - Name: Upgrading to Logging 6.0
+        File: log6x-upgrading-to-6
+      - Name: Configuring log forwarding
+        File: log6x-clf
+      - Name: Configuring LokiStack storage
+        File: log6x-loki
+      - Name: Visualization for logging
+        File: log6x-visual
+  - Name: Logging 5.8
+    Dir: logging_release_notes
+    Topics:
+    - Name: Release notes
+      File: logging-5-8-release-notes
+#  - Name: Release notes
+#    Dir: logging_release_notes
+#    Topics:
+#    - Name: Logging 5.9
+#      File: logging-5-9-release-notes
+#    - Name: Logging 5.7
+#      File: logging-5-7-release-notes
+#      - Name: API reference 6.0
+#        File: log6x-api-reference
+
 #  - Name: Support
 #    File: cluster-logging-support
 #  - Name: Troubleshooting logging


### PR DESCRIPTION
Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1520

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
