### PR TITLE
OCPBUGS-41989: Added a table to the nw-ingress-sharding.adoc

### DIFF
--- a/modules/nw-ingress-sharding.adoc
+++ b/modules/nw-ingress-sharding.adoc
@@ -6,25 +6,35 @@
 [id="nw-ingress-sharding_{context}"]
 = Ingress Controller sharding
 
-You can use Ingress sharding, also known as router sharding, to distribute a set of routes across multiple routers by adding labels to routes, namespaces, or both. The Ingress Controller uses a corresponding set of selectors to admit only the routes that have a specified label. Each Ingress shard comprises the routes that are filtered using a given selection expression.
+You can use Ingress sharding, also known as router sharding, to distribute a set of routes across multiple routers by adding labels to routes, namespaces, or both. The Ingress Controller uses a corresponding set of selectors to admit only the routes that have a specified label. Each Ingress shard comprises the routes that are filtered by using a given selection expression.
 
 As the primary mechanism for traffic to enter the cluster, the demands on the Ingress Controller can be significant. As a cluster administrator, you can shard the routes to:
 
-* Balance Ingress Controllers, or routers, with several routes to speed up responses to changes.
-* Allocate certain routes to have different reliability guarantees than other routes.
+* Balance Ingress Controllers, or routers, with several routes to accelerate responses to changes.
+* Assign certain routes to have different reliability guarantees than other routes.
 * Allow certain Ingress Controllers to have different policies defined.
 * Allow only specific routes to use additional features.
 * Expose different routes on different addresses so that internal and external users can see different routes, for example.
-* Transfer traffic from one version of an application to another during a blue green deployment.
+* Transfer traffic from one version of an application to another during a blue-green deployment.
 
-When Ingress Controllers are sharded, a given route is admitted to zero or more Ingress Controllers in the group. A route's status describes whether an Ingress Controller has admitted it or not. An Ingress Controller will only admit a route if it is unique to its shard.
+When Ingress Controllers are sharded, a given route is admitted to zero or more Ingress Controllers in the group. The status of a route describes whether an Ingress Controller has admitted the route. An Ingress Controller only admits a route if the route is unique to a shard.
 
-An Ingress Controller can use three sharding methods:
+With sharding, you can distribute subsets of routes over multiple Ingress Controllers. These subsets can be nonoverlapping, also called _traditional_ sharding, or overlapping, otherwise known as _overlapped_ sharding.
 
-* Adding only a namespace selector to the Ingress Controller, so that all routes in a namespace with labels that match the namespace selector are in the Ingress shard.
+The following table outlines three sharding methods:
 
-* Adding only a route selector to the Ingress Controller, so that all routes with labels that match the route selector are in the Ingress shard.
+[cols="1,3",options="header"]
+|===
+|Sharding method
+|Description
 
-* Adding both a namespace selector and route selector to the Ingress Controller, so that routes with labels that match the route selector in a namespace with labels that match the namespace selector are in the Ingress shard.
+|Namespace selector
+|After you add a namespace selector to the Ingress Controller, all routes in a namespace that have matching labels for the namespace selector are included in the Ingress shard. Consider this method when an Ingress Controller serves all routes created in a namespace.
 
-With sharding, you can distribute subsets of routes over multiple Ingress Controllers. These subsets can be non-overlapping, also called _traditional_ sharding, or overlapping, otherwise known as _overlapped_ sharding.
+|Route selector
+|After you add a route selector to the Ingress Controller, all routes with labels that match the route selector are included in the Ingress shard. Consider this method when you want an Ingress Controller to serve only a subset of routes or a specific route in a namespace.
+
+|Namespace and route selectors
+|Provides your Ingress Controller scope for both namespace selector and route selector methods. Consider this method when you want the flexibility of both the namespace selector and the route selector methods.
+|===
+


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-41989](https://issues.redhat.com/browse/OCPBUGS-41989)

Link to docs preview:
[Ingress Controller sharding](https://87848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#nw-ingress-sharding_configuring-ingress-cluster-traffic-ingress-controller)

- [x] QE has approved this change (Melvin Joseph).
