### PR TITLE
OCPBUGS-31917 added a note that states latency profiles do not suppor…

### DIFF
--- a/modules/nodes-cluster-worker-latency-profiles-about.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-about.adoc
@@ -124,3 +124,8 @@ The Kubernetes Controller Manager waits for 5 minutes to consider a node unhealt
 
 |===
 endif::openshift-rosa,openshift-dedicated[]
+
+[NOTE]
+====
+The latency profiles do not support custom machine config pools, only the default worker machine config pools.
+====


### PR DESCRIPTION
Version(s):
12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-31917

Link to docs preview:
https://87859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-worker-latency-profiles.html
https://87859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html
https://87859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/scaling-worker-latency-profiles.html


QE review:
- [x] QE has approved this change.



