### PR TITLE
TELCODOCS-2170 - Adding docs for the T-GM antenna delay settings

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1504,15 +1504,15 @@ Topics:
   Topics:
   - Name: About Precision Time Protocol in OpenShift cluster nodes
     File: about-ptp
-  - Name: Configuring Precision Time Protocol devices
+  - Name: Configuring PTP devices
     File: configuring-ptp
   - Name: Developing PTP events consumer applications with the REST API v2
     File: ptp-cloud-events-consumer-dev-reference-v2
-  - Name: Precision Time Protocol events REST API v2 reference
+  - Name: PTP events REST API v2 reference
     File: ptp-events-rest-api-reference-v2
   - Name: Developing PTP events consumer applications with the REST API v1
     File: ptp-cloud-events-consumer-dev-reference
-  - Name: Precision Time Protocol events REST API v1 reference
+  - Name: PTP events REST API v1 reference
     File: ptp-events-rest-api-reference
 - Name: CIDR range definitions
   File: cidr-range-definitions

--- a/modules/nw-ptp-e810-hardware-configuration-reference.adoc
+++ b/modules/nw-ptp-e810-hardware-configuration-reference.adoc
@@ -31,19 +31,31 @@ The `SMA2` connector is bidirectional.
 ====
 
 Set `spec.profile.plugins.e810.ublxCmds` parameters to configure the GNSS clock in the `PtpConfig` custom resource (CR).
+
+[IMPORTANT]
+====
+You must configure an offset value to compensate for T-GM GPS antenna cable signal delay.
+To configure the optimal T-GM antenna offset value, make precise measurements of the GNSS antenna cable signal delay.
+Red{nbsp}Hat cannot assist in this measurement or provide any values for the required delay offsets.
+====
+
 Each of these `ublxCmds` stanzas correspond to a configuration that is applied to the host NIC by using `ubxtool` commands.
 For example:
 
 [source,yaml]
 ----
 ublxCmds:
-  - args: #ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+  - args:
       - "-P"
       - "29.20"
       - "-z"
       - "CFG-HW-ANT_CFG_VOLTCTRL,1"
+      - "-z"
+      - "CFG-TP-ANT_CABLEDELAY,<antenna_delay_offset>"<1>
     reportOutput: false
 ----
+<1> Measured T-GM antenna delay offset in nanoseconds.
+To get the required delay offset value, you must measure the cable delay using external test equipment.
 
 The following table describes the equivalent `ubxtool` commands:
 
@@ -51,7 +63,7 @@ The following table describes the equivalent `ubxtool` commands:
 [width="90%", options="header"]
 |====
 |ubxtool command|Description
-|`ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1`|Enables antenna voltage control. Enables antenna status to be reported in the `UBX-MON-RF` and `UBX-INF-NOTICE` log messages.
+|`ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1 -z CFG-TP-ANT_CABLEDELAY,<antenna_delay_offset>`|Enables antenna voltage control, allows antenna status to be reported in the `UBX-MON-RF` and `UBX-INF-NOTICE` log messages, and sets a `<antenna_delay_offset>` value in nanoseconds that offsets the GPS antenna cable signal delay.
 |`ubxtool -P 29.20 -e GPS`|Enables the antenna to receive GPS signals.
 |`ubxtool -P 29.20 -d Galileo`|Configures the antenna to receive signal from the Galileo GPS satellite.
 |`ubxtool -P 29.20 -d GLONASS`|Disables the antenna from receiving signal from the GLONASS GPS satellite.
@@ -59,42 +71,4 @@ The following table describes the equivalent `ubxtool` commands:
 |`ubxtool -P 29.20 -d SBAS`|Disables the antenna from receiving signal from the SBAS GPS satellite.
 |`ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000`| Configures the GNSS receiver survey-in process to improve its initial position estimate. This can take up to 24 hours to achieve an optimal result.
 |`ubxtool -P 29.20 -p MON-HW`|Runs a single automated scan of the hardware and reports on the NIC state and configuration settings.
-|====
-
-The E810 plugin implements the following interfaces:
-
-.E810 plugin interfaces
-[cols="1,3", width="90%", options="header"]
-|====
-|Interface
-|Description
-
-|`OnPTPConfigChangeE810`
-|Runs whenever you update the `PtpConfig` CR.
-The function parses the plugin options and applies the required configurations to the network device pins based on the configuration data.
-
-|`AfterRunPTPCommandE810`
-|Runs after launching the PTP processes and running the `gpspipe` PTP command.
-The function processes the plugin options and runs `ubxtool` commands, storing the output in the plugin-specific data.
-
-|`PopulateHwConfigE810`
-|Populates the `NodePtpDevice` CR based on hardware-specific data in the `PtpConfig` CR.
-|====
-
-The E810 plugin has the following structs and variables:
-
-.E810 plugin structs and variables
-[cols="1,3", width="90%", options="header"]
-|====
-|Struct
-|Description
-
-|`E810Opts`
-|Represents options for the E810 plugin, including boolean flags and a map of network device pins.
-
-|`E810UblxCmds`
-|Represents configurations for `ubxtool` commands with a boolean flag and a slice of strings for command arguments.
-
-|`E810PluginData`
-|Holds plugin-specific data used during plugin execution.
 |====

--- a/networking/ptp/configuring-ptp.adoc
+++ b/networking/ptp/configuring-ptp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="configuring-ptp"]
-= Configuring Precision Time Protocol devices
+= Configuring PTP devices
 include::_attributes/common-attributes.adoc[]
 :context: configuring-ptp
 

--- a/networking/ptp/ptp-events-rest-api-reference-v2.adoc
+++ b/networking/ptp/ptp-events-rest-api-reference-v2.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ptp-events-rest-api-reference-v2"]
-= Precision Time Protocol events REST API v2 reference
+= PTP events REST API v2 reference
 include::_attributes/common-attributes.adoc[]
 :context: using-ptp-hardware-fast-events-framework-v2
 

--- a/networking/ptp/ptp-events-rest-api-reference.adoc
+++ b/networking/ptp/ptp-events-rest-api-reference.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ptp-events-rest-api-reference"]
-= Precision Time Protocol events REST API v1 reference
+= PTP events REST API v1 reference
 include::_attributes/common-attributes.adoc[]
 :context: using-ptp-hardware-fast-events-framework-v1
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-2170

Version(s):
enteprise-4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2170

Link to docs preview:
https://87860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp.html#nw-ptp-e810-hardware-pins-reference_configuring-ptp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
