### PR TITLE
OBSDOCS-1530: Support section was removed from Logging documentation in 4.17

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3008,6 +3008,8 @@ Topics:
   - Name: Logging 6.2
     Dir: logging-6.2
     Topics:
+    - Name: Support
+      File: log62-cluster-logging-support
     - Name: Release notes
       File: log6x-release-notes-6.2
     - Name: Configuring log forwarding
@@ -3019,6 +3021,8 @@ Topics:
   - Name: Logging 6.1
     Dir: logging-6.1
     Topics:
+    - Name: Support
+      File: log61-cluster-logging-support
     - Name: Release notes
       File: log6x-release-notes-6.1
     - Name: About logging 6.1

--- a/modules/cluster-logging-maintenance-support-list-6x.adoc
+++ b/modules/cluster-logging-maintenance-support-list-6x.adoc
@@ -1,24 +1,20 @@
 // Module included in the following assemblies:
 //
-// * observability/logging/cluster-logging-support.adoc
+// * observability/logging/logging-6.0/log60-cluster-logging-support.adoc
+// * observability/logging/logging-6.1/log61-cluster-logging-support.adoc
+// * observability/logging/logging-6.2/log62-cluster-logging-support.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-logging-maintenance-support-list_{context}"]
 = Unsupported configurations
 
 You must set the Red{nbsp}Hat OpenShift Logging Operator to the `Unmanaged` state to modify the following components:
 
-* The `fluent.conf` file
+* The collector configuration file
 
-* The Fluentd daemon set
-
-* The `vector.toml` file for Vector collector deployments
-
+* The collector daemonset
 
 Explicitly unsupported cases include:
-
-* *Configuring the collected log location*. You cannot change the location of the log collector output file, which by default is `/var/log/fluentd/fluentd.log`.
-
-* *Throttling log collection*. You cannot throttle down the rate at which the logs are read in by the log collector.
 
 * *Configuring the logging collector using environment variables*. You cannot use environment variables to modify the log collector.
 

--- a/observability/logging/logging-6.0/log60-cluster-logging-support.adoc
+++ b/observability/logging/logging-6.0/log60-cluster-logging-support.adoc
@@ -1,0 +1,48 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="log60-cluster-logging-support"]
+= Support
+include::_attributes/common-attributes.adoc[]
+:context: log60-cluster-logging-support
+
+toc::[]
+
+include::snippets/logging-supported-config-snip.adoc[]
+include::snippets/logging-compatibility-snip.adoc[]
+include::snippets/log6x-loki-statement-snip.adoc[]
+
+{logging-uc} {for} is an opinionated collector and normalizer of application, infrastructure, and audit logs. It is intended to be used for forwarding logs to various supported systems.
+
+{logging-uc} is not:
+
+* A high scale log collection system
+* Security Information and Event Monitoring (SIEM) compliant
+* A "bring your own" (BYO) log collector configuration
+* Historical or long term log retention or storage
+* A guaranteed log sink
+* Secure storage - audit logs are not stored by default
+
+[id="cluster-logging-support-CRDs_{context}"]
+== Supported API custom resource definitions
+
+The following table describes the supported {logging-uc} APIs.
+
+include::snippets/log6x-api-support-states-snip.adoc[]
+
+include::modules/cluster-logging-maintenance-support-list-6x.adoc[leveloffset=+1]
+include::modules/unmanaged-operators.adoc[leveloffset=+1]
+
+[id="support-exception-for-coo-logging-ui-plugin_{context}"]
+== Support exception for the Logging UI Plugin
+
+Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its Logging UI Plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
+
+[id="cluster-logging-support-must-gather_{context}"]
+== Collecting {logging} data for Red Hat Support
+
+When opening a support case, it is helpful to provide debugging information about your cluster to Red{nbsp}Hat Support.
+
+You can use the xref:../../../support/gathering-cluster-data.adoc#gathering-cluster-data[must-gather tool] to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
+For prompt support, supply diagnostic information for both {product-title} and {logging}.
+
+include::modules/cluster-logging-must-gather-about.adoc[leveloffset=+2]
+include::modules/cluster-logging-must-gather-collecting.adoc[leveloffset=+2]

--- a/observability/logging/logging-6.1/log61-cluster-logging-support.adoc
+++ b/observability/logging/logging-6.1/log61-cluster-logging-support.adoc
@@ -1,0 +1,48 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="log61-cluster-logging-support"]
+= Support
+include::_attributes/common-attributes.adoc[]
+:context: log61-cluster-logging-support
+
+toc::[]
+
+include::snippets/logging-supported-config-snip.adoc[]
+include::snippets/logging-compatibility-snip.adoc[]
+include::snippets/log6x-loki-statement-snip.adoc[]
+
+{logging-uc} {for} is an opinionated collector and normalizer of application, infrastructure, and audit logs. It is intended to be used for forwarding logs to various supported systems.
+
+{logging-uc} is not:
+
+* A high scale log collection system
+* Security Information and Event Monitoring (SIEM) compliant
+* A "bring your own" (BYO) log collector configuration
+* Historical or long term log retention or storage
+* A guaranteed log sink
+* Secure storage - audit logs are not stored by default
+
+[id="cluster-logging-support-CRDs_{context}"]
+== Supported API custom resource definitions
+
+The following table describes the supported {logging-uc} APIs.
+
+include::snippets/log6x-api-support-states-snip.adoc[]
+
+include::modules/cluster-logging-maintenance-support-list-6x.adoc[leveloffset=+1]
+include::modules/unmanaged-operators.adoc[leveloffset=+1]
+
+[id="support-exception-for-coo-logging-ui-plugin_{context}"]
+== Support exception for the Logging UI Plugin
+
+Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its Logging UI Plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
+
+[id="cluster-logging-support-must-gather_{context}"]
+== Collecting {logging} data for Red Hat Support
+
+When opening a support case, it is helpful to provide debugging information about your cluster to Red{nbsp}Hat Support.
+
+You can use the xref:../../../support/gathering-cluster-data.adoc#gathering-cluster-data[must-gather tool] to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
+For prompt support, supply diagnostic information for both {product-title} and {logging}.
+
+include::modules/cluster-logging-must-gather-about.adoc[leveloffset=+2]
+include::modules/cluster-logging-must-gather-collecting.adoc[leveloffset=+2]

--- a/observability/logging/logging-6.2/log62-cluster-logging-support.adoc
+++ b/observability/logging/logging-6.2/log62-cluster-logging-support.adoc
@@ -1,0 +1,48 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="log62-cluster-logging-support"]
+= Support
+include::_attributes/common-attributes.adoc[]
+:context: log62-cluster-logging-support
+
+toc::[]
+
+include::snippets/logging-supported-config-snip.adoc[]
+include::snippets/logging-compatibility-snip.adoc[]
+include::snippets/log6x-loki-statement-snip.adoc[]
+
+{logging-uc} {for} is an opinionated collector and normalizer of application, infrastructure, and audit logs. It is intended to be used for forwarding logs to various supported systems.
+
+{logging-uc} is not:
+
+* A high scale log collection system
+* Security Information and Event Monitoring (SIEM) compliant
+* A "bring your own" (BYO) log collector configuration
+* Historical or long term log retention or storage
+* A guaranteed log sink
+* Secure storage - audit logs are not stored by default
+
+[id="cluster-logging-support-CRDs_{context}"]
+== Supported API custom resource definitions
+
+The following table describes the supported {logging-uc} APIs.
+
+include::snippets/log6x-api-support-states-snip.adoc[]
+
+include::modules/cluster-logging-maintenance-support-list-6x.adoc[leveloffset=+1]
+include::modules/unmanaged-operators.adoc[leveloffset=+1]
+
+[id="support-exception-for-coo-logging-ui-plugin_{context}"]
+== Support exception for the Logging UI Plugin
+
+Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its Logging UI Plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
+
+[id="cluster-logging-support-must-gather_{context}"]
+== Collecting {logging} data for Red Hat Support
+
+When opening a support case, it is helpful to provide debugging information about your cluster to Red{nbsp}Hat Support.
+
+You can use the xref:../../../support/gathering-cluster-data.adoc#gathering-cluster-data[must-gather tool] to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
+For prompt support, supply diagnostic information for both {product-title} and {logging}.
+
+include::modules/cluster-logging-must-gather-about.adoc[leveloffset=+2]
+include::modules/cluster-logging-must-gather-collecting.adoc[leveloffset=+2]

--- a/observability/logging/logging-6.2/log6x-clf-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-clf-6.2.adoc
@@ -81,7 +81,7 @@ Outputs are configured in an array under `spec.outputs`. Each output must have a
 
 azureMonitor:: Forwards logs to Azure Monitor.
 cloudwatch:: Forwards logs to AWS CloudWatch.
-//elasticsearch:: Forwards logs to an external Elasticsearch instance.
+elasticsearch:: Forwards logs to an external Elasticsearch instance.
 googleCloudLogging:: Forwards logs to Google Cloud Logging.
 http:: Forwards logs to a generic HTTP endpoint.
 kafka:: Forwards logs to a Kafka broker.

--- a/observability/logging/logging_release_notes/cluster-logging-support.adoc
+++ b/observability/logging/logging_release_notes/cluster-logging-support.adoc
@@ -16,6 +16,7 @@ include::snippets/log6x-loki-statement-snip.adoc[]
 
 * A high scale log collection system
 * Security Information and Event Monitoring (SIEM) compliant
+* A "bring your own" (BYO) log collector configuration
 * Historical or long term log retention or storage
 * A guaranteed log sink
 * Secure storage - audit logs are not stored by default
@@ -23,7 +24,7 @@ include::snippets/log6x-loki-statement-snip.adoc[]
 [id="cluster-logging-support-CRDs_{context}"]
 == Supported API custom resource definitions
 
-LokiStack development is ongoing. Not all APIs are currently supported.
+The following table describes the supported {logging-uc} APIs.
 
 .Loki API support states
 [cols="3",options="header"]
@@ -34,19 +35,27 @@ LokiStack development is ongoing. Not all APIs are currently supported.
 
 |LokiStack
 |lokistack.loki.grafana.com/v1
-|Supported in 5.5
+|Supported from 5.5
 
 |RulerConfig
 |rulerconfig.loki.grafana/v1
-|Supported in 5.7
+|Supported from 5.7
 
 |AlertingRule
 |alertingrule.loki.grafana/v1
-|Supported in 5.7
+|Supported from 5.7
 
 |RecordingRule
 |recordingrule.loki.grafana/v1
-|Supported in 5.7
+|Supported from 5.7
+
+|LogFileMetricExporter
+|LogFileMetricExporter.logging.openshift.io/v1alpha1
+|Supported from 5.8
+
+|ClusterLogForwarder
+|clusterlogforwarder.logging.openshift.io/v1
+|Supported from 4.5.
 |===
 
 include::modules/cluster-logging-maintenance-support-list.adoc[leveloffset=+1]
@@ -62,14 +71,8 @@ Until the approaching General Availability (GA) release of the Cluster Observabi
 
 When opening a support case, it is helpful to provide debugging information about your cluster to Red{nbsp}Hat Support.
 
-You can use the xref:../../support/gathering-cluster-data.adoc#gathering-cluster-data[`must-gather` tool] to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
-
+You can use the xref:../../../support/gathering-cluster-data.adoc#gathering-cluster-data[must-gather tool] to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
 For prompt support, supply diagnostic information for both {product-title} and {logging}.
-
-[NOTE]
-====
-Do not use the `hack/logging-dump.sh` script. The script is no longer supported and does not collect data.
-====
 
 include::modules/cluster-logging-must-gather-about.adoc[leveloffset=+2]
 include::modules/cluster-logging-must-gather-collecting.adoc[leveloffset=+2]

--- a/snippets/log6x-api-support-states-snip.adoc
+++ b/snippets/log6x-api-support-states-snip.adoc
@@ -1,0 +1,40 @@
+// Text snippet included in the following assemblies:
+// logging/logging-6.2/log62-cluster-logging-support.adoc
+// logging/logging-6.1/log61-cluster-logging-support.adoc
+//logging/logging-6.0/log60-cluster-logging-support.adoc
+// Text snippet included in the following modules:
+//
+//
+:_mod-docs-content-type: SNIPPET
+
+.Logging API support states
+[cols="3",options="header"]
+|===
+|CustomResourceDefinition (CRD)
+|ApiVersion
+|Support state
+
+|LokiStack
+|lokistack.loki.grafana.com/v1
+|Supported from 5.5
+
+|RulerConfig
+|rulerconfig.loki.grafana/v1
+|Supported from 5.7
+
+|AlertingRule
+|alertingrule.loki.grafana/v1
+|Supported from 5.7
+
+|RecordingRule
+|recordingrule.loki.grafana/v1
+|Supported from 5.7
+
+|LogFileMetricExporter
+|LogFileMetricExporter.logging.openshift.io/v1alpha1
+|Supported from 5.8
+
+|ClusterLogForwarder
+|clusterlogforwarder.observability.openshift.io/v1
+|Supported from 6.0
+|===


### PR DESCRIPTION
Version(s): Version(s): 4.19, 4.18, 4.17,4.16. Note that this needs to be cherry-picked to logging-docs-6.2-4.18, logging-docs-6.2-4.17, logging-docs-6.2-4.16 release branches and not enterprise-4.18, enterprise-4.17 branches.

Issue: https://issues.redhat.com/browse/OBSDOCS-1530

Link to docs preview:

https://87864--ocpdocs-pr.netlify.app/
https://87864--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log61-cluster-logging-support.html
https://87864--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log62-cluster-logging-support.html

https://87864--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/index.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->