### PR TITLE
4.14 - OADP-5354: Backup is failing on validation PartiallyFailed

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
@@ -160,11 +160,13 @@ $ cat <<EOF > ${SCRATCH}/credentials
 [default]
 role_arn = ${ROLE_ARN}
 web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+region=<aws_region> # <1>
 EOF
 $ oc -n openshift-adp create secret generic cloud-credentials \
  --from-file=${SCRATCH}/credentials
 ----
-
++
+<1> Replace `<aws_region>` with the AWS region to use for the {sts-first} endpoint.
 . Deploy the OADP Operator:
 +
 [NOTE]

--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -46,9 +46,10 @@ $ cat <<EOF > ${SCRATCH}/credentials
   [default]
   role_arn = ${ROLE_ARN}
   web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+  region = <aws_region> # <1>
 EOF
 ----
-
+<1> Replace `<aws_region>` with the AWS region to use for the {sts-short} endpoint.
 .. Create a namespace for OADP:
 +
 [source,terminal]
@@ -162,7 +163,7 @@ $ cat << EOF | oc create -f -
     name: ${CLUSTER_NAME}-dpa
     namespace: openshift-adp
   spec:
-    backupImages: true <1>
+    backupImages: true # <1>
     features:
       dataMover:
         enable: false
@@ -183,11 +184,14 @@ $ cat << EOF | oc create -f -
         - openshift
         - aws
         - csi
-      restic:
+      nodeAgent:  # <2>
         enable: false
+        uploaderType: kopia # <3>
 EOF
 ----
 <1> ROSA supports internal image backup. Set this field to `false` if you do not want to use image backup.
+<2> See the important note regarding the `nodeAgent` attribute.
+<3> The type of uploader. The possible values are `restic` or `kopia`. The built-in Data Mover uses Kopia as the default uploader mechanism regardless of the value of the `uploaderType` field.
 
 // . Create the `DataProtectionApplication` resource, which is used to configure the connection to the storage where the backups and volume snapshots are stored:
 
@@ -202,10 +206,7 @@ $ cat << EOF | oc create -f -
     name: ${CLUSTER_NAME}-dpa
     namespace: openshift-adp
   spec:
-    backupImages: true <1>
-    features:
-      dataMover:
-         enable: false
+    backupImages: true # <1>
     backupLocations:
     - bucket:
         cloudStorageRef:
@@ -222,16 +223,16 @@ $ cat << EOF | oc create -f -
         defaultPlugins:
         - openshift
         - aws
-      nodeAgent: <2>
+      nodeAgent: # <2>
         enable: false
         uploaderType: restic
     snapshotLocations:
       - velero:
           config:
-            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials <3>
-            enableSharedConfig: "true" <4>
-            profile: default <5>
-            region: ${REGION} <6>
+            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials # <3>
+            enableSharedConfig: "true" # <4>
+            profile: default # <5>
+            region: ${REGION} # <6>
           provider: aws
 EOF
 ----


### PR DESCRIPTION
### CHERRY PICK

Cherry Picked from c5862af3198293a5ed436a32b859bbd9232dc5a6 xref: https://github.com/openshift/openshift-docs/pull/86780

### JIRA 

* [OADP-5354](https://issues.redhat.com/browse/OADP-5354)

### Version(s):

* OCP 4.14 → branch/enterprise-4.14


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
