### PR TITLE
4.12 - OADP-5354: Backup is failing on validation PartiallyFailed

### DIFF
--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -23,10 +23,7 @@ Example file systems include the following:
 * Local volumes
 
 For backing up volumes, OADP on ROSA with {aws-short} {sts-short} supports only native snapshots and Container Storage Interface (CSI) snapshots.
-====
 
-[IMPORTANT]
-====
 In an Amazon ROSA cluster that uses STS authentication, restoring backed-up data in a different {aws-short} region is not supported.
 
 The Data Mover feature is not currently supported in ROSA clusters. You can use native {aws-short} S3 tools for moving data.
@@ -49,9 +46,10 @@ $ cat <<EOF > ${SCRATCH}/credentials
   [default]
   role_arn = ${ROLE_ARN}
   web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+  region = <aws_region> # <1>
 EOF
 ----
-
+<1> Replace `<aws_region>` with the AWS region to use for the {sts-short} endpoint.
 .. Create a namespace for OADP:
 +
 [source,terminal]
@@ -165,7 +163,7 @@ $ cat << EOF | oc create -f -
     name: ${CLUSTER_NAME}-dpa
     namespace: openshift-adp
   spec:
-    backupImages: true <1>
+    backupImages: true # <1>
     features:
       dataMover:
         enable: false
@@ -186,11 +184,14 @@ $ cat << EOF | oc create -f -
         - openshift
         - aws
         - csi
-      restic:
+      nodeAgent:  # <2>
         enable: false
+        uploaderType: kopia # <3>
 EOF
 ----
 <1> ROSA supports internal image backup. Set this field to `false` if you do not want to use image backup.
+<2> See the important note regarding the `nodeAgent` attribute.
+<3> The type of uploader. The possible values are `restic` or `kopia`. The built-in Data Mover uses Kopia as the default uploader mechanism regardless of the value of the `uploaderType` field.
 
 // . Create the `DataProtectionApplication` resource, which is used to configure the connection to the storage where the backups and volume snapshots are stored:
 
@@ -205,10 +206,7 @@ $ cat << EOF | oc create -f -
     name: ${CLUSTER_NAME}-dpa
     namespace: openshift-adp
   spec:
-    backupImages: true <1>
-    features:
-      dataMover:
-         enable: false
+    backupImages: true # <1>
     backupLocations:
     - bucket:
         cloudStorageRef:
@@ -225,21 +223,21 @@ $ cat << EOF | oc create -f -
         defaultPlugins:
         - openshift
         - aws
-      nodeAgent: <2>
+      nodeAgent: # <2>
         enable: false
         uploaderType: restic
     snapshotLocations:
       - velero:
           config:
-            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials <3>
-            enableSharedConfig: "true" <4>
-            profile: default <5>
-            region: ${REGION} <6>
+            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials # <3>
+            enableSharedConfig: "true" # <4>
+            profile: default # <5>
+            region: ${REGION} # <6>
           provider: aws
 EOF
 ----
 <1> ROSA supports internal image backup. Set this field to false if you do not want to use image backup.
-<2> See the following note.
+<2> See the important note regarding the `nodeAgent` attribute.
 <3> The `credentialsFile` field is the mounted location of the bucket credential on the pod.
 <4> The `enableSharedConfig` field allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
 <5> Use the profile name set in the {aws-short} credentials file.
@@ -247,7 +245,7 @@ EOF
 +
 You are now ready to back up and restore {product-title} applications, as described in _Backing up applications_.
 
-[NOTE]
+[IMPORTANT]
 ====
 The `enable` parameter of `restic` is set to `false` in this configuration, because OADP does not support Restic in ROSA environments.
 
@@ -268,7 +266,5 @@ restic:
 ----
 ====
 
-[NOTE]
-====
 If you want to use two different clusters for backing up and restoring, the two clusters must have the same {aws-short} S3 storage names in both the cloud storage CR and the OADP `DataProtectionApplication` configuration.
-====
+


### PR DESCRIPTION
### CHERRY PICK

Cherry Picked from c5862af3198293a5ed436a32b859bbd9232dc5a6 xref: https://github.com/openshift/openshift-docs/pull/86780

### JIRA 

* [OADP-5354](https://issues.redhat.com/browse/OADP-5354)

### Version(s):

* OCP 4.12 → branch/enterprise-4.12

### Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
