### PR TITLE
OADP-5578: Formatting issue in installing-oadp-rosa-sts.adoc

### DIFF
--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -46,7 +46,7 @@ $ cat <<EOF > ${SCRATCH}/credentials
   [default]
   role_arn = ${ROLE_ARN}
   web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
-  region = <aws_region> <1>
+  region = <aws_region> # <1>
 EOF
 ----
 <1> Replace `<aws_region>` with the AWS region to use for the {sts-short} endpoint.
@@ -163,7 +163,7 @@ $ cat << EOF | oc create -f -
     name: ${CLUSTER_NAME}-dpa
     namespace: openshift-adp
   spec:
-    backupImages: true <1>
+    backupImages: true # <1>
     features:
       dataMover:
         enable: false
@@ -206,7 +206,7 @@ $ cat << EOF | oc create -f -
     name: ${CLUSTER_NAME}-dpa
     namespace: openshift-adp
   spec:
-    backupImages: true <1>
+    backupImages: true # <1>
     backupLocations:
     - bucket:
         cloudStorageRef:
@@ -223,16 +223,16 @@ $ cat << EOF | oc create -f -
         defaultPlugins:
         - openshift
         - aws
-      nodeAgent: <2>
+      nodeAgent: # <2>
         enable: false
         uploaderType: restic
     snapshotLocations:
       - velero:
           config:
-            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials <3>
-            enableSharedConfig: "true" <4>
-            profile: default <5>
-            region: ${REGION} <6>
+            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials # <3>
+            enableSharedConfig: "true" # <4>
+            profile: default # <5>
+            region: ${REGION} # <6>
           provider: aws
 EOF
 ----


### PR DESCRIPTION
### JIRA

* [OADP-5578](https://issues.redhat.com/browse/OADP-5578)



Small issue in `modules/installing-oadp-rosa-sts.adoc` callouts not commented

Required to ensure failing cherrypicks do not occur

See:
* https://github.com/openshift/openshift-docs/pull/87865
* https://github.com/openshift/openshift-docs/pull/87867
* https://github.com/openshift/openshift-docs/pull/87869
* https://github.com/openshift/openshift-docs/pull/87872

Formatting issue, so no QE needed.

### VERSIONS

* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18

### Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has *NOT* approved this change as it is a formatting change only.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
