### PR TITLE
OBSDOCS-1664: Power monitoring Tech Preview 0.4 release notes

### DIFF
--- a/observability/power_monitoring/power-monitoring-release-notes.adoc
+++ b/observability/power_monitoring/power-monitoring-release-notes.adoc
@@ -15,6 +15,34 @@ These release notes track the development of {PM-title} in the {product-title}.
 
 For an overview of the {PM-operator}, see xref:../power_monitoring/power-monitoring-overview.adoc#power-monitoring-about-power-monitoring_power-monitoring-overview[About {PM-shortname}].
 
+[id="power-monitoring-release-notes-0-4_{context}"]
+== {PM-shortname-c} 0.4 (Technology Preview)
+
+This release includes the following version updates:
+
+* {PM-kepler} 0.7.12
+* {PM-operator} 0.15.0
+
+
+[id="power-monitoring-0-4-features_{context}"]
+=== Features
+
+* With this release, FIPS mode is now enabled for {PM-title}. When installed on an {product-title} cluster in FIPS mode, {PM-operator} ensures compatibility without affecting the FIPS support status of the cluster.
+
+[id="power-monitoring-bug-fix-0-4_{context}"]
+=== Bug fixes
+
+* Before this update, the *Install* screen in the OperatorHub page for {PM-title} displayed incorrect documentation links. With this update, the links now direct to the correct paths.
+
+[id="power-monitoring-release-notes-0-4-cves_{context}"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-24790[CVE-2024-24790]
+* link:https://access.redhat.com/security/cve/CVE-2024-24791[CVE-2024-24791]
+* link:https://access.redhat.com/security/cve/CVE-2024-34155[CVE-2024-34155]
+* link:https://access.redhat.com/security/cve/CVE-2024-34158[CVE-2024-34158]
+
+
 [id="power-monitoring-release-notes-0-3"]
 == {PM-shortname-c} 0.3 (Technology Preview)
 


### PR DESCRIPTION
Change type: Doc update; Power Monitoring - Tech Preview Release Notes 0.4
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1664

Fix Version: 4.16+

Doc Preview: https://87880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/power_monitoring/power-monitoring-release-notes.html#power-monitoring-release-notes-0-4

SME Review: @vimalk78 
QE Review: @vprashar2929 
Peer Review: @xenolinux 