### PR TITLE
PR for SRVCOM-3552: [Post-Release Updates] Release notes, known issues and bug fixes for 1.35.0

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -61,7 +61,8 @@
 :builds-v2title: Builds for Red Hat OpenShift
 :builds-v2shortname: OpenShift Builds v2
 :builds-v1shortname: OpenShift Builds v1
-
+//Developer Hub
+:RHDHProductName: Red Hat Developer Hub
 //gitops
 :gitops-title: Red Hat OpenShift GitOps
 :gitops-shortname: GitOps

--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -27,8 +27,13 @@ include::modules/serverless-tech-preview-features.adoc[leveloffset=+1]
 include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
+
 // OCP + OSD + ROSA
 include::modules/serverless-rn-1-35-0.adoc[leveloffset=+1]
+// 1.35.0 additional resources
+[role="_additional-resources"]
+.Additional resources
+* xref:../serverless-logic/serverless-logic-global-config-settings.adoc#serverless-logic-global-config-settings[Global configuration settings]
 
 // OCP + OSD + ROSA
 include::modules/serverless-rn-1-34-1.adoc[leveloffset=+1]

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -21,6 +21,14 @@ For the most recent list of major functionality deprecated and removed within {S
 |1.34
 |1.35
 
+|Knative client `https://mirror.openshift.com/pub/openshift-v4/clients/serverless/` URL
+|-
+|-
+|-
+|-
+|-
+|Deprecated
+
 |EventTypes `v1beta1` API
 |-
 |-

--- a/modules/serverless-rn-1-35-0.adoc
+++ b/modules/serverless-rn-1-35-0.adoc
@@ -18,6 +18,14 @@
 * {ServerlessProductName} now uses Knative for Apache Kafka 1.15.
 * The `kn func` CLI plugin now uses `func` 1.16.
 
+* The current download path for the Knative (kn) client on `mirror.openshift.com` is deprecated and will no longer work starting with the next release. No automatic redirection will occur. If your project or CI/CD pipelines rely on this URL to install the {ServerlessProductName} CLI, you must update your configuration accordingly. Further migration details, including the new download location, will be provided when available.
++
+** Deprecated URL:
+https://mirror.openshift.com/pub/openshift-v4/clients/serverless/
+
+
+* Knative Eventing Catalog plugin is now available in the Backstage plugin listing, and you can also install it on {RHDHProductName}. This functionality is available as a Developer Preview.
+
 * Go functions using S2I builder are now available as a Generally Available (GA) feature for Linux and Mac developers, allowing them to implement and build Go functions on these platforms.
 
 * It is now possible to automatically discover and register `EventTypes` based on the structure of incoming events, simplifying the overall configuration and management of `EventTypes`.
@@ -40,7 +48,7 @@
 
 * {ServerlessLogicProductName} is now certified for use with PostgreSQL version `15.9`.
 
-* Event performance between {ServerlessLogicProductName} workflows and the Data Index is improved through event batching. Set `kogito.events.grouping=true` to group events. For further optimization, enable `kogito.events.grouping.binary=true` to reduce the size of grouped events with an alternate serialization algorithm. To compress these events, set `kogito.events.grouping.compress=true`, which lowers event size at the cost of additional CPU usage.
+* Event performance between {ServerlessLogicProductName} workflows and the Data Index is now improved with event grouping and compression.
 
 * Compensation states are now invoked when a workflow is aborted.
 


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.35`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3552

**Doc preview:** [Red Hat OpenShift Serverless Release notes 1.35](https://87881--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes#serverless-rn-1-35-0_serverless-release-notes)