### PR TITLE
RHDEVDOCS-6342: Content creation for sensitive annotations feature

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -147,6 +147,8 @@ Topics:
   File: configuring-secure-communication-with-redis
 - Name: Managing secrets securely using Secrets Store CSI driver with GitOps
   File: managing-secrets-securely-using-sscsid-with-gitops
+- Name: Masking sensitive annotations in the Argo CD Web UI
+  File: masking-sensitive-annotations-in-the-argo-cd-web-ui
 ---
 Name: GitOps CLI (argocd) reference
 Dir: gitops_cli_argocd

--- a/modules/gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui.adoc
+++ b/modules/gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui.adoc
@@ -1,0 +1,43 @@
+// Module is included in the following assemblies:
+//
+// * securing_openshift_gitops/masking-sensitive-annotations-in-the-argo-cd-web-ui.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui_{context}"]
+= Enabling sensitive annotations masking in the Argo CD Web UI
+
+To enable sensitive annotations masking in the Argo CD user interface (UI), you can add the annotation key, `resource.sensitive.mask.annotations`, in the Argo CD custom resource (CR).
+
+.Procedure
+
+. Log in to the {OCP} web console. 
+
+. In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators*.
+
+. From the *Project* list, create or select the project where you want to install the user-defined Argo CD instance.
+
+. From the installed Operators list, select *{gitops-title}*, and then click the *Argo CD* tab.
+
+. To edit the Argo CD CR, complete the following steps:
+.. Under the `.spec.extraConfig` section, add the `resource.sensitive.mask.annotations` key.
+.. To mask a comma-separated list of values, specify the annotation key in the following YAML snippet:
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example
+spec:
+  extraConfig:
+    resource.sensitive.mask.annotations: openshift.io/token-secret.value, api-key, token # <1>
+----
+<1> Specify a comma-separated list of sensitive annotation values, such as `openshift.io/token-secret.value`, `api-key`, and `token`.
++
+. To verify that the value in the Argo CD resource has been updated successfully, complete the following steps:
+.. In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators*.
+.. In the *Project* option, select the `Argo CD` namespace.
+.. From the installed Operators list, select *{gitops-title}*, and then click the *Argo CD* tab.
+.. Verify that the *Status* field of the ArgoCD instance shows as *Phase: Available*.
+
+Argo CD hides the values of the specified annotation keys in the Argo CD UI.

--- a/securing_openshift_gitops/masking-sensitive-annotations-in-the-argo-cd-web-ui.adoc
+++ b/securing_openshift_gitops/masking-sensitive-annotations-in-the-argo-cd-web-ui.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="masking-sensitive-annotations-in-the-argo-cd-web-ui"]
+= Masking sensitive annotations in the Argo CD Web UI
+:context: masking-sensitive-annotations-in-the-argo-cd-web-ui
+
+toc::[]
+
+Argo CD hides sensitive annotation values on `Secret` resources from the Argo CD user interface (UI) and command-line interface (CLI). Users can configure this by specifying annotation keys to be masked in the Argo CD custom resource (CR). This feature enhances security by preventing accidental exposure of sensitive information, such as tokens or API keys, stored in annotations on `Secret` resources.
+
+To enable this feature, add the `resource.sensitive.mask.annotations` key under `.spec.extraConfig` in the Argo CD CR. Specify a comma-separated list of annotation keys to mask.
+
+[IMPORTANT]
+====
+Ensure that the annotation keys listed in `resource.sensitive.mask.annotations` are accurate and relevant to your use case. This feature does not support wildcards and requires explicit configuration in the Argo CD CR.
+====
+
+.Prerequisites
+* You have created an Argo CD instance. For more information, see "Installing a user-defined Argo CD instance".
+
+// Enabling sensitive annotations masking in the Argo CD Web UI
+include::modules/gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../argocd_instance/setting-up-argocd-instance.adoc#gitops-argo-cd-installation[Installing a user-defined Argo CD instance]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6342

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Masking sensitive annotations in the Argo CD Web UI](https://87882--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/masking-sensitive-annotations-in-the-argo-cd-web-ui.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @svghadi 
QE review: @varshab1210 
Peer review: @GroceryBoyJr 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
