### PR TITLE
docs: replace references to RHACS resources grouped under Access

### DIFF
--- a/modules/configure-minimum-access-role.adoc
+++ b/modules/configure-minimum-access-role.adoc
@@ -17,7 +17,7 @@ To set a minimum access role, you must first configure an authentication provide
 ====
 
 .Prerequisites
-* You must have the *Admin* role, or read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete custom roles.
+* You must have the *Admin* role, or read and write permissions for the `Access` resource to create, modify, and delete custom roles.
 
 .Procedure
 . In the {product-title-short} portal, go to *Platform Configuration* -> *Access control*.

--- a/modules/create-a-custom-access-scope.adoc
+++ b/modules/create-a-custom-access-scope.adoc
@@ -9,7 +9,7 @@
 You can create new access scopes from the *Access Control* view.
 
 .Prerequisites
-* You must have the *Admin* role, or a role with the permission set with read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete permission sets.
+* You must have the *Admin* role, or a role with the permission set with read and write permissions for the `Access` resource to create, modify, and delete permission sets.
 
 .Procedure
 . In the {product-title-short} portal, go to *Platform Configuration* -> *Access control*.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
RHACS >= 4.1

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[ROX-11101](https://issues.redhat.com//browse/ROX-11101), [ROX-12750](https://issues.redhat.com//browse/ROX-12750), [ROX-14398](https://issues.redhat.com//browse/ROX-14398)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://87890--ocpdocs-pr.netlify.app/openshift-acs/latest/
Impacted pages:
https://87890--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/manage-role-based-access-control-3630.html

QE review: **ACS has no QE - approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
The resource replacements done in [ROX-11101](https://issues.redhat.com//browse/ROX-11101) [ROX-12750](https://issues.redhat.com//browse/ROX-12750) and [ROX-14398](https://issues.redhat.com//browse/ROX-14398) landed in versions 3.73 to 4.1, but the corresponding references in the doc were not updated. This PR aims at re-aligning the RHACS permissions for roles with the existing ones.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
