### PR TITLE
[SRVCOM-3550] Update "access.redhat.com" links with "docs.redhat.com" equiv.

### DIFF
--- a/about/about-knative-eventing.adoc
+++ b/about/about-knative-eventing.adoc
@@ -28,6 +28,6 @@ include::modules/serverless-kafka-developer.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 * xref:../install/installing-knative-eventing.adoc#serverless-install-kafka-odc_installing-knative-eventing[Installing the `KnativeKafka` custom resource]
-* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red Hat AMQ Streams documentation]
-* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[Red Hat AMQ Streams TLS and SASL on Apache Kafka documentation]
+* link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red{nbsp}Hat AMQ Streams documentation]
+* link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/using_amq_streams_on_rhel/configuring_kafka#con-kafka-securing-listeners-str[Red{nbsp}Hat AMQ Streams TLS and SASL on Apache Kafka documentation]
 * xref:../eventing/serverless-event-delivery.adoc#serverless-event-delivery[Event delivery]

--- a/about/about-serverless.adoc
+++ b/about/about-serverless.adoc
@@ -17,7 +17,7 @@ The {ServerlessProductName} documentation is available at link:https://docs.open
 
 Documentation for specific versions is available using the version selector dropdown, or directly by adding the version to the URL, for example, link:https://docs.openshift.com/serverless/1.28[].
 
-In addition, the {ServerlessProductName} documentation is also available on the Red Hat Portal at https://access.redhat.com/documentation/en-us/red_hat_openshift_serverless/[].
+In addition, the {ServerlessProductName} documentation is also available on the Red{nbsp}Hat Portal at https://docs.redhat.com/en/documentation/red_hat_openshift_serverless//[].
 
 For additional information about the {ServerlessProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[Operator Life Cycles].
 ====

--- a/eventing/brokers/kafka-broker.adoc
+++ b/eventing/brokers/kafka-broker.adoc
@@ -26,11 +26,11 @@ include::modules/serverless-kafka-broker-configmap.adoc[leveloffset=+1]
 [id="serverless-kafka-admin-security"]
 == Security configuration for the Knative broker implementation for Apache Kafka
 
-Kafka clusters are generally secured by using the TLS or SASL authentication methods. You can configure a Kafka broker or channel to work against a protected Red Hat AMQ Streams cluster by using TLS or SASL.
+Kafka clusters are generally secured by using the TLS or SASL authentication methods. You can configure a Kafka broker or channel to work against a protected Red{nbsp}Hat AMQ Streams cluster by using TLS or SASL.
 
 [NOTE]
 ====
-Red Hat recommends that you enable both SASL and TLS together.
+Red{nbsp}Hat recommends that you enable both SASL and TLS together.
 ====
 
 // kafka broker security config
@@ -41,5 +41,5 @@ include::modules/serverless-kafka-broker-sasl-default-config.adoc[leveloffset=+2
 [id="additional-resources_serverless-kafka-admin"]
 [role="_additional-resources"]
 == Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red Hat AMQ Streams documentation]
-* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]
+* link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red{nbsp}Hat AMQ Streams documentation]
+* link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/using_amq_streams_on_rhel/configuring_kafka#con-kafka-securing-listeners-str[TLS and SASL on Kafka]

--- a/modules/serverless-create-kafka-namespaced-broker.adoc
+++ b/modules/serverless-create-kafka-namespaced-broker.adoc
@@ -15,7 +15,7 @@ To create a `KafkaNamespaced` broker, you must set the `eventing.knative.dev/bro
 
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {ocp-product-title} cluster.
 
-* You have access to an Apache Kafka instance, such as link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red Hat AMQ Streams], and have created a Kafka topic.
+* You have access to an Apache Kafka instance, such as link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red{nbsp}Hat AMQ Streams], and have created a Kafka topic.
 
 * You have created a project, or have access to a project, with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 

--- a/modules/serverless-kafka-broker-with-kafka-topic.adoc
+++ b/modules/serverless-kafka-broker-with-kafka-topic.adoc
@@ -12,7 +12,7 @@ If you want to use a Kafka broker without allowing it to create its own internal
 
 * The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {ocp-product-title} cluster.
 
-* You have access to a Kafka instance such as link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red Hat AMQ Streams], and have created a Kafka topic.
+* You have access to a Kafka instance such as link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red{nbsp}Hat AMQ Streams], and have created a Kafka topic.
 
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 


### PR DESCRIPTION
Version(s):
serverless-docs-1.33+

Issue:
https://issues.redhat.com/browse/SRVCOM-3550

Link to docs preview:
_Links updated in:_

- https://87891--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/about-knative-eventing.html
- https://87891--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/about-serverless.html
- https://87891--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/brokers/kafka-broker.html

QE review:
_No changes to technical content_

Additional information:
- _current occurrences_: https://docs.google.com/spreadsheets/d/1ipdBP6iMzJ5yFmMvrSYRUgGWV5IRJD7dVVgYn61hYTc/edit?gid=0#gid=0
