### PR TITLE
OSDOCS-13262: Documented the 4.16.33 z-stream notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3347,6 +3347,42 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.33
+[id="ocp-4-16-33_{context}"]
+=== RHBA-2025:0828 - {product-title} {product-version}.33 bug fix and security update
+
+Issued: 06 February 2025
+
+{product-title} release {product-version}.33 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:0828[RHBA-2025:0828] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0830[RHSA-2025:0830] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.33 --pullspecs
+----
+
+[id="ocp-4-16-33-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, some cluster autoscaler metrics were not initialized and were unavailable. With this release, the cluster autoscaler metrics are initialized and available. (link:https://issues.redhat.com/browse/OCPBUGS-48732[*OCPBUGS-48732*])
+
+* Previously, every time a subcription was reconciled, the {olm} catalog Operator requested a full view of the catalog metadata from the catalog source pod of the subscription. These requests caused performance issues for the catalog pods. With this release, the {olm} catalog Operator now uses a local cache that is refreshed periodically and reused by all subscription reconciliations, so that the performance issue for the catalog pods no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-48696[*OCPBUGS-48696*])
+
+* Previously, if you specified a `forceSelinuxRelabel` field in the `ClusterResourceOverride` CR and then modified the CR at a later stage, the Cluster Resource Override Operator did not apply the update to the associated `ConfigMap` resource. This `ConfigMap` resource is important for an SELinux relabeling feature, `forceSelinuxRelabel`. With this release, the Cluster Resource Override Operator now applies and tracks any `ClusterResourceOverride` CR changes to the `ConfigMap` resource. (link:https://issues.redhat.com/browse/OCPBUGS-48690[*OCPBUGS-48690*])
+
+* Previously, after you deleted a pod from an {product-title} cluster, the crun container runtime failed to stop any running containers that existed in the pod. This caused the pod to remain in a `terminating` state. With this release, a fix ensures that if you delete a pod, crun stops any running containers without placing the pod in a permanent "terminating" state. (link:https://issues.redhat.com/browse/OCPBUGS-48564[*OCPBUGS-48564*]) 
+
+* Previously, the Cluster Version Operator (CVO) did not filter internal errors that were propogated to the `ClusterVersion Failing` condition message. As a result, errors that did not negatively impact the update were shown for the ClusterVersion Failing condition message. With this release, the errors that are propogated to the `ClusterVersion Failing` condition message are filtered. (link:https://issues.redhat.com/browse/OCPBUGS-46408[*OCPBUGS-46408*]) 
+ 
+
+[id="ocp-4-16-33-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.16.32
 [id="ocp-4-16-32_{context}"]
 === RHSA-2025:0650 - {product-title} {product-version}.32 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[4.16.33](https://issues.redhat.com/browse/OSDOCS-13262)

Link to docs preview:
[4.16.33](https://87894--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-33_release-notes)

