### PR TITLE
OSDOCS#12236: Updates to Welcome and Learn more OCP pages

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -28,6 +28,7 @@ To navigate the {product-title} {product-version} documentation, you can use one
 
 * Use the navigation bar to browse the documentation.
 * Select the task that interests you from xref:../welcome/learn_more_about_openshift.adoc#learn_more_about_openshift[Learn more about {product-title}].
+* {product-title} has a variety of layered offerings to add additional functionality and extend the capabilities of a cluster. For more information, see link:https://access.redhat.com/support/policy/updates/openshift_operators[{product-title} Operator Life Cycles]
 endif::openshift-rosa,openshift-dedicated,openshift-dpu,openshift-telco[]
 
 ifdef::openshift-dpu[]

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -8,33 +8,45 @@ toc::[]
 
 Use the following sections to find content to help you learn about and better understand {product-title} functions:
 
+[id="support"]
+== Learning and support
+
+[options="header",cols="2*"]
+|===
+| Learn about {product-title} |Optional additional resources
+
+|link:https://www.openshift.com/learn/whats-new[What's new in {product-title}]
+|link:https://www.openshift.com/blog?hsLang=en-us[OpenShift blog]
+
+|link:https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle Policy]
+|link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[{product-title} life cycle]
+
+|link:https://learn.openshift.com/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[OpenShift Interactive Learning Portal]
+|link:https://access.redhat.com/articles/4217411[OpenShift Knowledgebase articles]
+
+| xref:../support/getting-support.adoc#getting-support[Getting Support]
+| xref:../support/gathering-cluster-data.adoc#gathering-data[Gathering data about your cluster]
+
+|===
+
 [id="architecture"]
 == Architecture
 
-[options="header",cols="3*"]
+[options="header",cols="2*"]
 |===
-| Learn about {product-title} |Plan an {product-title} deployment |Optional additional resources
+| Learn about {product-title} |Optional additional resources
 
 | link:https://www.openshift.com/blog/enterprise-kubernetes-with-openshift-part-one?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[Enterprise Kubernetes with OpenShift]
 | link:https://access.redhat.com/articles/4128421[Tested platforms]
-| link:https://www.openshift.com/blog?hsLang=en-us[OpenShift blog]
 
 | xref:../architecture/architecture.adoc#architecture[Architecture]
 | xref:../security/container_security/security-understanding.adoc#understanding-security[Security and compliance]
-| link:https://www.openshift.com/learn/whats-new[What's new in {product-title}]
 
-|
 | xref:../networking/understanding-networking.adoc#understanding-networking[Networking]
-| link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[{product-title} life cycle]
+| xref:../networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly.adoc#ovn-kubernetes-architecture-con[OVN-Kubernetes architecture]
 
-|
 | xref:../backup_and_restore/index.adoc#backup-restore-overview[Backup and restore]
-|
-
-| link:https://learn.openshift.com/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[OpenShift Interactive Learning Portal]
-|
-a|* xref:../support/getting-support.adoc#getting-support[Getting Support]
-* link:https://access.redhat.com/articles/4217411[OpenShift Knowledgebase articles]
+| xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#scenario-2-restoring-cluster-state[Restoring to a previous cluster state]
 
 |===
 
@@ -50,7 +62,7 @@ Explore the following {product-title} installation tasks:
 | xref:../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
 
 | xref:../installing/overview/installing-fips.adoc#installing-fips-mode_installing-fips[Installing a cluster in FIPS mode]
-|
+| xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-installer-fips-compliance_preparing-to-install-with-agent-based-installer[About FIPS compliance]
 
 |===
 
@@ -61,8 +73,8 @@ Explore the following {product-title} installation tasks:
 |===
 | Learn about other installer tasks on {product-title} |Optional additional resources
 
-| xref:../installing/validation_and_troubleshooting/installing-troubleshooting.adoc#installing-troubleshooting[Check installation logs]
-|
+| xref:../installing/validation_and_troubleshooting/installing-troubleshooting.adoc#installing-troubleshooting[Troubleshooting installation issues]
+| xref:../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation]
 
 | xref:../storage/persistent_storage/persistent-storage-ocs.adoc#red-hat-openshift-data-foundation[Install {rh-storage-first}]
 | xref:../machine_configuration/mco-coreos-layering.adoc#mco-coreos-layering[{op-system-first} image layering]
@@ -134,34 +146,34 @@ a|* xref:../machine_management/index.adoc#machine-api-overview_overview-of-machi
 | Manage xref:../machine_management/index.adoc#machine-mgmt-intro-managing-compute_overview-of-machine-management[compute] and xref:../machine_management/index.adoc#machine-mgmt-intro-managing-control-plane_overview-of-machine-management[control plane] machines with machine sets.
 |
 
-|xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[Deploying machine health checks]
-|
+| xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[Deploying machine health checks]
+| xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[About control plane machine sets]
 
-|xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[Applying autoscaling to an {product-title} cluster]
-|
+| xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[Applying autoscaling to an {product-title} cluster]
+| xref:../nodes/pods/nodes-pods-priority.adoc#nodes-pods-priority[Including pod priority in pod scheduling decisions]
 
 | xref:../registry/index.adoc#registry-overview[Manage container registries]
 | link:https://access.redhat.com/documentation/en-us/red_hat_quay/[Red Hat Quay]
 
 | xref:../authentication/understanding-authentication.adoc#understanding-authentication[Manage users and groups]
-|
+| xref:../authentication/impersonating-system-admin.adoc#impersonating-system-admin[Impersonating the system:admin user]
 
 | xref:../authentication/understanding-authentication.adoc#understanding-authentication[Manage authentication]
-| xref:../authentication/understanding-identity-provider.adoc#supported-identity-providers[multiple identity providers]
+| xref:../authentication/understanding-identity-provider.adoc#supported-identity-providers[Multiple identity providers]
 
-| Manage xref:../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[ingress], xref:../security/certificates/api-server.adoc#api-server-certificates[API server], and xref:../security/certificates/service-serving-certificate.adoc#add-service-serving[service] certificates
-|
+| Manage xref:../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[Ingress], xref:../security/certificates/api-server.adoc#api-server-certificates[API server], and xref:../security/certificates/service-serving-certificate.adoc#add-service-serving[Service] certificates
+| xref:../networking/network_security/network-policy-apis.adoc#network-policy-apis[Network security]
 
 | xref:../networking/understanding-networking.adoc#understanding-networking[Manage networking]
 a|* xref:../networking/networking_operators/cluster-network-operator.adoc#nw-cluster-network-operator_cluster-network-operator[Cluster Network Operator]
-* xref:../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[multiple network interfaces]
-* xref:../networking/network_security/network_policy/about-network-policy.adoc#about-network-policy[network policy]
+* xref:../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[Multiple network interfaces]
+* xref:../networking/network_security/network_policy/about-network-policy.adoc#about-network-policy[Network policy]
 
 | xref:../operators/understanding/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[Manage Operators]
-|
+| xref:../operators/user/olm-creating-apps-from-installed-operators.adoc#olm-creating-apps-from-installed-operators[Creating applications from installed Operators]
 
+| xref:../windows_containers/index.adoc#index[{productwinc} overview]
 | xref:../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads_understanding-windows-container-workloads[Understanding Windows container workloads]
-|
 
 |===
 
@@ -178,17 +190,17 @@ a|* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updati
 * xref:../disconnected/updating/index.adoc#about-disconnected-updates[Using the OpenShift Update Service in a disconnected environment]
 
 | xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-extending-api-with-crds[Use custom resource definitions (CRDs) to modify the cluster]
-a|* xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-creating-custom-resources-definition_crd-extending-api-with-crds[create a CRD]
-* xref:../operators/understanding/crds/crd-managing-resources-from-crds.adoc#crd-managing-resources-from-crds[manage resources from CRDs]
+a|* xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-creating-custom-resources-definition_crd-extending-api-with-crds[Create a CRD]
+* xref:../operators/understanding/crds/crd-managing-resources-from-crds.adoc#crd-managing-resources-from-crds[Manage resources from CRDs]
 
 | xref:../applications/quotas/quotas-setting-per-project.adoc#quotas-setting-per-project[Set resource quotas]
-| xref:../applications/quotas/quotas-setting-per-project.adoc#quotas-setting-per-project[set quotas]
+| xref:../applications/quotas/quotas-setting-per-project.adoc#quotas-setting-per-project[Set quotas]
 
 | xref:../applications/pruning-objects.adoc#pruning-objects[Prune and reclaim resources]
-|
+| xref:../cicd/builds/advanced-build-operations.adoc#builds-build-pruning-advanced-build-operations[Performing advanced builds]
 
 | xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc#scaling-cluster-monitoring-operator[Scale] and xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[tune] clusters
-|
+| xref:../scalability_and_performance/index.adoc#index[{product-title} scalability and performance]
 
 |===
 
@@ -200,13 +212,13 @@ a|* xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-cr
 |Learn about {product-title} |Optional additional resources
 
 | xref:../observability/logging/cluster-logging.adoc#cluster-logging[OpenShift Logging]
-|
+| xref:../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI pluigin]
 
+| xref:../observability/distr_tracing/distr-tracing-rn.adoc#distr-tracing-rn[Release notes for the {DTProductName}]
 | xref:../observability/distr_tracing/distr_tracing_arch/distr-tracing-architecture.adoc#distr-tracing-architecture[{jaegername}]
-|
 
 | xref:../observability/otel/otel-installing.adoc#install-otel[Red Hat build of OpenTelemetry]
-|
+| xref:../observability/otel/otel-config-multicluster.adoc#otel-config-multicluster[Gathering the observability data from multiple clusters]
 
 | xref:../observability/network_observability/network-observability-overview.adoc#network-observability-overview[About Network Observability]
 a|* xref:../observability/network_observability/metrics-alerts-dashboards.adoc#metrics-alerts-dashboards_metrics-alerts-dashboards[Using metrics with dashboards and alerts]
@@ -225,40 +237,27 @@ a|* xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc
 |===
 |Learn about {product-title} |Optional additional resources
 
-| xref:../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Manage storage]
-|
-
-| xref:../storage/understanding-ephemeral-storage.adoc#understanding-ephemeral-storage[Storage]
-|
+| xref:../storage/index.adoc#storage-types[Storage types]
+a| * xref:../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Persistent storage]
+* xref:../storage/understanding-ephemeral-storage.adoc#understanding-ephemeral-storage[Ephemeral storage]
 
 |===
 
 [id="application_site_reliability_engineer"]
 == Application Site Reliability Engineer (App SRE)
 
-[options="header",cols="3*"]
+[options="header",cols="2*"]
 |===
-|Learn about {product-title} |Deploy and manage applications |Optional additional resources
+|Learn about {product-title} |Optional additional resources
 
-|
+| xref:../applications/index.adoc#building-applications-overview[Building applications overview]
 | xref:../applications/projects/working-with-projects.adoc#working-with-projects[Projects]
-| xref:../support/getting-support.adoc#getting-support[Getting Support]
 
-| xref:../architecture/architecture.adoc#architecture[Architecture]
 | xref:../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[Operators]
-| link:https://access.redhat.com/articles/4217411[OpenShift Knowledgebase articles]
+| xref:../operators/operator-reference.adoc#cluster-operator-reference[Cluster Operator reference]
 
-|
 | xref:../observability/logging/cluster-logging.adoc#cluster-logging[Logging]
-| link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[{product-title} Life Cycle]
-
-|
 | link:https://www.openshift.com/blog/tag/logging[Blogs about logging]
-|
-
-|
-| xref:../observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc#about-ocp-monitoring[Monitoring]
-|
 
 |===
 
@@ -302,20 +301,38 @@ a|* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-sched
 * xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
 |===
 
+[id="self-managed-hcp"]
+== {hcp-capital}
 
-//
-//[id="hosted-control-plane-activities"]
-//== Hosted control plane activities
+[options="header",cols="2*"]
+|===
+|Learn about {hcp} |Optional additional resources
 
-//[options="header",cols="2*"]
-// |===
-// |Learn about {hcp-capital} |Optional additional resources
+| xref:../hosted_control_planes/index.adoc#hosted-control-planes-overview[Hosted control planes overview]
+a|
+xref:../hosted_control_planes/index.adoc#hosted-control-planes-version-support_hcp-overview[Versioning for {hcp}]
 
-// | xref:../hosted_control_planes/index.adoc#hosted_control_planes[Hosted control planes overview]
-// | xref:../hosted_control_planes/index.adoc#hosted-control-planes-overview_hcp-overview[Introduction to hosted control planes]
+| Preparing to deploy
+a| * xref:../hosted_control_planes/hcp-prepare/hcp-requirements.adoc#hcp-requirements[Requirements for {hcp}]
+* xref:../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc#hcp-sizing-guidance[Sizing guidance for {hcp}]
+* xref:../hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc#hcp-override-resource-util[Overriding resource utilization measurements]
+* xref:../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli[Installing the {hcp} command-line interface]
+* xref:../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-distribute-workloads[Distributing hosted cluster workloads]
+* xref:../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-disable[Enabling or disabling the {hcp} feature]
 
-// | xref:../hosted_control_planes/hcp-getting-started.adoc#hcp-getting-started [Getting started with hosted control planes]
-// |
+| Deploying {hcp}
+a| * xref:../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc#hcp-deploy-virt[Deploying {hcp} on {VirtProductName}]
+* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc#hcp-deploy-aws[Deploying {hcp} on {aws-short}]
+* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-deploy-bm[Deploying {hcp} on bare metal]
+* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc#hcp-deploy-non-bm[Deploying {hcp} on non-bare-metal agent machines]
+* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc#hcp-deploy-ibmz[Deploying {hcp} on {ibm-z-title}]
+* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc#hcp-deploy-ibm-power[Deploying {hcp} on {ibm-power-title}]
 
-// |===
-//
+| Deploying {hcp} in a disconnected environment
+a| * xref:../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-deploy-dc-bm[Deploying {hcp} on bare metal in a disconnected environment]
+* xref:../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc#hcp-deploy-dc-virt[Deploying {hcp} on {VirtProductName} in a disconnected environment]
+
+| xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-troubleshooting[Troubleshooting {hcp}]
+a| xref:../hosted_control_planes/hcp-troubleshooting.adoc#hosted-control-planes-troubleshooting_hcp-troubleshooting[Gathering information to troubleshoot {hcp}]
+
+|===


### PR DESCRIPTION
OSDOCS#12236: Updates to Welcome and Learn more OCP pages

Version(s):
main to 4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-12236

Link to docs preview:
Welcome https://87905--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/index.html
Learn more https://87905--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/learn_more_about_openshift.html

QE review:
- [ ] QE has approved this change.
No QE needed

Additional information:
Updates to 4.18 release, adds info about layered products, refines tables and links.
