### PR TITLE
OSDOCS-13271: Documented the 4.17.15 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2872,6 +2872,36 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.15
+[id="ocp-4-17-15_{context}"]
+=== RHSA-2025:0876 - {product-title} {product-version}.15 bug fix, and security update advisory
+
+Issued: 05 February 2025
+
+{product-title} release {product-version}.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0876[RHSA-2025:0876] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0878[RHSA-2025:0878] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.15 --pullspecs
+----
+
+[id="ocp-4-17-15-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when you used the installation program to install a cluster in a Prism Central environment, the installation failed because a `prism-api` call that loads an {op-system} image timed out. This issue happened because the `prismAPICallTimeout` parameter was set to `5` minutes. With this release, the `prismAPICallTimeout` parameter in the `install-config.yaml` configuration file now defaults to `10` minutes. You can also configure the parameter if you need a longer timeout for a `prism-api` call. (link:https://issues.redhat.com/browse/OCPBUGS-49362[*OCPBUGS-49362*])
+
+* Previously, every time a subcription was reconciled, the {olm} catalog Operator requested a full view of the catalog metadata from the catalog source pod of the subscription. These requests caused performance issues for the catalog pods. With this release, the {olm} catalog Operator now uses a local cache that is refreshed periodically and reused by all subscription reconciliations, so that the performance issue for the catalog pods no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-48695[*OCPBUGS-48695*])
+
+* Previously, if you specified a `forceSelinuxRelabel` field in the `ClusterResourceOverride` CR and then modified the CR at a later stage, the Cluster Resource Override Operator did not apply the update to the associated `ConfigMap` resource. This `ConfigMap` resource is important for an SELinux relabeling feature, `forceSelinuxRelabel`. With this release, the Cluster Resource Override Operator now applies and tracks any `ClusterResourceOverride` CR changes to the `ConfigMap` resource. (link:https://issues.redhat.com/browse/OCPBUGS-48691[*OCPBUGS-48691*])
+
+[id="ocp-4-17-15-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.14
 [id="ocp-4-17-14_{context}"]
 === RHSA-2025:0654 - {product-title} {product-version}.14 bug fix, and security update advisory
@@ -2893,13 +2923,20 @@ $ oc adm release info 4.17.14 --pullspecs
 ==== Bug fixes
 
 * Previously, some cluster autoscaler metrics were not initialized and were unavailable. With this release, the cluster autoscaler metrics are initialized and available. (link:https://issues.redhat.com/browse/OCPBUGS-48606[*OCPBUGS-48606*])
+
 * Previously, you could not add a new worker by using the `oc adm node-image create` command if the node date or time was inaccurate. With this release, the issue is resolved by applying the same NTP configuration that is in the target cluster `machineconfig chrony` resource to the node ephemeral live environment. (link:https://issues.redhat.com/browse/OCPBUGS-45344[*OCPBUGS-45344*])
+
 * Previously, you could not use all available machine types in a zone because all zones in a region were assumed to have the same set of machine types. With this release, all machine types are available in all enabled zones. (link:https://issues.redhat.com/browse/OCPBUGS-46432[*OCPBUGS-46432*])
+
 * Previously, the installation program was not compliant with PCI-DSS/BAFIN regulations. With this release, the cross-tenant replication in {azure-first} is disabled, which reduces the chance of unauthorized data access and ensures strict adherence to data governance policies. (link:https://issues.redhat.com/browse/OCPBUGS-48119[*OCPBUGS-48119*])
+
 * Previously, when you clicked the *Don't show again* link in the Red Hat Ansible Lightspeed modal, it did not display the correct *General User Preference* tab when one of the other *User Preference* tabs was open. With this release, clicking the *Don't show again* link goes to the correct *General User Preference* tab. (link:https://issues.redhat.com/browse/OCPBUGS-48227[*OCPBUGS-48227*])
+
 * Previously, when a Google Cloud Platform (GCP) service account was created, the account would not always be immediately available. When the account was not available for updates, the installation program received failures when adding permissions to the account. According to link:https://cloud.google.com/iam/docs/retry-strategy[*Retry failed requests*], a service account might be created, but is not active for up to 60 seconds. With this release, the service account is updated on an exponential backoff to give the account enough time to update correctly. (link:https://issues.redhat.com/browse/OCPBUGS-48359[*OCPBUGS-48359*])
+
 * Previously, on RHEL 9 FIPS STIG compliant machines, The SHA-1 key caused the release signature verification to fail because of the restriction to use weak keys.
 With this release, the key used by the oc-mirror plugin for release signature verification is changed and release images are signed by a new SHA256 trusted-key that is different from the old SHA-1 key. (link:https://issues.redhat.com/browse/OCPBUGS-48363[*OCPBUGS-48363*])
+
 * Previously, the {olm-first} would sometimes concurrently resolve the same namespace in a cluster. This led to subscriptions reaching a terminal state of `ConstraintsNotSatisfiable`, because two concurrent processes interacted with a subscription and this caused a CSV file to become unassociated. With this release, {olm} can resolve concurrent namespaces for a subscription so no CSV remains unassociated. (link:https://issues.redhat.com/browse/OCPBUGS-45845[*OCPBUGS-45845*])
 
 [id="ocp-4-17-14-updating_{context}"]


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13271](https://issues.redhat.com/browse/OSDOCS-13271)

Link to docs preview:
* [4.17.15](https://87907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-15_release-notes)

