### PR TITLE
OCPBUGS#38353: Added a missing example to the Configuring the cluster…

### DIFF
--- a/networking/enable-cluster-wide-proxy.adoc
+++ b/networking/enable-cluster-wide-proxy.adoc
@@ -8,32 +8,71 @@ toc::[]
 
 Production environments can deny direct access to the internet and instead have an HTTP or HTTPS proxy available. You can configure {product-title} to use a proxy by xref:../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[modifying the Proxy object for existing clusters] or by configuring the proxy settings in the `install-config.yaml` file for new clusters.
 
-== Prerequisites
+After you enable a cluster-wide egress proxy for your cluster on a supported platform, {op-system-first} populates the `status.noProxy` parameter with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your `install-config.yaml` file that exists on the supported platform. 
 
-* Review the xref:../installing/install_config/configuring-firewall.adoc#configuring-firewall[sites that your cluster requires access to] and determine whether any of them must bypass the proxy. By default, all cluster system egress traffic is proxied, including calls to the cloud provider API for the cloud that hosts your cluster. System-wide proxy affects system components only, not user workloads. Add sites to the Proxy object's `spec.noProxy` field to bypass the proxy if necessary.
-+
 [NOTE]
 ====
-The Proxy object `status.noProxy` field is populated with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration with most installation types.
-
-For installations on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
+As a postinstallation task, you can change the `networking.clusterNetwork[].cidr` value, but not the `networking.machineNetwork[].cidr` and the `networking.serviceNetwork[]` values. For more information, see "Configuring the cluster network range".
 ====
-+
+
+For installations on {aws-first}, {gcp-first}, {azure-first}, and {rh-openstack-first}, the `status.noProxy` parameter is also populated with the instance metadata endpoint, `169.254.169.254`.
+
+.Example of values added to the `status:` segment of a `Proxy` object by {op-system}
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Proxy
+metadata:
+  name: cluster
+# ...
+networking:
+  clusterNetwork: <1>
+  - cidr: <ip_address_from_cidr>
+    hostPrefix: 23
+  network type: OVNKubernetes
+  machineNetwork: <2>
+  - cidr: <ip_address_from_cidr>
+  serviceNetwork: <3>
+  - 172.30.0.0/16
+# ...
+status:
+  noProxy:
+  - localhost
+  - .cluster.local
+  - .svc
+  - 127.0.0.1
+  - <api_server_internal_url> <4>
+# ...
+----
+<1> Specify IP address blocks from which pod IP addresses are allocated. The default value is `10.128.0.0/14` with a host prefix of `/23`.
+<2> Specify the IP address blocks for machines. The default value is `10.0.0.0/16`.
+<3> Specify IP address block for services. The default value is `172.30.0.0/16`.
+<4> You can find the URL of the internal API server by running the `oc get infrastructures.config.openshift.io cluster -o jsonpath='{.status.etcdDiscoveryDomain}'` command. 
+
 [IMPORTANT]
 ====
 If your installation type does not include setting the `networking.machineNetwork[].cidr` field, you must include the machine IP addresses manually in the `.status.noProxy` field to make sure that the traffic between nodes can bypass the proxy.
 ====
 
+[id="prerequisites_cluster-wide-proxy"]
+== Prerequisites
+
+Review the xref:../installing/install_config/configuring-firewall.adoc#configuring-firewall[sites that your cluster requires access to] and determine whether any of them must bypass the proxy. By default, all cluster system egress traffic is proxied, including calls to the cloud provider API for the cloud that hosts your cluster. The system-wide proxy affects system components only, not user workloads. If necessary, add sites to the `spec.noProxy` parameter of the `Proxy` object to bypass the proxy.
+
+// Enabling the cluster-wide proxy
 include::modules/nw-proxy-configure-object.adoc[leveloffset=+1]
 
+// Removing the cluster-wide proxy
 include::modules/nw-proxy-remove.adoc[leveloffset=+1]
 
+// Verifying the cluster-wide proxy configuration
 include::modules/nw-verify-proxy-configuration.adoc[leveloffset=+1]
 
 [discrete]
 [role="_additional-resources"]
 == Additional resources
 
+* xref:../networking/configuring-cluster-network-range.adoc#configuring-cluster-network-range[Configuring the cluster network range]
 * xref:../security/certificates/updating-ca-bundle.adoc#ca-bundle-understanding_updating-ca-bundle[Understanding the CA Bundle certificate]
 * xref:../security/certificate_types_descriptions/proxy-certificates.adoc#customization[Proxy certificates]
 * link:https://access.redhat.com/solutions/7065528[How is the cluster-wide proxy setting applied to {product-title} nodes?]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-38353](https://issues.redhat.com/browse/OCPBUGS-38353)

Link to docs preview:
* [Configuring the cluster-wide proxy](https://87909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html)

- [x] SME has approved this change (Simone Massimo Zucchi).
- [x] QE has approved this change.

