### PR TITLE
OSDOCS-12449: adds Additional release notes to MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -134,16 +134,37 @@ Previously, the greenboot health check marked some healthy Image mode for {op-sy
 //[id="microshift-4-18-pods-writing-files-excess-memory-limits-crash_{context}"]
 //=== tbd known issues
 
-[id="microshift-4-18-asynchronous-errata-updates_{context}"]
-== Asynchronous errata updates
-
-Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
-
-Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
+[id="microshift-4-18-additional-release-notes_{context}"]
+== Additional release notes
+Release notes for related components and products are available in the following documentation:
 
 [NOTE]
 ====
-Red Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
+The following release notes are for downstream Red{nbsp}Hat products only; upstream or community release notes for related products are not included.
+====
+
+[id="microshift-4-18-additional-release-notes-gitops_{context}"]
+=== GitOps release notes
+See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.15/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps 1.15: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package, link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
+
+[id="microshift-4-18-additional-release-notes-ocp_{context}"]
+=== {OCP} release notes
+See the https://docs.openshift.com/container-platform/4.18/release_notes/ocp-4-18-release-notes.html[{OCP} Release Notes] for information about the Operator Lifecycle Manager and other components. Not all of the changes to {OCP} apply to {microshift-short}. See the specific {microshift-short} implementation of an Operator or function for more information.
+
+[id="microshift-4-18-additional-release-notes-rhel_{context}"]
+=== {op-system-base-full} release notes
+See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.4_release_notes/index[Release Notes for Red{nbsp}Hat Enterprise Linux 9.4] for more information about {op-system-base}.
+
+[id="microshift-4-18-asynchronous-errata-updates_{context}"]
+== Asynchronous errata updates
+
+Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red{nbsp}Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
+
+Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
+
+[NOTE]
+====
+Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
 ====
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12449](https://issues.redhat.com/browse/OSDOCS-12449)

Link to docs preview:
[microshift-4-18-additional-release-notes_release-notes](https://87920--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-additional-release-notes_release-notes)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
