### PR TITLE
OSDOCS:13011 Doc page for Managing unused rendered machine configs does not have consistency

### DIFF
--- a/modules/machineconfig-garbage-collect-removing.adoc
+++ b/modules/machineconfig-garbage-collect-removing.adoc
@@ -8,9 +8,9 @@
 
 You can remove unused rendered machine configs by using the `oc adm prune renderedmachineconfigs` command with the `--confirm` command.  If any rendered machine config is not deleted, the command output indicates which was not deleted and lists the reason for skipping the deletion.
 
-.Procedure 
+.Procedure
 
-. Optional: List the rendered machine configs that you can remove automatically by running the following command. Any rendered machine config marked with `as it's currently in use` in the command output is not removed. 
+. Optional: List the rendered machine configs that you can remove automatically by running the following command. Any rendered machine config marked with the `as it's currently in use` message in the command output cannot be removed.
 +
 [source,terminal]
 ----
@@ -21,9 +21,9 @@ $ oc adm prune renderedmachineconfigs --pool-name=worker
 [source,terminal]
 ----
 Dry run enabled - no modifications will be made. Add --confirm to remove rendered machine configs.
-DRY RUN: Deleted rendered MachineConfig rendered-worker-23d7322831a57f02998e7e1600a0865f
-DRY RUN: Deleted rendered MachineConfig rendered-worker-fc94397dc7c43808c7014683c208956e
-DRY RUN: Skipping deletion of rendered MachineConfig rendered-worker-ad5a3cad36303c363cf458ab0524e7c0 as it's currently in use
+dry-run deleting rendered MachineConfig rendered-worker-f38bf61ced3c920cf5a29a200ed43243
+dry-run deleting MachineConfig rendered-worker-fc94397dc7c43808c7014683c208956e
+Skip dry-run deleting rendered MachineConfig rendered-worker-708c652868f7597eaa1e2622edc366ef as it's currently in use
 ----
 +
 --
@@ -40,12 +40,19 @@ $ oc adm prune renderedmachineconfigs --pool-name=worker --count=2 --confirm
 ----
 +
 --
-where: 
+where:
 
 `--count`:: Optional: Specifies the maximum number of unused rendered machine configs you want to delete, starting with the oldest.
 
 `--confirm`:: Optional: Indicate that pruning should occur, instead of performing a dry-run.
 
 `--pool-name`:: Optional: Specifies the machine config pool from which you want to delete the machine. If not specified, all the pools are evaluated.
-
 --
++
+.Example output
+[source,terminal]
+----
+deleting rendered MachineConfig rendered-worker-f38bf61ced3c920cf5a29a200ed43243
+deleting rendered MachineConfig rendered-worker-fc94397dc7c43808c7014683c208956e
+Skip deleting rendered MachineConfig rendered-worker-708c652868f7597eaa1e2622edc366ef as it's currently in use
+----

--- a/modules/machineconfig-garbage-collect-viewing.adoc
+++ b/modules/machineconfig-garbage-collect-viewing.adoc
@@ -6,7 +6,7 @@
 [id="machineconfig-garbage-collect-viewing_{context}"]
 = Viewing rendered machine configs
 
-You can view a list of rendered machine configs by using the `oc adm prune renderedmachineconfigs` command with the `list` subcommand.  
+You can view a list of rendered machine configs by using the `oc adm prune renderedmachineconfigs` command with the `list` subcommand.
 
 For example, the command in the following procedure would list all rendered machine configs for the `worker` machine config pool.
 
@@ -33,18 +33,20 @@ list:: Displays a list of rendered machine configs in your cluster.
 [source,terminal]
 ----
 worker
-status: rendered-worker-ae115e2b5e6ae05e0e6e5d62c7d0dd81
-spec: rendered-worker-ae115e2b5e6ae05e0e6e5d62c7d0dd81
+
+rendered-worker-f38bf61ced3c920cf5a29a200ed43243 -- 2025-01-21 13:45:01 +0000 UTC (Currently in use: false)
+rendered-worker-fc94397dc7c43808c7014683c208956e-- 2025-01-30 17:20:53 +0000 UTC (Currently in use: false)
+rendered-worker-708c652868f7597eaa1e2622edc366ef -- 2025-01-31 18:01:16 +0000 UTC (Currently in use: true)
 ----
 
-* List the rendered machine configs that you can remove automatically by running the following command. Any rendered machine config marked with `as it's currently in use` in the command output is not removed.
+* List the rendered machine configs that you can remove automatically by running the following command. Any rendered machine config marked with the `as it's currently in use` message in the command output cannot be removed.
 +
 [source,terminal]
 ----
 $ oc adm prune renderedmachineconfigs --pool-name=worker
 ----
 +
-The command runs in dry-run mode, and no machine configs are removed. 
+The command runs in dry-run mode, and no machine configs are removed.
 +
 --
 where:
@@ -56,7 +58,7 @@ where:
 [source,terminal]
 ----
 Dry run enabled - no modifications will be made. Add --confirm to remove rendered machine configs.
-DRY RUN: Deleted rendered MachineConfig rendered-worker-23d7322831a57f02998e7e1600a0865f
-DRY RUN: Deleted rendered MachineConfig rendered-worker-fc94397dc7c43808c7014683c208956e
-DRY RUN: Skipping deletion of rendered MachineConfig rendered-worker-ad5a3cad36303c363cf458ab0524e7c0 as it's currently in use
+dry-run deleting rendered MachineConfig rendered-worker-f38bf61ced3c920cf5a29a200ed43243
+dry-run deleting MachineConfig rendered-worker-fc94397dc7c43808c7014683c208956e
+Skip dry-run deleting rendered MachineConfig rendered-worker-708c652868f7597eaa1e2622edc366ef as it's currently in use
 ----


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13011

Machine configuration ->  Managing unused rendered machine configs ->[Removing unused rendered machine configs](https://87940--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-garbage-collection.html#machineconfig-garbage-collect-removing_machine-configs-garbage-collection) -- Updated wording in Step 1 and updated the example output in both steps.

Machine configuration ->  Managing unused rendered machine configs -> [Viewing rendered machine configs](https://87940--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-garbage-collection.html) -- Updated wording in second bullet and updated the example output in both bullets.
