### PR TITLE
[enterprise-4.14] OCPBUGS48047 As per the document it does not states that 'evictionPressureTransitionPeriod configuration' cannot be set to '0s'.

### DIFF
--- a/modules/nodes-nodes-garbage-collection-configuring.adoc
+++ b/modules/nodes-nodes-garbage-collection-configuring.adoc
@@ -102,7 +102,7 @@ spec:
       nodefs.inodesFree: "4%"
       imagefs.available: "10%"
       imagefs.inodesFree: "5%"
-    evictionPressureTransitionPeriod: 0s <7>
+    evictionPressureTransitionPeriod: 3m <7>
     imageMinimumGCAge: 5m <8>
     imageGCHighThresholdPercent: 80 <9>
     imageGCLowThresholdPercent: 75 <10>
@@ -115,7 +115,7 @@ spec:
 <5> For container garbage collection: Grace periods for the soft eviction. This parameter does not apply to `eviction-hard`.
 <6> For container garbage collection: Eviction thresholds based on a specific eviction trigger signal.
 For `evictionHard` you must specify all of these parameters.  If you do not specify all parameters, only the specified parameters are applied and the garbage collection will not function properly.
-<7> For container garbage collection: The duration to wait before transitioning out of an eviction pressure condition.
+<7> For container garbage collection: The duration to wait before transitioning out of an eviction pressure condition. Setting the `evictionPressureTransitionPeriod` parameter to `0` configures the default value of 5 minutes.
 <8> For image garbage collection: The minimum age for an unused image before the image is removed by garbage collection.
 <9> For image garbage collection: The percent of disk usage (expressed as an integer) that triggers image garbage collection.
 <10> For image garbage collection: The percent of disk usage (expressed as an integer) that image garbage collection attempts to free.

--- a/modules/nodes-nodes-garbage-collection-containers.adoc
+++ b/modules/nodes-nodes-garbage-collection-containers.adoc
@@ -41,4 +41,9 @@ For `evictionHard` you must specify all of these parameters.  If you do not spec
 
 If a node is oscillating above and below a soft eviction threshold, but not exceeding its associated grace period, the corresponding node would constantly oscillate between `true` and `false`. As a consequence, the scheduler could make poor scheduling decisions.
 
-To protect against this oscillation, use the `eviction-pressure-transition-period` flag to control how long {product-title} must wait before transitioning out of a pressure condition. {product-title} will not set an eviction threshold as being met for the specified pressure condition for the period specified before toggling the condition back to false.
+To protect against this oscillation, use the `evictionpressure-transition-period` flag to control how long {product-title} must wait before transitioning out of a pressure condition. {product-title} will not set an eviction threshold as being met for the specified pressure condition for the period specified before toggling the condition back to false.
+
+[NOTE]
+====
+Setting the `evictionPressureTransitionPeriod` parameter to `0` configures the default value of 5 minutes. You cannot set an eviction pressure transition period to zero seconds. 
+====


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/86885