### PR TITLE
Update service-accounts-creating.adoc

### DIFF
--- a/modules/service-accounts-creating.adoc
+++ b/modules/service-accounts-creating.adoc
@@ -71,6 +71,6 @@ Labels:	             <none>
 Annotations:	     <none>
 Image pull secrets:  robot-dockercfg-qzbhb
 Mountable secrets:   robot-dockercfg-qzbhb
-Tokens:              robot-token-f4khf
+Tokens:              <none>
 Events:              <none>
 ----


### PR DESCRIPTION
Updating service-accounts creating section as Service Account Tokens should not automatically created as per the OpenShift documentation.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> 4.16+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->  https://issues.redhat.com/browse/OCPBUGS-48650

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->  https://87954--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/using-service-accounts-in-applications

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
