### PR TITLE
OCPBUGS#43809: Clarifying what's created for each service account

### DIFF
--- a/authentication/understanding-and-creating-service-accounts.adoc
+++ b/authentication/understanding-and-creating-service-accounts.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 include::modules/service-accounts-overview.adoc[leveloffset=+1]
 
+include::modules/service-account-auto-secret-removed.adoc[leveloffset=+2]
+
 // include::modules/service-accounts-enabling-authentication.adoc[leveloffset=+1]
 
 include::modules/service-accounts-creating.adoc[leveloffset=+1]

--- a/modules/service-accounts-creating.adoc
+++ b/modules/service-accounts-creating.adoc
@@ -22,9 +22,9 @@ $ oc get sa
 [source,terminal]
 ----
 NAME       SECRETS   AGE
-builder    2         2d
-default    2         2d
-deployer   2         2d
+builder    1         2d
+default    1         2d
+deployer   1         2d
 ----
 
 . To create a new service account in the current project:
@@ -67,10 +67,10 @@ $ oc describe sa robot
 ----
 Name:                robot
 Namespace:           project1
-Labels:	             <none>
-Annotations:	     <none>
+Labels:              <none>
+Annotations:         openshift.io/internal-registry-pull-secret-ref: robot-dockercfg-qzbhb
 Image pull secrets:  robot-dockercfg-qzbhb
 Mountable secrets:   robot-dockercfg-qzbhb
-Tokens:              robot-token-f4khf
+Tokens:              <none>
 Events:              <none>
 ----

--- a/modules/service-accounts-granting-roles.adoc
+++ b/modules/service-accounts-granting-roles.adoc
@@ -3,7 +3,7 @@
 // * authentication/using-service-accounts.adoc
 
 [id="service-accounts-granting-roles_{context}"]
-= Examples of granting roles to service accounts
+= Granting roles to service accounts
 
 You can grant roles to service accounts in the same way that you grant roles
 to a regular user account.

--- a/modules/service-accounts-overview.adoc
+++ b/modules/service-accounts-overview.adoc
@@ -15,11 +15,12 @@ When you use the {product-title} CLI or web console, your API token
 authenticates you to the API. You can associate a component with a service account
 so that they can access the API without using a regular user's credentials.
 ifdef::openshift-online,openshift-origin,openshift-enterprise,openshift-webscale[]
+
 For example, service accounts can allow:
 
-* Replication controllers to make API calls to create or delete pods.
-* Applications inside containers to make API calls for discovery purposes.
-* External applications to make API calls for monitoring or integration purposes.
+* Replication controllers to make API calls to create or delete pods
+* Applications inside containers to make API calls for discovery purposes
+* External applications to make API calls for monitoring or integration purposes
 endif::[]
 
 Each service account's user name is derived from its project and name:
@@ -45,12 +46,3 @@ Every service account is also a member of two groups:
 specified project.
 
 |===
-
-Each service account automatically contains two secrets:
-
-* An API token
-* Credentials for the OpenShift Container Registry
-
-The generated API token and registry credentials do not expire, but you can
-revoke them by deleting the secret. When you delete the secret, a new one is
-automatically generated to take its place.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-43809

Link to docs preview:
* https://87965--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/understanding-and-creating-service-accounts#service-accounts-overview_understanding-service-accounts


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
