### PR TITLE
OSDOCS#13261: Update the 4.12.72 z-stream RNs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5052,3 +5052,28 @@ $ oc adm release info 4.12.71 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.12.72
+[id="ocp-4-12-72_{context}"]
+=== RHSA-2025:0832 - {product-title} 4.12.72 bug fix and security update
+
+Issued: 06 February 2025
+
+{product-title} release 4.12.72 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0832[RHSA-2025:0832] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0834[RHSA-2025:0834] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.72 --pullspecs
+----
+
+[id="ocp-4-12-72-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, during node reboots, especially during update operations, the node that interacted with the rebooting machine entered a `Ready=Unknown` state. This caused the Control Plane Machine Set Operator to enter an `UnavailableReplicas` condition and an `Available=false` state, which triggered alerts that demanded urgent action. However, manual intervention was not necessary because the condition was resolved when the node rebooted. With this release, a grace period for node unreadiness is provided. If a node enters an unready state, the Control Plane Machine Set Operator does not instantly enter an `UnavailableReplicas` condition or an `Available=false` state. (link:https://issues.redhat.com/browse/OCPBUGS-48325[*OCPBUGS-48325*]).
+
+[id="ocp-4-12-72-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-12361](https://issues.redhat.com/browse/OSDOCS-13261)

Link to docs preview:
[4.12.72](https://87975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-72_release-notes)

QE review:
- [ ] QE has approved this change.
QE review is not required for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 02/06/25.
