### PR TITLE
OSDOCS-13277: 4.17.2 Security Group Update for ROSA HCP

### DIFF
--- a/modules/rosa-hcp-aws-private-security-groups.adoc
+++ b/modules/rosa-hcp-aws-private-security-groups.adoc
@@ -1,11 +1,17 @@
 // Module included in the following assemblies:
 //
+// * rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
 
 [id="rosa-hcp-aws-private-security-groups_{context}"]
 :_mod-docs-content-type: PROCEDURE
-= Configuring AWS security groups to access the API
+= Adding additional AWS security groups to the AWS PrivateLink endpoint
 
-With {hcp-title} private clusters, the AWS PrivateLink endpoint exposed in the customer's VPC has a default security group. This security group has access to the PrivateLink endpoint that is limited to only those resources that exist within the VPC or resources that are present with an IP address associated with the VPC CIDR range. In order to grant access to any entities outside of the VPC, through VPC peering and transit gateway, you must create and attach another security group to the PrivateLink endpoint to grant the necessary access.
+With {hcp-title} clusters, the AWS PrivateLink endpoint exposed in the customer's VPC has a security group that limits access to requests that originate from within the cluster's Machine CIDR range. In order to grant access to the cluster's API to any entities outside of the VPC, through VPC peering, transit gateways, or other network connectivity, you must create and attach another security group to the PrivateLink endpoint to grant the necessary access.
+
+[IMPORTANT]
+====
+Adding additional AWS security groups to the AWS PrivateLink endpoint is only supported on {hcp-title} version 4.17.2 and later. 
+====
 
 .Prerequisites
 
@@ -41,20 +47,26 @@ hcp-private
 ----
 $ read -r VPCE_ID VPC_ID <<< $(aws ec2 describe-vpc-endpoints --filters "Name=tag:api.openshift.com/id,Values=$(rosa describe cluster -c ${CLUSTER_NAME} -o yaml | grep '^id: ' | cut -d' ' -f2)" --query 'VpcEndpoints[].[VpcEndpointId,VpcId]' --output text)
 ----
-
-. Create your security group by running the following command:
++
+[WARNING]
+====
+Modifying or removing the default AWS PrivateLink endpoint security group is not supported and might result in unexpected behavior.
+====
++
+. Create an additional security group by running the following command:
 +
 [source,terminal]
 ----
 $ export SG_ID=$(aws ec2 create-security-group --description "Granting API access to ${CLUSTER_NAME} from outside of VPC" --group-name "${CLUSTER_NAME}-api-sg" --vpc-id $VPC_ID --output text)
 ----
 
-. Add an ingress rule to the security group by running the following command:
+. Add an inbound (ingress) rule to the security group by running the following command:
 +
 [source,terminal]
 ----
-$ aws ec2 authorize-security-group-ingress --group-id $SG_ID --ip-permissions FromPort=443,ToPort=443,IpProtocol=tcp,IpRanges=[{CidrIp=0.0.0.0/0}]
+$ aws ec2 authorize-security-group-ingress --group-id $SG_ID --ip-permissions FromPort=443,ToPort=443,IpProtocol=tcp,IpRanges=[{CidrIp=<cidr-to-allow>}] <.> 
 ----
+<.> Specify the CIDR block you want to allow access from.
 
 . Add the new security group to the VPCE by running the following command:
 +
@@ -63,4 +75,4 @@ $ aws ec2 authorize-security-group-ingress --group-id $SG_ID --ip-permissions Fr
 $ aws ec2 modify-vpc-endpoint --vpc-endpoint-id $VPCE_ID --add-security-group-ids $SG_ID
 ----
 
-You now can access the API with your {hcp-title} private cluster.
+You now can access the API of your {hcp-title} private cluster from the specified CIDR block.

--- a/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+++ b/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
@@ -11,6 +11,7 @@ For {hcp-title-first} workloads that do not require public internet access, you 
 //include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
 //include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]
 include::modules/rosa-hcp-aws-private-create-cluster.adoc[leveloffset=+1]
+include::modules/rosa-hcp-aws-private-security-groups.adoc[leveloffset=+1]
 include::modules/rosa-additional-principals-overview.adoc[leveloffset=+1]
 include::modules/rosa-additional-principals-create.adoc[leveloffset=+2]
 include::modules/rosa-additional-principals-edit.adoc[leveloffset=+2]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -23,22 +23,26 @@ endif::openshift-rosa-hcp[]
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]
 * **{rosa-classic} cluster node limit update.** {rosa-classic} clusters versions 4.14.14 and greater can now scale to 249 worker nodes. This is an increase from the previous limit of 180 nodes. For more information, see xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability].
-
++
 [IMPORTANT]
 ====
 Egress lockdown is a Technology Preview feature.
 ====
-
++
 * **Egress lockdown is now available as a Technology Preview on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-lockdown-install.adoc#rosa-hcp-egress-lockdown-install[Creating a {product-title} cluster with egress lockdown].
 
-* **Red{nbsp}Hat SRE log-based alerting endpoints have been updated.** {product-title} customers who are using a firewall to control egress traffic can now remove all references to `*.osdsecuritylogs.splunkcloud.com:9997` from your firewall allowlist. {product-title} clusters still require the `http-inputs-osdsecuritylogs.splunkcloud.com:443` log-based alerting endpoint to be accessible from the cluster. This is applicable only to Red{nbsp}Hat OpenShift Service on AWS (classic architecture).
+* **ROSA with HCP now creates independent security groups for the AWS PrivateLink endpoint and worker nodes.** {hcp-title} clusters version 4.17.2 and greater can now add additional AWS security groups to the AWS PrivateLink endpoint to allow additional ingress traffic to the cluster's API. For more information, see xref:../rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc#rosa-hcp-aws-private-security-groups_rosa-hcp-aws-private-creating-cluster[Adding additional AWS security groups to the AWS PrivateLink endpoint].
+
+* **Red{nbsp}Hat SRE log-based alerting endpoints have been updated.** {rosa-classic} customers who are using a firewall to control egress traffic can now remove all references to `*.osdsecuritylogs.splunkcloud.com:9997` from your firewall allowlist. {rosa-classic} clusters still require the `http-inputs-osdsecuritylogs.splunkcloud.com:443` log-based alerting endpoint to be accessible from the cluster.
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
+* **ROSA with HCP now creates independent security groups for the AWS PrivateLink endpoint and worker nodes.** {hcp-title} clusters version 4.17.2 and greater can now add additional AWS security groups to the AWS PrivateLink endpoint to allow additional ingress traffic to the cluster's API. For more information, see xref:../rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc#rosa-hcp-aws-private-security-groups_rosa-hcp-aws-private-creating-cluster[Adding additional AWS security groups to the AWS PrivateLink endpoint].
++
 [IMPORTANT]
 ====
 Egress lockdown is a Technology Preview feature.
 ====
-
++
 * **Egress lockdown is now available as a Technology Preview on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-lockdown-install.adoc#rosa-hcp-egress-lockdown-install[Creating a {product-title} cluster with egress lockdown].
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): `enterprise-4.17`+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13277
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://87993--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-aws-private-creating-cluster.html
- https://87993--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html
- https://87993--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-aws-private-creating-cluster.html
- https://87993--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] ~~QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Two minor additional changes on the "What's new for ROSA" page:
- Updated the wording of the [OSDOCS-13243](https://issues.redhat.com//browse/OSDOCS-13243) release to use the `{rosa-classic}` shortcode.
- Brought the admonition for Egress Lockdown inline with the bullets.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
