### PR TITLE
OSDOCS-12356: Add OVN-Kubernetes secondary network mapping

### DIFF
--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -66,4 +66,9 @@ A comma-separated list of CIDRs and IP addresses. IP addresses are removed from 
 |
 If topology is set to `localnet`, the specified VLAN tag is assigned to traffic from this additional network. The default is to not assign a VLAN tag.
 
+|`physicalNetworkName`
+|`string`
+|
+If topology is set to `localnet`, you can reuse the same physical network mapping with multiple network overlays. Specifies the name of the physical network to which the OVN overlay connects. When omitted, the default value is the `name` of the `localnet` network. To isolate the different networks, ensure that a different VLAN tag is used when sharing the same physical network between overlays.
+
 |====


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-12356

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [OVN-Kubernetes network plugin JSON configuration table](https://87994--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.html#configuration-ovnk-network-plugin-json-object_configuring-additional-network-ovnk)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
