### PR TITLE
Add release note for OVN-Kubernetes secondary networks

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -897,6 +897,14 @@ The OVN-Kubernetes plugin can now use a Linux bridge interface as the Open vSwit
 ==== Cluster Network Operator exposing network overlap metrics for an issue
 
 When you start the limited live migration method and an issue exists with network overlap, the Cluster Network Operator (CNO) can now expose network overlap metrics for the issue. This is possible because the `openshift_network_operator_live_migration_blocked` metric now includes the new `NetworkOverlap` label. (link:https://issues.redhat.com/browse/OCPBUGS-39096[*OCPBUGS-39096*])
+[id="ocp-release-notes-networking-network-attachment-definition_{context}"]
+==== Network attachments support dynamic reconfiguration
+
+Previously, the `NetworkAttachmentDefinition` CR was immutable. With this release, you can edit an existing `NetworkAttachmentDefinition` CR. Support for editing makes it easier to accommodate changes in the underlying network infrastructure, such as adjusting the MTU of a network interface.
+
+You must ensure that the configurations of each `NetworkAttachmentDefinition` CR that reference the same network `name` and `type: ovn-k8s-cni-overlay` are in sync. Only when these values are in sync is the network attachment update successful. If the configurations are not in sync, the behavior is undefined because there is no guarantee about which `NetworkAttachmentDefinition` CR {product-title} uses for the configuration.
+
+You still must restart any workloads that use the network attachment definition for the network changes to take effect for those pods.
 
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-12356

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- https://87995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-networking-ovn-kubernetes-secondary-network-localnet-physical-network-name_release-notes
- https://87995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-networking-network-attachment-definition_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
