### PR TITLE
OCPBUGS#49820: Added missing SDN MTU statements

### DIFF
--- a/modules/nw-cluster-mtu-change-about.adoc
+++ b/modules/nw-cluster-mtu-change-about.adoc
@@ -29,7 +29,7 @@ When you initiate an MTU change on your cluster the following effects might impa
 When planning your MTU migration there are two related but distinct MTU values to consider.
 
 * *Hardware MTU*: This MTU value is set based on the specifics of your network infrastructure.
-* *Cluster network MTU*: This MTU value is always less than your hardware MTU to account for the cluster network overlay overhead. The specific overhead is determined by your network plugin. For OVN-Kubernetes, the overhead is `100` bytes.
+* *Cluster network MTU*: This MTU value is always less than your hardware MTU to account for the cluster network overlay overhead. The specific overhead is determined by your network plugin. For OVN-Kubernetes, the overhead is `100` bytes. For OpenShift SDN, the overhead is `50` bytes.
 
 If your cluster requires different MTU values for different nodes, you must subtract the overhead value for your network plugin from the lowest MTU value that is used by any node in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1400`.
 
@@ -61,7 +61,7 @@ Set the following values in the Cluster Network Operator configuration:
 
 - The `mtu.machine.to` must be set to either the new hardware MTU or to the current hardware MTU if the MTU for the hardware is not changing. This value is transient and is used as part of the migration process. Separately, if you specify a hardware MTU that is different from your existing hardware MTU value, you must manually configure the MTU to persist by other means, such as with a machine config, DHCP setting, or a Linux kernel command line.
 - The `mtu.network.from` field must equal the `network.status.clusterNetworkMTU` field, which is the current MTU of the cluster network.
-- The `mtu.network.to` field must be set to the target cluster network MTU and must be lower than the hardware MTU to allow for the overlay overhead of the network plugin. For OVN-Kubernetes, the overhead is `100` bytes.
+- The `mtu.network.to` field must be set to the target cluster network MTU and must be lower than the hardware MTU to allow for the overlay overhead of the network plugin. The overhead for OVN-Kubernetes is `100` bytes and for OpenShift SDN is `50` bytes.
 
 If the values provided are valid, the CNO writes out a new temporary configuration with the MTU for the cluster network set to the value of the `mtu.network.to` field.
 

--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -44,7 +44,9 @@ endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
 * You have installed the {oc-first}.
 * You have access to the cluster using an account with `cluster-admin` permissions.
-* You have identified the target MTU for your cluster. The MTU for the OVN-Kubernetes network plugin must be set to `100` less than the lowest hardware MTU value in your cluster.
+* You have identified the target MTU for your cluster. 
+** The MTU for the OVN-Kubernetes network plugin must be set to `100` less than the lowest hardware MTU value in your cluster.
+** The MTU for the OpenShift SDN network plugin must be set to `50` less than the lowest hardware MTU value in your cluster.
 
 .Procedure
 
@@ -204,7 +206,7 @@ $ oc patch Network.operator.openshift.io cluster --type=merge --patch \
 where:
 
 `<overlay_from>`:: Specifies the current cluster network MTU value.
-`<overlay_to>`:: Specifies the target MTU for the cluster network. This value is set relative to the value of `<machine_to>`. For OVN-Kubernetes, this value must be `100` less than the value of `<machine_to>`.
+`<overlay_to>`:: Specifies the target MTU for the cluster network. This value is set relative to the value of `<machine_to>`. For OVN-Kubernetes, this value must be `100` less than the value of `<machine_to>`. For OpenShift SDN, this value must be `50` less than the value of `<machine_to>`.
 `<machine_to>`:: Specifies the MTU for the primary network interface on the underlying host network.
 --
 +
@@ -347,20 +349,24 @@ where `<config_name>` is the name of the machine config from the `machineconfigu
 If the machine config is successfully deployed, the previous output contains the `/etc/NetworkManager/conf.d/99-<interface>-mtu.conf` file path and the `ExecStart=/usr/local/bin/mtu-migration.sh` line.
 endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
-. To finalize the MTU migration, enter the following command for the OVN-Kubernetes network plugin:
+. Finalize the MTU migration for your plugin. In both example commands, `<mtu>` specifies the new cluster network MTU that you specified with `<overlay_to>`.
++
+** To finalize the MTU migration, enter the following command for the OVN-Kubernetes network plugin:
 +
 [source,terminal]
-+
 ----
 $ oc patch Network.operator.openshift.io cluster --type=merge --patch \
   '{"spec": { "migration": null, "defaultNetwork":{ "ovnKubernetesConfig": { "mtu": <mtu> }}}}'
 ----
 +
---
-where:
-
-`<mtu>`:: Specifies the new cluster network MTU that you specified with `<overlay_to>`.
---
+** To finalize the MTU migration, enter the following command for the OpenShift SDN network plugin:
++
+[source,terminal]
++
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge --patch \
+  '{"spec": { "migration": null, "defaultNetwork":{ "openshiftSDNConfig": { "mtu": <mtu> }}}}'
+----
 
 . After finalizing the MTU migration, each machine config pool node is rebooted one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
 +


### PR DESCRIPTION
Version(s):
4.16 and 4.15

Issue:
[OCPBUGS-49820](https://issues.redhat.com/browse/OCPBUGS-49820)


Link to docs preview:
* [Changing the MTU for the cluster network - AWS](https://88011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks.html#nw-cluster-mtu-change_aws-compute-edge-zone-tasks)
* [Changing the cluster network MTU to support AWS Outposts](https://88011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-outposts.html#nw-cluster-mtu-change_installing-aws-outposts)
* [Changing the MTU for the cluster network: general networking](https://88011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu.html)

- [x] SME has approved this change (Aniket).
- [x] QE has approved this change (Weliang).


Follows on from https://github.com/openshift/openshift-docs/pull/87257


