### PR TITLE
TELCODOCS-2051 NUMA-aware scheduling: clarify the operator configuration

### DIFF
--- a/modules/cnf-creating-nrop-cr.adoc
+++ b/modules/cnf-creating-nrop-cr.adoc
@@ -33,7 +33,7 @@ spec:
         pools.operator.machineconfiguration.openshift.io/worker: "" <1>
 ----
 +
-<1> This should match the `MachineConfigPool` that you want to configure the NUMA Resources Operator on. For example, you might have created a `MachineConfigPool` named `worker-cnf` that designates a set of nodes expected to run telecommunications workloads.
+<1> This must match the `MachineConfigPool` resource that you want to configure the NUMA Resources Operator on. For example, you might have created a `MachineConfigPool` resource named `worker-cnf` that designates a set of nodes expected to run telecommunications workloads. Each `NodeGroup` must match exactly one `MachineConfigPool`. Configurations where `NodeGroup` matches more than one `MachineConfigPool` are not supported.
 
 .. Create the `NUMAResourcesOperator` CR by running the following command:
 +


### PR DESCRIPTION
[TELCODOCS-2051]: NUMA-aware scheduling: clarify the operator configuration
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2051
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://88012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-creating-nrop-cr_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
