### PR TITLE
OSDOCS-13248: Added RHCOS and K8S Operator note

### DIFF
--- a/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -7,11 +7,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Kubernetes NMState Operator provides a Kubernetes API for performing state-driven network configuration across the {product-title} cluster's nodes with NMState. The Kubernetes NMState Operator provides users with functionality to configure various network interface types, DNS, and routing on cluster nodes. Additionally, the daemons on the cluster nodes periodically report on the state of each node's network interfaces to the API server.
+The Kubernetes NMState Operator provides a Kubernetes API for performing state-driven network configuration across the nodes with NMState in a {product-title} cluster. The Kubernetes NMState Operator provides users with functionality to configure various network interface types, DNS, and routing on cluster nodes. 
+
+[NOTE]
+====
+For a cluster running {rh-openstack-first}, after you use the Kubernetes NMState Operator to configure DNS settings for your cluster, you must initially add nodes to the cluster and then start the Kubernetes NMState Operator. Otherwise, the DNS settings do not apply to nodes in your cluster.
+====
+
+Additionally, the daemons on the cluster nodes periodically report on the state of the network interfaces on each node to the API server.
 
 [IMPORTANT]
 ====
-Red{nbsp}Hat supports the Kubernetes NMState Operator in production environments on bare-metal, {ibm-power-name}, {ibm-z-name}, {ibm-linuxone-name}, {vmw-first}, and {rh-openstack-first} installations.
+Red{nbsp}Hat supports the Kubernetes NMState Operator in production environments on bare-metal, {ibm-power-name}, {ibm-z-name}, {ibm-linuxone-name}, {vmw-first}, and {rh-openstack} installations.
 
 Red{nbsp}Hat support exists for using the Kubernetes NMState Operator on {azure-first} but in a limited capacity. Support is limited to configuring DNS servers on your system as a postinstallation task.
 ====


### PR DESCRIPTION
ON HOLD FOR FURTHER CLARIFICATION

Version(s):
4.12+

Issue:
[OSDOCS-13248](https://issues.redhat.com/browse/OSDOCS-13248)

Link to docs preview:
* [Kubernetes NMState Operator](https://88017--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html)

- [ ] SME has approved this change.
- [ ] QE has approved this change.

