### PR TITLE
OCPBUGS-42016 Fix incorrect configMap name.

### DIFF
--- a/modules/certificate-injection-using-operators.adoc
+++ b/modules/certificate-injection-using-operators.adoc
@@ -73,7 +73,7 @@ spec:
       volumes:
       - name: trusted-ca
         configMap:
-          name: trusted-ca
+          name: ca-inject
           items:
             - key: ca-bundle.crt <1>
               path: tls-ca-bundle.pem <2>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-42016

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- [Certificate injection using Operators](https://88032--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki): This section contains the example YAML file with the corrected configMap dict. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
