### PR TITLE
OSDOCS#12864: node adding procedure enhancements

### DIFF
--- a/nodes/nodes/nodes-nodes-adding-node-iso.adoc
+++ b/nodes/nodes/nodes-nodes-adding-node-iso.adoc
@@ -12,6 +12,11 @@ This process can be used regardless of how you installed your cluster.
 You can add one or more nodes at a time while customizing each node with more complex configurations, such as static network configuration, or you can specify only the MAC address of each node.
 Any required configurations that are not specified during ISO generation are retrieved from the target cluster and applied to the new nodes.
 
+[NOTE]
+====
+`Machine` or `BareMetalHost` resources are not automatically created after a node has been successfully added to the cluster.
+====
+
 Preflight validation checks are also performed when booting the ISO image to inform you of failure-causing issues before you attempt to boot each node.
 
 [id="supported-platforms_{context}"]
@@ -23,6 +28,16 @@ The following platforms are supported for this method of adding nodes:
 * `vsphere`
 * `none`
 * `external`
+
+[id="supported-architectures_{context}"]
+== Supported architectures
+
+The following architecture combinations have been validated to work when adding worker nodes using this process:
+
+* `amd64` worker nodes on `amd64` or `arm64` clusters
+* `arm64` worker nodes on `amd64` or `arm64` clusters
+* `s390x` worker nodes on `s390x` clusters
+* `ppc64le` worker nodes on `ppc64le` clusters
 
 [id="adding-nodes-cluster_{context}"]
 == Adding nodes to your cluster


### PR DESCRIPTION
[OSDOCS-12864](https://issues.redhat.com/browse/OSDOCS-12864)

Version(s): 4.17+

This PR adds a few clarifications to the procedure for adding worker nodes to on-premise clusters.

QE review:
- [x] QE has approved this change.

Previews:

- [Clarification](https://88033--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso.html#:~:text=the%20new%20nodes.-,However%2C,-Machine%20or%20BareMetalHost)
- [Supported architectures](https://88033--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso.html#supported-architectures_adding-node-iso)