### PR TITLE
OSDOCS#12887: adding external platform

### DIFF
--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -65,6 +65,7 @@ In the `install-config.yaml`, specify the platform on which to perform the insta
 
 * `baremetal`
 * `vsphere`
+* `external`
 * `none`
 +
 [IMPORTANT]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-12887

Version(s): 4.14+

This PR adds `external` to the list of supported platforms for Agent Installer, this was missed back when it was enabled for 4.14+

QE review:
- [x] QE has approved this change.

Preview: [Recommended resources for topologies](https://88035--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-based-installer-recommended-resources_preparing-to-install-with-agent-based-installer)
