### PR TITLE
Adds warning messages for readonly IR storage backend

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -506,6 +506,24 @@ For more information, see  xref:../installing/install_config/configuring-firewal
 [id="ocp-release-notes-registry_{context}"]
 === Registry
 
+[discrete]
+[id="ocp-4-release-notes-read-only-registry-enhancements_{context}"]
+==== Read-only registry enhancements
+
+In previous versions of {product-title}, storage mounted as read-only returned no specific metrics or information about storage errors. This could result in silent failures of a registry when the storage backend was read-only. With this release, the following alerts have been added to return storage information when the backend is set to read-only:
+
+[cols="2", options="header"]
+|===
+| Alert Name | Message
+
+| `ImageRegistryStorageReadOnly`
+| The image registry storage is read-only and no images will be committed to storage.
+
+| `ImageRegistryStorageFull`
+| The image registry storage disk is full and no images will be committed to storage.
+
+|===
+
 [id="ocp-release-notes-rhcos_{context}"]
 === {op-system-first}
 


### PR DESCRIPTION
Approved by SME in Slack: 

Version(s):
4.18 

Issue:
https://issues.redhat.com/browse/OSDOCS-13281

Link to docs preview:
https://88042--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-registry_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
