### PR TITLE
OCPBUGS#49859: Added br-ex note to the networking route doc

### DIFF
--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -103,7 +103,7 @@ To define a DNS configuration for a network interface, you must initially specif
 
 [IMPORTANT]
 ====
-You cannot use `br-ex` bridge, an OVNKubernetes-managed Open vSwitch bridge, as the interface when configuring DNS resolvers unless you manually configured a customized `br-ex` bridge.
+You cannot use the `br-ex` bridge, an OVN-Kubernetes-managed Open vSwitch bridge, as the interface when configuring DNS resolvers unless you manually configured a customized `br-ex` bridge.
 
 For more information, see "Creating a manifest object that includes a customized br-ex bridge" in the _Deploying installer-provisioned clusters on bare metal_ document or the _Installing a user-provisioned cluster on bare metal_ document.
 ====
@@ -285,4 +285,11 @@ routes:
 # ...
 ----
 <1> The static IP address for the Ethernet interface.
-<2> Next hop address for the node traffic. This must be in the same subnet as the IP address set for the Ethernet interface.
+<2> The next hop address for the node traffic. This must be in the same subnet as the IP address set for the Ethernet interface.
+
+[IMPORTANT]
+====
+You cannot use the OVN-Kubernetes `br-ex` bridge as the next hop interface when configuring a static route unless you manually configured a customized `br-ex` bridge.
+
+For more information, see "Creating a manifest object that includes a customized br-ex bridge" in the _Deploying installer-provisioned clusters on bare metal_ document or the _Installing a user-provisioned cluster on bare metal_ document.
+====


### PR DESCRIPTION
Version(s):
4.12+ 

Issue:

[OCPBUGS-49859](https://issues.redhat.com/browse/OCPBUGS-49859)

Link to docs preview:
* [Static routing](https://88066--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-IP-management-static-routing_k8s-nmstate-updating-node-network-config)

- [x] SME has approved this change.
- [x] QE has approved this change.

