### PR TITLE
[SRVCLI-403] Option `--to` replaces `--to-url`

### DIFF
--- a/modules/serverless-send-events-kn.adoc
+++ b/modules/serverless-send-events-kn.adoc
@@ -14,22 +14,38 @@ You can use the `kn event send` command to send an event. The events can be sent
 +
 [source,terminal]
 ----
-$ kn event send --field <field-name>=<value> --type <type-name> --id <id> --to-url <url> --to <cluster-resource> --namespace <namespace>
+$ kn event send \
+  --field <field_name>=<value> \
+  --type <type_name> \
+  --id <id> \
+  --to <url_or_cluster_resource> \
+  --namespace <namespace>
 ----
 where:
 ** The `--field` flag adds data to the event as a field-value pair. You can use it multiple times.
 ** The `--type` flag enables you to specify a string that designates the type of the event.
 ** The `--id` flag specifies the ID of the event.
-** If you are sending the event to a publicly accessible destination, specify the URL using the `--to-url` flag.
-** If you are sending the event to an in-cluster Kubernetes resource, specify the destination using the `--to` flag.
-*** Specify the Kubernetes resource using the `<Kind>:<ApiVersion>:<name>` format.
+** The `--to` flag specifies the destination of the event.
 ** The `--namespace` flag specifies the namespace. If omitted, the namespace is taken from the current context.
 +
-All of these flags are optional, except for the destination specification, for which you need to use either `--to-url` or `--to`.
-+
-The following example shows sending an event to a URL:
-+
-.Example command
+All of these flags are optional, except for the destination specification.
+
+[NOTE]
+====
+You can use the following destination formats for the `--to` flag:
+
+* `--to broker:<broker>`: Specifies a broker
+* `--to channel:<channel>`: Specifies a channel
+* `--to ksvc:<service>` or `--to <service>`: Specifies a Knative service in the current namespace
+* `--to ksvc:<service>:<namespace>`: Specifies a Knative service in another namespace
+* `--to svc:<service>:<namespace>`: Specifies a Kubernetes service in another namespace
+* `--to special.eventing.dev/v1alpha1/channels:<channel>`: Specifies `GroupVersionResource` of `v1alpha1` channel
+* `--to \https://example.receiver.uri`: Specifies an HTTP URL
+
+If you do not provide a prefix, the destination defaults to a Knative service in the current namespace.
+====
+
+.Sending an event to a URL
 [source,terminal]
 ----
 $ kn event send \
@@ -37,12 +53,10 @@ $ kn event send \
     --field player.game=2345 \
     --field points=456 \
     --type org.example.gaming.foo \
-    --to-url http://ce-api.foo.example.com/
+    --to http://ce-api.foo.example.com/
 ----
-+
-The following example shows sending an event to an in-cluster resource:
-+
-.Example command
+
+.Sending and event to an in-cluster resource
 [source,terminal]
 ----
 $ kn event send \
@@ -50,5 +64,5 @@ $ kn event send \
     --id $(uuidgen) \
     --field event.type=test \
     --field event.data=98765 \
-    --to Service:serving.knative.dev/v1:event-display
+    --to ksvc:event-display
 ----


### PR DESCRIPTION
Version(s):
serverless-docs-1.36

Issue:
https://issues.redhat.com/browse/SRVCLI-403

Link to docs preview:
https://88080--ocpdocs-pr.netlify.app/openshift-serverless/latest/cli_tools/kn-plugins.html#serverless-send-events-kn_kn-plugins

QE review:
- [x] QE has approved this change.
