### PR TITLE
[OSDOCS-7205] fixing CIDR default

### DIFF
--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -129,7 +129,7 @@ endif::tf-classic,tf-hcp[]
 ifndef::tf-classic,tf-hcp[]
 * Machine CIDR: 10.0.0.0/16
 * Service CIDR: 172.30.0.0/16
-* Pod CIDR: 10.128.0.0/16
+* Pod CIDR: 10.128.0.0/14
 endif::tf-classic,tf-hcp[]
 * Host prefix: /23
 +


### PR DESCRIPTION
[OSDOCS-7205] fixing CIDR default

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-7205

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
