### PR TITLE
OSDOCS-13266: z-stream 4.14.46 RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3402,6 +3402,34 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+// 4.14.46
+[id="ocp-4-14-46_{context}"]
+=== RHSA-2025:0840 - {product-title} 4.14.46 bug fix and security update
+
+Issued: 06 February 2025
+
+{product-title} release 4.14.46, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0840[RHSA-2025:0840] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0842[RHSA-2025:0842] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.46 --pullspecs
+----
+
+[id="ocp-4-14-46-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, crun failed to stop a container if you opened a terminal session and then disconnected from it. With this release, the issue is resolved.  (link:https://issues.redhat.com/browse/OCPBUGS-48752[*OCPBUGS-48752*])
+
+* Previously, you could not remove a "finally" pipeline task from the *edit Pipeline* form if you created a pipeline with only one "finally" task. With this release, you can remove the "finally" task from the *edit Pipeline* form and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-46603[*OCPBUGS-46603*])
+
+[id="ocp-4-14-46-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 // 4.14.45
 [id="ocp-4-14-45_{context}"]


### PR DESCRIPTION
Version(s):
4.14.46

Issue:
[OSDOCS-13266](https://issues.redhat.com/browse/OSDOCS-13266)

Link to docs preview:
https://88090--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-46_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (2/6/25)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
