### PR TITLE
[enterprise-4.13] OSDOCS-13230: Documenting uninstalling the K8S NMState Operator

### DIFF
--- a/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
+++ b/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-the-kubernetes-nmstate-operator-CLI_{context}"]
-= Installing the Kubernetes NMState Operator using the CLI
+= Installing the Kubernetes NMState Operator by using the CLI
 
 You can install the Kubernetes NMState Operator by using the OpenShift CLI (`oc)`. After it is installed, the Operator can deploy the NMState State Controller as a daemon set across all of the cluster nodes.
 

--- a/modules/k8s-nmstate-uninstall-operator.adoc
+++ b/modules/k8s-nmstate-uninstall-operator.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// networking/k8s_nmstate/k8s-nmstate-about-the-kubernetes-nmstate-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="k8s-nmstate-uninstall-operator_{context}"]
+= Uninstalling the Kubernetes NMState Operator
+
+You can use the Operator Lifecycle Manager (OLM) to uninstall the Kubernetes NMState Operator, but by design OLM does not delete any associated custom resource definitions (CRDs), custom resources (CRs), or API Services. 
+
+Before you uninstall the Kubernetes NMState Operator from the `Subcription` resource used by OLM, identify what Kubernetes NMState Operator resources to delete. This identification ensures that you can delete resources without impacting your running cluster.
+
+If you need to reinstall the Kubernetes NMState Operator, see "Installing the Kubernetes NMState Operator by using the CLI" or "Installing the Kubernetes NMState Operator by using the web console".
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+* You are logged in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Unsubscribe the Kubernetes NMState Operator from the `Subcription` resource by running the following command:
++
+[source,terminal]
+----
+$ oc delete --namespace openshift-nmstate subscription kubernetes-nmstate-operator
+----
+
+. Find the `ClusterServiceVersion` (CSV) resource that associates with the Kubernetes NMState Operator:
++
+[source,terminal]
+----
+$ oc get --namespace openshift-nmstate clusterserviceversion
+----
++
+.Example output that lists a CSV resource
+[source,terminal]
+----
+NAME                              	  DISPLAY                   	VERSION   REPLACES     PHASE
+kubernetes-nmstate-operator.v4.18.0   Kubernetes NMState Operator   4.18.0           	   Succeeded
+----
+
+. Delete the CSV resource. After you delete the file, OLM deletes certain resources, such as `RBAC`, that it created for the Operator.
++
+[source,terminal]
+----
+$ oc delete --namespace openshift-nmstate clusterserviceversion kubernetes-nmstate-operator.v4.18.0
+----
+
+. Delete the `nmstate` CR and any associated `Deployment` resources by running the following commands:
++
+[source,terminal]
+----
+$ oc -n openshift-nmstate delete nmstate nmstate
+----
++
+[source,terminal]
+----
+$ oc delete --all deployments --namespace=openshift-nmstate
+----
+
+. Delete all the custom resource definition (CRD), such as `nmstates`, that exist in the `nmstate.io` namespace by running the following commands:
++
+[source,terminal]
+----
+$ oc delete crd nmstates.nmstate.io
+----
++
+[source,terminal]
+----
+$ oc delete crd nodenetworkconfigurationenactments.nmstate.io
+----
++
+[source,terminal]
+----
+$ oc delete crd nodenetworkstates.nmstate.io
+----
++
+[source,terminal]
+----
+$ oc delete crd nodenetworkconfigurationpolicies.nmstate.io
+----
+
+. Delete the namespace:
++
+[source,terminal]
+----
+$ oc delete namespace kubernetes-nmstate
+----
+

--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -35,4 +35,8 @@ Node networking is monitored and updated by the following objects:
 You can install the Kubernetes NMState Operator by using the web console or the CLI.
 
 include::modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc[leveloffset=+2]
+
 include::modules/k8s-nmstate-deploying-nmstate-CLI.adoc[leveloffset=+2]
+
+// Uninstalling the Kubernetes NMState Operator
+include::modules/k8s-nmstate-uninstall-operator.adoc[leveloffset=+1]

--- a/operators/understanding/olm/olm-workflow.adoc
+++ b/operators/understanding/olm/olm-workflow.adoc
@@ -8,4 +8,5 @@ toc::[]
 
 This guide outlines the workflow of Operator Lifecycle Manager (OLM) in {product-title}.
 
+// Operator installation and upgrade workflow in OLM
 include::modules/olm-upgrades.adoc[leveloffset=+1]


### PR DESCRIPTION
Cherry pick of #87708 with commit ID 70d9be20a6dbdf80d30fadec02a3ca712f87b22c

Version(s):
4.13

Issue:
[OSDOCS-13230](https://issues.redhat.com/browse/OSDOCS-13230)

Link to docs preview:
https://88094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html#k8s-nmstate-uninstall-operator_k8s-nmstate-operator
