### PR TITLE
OSSM-5365: Delete CRDs when deleting the operator

### DIFF
--- a/modules/ossm-uninstalling-service-mesh-operator-control-plane-web-console.adoc
+++ b/modules/ossm-uninstalling-service-mesh-operator-control-plane-web-console.adoc
@@ -38,7 +38,8 @@ You can uninstall the {SMProductName} Operator 3 either by using the {ocp-produc
 .. In the {ocp-short-name} web console, click *Operators* -> *Installed Operators*.
 .. Locate {SMProductName} 3 Operator.
 .. Click the *Options* menu -> *Uninstall Operator*.
-.. At the prompt to confirm the action, click *Uninstall*.
+.. At the prompt to confirm the action, select the *Delete all operand instances for this operator* checkbox. 
+.. Click *Uninstall*.
 
 . Delete the `istio-system` project:
 .. In the {ocp-short-name} web console, click  *Home* -> *Projects*.


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 and 3.0 branches.

Version(s): TP, 3.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-5365
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://88108--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/uninstalling/ossm-uninstalling-openshift-service-mesh.html#uninstalling-service-mesh-operator-control-plane-web-console_ossm-uninstalling-openshift-service-mesh
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
