### PR TITLE
OCPBUGS-13065 removing incorrect output line

### DIFF
--- a/modules/getting-started-cli-creating-secret.adoc
+++ b/modules/getting-started-cli-creating-secret.adoc
@@ -72,6 +72,5 @@ $ oc rollout status deployment mongodb-nationalparks
 +
 [source,terminal]
 ----
-deployment "nationalparks" successfully rolled out
 deployment "mongodb-nationalparks" successfully rolled out
 ----


### PR DESCRIPTION
Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13065](https://issues.redhat.com/browse/OSDOCS-13065)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://88109--ocpdocs-pr.netlify.app/openshift-enterprise/latest/getting_started/openshift-cli.html#getting-started-cli-creating-secret_openshift-cli 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
