### PR TITLE
OSSM-8669: [DOC] Document url_format parameter (tracing)

### DIFF
--- a/modules/ossm-config-otel-kiali.adoc
+++ b/modules/ossm-config-otel-kiali.adoc
@@ -25,13 +25,26 @@ spec:
   external_services:
     tracing:
       enabled: true #<1>
-      provider: tempo
+      provider: tempo #<2>
       use_grpc: false
-      in_cluster_url: http://tempo-sample-query-frontend.tempo:3200
-      url: https://tempo-sample-query-frontend-tempo.apps-crc.testing #<2>
+      internal_url: https://tempo-sample-gateway.tempo.svc.cluster.local:8080/api/traces/v1/default/tempo #<3>
+      external_url: https://tempo-sample-gateway-tempo.apps-crc.testing/api/traces/v1/default/search #<4>
+      health_check_url: https://tempo-sample-gateway-tempo.apps-crc.testing/api/traces/v1/north/tempo/api/echo #<5> 
+      auth: #<6>
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        insecure_skip_verify: false
+        type: bearer
+        use_kiali_token: true
+      tempo_config:
+         url_format: "jaeger" #<7>
 ----
-<1> Enable tracing.
-<2> The {ocp-short-name} route for Jaeger UI must be created in the Tempo namespace. You can either manually create it for the `tempo-sample-query-frontend` service, or update the `Tempo` custom resource with `.spec.template.queryFrontend.jaegerQuery.ingress.type: route`.
+<1> Specifies whether tracing is enabled.
+<2> Specifies either {TempoShortName} or {JaegerShortName}. Tempo can expose a Jaeger or Tempo API.
+<3> Specifies the internal URL for the Tempo API. If Tempo is deployed in a multi-tenant model, you must include the `tenant name` name.
+<4> Specifies the {ocp-short-name} route for the Jaeger UI. When deployed in a multi-tenant model, the gateway creates the route. Otherwise, you must create the route in the `Tempo` namespace. You can manually create the route for the `tempo-sample-query-frontend` service or update the `Tempo` CR with `.spec.template.queryFrontend.jaegerQuery.ingress.type: route`.
+<5> Specifies the health check URL. Not required by default. When Tempo is deployed in a multi-tenant model, Kiali does not expose the default health check URL. This is an example of a valid health URL.
+<6> Specifies the configuration used when the access URL is `HTTPS` or requires authentication. Not required by default.
+<7> Specifies the configuration that defaults to `grafana`. Not required by default. Change to `jaeger` if the Kiali `View in tracing` link redirects to the Jaeger console UI.
 
 . Save the updated `spec` in `kiali_cr.yaml`.
 


### PR DESCRIPTION
Change type: Doc update; Document url_format parameter (tracing)

Doc JIRA: https://issues.redhat.com/browse/OSSM-8669

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://88136--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/kiali/ossm-kiali-assembly.html#ossm-config-otel-kiali_ossm-kiali-assembly

SME/QE Review: @josunect @jshaughn @jmazzitelli 
Peer Review: @xenolinux 