### PR TITLE
OSDOCS-13230-ui: Added nmstate-console-plugin step to Uninstall K8S N…

### DIFF
--- a/modules/k8s-nmstate-uninstall-operator.adoc
+++ b/modules/k8s-nmstate-uninstall-operator.adoc
@@ -15,6 +15,7 @@ If you need to reinstall the Kubernetes NMState Operator, see "Installing the Ku
 .Prerequisites
 
 * You have installed the {oc-first}.
+* You have installed the `jq` CLI tool.
 * You are logged in as a user with `cluster-admin` privileges.
 
 .Procedure
@@ -59,7 +60,24 @@ $ oc -n openshift-nmstate delete nmstate nmstate
 $ oc delete --all deployments --namespace=openshift-nmstate
 ----
 
-. Delete all the custom resource definition (CRD), such as `nmstates`, that exist in the `nmstate.io` namespace by running the following commands:
+. After you deleted the `nmstate` CR, remove the `nmstate-console-plugin` console plugin name from the `console.operator.openshift.io/cluster` CR.
++
+.. Store the position of the `nmstate-console-plugin` entry that exists among the list of enable plugins by running the following command. The following command uses the `jq` CLI tool to store the index of the entry in an environment variable named `INDEX`:
++
+[source,terminal]
+----
+INDEX=$(oc get console.operator.openshift.io cluster -o json | jq -r '.spec.plugins | to_entries[] | select(.value == "nmstate-console-plugin") | .key')
+----
++
+.. Remove the `nmstate-console-plugin` entry from the `console.operator.openshift.io/cluster` CR by running the following patch command:
++
+[source,terminal]
+----
+$ oc patch console.operator.openshift.io cluster --type=json -p "[{\"op\": \"remove\", \"path\": \"/spec/plugins/$INDEX\"}]" <1>
+----
+<1> `INDEX` is an auxiliary variable. You can specify a different name for this variable.
+
+. Delete all the custom resource definitions (CRDs), such as `nmstates.nmstate.io`, by running the following commands:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-13230](https://issues.redhat.com/browse/OSDOCS-13230)

Link to docs preview:

* [K8S NMState Operator](https://88152--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html#k8s-nmstate-uninstall-operator_k8s-nmstate-operator)

- [x] SME has approved this change.
- [x] QE has approved this change (Qiong Wang)

Add. resources
* [GDoc](https://docs.google.com/document/d/1Oa72uZRNmQ050UGVpBBvZc4WhXpyZe42DDdkBGuVf6c/edit?tab=t.0#heading=h.laj7erjhas7r)

