### PR TITLE
MIG-1691: PSA labels should be called out explicitly in the docs

### DIFF
--- a/migration_toolkit_for_containers/mtc-direct-migration-requirements.adoc
+++ b/migration_toolkit_for_containers/mtc-direct-migration-requirements.adoc
@@ -48,7 +48,12 @@ include::modules/configuring-retries-for-rsync.adoc[leveloffset=+3]
 
 include::modules/ocp-running-rsync-root-or-non-root.adoc[leveloffset=+3]
 
-To learn more about Pod Security Admission and setting values for labels, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-opting_understanding-and-managing-pod-security-admission[Controlling pod security admission synchronization].
+include::modules/security-context-constraints-psa-about.adoc[leveloffset=+4]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-opting_understanding-and-managing-pod-security-admission[Controlling pod security admission synchronization].
 
 include::modules/migration-rsync-migration-controller-root-non-root.adoc[leveloffset=+3]
 

--- a/modules/ocp-running-rsync-root-or-non-root.adoc
+++ b/modules/ocp-running-rsync-root-or-non-root.adoc
@@ -6,7 +6,7 @@
 [id="ocp-running-rsync-root-or-non-root_{context}"]
 = Running Rsync as either root or non-root
 
-{OCP} environments have the `PodSecurityAdmission` controller enabled by default. This controller requires cluster administrators to enforce Pod Security Standards by means of namespace labels. All workloads in the cluster are expected to run one of the following Pod Security Standard levels: `Privileged`, `Baseline` or `Restricted`. Every cluster has its own default policy set.
+{OCP} environments have the `PodSecurityAdmission` controller enabled by default. This controller requires cluster administrators to enforce Pod Security Standards by means of namespace labels. All workloads in the cluster are expected to run one of the following Pod Security Standard levels: `privileged`, `baseline` or `restricted`. Every cluster has its own default policy set.
 
 To guarantee successful data transfer in all environments, {mtc-first} 1.7.5 introduced changes in Rsync pods, including running Rsync pods as non-root user by default. This ensures that data transfer is possible even for workloads that do not necessarily require higher privileges. This change was made because it is best to run workloads with the lowest level of privileges possible.
 

--- a/modules/security-context-constraints-psa-about.adoc
+++ b/modules/security-context-constraints-psa-about.adoc
@@ -71,3 +71,19 @@ The following system namespaces are always set to the `privileged` pod security 
 * `kube-system`
 
 You cannot change the pod security profile for these privileged namespaces.
+
+.Example privileged namespace configuration
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: "<mig_namespace>"
+# ...
+----


### PR DESCRIPTION
### JIRA

* [MIG-1691](https://issues.redhat.com/browse/MIG-1691)

### VERSIONS

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19

### PREVIEW

* [Resource limit configurations for Rsync pods](https://88156--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-direct-migration-requirements.html#configuring-resource-limits-on-rsync-pods_mtc-direct-migration-requirements)

*  [Installing MTC - Running Rsync as either root or non-root](https://88156--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html#ocp-running-rsync-root-or-non-root_installing-mtc)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
