### PR TITLE
TELCODOCS-1871 - Corrected typo -  Configuring an RDMA subsystem for …

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1568,7 +1568,7 @@ Topics:
     File: configuring-sriov-net-attach
   - Name: Configuring an SR-IOV InfiniBand network attachment
     File: configuring-sriov-ib-attach
-  - Name: Configuring an RDMA subsytem for SR-IOV
+  - Name: Configuring an RDMA subsystem for SR-IOV
     File: configuring-sriov-rdma-cni
   - Name: Adding a pod to an SR-IOV network
     File: add-pod

--- a/networking/hardware_networks/configuring-sriov-rdma-cni.adoc
+++ b/networking/hardware_networks/configuring-sriov-rdma-cni.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="configuring-sriov-rdma-cni"]
-= Configuring an RDMA subsytem for SR-IOV
+= Configuring an RDMA subsystem for SR-IOV
 include::_attributes/common-attributes.adoc[]
 :context: configuring-sriov-rdma-cni
 


### PR DESCRIPTION
…SR-IOV

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1871
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Configuring an RDMA subsystem for SR-IOV](https://88157--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-rdma-cni.html) 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
