### PR TITLE
OCPBUGS#44833: Documented the known issue for the 4.18 client used wi…

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1989,6 +1989,18 @@ In the following tables, features are marked with the following statuses:
 
 * There is a known issue with user-defined networks (UDN) that causes OVN-Kubernetes to delete any routing table ID equal or higher to 1000 that it does not manage. Consequently, any Virtual Routing and Forwarding (VRF) instance created outside OVN-Kubernetes is deleted. This issue impacts users who have created user-defined VRFs with a table ID greater than or equal to 1000. As a workaround, users must change their VRFs to a table ID lower than 1000 as these are reserved for {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-50855[*OCPBUGS-50855*])
 
+* If you attempted to log in to a {product-title} 4.17 server by using the {oc-first} that you installed as part of the {product-title} {product-version}, you would see the following warning message in your terminal:
++
+[source,terminal]
+----
+Warning: unknown field "metadata"
+You don't have any projects. You can try to create a new project, by running
+
+    oc new-project <projectname>
+----
++
+This warning message is a known issue but does not indicate any functionality issues with {product-title}. You can safely ignore the warning message and continue to use {product-title} as intended. (link:https://issues.redhat.com/browse/OCPBUGS-44833[*OCPBUGS-44833*])
+
 [id="ocp-telco-ran-4-18-known-issues_{context}"]
 
 * When you run Cloud-native Network Functions (CNF) latency tests on an {product-title} cluster, the test can sometimes return results greater than the latency threshold for the test; for example, 20 microseconds for `cyclictest` testing. This results in a test failure.


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OCPBUGS-44833](https://issues.redhat.com/browse/OCPBUGS-44833)

Link to docs preview:
[4.18 Known issues](https://88159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-known-issues_release-notes)

- [x] SME has approved this change (Arnab Gosh).
- [x] QE has approved this change (Xingxing Xia).
