### PR TITLE
Network Observability 1.8 release notes for 4.17, 4.18

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -12,6 +12,95 @@ The Network Observability Operator enables administrators to observe and analyze
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
 For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
+
+[id="network-observability-operator-release-notes-1-8_{context}"]
+== Network Observability Operator 1.8.0
+The following advisory is available for the Network Observability Operator 1.8.0:
+
+* link:https://access.redhat.com/errata/RHEA-2025:1825[Network Observability Operator 1.8.0]
+
+[id="network-observability-operator-1.8.0-features-enhancements_{context}"]
+=== New features and enhancements
+
+[id="network-observability-operator-pkt-xlat-1-8_{context}"]
+==== Packet translation
+You can now enrich network flows with translated endpoint information, showing not only the service but also the specific backend pod, so you can see which pod served a request.
+
+For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-translation-overview_nw-observe-network-traffic[Endpoint translation (xlat)] and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-translation_nw-observe-network-traffic[Working with endpoint translation (xlat)].
+
+[id="network-observability-operator-OVN-observability-1-8_{context}"]
+==== OVN-Kubernetes networking events tracking
+
+:FeatureName: OVN-Kubernetes networking events tracking
+include::snippets/technology-preview.adoc[]
+
+You can now use network event tracking in Network Observability to gain insight into OVN-Kubernetes events, including network policies, admin network policies, and egress firewalls.
+
+For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-viewing-network-events_nw-observe-network-traffic[Viewing network events].
+
+[id="network-observability-operator-ebpf-perf-improvements-1-8_{context}"]
+==== eBPF performance improvements in 1.8
+
+* Network Observability now uses hash maps instead of per-CPU maps. This means that network flows data is now tracked in the kernel space and new packets are also aggregated there. The de-duplication of network flows can now occur in the kernel, so the size of data transfer between the kernel and the user spaces yields better performance. With these eBPF performance improvements, there is potential to observe a CPU resource reduction between 40% and 57% in the eBPF Agent.
+
+[id="network-observability-cli-1-8_{context}"]
+==== Network Observability CLI
+The following new features, options, and filters are added to the Network Observability CLI for this release:
+
+* Capture metrics with filters enabled by running the `oc netobserv metrics` command.
+* Run the CLI in the background by using the `--background` option with flows and packets capture and running `oc netobserv follow` to see the progress of the background run and `oc netobserv copy` to download the generated logs.
+* Enrich flows and metrics capture with Machines, Pods, and Services subnets by using the `--get-subnets` option.
+* New filtering options available with packets, flows, and metrics capture:
+
+** eBPF filters on IPs, Ports, Protocol, Action, TCP Flags and more
+** Custom nodes using `--node-selector`
+** Drops only using `--drops`
+** Any field using `--regexes`
+
+For more information, see xref:../../observability/network_observability/netobserv_cli/netobserv-cli-reference.adoc#network-observability-netobserv-cli-reference_netobserv-cli-reference[Network Observability CLI reference].
+
+observability/network_observability/netobserv_cli/netobserv-cli-reference.html#network-observability-netobserv-cli-reference_netobserv-cli-reference
+[id="network-observability-operator-1-8-bug-fixes_{context}"]
+=== Bug fixes
+* Previously, the Network Observability Operator came with a "kube-rbac-proxy" container to manage RBAC for its metrics server. Since this external component is deprecated, it was necessary to remove it. It is now replaced with direct TLS and RBAC management through Kubernetes controller-runtime, without the need for a side-car proxy. (link:https://issues.redhat.com/browse/NETOBSERV-1999[*NETOBSERV-1999*])
+
+* Previously in the {product-title} console plugin, filtering on a key that was not equal to multiple values would not filter anything. With this fix, the expected results are returned, which is all flows not having any of the filtered values. (link:https://issues.redhat.com/browse/NETOBSERV-1990[*NETOBSERV-1990*])
+
+* Previously in the {product-title} console plugin with disabled Loki, it was very likely to generate a "Can't build query" error due to selecting an incompatible set of filters and aggregations. Now this error is avoided avoid by automatically disabling incompatible filters while still making the user aware of the filter incompatibility. (link:https://issues.redhat.com/browse/NETOBSERV-1977[*NETOBSERV-1977*])
+
+* Previously, when viewing flow details from the console plugin, the ICMP info was always displayed in the side panel, showing "undefined" values for non-ICMP flows. With this fix, ICMP info is not displayed for non-ICMP flows. (link:https://issues.redhat.com/browse/NETOBSERV-1969[*NETOBSERV-1969*])
+
+* Previously, the "Export data" link from the *Traffic flows* view did not work as intended, generating empty CSV reports. Now, the export feature is restored, generating non-empty CSV data. (link:https://issues.redhat.com/browse/NETOBSERV-1958[*NETOBSERV-1958*])
+
+* Previously, it was possible to configure the `FlowCollector` with `processor.logTypes` `Conversations`, `EndedConversations` or `All` with `loki.enable` set to `false`, despite the conversation logs being only useful when Loki is enabled. This resulted in resource usage waste. Now, this configuration is invalid and is rejected by the validation webhook. (link:https://issues.redhat.com/browse/NETOBSERV-1957[*NETOBSERV-1957*])
+
+* Configuring the `FlowCollector` with `processor.logTypes` set to `All` consumes much more resources, such as CPU, memory and network bandwidth, than the other options. This was previously not documented. It is now documented, and triggers a warning from the validation webhook. (link:https://issues.redhat.com/browse/NETOBSERV-1956[*NETOBSERV-1956*])
+
+* Previously, under high stress, some flows generated by the eBPF agent were mistakenly dismissed, resulting in traffic bandwidth under-estimation. Now, those generated flows are not dismissed. (link:https://issues.redhat.com/browse/NETOBSERV-1954[*NETOBSERV-1954*])
+
+* Previously, when enabling the network policy in the `FlowCollector` configuration, the traffic to the Operator webhooks was blocked, breaking the `FlowMetrics` API validation. Now traffic to the webhooks is allowed. (link:https://issues.redhat.com/browse/NETOBSERV-1934[*NETOBSERV-1934*])
+
+* Previously, when deploying the default network policy, namespaces `openshift-console` and `openshift-monitoring` were set by default in the `additionalNamespaces` field, resulting in duplicated rules. Now there is no additional namespace set by default, which helps avoid getting duplicated rules.(link:https://issues.redhat.com/browse/NETOBSERV-1933[*NETOBSERV-1933*])
+
+* Previously from the {product-title} console plugin, filtering on TCP flags would match flows having only the exact desired flag. Now, any flow having at least the desired flag appears in filtered flows. (link:https://issues.redhat.com/browse/NETOBSERV-1890[*NETOBSERV-1890*])
+
+* When the eBPF agent runs in privileged mode and pods are continuously added or deleted, a file descriptor (FD) leak occurs. The fix ensures proper closure of the FD when a network namespace is deleted. (link:https://issues.redhat.com/browse/NETOBSERV-2063[*NETOBSERV-2063*])
+
+* Previously, the CLI agent `DaemonSet` did not deploy on master nodes. Now, a  toleration is added on the agent `DaemonSet` to schedule on every node when taints are set. Now, CLI agent `DaemonSet` pods run on all nodes. (link:https://issues.redhat.com/browse/NETOBSERV-2030[*NETOBSERV-2030*])
+
+* Previously, the *Source Resource* and *Source Destination* filters autocomplete were not working when using Prometheus storage only. Now this issue is fixed and suggestions displays as expected. (link:https://issues.redhat.com/browse/NETOBSERV-1885[*NETOBSERV-1885*])
+
+* Previously, a resource using multiple IPs was displayed separately in the *Topology* view. Now, the resource shows as a single topology node in the view. (link:https://issues.redhat.com/browse/NETOBSERV-1818[*NETOBSERV-1818*])
+
+* Previously, the console refreshed the *Network traffic* table view contents when the mouse pointer hovered over the columns. Now, the the display is fixed, so row height remains constant with a mouse hover. (link:https://issues.redhat.com/browse/NETOBSERV-2049[*NETOBSERV-2049*])
+
+[id="network-observability-operator-1-8-known-issues_{context}"]
+=== Known issues
+
+* If there is traffic that uses overlapping subnets in your cluster, there is a small risk that the eBPF Agent mixes up the flows from overlapped IPs. This can happen if different connections happen to have the exact same source and destination IPs and if ports and protocol are within a 5 seconds time frame and happening on the same node. This should not be possible unless you configured secondary networks or UDN. Even in that case, it is still very unlikely in usual traffic, as source ports are usually a good differentiator. (link:https://issues.redhat.com/browse/NETOBSERV-2115[*NETOBSERV-2115*])
+
+* After selecting a type of exporter to configure in the `FlowCollector` resource `spec.exporters` section from the {product-title} web console form view, the detailed configuration for that type does not show up in the form. The workaround is to configure directly the YAML. (link:https://issues.redhat.com/browse/NETOBSERV-1981[*NETOBSERV-1981*])
+
 [id="network-observability-operator-release-notes-1-7_{context}"]
 == Network Observability Operator 1.7.0
 The following advisory is available for the Network Observability Operator 1.7.0:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
The OVN-Observability feature is only for 4.17 and 4.18 versions running Network Observability, so this PR only goes to 4.17 and 4.18. 
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://88163--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
