### PR TITLE
HCIDOCS-417: Remove IDRAC 8 from Firmware requirements for installing with virtual media

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -29,7 +29,6 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 | 16th Generation | iDRAC 9 | v7.10.70.00
 | 15th Generation | iDRAC 9 | v6.10.30.00 and v7.10.70.00
 | 14th Generation | iDRAC 9 | v6.10.30.00
-| 13th Generation .2+| iDRAC 8 | v2.75.75.75 or later
 
 |====
 


### PR DESCRIPTION
**Fixes:** [HCIDOCS-417](https://issues.redhat.com/browse/HCIDOCS-417)

**For:** OCP 4.16 and later

[**Preview**](https://--ocpdocs-pr.netlify.app)

**Approvals -** `/lgtm`:
- [x] SME
- [x] QE
- [x] Peer Review