### PR TITLE
OSDOCS-13318: adds missing steps to EUS repo config MicroShift

### DIFF
--- a/modules/microshift-embed-ostree-enable-eus-repos.adoc
+++ b/modules/microshift-embed-ostree-enable-eus-repos.adoc
@@ -6,17 +6,31 @@
 [id="microshift-enable-eus-repos_{context}"]
 = Enabling extended support repositories for image building
 
-If you have an extended support (EUS) release of {microshift-short}, you must enable the {op-system-base-full} EUS repositories for image builder to use. If you do not have an EUS version, you can skip these steps.
+If you have an extended support (EUS) release of {microshift-short} or {op-system-base-full}, you must enable the {op-system-base} EUS repositories for image builder to use. If you do not have an EUS version, you can skip these steps.
 
 .Prerequisites
 
-* You have an EUS version of {microshift-short} or are updating to one.
+* You have an EUS version of {microshift-short} or {op-system-base} or are updating to one.
 * You have root-user access to your build host.
 * You reviewed the link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/getting_ready_to_install_microshift/microshift-install-get-ready#get-ready-install-rhde-compatibility-table_microshift-install-get-ready[{op-system-bundle} release compatibility matrix].
 
 include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
 
 .Procedure
+
+. Create the `/etc/osbuild-composer/repositories` directory by running the following command:
++
+[source,terminal]
+----
+$ sudo mkdir -p /etc/osbuild-composer/repositories
+----
+
+. Copy the `/usr/share/osbuild-composer/repositories/rhel-9.4.json` file into the `/etc/osbuild-composer/repositories` directory by running the following command:
++
+[source,terminal]
+----
+$ sudo cp /usr/share/osbuild-composer/repositories/rhel-9.4.json /etc/osbuild-composer/repositories/rhel-9.4.json
+----
 
 . Update the `baseos` source by modifying the `/etc/osbuild-composer/repositories/rhel-9.4.json` file with the following values:
 +

--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -29,10 +29,10 @@ You cannot downgrade {microshift-short} with this process. Downgrades are not su
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-<4.18>-for-<9>-$(uname -m)-rpms \ # <1>
+    --enable rhocp-<x.y>-for-<9>-$(uname -m)-rpms \ # <1>
     --enable fast-datapath-for-<9>-$(uname -m)-rpms # <2>
 ----
-<1> Replace _<4.18>_ and _<9>_ with the compatible versions of your {microshift-short} and {op-system-base-full}.
+<1> Replace _<x.y>_ and _<9>_ with the compatible versions of your {microshift-short} and {op-system-base-full}.
 <2> Replace  _<9>_ with the compatible version of {op-system-base}.
 
 . For extended support (EUS) releases, also enable the EUS repositories by running the following command:


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-13318](https://issues.redhat.com/browse/OSDOCS-13318)

Link to docs preview:
[microshift-embed-in-rpm-ostree](https://88190--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updates https://github.com/openshift/openshift-docs/pull/87660

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
