### PR TITLE
OSDOCS-13070-415: backport adding EUS repos MicroShift 4.15

### DIFF
--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -21,6 +21,9 @@ include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 
 include::modules/microshift-preparing-for-image-building.adoc[leveloffset=+1]
 
+//This module version is specifically for the 4.15 branch due to refactors in 4.17.
+include::modules/microshift-embed-ostree-enable-eus-repos.adoc[leveloffset=+1]
+
 include::modules/microshift-adding-repos-to-image-builder.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/microshift_updating/microshift-update-options.adoc
+++ b/microshift_updating/microshift-update-options.adoc
@@ -24,6 +24,8 @@ You can update {microshift-short} without reinstalling your applications. {op-sy
 
 {microshift-short} operates as an in-place update and does not require removal of the previous version. Data backups beyond those required for the usual functioning of your applications are also not required.
 
+include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
+
 [id="microshift-update-options-rpm-ostree-updates_{context}"]
 === RPM-OSTree updates
 You can update {microshift-short} on an `rpm-ostree` system such as {op-system-ostree} by building a new image containing the new version of {microshift-short}. Ensure that the version of the operating system you want to use is compatible with the new version of {microshift-short} that you update to.

--- a/microshift_updating/microshift-update-rpms-manually.adoc
+++ b/microshift_updating/microshift-update-rpms-manually.adoc
@@ -22,4 +22,4 @@ include::modules/microshift-updating-rpms-y.adoc[leveloffset=+1]
 //additional resources for backup and restore
 [role="_additional-resources"]
 .Additional resources
-* xref:../microshift_backup_and_restore/microshift-backup-and-restore.adoc#microshift-backup-and-restore[Backup and restore]
+* xref:../microshift_backup_and_restore/microshift-backup-and-restore.adoc#microshift-backup-and-restore[Backing up and restoring {microshift-short} data]

--- a/modules/microshift-embed-ostree-enable-eus-repos.adoc
+++ b/modules/microshift-embed-ostree-enable-eus-repos.adoc
@@ -1,0 +1,105 @@
+// Module included in the following assemblies:
+//
+// * microshift_install/microshift-embed-into-rpm-ostree.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-enable-eus-repos_{context}"]
+= Enabling extended support repositories for image building
+
+If you have an extended support (EUS) release of {microshift-short} or {op-system-base-full}, you must enable the {op-system-base} EUS repositories for image builder to use. If you do not have an EUS version, you can skip these steps.
+
+.Prerequisites
+
+* You have either an EUS version of {microshift-short} or are updating to one, or an EUS version of{op-system-base}.
+* You have root-user access to your build host.
+* You reviewed the link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.15/html/installing/microshift-install-rpm#install-rpm-rhde-compatibility-table[{op-system-bundle} release compatibility matrix].
+
+include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
+
+.Procedure
+
+. Create the `/etc/osbuild-composer/repositories` directory by running the following command:
++
+[source,terminal]
+----
+$ sudo mkdir -p /etc/osbuild-composer/repositories
+----
+
+. Copy the `/usr/share/osbuild-composer/repositories/rhel-9.2.json` file into the `/etc/osbuild-composer/repositories` directory by running the following command:
++
+[source,terminal]
+----
+$ sudo cp /usr/share/osbuild-composer/repositories/rhel-9.2.json /etc/osbuild-composer/repositories/rhel-9.2.json
+----
+
+. Update the `baseos` source by modifying the `/etc/osbuild-composer/repositories/rhel-9.2.json` file with the following values:
++
+[source,terminal]
+----
+# ...
+"baseurl": "https://cdn.redhat.com/content/eus/rhel<9>/<9.2>//baseos/os", # <1>
+# ...
+----
+<1> Replace _<9>_ with the major {op-system-base} version you are using, and replace _<9.2>_ with the _<major.minor>_ version. Be certain that the {op-system-base} version you choose is compatible with the {microshift-short} version you are using.
+
+. Optional. Apply the `baseos` update by running the following command:
++
+[source,terminal]
+----
+$ sudo sed -i "s,dist/rhel<9>/<9.2>/$(uname -m)/baseos/,eus/rhel<9>/<9.2>/$(uname -m)/baseos/,g" \
+/etc/osbuild-composer/repositories/rhel-<9.2>.json # <1>
+----
+<1> Replace _<9>_ with the major {op-system-base} version you are using, and replace _<9.2>_ with the _<major.minor>_ version. Be certain that the {op-system-base} version you choose is compatible with the {microshift-short} version you are using.
+
+. Update the `appstream` source by modifying the `/etc/osbuild-composer/repositories/rhel-<major.minor>.json` file with the following values:
++
+[source,terminal]
+----
+# ...
+"baseurl": "https://cdn.redhat.com/content/eus/rhel<9>/<9.2>//appstream/os", # <1>
+# ...
+----
+<1> Replace _<9>_ with the major {op-system-base} version you are using, and replace _<9.2>_ with the _<major.minor>_ version. Be certain that the {op-system-base} version you choose is compatible with the {microshift-short} version you are using.
+
+. Optional. Apply the `appstream` update by running the following command:
++
+[source,terminal]
+----
+$ sudo sed -i "s,dist/rhel<9>/<9.2>/$(uname -m)/appstream/,eus/rhel<9>/<9.2>/$(uname -m)/appstream/,g" \
+/etc/osbuild-composer/repositories/rhel-<9.2>.json # <1>
+----
+<1> Replace _<9>_ with the major {op-system-base} version you are using, and replace _<9.2>_ with the _<major.minor>_ version. Be certain that the {op-system-base} version you choose is compatible with the {microshift-short} version you are using.
+
+.Verification
+
+You can verify the repositories by using the `composer-cli` tool to display information about the source.
+
+. Verify the `baseos` source by running the following command:
++
+[source,terminal]
+----
+$ sudo composer-cli sources info baseos | grep 'url ='
+----
+.Example output
++
+[source,text]
+----
+url = "https://cdn.redhat.com/content/eus/rhel9/9.2/x86_64/baseos/os"
+----
+
+. Verify the `appstream` source by running the following command:
++
+[source,terminal]
+----
+$ sudo composer-cli sources info appstream | grep 'url ='
+----
+.Example output
++
+[source,text]
+----
+url = "https://cdn.redhat.com/content/eus/rhel9/9.2/x86_64/appstream/os"
+----
+
+.Troubleshooting
+
+ * If you cannot verify the updated sources, restart the host and run the verification steps again.

--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -27,14 +27,31 @@ You cannot downgrade {microshift-short} with this process. Downgrades are not su
 
 .Procedure
 
-. Enable the {microshift-short} repositories by running the following command:
+. For all lifecycles, enable the repository for your release by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-{ocp-version}-for-{rhel-major}-$(uname -m)-rpms \
-    --enable fast-datapath-for-{rhel-major}-$(uname -m)-rpms
+    --enable rhocp-4.15-for-9-$(uname -m)-rpms \
+    --enable fast-datapath-for-9-$(uname -m)-rpms
 ----
+
+. For extended support (EUS) releases, also enable the EUS repositories by running the following command:
++
+[source,terminal]
+----
+`$ sudo subscription-manager repos \
+    --enable rhel-9-for-x86_64-appstream-eus-rpms \
+    --enable rhel-9-for-x86_64-baseos-eus-rpms`
+----
+
+. Avoid unintended future updates into an unsupported configuration by locking your operating system version with the following command:
++
+[source,terminal]
+----
+$ sudo subscription-manager release --set=<9.2> command. # <1>
+----
+<1> Replace _<9.2>_ with the major and minor version of your compatible {op-system-base} system.
 
 . Update the {microshift-short} RPMs by running the following command:
 +

--- a/snippets/microshift-unsupported-config-warn.adoc
+++ b/snippets/microshift-unsupported-config-warn.adoc
@@ -1,0 +1,15 @@
+// Text snippet included in the following modules:
+//
+// * modules/microshift-updating-rpms-y.adoc
+// * modules/microshift-embed-ostree-enable-eus-repos.adoc
+// * assemblies/microshift-update-options.adoc
+// * assemblies/microshift-embed-in-rpm-ostree.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[WARNING]
+====
+Keeping component versions in a supported configuration of {op-system-bundle} can require updating {microshift-short} and {op-system-base} at the same time. Ensure that your version of {op-system-base} is compatible with the version of {microshift-short} you are updating to, especially if you are updating {microshift-short} across two minor versions. Otherwise, you can create an unsupported configuration, break your cluster, or both. For more information, see the link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.15/html/installing/microshift-install-rpm#install-rpm-rhde-compatibility-table[Red Hat Device Edge release compatibility matrix].
+====
+
+//This snippet is specifically for the 4.15 branch due to refactors in 4.17.


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-13070](https://issues.redhat.com/browse/OSDOCS-13070)

Link to docs preview:
https://88192--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html
https://88192--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options.html
https://88192--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Backports https://github.com/openshift/openshift-docs/pull/87660, incorporates https://github.com/openshift/openshift-docs/pull/88190

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
