### PR TITLE
OLS-1385: Release Notes for Lightspeed 0.3 release

### DIFF
--- a/modules/ols-0-3-0-release-notes.adoc
+++ b/modules/ols-0-3-0-release-notes.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-3-0-release-notes_{context}"]
+= {ols-long} version 0.3.0
+
+{ols-official} 0.3.0 is now available on {ocp-product-title} 4.15 or later.
+
+[IMPORTANT]
+====
+{ols-official} is designed for FIPS. When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/compliance_activities_and_gov_standards#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
+====
+
+[id="ols-0-3-0-enhancements_{context}"]
+== Enhancements
+
+The following enhancements are made with {ols-official} 0.3.0:
+
+* Beginning with this release the {ols-long} Operator can be installed in any namespace.

--- a/modules/ols-release-0-3-0-known-issues.adoc
+++ b/modules/ols-release-0-3-0-known-issues.adoc
@@ -1,0 +1,13 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-release-0-3-known-issues_{context}"]
+= Known issues
+
+The following issues are identified with {ols-official} 0.3.0:
+
+* If the {ols-long} Operator is installed in a namespace other than `openshift-lightspeed`, the Operator cannot reconcile the secret used to authenticate the Large Language Model (LLM) provider. 
++
+Workaround: The LLM provider secret must be created before the `OLSConfig` custom resource is created. Then, the Operator can reconcile the secret. link:https://issues.redhat.com/browse/OLS-1426[OLS-1426]. 

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -8,10 +8,10 @@ toc::[]
 
 The release notes highlight what is new and what has changed with each {ols-official} release.
 
+include::modules/ols-0-3-0-release-notes.adoc[leveloffset=+1]
+include::modules/ols-release-0-3-0-known-issues.adoc[leveloffset=+2]
 include::modules/ols-0-2-1-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-2-0-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-1-7-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-1-6-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-1-5-release-notes.adoc[leveloffset=+1]
-
-// include::modules/ols-release-notes-known-issues.adoc[leveloffset=+2]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OLS-1385
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://88206--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
