### PR TITLE
OSSM-8700: [DOC] Remove 2.6 and 3.0 side-by-side content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -30,8 +30,6 @@ Topics:
   File: ossm-installing-openshift-service-mesh
 - Name: Sidecar injection
   File: ossm-sidecar-injection-assembly
-- Name: Running Service Mesh 2.6 in the same cluster as Service Mesh 3
-  File: ossm-running-v2-same-cluster-as-v3-assembly
 - Name: Red Hat OpenShift Service Mesh and cert-manager
   File: ossm-cert-manager-assembly
 - Name: Multi-Cluster topologies

--- a/migrating/ossm-migrating-read-me-assembly.adoc
+++ b/migrating/ossm-migrating-read-me-assembly.adoc
@@ -10,14 +10,6 @@ If you are moving from {SMProductName} 2.6 to {SMProductName} 3, read the conten
 
 include::modules/ossm-migrating-2-and-3-differences.adoc[leveloffset=+1]
 include::modules/ossm-migrating-read-me-new-operator.adoc[leveloffset=+1]
-
-.Next steps
-You can install the {SMProduct} 3 Operator, or you can run {SMProduct} 2.6 and {SMProduct} 3 in the same cluster using either the multi-tenant deployment model, or the cluster-wide model.
-
-* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-installing-operator_ossm-about-deployment-and-update-strategies[Installing the Service Mesh Operator]
-* xref:../install/ossm-running-v2-same-cluster-as-v3-assembly.adoc#ossm-running-v2-v3-multitenant-deployment-model_ossm-running-v2-same-cluster-as-v3-assembly[Running OpenShift Service Mesh 2.6 and OpenShift Service Mesh 3 using multi-tenant model]
-* xref:../install/ossm-running-v2-same-cluster-as-v3-assembly.adoc#ossm-running-v2-v3-cluster-wide-deployment-model_ossm-running-v2-same-cluster-as-v3-assembly[Running OpenShift Service Mesh 2.6 and OpenShift Service Mesh 3 using cluster-wide deployment model]
-
 include::modules/ossm-migrating-read-me-new-resources.adoc[leveloffset=+1]
 include::modules/ossm-migrating-read-me-observability-integrations.adoc[leveloffset=+1]
 include::modules/ossm-migrating-read-me-scoping-discovery-selectors.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Remove 2.6 and 3.0 side-by-side content

Doc JIRA: https://issues.redhat.com/browse/OSSM-8700

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: 
Check if removed from Installing assembly: https://88215--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh

Check if removed from Next Steps: https://88215--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/ossm-migrating-read-me-assembly#ossm-service-mesh-3-operator_ossm-migrating-read-me-assembly

SME Review: @sridhargaddam 
QE Review: @FilipB 
Peer Review: @xenolinux 