### PR TITLE
OSSM-8699: [DOC] Add warning to installation documentation about potential conflicts with 2.6

### DIFF
--- a/install/ossm-installing-openshift-service-mesh.adoc
+++ b/install/ossm-installing-openshift-service-mesh.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Installing {ocp-short-name} {SMProductShortName} consists of three main tasks: installing the {ocp-short-name} Operator, deploying {istio}, and customizing the {istio} configuration. Then, you can also choose to install the sample `bookinfo` application to push data through the mesh and explore mesh functionality.
 
+[WARNING]
+====
+Before migrating from {SMProduct} 2, make sure you are not running {SMProduct} 3 and {SMProduct} 2 in the same cluster, because it causes conflicts unless configured correctly. To migrate from {SMProduct} 2, see xref:../migrating/ossm-migrating-read-me-assembly.adoc#ossm-migrating-read-me-assembly[Migrating from {SMProduct} 2.6].
+====
+
 include::modules/ossm-about-deploying-istio-using-service-mesh-operator.adoc[leveloffset=+1]
 include::modules/ossm-about-deployment-and-update-strategies.adoc[leveloffset=+2]
 include::modules/ossm-installing-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Add warning to installation documentation about potential conflicts with 2.6

Doc JIRA: https://issues.redhat.com/browse/OSSM-8699

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://88216--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html

SME Review: @sridhargaddam 
QE Review: @FilipB 
Peer Review: @xenolinux 