### PR TITLE
OADP-4882: Update OADP version to 1.4.2

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -44,7 +44,7 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.4.1
+:oadp-version: 1.4.2
 :oadp-version-1-3: 1.3.3
 :oadp-version-1-4: 1.4.2
 :oadp-bsl-api: backupstoragelocations.velero.io


### PR DESCRIPTION
Version(s):
OCP 4.14 - 4.18

Issue:
[OADP-4882](https://issues.redhat.com/browse/OADP-4882)

Additional information: This PR focuses on updating the oadp-version attribute to 1.4.2, which was missed while working on this [#87467](https://github.com/openshift/openshift-docs/pull/87467) PR.