### PR TITLE
OCPBUGS-46428-4-18-known-issue: Adding KI to 4.18 release notes for Telco team

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1774,6 +1774,10 @@ In the following tables, features are marked with the following statuses:
 
 [id="ocp-telco-core-4-18-known-issues_{context}"]
 
+* Due to an issue with Kubernetes, the CPU Manager is unable to return CPU resources from the last pod admitted to a node to the pool of available CPU resources. These resources are allocatable if a subsequent pod is admitted to the node. However, this pod then becomes the last pod, and again, the CPU manager cannot return this pod's resources to the available pool.
++
+This issue affects CPU load balancing features, which depend on the CPU Manager releasing CPUs to the available pool. Consequently, non-guaranteed pods might run with a reduced number of CPUs. As a workaround, schedule a pod with a `best-effort` CPU Manager policy on the affected node. This pod will be the last admitted pod and this ensures the resources will be correctly released to the available pool. (link:https://issues.redhat.com/browse/OCPBUGS-17792[*OCPBUGS-17792*])
+
 [id="ocp-storage-core-4-18-known-issues_{context}"]
 
 [id="ocp-hosted-control-planes-4-18-known-issues_{context}"]


### PR DESCRIPTION
OCPBUGS-46428: Adding KI to 4.18 release notes for Telco team

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-46428
https://issues.redhat.com/browse/TELCODOCS-2070

Link to docs preview:
https://88221--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-known-issues_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This KI is being carried forward from a previous release. It's previously been reviewed. 