### PR TITLE
[ROX-27310]: New page: Understanding the differences in Node CVEs between the Stackrox Scanner and Scanner V4

### DIFF
--- a/modules/understanding-node-cves-scanner-v4.adoc
+++ b/modules/understanding-node-cves-scanner-v4.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-vulnerabilities/common-vuln-management-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+// DO NOT RENAME THE ID - there are UI links using it in ACS
+[id="understanding-node-cves-scanner-v4_{context}"]
+= Understanding differences in scanning results between the Stackrox Scanner and Scanner V4
+
+== Summary
+
+Scanning {op-system} node hosts with Scanner V4 reports significantly more CVEs for the same operating system version. For example, Scanner V4 reports about 390 CVEs, compared to about 50 CVEs that are reported by StackRox Scanner. A manual review of selected vulnerabilities revealed the following causes:
+
+* The Vulnerability Exploitability eXchange (VEX) data used in Scanner V4 is more accurate.
+* The VEX data includes granular statuses, such as "no fix planned" and "fix deferred".
+* Some vulnerabilities reported by StackRox Scanner were false positives.
+
+As a result, Scanner V4 provides a more accurate and realistic vulnerability assessment.
+
+Users might find discrepancies in reported vulnerabilities surprising, especially if some secured clusters still use older {product-title-short} versions with StackRox Scanner while others use Scanner V4. To help you understand this difference, the following example provides an explanation and guidance on how to manually verify reported vulnerabilities.
+
+== Example of discrepancies in reported vulnerabilities
+
+In this example, we analyzed the differences in reported CVEs for three arbitrarily selected {op-system} versions. This example presents findings for {op-system} version `417.94.202501071621-0`.
+For this version, {product-title-short} provided the following scan results:
+
+* StackRox Scanner reported 49 CVEs.
+* Scanner V4 reported 389 CVEs.
+
+The breakdown is as follows:
+
+* 1 CVE is reported only by the StackRox Scanner.
+* 48 CVEs are reported by both scanners.
+* 341 CVEs are reported only by Scanner V4.
+
+=== CVEs reported only by the StackRox Scanner
+
+The single CVE reported exclusively by StackRox Scanner was a false positive. CVE-2022-4122 was flagged for the `podman` package in version `5:5.2.2-1.rhaos4.17.el9.x86_64`. However, a manual review of VEX data from link:https://access.redhat.com/errata/RHSA-2024:9102[RHSA-2024:9102] indicated that this vulnerability was fixed in version `5:5.2.2-1.el9`. Therefore, the package version scanned was the first to contain the fix and was no longer affected.
+
+=== CVEs reported only by Scanner V4
+
+We randomly selected 10 CVEs from the 341 unique to Scanner V4 and conducted a detailed analysis using VEX data. The vulnerabilities fell into two categories:
+
+* Affected packages with a fine-grained status indicating that no fix is planned
+* Affected packages with no additional status details regarding a fix
+
+For example, the following results were analyzed:
+
+* The `git-core` package (version `2.43.5-1.el9_4`) was flagged for CVE-2024-50349 (link:https://access.redhat.com/security/cve/cve-2024-50349[VEX data]) and marked as "Affected" with a fine-grained status of "Fix deferred." This means a fix is not guaranteed due to higher-priority development work. The package is affected by three CVEs in total.
+
+* The `vim-minimal` package (version `2:8.2.2637-20.el9_1`) was flagged for 109 CVEs, 108 of which have low CVSS scores. Most are marked as "Affected" with a fine-grained status of "Will not fix."
+
+* The `krb5-libs` package (version `1.21.1-2.el9_4.1`) was flagged for CVE-2025-24528 (link:https://access.redhat.com/security/cve/cve-2025-24528[VEX data]), but no fine-grained status was available. Given that this CVE was recently discovered at the time of this analysis, its status might be updated soon.
+
+=== CVEs reported by both scanners
+
+We manually verified three randomly selected packages, finding that the OVAL v2 data used in the StackRox Scanner and the VEX data used in Scanner V4 provided consistent explanations for the detected CVEs. In some cases, CVSS scores differed slightly, which is expected due to variations in VEX publisher data.
+
+== Verifying the status of vulnerabilities
+
+As a best practice, verify the fine-grained statuses of vulnerabilities in node host components that are critical to your environment using publicly available VEX data. VEX data is accessible in both human-readable and machine-readable formats. For more information about interpreting VEX data, visit link:https://www.redhat.com/en/blog/recent-improvements-red-hat-enterprise-linux-coreos-security-data[Recent improvements in Red Hat Enterprise Linux CoreOS security data].

--- a/modules/viewing-node-cves.adoc
+++ b/modules/viewing-node-cves.adoc
@@ -3,7 +3,7 @@
 // * operating/manage-vulnerabilities/common-vuln-management-tasks.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="identify-vulnerabilities-in-nodes-vm20_{context}"]
+[id="viewing-node-cves_{context}"]
 = Viewing Node CVEs
 
 You can identify vulnerabilities in your nodes by using {product-title-short}. The vulnerabilities that are identified include the following:

--- a/operating/manage-vulnerabilities/common-vuln-management-tasks.adoc
+++ b/operating/manage-vulnerabilities/common-vuln-management-tasks.adoc
@@ -43,7 +43,7 @@ include::modules/deployments-tab.adoc[leveloffset=3]
 
 :context: vulns-nodes
 //Viewing vulns in nodes
-include::modules/identify-vulnerabilities-in-nodes-vm20.adoc[leveloffset=+1]
+include::modules/viewing-node-cves.adoc[leveloffset=+1]
 
 include::modules/disable-identify-vulnerabilities-in-nodes.adoc[leveloffset=+2]
 

--- a/operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
+++ b/operating/manage-vulnerabilities/scan-rhcos-node-host.adoc
@@ -45,4 +45,6 @@ include::modules/rhcos-environment-variables.adoc[leveloffset=+1]
 
 include::modules/identify-vulnerabilities-in-nodes.adoc[leveloffset=+1]
 
-include::modules/identify-vulnerabilities-in-nodes-vm20.adoc[leveloffset=+1]
+include::modules/viewing-node-cves.adoc[leveloffset=+1]
+
+include::modules/understanding-node-cves-scanner-v4.adoc[leveloffset=+1]


### PR DESCRIPTION
For users with clusters:
- switching from Stackrox Scanner to Scanner V4 and
- using RHCOS node scanning

there may be a surprise effect that there are roughly ~7 times more vulnerabilities reported for the Nodes in the UI.
The document contributed in this PR should be linked to the respective UI page and should serve as an explanation why the users see so many new CVEs.
The PR that adds a banner linking to the page added in this PR: https://github.com/stackrox/stackrox/pull/14130

Version(s):
- 4.6 (for customer who decided to try tech-preview of Node scanning with Scanner V4)
- 4.7 (for all customers who use Scanner V4)

Issue:
- [ROX-27310](https://issues.redhat.com/browse/ROX-27310)

Link to docs preview:
- The text: https://88222--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-vulnerabilities/scan-rhcos-node-host.html
- generated due to a rename of an adoc file (aesthetics): https://88222--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-vulnerabilities/common-vuln-management-tasks.html

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
