### PR TITLE
change short attribute to first

### DIFF
--- a/modules/rotating-bound-service-keys.adoc
+++ b/modules/rotating-bound-service-keys.adoc
@@ -25,7 +25,7 @@ ifdef::rotate-azure[on {azure-first}]
 is configured to operate in manual mode with 
 ifdef::rotate-aws[{sts-short},]
 ifdef::rotate-gcp[{gcp-wid-short},]
-ifdef::rotate-azure[{entra-short},]
+ifdef::rotate-azure[{entra-first},]
 you can rotate the bound service account signer key.
 
 To rotate the key, you delete the existing key on your cluster, which causes the Kubernetes API server to create a new key.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-12745](https://issues.redhat.com//browse/OSDOCS-12745)

Link to docs preview:
[Rotating Azure OIDC bound service account signer keys](https://88224--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration#rotating-bound-service-keys_key-rotation-azure)

QE review:
N/A

Additional information: