### PR TITLE
Updates additional configuration rules for UDN

### DIFF
--- a/modules/nw-udn-additional-config-details.adoc
+++ b/modules/nw-udn-additional-config-details.adoc
@@ -20,12 +20,25 @@ The following table explains additional configurations for UDN that are optional
 
 The `joinSubnets` field configures the routing between different segments within a user-defined network. Dual-stack clusters can set 2 subnets, one for each IP family; otherwise, only 1 subnet is allowed. This field is only allowed for the `Primary` network.
 
-|`spec.IPAMLifecycle`
+|`spec.ipam.lifecycle`
 |object
-|The `IPAMLifecycle` field configures the IP address management system (IPAM). You might use this field for virtual workloads to ensure persistent IP addresses. This field is allowed when `topology` is `layer2`. The `subnets` field must be specified when this field is specified. Setting a value of `Persistent` ensures that your virtual workloads have persistent IP addresses across reboots and migration. These are assigned by the container network interface (CNI) and used by OVN-Kubernetes to program pod IP addresses. You must not change this for pod annotations.
+|The `spec.ipam.lifecycle` field configures the IP address management system (IPAM). You might use this field for virtual workloads to ensure persistent IP addresses. The only allowed value is `Persistent`, which 
+ensures that your virtual workloads have persistent IP addresses across reboots and migration. These are assigned by the container network interface (CNI) and used by OVN-Kubernetes to program pod IP addresses. You must not change this for pod annotations. 
+
+Setting a value of `Persistent` is only supported when `spec.ipam.mode` is set to `Enabled`. 
+
+|`spec.ipam.mode`
+|object
+|The `spec.ipam.mode` field controls how much of the IP configuration is managed by OVN-Kubernetes. The following options are available:
+
+**Enabled:** +
+When enabled, OVN-Kubernetes applies the IP configuration to the SDN infrastructure and assigns IP addresses from the selected subnet to the individual pods. This is the default setting. When set to `Enabled`, the `subnets` field must be defined. `Enabled` is the default configuration.
+
+**Disabled:** +
+When disabled, OVN-Kubernetes only assigns MAC addresses and provides layer 2 communication, which allows users to configure IP addresses. `Disabled` is only available for layer 2 (secondary) networks. By disabling IPAM, features that rely on selecting pods by IP, for example, network policy, services, and so on, no longer function. Additionally, IP port security is also disabled for interfaces attached to this network. The `subnets` field must be empty when `spec.ipam.mode` is set to `Disabled.`
 
 |`spec.layer2.mtu` and `spec.layer3.mtu`
 |integer
-|The maximum transmission units (MTU). The default value is `1400`. The boundary for IPv4 is `574`, and for IPv6 it is `1280`.
+|The maximum transmission units (MTU). The default value is `1400`. The boundary for IPv4 is `576`, and for IPv6 it is `1280`.
 
 |====


### PR DESCRIPTION
Addresses https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4933 
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-13331

Link to docs preview:
https://88231--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html#nw-udn-additional-config-details_about-user-defined-networks

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
