### PR TITLE
OSDOCS-12868: multi-NIC support in vSphere FDs

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
@@ -31,3 +31,7 @@ You can enable features by updating values in the control plane machine set.
 
 //Adding tags to machines by using machine sets
 include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+2,tag=!compute]
+
+//Configuring multiple NICs by using machine sets
+//pulled from 4.18 GA
+//include::modules/machineset-vsphere-multiple-nics.adoc[leveloffset=+1,tag=!compute]

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -47,3 +47,6 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 //Adding tags to machines by using machine sets
 include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+1,tag=!controlplane]
+
+//Configuring multiple NICs by using machine sets
+include::modules/machineset-vsphere-multiple-nics.adoc[leveloffset=+1,tag=!controlplane]

--- a/modules/cpmso-yaml-failure-domain-vsphere.adoc
+++ b/modules/cpmso-yaml-failure-domain-vsphere.adoc
@@ -34,8 +34,8 @@ spec:
       failureDomains: # <1>
         platform: VSphere
         vsphere: # <2>
-        - name: <failure_domain_name1>
-        - name: <failure_domain_name2>
+        - name: <failure_domain_name_1>
+        - name: <failure_domain_name_2>
 # ...
 ----
 <1> Specifies the vCenter location for {product-title} cluster nodes.

--- a/modules/machineset-vsphere-multiple-nics.adoc
+++ b/modules/machineset-vsphere-multiple-nics.adoc
@@ -1,0 +1,150 @@
+
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machineset-vsphere-multiple-nics_{context}"]
+= Configuring multiple network interface controllers by using machine sets
+
+{product-title} clusters on {vmw-first} support connecting up to 10 network interface controllers (NICs) to a node. 
+By configuring multiple NICs, you can provide dedicated network links in the node virtual machines (VMs) for uses such as storage or databases.
+
+You can use machine sets to manage this configuration.
+
+* If you want to use multiple NICs in a {vmw-short} cluster that was not configured to do so during installation, you can use machine sets to implement this configuration.
+* If your cluster was set up during installation to use multiple NICs, machine sets that you create can use your existing failure domain configuration.
+* If your failure domain configuration changes, you can use machine sets to make updates that reflect those changes.
+
+tag::controlplane[]
+[NOTE]
+====
+This feature is not compatible with a control plane machine set that uses more than one failure domain.
+====
+end::controlplane[]
+
+:FeatureName: Configuring multiple NICs
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You have administrator access to {oc-first} for an {product-title} cluster on {vmw-short}.
+
+.Procedure
+
+. For a cluster that already uses multiple NICs, obtain the following values from the `Infrastructure` resource by running the following command:
++
+[source,terminal]
+----
+$ oc get infrastructure cluster -o=jsonpath={.spec.platformSpec.vsphere.failureDomains}
+----
++
+.Required network interface controller values
+|===
+|`Infrastructure` resource value | Placeholder value for sample machine set | Description
+
+|`failureDomain.topology.networks[0]`
+|`<vm_network_name_1>`
+|The name of the first NIC to use.
+
+|`failureDomain.topology.networks[1]`
+|`<vm_network_name_2>`
+|The name of the second NIC to use.
+
+|`failureDomain.topology.networks[<n-1>]`
+|`<vm_network_name_n>`
+|The name of the __n__th NIC to use.
+Collect the name of each NIC in the `Infrastructure` resource.
+
+|`failureDomain.topology.template`
+|`<vm_template_name>`
+|The {vmw-short} VM template to use.
+
+|`failureDomain.topology.datacenter`
+|`<vcenter_data_center_name>`
+|The vCenter data center to deploy the machine set on.
+
+|`failureDomain.topology.datastore`
+|`<vcenter_datastore_name>`
+|The vCenter datastore to deploy the machine set on.
+
+|`failureDomain.topology.folder`
+|`<vcenter_vm_folder_path>`
+|The path to the {vmw-short} VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+
+|`failureDomain.topology.computeCluster` + `/Resources`
+|`<vsphere_resource_pool>`
+|The {vmw-short} resource pool for your VMs.
+
+|`failureDomain.server`
+|`<vcenter_server_ip>`
+|The vCenter server IP or fully qualified domain name (FQDN).
+|===
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Use a machine set configuration formatted like the following example.
++
+--
+* For a cluster that currently uses multiple NICs, use the values from the `Infrastructure` resource to populate the values in the machine set custom resource.
+* For a cluster that is not using multiple NICs, populate the values you want to use in the machine set custom resource.
+--
++
+.Sample machine set
+[source,yaml]
+----
+tag::compute[]
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+# ...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          network:
+            devices: # <1>
+            - networkName: "<vm_network_name_1>"
+            - networkName: "<vm_network_name_2>"
+          template: <vm_template_name> # <2>
+          workspace:
+            datacenter: <vcenter_data_center_name> # <3>
+            datastore: <vcenter_datastore_name> # <4>
+            folder: <vcenter_vm_folder_path> # <5>
+            resourcepool: <vsphere_resource_pool> # <6>
+            server: <vcenter_server_ip> # <7>
+# ...
+end::compute[]
+tag::controlplane[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+# ...
+spec:
+  template:
+    machines_v1beta1_machine_openshift_io:
+      spec:
+        providerSpec:
+          value:
+            network:
+              devices: # <1>
+              - networkName: "<vm_network_name_1>"
+              - networkName: "<vm_network_name_2>"
+            template: <vm_template_name> # <2>
+            workspace:
+              datacenter: <vcenter_data_center_name> # <3>
+              datastore: <vcenter_datastore_name> # <4>
+              folder: <vcenter_vm_folder_path> # <5>
+              resourcepool: <vsphere_resource_pool> # <6>
+              server: <vcenter_server_ip> # <7>
+
+# ...
+end::controlplane[]
+----
+<1> Specify a list of up to 10 NICs to use.
+<2> Specify the {vmw-short} VM template to use, such as `user-5ddjd-rhcos`.
+<3> Specify the vCenter data center to deploy the machine set on.
+<4> Specify the vCenter datastore to deploy the machine set on.
+<5> Specify the path to the {vmw-short} VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+<6> Specify the {vmw-short} resource pool for your VMs.
+<7> Specify the vCenter server IP or fully qualified domain name (FQDN).


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-12868](https://issues.redhat.com//browse/OSDOCS-12868)

Link to docs preview:
[Configuring multiple network interface controllers by using machine sets](https://88235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere.html#machineset-vsphere-multiple-nics_creating-machineset-vsphere) (compute)
[Configuring multiple network interface controllers by using machine sets](https://88235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.html#machineset-vsphere-multiple-nics_cpmso-config-options-vsphere) (control planes)

QE review:
- [x] QE has approved this change.

Additional information: