### PR TITLE
4.12 - OADP-5489: release notes for OADP 1.3.5

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -14,7 +14,8 @@
 :op-system-lowercase: rhcos
 :op-system-base: RHEL
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
-:op-system-version: 8.x
+:op-system-version: 9.x
+:op-system-version-9: 9
 ifdef::openshift-origin[]
 :op-system-first: Fedora CoreOS (FCOS)
 :op-system: FCOS
@@ -25,55 +26,50 @@ ifdef::openshift-origin[]
 endif::[]
 :tsb-name: Template Service Broker
 :kebab: image:kebab.png[title="Options menu"]
-ifndef::openshift-origin[]
-:rh-openstack-first: Red Hat OpenStack Platform (RHOSP)
-:rh-openstack: RHOSP
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-:rh-openstack-first: OpenStack
-:rh-openstack: OpenStack
-endif::openshift-origin[]
 :ai-full: Assisted Installer
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
 :cluster-manager: OpenShift Cluster Manager
-:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager Hybrid Cloud Console]
-:cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager]
+:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager]
+:cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from Red Hat OpenShift Cluster Manager]
 :insights-advisor-url: link:https://console.redhat.com/openshift/insights/advisor/[Insights Advisor]
 :hybrid-console: Red Hat Hybrid Cloud Console
 :hybrid-console-second: Hybrid Cloud Console
+:hybrid-console-url: link:https://console.redhat.com[Red Hat Hybrid Cloud Console]
+// OADP attributes
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version-1-3: 1.3.3
+:oadp-version: 1.4.1
+:oadp-version-1-3: 1.3.5
+:oadp-version-1-4: 1.4.2
+:oadp-bsl-api: backupstoragelocations.velero.io
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
+:product-mirror-registry: Mirror registry for Red Hat OpenShift
 :rh-storage-first: Red Hat OpenShift Data Foundation
 :rh-storage: OpenShift Data Foundation
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
 :rh-rhacm: RHACM
-:rh-rhacm-version: 2.7
+:rh-rhacm-version: 2.9
 :sandboxed-containers-first: OpenShift sandboxed containers
+:sandboxed-containers-operator: OpenShift sandboxed containers Operator
+:sandboxed-containers-version: 1.5
+:sandboxed-containers-version-z: 1.5.0
+:sandboxed-containers-legacy-version: 1.4.1
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
 :secondary-scheduler-operator: Secondary Scheduler Operator
-:rh-virtualization-first: Red Hat Virtualization (RHV)
-:rh-virtualization: RHV
-:rh-virtualization-hyper-first: Red Hat Virtualization Hypervisor (RHV-H)
-:rh-virtualization-hyper: RHV-H
-:rh-virtualization-engine-name: Manager
-ifdef::openshift-origin[]
-:rh-virtualization-first: oVirt
-:rh-virtualization: oVirt
-:rh-virtualization-engine-name: Engine
-endif::[]
+:descheduler-operator: Kube Descheduler Operator
 // Backup and restore
 :velero-domain: velero.io
-:velero-version: 1.12
+:velero-version: 1.14
 :launch: image:app-launcher.png[title="Application Launcher"]
+:mtc-first: Migration Toolkit for Containers (MTC)
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8.4
+:mtc-version-z: 1.8.5
+:mtc-legacy-image: 1.7
 // builds (Valid only in 4.11 and later)
 :builds-v2title: Builds for Red Hat OpenShift
 :builds-v2shortname: OpenShift Builds v2
@@ -83,36 +79,43 @@ ifdef::openshift-origin[]
 :builds-v2shortname: Shipwright
 :builds-v1shortname: Builds v1
 endif::[]
-//gitops
+// gitops
 :gitops-title: Red Hat OpenShift GitOps
 :gitops-shortname: GitOps
 :gitops-ver: 1.1
 :rh-app-icon: image:red-hat-applications-menu-icon.jpg[title="Red Hat applications"]
-//pipelines
+// pipelines
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: OpenShift Pipelines
-:pipelines-ver: pipelines-1.13
-:pipelines-version-number: 1.13
+:pipelines-ver: pipelines-1.17
+:pipelines-version-number: 1.17
 :tekton-chains: Tekton Chains
 :tekton-hub: Tekton Hub
 :artifact-hub: Artifact Hub
 :pac: Pipelines as Code
-//odo
+// odo
 :odo-title: odo
-//OpenShift Kubernetes Engine
+// OpenShift Kubernetes Engine
 :oke: OpenShift Kubernetes Engine
-//OpenShift Platform Plus
+// OpenShift Platform Plus
 :opp: OpenShift Platform Plus
-//openshift virtualization (cnv)
+// openshift virtualization (cnv)
 :VirtProductName: OpenShift Virtualization
-:VirtVersion: 4.12
-:KubeVirtVersion: v0.58.0
-:HCOVersion: 4.12.16
+:VirtVersion: 4.15
+:HCOVersion: 4.15.8
+:CNVNamespace: openshift-cnv
+:CNVOperatorDisplayName: OpenShift Virtualization Operator
+:CNVSubscriptionSpecSource: redhat-operators
+:CNVSubscriptionSpecName: kubevirt-hyperconverged
 :delete: image:delete.png[title="Delete"]
 ifdef::openshift-origin[]
 :VirtProductName: OKD Virtualization
+:CNVNamespace: kubevirt-hyperconverged
+:CNVOperatorDisplayName: KubeVirt HyperConverged Cluster Operator
+:CNVSubscriptionSpecSource: community-operators
+:CNVSubscriptionSpecName: community-kubevirt-hyperconverged
 endif::[]
-//distributed tracing
+// distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing platform
 :DTShortName: distributed tracing platform
 :DTProductVersion: 3.1
@@ -129,7 +132,20 @@ endif::[]
 :TempoShortName: distributed tracing platform (Tempo)
 :TempoOperator: Tempo Operator
 :TempoVersion: 2.3.1
-//logging
+// telco
+ifdef::telco-ran[]
+:rds: telco RAN DU
+:rds-caps: Telco RAN DU
+:rds-first: Telco RAN distributed unit (DU)
+endif::[]
+ifdef::telco-core[]
+:rds: telco core
+:rds-caps: Telco core
+endif::[]
+// lightspeed
+:ols-official: Red Hat OpenShift Lightspeed
+:ols: OpenShift Lightspeed
+// logging
 :logging: logging
 :logging-uc: Logging
 :for: for Red Hat OpenShift
@@ -137,31 +153,38 @@ endif::[]
 :loki-op: Loki Operator
 :es-op: OpenShift Elasticsearch Operator
 :log-plug: logging Console plugin
-//observability
+// observability
 :ObservabilityLongName: Red Hat OpenShift Observability
 :ObservabilityShortName: Observability
 // Cluster Monitoring Operator
 :cmo-first: Cluster Monitoring Operator (CMO)
 :cmo-full: Cluster Monitoring Operator
 :cmo-short: CMO
-//serverless
+// power monitoring
+:PM-title-c: Power monitoring for Red Hat OpenShift
+:PM-title: power monitoring for Red Hat OpenShift
+:PM-shortname: power monitoring
+:PM-shortname-c: Power monitoring
+:PM-operator: Power monitoring Operator
+:PM-kepler: Kepler
+// serverless
 :ServerlessProductName: OpenShift Serverless
 :ServerlessProductShortName: Serverless
 :ServerlessOperatorName: OpenShift Serverless Operator
 :FunctionsProductName: OpenShift Serverless Functions
-//service mesh v2
+// service mesh v2
 :product-dedicated: Red Hat OpenShift Dedicated
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.5.2
-:MaistraVersion: 2.5
+:SMProductVersion: 2.6.5
+:MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
 :SMPluginShort: OSSMC plugin
-//Service Mesh v1
+// Service Mesh v1
 :SMProductVersion1x: 1.1.18.2
-//Windows containers
+// Windows containers
 :productwinc: Red Hat OpenShift support for Windows Containers
 // Red Hat Quay Container Security Operator
 :rhq-cso: Red Hat Quay Container Security Operator
@@ -169,12 +192,14 @@ endif::[]
 :quay: Red Hat Quay
 :sno: single-node OpenShift
 :sno-caps: Single-node OpenShift
-//TALO and Redfish events Operators
+:sno-okd: single-node OKD
+:sno-caps-okd: Single-node OKD
+// TALO and Redfish events Operators
 :cgu-operator-first: Topology Aware Lifecycle Manager (TALM)
 :cgu-operator-full: Topology Aware Lifecycle Manager
 :cgu-operator: TALM
 :redfish-operator: Bare Metal Event Relay
-//Formerly known as CodeReady Containers and CodeReady Workspaces
+// Formerly known as CodeReady Containers and CodeReady Workspaces
 :openshift-local-productname: Red Hat OpenShift Local
 :openshift-dev-spaces-productname: Red Hat OpenShift Dev Spaces
 // Factory-precaching-cli tool
@@ -182,56 +207,68 @@ endif::[]
 :factory-prestaging-tool-caps: Factory-precaching-cli tool
 :openshift-networking: Red Hat OpenShift Networking
 // TODO - this probably needs to be different for OKD
-//ifdef::openshift-origin[]
-//:openshift-networking: OKD Networking
-//endif::[]
+// ifdef::openshift-origin[]
+// :openshift-networking: OKD Networking
+// endif::[]
 // logical volume manager storage
 :lvms-first: Logical Volume Manager (LVM) Storage
 :lvms: LVM Storage
-//Operator SDK version
-:osdk_ver: 1.25.4
-//Operator SDK version that shipped with the previous OCP 4.x release
-:osdk_ver_n1: 1.22.2
-//ZTP related
+// Operator SDK version
+:osdk_ver: 1.31.0
+// Operator SDK version that shipped with the previous OCP 4.x release
+:osdk_ver_n1: 1.28.0
+// Next-gen (OCP 4.14+) Operator Lifecycle Manager, aka "v1"
+:olmv1: OLM 1.0
+:olmv1-first: Operator Lifecycle Manager (OLM) 1.0
 :ztp-first: GitOps Zero Touch Provisioning (ZTP)
+:ztp: GitOps ZTP
+:3no: three-node OpenShift
+:3no-caps: Three-node OpenShift
+:run-once-operator: Run Once Duration Override Operator
 // Web terminal
 :web-terminal-op: Web Terminal Operator
 :devworkspace-op: DevWorkspace Operator
-//AWS STS
-:sts-first: Security Token Service (STS)
-:sts-full: Security Token Service
-:sts-short: STS
-//Cloud provider names
-//AWS
+:secrets-store-driver: Secrets Store CSI driver
+:secrets-store-operator: Secrets Store CSI Driver Operator
+// Cluster Observability Operator
+:coo-first: Cluster Observability Operator (COO)
+:coo-full: Cluster Observability Operator
+:coo-short: COO
+// ODF
+:odf-first: Red Hat OpenShift Data Foundation (ODF)
+:odf-full: Red Hat OpenShift Data Foundation
+:odf-short: ODF
+:rh-dev-hub: Red Hat Developer Hub
+// IBU
+:lcao: Lifecycle Agent
+// Cloud provider names
+// Alibaba Cloud
+:alibaba: Alibaba Cloud
+// Amazon Web Services (AWS)
 :aws-first: Amazon Web Services (AWS)
 :aws-full: Amazon Web Services
 :aws-short: AWS
-//GCP
+// Google Cloud Platform (GCP)
 :gcp-first: Google Cloud Platform (GCP)
 :gcp-full: Google Cloud Platform
 :gcp-short: GCP
-//alibaba cloud
-:alibaba: Alibaba Cloud
 // IBM general
 :ibm-name: IBM(R)
 :ibm-title: IBM
 // IBM Cloud
-:ibmcloudBMProductName: IBM Cloud Bare Metal (Classic)
-:ibmcloudBMRegProductName: IBM Cloud(R) Bare Metal (Classic)
 :ibm-cloud-name: IBM Cloud(R)
 :ibm-cloud-title: IBM Cloud
 // IBM Cloud Bare Metal (Classic)
 :ibm-cloud-bm: IBM Cloud(R) Bare Metal (Classic)
 :ibm-cloud-bm-title: IBM Cloud Bare Metal (Classic)
+// IBM Cloud Object Storage (COS)
+:ibm-cloud-object-storage: IBM Cloud Object Storage (COS)
 // IBM Power
-:ibmpowerProductName: IBM Power
 :ibm-power-name: IBM Power(R)
 :ibm-power-title: IBM Power
 :ibm-power-server-name: IBM Power(R) Virtual Server
 :ibm-power-server-title: IBM Power Virtual Server
 // IBM zSystems
-:ibmzProductName: IBM Z
-:linuxoneProductName: IBM(R) LinuxONE
 :ibm-z-name: IBM Z(R)
 :ibm-z-title: IBM Z
 :ibm-linuxone-name: IBM(R) LinuxONE
@@ -240,13 +277,39 @@ endif::[]
 :azure-first: Microsoft Azure
 :azure-full: Microsoft Azure
 :azure-short: Azure
-//vSphere
+// Oracle
+:oci-first: Oracle(R) Cloud Infrastructure (OCI)
+:oci-first-no-rt: Oracle Cloud Infrastructure (OCI)
+:oci: OCI
+:oci-ccm-full: Oracle Cloud Controller Manager (CCM)
+:oci-ccm: Oracle CCM
+:oci-csi-full: Oracle Container Storage Interface (CSI)
+:oci-csi: Oracle CSI
+:ocid-first: Oracle(R) Cloud Identifier (OCID)
+:ocid: OCID
+:ocvs-first: Oracle(R) Cloud VMware Solution (OCVS)
+:ocvs: OCVS
+// Red Hat OpenStack Platform (RHOSP)/OpenStack
+ifndef::openshift-origin[]
+:rh-openstack-first: Red Hat OpenStack Platform (RHOSP)
+:rh-openstack: RHOSP
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+:rh-openstack-first: OpenStack
+:rh-openstack: OpenStack
+endif::openshift-origin[]
+// VMware vSphere
+:vmw-first: VMware vSphere
 :vmw-full: VMware vSphere
 :vmw-short: vSphere
-// Cluster Observability Operator
-:coo-first: Cluster Observability Operator (COO)
-:coo-full: Cluster Observability Operator
-:coo-short: COO
+// Token-based auth products
+// AWS Security Token Service
+:sts-first: Security Token Service (STS)
+:sts-full: Security Token Service
+:sts-short: STS
+// Microsoft Entra Workload ID (FKA Azure Active Directory Workload Identities)
+:entra-first: Microsoft Entra Workload ID
+:entra-short: Workload ID
 // Cluster API terminology
 // Cluster CAPI Operator
 :cluster-capi-operator: Cluster CAPI Operator

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -7,8 +7,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
+The release notes for OpenShift API for Data Protection (OADP) 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-3-5.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-4.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-3.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-2.adoc[leveloffset=+1]
@@ -17,6 +18,7 @@ include::modules/oadp-release-notes-1-3-0.adoc[leveloffset=+1]
 include::modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc[leveloffset=+3]
 include::modules/oadp-backing-up-dpa-configuration-1-3-0.adoc[leveloffset=+3]
 include::modules/oadp-upgrading-oadp-operator-1-3-0.adoc[leveloffset=+3]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]

--- a/modules/oadp-release-notes-1-3-5.adoc
+++ b/modules/oadp-release-notes-1-3-5.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="oadp-release-notes-1-3-5_{context}"]
+= {oadp-short} 1.3.5 release notes
+
+{oadp-first} 1.3.5 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.3.4.


### PR DESCRIPTION
### JIRA

* [OADP-5489](https://issues.redhat.com/browse/OADP-5489)

### VERSION

   * OCP-4.12
   
### Link to docs preview:

* [OADP 1.3.5 Release Notes](https://88236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3#oadp-release-notes-1-3-5_oadp-release-notes)


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
