### PR TITLE
OSSM-8754: Update CRD references to use version v1

### DIFF
--- a/modules/ossm-about-concepts-resources.adoc
+++ b/modules/ossm-about-concepts-resources.adoc
@@ -32,7 +32,7 @@ You can access all `Istio` custom resource definition (CRD) options through `spe
 .Example `Istio` resource CRD
 [source,yaml]
 ----
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default
@@ -88,7 +88,7 @@ The `IstioCNI` resource is a cluster-wide resource as it installs a daemon set t
 .Example `IstioCNI` resource
 [source,yaml]
 ----
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: IstioCNI
 metadata:
   name: default

--- a/modules/ossm-cert-manager-installing-istio-resource.adoc
+++ b/modules/ossm-cert-manager-installing-istio-resource.adoc
@@ -22,7 +22,7 @@ You need to disable Istio's built in CA server and tell istiod to use the `istio
 .Example `istio.yaml` object
 [source, yaml]
 ----
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default

--- a/modules/ossm-cert-manager-update-istio-csr-revisionbased-only.adoc
+++ b/modules/ossm-cert-manager-update-istio-csr-revisionbased-only.adoc
@@ -33,7 +33,7 @@ where:
 .Example `istio.yaml` file
 [source, yaml]
 ----
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default

--- a/modules/ossm-config-otel.adoc
+++ b/modules/ossm-config-otel.adoc
@@ -58,7 +58,7 @@ spec:
 .Example enabling tracing and defining tracing providers
 [source,yaml]
 ----
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
 #  ...

--- a/modules/ossm-deploying-first-control-plane.adoc
+++ b/modules/ossm-deploying-first-control-plane.adoc
@@ -29,7 +29,7 @@ $ oc label namespace istio-system-1 istio-discovery=mesh-1
 [source,yaml,subs="attributes,verbatim"]
 ----
 kind: Istio
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 metadata:
   name: mesh-1
 spec:

--- a/modules/ossm-deploying-second-control-plane.adoc
+++ b/modules/ossm-deploying-second-control-plane.adoc
@@ -29,7 +29,7 @@ $ oc label namespace istio-system-2 istio-discovery=mesh-2
 [source,yaml,subs="attributes,verbatim"]
 ----
 kind: Istio
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 metadata:
   name: mesh-2
 spec:

--- a/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
@@ -86,7 +86,7 @@ $ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubuser
 [source,terminal]
 ----
 $ cat <<EOF | oc --context "${CTX_CLUSTER2}" apply -f -
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default

--- a/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
+++ b/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
@@ -49,7 +49,7 @@ $ oc --context="${CTX_CLUSTER1}" label namespace istio-system topology.istio.io/
 [source,terminal]
 ----
 $ cat <<EOF | oc --context "${CTX_CLUSTER1}" apply -f -
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default
@@ -111,7 +111,7 @@ $ export DISCOVERY_ADDRESS=$(oc --context="${CTX_CLUSTER1}" \
 [source,terminal]
 ----
 $ cat <<EOF | oc --context "${CTX_CLUSTER2}" apply -f -
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default

--- a/modules/ossm-running-v2-v3-cluster-wide-deployment-model.adoc
+++ b/modules/ossm-running-v2-v3-cluster-wide-deployment-model.adoc
@@ -79,7 +79,7 @@ spec:
 [source, yaml]
 ----
 kind: Istio
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 metadata:
   name: ossm3 # <1>
 spec:

--- a/modules/ossm-using-discoveryselectors-scope-service-mesh.adoc
+++ b/modules/ossm-using-discoveryselectors-scope-service-mesh.adoc
@@ -25,7 +25,7 @@ $ oc label namespace istio-system istio-discovery=enabled
 [source,yaml]
 ----
 kind: Istio
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 metadata:
   name: default
 spec:


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

This PR is part of the standalone doc set for the Service Mesh 3.0 project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the 3.0 branch.

Version(s): Tech Preview

Issue: https://issues.redhat.com/browse/OSSM-8754
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
