### PR TITLE
TELCODOCS-2199: Update MIG note

### DIFF
--- a/hardware_accelerators/nvidia-gpu-architecture.adoc
+++ b/hardware_accelerators/nvidia-gpu-architecture.adoc
@@ -24,7 +24,6 @@ include::modules/nvidia-gpu-prerequisites.adoc[leveloffset=+1]
 // New enablement modules
 ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/nvidia-gpu-enablement.adoc[leveloffset=+1]
-
 include::modules/nvidia-gpu-bare-metal.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources

--- a/modules/nvidia-gpu-enablement.adoc
+++ b/modules/nvidia-gpu-enablement.adoc
@@ -14,5 +14,5 @@ image::512_OpenShift_NVIDIA_GPU_enablement_1223.png[NVIDIA GPU enablement]
 
 [NOTE]
 ====
-MIG is only supported with A30, A100, A100X, A800, AX800, H100, and H800.
+MIG is supported on GPUs starting with the NVIDIA Ampere generation. For a list of GPUs that support MIG, see the link:https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#supported-gpus[NVIDIA MIG User Guide].
 ====


### PR DESCRIPTION
BUG: Rewrite text of note for supported MIG GPUs. Add link to NVIDIA MIG Guide.

Versions:  openshift-4.18, openshift-4.17.z 

Jira: https://issues.redhat.com/browse/TELCODOCS-2199

Preview: https://88246--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_accelerators/nvidia-gpu-architecture.html

Dev review: @egallen 
QE review: @wabouhamad 