### PR TITLE
4.12 - OADP-5489: release notes for OADP 1.3.5

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -44,7 +44,7 @@ endif::openshift-origin[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version-1-3: 1.3.3
+:oadp-version-1-3: 1.3.5
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
 :rh-storage-first: Red Hat OpenShift Data Foundation

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -7,8 +7,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
+The release notes for OpenShift API for Data Protection (OADP) 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-3-5.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-4.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-3.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-2.adoc[leveloffset=+1]
@@ -17,6 +18,7 @@ include::modules/oadp-release-notes-1-3-0.adoc[leveloffset=+1]
 include::modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc[leveloffset=+3]
 include::modules/oadp-backing-up-dpa-configuration-1-3-0.adoc[leveloffset=+3]
 include::modules/oadp-upgrading-oadp-operator-1-3-0.adoc[leveloffset=+3]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]

--- a/modules/oadp-release-notes-1-3-5.adoc
+++ b/modules/oadp-release-notes-1-3-5.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="oadp-release-notes-1-3-5_{context}"]
+= {oadp-short} 1.3.5 release notes
+
+{oadp-first} 1.3.5 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.3.4.


### PR DESCRIPTION
### JIRA

* [OADP-5489](https://issues.redhat.com/browse/OADP-5489)

Peer-reviewed and merged-reviewed in this [PR](https://github.com/openshift/openshift-docs/pull/88232#event-16263323171)

I knew there would be issues so I created this PR as well

### VERSION

   * OCP-4.12
   
   OADP 1.3.z is still supported on 4.12
### Link to docs preview:

* [OADP 1.3.5 Release Notes](https://88232--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3#oadp-release-notes-1-3-5_oadp-release-notes)

### QE review:

- [X ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
