### PR TITLE
OSDOCS-13310 Remove unverified perfscale info from ROSA docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -236,11 +236,13 @@ Topics:
   File: rosa-sts-aws-prereqs
 - Name: ROSA IAM role resources
   File: rosa-sts-ocm-role
-- Name: Limits and scalability
-  File: rosa-limits-scalability
-- Name: ROSA with HCP limits and scalability
-  File: rosa-hcp-limits-scalability
-- Name: Planning resource usage in your cluster
+##### NOTE: THE BELOW IS REMOVED AS PART OF OSDOCS-13310
+# - Name: Limits and scalability
+#   File: rosa-limits-scalability
+#- Name: ROSA with HCP limits and scalability
+#  File: rosa-hcp-limits-scalability
+##### NOTE: THE ABOVE IS REMOVED AS PART OF OSDOCS-13310F
+- Name: Planning your environment
   File: rosa-planning-environment
 - Name: Required AWS service quotas
   File: rosa-sts-required-aws-service-quotas

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -167,8 +167,12 @@ Topics:
   File: rosa-sts-aws-prereqs
 - Name: Required IAM roles and resources
   File: rosa-hcp-prepare-iam-roles-resources
-- Name: ROSA with HCP limits and scalability
-  File: rosa-hcp-limits-scalability
+##### NOTE: THE BELOW IS REMOVED AS PART OF OSDOCS-13310
+# - Name: Limits and scalability
+#   File: rosa-limits-scalability
+#- Name: ROSA with HCP limits and scalability
+#  File: rosa-hcp-limits-scalability
+##### NOTE: THE ABOVE IS REMOVED AS PART OF OSDOCS-13310
 - Name: Required AWS service quotas
   File: rosa-sts-required-aws-service-quotas
 - Name: Setting up your environment

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
@@ -61,12 +61,8 @@ Autoscaling allows you to automatically adjust the size of the cluster based on 
 
 === Maximum number of worker nodes
 The maximum number of worker nodes in ROSA clusters versions 4.14.14 and later is 249. For earlier versions, the limit is 180 nodes.
-ifdef::temp-ifdef[]
-See xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] for more details on node counts.
-endif::[]
-ifdef::temp-ifdef[]
-See xref:../../rosa_planning/rosa-hcp-limits-scalability.adoc#rosa-hcp-limits-scalability[limits and scalability] for more details on node counts.
-endif::[]
+// Removed as part of OSDOCS-13310, until figures are verified.
+//See xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] for more details on node counts.
 
 A list of the account-wide and per-cluster roles is provided in the xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[ROSA documentation].
 
@@ -207,12 +203,8 @@ Ingress can be limited to a PrivateLink for Red{nbsp}Hat SREs and a VPN for cust
 ** xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding Process and Security]
 ** xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-understand-availability.adoc#rosa-policy-understand-availability[About Availability]
 ** xref:../../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[Updates Lifecycle]
-ifdef::temp-ifdef[]
-** xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability]
-endif::[]
-ifdef::temp-ifdef[]
-** xref:../../rosa_planning/rosa-hcp-limits-scalability.adoc#rosa-hcp-limits-scalability[limits and scalability]
-endif::[]
+// Removed as part of OSDOCS-13310, until figures are verified.
+//** xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and Scalability]
 ** link:https://red.ht/rosa-roadmap[ROSA roadmap]
 * link:https://learn.openshift.com[Learn about OpenShift]
 * {cluster-manager-url}

--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -33,9 +33,10 @@ endif::openshift-rosa-hcp[]
 
 The instance type shown for worker nodes is the default value, but you can customize the instance type for worker nodes according to the needs of your workload.
 
-ifndef::openshift-rosa-hcp[]
-For further guidance on worker node counts, see the information about initial planning considerations in the "Limits and scalability" topic listed in the "Additional resources" section of this page.
-endif::openshift-rosa-hcp[]
+//Commented out for OSDOCS-13310
+// ifndef::openshift-rosa-hcp[]
+// For further guidance on worker node counts, see the information about initial planning considerations in the "Limits and scalability" topic listed in the "Additional resources" section of this page.
+// endif::openshift-rosa-hcp[]
 
 [id="rosa-ebs-storage_{context}"]
 == Amazon Elastic Block Store storage

--- a/rosa_architecture/about-hcp.adoc
+++ b/rosa_architecture/about-hcp.adoc
@@ -96,12 +96,13 @@ xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-defini
 |
 xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[Updates lifecycle]
 | 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_planning/rosa-limits-scalability.html#rosa-limits-scalability[Limits and scalability]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
-endif::openshift-rosa-hcp[]
+// Removed as part of OSDOCS-13310, until figures are verified.
+// ifdef::openshift-rosa-hcp[]
+// link:https://docs.openshift.com/rosa/rosa_planning/rosa-limits-scalability.html#rosa-limits-scalability[Limits and scalability]
+// endif::openshift-rosa-hcp[]
+// ifndef::openshift-rosa-hcp[]
+// xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
+// endif::openshift-rosa-hcp[]
 | 
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/support/index.html#support-overview[Getting support]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-instance-types.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-instance-types.adoc
@@ -13,5 +13,6 @@ include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
+// Removed as part of OSDOCS-13310, until figures are verified.
+//* xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 * link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -42,7 +42,10 @@ ifdef::openshift-rosa-hcp[]
 * xref:../rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-instance-types[{product-title} instance types].
 endif::openshift-rosa-hcp[]
 ifndef::openshift-rosa-hcp[]
-xref:../rosa_policy_service_definition/rosa-instance-types.adoc#rosa-instance-types[{product-title} instance types].
+* xref:../rosa_policy_service_definition/rosa-instance-types.adoc#rosa-instance-types[{product-title} instance types]
+
+// Removed as part of OSDOCS-13310, until figures are verified.
+//* xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 endif::openshift-rosa-hcp[]
 
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]

--- a/rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+++ b/rosa_cluster_admin/rosa-configuring-pid-limits.adoc
@@ -41,7 +41,8 @@ ifndef::openshift-rosa-hcp[]
 
 * xref:../rosa_planning/rosa-planning-environment.adoc#rosa-planning-environment[Planning your environment]
 
-* xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
+// Removed as part of OSDOCS-13310, until figures are verified.
+//* xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]

--- a/rosa_getting_started/rosa-getting-started.adoc
+++ b/rosa_getting_started/rosa-getting-started.adoc
@@ -20,7 +20,9 @@ You can create a ROSA cluster either with or without the AWS Security Token Serv
 
 * You reviewed the xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding[introduction to {product-title} (ROSA)], and the documentation on ROSA xref:../architecture/rosa-architecture-models.adoc#rosa-architecture-models[architecture models] and xref:../architecture/architecture.adoc#architecture[architecture concepts].
 
-* You have read the documentation on xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] and the xref:../rosa_planning/rosa-planning-environment.adoc#rosa-planning-environment[guidelines for planning your environment].
+* You have read the documentation on the xref:../rosa_planning/rosa-planning-environment.adoc#rosa-planning-environment[guidelines for planning your environment].
+// Removed as part of OSDOCS-13310, until figures are verified.
+//xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] and 
 
 * You have reviewed the detailed xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
 

--- a/rosa_getting_started/rosa-quickstart-guide-ui.adoc
+++ b/rosa_getting_started/rosa-quickstart-guide-ui.adoc
@@ -22,7 +22,9 @@ image::291_OpenShift_on_AWS_Intro_1122_docs.png[{product-title}]
 
 * You reviewed the xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding[introduction to {product-title} (ROSA)], and the documentation on ROSA xref:../architecture/rosa-architecture-models.adoc#rosa-architecture-models[architecture models] and xref:../architecture/architecture.adoc#architecture[architecture concepts].
 
-* You have read the documentation on xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] and the xref:../rosa_planning/rosa-planning-environment.adoc#rosa-planning-environment[guidelines for planning your environment].
+* You have read the documentation on the xref:../rosa_planning/rosa-planning-environment.adoc#rosa-planning-environment[guidelines for planning your environment].
+// Removed as part of OSDOCS-13310, until figures are verified.
+// xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] and 
 
 * You have reviewed the detailed xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
 

--- a/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.adoc
@@ -15,7 +15,8 @@ include::modules/rosa-sts-interactive-cluster-creation-mode-options.adoc[levelof
 [id="additional-resources_rosa-sts-interactive-mode-reference"]
 == Additional resources
 * For more information about using custom ARN paths for the OCM role, user role, and account-wide roles, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-arn-path-customization-for-iam-roles-and-policies_rosa-sts-creating-a-cluster-with-customizations[ARN path customization for IAM roles and policies].
-* For a list of the supported maximums, see xref:../rosa_planning/rosa-limits-scalability.adoc#tested-cluster-maximums_rosa-limits-scalability[ROSA tested cluster maximums].
+// Removed as part of OSDOCS-13310, until figures are verified.
+//* For a list of the supported maximums, see xref:../rosa_planning/rosa-limits-scalability.adoc#tested-cluster-maximums_rosa-limits-scalability[ROSA tested cluster maximums].
 * For detailed steps to quickly create a ROSA cluster with STS, including the AWS IAM resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Creating a ROSA cluster with STS using the default options].
 * For detailed steps to create a ROSA cluster with STS using customizations, including the AWS IAM resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-a-cluster-with-customizations[Creating a ROSA cluster with STS using customizations].
 * For more information about etcd encryption, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-etcd-encryption_rosa-service-definition[etcd encryption service definition].

--- a/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
+++ b/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
@@ -37,6 +37,7 @@ include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 == Additional resources
-* xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
+// Removed as part of OSDOCS-13310, until figures are verified.
+//* xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-sre-access_rosa-policy-process-security[SRE access to all Red{nbsp}Hat OpenShift Service on AWS clusters]
 * xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-getting-started-workflow.adoc#rosa-understanding-the-deployment-workflow[Understanding the ROSA deployment workflow]

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -42,6 +42,8 @@ ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 [id="additional-resources_aws-account-requirements_{context}"]
 .Additional resources
+// Removed as part of OSDOCS-13310, until figures are verified.
+//* xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 * xref:../support/troubleshooting/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-elb-service-role_rosa-troubleshooting-cluster-deployments[Creating the Elastic Load Balancing (ELB) service-linked role]
 endif::openshift-rosa-hcp[]
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -63,7 +63,16 @@ endif::openshift-rosa-hcp[]
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]
-* **{rosa-classic} cluster node limit update.** {rosa-classic} clusters versions 4.14.14 and greater can now scale to 249 worker nodes. This is an increase from the previous limit of 180 nodes. For more information, see xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability].
+* **{rosa-classic} cluster node limit update.** {rosa-classic} clusters versions 4.14.14 and greater can now scale to 249 worker nodes. This is an increase from the previous limit of 180 nodes.
+// Removed as part of OSDOCS-13310, until figures are verified.
+//For more information, see xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability].
+
+* **Egress lockdown is now available as a Technology Preview on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-lockdown-install.adoc#rosa-hcp-egress-lockdown-install[Creating a {product-title} cluster with egress lockdown].
++
+[IMPORTANT]
+====
+Egress lockdown is a Technology Preview feature.
+====
 
 // * **{product-title} SDN network plugin blocks future major upgrades**
 * **Initiate live migration from OpenShift SDN to OVN-Kubernetes.**
@@ -112,7 +121,9 @@ ifdef::openshift-rosa[]
 
 * **{hcp-title} multi-architecture cluster update.** {hcp-title-first} clusters created before 25 July, 2024 will migrate to a multi-architecture image on their next upgrade allowing you to use {AWS} Arm-based Graviton instance types for your workloads. For more information, see xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-upgrade-options_rosa-hcp-upgrading[Upgrading ROSA with HCP clusters].
 
-* **{hcp-title} cluster node limit update.** {hcp-title} clusters can now scale to 500 worker nodes. This is an increase from the previous limit of 250 nodes. The 250 node limit is an increase from the previous limit 90 nodes on 26 August, 2024. For more information, see xref:../rosa_planning/rosa-hcp-limits-scalability.adoc#tested-cluster-maximums-hcp-sd_rosa-hcp-limits-scalability[ROSA with HCP cluster maximums].
+* **{hcp-title} cluster node limit update.** {hcp-title} clusters can now scale to 500 worker nodes. This is an increase from the previous limit of 250 nodes. The 250 node limit is an increase from the previous limit 90 nodes on 26 August, 2024.
+// Removed as part of OSDOCS-13310, until figures are verified.
+// For more information, see xref:../rosa_planning/rosa-hcp-limits-scalability.adoc#tested-cluster-maximums-hcp-sd_rosa-hcp-limits-scalability[ROSA with HCP cluster maximums].
 
 * **IMDSv2 support in {hcp-title}.** You can now enforce the use of the IMDSv2 endpoint for default machine pool worker nodes on new {hcp-title} clusters and for new machine pools on existing clusters. For more information, see xref:../rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc#rosa-hcp-creating-a-cluster-quickly-terraform[Creating a default ROSA cluster using Terraform].
 


### PR DESCRIPTION
Version(s): 4.18+

Issue: https://issues.redhat.com/browse/OSDOCS-13310

Link to docs preview:

The live version of the combined ROSA docs still contains these sections:
- ROSA limits: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-limits-scalability
- HCP limits: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-hcp-limits-scalability

The builds for this PR do not contain this:
- Separate ROSA Classic build: https://88263--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-cloud-expert-prereq-checklist
- Separate ROSA with HCP build: https://88263--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-cloud-expert-prereq-checklist

QE review:
- [x] QE has approved this change.

Additional information: N/A