### PR TITLE
OCPBUGS-38212-14-remove: Removed the duplicate note for Open Virtual …

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -929,11 +929,6 @@ With this update, you can configure the SR-IOV Network Operator to drain nodes i
 
 For more information, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#configure-sr-iov-operator-parallel-nodes_configuring-sriov-device[Configuring parallel node draining during SR-IOV network policy updates].
 
-[id="ocp-4-14-networking-OVN-IC-IP-range"]
-==== Change in the IP address range that Open Virtual Network Infrastructure Controller uses
-
-In the {product-title} 4,13 release, the `168.254.0.0/16` IP address range was the reserved IP address range that the Open Virtual Network Infrastructure Controller used for the transit switch subnet. For {product-title} {product-version}, the Open Virtual Network Infrastructure Controller uses `100.88.0.0/16` as the reserved IP address range. The `100.88.0.0/16` range must not conflict with any connected networks. See link:https://issues.redhat.com/browse/OCPBUGS-20178[OCPBUGS-20178] and xref:../networking/cidr-range-definitions.adoc[CIDR range definitions].
-
 [id="ocp-4-14-registry"]
 === Registry
 


### PR DESCRIPTION
Removed a duplicate note that collides with the update onhttps://github.com/openshift/openshift-docs/pull/87422

Version(s):
4.14

Issue:
[OCPBUGS-38212](https://issues.redhat.com/browse/OCPBUGS-38212)

Link to docs preview:
[4.14 RN doc](https://88280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html)

