### PR TITLE
[enterprise-4.14] OCPBUGS-41970: Updated MTU data type in MACVLAN table

### DIFF
--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -5,7 +5,7 @@
 [id="nw-multus-macvlan-object_{context}"]
 = Configuration for a MACVLAN additional network
 
-The following object describes the configuration parameters for the macvlan CNI plugin:
+The following object describes the configuration parameters for the MAC Virtual LAN (MACVLAN) Container Network Interface (CNI) plugin:
 
 .MACVLAN CNI plugin JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
@@ -37,7 +37,7 @@ The following object describes the configuration parameters for the macvlan CNI 
 |Optional: The host network interface to associate with the newly created macvlan interface. If a value is not specified, then the default route interface is used.
 
 |`mtu`
-|`string`
+|`integer`
 |Optional: The maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
 |`linkInContainer`
@@ -52,7 +52,7 @@ If you specify the `master` key for the plugin configuration, use a different ph
 ====
 
 [id="nw-multus-macvlan-config-example_{context}"]
-== macvlan configuration example
+== MACVLAN configuration example
 
 The following example configures an additional network named `macvlan-net`:
 


### PR DESCRIPTION
Cherry pick of #87836 with commit ID b9410f757d98606853dac5dfd3afb08dca923f80

Version(s):
4.14

Issue:
[OCPBUGS-41970](https://issues.redhat.com/browse/OCPBUGS-41970)

Link to docs preview:
https://88295--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network#nw-multus-macvlan-object_configuring-additional-network
