### PR TITLE
OSDOCS-13344: Documented the 4.12.73 z-stream notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5077,3 +5077,28 @@ $ oc adm release info 4.12.72 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-73_{context}"]
+=== RHSA-2025:1242 - {product-title} 4.12.73 bug fix and security update
+
+Issued: 13 February 2025
+
+{product-title} release 4.12.73 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1242[RHSA-2025:1242] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:1244[RHBA-2025:1244] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.73 --pullspecs
+----
+
+[id="ocp-4-12-73-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, pods could get stuck when generating `FailedMount` errors. These errors caused nodes to need additional reboots and for the Network File System (NFS) volume mount to stay in a pending state. With this release, a kernel update fixes the issue so that pods no longer get stuck because nodes no longer need to be rebooted to clear the `FailedMount` errors. (link:https://issues.redhat.com/browse/OCPBUGS-49398[*OCPBUGS-49398*])
+
+[id="ocp-4-12-73-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-13344](https://issues.redhat.com/browse/OSDOCS-13344)

Link to docs preview:
[4.12.73](https://88303--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-73_release-notes)
