### PR TITLE
OSDOCS-13374: Updating oc adm upgrade status for 4.18+

### DIFF
--- a/modules/update-upgrading-oc-adm-upgrade-status.adoc
+++ b/modules/update-upgrading-oc-adm-upgrade-status.adoc
@@ -41,42 +41,35 @@ $ oc adm upgrade status
 ----
 = Control Plane =
 Assessment:      Progressing
-Target Version:  4.14.1 (from 4.14.0)
-Completion:      97%
-Duration:        54m
+Target Version:  4.17.1 (from 4.17.0)
+Updating:        machine-config
+Completion:      97% (32 operators updated, 1 updating, 0 waiting)
+Duration:        54m (Est. Time Remaining: <10m)
 Operator Status: 32 Healthy, 1 Unavailable
 
 Control Plane Nodes
 NAME                                        ASSESSMENT    PHASE      VERSION   EST    MESSAGE
-ip-10-0-53-40.us-east-2.compute.internal    Progressing   Draining   4.14.0    +10m
-ip-10-0-30-217.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?
-ip-10-0-92-180.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?
+ip-10-0-53-40.us-east-2.compute.internal    Progressing   Draining   4.17.0    +10m
+ip-10-0-30-217.us-east-2.compute.internal   Outdated      Pending    4.17.0    ?
+ip-10-0-92-180.us-east-2.compute.internal   Outdated      Pending    4.17.0    ?
 
 = Worker Upgrade =
 
-= Worker Pool =
-Worker Pool:     worker
-Assessment:      Progressing
-Completion:      0%
-Worker Status:   3 Total, 2 Available, 1 Progressing, 3 Outdated, 1 Draining, 0 Excluded, 0 Degraded
+WORKER POOL   ASSESSMENT    COMPLETION   STATUS
+worker        Progressing   0% (0/2)     1 Available, 1 Progressing, 1 Draining
+infra         Progressing   50% (1/2)    1 Available, 1 Progressing, 1 Draining
 
-Worker Pool Nodes
-NAME                                        ASSESSMENT    PHASE      VERSION   EST    MESSAGE
-ip-10-0-4-159.us-east-2.compute.internal    Progressing   Draining   4.14.0    +10m
-ip-10-0-20-162.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?
-ip-10-0-99-40.us-east-2.compute.internal    Outdated      Pending    4.14.0    ?
+Worker Pool Nodes: Worker
+NAME                                       ASSESSMENT    PHASE      VERSION   EST    MESSAGE
+ip-10-0-4-159.us-east-2.compute.internal   Progressing   Draining   4.17.0    +10m 
+ip-10-0-99-40.us-east-2.compute.internal   Outdated      Pending    4.17.0    ?
 
-= Worker Pool =
-Worker Pool:     infra
-Assessment:      Progressing
-Completion:      0%
-Worker Status:   1 Total, 0 Available, 1 Progressing, 1 Outdated, 1 Draining, 0 Excluded, 0 Degraded
-
-Worker Pool Node
+Worker Pool Nodes: infra
 NAME                                             ASSESSMENT    PHASE      VERSION   EST    MESSAGE
-ip-10-0-4-159-infra.us-east-2.compute.internal   Progressing   Draining   4.14.0    +10m
+ip-10-0-4-159-infra.us-east-2.compute.internal   Progressing   Draining   4.17.0    +10m
+ip-10-0-20-162.us-east-2.compute.internal        Completed     Updated    4.17.1    - 
 
 = Update Health =
 SINCE   LEVEL   IMPACT   MESSAGE
-14m4s   Info    None     Update is proceeding well
+54m4s   Info    None     Update is proceeding well
 ----


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13374

Link to docs preview:
https://88323--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli.html#update-upgrading-oc-adm-upgrade-status_updating-cluster-cli
https://88323--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update.html#update-upgrading-oc-adm-upgrade-status_troubleshooting_updates


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
