### PR TITLE
OSDOCS#13315: Update the 4.13.55 z-stream RN

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4458,3 +4458,31 @@ $ oc adm release info 4.13.53 --pullspecs
 [id="ocp-4-13-53-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.13.55
+[id="ocp-4-13-55_{context}"]
+=== RHSA-2025:1116 - {product-title} 4.13.55 bug fix and security updates
+
+Issued: 13 January 2025
+
+{product-title} release 4.13.55, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1116[RHSA-2025:1116] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1118[RHSA-2025:1118] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.55 --pullspecs
+----
+
+[id="ocp-4-13-55-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, during node restarts, especially during update operations, the node that interacted with the restarting machine entered a `Ready=Unknown` state for a short amount of time. This situation caused the Control Plane Machine Set Operator to enter an `UnavailableReplicas` condition followed by an `Available=false` state. The `Available=false` state triggered alerts that demanded urgent action. Intervention was required until the node restarted. With this release, a grace period for node unreadiness is available so if a node enters an unready state, the Control Plane Machine Set Operator does not instantly enter an `UnavailableReplicas` condition or an `Available=false` state. (link:https://issues.redhat.com/browse/OCPBUGS-48259[*OCPBUGS-48259*])
+
+* Previously, problems resulted when users had spurious custom resource definition (CRD) incompatibility claims while updating Operators. This was due to a failure in the Operator Lifecycle Manager (OLM) code that validated existing custom resources (CRs) against incoming CRs. With this release, OLM code validates the CRs properly and no problems occur. (link:https://issues.redhat.com/browse/OCPBUGS-47507[*OCPBUGS-47507*])
+
+[id="ocp-4-13-55-updating_{context}"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-13315](https://issues.redhat.com/browse/OSDOCS-13315)

Link to docs preview:
[4.13.55](https://88328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-55_release-notes)

QE review:
- [ ] QE has approved this change.
n/a for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 02/13/25.