### PR TITLE
OBSDOCS-1665: Update docs for FIPS enablement in power monitoring

### DIFF
--- a/modules/power-monitoring-fips-support.adoc
+++ b/modules/power-monitoring-fips-support.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * power_monitoring/power-monitoring-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="power-monitoring-fips-support_{context}"]
+= About FIPS compliance for {PM-operator}
+
+Starting with version 0.4, {PM-operator} for Red Hat OpenShift is FIPS compliant. When deployed on an {product-title} cluster in FIPS mode, it uses {op-system-base-full} cryptographic libraries validated by National Institute of Standards and Technology (NIST).
+
+For details on the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic module validation program]. For the latest NIST status of {op-system-base} cryptographic libraries, see link:https://access.redhat.com/en/compliance[Compliance activities and government standards].
+
+To enable FIPS mode, you must install {PM-operator} for Red{nbsp}Hat OpenShift on an {product-title} cluster. For more information, see "Do you need extra security for your cluster?"

--- a/observability/power_monitoring/power-monitoring-overview.adoc
+++ b/observability/power_monitoring/power-monitoring-overview.adoc
@@ -15,7 +15,11 @@ include::modules/power-monitoring-kepler-architecture.adoc[leveloffset=+1]
 
 include::modules/power-monitoring-hardware-virtualization-support.adoc[leveloffset=+1]
 
+include::modules/power-monitoring-fips-support.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_power-monitoring-overview"]
 == Additional resources
 * xref:../power_monitoring/visualizing-power-monitoring-metrics.adoc#power-monitoring-dashboards-overview_visualizing-power-monitoring-metrics[{PM-shortname-c} dashboards overview]
+
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing-security[Do you need extra security for your cluster?]


### PR DESCRIPTION
Change type: Doc update; Update docs for FIPS enablement in power monitoring
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1665

Fix Version: 4.16+

Doc Preview: https://88330--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/power_monitoring/power-monitoring-overview.html#power-monitoring-fips-support_power-monitoring-overview

SME Review: @KaiyiLiu1234
QE Review: @vprashar2929 
Peer Review: @xenolinux 