### PR TITLE
OSDOCS-11442#multiple NICs Nutanix

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -3479,7 +3479,7 @@ The name of one or more failures domains.
         uuid:
       subnetUUIDs:
       -
-a|By default, the installation program installs cluster machines to a single Prism Element instance. You can specify additional Prism Element instances for fault tolerance, and then apply them to:
+a|By default, the installation program installs cluster machines to a single Prism Element instance.  A maximum of 32 subnets for each failure domain (Prism Element) in an {product-title} cluster is supported. All `subnetUUID` values must be unique. You can specify additional Prism Element instances for fault tolerance, and then apply them to:
 
 * The cluster's default machine configuration
 * Only control plane or compute machine pools
@@ -3567,7 +3567,7 @@ For more information on usage, see "Configuring a failure domain" in "Installing
 [.small]
 --
 1. The `prismElements` section holds a list of Prism Elements (clusters). A Prism Element encompasses all of the Nutanix resources, for example virtual machines and subnets, that are used to host the {product-title} cluster.
-2. Only one subnet per Prism Element in an {product-title} cluster is supported.
+2. A maximum of 32 subnets for each Prism Element in an {product-title} cluster is supported. All `subnetUUID` values must be unique.
 --
 endif::nutanix[]
 

--- a/modules/installation-configuring-nutanix-failure-domains.adoc
+++ b/modules/installation-configuring-nutanix-failure-domains.adoc
@@ -45,7 +45,7 @@ where:
 `<failure_domain_name>`:: Specifies a unique name for the failure domain. The name is limited to 64 or fewer characters, which can include lower-case letters, digits, and a dash (`-`). The dash cannot be in the leading or ending position of the name.
 `<prism_element_name>`:: Optional. Specifies the name of the Prism Element.
 `<prism_element_uuid`>:: Specifies the UUID of the Prism Element.
-`<network_uuid`>:: Specifies the UUID of the Prism Element subnet object. The subnet's IP address prefix (CIDR) should contain the virtual IP addresses that the {product-title} cluster uses. Only one subnet per failure domain (Prism Element) in an {product-title} cluster is supported.
+`<network_uuid`>:: Specifies the one or more UUIDs of the Prism Element subnet objects. Among them, one of the subnet's IP address prefixes (CIDRs) must contain the virtual IP addresses that the {product-title} cluster uses. A maximum of 32 subnets for each failure domain (Prism Element) in an {product-title} cluster is supported. All `subnetUUID` values must be unique.
 
 . As required, configure additional failure domains.
 . To distribute control plane and compute machines across the failure domains, do one of the following:


### PR DESCRIPTION
Versions:
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-11442

Link to docs preview:

- [Additional Nutanix configuration parameters](https://88361--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installation-config-parameters-nutanix#installation-configuration-parameters-additional-nutanix_installation-config-parameters-nutanix)
- [Configuring failure domains](https://88361--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#installation-configuring-nutanix-failure-domains_installing-nutanix-installer-provisioned)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
