### PR TITLE
OSDOCS-11354: corrects blueprint file reference

### DIFF
--- a/modules/microshift-embed-microshift-image-offline-deploy.adoc
+++ b/modules/microshift-embed-microshift-image-offline-deploy.adoc
@@ -7,15 +7,15 @@
 [id="microshift-embed-microshift-image-offline-deployment_{context}"]
 = Embedding {microshift-short} containers for offline deployments
 
-You can use image builder to create `rpm-ostree` system images with embedded {microshift-short} container images. To embed container images, you must add the image references to your image builder blueprint.
+You can use image builder to create {op-system-ostree} images with embedded {microshift-short} container images. To embed container images, you must add the image references to your image builder blueprint file.
 
 .Prerequisites
 
 * You have root-user access to your build host.
 * Your build host meets the image builder system requirements.
-* You have installed and set up image builder and the `composer-cli` tool.
-* You have created a {op-system-ostree} image blueprint.
-* You have installed jq.
+* You installed and set up image builder and the `composer-cli` tool.
+* You created a {op-system-ostree} image blueprint.
+* You installed jq.
 
 .Procedure
 
@@ -35,7 +35,7 @@ Replace `<release_version>` with the numerical value of the release you are depl
 +
 [source,terminal]
 ----
-$ ls /usr/share/microshift/release
+$ sudo ls /usr/share/microshift/release
 ----
 +
 .Example output
@@ -45,50 +45,49 @@ release-x86_64.json
 release-aarch64.json
 ----
 +
-If you installed the `microshift-release-info` RPM, you can proceed to step 4.
+If you installed the `microshift-release-info` RPM, proceed to step 4.
 
 . If you did not complete step 2, download and unpack the `microshift-release-info` RPM without installing it:
 
 .. Download the RPM package by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo dnf download microshift-release-info-<release_version>
+$ sudo dnf download microshift-release-info-_<release_version>_ # <1>
 ----
-Replace `<release_version>` with the numerical value of the release you are deploying, using the entire version number, such as `4.18.1`.
+<1> Replace `_<release_version>_` with the numerical value of the release you are deploying, using the entire version number, such as `4.18.1`.
 +
-.Example rpm
-[source,terminal]
+.Example RPM output
+[source,terminal,subs="+quotes"]
 ----
-microshift-release-info-4.18.1.*.el9.noarch.rpm <1>
+microshift-release-info-4.18.1.-202511101230.p0.g7dc6a00.assembly.4.18.1.el9.noarch.rpm
 ----
-<1> The `*` represents the date and commit ID. Your output should contain both, for example `-202511101230.p0.g7dc6a00.assembly.4.18.1`.
 
 .. Unpack the RPM package without installing it by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ rpm2cpio <my_microshift_release_info> | cpio -idmv <1>
+$ rpm2cpio _<my_microshift_release_info>_ | cpio -idmv # <1>
 ./usr/share/microshift/release/release-aarch64.json
 ./usr/share/microshift/release/release-x86_64.json
 ----
-<1> Replace `<my_microshift_release_info>` with the name of the RPM package from the previous step.
+<1> Replace `_<my_microshift_release_info>_` with the name of the RPM package from the previous step.
 
 . Define the location of your JSON file, which contains the container reference information, by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ RELEASE_FILE=</path/to/your/release-$(uname -m).json>
+$ RELEASE_FILE=_</path/to/your/release-$(uname -m).json>_ # <1>
 ----
-Replace `</path/to/your/release-$(uname -m).json>` with the full path to your JSON file. Be sure to use the file needed for your architecture.
+<1> Replace `_</path/to/your/release-$(uname -m).json>_` with the full path to your JSON file. Be sure to use the file needed for your architecture.
 
 . Define the location of your TOML file, which contains instructions for building the image, by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ BLUEPRINT_FILE=</path/to/your/blueprint.toml>
+$ BLUEPRINT_FILE=_</path/to/your/blueprint.toml>_ # <1>
 ----
-Replace `</path/to/your/blueprint.toml>` with the full path to your JSON file.
+<1> Replace `_</path/to/your/blueprint.toml>_` with the full path to your TOML file.
 
 . Generate and then embed the container image references in your blueprint TOML file by running the following command:
 +
@@ -97,7 +96,7 @@ Replace `</path/to/your/blueprint.toml>` with the full path to your JSON file.
 $  jq -r '.images | .[] | ("[[containers]]\nsource = \"" + . + "\"\n")' "${RELEASE_FILE}" >> "${BLUEPRINT_FILE}"
 ----
 +
-.Example resulting `<my_blueprint.toml>` fragment showing container references
+.Example resulting TOML fragment showing container references
 [source,terminal]
 ----
 [[containers]]
@@ -107,12 +106,12 @@ source = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82cfef91557f9a70
 source = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82cfef91557f9a70cff5a90accba45841a37524e9b93f98a97b20f6b2b69e5db"
 ----
 
-. You can manually embed any container image by adding it to the image builder blueprint using the following example:
+. You can manually embed any container image by adding it to an image builder blueprint file using the following example:
 +
-.Example section for manually embedding container image to image builder
-[source,terminal]
+.Example section for manually embedding container image to a blueprint
+[source,text,subs="+quotes"]
 ----
 [[containers]]
-source = "<my_image_pullspec_with_tag_or_digest>"
+source = "_<my_image_pullspec_with_tag_or_digest>_"
 ----
-Replace `<my_image_pullspec_with_tag_or_digest>` with the exact reference to a container image used by the {microshift-short} version you are deploying.
+Replace `_<my_image_pullspec_with_tag_or_digest>_` with the exact reference to a container image used by the {microshift-short} version you are deploying.


### PR DESCRIPTION
Version(s):
4.17, 4.18

Issue:
[OSDOCS-13354](https://issues.redhat.com/browse/OSDOCS-13354)

Link to docs preview:
[microshift-embed-rpm-ostree-offline-use](https://88370--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree-offline-use.html#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
