### PR TITLE
Unify the web console name in CNV docs

### DIFF
--- a/modules/virt-about-auto-bootsource-updates.adoc
+++ b/modules/virt-about-auto-bootsource-updates.adoc
@@ -15,4 +15,4 @@ When the `enableCommonBootImageImport` feature gate is disabled, `DataSource` ob
 
 _Custom_ boot sources that are not provided by {VirtProductName} are not controlled by the feature gate. You must manage them individually by editing the `HyperConverged` custom resource (CR). You can also use this method to manage individual system-defined boot sources.
 
-Cluster administrators can enable automatic subscription for {op-system-base-full} virtual machines in the {VirtProductName} web console.
+Cluster administrators can enable automatic subscription for {op-system-base-full} virtual machines in the {product-title} web console.

--- a/modules/virt-defining-apps-for-dr.adoc
+++ b/modules/virt-defining-apps-for-dr.adoc
@@ -33,14 +33,14 @@ Use the pod `pullMethod: node` when creating a data volume from a registry sourc
 [id="best-practices-{rh-rhacm}-discovered-vm_{context}"]
 == Best practices when defining an {rh-rhacm}-discovered VM
 
-You can configure any VM in the cluster that is not an {rh-rhacm}-managed application as an {rh-rhacm}-discovered application. This includes VMs imported by using the Migration Toolkit for Virtualization (MTV), VMs created by using the {VirtProductName} web console, or VMs created by any other means, such as the CLI.
+You can configure any VM in the cluster that is not an {rh-rhacm}-managed application as an {rh-rhacm}-discovered application. This includes VMs imported by using the Migration Toolkit for Virtualization (MTV), VMs created by using the {product-title} web console, or VMs created by any other means, such as the CLI.
 
 There are several actions you can take to improve your experience and chance of success when defining an {rh-rhacm}-discovered VM.
 
 [discrete]
 [id="protect-the-vm_{context}"]
-=== Protect the VM when using MTV, the {VirtProductName} web console, or a custom VM
-Because automatic labeling is not currently available, the application owner must manually label the components of the VM application when using MTV, the {VirtProductName} web console, or a custom VM.
+=== Protect the VM when using MTV, the {product-title} web console, or a custom VM
+Because automatic labeling is not currently available, the application owner must manually label the components of the VM application when using MTV, the {product-title} web console, or a custom VM.
 
 After creating the VM, apply a common label to the following resources associated with the VM: `VirtualMachine`, `DataVolume`, `PersistentVolumeClaim`, `Service`, `Route`, `Secret`, `ConfigMap`, `VirtualMachinePreference`, and `VirtualMachineInstancetype`. Do not label virtual machine instances (VMIs) or pods; {VirtProductName} creates and manages these automatically.
 

--- a/virt/live_migration/virt-about-live-migration.adoc
+++ b/virt/live_migration/virt-about-live-migration.adoc
@@ -42,7 +42,7 @@ You can perform the following live migration tasks:
 * xref:../../virt/live_migration/virt-configuring-live-migration.adoc#virt-configuring-live-migration[Configure live migration settings]
 * xref:../../virt/live_migration/virt-configuring-live-migration.adoc#virt-configuring-live-migration-heavy_virt-configuring-live-migration[Configure live migration for heavy workloads]
 * xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-initiating-live-migration[Initiate and cancel live migration]
-* Monitor the progress of all live migrations in the *Migration* tab of the {virtproductname} web console.
+* Monitor the progress of all live migrations in the *Migration* tab of the {product-title} web console.
 * View VM migration metrics in the *Metrics* tab of the web console.
 
 

--- a/virt/live_migration/virt-configuring-live-migration.adoc
+++ b/virt/live_migration/virt-configuring-live-migration.adoc
@@ -26,7 +26,7 @@ You can create live migration policies to apply different migration configuratio
 
 [TIP]
 ====
-You can create live migration policies by using the {VirtProductName} web console.
+You can create live migration policies by using the {product-title} web console.
 ====
 
 include::modules/virt-configuring-a-live-migration-policy.adoc[leveloffset=+2]

--- a/virt/nodes/virt-node-maintenance.adoc
+++ b/virt/nodes/virt-node-maintenance.adoc
@@ -38,7 +38,7 @@ VM eviction strategy::
 
 The VM `LiveMigrate` eviction strategy ensures that a virtual machine instance (VMI) is not interrupted if the node is placed into maintenance or drained. VMIs with this eviction strategy will be live migrated to another node.
 +
-You can configure eviction strategies for virtual machines (VMs) by using the {VirtProductName} web console or the xref:../../virt/live_migration/virt-configuring-live-migration.adoc#virt-configuring-a-live-migration-policy_virt-configuring-live-migration[command line].
+You can configure eviction strategies for virtual machines (VMs) by using the {product-title} web console or the xref:../../virt/live_migration/virt-configuring-live-migration.adoc#virt-configuring-a-live-migration-policy_virt-configuring-live-migration[command line].
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://88377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-disaster-recovery.html#best-practices-RHACM-discovered-vm_virt-disaster-recovery
- https://88377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-disaster-recovery.html#protect-the-vm_virt-disaster-recovery
- https://88377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-about-live-migration.html#common-live-migration-tasks_virt-about-live-migration
- https://88377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-configuring-live-migration.html#live-migration-policies
- https://88377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-node-maintenance.html#eviction-strategies
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
While reading through the Virtualization documentation, I noticed that in a few cases, the documentation addresses the _OpenShift Container Platform web console_ as _OpenShift Virtualization web console_. I believe this is incorrect as no matter which operator you install and which perspective you use, the web console remains the same. To avoid confusion, I propose to unify the way web console is addressed in the CNV documentation.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
