### PR TITLE
OBSDOCS-1652: Logging 6.1.2 Release Notes

### DIFF
--- a/modules/log6x-6-1-2-rn.adoc
+++ b/modules/log6x-6-1-2-rn.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.1/log6x-release-notes-6.1.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-2_{context}"]
+= Logging 6.1.2 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:1229[{logging-uc} {for} Bug Fix Release 6.1.2].
+
+[id="logging-release-notes-6-1-2-enhancements_{context}"]
+== New Features and Enhancements
+
+* This enhancement adds `OTel` semantic stream labels to the `lokiStack` output so that you can query logs by using both `ViaQ` and `OTel` stream labels.
+(link:https://issues.redhat.com/browse/LOG-6579[LOG-6579])
+
+[id="logging-release-notes-6-1-2-bug-fixes_{context}"]
+== Bug Fixes
+
+* Before this update, the collector alerting rules contained summary and message fields. With this update, the collector alerting rules contain summary and description fields.
+(link:https://issues.redhat.com/browse/LOG-6126[LOG-6126])
+
+* Before this update, the collector metrics dashboard could get removed after an operator upgrade due to a race condition during the transition from the old to the new pod deployment. With this update, labels are added to the dashboard `ConfigMap` to identify the upgraded deployment as the current owner so that it will not be removed.
+(link:https://issues.redhat.com/browse/LOG-6280[LOG-6280])
+
+* Before this update, when you included infrastructure namespaces in application inputs, their `log_type` would be set to `application`. With this update, the `log_type` of infrastructure namespaces included in application inputs is set to `infrastructure`.
+(link:https://issues.redhat.com/browse/LOG-6373[LOG-6373])
+
+* Before this update, the Cluster Logging Operator used a cached client to fetch the `SecurityContextConstraint` cluster resource, which could result in an error when the cache is invalid. With this update, the operator now always retrieves data from the API server instead of using a cache.
+(link:https://issues.redhat.com/browse/LOG-6418[LOG-6418])
+
+* Before this update, the logging `must-gather` did not collect resources such as `UIPlugin`, `ClusterLogForwarder`, `LogFileMetricExporter`, and `LokiStack`. With this update, the `must-gather` now collects all of these resources and places them in their respective namespace directory instead of the `cluster-logging` directory.
+(link:https://issues.redhat.com/browse/LOG-6422[LOG-6422])
+
+* Before this update, the Vector startup script attempted to delete buffer lock files during startup. With this update, the Vector startup script no longer attempts to delete buffer lock files during startup.
+(link:https://issues.redhat.com/browse/LOG-6506[LOG-6506])
+
+* Before this update, the API documentation incorrectly claimed that `lokiStack` outputs would default the target namespace, which could prevent the collector from writing to that output. With this update, this claim has been removed from the API documentation and the Cluster Logging Operator now validates that a target namespace is present.
+(link:https://issues.redhat.com/browse/LOG-6573[LOG-6573])
+
+* Before this update, the Cluster Logging Operator could deploy the collector with output configurations that were not referenced by any inputs. With this update, a validation check for the `ClusterLogForwarder` resource prevents the Operator from deploying the collector.
+(link:https://issues.redhat.com/browse/LOG-6585[LOG-6585])
+
+[id="logging-release-notes-6-1-2-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]

--- a/observability/logging/logging-6.1/log6x-release-notes-6.1.adoc
+++ b/observability/logging/logging-6.1/log6x-release-notes-6.1.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/log6x-6-1-2-rn.adoc[leveloffset=+1]
+
 include::modules/log6x-6-1-1-rn.adoc[leveloffset=+1]
 
 include::modules/log6x-6-1-0-rn.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17, 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1652
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://88392--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-release-notes-6.1.html#logging-release-notes-6-1-2_logging-6x-6.1
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @kabirbhartiRH
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
SME Review: @xperimental
Peer Review: @xenolinux 

Logging 6.1 support 4.15,4.16,4.17,4.18
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
