### PR TITLE
Adds an extraction command to exposing the registry

### DIFF
--- a/modules/registry-exposing-default-registry-manually.adoc
+++ b/modules/registry-exposing-default-registry-manually.adoc
@@ -17,35 +17,42 @@ You can expose the route by using the `defaultRoute` parameter in the `configs.i
 
 To expose the registry using the `defaultRoute`:
 
-. Set `defaultRoute` to `true`:
+. Set `defaultRoute` to `true` by running the following command:
 +
 [source,terminal]
 ----
 $ oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
 ----
 +
-. Get the default registry route:
+. Get the default registry route by running the following command:
 +
 [source,terminal]
 ----
 $ HOST=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
 ----
 
-. Get the certificate of the Ingress Operator:
+. Get the certificate of the Ingress Operator by running the following command:
 +
 [source,terminal]
 ----
 $ oc extract secret/$(oc get ingresscontroller -n openshift-ingress-operator default -o json | jq '.spec.defaultCertificate.name // "router-certs-default"' -r) -n openshift-ingress --confirm
 ----
 
-. Enable the cluster's default certificate to trust the route using the following commands:
+. Move the extracted certificate to the system's trusted CA directory by running the following command:
++
+[source,terminal]
+----
+$ sudo mv tls.crt /etc/pki/ca-trust/source/anchors/
+----
+
+. Enable the cluster's default certificate to trust the route by running the following command:
 +
 [source,terminal]
 ----
 $ sudo update-ca-trust enable
 ----
 
-. Log in with podman using the default route:
+. Log in with podman using the default route by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-50509

Link to docs preview:
https://88395--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/securing-exposing-registry.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
