### PR TITLE
CNV-47365: Add a release note for storage class migration

### DIFF
--- a/virt/release_notes/virt-4-18-release-notes.adoc
+++ b/virt/release_notes/virt-4-18-release-notes.adoc
@@ -145,6 +145,9 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //CNV-52362: IBM Z
 * You can use {VirtProductName} on an {product-title} cluster that has been deployed in a logical partition (LPAR) on {ibm-z-name} and {ibm-linuxone-name} (s390x architecture) systems. For more information, see xref:../../virt/install/preparing-cluster-for-virt.adoc#ibm-z-linuxone-compatibility_preparing-cluster-for-virt[{ibm-z-title} and {ibm-linuxone-title} compatibility].
 
+// CNV-47365: Release note: TP to GA
+* You can now use the {product-title} web console to migrate one or more disks attached to a virtual machine (VM) to a different storage class. For the storage class migration to be successful, the VM must be running and the cluster must have a node available for live migration of the VM.
+
 [id="virt-4-18-bug-fixes"]
 == Bug fixes
 
@@ -174,6 +177,14 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //CNV-23501: 4.16 - Keep per Dominik Holler
 * If you clone more than 100 VMs using the `csi-clone` cloning strategy, then the Ceph CSI might not purge the clones. Manually deleting the clones might also fail. (link:https://issues.redhat.com/browse/CNV-23501[*CNV-23501*])
 ** As a workaround, you can restart the `ceph-mgr` to purge the VM clones.
+
+// CNV-55104: 4.18 - Unresolved
+* If you perform storage class migration for a stopped VM, the VM might not be able to start because of a missing bootable device. To prevent this, do not attempt storage class migration if the VM is not running. (link:https://issues.redhat.com/browse/CNV-55104[*CNV-55104*])
++
+--
+:FeatureName: Storage class migration
+include::snippets/technology-preview.adoc[]
+--
 
 [discrete]
 [id="virt-4-18-ki-virtualization"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-47365](https://issues.redhat.com/browse/CNV-47365)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://88398--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-18-release-notes.html#virt-4-18-storage
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Related to work documented in #86954 and #81461.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
