### PR TITLE
Re-adds an sdn command to cluster mtu change docs

### DIFF
--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -347,6 +347,7 @@ where `<config_name>` is the name of the machine config from the `machineconfigu
 If the machine config is successfully deployed, the previous output contains the `/etc/NetworkManager/conf.d/99-<interface>-mtu.conf` file path and the `ExecStart=/usr/local/bin/mtu-migration.sh` line.
 endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
+ifdef::local-zone,wavelength-zone,post-aws-zones,outposts[]
 . To finalize the MTU migration, enter the following command for the OVN-Kubernetes network plugin:
 +
 [source,terminal]
@@ -361,6 +362,39 @@ where:
 
 `<mtu>`:: Specifies the new cluster network MTU that you specified with `<overlay_to>`.
 --
+endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
+
+ifndef::local-zone,wavelength-zone,post-aws-zones,outposts[]
+. To finalize the MTU migration, enter one of the following commands:
+** If you are using the OVN-Kubernetes network plugin:
++
+[source,terminal]
++
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge --patch \
+  '{"spec": { "migration": null, "defaultNetwork":{ "ovnKubernetesConfig": { "mtu": <mtu> }}}}'
+----
++
+--
+where:
+
+`<mtu>`:: Specifies the new cluster network MTU that you specified with `<overlay_to>`.
+--
+
+** If you are using the OpenShift SDN network plugin:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge --patch \
+  '{"spec": { "migration": null, "defaultNetwork":{ "openshiftSDNConfig": { "mtu": <mtu> }}}}'
+----
++
+--
+where:
+
+`<mtu>`:: Specifies the new cluster network MTU that you specified with `<overlay_to>`.
+--
+endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
 . After finalizing the MTU migration, each machine config pool node is rebooted one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16, 4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-12901

Link to docs preview:

Content *should not* appear in aws-related docs.

https://88401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks.html
https://88401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-outposts.html
https://88401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu.html#nw-cluster-mtu-change_changing-cluster-network-mtu

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
