### PR TITLE
OBSDOCS-1678: Port About logging 6.1 Chapter

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3010,6 +3010,8 @@ Topics:
     Topics:
     - Name: Release notes
       File: log6x-release-notes-6.2
+    - Name: About logging 6.2
+      File: log6x-about-6.2
     - Name: Configuring log forwarding
       File: log6x-clf-6.2
     - Name: Configuring LokiStack storage

--- a/observability/logging/logging-6.0/log6x-about.adoc
+++ b/observability/logging/logging-6.0/log6x-about.adoc
@@ -10,7 +10,14 @@ The `ClusterLogForwarder` custom resource (CR) is the central configuration poin
 
 == Inputs and Outputs
 
-Inputs specify the sources of logs to be forwarded. Logging provides built-in input types: `application`, `infrastructure`, and `audit`, which select logs from different parts of your cluster. You can also define custom inputs based on namespaces or pod labels to fine-tune log selection.
+Inputs specify the sources of logs to be forwarded. Logging provides the following built-in input types that select logs from different parts of your cluster: 
+
+* `application`
+* `receiver`
+* `infrastructure`
+* `audit`
+
+You can also define custom inputs based on namespaces or pod labels to fine-tune log selection.
 
 Outputs define the destinations where logs are sent. Each output type has its own set of configuration options, allowing you to customize the behavior and authentication settings.
 
@@ -18,18 +25,18 @@ Outputs define the destinations where logs are sent. Each output type has its ow
 == Receiver Input Type
 The receiver input type enables the Logging system to accept logs from external sources. It supports two formats for receiving logs: `http` and `syslog`.
 
-The `ReceiverSpec` defines the configuration for a receiver input.
+The `ReceiverSpec` field defines the configuration for a receiver input.
 
 == Pipelines and Filters
 
-Pipelines determine the flow of logs from inputs to outputs. A pipeline consists of one or more input refs, output refs, and optional filter refs. Filters can be used to transform or drop log messages within a pipeline. The order of filters matters, as they are applied sequentially, and earlier filters can prevent log messages from reaching later stages.
+Pipelines determine the flow of logs from inputs to outputs. A pipeline consists of one or more input refs, output refs, and optional filter refs. You can use filters to transform or drop log messages within a pipeline. The order of filters matters, as they are applied sequentially, and earlier filters can prevent log messages from reaching later stages.
 
 == Operator Behavior
 
 The Cluster Logging Operator manages the deployment and configuration of the collector based on the `managementState` field:
 
-- When set to `Managed` (default), the operator actively manages the logging resources to match the configuration defined in the spec.
-- When set to `Unmanaged`, the operator does not take any action, allowing you to manually manage the logging components.
+- When set to `Managed` (default), the Operator actively manages the logging resources to match the configuration defined in the spec.
+- When set to `Unmanaged`, the Operator does not take any action, allowing you to manually manage the logging components.
 
 == Validation
 Logging includes extensive validation rules and default values to ensure a smooth and error-free configuration experience. The `ClusterLogForwarder` resource enforces validation checks on required fields, dependencies between fields, and the format of input values. Default values are provided for certain fields, reducing the need for explicit configuration in common scenarios.

--- a/observability/logging/logging-6.2/log6x-about-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-about-6.2.adoc
@@ -1,14 +1,15 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
-[id="log6x-about-6-1"]
-= Logging 6.1
-:context: logging-6x-6.1
+[id="log6x-about-6-2"]
+= Logging 6.2
+
+:context: logging-6x-6.2
 
 toc::[]
 
 The `ClusterLogForwarder` custom resource (CR) is the central configuration point for log collection and forwarding.
 
-[id="inputs-and-outputs_6-1_{context}"]
+[id="inputs-and-outputs_6-2_{context}"]
 == Inputs and outputs
 
 Inputs specify the sources of logs to be forwarded. Logging provides the following built-in input types that select logs from different parts of your cluster:
@@ -22,18 +23,18 @@ You can also define custom inputs based on namespaces or pod labels to fine-tune
 
 Outputs define the destinations where logs are sent. Each output type has its own set of configuration options, allowing you to customize the behavior and authentication settings.
 
-[id="receiver-input-type_6-1_{context}"]
+[id="receiver-input-type_6-2_{context}"]
 == Receiver input type
 The receiver input type enables the Logging system to accept logs from external sources. It supports two formats for receiving logs: `http` and `syslog`.
 
 The `ReceiverSpec` field defines the configuration for a receiver input.
 
-[id="pipelines-and-filters_6-1_{context}"]
+[id="pipelines-and-filters_6-2_{context}"]
 == Pipelines and filters
 
 Pipelines determine the flow of logs from inputs to outputs. A pipeline consists of one or more input refs, output refs, and optional filter refs. You can use filters to transform or drop log messages within a pipeline. The order of filters matters, as they are applied sequentially, and earlier filters can prevent log messages from reaching later stages.
 
-[id="operator-behavior_6-1_{context}"]
+[id="operator-behavior_6-2_{context}"]
 == Operator behavior
 
 The Cluster Logging Operator manages the deployment and configuration of the collector based on the `managementState` field of the `ClusterLogForwarder` resource:
@@ -41,11 +42,11 @@ The Cluster Logging Operator manages the deployment and configuration of the col
 - When set to `Managed` (default), the Operator actively manages the logging resources to match the configuration defined in the spec.
 - When set to `Unmanaged`, the Operator does not take any action, allowing you to manually manage the logging components.
 
-[id="validation_6-1_{context}"]
+[id="validation_6-2_{context}"]
 == Validation
 Logging includes extensive validation rules and default values to ensure a smooth and error-free configuration experience. The `ClusterLogForwarder` resource enforces validation checks on required fields, dependencies between fields, and the format of input values. Default values are provided for certain fields, reducing the need for explicit configuration in common scenarios.
 
-[id="quick-start_6-1_{context}"]
+[id="quick-start_6-2_{context}"]
 == Quick start
 
 OpenShift Logging supports two data models:


### PR DESCRIPTION
Version(s): 4.19, 4.18, 4.17. Note that this needs to be cherry-picked to logging-docs-6.2-4.18, logging-docs-6.2-4.17 release branches and not enterprise-4.18, enterprise-4.17 branches.  


Issue: https://issues.redhat.com/browse/OBSDOCS-1678
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

https://88402--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-about-6.2.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR only ports exiting and already published content to a newer release. Content enhancement is beyond the scope of the Jira/PR.

Existing published content: https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.1/log6x-about-6.1.html
Existing file that was copied: https://github.com/openshift/openshift-docs/blob/main/observability/logging/logging-6.1/log6x-about-6.1.adoc