### PR TITLE
Core RDS: version for logging operator

### DIFF
--- a/modules/telco-core-software-stack.adoc
+++ b/modules/telco-core-software-stack.adoc
@@ -14,7 +14,7 @@ The following software versions were used for validating the telco core referenc
 |===
 |Component |Software version
 
-|Cluster Logging Operator |5.9.1
+|Cluster Logging Operator |5.9.1,6.0
 
 |{rh-storage} |4.16
 


### PR DESCRIPTION
Version(s): OCP 4.16, RDS Core 4.16

Version of the RDS Core for openshift logging operator shall include 6.0 as per https://github.com/openshift-kni/telco-reference/blob/release-4.16/telco-core/configuration/reference-crs/optional/logging/ClusterLogSubscription.yaml#L7

@aireilly^^^
