### PR TITLE
OSDOCS-13365: multi-NIC support in Nutanix

### DIFF
--- a/modules/cpmso-yaml-provider-spec-nutanix.adoc
+++ b/modules/cpmso-yaml-provider-spec-nutanix.adoc
@@ -78,7 +78,7 @@ You must use the `Legacy` boot type in {product-title} {product-version}.
 ====
 Clusters that use {product-title} version 4.15 or later can use failure domain configurations.
 
-If the cluster is configured to use a failure domain, this parameter is configured in the failure domain.
+If the cluster uses a failure domain, configure this parameter in the failure domain.
 If you specify this value in the provider specification when using failure domains, the Control Plane Machine Set Operator ignores it.
 ====
 <4> Specifies the secret name for the cluster. Do not change this value.
@@ -86,13 +86,32 @@ If you specify this value in the provider specification when using failure domai
 <6> Specifies the cloud provider platform type. Do not change this value.
 <7> Specifies the memory allocated for the control plane machines.
 <8> Specifies the Nutanix project that you use for your cluster. In this example, the project type is `name`, so there is a `name` stanza.
-<9> Specifies a subnet configuration. In this example, the subnet type is `uuid`, so there is a `uuid` stanza.
+<9> Specify one or more Prism Element subnet objects.
+In this example, the subnet type is `uuid`, so there is a `uuid` stanza.
+A maximum of 32 subnets for each Prism Element failure domain in the cluster is supported.
++
+[IMPORTANT]
+====
+The following known issues with configuring multiple subnets for an existing Nutanix cluster by using a control plane machine set exist in {product-title} version 4.18:
+
+* Adding subnets above the existing subnet in the `subnets` stanza causes a control plane node to become stuck in the `Deleting` state.
+As a workaround, only add subnets below the existing subnet in the `subnets` stanza.
+
+* Sometimes, after adding a subnet, the updated control plane machines appear in the Nutanix console but the {product-title} cluster is unreachable.
+There is no workaround for this issue.
+
+These issues occur on clusters that use a control plane machine set to configure subnets regardless of whether subnets are specified in a failure domain or the provider specification.
+For more information, see link:https://issues.redhat.com/browse/OCPBUGS-50904[*OCPBUGS-50904*].
+====
++
+The CIDR IP address prefix for one of the specified subnets must contain the virtual IP addresses that the {product-title} cluster uses. 
+All subnet UUID values must be unique.
 +
 [NOTE]
 ====
 Clusters that use {product-title} version 4.15 or later can use failure domain configurations.
 
-If the cluster is configured to use a failure domain, this parameter is configured in the failure domain.
+If the cluster uses a failure domain, configure this parameter in the failure domain.
 If you specify this value in the provider specification when using failure domains, the Control Plane Machine Set Operator ignores it.
 ====
 <10> Specifies the VM disk size for the control plane machines.

--- a/modules/machineset-yaml-nutanix.adoc
+++ b/modules/machineset-yaml-nutanix.adoc
@@ -108,16 +108,16 @@ endif::infra[]
           project: <10>
             type: name
             name: <project_name>
-          subnets:
+          subnets: <11>
           - type: uuid
             uuid: <subnet_uuid>
-          systemDiskSize: 120Gi <11>
+          systemDiskSize: 120Gi <12>
           userDataSecret:
-            name: <user_data_secret> <12>
-          vcpuSockets: 4 <13>
-          vcpusPerSocket: 1 <14>
+            name: <user_data_secret> <13>
+          vcpuSockets: 4 <14>
+          vcpusPerSocket: 1 <15>
 ifdef::infra[]
-      taints: <15>
+      taints: <16>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -143,12 +143,16 @@ You must use the `Legacy` boot type in {product-title} {product-version}.
 <8> Specify the image to use. Use an image from an existing default compute machine set for the cluster.
 <9> Specify the amount of memory for the cluster in Gi.
 <10> Specify the Nutanix project that you use for your cluster. In this example, the project type is `name`, so there is a `name` stanza.
-<11> Specify the size of the system disk in Gi.
-<12> Specify the name of the secret in the user data YAML file that is in the `openshift-machine-api` namespace. Use the value that installation program populates in the default compute machine set.
-<13> Specify the number of vCPU sockets.
-<14> Specify the number of vCPUs per socket.
+<11> Specify one or more UUID for the Prism Element subnet object. 
+The CIDR IP address prefix for one of the specified subnets must contain the virtual IP addresses that the {product-title} cluster uses. 
+A maximum of 32 subnets for each Prism Element failure domain in the cluster is supported.
+All subnet UUID values must be unique.
+<12> Specify the size of the system disk in Gi.
+<13> Specify the name of the secret in the user data YAML file that is in the `openshift-machine-api` namespace. Use the value that installation program populates in the default compute machine set.
+<14> Specify the number of vCPU sockets.
+<15> Specify the number of vCPUs per socket.
 ifdef::infra[]
-<15> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<16> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====

--- a/modules/post-installation-configuring-nutanix-failure-domains.adoc
+++ b/modules/post-installation-configuring-nutanix-failure-domains.adoc
@@ -10,7 +10,7 @@ You add failure domains to an existing Nutanix cluster by modifying its Infrastr
 
 [TIP]
 ====
-It is recommended that you configure three failure domains to ensure high-availability.
+To ensure high-availability, configure three failure domains.
 ====
 
 .Procedure
@@ -62,6 +62,16 @@ where:
 
 `<uuid>`:: Specifies the universally unique identifier (UUID) of the Prism Element.
 `<failure_domain_name>`:: Specifies a unique name for the failure domain. The name is limited to 64 or fewer characters, which can include lower-case letters, digits, and a dash (`-`). The dash cannot be in the leading or ending position of the name.
-`<network_uuid>`:: Specifies the UUID of the Prism Element subnet object. The subnet's IP address prefix (CIDR) should contain the virtual IP addresses that the {product-title} cluster uses. Only one subnet per failure domain (Prism Element) in an {product-title} cluster is supported.
+`<network_uuid>`:: Specifies one or more UUID for the Prism Element subnet object. 
+The CIDR IP address prefix for one of the specified subnets must contain the virtual IP addresses that the {product-title} cluster uses.
++
+--
+:FeatureName: Configuring multiple subnets
+include::snippets/technology-preview.adoc[]
+--
++
+To configure multiple subnets in the Infrastructure CR, you must enable the `NutanixMultiSubnets` feature gate.
+A maximum of 32 subnets for each failure domain (Prism Element) in an {product-title} cluster is supported.
+All subnet UUID values must be unique.
 
 . Save the CR to apply the changes.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-13365](https://issues.redhat.com//browse/OSDOCS-13365)

Link to docs preview:
* [Sample Nutanix provider specification](https://88405--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-nutanix.html#cpmso-yaml-provider-spec-nutanix_cpmso-config-options-nutanix)
* [Sample YAML for a compute machine set custom resource on Nutanix](https://88405--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-nutanix.html#machineset-yaml-nutanix_creating-machineset-nutanix)
* [Adding failure domains to the Infrastructure CR ](https://88405--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/nutanix-failure-domains.html#post-installation-configuring-nutanix-failure-domains_nutanix-failure-domains)

QE review:
- [x] QE has approved this change.

Additional information: