### PR TITLE
HCIDOCS-548: DocBug | BareMetal IPI installations support for Network Customization 

### DIFF
--- a/installing/overview/installing-preparing.adoc
+++ b/installing/overview/installing-preparing.adoc
@@ -181,8 +181,8 @@ ifndef::openshift-origin[]
 |xref:../../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[&#10003;]
 |
 |
-|
-|
+|xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow[&#10003;]
+|xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow[&#10003;]
 |xref:../../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[&#10003;]
 |xref:../../installing/installing_ibm_cloud/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[&#10003;]
 |


### PR DESCRIPTION
Added hyperlink and checkmark to IPI bare metal for the network customizations row of the supported installation methods table.

Fixes: [HCIDOCS-548](https://issues.redhat.com//browse/HCIDOCS-548)

See https://issues.redhat.com/browse/HCIDOCS-548 for additional details.

Preview URL: https://88413--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/installing-preparing.html#supported-installation-methods-for-different-platforms

For release(s): 4.18
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
