### PR TITLE
OSDOCS#12855: Migrating the x86 control plane to arm64 architecture on AWS

### DIFF
--- a/modules/images-imagestream-specify-architecture.adoc
+++ b/modules/images-imagestream-specify-architecture.adoc
@@ -18,8 +18,6 @@ $ oc import-image <multiarch-image-stream-tag> --from=<registry>/<project_name>/
 
 * Run the following command to update your image stream from single-architecture to multi-architecture:
 +
-[source,terminal]
-----
-$ oc import-image <multiarch-image-stream-tag>  --from=<registry>/<project_name>/<image-name> \
---import-mode='PreserveOriginal'
-----
+--
+include::snippets/update-image-stream-to-multi-arch.adoc[]
+--

--- a/modules/migrating-from-x86-to-arm-cp.adoc
+++ b/modules/migrating-from-x86-to-arm-cp.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * updating/updating_a_cluster/migrating-to-multi-payload.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="migrating-from-x86-to-arm64-cp_{context}"]
+= Migrating the x86 control plane to arm64 architecture on {aws-full}
+
+You can migrate the control plane in your cluster from `x86` to `arm64` architecture on {aws-first}.
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+* You logged in to `oc` as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Check the architecture of the control plane nodes by running the following command:
++
+[source,terminal]
+----
+$ oc get nodes -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          STATUS   ROLES                  AGE    VERSION   INTERNAL-IP EXTERNAL-IP   OS-IMAGE                                         KERNEL-VERSION                 CONTAINER-RUNTIME
+worker-001.example.com        Ready    worker                 100d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+worker-002.example.com        Ready    worker                 98d    v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+worker-003.example.com        Ready    worker                 98d    v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+master-001.example.com        Ready    control-plane,master   120d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+master-002.example.com        Ready    control-plane,master   120d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+master-003.example.com        Ready    control-plane,master   120d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+----
++
+The `KERNEL-VERSION` field in the output indicates the architecture of the nodes.
+
+. Check that your cluster uses the multi payload by running the following command:
++
+[source,terminal]
+----
+$ oc adm release info -o jsonpath="{ .metadata.metadata}"
+----
++
+If you see the following output, the cluster is multi-architecture compatible.
++
+[source,terminal]
+----
+{
+ "release.openshift.io/architecture": "multi",
+ "url": "https://access.redhat.com/errata/<errata_version>"
+}
+----
++
+If the cluster is not using the multi payload, migrate the cluster to a multi-architecture cluster. For more information, see "Migrating to a cluster with multi-architecture compute machines". 
+
+. Update your image stream from single-architecture to multi-architecture by running the following command:
++
+--
+include::snippets/update-image-stream-to-multi-arch.adoc[]
+--
+
+. Get the `arm64` compatible Amazon Machine Image (AMI) for configuring the control plane machine set by running the following command:
++
+[source,terminal]
+----
+$ oc get configmap/coreos-bootimages -n openshift-machine-config-operator -o jsonpath='{.data.stream}' | jq -r '.architectures.aarch64.images.aws.regions."<aws_region>".image' <1>
+----
+<1> Replace `<aws_region>` with the {aws-short} region where the current cluster is installed. You can get the {aws-short} region for the installed cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}'
+----
++
+.Example output
+[source,terminal]
+----
+ami-xxxxxxx
+----
+
+. Update the control plane machine set to support the `arm64` architecture by running the following command:
++
+[source,terminal]
+----
+$ oc edit controlplanemachineset.machine.openshift.io cluster -n openshift-machine-api
+----
++
+Update the `instanceType` field to a type that supports the `arm64` architecture, and set the `ami.id` field to an AMI that is compatible with the `arm64` architecture. For information about supported instance types, see "Tested instance types for {aws-short} on 64-bit ARM infrastructures".
++
+For more information about configuring the control plane machine set for {aws-short}, see "Control plane configuration options for {aws-full}".
+
+.Verification
+
+* Verify that the control plane nodes are now running on the `arm64` architecture:
++
+[source,terminal]
+----
+$ oc get nodes -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          STATUS   ROLES                  AGE    VERSION   INTERNAL-IP EXTERNAL-IP   OS-IMAGE                                         KERNEL-VERSION                 CONTAINER-RUNTIME
+worker-001.example.com        Ready    worker                 100d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+worker-002.example.com        Ready    worker                 98d    v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+worker-003.example.com        Ready    worker                 98d    v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+master-001.example.com        Ready    control-plane,master   120d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.aarch64   cri-o://1.30.x
+master-002.example.com        Ready    control-plane,master   120d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.aarch64   cri-o://1.30.x
+master-003.example.com        Ready    control-plane,master   120d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.aarch64   cri-o://1.30.x
+----

--- a/snippets/update-image-stream-to-multi-arch.adoc
+++ b/snippets/update-image-stream-to-multi-arch.adoc
@@ -1,0 +1,11 @@
+// Snippet included in the following assemblies:
+//
+// * updating/updating_a_cluster/migrating-from-x86-to-arm64-cp.adoc
+// * openshift_images/images-imagestream-specify-architecture.adoc
+
+:_mod-docs-content-type: SNIPPET
+[source,terminal]
+----
+$ oc import-image <multiarch_image_stream_tag>  --from=<registry>/<project_name>/<image_name> \
+--import-mode='PreserveOriginal'
+----

--- a/updating/updating_a_cluster/migrating-to-multi-payload.adoc
+++ b/updating/updating_a_cluster/migrating-to-multi-payload.adoc
@@ -37,3 +37,15 @@ include::modules/migrating-to-multi-arch-cli.adoc[leveloffset=+1]
 * xref:../../installing/overview/installing-preparing.adoc#installing-preparing-selecting-cluster-type[Selecting a cluster installation type]
 * xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[About machine health checks]
 * xref:../../updating/updating_a_cluster/updating-cluster-cli.adoc#update-upgrading-oc-adm-upgrade-status_updating-cluster-cli[Gathering cluster update status using oc adm upgrade status (Technology Preview)]
+
+//  Migrating the x86 control plane to the arm64 architecture on AWS
+include::modules/migrating-from-x86-to-arm-cp.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc#cpmso-config-options-aws[Control plane configuration options for {aws-full}]
+
+* xref:../../installing/installing_aws/upi/upi-aws-installation-reqs.adoc#installation-aws-arm-tested-machine-types_upi-aws-installation-reqs[Tested instance types for AWS on 64-bit ARM infrastructures]
+
+* xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-arch-cli_updating-clusters-overview[Migrating to a cluster with multi-architecture compute machines using the CLI]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-12855](https://issues.redhat.com/browse/OSDOCS-12855)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Migrating the x86 control plane to arm64 architecture on AWS](https://88421--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/migrating-to-multi-payload.html#migrating-from-x86-to-arm64-cp_updating-clusters-overview)
- [Specifying architecture for --import-mode](https://88421--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-streams-manage.html#images-imagestream-specify-architecture_image-streams-managing)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->