### PR TITLE
OBSDOCS-1679: Port the Configuring log forwarding chapter

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2932,6 +2932,8 @@ Topics:
     Topics:
     - Name: Release notes
       File: log6x-release-notes-6.2
+    - Name: Configuring log forwarding
+      File: log6x-clf-6.2
   - Name: Logging 6.1
     Dir: logging-6.1
     Topics:

--- a/modules/log6x-collection-setup.adoc
+++ b/modules/log6x-collection-setup.adoc
@@ -92,7 +92,7 @@ rules:                                              <1>
       - logs                                        <7>
     verbs:                                          <8>
       - create                                      <9>
-Annotations
+----
 <1> rules: Specifies the permissions granted by this ClusterRole.
 <2> apiGroups: Refers to the API group loki.grafana.com, which relates to the Loki logging system.
 <3> loki.grafana.com: The API group for managing Loki-related resources.
@@ -102,7 +102,7 @@ Annotations
 <7> logs: Refers to the log resources that can be created.
 <8> verbs: The actions allowed on the resources.
 <9> create: Grants permission to create new logs in the Loki system.
-----
+
 
 === Writing audit logs
 The write-audit-logs-clusterrole.yaml file defines a ClusterRole that grants permissions to create audit logs in the Loki logging system.

--- a/observability/logging/logging-6.0/log6x-clf.adoc
+++ b/observability/logging/logging-6.0/log6x-clf.adoc
@@ -80,7 +80,7 @@ Outputs are configured in an array under `spec.outputs`. Each output must have a
 
 azureMonitor:: Forwards logs to Azure Monitor.
 cloudwatch:: Forwards logs to AWS CloudWatch.
-elasticsearch:: Forwards logs to an external Elasticsearch instance.
+//elasticsearch:: Forwards logs to an external Elasticsearch instance.
 googleCloudLogging:: Forwards logs to Google Cloud Logging.
 http:: Forwards logs to a generic HTTP endpoint.
 kafka:: Forwards logs to a Kafka broker.

--- a/observability/logging/logging-6.2/log6x-clf-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-clf-6.2.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
-[id="log6x-clf-6-1"]
+[id="log6x-clf-6-2"]
 = Configuring log forwarding
-:context: logging-6x-6.1
+:context: logging-6x-6.2
 
 toc::[]
 
@@ -16,7 +16,7 @@ The `ClusterLogForwarder` (CLF) allows users to configure forwarding of logs to 
 
 include::modules/log6x-collection-setup.adoc[leveloffset=+1]
 
-[id="modifying-log-level_6-1_{context}"]
+[id="modifying-log-level_6-2_{context}"]
 == Modifying log level in collector
 
 To modify the log level in the collector, you can set the `observability.openshift.io/log-level` annotation to `trace`, `debug`, `info`, `warn`, `error`, and `off`.
@@ -33,7 +33,7 @@ metadata:
 # ...
 ----
 
-[id="managing-the-operator_6-1_{context}"]
+[id="managing-the-operator_6-2_{context}"]
 == Managing the Operator
 
 The `ClusterLogForwarder` resource has a `managementState` field that controls whether the operator actively manages its resources or leaves them Unmanaged:
@@ -44,7 +44,7 @@ Unmanaged:: The operator will not take any action related to the logging compone
 
 This allows administrators to temporarily pause log forwarding by setting `managementState` to `Unmanaged`.
 
-[id="clf-structure_6-1_{context}"]
+[id="clf-structure_6-2_{context}"]
 == Structure of the ClusterLogForwarder
 
 The CLF has a `spec` section that contains the following key components:
@@ -57,7 +57,7 @@ Pipelines:: Define the path logs take from inputs, through filters, to outputs. 
 
 Filters:: Transform or drop log messages in the pipeline. Users can define filters that match certain log fields and drop or modify the messages. Filters are applied in the order specified in the pipeline.
 
-[id="clf-inputs_6-1_{context}"]
+[id="clf-inputs_6-2_{context}"]
 === Inputs
 
 Inputs are configured in an array under `spec.inputs`. There are three built-in input types:
@@ -74,7 +74,7 @@ audit:: Selects logs from the OpenShift API server audit logs, Kubernetes API se
 
 Users can define custom inputs of type `application` that select logs from specific namespaces or using pod labels.
 
-[id="clf-outputs_6-1_{context}"]
+[id="clf-outputs_6-2_{context}"]
 === Outputs
 
 Outputs are configured in an array under `spec.outputs`. Each output must have a unique name and a type. Supported types are:
@@ -95,7 +95,7 @@ Each output type has its own configuration fields.
 
 include::modules/log6x-configuring-otlp-output.adoc[leveloffset=+1]
 
-[id="clf-pipelines_6-1_{context}"]
+[id="clf-pipelines_6-2_{context}"]
 === Pipelines
 
 Pipelines are configured in an array under `spec.pipelines`. Each pipeline must have a unique name and consists of:
@@ -106,7 +106,7 @@ filterRefs:: (optional) Names of filters to apply.
 
 The order of filterRefs matters, as they are applied sequentially. Earlier filters can drop messages that will not be processed by later filters.
 
-[id="clf-filters_6-1_{context}"]
+[id="clf-filters_6-2_{context}"]
 === Filters
 
 Filters are configured in an array under `spec.filters`. They can match incoming log messages based on the value of structured fields and modify or drop them.


### PR DESCRIPTION
Version(s): 4.18, 4.17. Note that this needs to be cherry-picked to logging-docs-6.2-4.18, logging-docs-6.2-4.17 release branches and not enterprise-4.18, enterprise-4.17 branches.

Issue: https://issues.redhat.com/browse/OBSDOCS-1679

Link to docs preview:
https://88423--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-clf.html
https://88423--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-clf-6.1.html
https://88423--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-clf-6.2.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR only ports exiting and already published content to a newer release. Content enhancement is beyond the scope of the Jira/PR.

Existing published content: https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.1/log6x-clf-6.1.html
Existing file that was copied: https://github.com/openshift/openshift-docs/blob/main/observability/logging/logging-6.1/log6x-clf-6.1.adoc
