### PR TITLE
OBSDOCS-1680: Port the Configuring LokiStack storage chapter

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3001,6 +3001,8 @@ Topics:
       File: log6x-release-notes-6.2
     - Name: Configuring log forwarding
       File: log6x-clf-6.2
+    - Name: Configuring LokiStack storage
+      File: log6x-loki-6.2
     - Name: Visualization for logging
       File: log6x-visual-6.2
   - Name: Logging 6.1

--- a/modules/log6x-enabling-loki-alerts.adoc
+++ b/modules/log6x-enabling-loki-alerts.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // observability/logging/logging-6.0/log6x-loki.adoc
+// observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-enabling-loki-alerts_{context}"]

--- a/modules/log6x-identity-federation.adoc
+++ b/modules/log6x-identity-federation.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // observability/logging/logging-6.0/log6x-loki.adoc
+// observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-identity-federation_{context}"]

--- a/modules/log6x-loki-memberlist-ip.adoc
+++ b/modules/log6x-loki-memberlist-ip.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * logging/cluster-logging-loki.adoc
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-memberlist-ip_{context}"]

--- a/modules/log6x-loki-pod-placement.adoc
+++ b/modules/log6x-loki-pod-placement.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // observability/logging/logging-6.0/log6x-loki.adoc
+// observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-pod-placement_{context}"]

--- a/modules/log6x-loki-rate-limit-errors.adoc
+++ b/modules/log6x-loki-rate-limit-errors.adoc
@@ -2,6 +2,7 @@
 // * logging/cluster-logging-loki.adoc
 // * observability/logging/log_collection_forwarding/log-forwarding.adoc
 // * observability/logging/troubleshooting/log-forwarding-troubleshooting.adoc
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="loki-rate-limit-errors_{context}"]
@@ -45,12 +46,6 @@ The `LokiStack` CR is not available on Grafana-hosted Loki. This topic does not 
 [source,text]
 ----
 2023-08-25T16:08:49.301780Z  WARN sink{component_kind="sink" component_id=default_loki_infra component_type=loki component_name=default_loki_infra}: vector::sinks::util::retries: Retrying after error. error=Server responded with an error: 429 Too Many Requests internal_log_rate_limit=true
-----
-+
-.Example Fluentd error message
-[source,text]
-----
-2023-08-30 14:52:15 +0000 [warn]: [default_loki_infra] failed to flush the buffer. retry_times=2 next_retry_time=2023-08-30 14:52:19 +0000 chunk="604251225bf5378ed1567231a1c03b8b" error_class=Fluent::Plugin::LokiOutput::LogPostError error="429 Too Many Requests Ingestion rate limit exceeded for user infrastructure (limit: 4194304 bytes/sec) while attempting to ingest '4082' lines totaling '7820025' bytes, reduce log volume or contact your Loki administrator to see if the limit can be increased\n"
 ----
 +
 The error is also visible on the receiving end. For example, in the LokiStack ingester pod:

--- a/modules/log6x-loki-rbac-rules-perms.adoc
+++ b/modules/log6x-loki-rbac-rules-perms.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-//
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 
 :_mod-docs-content-type: REFERENCE

--- a/modules/log6x-loki-reliability-hardening.adoc
+++ b/modules/log6x-loki-reliability-hardening.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * logging/cluster-logging-loki.adoc
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-reliability-hardening_{context}"]

--- a/modules/log6x-loki-restart-hardening.adoc
+++ b/modules/log6x-loki-restart-hardening.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * logging/cluster-logging-loki.adoc
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-restart-hardening_{context}"]

--- a/modules/log6x-loki-retention.adoc
+++ b/modules/log6x-loki-retention.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-//
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/log6x-loki-sizing.adoc
+++ b/modules/log6x-loki-sizing.adoc
@@ -1,5 +1,6 @@
 // Module is included in the following assemblies:
 // * observability/logging/logging-6.1/log6x-loki-6.1.adoc
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="log6x-loki-sizing_{context}"]

--- a/modules/log6x-loki-zone-aware-rep.adoc
+++ b/modules/log6x-loki-zone-aware-rep.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * logging/cluster-logging-loki.adoc
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-zone-aware-rep_{context}"]

--- a/modules/log6x-loki-zone-fail-recovery.adoc
+++ b/modules/log6x-loki-zone-fail-recovery.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * logging/cluster-logging-loki.adoc
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-zone-fail-recovery_{context}"]

--- a/observability/logging/logging-6.2/log6x-loki-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-loki-6.2.adoc
@@ -1,0 +1,49 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[leveloffset=+1]
+[id="log6x-loki-6-2"]
+= Storing logs with LokiStack
+:context: log6x-loki-6.2
+
+toc::[]
+
+You can configure a `LokiStack` custom resource (CR) to store application, audit, and infrastructure-related logs.
+
+include::snippets/log6x-loki-statement-snip.adoc[leveloffset=+1]
+
+include::modules/log6x-loki-sizing.adoc[leveloffset=+1]
+
+[id="prerequisites-6-2_{context}"]
+== Prerequisites
+
+* You have installed the {loki-op} by using the command-line interface (CLI) or web console.
+* You have created a `serviceAccount` CR in the same namespace as the `ClusterLogForwarder` CR.
+* You have assigned the `collect-audit-logs`, `collect-application-logs`, and `collect-infrastructure-logs` cluster roles to the `serviceAccount` CR.
+
+[id="setup-6-2_{context}"]
+== Core set up and configuration
+
+Use role-based access controls, basic monitoring, and pod placement to deploy Loki.
+
+include::modules/log6x-loki-rbac-rules-perms.adoc[leveloffset=+1]
+include::modules/log6x-enabling-loki-alerts.adoc[leveloffset=+1]
+include::modules/log6x-loki-memberlist-ip.adoc[leveloffset=+1]
+include::modules/log6x-loki-retention.adoc[leveloffset=+1]
+include::modules/log6x-loki-pod-placement.adoc[leveloffset=+1]
+
+[id="performance-6-2_{context}"]
+== Enhanced reliability and performance
+
+Use the following configurations to ensure reliability and efficiency of Loki in production.
+
+include::modules/log6x-identity-federation.adoc[leveloffset=+1]
+include::modules/log6x-loki-reliability-hardening.adoc[leveloffset=+1]
+include::modules/log6x-loki-restart-hardening.adoc[leveloffset=+1]
+
+[id="advanced-6-2_{context}"]
+== Advanced deployment and scalability
+
+To configure high availability, scalability, and error handling, use the following information.
+
+include::modules/log6x-loki-zone-aware-rep.adoc[leveloffset=+1]
+include::modules/log6x-loki-zone-fail-recovery.adoc[leveloffset=+1]
+include::modules/log6x-loki-rate-limit-errors.adoc[leveloffset=+1]

--- a/snippets/log6x-loki-statement-snip.adoc
+++ b/snippets/log6x-loki-statement-snip.adoc
@@ -1,5 +1,6 @@
 // Text snippet included in the following assemblies:
 // * observability/logging/logging-6.0/log6x-loki.adoc
+// * observability/logging/logging-6.2/log6x-loki-6.2.adoc
 // Text snippet included in the following modules:
 //
 //


### PR DESCRIPTION
Version(s): 4.18, 4.17. Note that this needs to be cherry-picked to logging-docs-6.2-4.18, logging-docs-6.2-4.17 release branches and not enterprise-4.18, enterprise-4.17 branches.

Issue: https://issues.redhat.com/browse/OBSDOCS-1680
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://88436--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-loki.html
- https://88436--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-loki-6.1.html
- https://88436--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-loki-6.2.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR only ports exiting and already published content to a newer release. Content enhancement is beyond the scope of the Jira/PR.

Existing published content: https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.1/log6x-loki-6.1.html
Existing file that was copied: https://github.com/openshift/openshift-docs/blob/main/observability/logging/logging-6.1/log6x-loki-6.1.adoc
