### PR TITLE
TELCODOCS-2168 MetalLB Annotation used by service need to be revised from metallb.universe.tf to metallb.io

### DIFF
--- a/modules/hcp-bm-ingress.adoc
+++ b/modules/hcp-bm-ingress.adoc
@@ -146,7 +146,7 @@ kind: Service
 apiVersion: v1
 metadata:
   annotations:
-    metallb.universe.tf/address-pool: ingress-public-ip
+   metallb.io/address-pool: ingress-public-ip
   name: metallb-ingress
   namespace: openshift-ingress
 spec:

--- a/modules/nw-egress-service-ovn.adoc
+++ b/modules/nw-egress-service-ovn.adoc
@@ -53,7 +53,7 @@ metadata:
   name: example-service
   namespace: example-namespace
   annotations:
-    metallb.universe.tf/address-pool: example-pool <1>
+    metallb.io/address-pool: example-pool <1>
 spec:
   selector:
     app: example

--- a/modules/nw-metallb-addresspool-cr.adoc
+++ b/modules/nw-metallb-addresspool-cr.adoc
@@ -19,7 +19,7 @@ The fields for the `IPAddressPool` custom resource are described in the followin
 |`metadata.name`
 |`string`
 |Specifies the name for the address pool.
-When you add a service, you can specify this pool name in the `metallb.universe.tf/address-pool` annotation to select an IP address from a specific pool.
+When you add a service, you can specify this pool name in the `metallb.io/address-pool` annotation to select an IP address from a specific pool.
 The names `doc-example`, `silver`, and `gold` are used throughout the documentation.
 
 |`metadata.namespace`
@@ -40,7 +40,7 @@ Specify each range in CIDR notation or as starting and ending IP addresses separ
 |`spec.autoAssign`
 |`boolean`
 |Optional: Specifies whether MetalLB automatically assigns IP addresses from this pool.
-Specify `false` if you want explicitly request an IP address from this pool with the `metallb.universe.tf/address-pool` annotation.
+Specify `false` if you want explicitly request an IP address from this pool with the `metallb.io/address-pool` annotation.
 The default value is `true`.
 
 |`spec.avoidBuggyIPs`

--- a/modules/nw-metallb-configure-svc.adoc
+++ b/modules/nw-metallb-configure-svc.adoc
@@ -51,7 +51,7 @@ $ oc describe service <service_name>
 Name:                     <service_name>
 Namespace:                default
 Labels:                   <none>
-Annotations:              metallb.universe.tf/address-pool: doc-example  <1>
+Annotations:              metallb.io/address-pool: doc-example  <1>
 Selector:                 app=service_name
 Type:                     LoadBalancer  <2>
 IP Family Policy:         SingleStack

--- a/networking/metallb/metallb-configure-services.adoc
+++ b/networking/metallb/metallb-configure-services.adoc
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: <service_name>
   annotations:
-    metallb.universe.tf/address-pool: <address_pool_name>
+    metallb.io/address-pool: <address_pool_name>
 spec:
   selector:
     <label_key>: <label_value>
@@ -52,7 +52,7 @@ Events:
 [id="request-ip-address-from-pool_{context}"]
 == Request an IP address from a specific pool
 
-To assign an IP address from a specific range, but you are not concerned with the specific IP address, then you can use the `metallb.universe.tf/address-pool` annotation to request an IP address from the specified address pool.
+To assign an IP address from a specific range, but you are not concerned with the specific IP address, then you can use the `metallb.io/address-pool` annotation to request an IP address from the specified address pool.
 
 .Example service YAML for an IP address from a specific pool
 [source,yaml]
@@ -62,7 +62,7 @@ kind: Service
 metadata:
   name: <service_name>
   annotations:
-    metallb.universe.tf/address-pool: <address_pool_name>
+    metallb.io/address-pool: <address_pool_name>
 spec:
   selector:
     <label_key>: <label_value>
@@ -104,7 +104,7 @@ spec:
 == Share a specific IP address
 
 By default, services do not share IP addresses.
-However, if you need to colocate services on a single IP address, you can enable selective IP sharing by adding the `metallb.universe.tf/allow-shared-ip` annotation to the services.
+However, if you need to colocate services on a single IP address, you can enable selective IP sharing by adding the `metallb.io/allow-shared-ip` annotation to the services.
 
 [source,yaml]
 ----
@@ -113,8 +113,8 @@ kind: Service
 metadata:
   name: service-http
   annotations:
-    metallb.universe.tf/address-pool: doc-example
-    metallb.universe.tf/allow-shared-ip: "web-server-svc"  <1>
+    metallb.io/address-pool: doc-example
+    metallb.io/allow-shared-ip: "web-server-svc"  <1>
 spec:
   ports:
     - name: http
@@ -131,8 +131,8 @@ kind: Service
 metadata:
   name: service-https
   annotations:
-    metallb.universe.tf/address-pool: doc-example
-    metallb.universe.tf/allow-shared-ip: "web-server-svc"
+    metallb.io/address-pool: doc-example
+    metallb.io/allow-shared-ip: "web-server-svc"
 spec:
   ports:
     - name: https
@@ -144,7 +144,7 @@ spec:
   type: LoadBalancer
   loadBalancerIP: 172.31.249.7
 ----
-<1> Specify the same value for the `metallb.universe.tf/allow-shared-ip` annotation. This value is referred to as the _sharing key_.
+<1> Specify the same value for the `metallb.io/allow-shared-ip` annotation. This value is referred to as the _sharing key_.
 <2> Specify different port numbers for the services.
 <3> Specify identical pod selectors if you must specify `externalTrafficPolicy: local` so the services send traffic to the same set of pods. If you use the `cluster` external traffic policy, then the pod selectors do not need to be identical.
 <4> Optional: If you specify the three preceding items, MetalLB might colocate the services on the same IP address. To ensure that services share an IP address, specify the IP address to share.


### PR DESCRIPTION
[TELCODOCS-2168]: MetalLB Annotation used by service need to be revised from "metallb.universe.tf" to "metallb.io"

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2168
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://88442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-bm.html
https://88442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-non-bm.html
https://88442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-address-pools.html
https://88442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-services.html
https://88442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
