### PR TITLE
OBSDOCS-1683: Port the Visualization for logging chapter

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2934,6 +2934,8 @@ Topics:
       File: log6x-release-notes-6.2
     - Name: Configuring log forwarding
       File: log6x-clf-6.2
+    - Name: Visualization for logging
+      File: log6x-visual-6.2
   - Name: Logging 6.1
     Dir: logging-6.1
     Topics:

--- a/observability/logging/logging-6.2/log6x-visual-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-visual-6.2.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="log6x-visual-6-2"]
+= Visualization for logging
+include::_attributes/common-attributes.adoc[]
+:context: logging-6x-6.2
+
+toc::[]
+
+Visualization for logging is provided by deploying the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator], which requires Operator installation.
+
+include::snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc[]


### PR DESCRIPTION
Version(s): 4.18, 4.17, 4.16. Note that this needs to be cherry-picked to logging-docs-6.2-4.18, logging-docs-6.2-4.17, and logging-docs-6.2-4.16 release branches and not enterprise-4.18, enterprise-4.17 branches, and enterprise-4.16 branches.

Issue: https://issues.redhat.com/browse/OBSDOCS-1683

Link to docs preview: https://88447--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-visual-6.2.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Existing published content: https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.1/log6x-visual-6.1.html
Existing file that was copied: https://github.com/openshift/openshift-docs/blob/main/observability/logging/logging-6.1/log6x-visual-6.1.adoc