### PR TITLE
MCO replace TP note in on-clusterlayering docs

### DIFF
--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -21,7 +21,12 @@ You should not need to interact with these new objects or the `machine-os-builde
 
 You need a separate `MachineOSConfig` CR for each machine config pool where you want to use a custom layered image.
 
+:FeatureName: On-cluster image layering
+include::snippets/technology-preview.adoc[]
+
 .Prerequisites
+
+* You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates".
 
 * You have a copy of the global pull secret in the `openshift-machine-config-operator` namespace that the MCO needs in order to pull the base operating system image.
 


### PR DESCRIPTION
Accidentally removed the TP note from the MCO on-cluster layering docs. This PR replaces the note. No QE needed.