### PR TITLE
Removes mentioning of CUDN in 4.17

### DIFF
--- a/networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
+++ b/networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
@@ -17,10 +17,13 @@ User-defined networks provide cluster administrators and users with highly custo
 ====
 * Support for the Localnet topology on both primary and secondary networks will be added in a future version of {product-title}.
 ====
+////
+Unlike NADs, which are only namespaced scope, UDNs offer administrators the ability to create and define additional networks spanning multiple namespaces at the cluster level by leveraging the `ClusterUserDefinedNetwork` custom resource (CR). 
 
-Unlike NADs, which are only namespaced scope, UDNs offer administrators the ability to create and define additional networks spanning multiple namespaces at the cluster level by leveraging the `ClusterUserDefinedNetwork` custom resource (CR). UDNs also offer both administrators and users the ability to define additional networks at the namespace level with the `UserDefinedNetwork` CR. 
+UDNs also offer both administrators and users the ability to define additional networks at the namespace level with the `UserDefinedNetwork` CR. 
+////
 
-The following sections further emphasize the benefits and limitations of user-defined networks, the best practices when creating a `ClusterUserDefinedNetwork` or `UserDefinedNetwork` custom resource, how to create the custom resource, and additional configuration details that might be relevant to your deployment.
+The following sections further emphasize the benefits and limitations of user-defined networks, the best practices when creating a `UserDefinedNetwork` custom resource, how to create the custom resource, and additional configuration details that might be relevant to your deployment.
 
 // Looks like this may be out for 4.17, but in for 4.18 as of 8/19/24
 //. Ingress and egress support


### PR DESCRIPTION
a CP from https://github.com/openshift/openshift-docs/pull/84239/files#diff-3b931ff4d98ce8b85a1482e4b33a95a0ca205fb5868b95611ec0a0073ae7584dR22-R23 erroneously copied content about CUDN CR to 4.17. The CUDN CR is not available in 4.17 at this time. This content needs removed until the feature is backported. 