### PR TITLE
OCPBUGS#49995: Added state:down important notice to No IP address

### DIFF
--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -51,6 +51,11 @@ The following snippet ensures that the interface has no IP address:
 # ...
 ----
 
+[IMPORTANT]
+====
+Always set the `state` parameter to `up` when you set both the `ipv4.enabled` and the `ipv6.enabled` parameter to `false` to disable an interface. If you set `state: down` with this configuration, the interface receives a DHCP IP address because of automatic DHCP assignment. 
+====
+
 [id="virt-example-nmstate-IP-management-dhcp_{context}"]
 == Dynamic host configuration
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-49995](https://issues.redhat.com/browse/OCPBUGS-49995)

Link to docs preview:
[No IP address](https://88490--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-IP-management-no-ip_k8s-nmstate-updating-node-network-config)


- [x] SME has approved this change.
- [x] QE has approved this change.

