### PR TITLE
CNV#55937 4.18: WSFC validation is not working with multipath LUNs

### DIFF
--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -19,6 +19,11 @@ You can set an error policy for each LUN disk. The error policy controls how the
 
 For a LUN disk with an SCSi connection and a persistent reservation, as required for Windows Failover Clustering for shared volumes, you set the error policy to `report`.
 
+[IMPORTANT]
+====
+{VirtProductName} does not currently support SCSI-3 Persistent Reservations (SCSI-3 PR) over multipath storage. As a workaround, disable multipath or ensure the Windows Server Failover Clustering (WSFC) shared disk is setup from a single device and not part of multipath.
+====
+
 .Prerequisites
 
 * You must have cluster administrator privileges to configure the feature gate option.


### PR DESCRIPTION
**Version(s):**
4.15+

**Issue:**
https://issues.redhat.com/browse/CNV-55937

**Link to docs preview:**
https://88492--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virtual_disks/virt-configuring-shared-volumes-for-vms.html

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->