### PR TITLE
OSSM-8860 Update smv2version attribute to 2.6.6

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -19,7 +19,8 @@
 :SMProductShortName: Service Mesh
 :SMProductVersion: 3.0
 //service mesh v2
-:SMv2Version: 2.6.5
+//Update when there is a new 2.6.z release
+:SMv2Version: 2.6.6
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version.
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat


### PR DESCRIPTION
**OSSM 3.0 GA**

**Merge to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

This PR is part of the standalone doc set for the OpenShift Service Mesh project.

Issue:
https://issues.redhat.com/browse/OSSM-8860

Link to docs preview:
No docs preview for updating attribute

QE review:
QE is not required for this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
