### PR TITLE
OADP-5637: Update recommendation for velero loglevel values

### DIFF
--- a/modules/oadp-debugging-oc-cli.adoc
+++ b/modules/oadp-debugging-oc-cli.adoc
@@ -63,4 +63,4 @@ The following `logLevel` values are available:
 * `fatal`
 * `panic`
 
-It is recommended to use `debug` for most logs.
+It is recommended to use the `info` `logLevel` value for most logs.


### PR DESCRIPTION
Version(s):
OCP 4.14-4.18

Issue:
[OADP-5637](https://issues.redhat.com/browse/OADP-5637)

Link to docs preview:
https://88495--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#oadp-debugging-oc-cli_oadp-troubleshooting 

QE review:
- [x] QE has approved this change.


