### PR TITLE
OSDOCS-5775: Azure CAPI TP RNs

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -506,6 +506,13 @@ Updated boot images has been promoted to GA for Amazon Web Services (AWS) cluste
 [id="ocp-release-notes-machine-management_{context}"]
 === Machine management
 
+[id="ocp-4-18-capi-tp-azure_{context}"]
+==== Managing machines with the Cluster API for {azure-full} (Technology Preview)
+
+This release introduces the ability to manage machines by using the upstream Cluster API, integrated into {product-title}, as a Technology Preview for {azure-full} clusters. 
+This capability is in addition or an alternative to managing machines with the Machine API. 
+For more information, see xref:../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[About the Cluster API].
+
 [id="ocp-release-notes-monitoring_{context}"]
 === Monitoring
 
@@ -1346,7 +1353,7 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
-[id="ocp-release-notes-omachine-management-tech-preview_{context}"]
+[id="ocp-release-notes-machine-management-tech-preview_{context}"]
 === Machine management Technology Preview features
 
 .Machine management Technology Preview tracker
@@ -1362,6 +1369,11 @@ In the following tables, features are marked with the following statuses:
 |Managing machines with the Cluster API for {gcp-full}
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|Managing machines with the Cluster API for {azure-full}
+|Not Available
+|Not Available
 |Technology Preview
 
 |Managing machines with the Cluster API for {vmw-full}


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-5775](https://issues.redhat.com//browse/OSDOCS-5775)

Link to docs preview:
* [Managing machines with the Cluster API for Microsoft Azure (Technology Preview)](https://88496--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-capi-tp-azure_release-notes)
* [Machine management Technology Preview features](https://88496--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-machine-management-tech-preview_release-notes)

QE review:
- [x] QE has approved this change.

Additional information:
Note: I noticed when adding this to the TP tracker that all the feature status items are wrong (they were copied from 4.17). I am fixing the rest in https://github.com/openshift/openshift-docs/pull/88500