### PR TITLE
OSDOCS-12248: fix 4.16 feature tables, add 4.18 (cluster infra/CCO)

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -764,12 +764,12 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.16 |4.17 |4.18
 
 |Managing machine with Machine API for {alibaba}
-|Technology Preview
+|Removed
 |Removed
 |Removed
 
 |Cloud controller manager for {alibaba}
-|Technology Preview
+|Removed
 |Removed
 |Removed
 |====
@@ -1376,24 +1376,19 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Managing machines with the Cluster API for {vmw-full}
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Defining a {vmw-short} failure domain for a control plane machine set
-|Technology Preview
+|General Availability
 |General Availability
 |General Availability
 
 |Cloud controller manager for {alibaba}
-|Technology Preview
 |Removed
 |Removed
-
-|Cloud controller manager for {gcp-full}
-|General Availability
-|General Availability
-|General Availability
+|Removed
 
 |Cloud controller manager for {ibm-power-server-name}
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12248](https://issues.redhat.com//browse/OSDOCS-12248)

Link to docs preview:
* [Machine management Technology Preview features](https://88500--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-machine-management-tech-preview_release-notes)
* [Machine management deprecated and removed features](https://88500--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#machine-management-deprecated-and-removed-features)

QE review:
- [x] QE has approved this change.

Additional information:
- Fixes incorrect 4.16 table entries for cluster infra (checked CCO, no issues)
- Adds 4.18 entries
- Duplicates TP table entry from #88496 for full preview