### PR TITLE
OSDOCS-12251:Scalability and performance TP/Dep Tables

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1704,11 +1704,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|HTTP transport replaces AMQP for PTP and bare-metal events
-|Technology Preview
-|General Availability
-|General Availability
-
 |Mount namespace encapsulation
 |Technology Preview
 |Technology Preview
@@ -1719,23 +1714,18 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Tuning etcd latency tolerances
-|Technology Preview
-|General Availability
-|General Availability
-
 |Increasing the etcd database size
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Using {rh-rhacm} `PolicyGenerator` resources to manage {ztp} cluster policies
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Pinned Image Sets
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> Scalability and performance TP/Dep Tables

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): Release Notes, enterprise 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12251
Update the Scalability and performance TP/Dep Tables in the 4.18 release notes
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://88526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

NOTE TO REVIEWERS: This table contains features that belong to three different development groups, therefore I am asking for multiple "qe_approved" from multiple QE folks. The plan is for this table to be split into separate tables in the future when all dev groups are identified. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
