### PR TITLE
OSDOCS-12241: Updated the dep, remove, GA tables for 4.18

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -712,7 +712,7 @@ In the following tables, features are marked with the following statuses:
 
 |Bare Metal Event Relay Operator
 |Deprecated
-|Deprecated
+|Removed
 |Removed
 |====
 
@@ -726,7 +726,7 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.16 |4.17 |4.18
 
 |Cluster Samples Operator
-|General Availability
+|Deprecated
 |Deprecated
 |Deprecated
 |====
@@ -766,30 +766,26 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 
 |Package-based {op-system-base} compute machines
-|General Availability
 |Deprecated
 |Deprecated
+|Deprecated
+
+|Managing machines with the Cluster API for {azure-full}
+|Not Available
+|Not Available
+|Technology Preview
 
 |`platform.aws.preserveBootstrapIgnition` parameter for {aws-first}
-|General Availability
 |Deprecated
 |Deprecated
-
-|Terraform infrastructure provider for {aws-first}, {vmw-first} and Nutanix
-|General Availability
-|Removed
-|Removed
-
-|Installing a cluster on {alibaba} with installer-provisioned infrastructure
-|Technology Preview
-|Removed
-|Removed
+|Deprecated
 
 |Installing a cluster on {aws-short} with compute nodes in {aws-short} Outposts
 |Deprecated
 |Deprecated
 |Deprecated
 |====
+
 
 [discrete]
 === Machine management deprecated and removed features
@@ -808,8 +804,10 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |Removed
 |Removed
+
 |====
 
+////
 [discrete]
 [id="ocp-release-note-monitoring-dep-rem_{context}"]
 === Monitoring deprecated and removed features
@@ -818,17 +816,8 @@ In the following tables, features are marked with the following statuses:
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.16 |4.17 |4.18
-
-|`dedicatedServiceMonitors` setting that enables dedicated service monitors for core platform monitoring
-|Deprecated
-|Removed
-|Removed
-
-|`prometheus-adapter` component that queries resource metrics from Prometheus and exposes them in the metrics API
-|Deprecated
-|Removed
-|Removed
 |====
+////
 
 
 [discrete]
@@ -842,7 +831,7 @@ In the following tables, features are marked with the following statuses:
 
 |OpenShift SDN network plugin
 |Deprecated
-|Deprecated
+|Removed
 |Removed
 
 |iptables
@@ -877,11 +866,12 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 
 |cgroup v1
-|General Availability
+|Deprecated
 |Deprecated
 |Deprecated
 |====
 
+////
 [discrete]
 [id="ocp-release-note-cli-dep-rem_{context}"]
 === OpenShift CLI (oc) deprecated and removed features
@@ -892,6 +882,7 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.16 |4.17 |4.18
 
 |====
+////
 
 [discrete]
 [id="ocp-release-note-operators-dep-rem_{context}"]
@@ -903,44 +894,34 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.16 |4.17 |4.18
 
 |Operator SDK
-|General Availability
+|Deprecated
 |Deprecated
 |Deprecated
 
 |Scaffolding tools for Ansible-based Operator projects
-|General Availability
+|Deprecated
 |Deprecated
 |Deprecated
 
 |Scaffolding tools for Helm-based Operator projects
-|General Availability
+|Deprecated
 |Deprecated
 |Deprecated
 
 |Scaffolding tools for Go-based Operator projects
-|General Availability
+|Deprecated
 |Deprecated
 |Deprecated
 
 |Scaffolding tools for Hybrid Helm-based Operator projects
-|Technology Preview
+|Deprecated
 |Deprecated
 |Deprecated
 
 |Scaffolding tools for Java-based Operator projects
-|Technology Preview
 |Deprecated
 |Deprecated
-
-|Platform Operators
-|Technology Preview
-|Removed
-|Removed
-
-|Plain bundles
-|Technology Preview
-|Removed
-|Removed
+|Deprecated
 
 // Do not remove the SQLite database... entry until otherwise directed by the Operator Framework PM
 |SQLite database format for Operator catalogs
@@ -949,6 +930,7 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |====
 
+////
 [discrete]
 [id="ocp-4-18-hardware-an-driver-dep-rem_{context}"]
 === Specialized hardware and driver enablement deprecated and removed features
@@ -967,11 +949,8 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.16 |4.17 |4.18
 
-|AliCloud Disk CSI Driver Operator
-|General Availability
-|Removed
-|Removed
 |====
+
 
 [discrete]
 [id="ocp-4-18-clusters-dep-rem_{context}"]
@@ -982,6 +961,7 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.16 |4.17 |4.18
 |====
+////
 
 [discrete]
 [id="ocp-release-note-web-console-dep-rem_{context}"]
@@ -1218,13 +1198,13 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.16 |4.17 |4.18
 
 |Accelerated provisioning of {ztp}
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Enabling disk encryption with TPM and PCR protection
 |Not Available
-|Not Available
+|Technology Preview
 |Technology Preview
 
 |====
@@ -1238,32 +1218,27 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.16 |4.17 |4.18
 
-|Hosted control planes for {product-title} on {aws-first}
+|{hcp-capital} for {product-title} using non-bare metal agent machines
 |Technology Preview
 |Technology Preview
 |Technology Preview
 
-|Hosted control planes for {product-title} using non-bare metal agent machines
+|{hcp-capital} for an ARM64 {product-title} cluster on {aws-full}
 |Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
 
-|Hosted control planes for an ARM64 {product-title} cluster on {aws-full}
+|{hcp-capital} for {product-title} on {ibm-power-title}
 |Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
 
-|Hosted control planes for {product-title} on {ibm-power-title}
+|{hcp-capital} for {product-title} on {ibm-z-title}
 |Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
 
-|Hosted control planes for {product-title} on {ibm-z-title}
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|Hosted control planes for {product-title} on {rh-openstack}
+|{hcp-capital} for {product-title} on {rh-openstack}
 |Not Available
 |Not Available
 |Developer Preview
@@ -1279,6 +1254,7 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.16 |4.17 |4.18
 
+// All GA in 4.17 notes for oci-first
 |Installing {product-title} on {oci-first} with VMs
 |Technology Preview
 |Technology Preview
@@ -1296,21 +1272,16 @@ In the following tables, features are marked with the following statuses:
 
 |Enabling NIC partitioning for SR-IOV devices
 |Technology Preview
-|Technology Preview
+|General Availability
 |General Availability
 
 |User-defined labels and tags for {gcp-first}
 |Technology Preview
-|Technology Preview
+|General Availability
 |General Availability
 
-|Installing a cluster on {alibaba} by using installer-provisioned infrastructure
-|Technology Preview
-|Not Available
-|Not Available
-
 |Installing a cluster on Alibaba Cloud by using Assisted Installer
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
@@ -1329,22 +1300,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Static IP addresses with {vmw-first} (IPI only)
-|Technology Preview
-|General Availability
-|General Availability
-
-|Support for iSCSI devices in {op-system}
-|Technology Preview
-|General Availability
-|General Availability
-
 |Installing a cluster on {gcp-short} using the Cluster API implementation
-|Not Available
-|Technology Preview
-|General Availability
-
-|Support for Intel(R) VROC-enabled RAID devices in {op-system}
 |Technology Preview
 |General Availability
 |General Availability
@@ -1406,12 +1362,12 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Managing machines with the Cluster API for {azure-full}
-|Not Available
-|Not Available
+|Managing machines with the Cluster API for {vmw-full}
+|Technology Preview
+|Technology Preview
 |Technology Preview
 
-|Managing machines with the Cluster API for {vmw-full}
+|Cloud controller manager for {ibm-power-server-name}
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -1425,11 +1381,6 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |Removed
 |Removed
-
-|Cloud controller manager for {ibm-power-server-name}
-|Technology Preview
-|Technology Preview
-|Technology Preview
 
 |====
 
@@ -1447,13 +1398,8 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Metrics Server
-|Technology Preview
-|General Availability
-|General Availability
-
 |{ols-official} in the {product-title} web console
-| Not Available
+| Developer Preview
 | Developer Preview
 | Developer Preview
 
@@ -1467,11 +1413,6 @@ In the following tables, features are marked with the following statuses:
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.16 |4.17 |4.18
-
-|{ibm-power-server-name} using installer-provisioned infrastructure
-|General Availability
-|General Availability
-|General Availability
 
 |`kdump` on `arm64` architecture
 |Technology Preview
@@ -1489,7 +1430,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Multiarch Tuning Operator
-|Not available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
@@ -1508,11 +1449,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 |Technology Preview
-
-|Multi-network policies for SR-IOV networks
-|General Availability
-|General Availability
-|General Availability
 
 |Updating the interface-specific safe sysctls list
 |Technology Preview
@@ -1534,49 +1470,24 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Admin Network Policy (`AdminNetworkPolicy`)
-|Technology Preview
-|General Availability
-|General Availability
-
-|IPsec external traffic (north-south)
-|General Availability
-|General Availability
-|General Availability
-
 |Host network settings for SR-IOV VFs
 |Technology Preview
-|Technology Preview
+|General Availability
 |General Availability
 
 |Integration of MetalLB and FRR-K8s
-|Not Available
-|Technology Preview
-|General Availability
-
-|Dual-NIC Intel E810 PTP boundary clock with highly available system clock
-|Not Available
-|General Availability
-|General Availability
-
-|Intel E810 Westport Channel NIC as PTP grandmaster clock
-|Technology Preview
-|General Availability
-|General Availability
-
-|Dual-NIC Intel E810 Westport Channel as PTP grandmaster clock
 |Technology Preview
 |General Availability
 |General Availability
 
 |Automatic leap seconds handling for PTP grandmaster clocks
 |Not Available
-|Not Available
+|General Availability
 |General Availability
 
 |PTP events REST API v2
 |Not Available
-|Not Available
+|General Availability
 |General Availability
 
 |Customized `br-ex` bridge needed by OVN-Kuberenetes to use NMState
@@ -1588,11 +1499,6 @@ In the following tables, features are marked with the following statuses:
 | Not Available
 | General Availability
 | Not Available
-
-| Overlapping IP configuration for multi-tenant networks with Whereabouts
-| Not Available
-| General Availability
-| General Availability
 
 |User defined network segmentation
 |Not Available
@@ -1623,7 +1529,7 @@ In the following tables, features are marked with the following statuses:
 
 |Linux user namespace support
 |Not Available
-|Not Available
+|Technology Preview
 |Technology Preview
 
 |====
@@ -1638,17 +1544,17 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.16 |4.17 |4.18
 
 |oc-mirror plugin v2
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Enclave support
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Delete functionality
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
@@ -1670,21 +1576,16 @@ In the following tables, features are marked with the following statuses:
 
 |RukPak
 |Technology Preview
-|Technology Preview
-|Removed
-
-|Platform Operators
-|Technology Preview
 |Removed
 |Removed
 
 |Scaffolding tools for Hybrid Helm-based Operator projects
-|Technology Preview
+|Deprecated
 |Deprecated
 |Deprecated
 
 |Scaffolding tools for Java-based Operator projects
-|Technology Preview
+|Deprecated
 |Deprecated
 |Deprecated
 
@@ -1699,16 +1600,6 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.16 |4.17 |4.18
 
-|Dual-stack networking with installer-provisioned infrastructure
-|General Availability
-|General Availability
-|General Availability
-
-|Dual-stack networking with user-provisioned infrastructure
-|General Availability
-|General Availability
-|General Availability
-
 |{rh-openstack} integration into the {cluster-capi-operator}
 |Technology Preview
 |Technology Preview
@@ -1716,7 +1607,7 @@ In the following tables, features are marked with the following statuses:
 
 |Control Plane with `rootVolumes` and `etcd` on local disk
 |Technology Preview
-|Technology Preview
+|General Availability
 |General Availability
 
 |====
@@ -1740,11 +1631,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|HTTP transport replaces AMQP for PTP and bare-metal events
-|Technology Preview
-|General Availability
-|General Availability
-
 |Mount namespace encapsulation
 |Technology Preview
 |Technology Preview
@@ -1755,28 +1641,24 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Tuning etcd latency tolerances
-|Technology Preview
-|General Availability
-|General Availability
-
 |Increasing the etcd database size
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Using {rh-rhacm} `PolicyGenerator` resources to manage {ztp} cluster policies
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |Pinned Image Sets
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |====
 
+////
 [discrete]
 [id="ocp-release-notes-special-hardware-tech-preview_{context}"]
 === Specialized hardware and driver enablement Technology Preview features
@@ -1787,6 +1669,7 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.16 |4.17 |4.18
 
 |====
+////
 
 [discrete]
 [id="ocp-release-notes-storage-tech-preview_{context}"]
@@ -1799,7 +1682,7 @@ In the following tables, features are marked with the following statuses:
 
 |AWS EFS storage CSI usage metrics
 |Not Available
-|Not Available
+|General Availability
 |General Availability
 
 |Automatic device discovery and provisioning with Local Storage Operator
@@ -1809,18 +1692,8 @@ In the following tables, features are marked with the following statuses:
 
 |Azure File CSI snapshot support
 |Not Available
-|Not Available
 |Technology Preview
-
-|{ibm-power-server-name} Block CSI Driver Operator
-|General Availability
-|General Availability
-|General Availability
-
-|Read Write Once Pod access mode
 |Technology Preview
-|General Availability
-|General Availability
 
 |Shared Resources CSI Driver in OpenShift Builds
 |Technology Preview
@@ -1833,28 +1706,28 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |CIFS/SMB CSI Driver Operator
-|Not Available
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
 |VMWare vSphere multiple vCenter support
 |Not Available
-|Not Available
+|Technology Preview
 |Technology Preview
 
 |Disabling/enabling storage on vSphere
 |Not Available
-|Not Available
+|Technology Preview
 |Technology Preview
 
 |RWX/RWO SELinux Mount
 |Not Available
-|Not Available
+|Developer Preview
 |Developer Preview
 
 |Migrating CNS Volumes Between Datastores
 |Not Available
-|Not Available
+|Developer Preview
 |Developer Preview
 
 |====


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12241](https://issues.redhat.com/browse/OSDOCS-12241)

Link to docs preview:
[4.18 RNs doc](https://88542--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html)

