### PR TITLE
OCPBUGS-45272: KI for CNI plugin, 4.18 GA, from Telco team. 

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1831,7 +1831,9 @@ In the following tables, features are marked with the following statuses:
 
 * Due to an issue with Kubernetes, the CPU Manager is unable to return CPU resources from the last pod admitted to a node to the pool of available CPU resources. These resources are allocatable if a subsequent pod is admitted to the node. However, this pod then becomes the last pod, and again, the CPU manager cannot return this pod's resources to the available pool.
 +
-This issue affects CPU load balancing features, which depend on the CPU Manager releasing CPUs to the available pool. Consequently, non-guaranteed pods might run with a reduced number of CPUs. As a workaround, schedule a pod with a `best-effort` CPU Manager policy on the affected node. This pod will be the last admitted pod and this ensures the resources will be correctly released to the available pool. (link:https://issues.redhat.com/browse/OCPBUGS-17792[*OCPBUGS-17792*])
+This issue affects CPU load-balancing features, which depend on the CPU Manager releasing CPUs to the available pool. Consequently, non-guaranteed pods might run with a reduced number of CPUs. As a workaround, schedule a pod with a `best-effort` CPU Manager policy on the affected node. This pod will be the last admitted pod and this ensures the resources will be correctly released to the available pool. (link:https://issues.redhat.com/browse/OCPBUGS-46428[*OCPBUGS-46428*])
+
+* When a pod uses the CNI plugin for DHCP address assignment in conjunction with other CNI plugins, the network interface for the pod might be unexpectedly deleted. As a result, when the DHCP lease for the pod expires, the DHCP proxy enters a loop when trying to re-create a new lease, leading to the node becoming unresponsive. There is currently no workaround. (link:https://issues.redhat.com/browse/OCPBUGS-45272[*OCPBUGS-45272*])
 
 [id="ocp-storage-core-4-18-known-issues_{context}"]
 


### PR DESCRIPTION
OCPBUGS-45272: KI for CNI plugin, 4.18 GA, from Telco team. 

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/TELCODOCS-2070

Link to docs preview:
https://88543--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-known-issues_release-notes

Additional info:
Also just corrected the link in a previous KI I added. It now points to the 4.18 version of the bug. 
