### PR TITLE
OSDOCS-11947: adds 4.18.0 release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -34,10 +34,7 @@ This release adds improvements related to the following components and concepts.
 === Updating
 Updating two minor EUS versions in a single step is supported in 4.18. Updates for both single-version minor releases and patch releases are also supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
 
-//TODO add new features and enhancements as needed, L4 [discrete] headings
-
-//[id="microshift-4-18-installation_{context}"]
-//=== Installation
+//TODO add new features and enhancements as needed, follow doc TOC titles as L3s, then add L4 headings for each feature
 
 [id="microshift-4-18-configuring_{context}"]
 === Configuring
@@ -50,18 +47,6 @@ With this release, make configuring your {microshift-short} instances easier by 
 ==== Control ingress for your use case with additional parameters
 With this update, you have greater control over ingress to your {microshift-short} cluster by configuring more parameters. You can use these parameters to define secure connections and the number of connections per pod, plus more. See xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller_microshift-configuring[Using ingress control for a {microshift-short} cluster] for details.
 
-//[id="microshift-4-18-networking_{context}"]
-//=== Networking
-
-//[id="microshift-4-18-nw-feature_{context}"]
-//==== tbd nw feature here
-
-//[id="microshift-4-18-storage_{context}"]
-//=== Storage
-
-//[id="microshift-4-18-storage_{context}"]
-//==== tbd storage feature here
-
 [id="microshift-4-18-running-apps_{context}"]
 === Running applications
 
@@ -72,12 +57,6 @@ With this release, you can delete or upgrade the Kustomize manifest resources. F
 [id="microshift-4-18-greenboot-workload-scripts-by-os_{context}"]
 ==== Greenboot example outputs for image mode for RHEL available
 With this release, you can see detailed explanations and example outputs to check whether greenboot workload scripts are running properly. For more information, see xref:../microshift_running_apps/microshift-greenboot-workload-scripts.adoc#microshift-greenboot-test-workload-health-check-script_microshift-greenboot-workload-scripts[Testing a workload health check script].
-
-//[id="microshift-4-18-run-apps_{context}"]
-//====  tbd run apps feature here
-
-//[id="microshift-4-18-support_{context}"]
-//=== Support
 
 [id="microshift-4-18-backup_and_restore_{context}"]
 === Backup and restore
@@ -119,21 +98,6 @@ With this release, the CSI snapshot webhook feature available in previous releas
 === Installation
 Previously, the greenboot health check marked some healthy Image mode for {op-system-base} systems as unhealthy due to a 300-second timeout, which was insufficient for systems with slow networks. Beginning in {product-title} 4.18, the default greenboot wait timeout has been extended to 600 seconds to provide more time to download images and ensure accurate system checks. (https://issues.redhat.com/browse/OCPBUGS-47463[OCPBUGS-47463])
 
-//[discrete]
-//[id="microshift-4-18-networking-bug-fixes"]
-//=== Networking
-
-//[discrete]
-//[id="microshift-4-18-support-bug-fixes"]
-//=== Support
-
-//check status for next release+
-//[id="microshift-4-18-known-issues_{context}"]
-//== Known issues
-
-//[id="microshift-4-18-pods-writing-files-excess-memory-limits-crash_{context}"]
-//=== tbd known issues
-
 [id="microshift-4-18-additional-release-notes_{context}"]
 == Additional release notes
 Release notes for related components and products are available in the following documentation:
@@ -169,12 +133,11 @@ Red{nbsp}Hat Customer Portal user accounts must have systems registered and cons
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
-//TODO verify info prior to merge
 [id="microshift-4-18-0-dp_{context}"]
-=== RHEA-2025:XXXX - {microshift-short} 4.18.0 bug fix and security update advisory
+=== RHSA-2024:6124 - {microshift-short} 4.18.0 bug fix and security update advisory
 
-Issued: DD Month 2025
+Issued: 25 February 2025
 
-{product-title} release 4.18.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2025:XXXX[RHEA-2025:XXXX] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2025:XXXX[RHEA-2025:XXXX] advisory.
+{product-title} release 4.18.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2024:6124[RHSA-2024:6124] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2024:6122[RHEA-2024:6122] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-11947](https://issues.redhat.com/browse/OSDOCS-11947)

Link to docs preview:
[microshift-4-18-0-dp_release-notes](https://88556--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-0-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
