### PR TITLE
OCPBUGS-31038 Openshift multus docs mention plugin chaining but do no…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1556,6 +1556,8 @@ Topics:
     File: about-virtual-routing-and-forwarding
   - Name: Assigning a secondary network to a VRF
     File: assigning-a-secondary-network-to-a-vrf
+  - Name: Enabling multi-networking for advanced use cases with CNI Plugin chaining
+    File: about-chaining
 - Name: Hardware networks
   Dir: hardware_networks
   Distros: openshift-enterprise,openshift-origin

--- a/modules/cnf-about-cni-chaining.adoc
+++ b/modules/cnf-about-cni-chaining.adoc
@@ -14,5 +14,5 @@ Some scenarios where this might be useful include:
 
 * *Multi-Network topologies*: You may need to attach pods to multiple networks, each with its own traffic policy.
 * *Traffic isolation*: Separate networks for management, storage, and application traffic to ensure each has the appropriate security and QoS settings.
-* *Custom routing rules*: Specific traffic (e.g., SIP traffic) should always use a designated network interface, while other traffic follows the default network.
+* *Custom routing rules*: Specific traffic for example SIP traffic should always use a designated network interface, while other traffic follows the default network.
 * *Enhanced network performance*: Prioritize certain traffic types or manage congestion by directing them through dedicated network interfaces.

--- a/modules/cnf-about-cni-chaining.adoc
+++ b/modules/cnf-about-cni-chaining.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// networking/multiple_networks/about-chaining.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cnf-about-cni-chaining_{context}"]
+= About CNI chaining
+
+Chaining CNI plugins is a powerful feature for advanced networking use cases, enabling Pods to be configured with multiple network interfaces and fine-grained traffic routing policies. This allows for the implementation of complex network topologies, such as multi-network applications in Telco environments that require traffic isolation and prioritized routing.
+
+By using CNI plugin chaining, different types of traffic can be isolated to meet performance, security, and compliance requirements, providing greater flexibility in network design and traffic management.

--- a/modules/cnf-about-cni-chaining.adoc
+++ b/modules/cnf-about-cni-chaining.adoc
@@ -9,3 +9,10 @@
 Chaining CNI plugins is a powerful feature for advanced networking use cases, enabling Pods to be configured with multiple network interfaces and fine-grained traffic routing policies. This allows for the implementation of complex network topologies, such as multi-network applications in Telco environments that require traffic isolation and prioritized routing.
 
 By using CNI plugin chaining, different types of traffic can be isolated to meet performance, security, and compliance requirements, providing greater flexibility in network design and traffic management.
+
+Chaining CNI plugins gives you greater flexibility and control over how network traffic is handled in your {product-title} cluster. Some scenarios where this might be useful include:
+
+* Multi-Network Topologies: You may need to attach pods to multiple networks, each with its own traffic policy.
+* Traffic Isolation: Separate networks for management, storage, and application traffic to ensure each has the appropriate security and QoS settings.
+* Custom Routing Rules: Specific traffic (e.g., SIP traffic) should always use a designated network interface, while other traffic follows the default network.
+* Enhanced Network Performance: Prioritize certain traffic types or manage congestion by directing them through dedicated network interfaces.

--- a/modules/cnf-about-cni-chaining.adoc
+++ b/modules/cnf-about-cni-chaining.adoc
@@ -10,9 +10,9 @@ Chaining CNI plugins is a powerful feature for advanced networking use cases, en
 
 By using CNI plugin chaining, different types of traffic can be isolated to meet performance, security, and compliance requirements, providing greater flexibility in network design and traffic management.
 
-Chaining CNI plugins gives you greater flexibility and control over how network traffic is handled in your {product-title} cluster. Some scenarios where this might be useful include:
+Some scenarios where this might be useful include:
 
-* Multi-Network Topologies: You may need to attach pods to multiple networks, each with its own traffic policy.
-* Traffic Isolation: Separate networks for management, storage, and application traffic to ensure each has the appropriate security and QoS settings.
-* Custom Routing Rules: Specific traffic (e.g., SIP traffic) should always use a designated network interface, while other traffic follows the default network.
-* Enhanced Network Performance: Prioritize certain traffic types or manage congestion by directing them through dedicated network interfaces.
+* *Multi-Network topologies*: You may need to attach pods to multiple networks, each with its own traffic policy.
+* *Traffic isolation*: Separate networks for management, storage, and application traffic to ensure each has the appropriate security and QoS settings.
+* *Custom routing rules*: Specific traffic (e.g., SIP traffic) should always use a designated network interface, while other traffic follows the default network.
+* *Enhanced network performance*: Prioritize certain traffic types or manage congestion by directing them through dedicated network interfaces.

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -230,7 +230,10 @@ $ oc exec -it voip-app-pod -n telco-app -- ip a
        valid_lft forever preferred_lft forever
 ----
 +
-This output show the pod is attached connected to multiple networks, enabling it to interact with different external services or data planes.
+This output show the pod is attached connected to multiple networks, enabling it to interact with different external services or data planes:
+* `eth0`: The default interface for the pod, connected to the cluster network.
+* `eth1`: management-net, IP: 192.168.100.10
+* `eth2`: sip-net, IP: 192.168.200.10
 
 . Run the following command to view the routing table. 
 +

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -58,7 +58,7 @@ spec:
       {
         "type": "macvlan",
         "master": "br-ex",
-	      "vlan": 100,
+        "vlan": 100,
         "mode": "bridge",
         "ipam": {
           "type": "static",

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -57,7 +57,8 @@ spec:
     "plugins": [
       {
         "type": "macvlan",
-        "master": "ens5f0",
+        "master": "br-ex",
+	"vlan": 100,
         "mode": "bridge",
         "ipam": {
           "type": "static",
@@ -72,6 +73,12 @@ spec:
       {
         "type": "route-override",
         "table": 100,
+        "srcRules": [
+          {
+            "from": "192.168.100.10/32",
+            "table": 100
+          }
+        ],
         "routes": [
           { "dst": "0.0.0.0/0", "gw": "192.168.100.1" }
         ]
@@ -105,7 +112,8 @@ spec:
     "plugins": [
       {
         "type": "macvlan",
-        "master": "ens5f1",
+        "master": "br-ex",
+        "vlan": 200,
         "mode": "bridge",
         "ipam": {
           "type": "static",
@@ -120,6 +128,12 @@ spec:
       {
         "type": "route-override",
         "table": 200,
+        "srcRules": [
+          {
+            "from": "192.168.200.10/32",
+            "table": 200
+          }
+        ],
         "routes": [
           { "dst": "0.0.0.0/0", "gw": "192.168.200.1" }
         ]
@@ -144,15 +158,28 @@ kind: Pod
 metadata:
   name: telco-app-pod
   namespace: telco-app
-  k8s.v1.cni.cncf.io/networks: '[
+  labels:
+    app: telco-app
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[
       { "name": "management-net", "interface": "eth1" },
       { "name": "sip-net", "interface": "eth2" }
     ]'
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: app-container
     image: centos/tools
     command: ["sleep", "infinity"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsUser: 1000
+      runAsGroup: 1000
 ----
 
 . Create the pod by running the following command:
@@ -185,14 +212,14 @@ $ oc exec -it telco-app-pod -n telco-app -- ip rule show
 $ oc exec -it telco-app-pod -n telco-app -- ip route show table 200
 ----
 
-. Run the following command to send an HTTP HEAD request to sip-server.example.com from the telco-app-pod, explicitly using the eth2 interface. This helps verify that SIP traffic is correctly routed through the designated network interface:
+. Run the following command to send an HTTP HEAD request to sip-server.example.com from the telco-app-pod, explicitly using the `eth2` interface. This helps verify that SIP traffic is correctly routed through the designated network interface:
 +
 [source,terminal]   
 ----
 $ oc exec -it telco-app-pod -n telco-app -- curl -I --interface eth2 sip-server.example.com
 ----
 
-. Run the following command to send an HTTP HEAD request to example.com from the telco-app-pod, explicitly using the eth1 interface. This helps verify that non-SIP traffic is correctly routed through the management network:
+. Run the following command to send an HTTP HEAD request to example.com from the telco-app-pod, explicitly using the `eth1` interface. This helps verify that non-SIP traffic is correctly routed through the management network:
 +
 [source,terminal]
 ----

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-plugin-chaining-with-multus-cni_{context}"]
-= Configuring plugin chaining with Multus CNI
+= Configuring plugin chaining with the route-override CNI plugin
 
 Plugin chaining allows you to configure multiple CNI plugins to be applied sequentially to the same network interface. This approach is useful when you need to implement complex network configurations, such as routing traffic over different network paths or creating isolated networks for specialized traffic types.
 
 For instance, in a telco environment, you might have the following requirements:
 
-* SIP traffic (Voice over IP) must always be routed over a dedicated SIP network for optimized performance.
+* Session Initiation Protocol (SIP) traffic for instance voice over IP must always be routed over a dedicated SIP network for optimized performance.
 * Management traffic must go over a separate management network for administrative purposes.
 
 Consider a telco application where SIP (telephony) traffic must be isolated from other types of traffic for example management or data traffic. This requires two networks:
@@ -23,7 +23,7 @@ In this case, you can configure a pod with two interfaces:
 * `eth1` for management traffic, routed through the management network.
 * `eth2` for SIP traffic, routed through the SIP network.
 
-Following this example you can use plugin chaining with the `route-override` CNI, to attach both interfaces to the pod and use source-based routing to ensure SIP traffic is only routed through `eth2` while all other traffic flows over `eth1`.
+This example uses plugin chaining with the `route-override` CNI, to attach both interfaces ensuring SIP traffic is only routed through `eth2` while management traffic flows is routed through `eth1`.
 
 .Prerequisites
 
@@ -39,7 +39,7 @@ Following this example you can use plugin chaining with the `route-override` CNI
 $ oc create namespace telco-app
 ----
 
-. Create NetworkAttachmentDefinition for Management Network
+. Create the NetworkAttachmentDefinition for the management network
 
 .. Create a YAML file, such as `management.yaml`, to define a NetworkAttachmentDefinition (NAD) that configures a new interface, `eth1`, with the following configuration:
 +
@@ -58,7 +58,7 @@ spec:
       {
         "type": "macvlan",
         "master": "br-ex",
-	"vlan": 100,
+	      "vlan": 100,
         "mode": "bridge",
         "ipam": {
           "type": "static",
@@ -94,7 +94,7 @@ spec:
 $ oc apply -f management.yaml
 ----
 
-. Create NetworkAttachmentDefinition for SIP Network.
+. Create the NetworkAttachmentDefinition for the SIP Network.
 
 .. Create a YAML file, such as `sip.yaml`, to define a NetworkAttachmentDefinition (NAD) that configures a new interface, `eth2`, with the following configuration:
 +
@@ -156,10 +156,10 @@ $ oc apply -f sip.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: telco-app-pod
+  name: voip-app-pod
   namespace: telco-app
   labels:
-    app: telco-app
+    app: voip-app
   annotations:
     k8s.v1.cni.cncf.io/networks: '[
       { "name": "management-net", "interface": "eth1" },
@@ -171,9 +171,12 @@ spec:
     seccompProfile:
       type: RuntimeDefault
   containers:
-  - name: app-container
-    image: centos/tools
-    command: ["sleep", "infinity"]
+  - name: voip-container
+    image: dougbtv/asterisk:latest    # This can be any VOIP application like Asterisk or FreeSWITCH
+    command: ["/bin/bash", "-c", "asterisk -f"]  # Asterisk command to start the server
+    ports:
+      - containerPort: 5060          # SIP traffic port (UDP)
+      - containerPort: 8088          # Management port (HTTP)
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -191,49 +194,42 @@ $ oc apply -f pod.yaml
 
 .Verification
 
-. Run the following command to list all network interfaces and their assigned IP addresses inside the `telco-app-pod`. This verifies that the pod has multiple network interfaces configured as expected:
+. Run the following command to list all network interfaces and their assigned IP addresses inside the `voip-app-pod`. This verifies that the pod has multiple network interfaces configured as expected:
 +
 [source,terminal]
 ----
-$ oc exec -it telco-app-pod -n telco-app -- ip a
-----
-
-. Run the following command to inspect the IP routing rules inside the `telco-app-pod`. This displays the source-based routing rules applied within the pod to ensure SIP traffic is routed through `eth2`:
-+
-[source,terminal]
-----
-$ oc exec -it telco-app-pod -n telco-app -- ip rule show
+$ oc exec -it voip-app-pod -n telco-app -- ip a
 ----
 +
 .Example output
 [source,terminal]
 ----
-1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
     inet 127.0.0.1/8 scope host lo
        valid_lft forever preferred_lft forever
     inet6 ::1/128 scope host 
        valid_lft forever preferred_lft forever
-2: eth0@if21: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP group default 
-    link/ether 0a:58:0a:83:00:11 brd ff:ff:ff:ff:ff:ff link-netnsid 0
-    inet 10.131.0.17/23 brd 10.131.1.255 scope global eth0
+2: eth0@if31: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP 
+    link/ether 0a:58:0a:83:02:19 brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 10.131.2.25/23 brd 10.131.3.255 scope global eth0
        valid_lft forever preferred_lft forever
-    inet6 fe80::858:aff:fe83:11/64 scope link 
+    inet6 fe80::858:aff:fe83:219/64 scope link 
        valid_lft forever preferred_lft forever
-3: eth1@if5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc noqueue state UP group default qlen 1000
-    link/ether 86:6b:14:37:cb:24 brd ff:ff:ff:ff:ff:ff link-netnsid 0
+3: eth1@if5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc noqueue state UP qlen 1000
+    link/ether aa:25:73:ff:a7:00 brd ff:ff:ff:ff:ff:ff link-netnsid 0
     inet 192.168.100.10/24 brd 192.168.100.255 scope global eth1
        valid_lft forever preferred_lft forever
-    inet6 fe80::846b:14ff:fe37:cb24/64 scope link 
+    inet6 fe80::a825:73ff:feff:a700/64 scope link 
        valid_lft forever preferred_lft forever
-4: eth2@if5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc noqueue state UP group default qlen 1000
-    link/ether da:a7:46:a2:0b:cd brd ff:ff:ff:ff:ff:ff link-netnsid 0
+4: eth2@if5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc noqueue state UP qlen 1000
+    link/ether aa:a4:6c:4e:e8:97 brd ff:ff:ff:ff:ff:ff link-netnsid 0
     inet 192.168.200.10/24 brd 192.168.200.255 scope global eth2
        valid_lft forever preferred_lft forever
-    inet6 fe80::d8a7:46ff:fea2:bcd/64 scope link 
+    inet6 fe80::a8a4:6cff:fe4e:e897/64 scope link 
        valid_lft forever preferred_lft forever
 ----
-
++
 This output show the pod is attached connected to multiple networks, enabling it to interact with different external services or data planes.
 
 . Run the following command to view the routing table. 
@@ -255,11 +251,11 @@ default via 10.131.0.1 dev eth0
 192.168.100.0/24 dev eth1 proto kernel scope link src 192.168.100.10 
 192.168.200.0/24 dev eth2 proto kernel scope link src 192.168.200.10
 ----
-
++
 This output shows the routing table inside the pod, which includes the default route and routes for the management and SIP networks. 
 
 * SIP Network Traffic (eth2)
-** The pod has an interface `eth2` with an IP address `192.168.200.10` on the `192.168.200.0/24` network. Traffic destined for the `192.168.200.0/24` network will be routed through `eth2`, as expected for the SIP traffic.
+** The pod has an interface `eth2` with an IP address `192.168.200.10` on the `192.168.200.0/24` network. Traffic destined for the `192.168.200.0/24` network is routed through `eth2`, as expected for the SIP traffic.
 
 * Management Network Traffic (eth1)
-** The pod has an interface `eth1` with an IP address `192.168.100.10` on the `192.168.100.0/24` network. Traffic destined for 192.168.100.0/24 (management traffic) will be routed through eth1, which meets the requirement for handling administrative traffic.
+** The pod has an interface `eth1` with an IP address `192.168.100.10` on the `192.168.100.0/24` network. Traffic destined for `192.168.100.0/24` (management traffic) is routed through `eth1`, which meets the requirement for handling administrative traffic.

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -32,93 +32,107 @@ Following this example you can use plugin chaining with Multus CNI, to attach bo
 
 .Procedure
 
-. Create the `telco-app`` namespace by running the following command:
+. Create the `telco-app` namespace by running the following command:
 +
 [source,terminal]
 ----
 $ oc create namespace telco-app
 ----
 
-. Create a YAML file, such as `chained.yaml`, to define a chained NetworkAttachmentDefinition (NAD) that configures two additional interfaces, `eth1` and `eth2`, with the following configuration:
+. Create NetworkAttachmentDefinition for Management Network
+
+.. Create a YAML file, such as `management.yaml`, to define a NetworkAttachmentDefinition (NAD) that configures a new interface, `eth1`, with the following configuration:
 +
 [source,yaml]
 ----
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
-  name: chained-net
+  name: management-net
   namespace: telco-app
 spec:
   config: '{
-    "cniVersion": "0.4.0",
-    "name": "chained-net",
+    "cniVersion": "1.0.0",
+    "name": "management-net",
     "plugins": [
       {
-        "type": "macvlan", <1>
-        "capabilities": { "ips": true },
-        "master": "eth1", <2>
+        "type": "macvlan",
+        "master": "ens5f0",
         "mode": "bridge",
         "ipam": {
           "type": "static",
           "addresses": [
             {
-              "address": "192.168.100.10/24", <3>
-              "gateway": "192.168.100.1" <4>
+              "address": "192.168.100.10/24",
+              "gateway": "192.168.100.1"
             }
           ]
         }
       },
       {
-        "type": "macvlan",<5>
-        "capabilities": { "ips": true },
-        "master": "eth2", <6>
-        "mode": "bridge",
-        "ipam": {
-          "type": "static",
-          "addresses": [
-            {
-              "address": "10.0.0.10/24", <7>
-              "gateway": "10.0.0.1" <8>
-            }
-          ]
-        }
-      },
-      {
-        "type": "route-override", <9>
+        "type": "route-override",
         "table": 100,
         "routes": [
           { "dst": "0.0.0.0/0", "gw": "192.168.100.1" }
-        ]
-      },
-      {
-        "type": "static",
-        "routes": [
-          { "dst": "192.168.100.0/24", "gw": "192.168.100.1" },
-          { "dst": "10.0.0.0/24", "gw": "10.0.0.1", "table": 200 }
-        ],
-        "rules": [
-          { "priority": 100, "src": "10.0.0.10/32", "table": 200 } <8>
         ]
       }
     ]
   }'
 ----
+
+. Create a chained NAD by running the following command:
 +
-<1> The first plugin is a `macvlan` plugin that creates a new interface for example the management interface `eth1` with a static IP address.
-<2> The `master` field specifies the parent interface to attach the new interface to.
-<3> Pods will be assigned an IP from the 192.168.100.0/24 range.
-<4> The `gateway` field specifies the gateway IP address for the new interface.
-<5> The second plugin is a `macvlan` plugin that creates a new interface for example the SIP interface `eth2` with a static IP address.
-<6> The `master` field specifies the parent interface to attach the new interface to.
-<7> Pods will be assigned an IP from the 10.0.0.0/24 range.
-<8> The `gateway` field specifies the gateway IP address for the new interface.
-<9> The third plugin is a `route-override` plugin that sets the default route for the pod to use the `eth1` interface. The `route-override` plugin ensures non-SIP traffic is routed via the management network.
+[source,terminal]
+----
+$ oc apply -f management.yaml
+----
+
+. Create NetworkAttachmentDefinition for SIP Network.
+
+.. Create a YAML file, such as `sip.yaml`, to define a NetworkAttachmentDefinition (NAD) that configures a new interface, `eth2`, with the following configuration:
++
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sip-net
+  namespace: telco-app
+spec:
+  config: '{
+    "cniVersion": "1.0.0",
+    "name": "sip-net",
+    "plugins": [
+      {
+        "type": "macvlan",
+        "master": "ens5f1",
+        "mode": "bridge",
+        "ipam": {
+          "type": "static",
+          "addresses": [
+            {
+              "address": "192.168.200.10/24",
+              "gateway": "192.168.200.1"
+            }
+          ]
+        }
+      },
+      {
+        "type": "route-override",
+        "table": 200,
+        "routes": [
+          { "dst": "0.0.0.0/0", "gw": "192.168.200.1" }
+        ]
+      }
+    ]
+  }'
+----
 
 . Create the chained NAD by running the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f chained.yaml
+$ oc apply -f sip.yaml
 ----
 
 .  Attach the NAD to a pod by creating a Pod definition file, such as `pod.yaml`, with the following configuration:
@@ -130,8 +144,10 @@ kind: Pod
 metadata:
   name: telco-app-pod
   namespace: telco-app
-  annotations:
-    k8s.v1.cni.cncf.io/networks: '[{ "name": "chained-net" }]'
+  k8s.v1.cni.cncf.io/networks: '[
+      { "name": "management-net", "interface": "eth1" },
+      { "name": "sip-net", "interface": "eth2" }
+    ]'
 spec:
   containers:
   - name: app-container

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -23,7 +23,7 @@ In this case, you can configure a pod with two interfaces:
 * `eth1` for management traffic, routed through the management network.
 * `eth2` for SIP traffic, routed through the SIP network.
 
-Following this example you can use plugin chaining with Multus CNI, to attach both interfaces to the pod and use source-based routing to ensure SIP traffic is only routed through `eth2` while all other traffic flows over `eth1`.
+Following this example you can use plugin chaining with the `route-override` CNI, to attach both interfaces to the pod and use source-based routing to ensure SIP traffic is only routed through `eth2` while all other traffic flows over `eth1`.
 
 .Prerequisites
 
@@ -149,7 +149,7 @@ spec:
 $ oc apply -f sip.yaml
 ----
 
-.  Attach the NAD to a pod by creating a Pod definition file, such as `pod.yaml`, with the following configuration:
+.  Attach the NADs to a pod by creating a Pod definition file, such as `pod.yaml`, with the following configuration:
 +
 [source,yaml]
 ----
@@ -204,26 +204,62 @@ $ oc exec -it telco-app-pod -n telco-app -- ip a
 ----
 $ oc exec -it telco-app-pod -n telco-app -- ip rule show
 ----
++
+.Example output
+[source,terminal]
+----
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host 
+       valid_lft forever preferred_lft forever
+2: eth0@if21: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP group default 
+    link/ether 0a:58:0a:83:00:11 brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 10.131.0.17/23 brd 10.131.1.255 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::858:aff:fe83:11/64 scope link 
+       valid_lft forever preferred_lft forever
+3: eth1@if5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc noqueue state UP group default qlen 1000
+    link/ether 86:6b:14:37:cb:24 brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 192.168.100.10/24 brd 192.168.100.255 scope global eth1
+       valid_lft forever preferred_lft forever
+    inet6 fe80::846b:14ff:fe37:cb24/64 scope link 
+       valid_lft forever preferred_lft forever
+4: eth2@if5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc noqueue state UP group default qlen 1000
+    link/ether da:a7:46:a2:0b:cd brd ff:ff:ff:ff:ff:ff link-netnsid 0
+    inet 192.168.200.10/24 brd 192.168.200.255 scope global eth2
+       valid_lft forever preferred_lft forever
+    inet6 fe80::d8a7:46ff:fea2:bcd/64 scope link 
+       valid_lft forever preferred_lft forever
+----
 
-. Run the following command to view the routing table (Table 200) inside the `telco-app-pod`. This verifies that traffic destined for the SIP network is correctly routed according to the source-based routing rules:
+This output show the pod is attached connected to multiple networks, enabling it to interact with different external services or data planes.
+
+. Run the following command to view the routing table. 
 +
 [source,terminal]
 ----
-$ oc exec -it telco-app-pod -n telco-app -- ip route show table 200
+$ oc exec -it telco-app-pod -n telco-app -- ip route
 ----
-
-. Run the following command to send an HTTP HEAD request to sip-server.example.com from the telco-app-pod, explicitly using the `eth2` interface. This helps verify that SIP traffic is correctly routed through the designated network interface:
 +
-[source,terminal]   
-----
-$ oc exec -it telco-app-pod -n telco-app -- curl -I --interface eth2 sip-server.example.com
-----
-
-. Run the following command to send an HTTP HEAD request to example.com from the telco-app-pod, explicitly using the `eth1` interface. This helps verify that non-SIP traffic is correctly routed through the management network:
-+
+.Example output
 [source,terminal]
 ----
-$ oc exec -it telco-app-pod -n telco-app -- curl -I --interface eth1 example.com
+default via 10.131.0.1 dev eth0 
+10.128.0.0/14 via 10.131.0.1 dev eth0 
+10.131.0.0/23 dev eth0 proto kernel scope link src 10.131.0.17 
+100.64.0.0/16 via 10.131.0.1 dev eth0 
+169.254.0.5 via 10.131.0.1 dev eth0 
+172.30.0.0/16 via 10.131.0.1 dev eth0 
+192.168.100.0/24 dev eth1 proto kernel scope link src 192.168.100.10 
+192.168.200.0/24 dev eth2 proto kernel scope link src 192.168.200.10
 ----
 
-The first command should return a response from the SIP server, while the second command should return a response from the default server.
+This output shows the routing table inside the pod, which includes the default route and routes for the management and SIP networks. 
+
+* SIP Network Traffic (eth2)
+** The pod has an interface `eth2` with an IP address `192.168.200.10` on the `192.168.200.0/24` network. Traffic destined for the `192.168.200.0/24` network will be routed through `eth2`, as expected for the SIP traffic.
+
+* Management Network Traffic (eth1)
+** The pod has an interface `eth1` with an IP address `192.168.100.10` on the `192.168.100.0/24` network. Traffic destined for 192.168.100.0/24 (management traffic) will be routed through eth1, which meets the requirement for handling administrative traffic.

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -1,0 +1,197 @@
+// Module included in the following assemblies:
+//
+// networking/multiple_networks/about-chaining.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-plugin-chaining-with-multus-cni_{context}"]
+= Configuring plugin chaining with Multus CNI
+
+Plugin chaining allows you to configure multiple CNI plugins to be applied sequentially to the same network interface. This approach is useful when you need to implement complex network configurations, such as routing traffic over different network paths or creating isolated networks for specialized traffic types.
+
+For instance, in a telco environment, you may have the following requirements:
+
+* SIP traffic (Voice over IP) must always be routed over a dedicated SIP network for optimized performance.
+* Management traffic must go over a separate management network for administrative purposes.
+
+Consider a telco application where SIP (telephony) traffic must be isolated from other types of traffic for example management or data traffic. This requires two networks:
+
+* SIP Network: Handles all telephony traffic to ensure quality of service (QoS) and low latency.
+* Management Network: Handles administrative traffic such as monitoring and configuration.
+
+In this case, you can configure a pod with two interfaces:
+
+* `eth1` for management traffic, routed through the management network.
+* `eth2` for SIP traffic, routed through the SIP network.
+
+Following this example you can use plugin chaining with Multus CNI, to attach both interfaces to the pod and use source-based routing to ensure SIP traffic is only routed through `eth2` while all other traffic flows over eth1.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* An account with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a YAML file, such as `chained.yaml`, to define a chained NetworkAttachmentDefinition (NAD) that configures two additional interfaces, `eth1` and `eth2`, with the following configuration:
++
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: chained-net
+  namespace: telco-app
+spec:
+  config: '{
+    "cniVersion": "0.4.0",
+    "name": "chained-net",
+    "plugins": [
+      {
+        "type": "macvlan", <1>
+        "capabilities": { "ips": true },
+        "master": "eth1", <2>
+        "mode": "bridge",
+        "ipam": {
+          "type": "static",
+          "addresses": [
+            {
+              "address": "192.168.100.10/24", <3>
+              "gateway": "192.168.100.1" <4>
+            }
+          ]
+        }
+      },
+      {
+        "type": "macvlan",<5>
+        "capabilities": { "ips": true },
+        "master": "eth2", <6>
+        "mode": "bridge",
+        "ipam": {
+          "type": "static",
+          "addresses": [
+            {
+              "address": "10.0.0.10/24", <7>
+              "gateway": "10.0.0.1" <8>
+            }
+          ]
+        }
+      },
+      {
+        "type": "route-override", <9>
+        "table": 100,
+        "routes": [
+          { "dst": "0.0.0.0/0", "gw": "192.168.100.1" }
+        ]
+      },
+      {
+        "type": "static",
+        "routes": [
+          { "dst": "192.168.100.0/24", "gw": "192.168.100.1" },
+          { "dst": "10.0.0.0/24", "gw": "10.0.0.1", "table": 200 }
+        ],
+        "rules": [
+          { "priority": 100, "src": "10.0.0.10/32", "table": 200 } <8>
+        ]
+      }
+    ]
+  }'
+----
+
+<1> The first plugin is a `macvlan` plugin that creates a new interface for example the management interface `eth1` with a static IP address.
+<2> The `master` field specifies the parent interface to attach the new interface to.
+<3> Pods will be assigned an IP from the 192.168.100.0/24 range.
+<4> The `gateway` field specifies the gateway IP address for the new interface.
+<5> The second plugin is a `macvlan` plugin that creates a new interface for example the SIP interface `eth2` with a static IP address.
+<6> The `master` field specifies the parent interface to attach the new interface to.
+<7> Pods will be assigned an IP from the 10.0.0.0/24 range.
+<8> The `gateway` field specifies the gateway IP address for the new interface.
+<9> The third plugin is a `route-override` plugin that sets the default route for the pod to use the `eth1` interface. The `route-override` plugin ensures non-SIP traffic is routed via the management network.
+
+.  Attach the NAD to a pod by creating a Pod definition file, such as `pod.yaml`, with the following configuration:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: telco-app-pod
+  namespace: telco-app
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[{ "name": "chained-net" }]'
+spec:
+  containers:
+  - name: app-container
+    image: centos/tools
+    command: ["sleep", "infinity"]
+----
+
+.Verification
+
+* Check that the Operator is installed by entering the following command:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-sriov-network-operator \
+  -o custom-columns=Name:.metadata.name,Phase:.status.phase
+----
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+Name                                         Phase
+sriov-network-operator.{product-version}.0-202406131906   Succeeded
+----
+
+[id="install-operator-web-console_{context}"]
+== Web console: Installing the SR-IOV Network Operator
+
+As a cluster administrator, you can install the Operator using the web console.
+
+.Prerequisites
+
+* A cluster installed on bare-metal hardware with nodes that have hardware that supports SR-IOV.
+* Install the OpenShift CLI (`oc`).
+* An account with `cluster-admin` privileges.
+
+.Procedure
+
+
+. Install the SR-IOV Network Operator:
+
+.. In the {product-title} web console, click *Operators* -> *OperatorHub*.
+
+.. Select *SR-IOV Network Operator* from the list of available Operators, and then click *Install*.
+
+.. On the *Install Operator* page, under *Installed Namespace*, select *Operator recommended Namespace*.
+
+.. Click *Install*.
+
+. Verify that the SR-IOV Network Operator is installed successfully:
+
+.. Navigate to the *Operators* -> *Installed Operators* page.
+
+.. Ensure that *SR-IOV Network Operator* is listed in the *openshift-sriov-network-operator* project with a *Status* of *InstallSucceeded*.
++
+[NOTE]
+====
+During installation an Operator might display a *Failed* status.
+If the installation later succeeds with an *InstallSucceeded* message, you can ignore the *Failed* message.
+====
+
++
+If the Operator does not appear as installed, to troubleshoot further:
+
++
+* Inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors under *Status*.
+* Navigate to the *Workloads* -> *Pods* page and check the logs for pods in the `openshift-sriov-network-operator` project.
+* Check the namespace of the YAML file. If the annotation is missing, you can add the annotation `workload.openshift.io/allowed=management` to the Operator namespace with the following command:
++
+[source,terminal]
+----
+$ oc annotate ns/openshift-sriov-network-operator workload.openshift.io/allowed=management
+----
++
+[NOTE]
+====
+For {sno} clusters, the annotation `workload.openshift.io/allowed=management` is required for the namespace.
+====

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -96,7 +96,7 @@ spec:
     ]
   }'
 ----
-
++
 <1> The first plugin is a `macvlan` plugin that creates a new interface for example the management interface `eth1` with a static IP address.
 <2> The `master` field specifies the parent interface to attach the new interface to.
 <3> Pods will be assigned an IP from the 192.168.100.0/24 range.
@@ -127,71 +127,39 @@ spec:
 
 .Verification
 
-* Check that the Operator is installed by entering the following command:
+. Run the following command to list all network interfaces and their assigned IP addresses inside the `telco-app-pod`. This will help verify that the pod has multiple network interfaces configured as expected:
 +
 [source,terminal]
 ----
-$ oc get csv -n openshift-sriov-network-operator \
-  -o custom-columns=Name:.metadata.name,Phase:.status.phase
-----
-+
-.Example output
-[source,terminal,subs="attributes+"]
-----
-Name                                         Phase
-sriov-network-operator.{product-version}.0-202406131906   Succeeded
+$ oc exec -it telco-app-pod -n telco-app -- ip a
 ----
 
-[id="install-operator-web-console_{context}"]
-== Web console: Installing the SR-IOV Network Operator
-
-As a cluster administrator, you can install the Operator using the web console.
-
-.Prerequisites
-
-* A cluster installed on bare-metal hardware with nodes that have hardware that supports SR-IOV.
-* Install the OpenShift CLI (`oc`).
-* An account with `cluster-admin` privileges.
-
-.Procedure
-
-
-. Install the SR-IOV Network Operator:
-
-.. In the {product-title} web console, click *Operators* -> *OperatorHub*.
-
-.. Select *SR-IOV Network Operator* from the list of available Operators, and then click *Install*.
-
-.. On the *Install Operator* page, under *Installed Namespace*, select *Operator recommended Namespace*.
-
-.. Click *Install*.
-
-. Verify that the SR-IOV Network Operator is installed successfully:
-
-.. Navigate to the *Operators* -> *Installed Operators* page.
-
-.. Ensure that *SR-IOV Network Operator* is listed in the *openshift-sriov-network-operator* project with a *Status* of *InstallSucceeded*.
-+
-[NOTE]
-====
-During installation an Operator might display a *Failed* status.
-If the installation later succeeds with an *InstallSucceeded* message, you can ignore the *Failed* message.
-====
-
-+
-If the Operator does not appear as installed, to troubleshoot further:
-
-+
-* Inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors under *Status*.
-* Navigate to the *Workloads* -> *Pods* page and check the logs for pods in the `openshift-sriov-network-operator` project.
-* Check the namespace of the YAML file. If the annotation is missing, you can add the annotation `workload.openshift.io/allowed=management` to the Operator namespace with the following command:
+. Run the following command to inspect the IP routing rules inside the `telco-app-pod`. This will display the source-based routing rules applied within the pod to ensure SIP traffic is routed through `eth2`:
 +
 [source,terminal]
 ----
-$ oc annotate ns/openshift-sriov-network-operator workload.openshift.io/allowed=management
+$ oc exec -it telco-app-pod -n telco-app -- ip rule show
 ----
+
+. Run the following command to view the routing table (Table 200) inside the `telco-app-pod`. This will help verify that traffic destined for the SIP network is correctly routed according to the source-based routing rules:
 +
-[NOTE]
-====
-For {sno} clusters, the annotation `workload.openshift.io/allowed=management` is required for the namespace.
-====
+[source,terminal]
+----
+$ oc exec -it telco-app-pod -n telco-app -- ip route show table 200
+----
+
+. Run the following command to send an HTTP HEAD request to sip-server.example.com from the telco-app-pod, explicitly using the eth2 interface. This helps verify that SIP traffic is correctly routed through the designated network interface:
++
+[source,terminal]   
+----
+$ oc exec -it telco-app-pod -n telco-app -- curl -I --interface eth2 sip-server.example.com
+----
+
+. Run the following command to send an HTTP HEAD request to example.com from the telco-app-pod, explicitly using the eth1 interface. This helps verify that non-SIP traffic is correctly routed through the management network:
++
+[source,terminal]
+----
+$ oc exec -it telco-app-pod -n telco-app -- curl -I --interface eth1 example.com
+----
+
+The first command should return a response from the SIP server, while the second command should return a response from the default server.

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -32,6 +32,13 @@ Following this example you can use plugin chaining with Multus CNI, to attach bo
 
 .Procedure
 
+. Create the `telco-app`` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace telco-app
+----
+
 . Create a YAML file, such as `chained.yaml`, to define a chained NetworkAttachmentDefinition (NAD) that configures two additional interfaces, `eth1` and `eth2`, with the following configuration:
 +
 [source,yaml]
@@ -107,6 +114,13 @@ spec:
 <8> The `gateway` field specifies the gateway IP address for the new interface.
 <9> The third plugin is a `route-override` plugin that sets the default route for the pod to use the `eth1` interface. The `route-override` plugin ensures non-SIP traffic is routed via the management network.
 
+. Create the chained NAD by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f chained.yaml
+----
+
 .  Attach the NAD to a pod by creating a Pod definition file, such as `pod.yaml`, with the following configuration:
 +
 [source,yaml]
@@ -123,6 +137,13 @@ spec:
   - name: app-container
     image: centos/tools
     command: ["sleep", "infinity"]
+----
+
+. Create the pod by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f pod.yaml
 ----
 
 .Verification

--- a/modules/plugin-chaining-with-multus-cni.adoc
+++ b/modules/plugin-chaining-with-multus-cni.adoc
@@ -8,7 +8,7 @@
 
 Plugin chaining allows you to configure multiple CNI plugins to be applied sequentially to the same network interface. This approach is useful when you need to implement complex network configurations, such as routing traffic over different network paths or creating isolated networks for specialized traffic types.
 
-For instance, in a telco environment, you may have the following requirements:
+For instance, in a telco environment, you might have the following requirements:
 
 * SIP traffic (Voice over IP) must always be routed over a dedicated SIP network for optimized performance.
 * Management traffic must go over a separate management network for administrative purposes.
@@ -23,7 +23,7 @@ In this case, you can configure a pod with two interfaces:
 * `eth1` for management traffic, routed through the management network.
 * `eth2` for SIP traffic, routed through the SIP network.
 
-Following this example you can use plugin chaining with Multus CNI, to attach both interfaces to the pod and use source-based routing to ensure SIP traffic is only routed through `eth2` while all other traffic flows over eth1.
+Following this example you can use plugin chaining with Multus CNI, to attach both interfaces to the pod and use source-based routing to ensure SIP traffic is only routed through `eth2` while all other traffic flows over `eth1`.
 
 .Prerequisites
 
@@ -127,21 +127,21 @@ spec:
 
 .Verification
 
-. Run the following command to list all network interfaces and their assigned IP addresses inside the `telco-app-pod`. This will help verify that the pod has multiple network interfaces configured as expected:
+. Run the following command to list all network interfaces and their assigned IP addresses inside the `telco-app-pod`. This verifies that the pod has multiple network interfaces configured as expected:
 +
 [source,terminal]
 ----
 $ oc exec -it telco-app-pod -n telco-app -- ip a
 ----
 
-. Run the following command to inspect the IP routing rules inside the `telco-app-pod`. This will display the source-based routing rules applied within the pod to ensure SIP traffic is routed through `eth2`:
+. Run the following command to inspect the IP routing rules inside the `telco-app-pod`. This displays the source-based routing rules applied within the pod to ensure SIP traffic is routed through `eth2`:
 +
 [source,terminal]
 ----
 $ oc exec -it telco-app-pod -n telco-app -- ip rule show
 ----
 
-. Run the following command to view the routing table (Table 200) inside the `telco-app-pod`. This will help verify that traffic destined for the SIP network is correctly routed according to the source-based routing rules:
+. Run the following command to view the routing table (Table 200) inside the `telco-app-pod`. This verifies that traffic destined for the SIP network is correctly routed according to the source-based routing rules:
 +
 [source,terminal]
 ----

--- a/networking/multiple_networks/about-chaining.adoc
+++ b/networking/multiple_networks/about-chaining.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="enabling-multi-networking-for-advanced-use-cases-with-cni-plugin-chaining"]
+= Enabling multi-networking for advanced use cases with CNI Plugin chaining
+include::_attributes/common-attributes.adoc[]
+:context: enabling-multi-networking-for-advanced-use-cases-with-cni-plugin-chaining
+
+toc::[]
+
+include::modules/cnf-about-cni-chaining.adoc[leveloffset=+1]

--- a/networking/multiple_networks/about-chaining.adoc
+++ b/networking/multiple_networks/about-chaining.adoc
@@ -7,3 +7,5 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 include::modules/cnf-about-cni-chaining.adoc[leveloffset=+1]
+
+include::modules/plugin-chaining-with-multus-cni.adoc[leveloffset=+1]

--- a/networking/multiple_networks/about-chaining.adoc
+++ b/networking/multiple_networks/about-chaining.adoc
@@ -8,4 +8,4 @@ toc::[]
 
 include::modules/cnf-about-cni-chaining.adoc[leveloffset=+1]
 
-include::modules/plugin-chaining-with-multus-cni.adoc[leveloffset=+1]
+include::modules/plugin-chaining-with-multus-cni.adoc[leveloffset=+2]

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -37,6 +37,11 @@ $ openstack subnet set --dns-nameserver 0.0.0.0 <subnet_id>
 ----
 ====
 
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about chaining of CNI plugins, see xref:../../networking/configure-syscontrols-interface-tuning-cni.adoc#configure-syscontrols-interface-tuning-cni[Configuring system controls and interface attributes using the tuning plugin]
+
 [id="ip-address-assignment-for-additional-networks_{context}"]
 == IP address assignment for additional networks
 


### PR DESCRIPTION
[OCPBUGS-31038]: Openshift multus docs mention plugin chaining but do

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-31038
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://88557--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/about-chaining.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
