### PR TITLE
TELCODOCS-2207: Updating NROP section to reflect new SELinux policy

### DIFF
--- a/modules/cnf-creating-nrop-cr.adoc
+++ b/modules/cnf-creating-nrop-cr.adoc
@@ -41,11 +41,6 @@ spec:
 ----
 $ oc create -f nrop.yaml
 ----
-+
-[NOTE]
-====
-Creating the `NUMAResourcesOperator` triggers a reboot on the corresponding machine config pool and therefore the affected node.
-====
 
 .Verification
 


### PR DESCRIPTION
[TELCODOCS-2207](https://issues.redhat.com//browse/TELCODOCS-2207): Updating NROP section to reflect new SELinux policy

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2207

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
