### PR TITLE
CNV#55937 4.16: WSFC validation is not working with multipath LUNs

### DIFF
--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -19,6 +19,11 @@ You can set an error policy for each LUN disk. The error policy controls how the
 
 For a LUN disk with an iSCSi connection and a persistent reservation, as required for Windows Failover Clustering for shared volumes, you set the error policy to `report`.
 
+[IMPORTANT]
+====
+{VirtProductName} does not currently support SCSI-3 Persistent Reservations (SCSI-3 PR) over multipath storage. As a workaround, disable multipath or ensure the Windows Server Failover Clustering (WSFC) shared disk is setup from a single device and not part of multipath.
+====
+
 .Prerequisites
 
 * You must have cluster administrator privileges to configure the feature gate option.


### PR DESCRIPTION
**Version(s):**
4.16

**Issue:**
https://issues.redhat.com/browse/CNV-55937

**Link to docs preview:**
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

**QE review:**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
[4.17 PR](https://github.com/openshift/openshift-docs/pull/88487)
[4.18 PR](https://github.com/openshift/openshift-docs/pull/88492)