### PR TITLE
Adds annotation for opening default network ports on udn pods

### DIFF
--- a/modules/opening-default-network-ports-udn.adoc
+++ b/modules/opening-default-network-ports-udn.adoc
@@ -1,0 +1,31 @@
+//module included in the following assembly:
+//
+// * networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="opening-default-network-ports-udn_{context}"]
+= Opening default network ports on user-defined network pods
+
+By default, pods on a user-defined network are isolated from the default network. This means that default network pods, such as those running monitoring services (Prometheus or Alertmanager) or the {product-title} image registry, cannot initiate connections to UDN pods.
+
+To allow default network pods to connect to a user-defined network pod, you can use the `k8s.ovn.org/open-default-ports` annotation. This annotation opens specific ports on the user-defined network pod for access from the default network.
+
+The following pod specification allows incoming TCP connections on port `80` and UDP traffic on port `53` from the default network:
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.ovn.org/open-default-ports: |
+      - protocol: tcp
+        port: 80
+      - protocol: udp
+        port: 53
+# ...
+----
+ 
+[NOTE]
+====
+Open ports are accessible on the pod's default network IP, not its UDN network IP.
+====

--- a/networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
+++ b/networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
@@ -52,6 +52,8 @@ include::modules/nw-udn-cr.adoc[leveloffset=+1]
 //Explanation of optional config details
 include::modules/nw-udn-additional-config-details.adoc[leveloffset=+1]
 
+include::modules/opening-default-network-ports-udn.adoc[leveloffset=+1]
+
 //Support matrix for UDN
 //include::modules
 


### PR DESCRIPTION
Version(s):
4.18 

Issue:
https://issues.redhat.com/browse/OSDOCS-12286

Link to docs preview:
https://88580--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME approved.