### PR TITLE
OSDOCS#13054: Adds Admin/Dev Console Rel Notes

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -746,6 +746,34 @@ Previously, the `thinPoolConfig.overprovisionRatio` field in the `LVMCluster` cu
 [id="ocp-release-notes-web-console_{context}"]
 === Web console
 
+[id="ocp-4-18-administrator-perspective_{context}"]
+==== Administrator perspective
+
+This release introduces the following updates to the *Administrator* perspective of the web console:
+
+* A new setting for hiding the *Getting started resources* card on the *Overview* page allowing for maximum use of the dashboard.
+* A *Start Job* option was added to the CronJob *List* and *Details* pages, so you can start individual CronJobs manually directly in the web console without having to use the `oc` CLI.
+* The *Import YAML* button in the masthead is now a *Quick Create* button that you can use for the rapid deployment of workloads by imprting from YAML, Git, or using container images.
+* You can build your own generative-AI chat bot with a chat bot sample. The generative-AI chat bot sample is deployed with Helm and includes a full CI/CD pipeline. You can also run this sample on your cluster with no CPUs.
+* You can import YAML into the console using {ols}.
+
+[id="ocp-4-18-administrator-perspective_content-security-policy{context}"]
+===== Content Security Policy (CSP)
+
+With this release, the console Content Security Policy (CSP) is deployed in report-only mode. CSP violations will be logged in the browser console, but the associated CSP directives will not be enforced. Dynamic plugin creators can add their own policies.
+
+Additionally, you can report any plugins that break security policies. Administrators have the ability to disable any plugin breaking those policies. CSP violations will be logged in the browser console, but the associated CSP directives will not be enforced. This feature is behind a `feature-gate`, so you will need to manually enable it.
+
+For more information, see xref:../web_console/dynamic-plugin/content-security-policy.adoc#content-security-policy[Content Security Policy (CSP)]and xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-console_nodes-cluster-enabling[Enabling feature sets using the web console].
+
+[id="ocp-4-18-developer-perspective_{context}"]
+==== Developer Perspective
+
+This release introduces the following updates to the *Developer* perspective of the web console:
+
+* Added a {product-title} toolkit, Quarkus tools and JBoss EAP, and a Language Server Protocol Plugin for Visual Studio Code and IntelliJ.
+* Previously, when moving from light mode to dark mode in the Monaco editor, the console remained in dark mode. With this update, the Monaco code editor will match the selected theme.
+
 [id="ocp-4-18-notable-technical-changes_{context}"]
 == Notable technical changes
 
@@ -1489,10 +1517,21 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
+|====
+
+[discrete]
+[id="ocp-release-notes-web-console-tech-preview_{context}"]
+=== Web console Technology Preview features
+
+.Web console Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.16 |4.17 |4.18
+
 |{ols-official} in the {product-title} web console
-| Developer Preview
-| Developer Preview
-| Developer Preview
+| Technology Preview
+| Technology Preview
+| Technology Peview
 
 |====
 


### PR DESCRIPTION
Admin and dev console release notes

Version(s):
4.18 only

Issue:
https://issues.redhat.com/browse/OSDOCS-13054

Link to docs preview:
https://88582--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-web-console_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
