### PR TITLE
OSDOCS#13054-2: Adds missing extension type to the dynamic plugin reference docs

### DIFF
--- a/modules/dynamic-plugin-sdk-extensions.adoc
+++ b/modules/dynamic-plugin-sdk-extensions.adoc
@@ -270,6 +270,17 @@ Adds a new React context provider to the web console application root.
 |===
 
 [discrete]
+== `console.create-project-modal`
+
+This extension can be used to pass a component that will be rendered in place of the standard create project modal.
+
+[cols=",,,",options="header",]
+|===
+|Name |Value Type |Optional |Description
+|`component` |`CodeRef<ModalComponent<CreateProjectModalProps>>` |no |A component to render in place of the create project modal.
+|===
+
+[discrete]
 == `console.dashboards/card`
 
 Adds a new dashboard card.


### PR DESCRIPTION
OSDOCS#13054-2: Adds missing extension type to the dynamic plugin reference docs

Version(s):
4.17 & 4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-13054

Link to docs preview:
https://88586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/dynamic-plugins-reference.html#:~:text=console.create%2Dproject%2Dmodal

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
