### PR TITLE
OSDOCS#13355: Agent Installer with C3

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -307,6 +307,9 @@ endif::[]
 :ocid: OCID
 :ocvs-first: Oracle(R) Cloud VMware Solution (OCVS)
 :ocvs: OCVS
+:oci-c3: Oracle(R) Compute Cloud@Customer
+:oci-c3-no-rt: Oracle Compute Cloud@Customer
+:oci-c3-short: Compute Cloud@Customer
 // Red Hat OpenStack Platform (RHOSP)/OpenStack
 ifndef::openshift-origin[]
 :rh-openstack-first: Red Hat OpenStack Platform (RHOSP)

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -577,6 +577,8 @@ Topics:
     File: installing-oci-assisted-installer
   - Name: Installing a cluster on Oracle Cloud Infrastructure by using the Agent-based Installer
     File: installing-oci-agent-based-installer
+  - Name: Installing a cluster on Oracle Compute Cloud@Customer by using the Agent-based Installer
+    File: installing-c3-agent-based-installer
 - Name: Installing on VMware vSphere
   Dir: installing_vsphere
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_oci/installing-c3-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-c3-agent-based-installer.adoc
@@ -1,0 +1,70 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="installing-c3-agent-based-installer"]
+= Installing a cluster on {oci-c3-no-rt} by using the Agent-based Installer
+:context: installing-c3-agent-based-installer
+
+toc::[]
+
+You can use the Agent-based Installer to install a cluster on {oci-c3}, so that you can run cluster workloads on on-premise infrastructure while still using {oci-first} services.
+
+////
+Do I need to add a BM/VM support statement like the one below?
+
+Installing a cluster on {oci-c3-short} is supported for virtual-machines (VMs) and bare-metal machines.
+////
+
+[id="abi-oci-c3-process-checklist_{context}"]
+== Installation process workflow
+
+The following workflow describes a high-level outline for the process of installing an {product-title} cluster on {oci-c3-short} using the Agent-based Installer:
+
+. Create {oci-c3-short} resources and services (Oracle).
+. Prepare configuration files for the Agent-based Installer (Red{nbsp}Hat).
+. Generate the agent ISO image (Red{nbsp}Hat).
+. Convert the ISO image to an {oci-first-no-rt} image, upload it to an {oci} Home Region Bucket, and then import the uploaded image to the {oci-c3-short} system (Oracle).
+. Disconnected environments: Prepare a web server that is accessible by {oci} instances (Red{nbsp}Hat).
+. Disconnected environments: Upload the rootfs image to the web server (Red{nbsp}Hat).
+. Configure your firewall for {product-title} (Red{nbsp}Hat).
+. Create control plane nodes and configure load balancers (Oracle).
+. Create compute nodes and configure load balancers (Oracle).
+. Verify that your cluster runs on {oci} (Oracle).
+
+// Creating Compute Cloud@Customer infrastructure resources and services
+include::modules/abi-c3-resources-services.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts.htm[Learn About Oracle Cloud Basics (Oracle documentation)]
+
+// Creating configuration files for installing a cluster on Compute Cloud@Customer
+include::modules/creating-config-files-cluster-install-oci.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#installation-overview_architecture-installation[About {product-title} installation]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing-selecting-cluster-type[Selecting a cluster installation type]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer]
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-retrieve_installing-with-agent-based-installer[Downloading the Agent-based Installer]
+* xref:../../disconnected/mirroring/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red{nbsp}Hat OpenShift]
+* xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository]
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-ztp_installing-with-agent-based-installer[Optional: Using ZTP manifests]
+
+// Configuring your firewall
+include::modules/configuring-firewall.adoc[leveloffset=+1]
+
+// Running your cluster on Compute Cloud@Customer
+include::modules/running-cluster-oci-c3-agent-based.adoc[leveloffset=+1]
+
+// Verifying that your Agent-based cluster installation runs on {oci}
+include::modules/verifying-cluster-install-oci-agent-based.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-gather-log_installing-with-agent-based-installer[Gathering log data from a failed Agent-based installation]
+
+* xref:../../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster]

--- a/modules/abi-c3-resources-services.adoc
+++ b/modules/abi-c3-resources-services.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-c3-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="abi-c3-resources-services_{context}"]
+= Creating {oci-c3-no-rt} infrastructure resources and services
+
+You must create an {oci-c3-short} environment on your virtual machine (VM) or bare-metal shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
+
+[IMPORTANT]
+====
+To ensure compatibility with {product-title}, you must set `A` as the record type for each DNS record and name records as follows:
+
+* `api.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer.
+* `api-int.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer.
+* `*.apps.<cluster_name>.<base_domain>`, which targets the `ingressVIP` parameter of the Ingress load balancer.
+
+The `api.{asterisk}` and `api-int.{asterisk}` DNS records relate to control plane machines, so you must ensure that all nodes in your installed {product-title} cluster can access these DNS records.
+====
+
+.Prerequisites
+
+* You configured an {oci} account to host the {product-title} cluster.
+See "Access and Considerations" in link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Compute
+Cloud@Customer] (Oracle documentation).
+
+.Procedure
+
+* Create the required {oci-c3-short} resources and services.
++
+For more information, see "Terraform Script Execution" in link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Compute
+Cloud@Customer] (Oracle documentation).

--- a/modules/creating-config-files-cluster-install-oci.adoc
+++ b/modules/creating-config-files-cluster-install-oci.adoc
@@ -2,13 +2,28 @@
 //
 // * installing/installing_oci/installing-oci-agent-based-installer.adoc
 
+
+ifeval::["{context}" == "installing-c3-agent-based-installer"]
+:c3:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
+
+ifdef::c3[]
+[id="creating-config-files-cluster-install-c3_{context}"]
+= Creating configuration files for installing a cluster on {oci-c3-short}
+
+You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
+endif::c3[]
+
+ifndef::c3[]
 [id="creating-config-files-cluster-install-oci_{context}"]
 = Creating configuration files for installing a cluster on {oci}
 
 You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
 
-At a later stage, you must follow the steps in the Oracle documentation for uploading your generated agent ISO image to Oracle's default Object Storage bucket, which is the initial step for integrating your {product-title} cluster on {oci-first}.
+At a later stage, you must follow the steps in the Oracle documentation for uploading your generated Agent ISO image to a default Oracle Object Storage bucket, which is the initial step for integrating your {product-title} cluster on {oci-first}.
+endif::c3[]
 
 [NOTE]
 ====
@@ -101,15 +116,30 @@ pullSecret: '<pull_secret>' <6>
 Do not move the `install-config.yaml` or `agent-config.yaml` configuration files to the `openshift` directory.
 ====
 
+ifndef::c3[]
 . If you used a stack to provision OCI infrastructure resources: Copy and paste the `dynamic_custom_manifest` output of the OCI stack into a file titled `manifest.yaml` and save the file in the `openshift` directory.
 
 . If you did not use a stack to provision OCI infrastructure resources: Download and prepare custom manifests to create an Agent ISO image:
+
 
 .. Go to link:https://docs.oracle.com/iaas/Content/openshift-on-oci/install-prereq.htm#install-configuration-files[Configuration Files] (Oracle documentation) and follow the link to the custom manifests directory on GitHub.
 
 .. Copy the contents of the `condensed-manifest.yml` file and save it locally to a file in the `openshift` directory.
 
 .. In the `condensed-manifest.yml` file, update the sections marked with `TODO` to specify the compartment {ocid-first}, VCN {ocid}, subnet {ocid} from the load balancer, and the security lists {ocid}.
+endif::c3[]
+
+ifdef::c3[]
+. Configure the Oracle custom manifest files.
+
+.. Go to "Prepare the OpenShift Master Images" in link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Compute
+Cloud@Customer] (Oracle documentation).
+
+.. Copy and paste the `oci-ccm.yml`, `oci-csi.yml`, and `machineconfig-ccm.yml` files into your `openshift` directory.
+
+.. Edit the `oci-ccm.yml` and `oci-csi.yml` files to specify the compartment {ocid-first}, VCN {ocid}, subnet {ocid} from the load balancer, the security lists {ocid}, and the `c3-cert.pem` section.
+endif::c3[]
 
 . Configure the `agent-config.yaml` configuration file to meet your organization's requirements.
 +
@@ -164,3 +194,7 @@ The Agent-based Installer also adds the value of the `bootArtifactsBaseURL` to t
 ====
 Consider that the full ISO image, which is in excess of `1` GB, includes the rootfs image. The image is larger than the minimal ISO Image, which is typically less than `150` MB.
 ====
+
+ifeval::["{context}" == "installing-c3-agent-based-installer"]
+:!c3:
+endif::[]

--- a/modules/running-cluster-oci-c3-agent-based.adoc
+++ b/modules/running-cluster-oci-c3-agent-based.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="running-cluster-oci-c3-agent-based_{context}"]
+= Running a cluster on {oci-c3-short}
+
+To run a cluster on {oci-c3}, you must first convert your generated Agent ISO image into an {oci} image, upload it to an {oci} Home Region Bucket, and then import the uploaded image to the {oci-c3-short} system.
+
+[NOTE]
+====
+{oci-c3-short} supports the following {product-title} cluster topologies:
+
+* Installing an {product-title} cluster on a single node.
+* A highly available cluster that has a minimum of three control plane instances and two compute instances.
+* A compact three-node cluster that has a minimum of three control plane instances.
+====
+
+.Prerequisites
+
+* You generated an Agent ISO image. See the "Creating configuration files for installing a cluster on {oci-c3-short}" section.
+
+.Procedure
+
+. Convert the agent ISO image to an {oci} image, upload it to an {oci} Home Region Bucket, and then import the uploaded image to the {oci-c3-short} system.
+See "Prepare the OpenShift Master Images" in link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Compute
+Cloud@Customer (Oracle documentation)] for instructions.
+
+. Create control plane instances on {oci-c3-short}.
+See "Create control plane instances on C3 and Master Node LB Backend Sets" in link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Compute
+Cloud@Customer (Oracle documentation)] for instructions.
+
+. Create a compute instance from the supplied base image for your cluster topology.
+See "Add worker nodes" in link:https://www.oracle.com/a/otn/docs/compute_cloud_at_customer_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Compute
+Cloud@Customer (Oracle documentation)] for instructions.
++
+[IMPORTANT]
+====
+Before you create the compute instance, check that you have enough memory and disk resources for your cluster. Additionally, ensure that at least one compute instance has the same IP address as the address stated under `rendezvousIP` in the `agent-config.yaml` file.
+====

--- a/modules/verifying-cluster-install-oci-agent-based.adoc
+++ b/modules/verifying-cluster-install-oci-agent-based.adoc
@@ -2,7 +2,26 @@
 //
 // * installing/installing_oci/installing-oci-agent-based-installer.adoc
 
+ifeval::["{context}" == "installing-c3-agent-based-installer"]
+:c3:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
+
+ifdef::c3[]
+[id="verifying-cluster-install-oci-agent-based_{context}"]
+= Verifying that your Agent-based cluster installation runs on {oci-c3-short}
+
+Verify that your cluster was installed and is running effectively on {oci-first}.
+
+.Prerequisites
+
+* You created all the required {oci-c3} resources and services. See the "Creating {oci-c3-no-rt} infrastructure resources and services" section.
+* You created `install-config.yaml` and `agent-config.yaml` configuration files. See the "Creating configuration files for installing a cluster on {oci-c3-short}" section.
+* You uploaded the agent ISO image to a default Oracle Object Storage bucket, and you created a compute instance on {oci-c3-short}. For more information, see "Running a cluster on {oci-c3-short}".
+endif::c3[]
+
+ifndef::c3[]
 [id="verifying-cluster-install-oci-agent-based_{context}"]
 = Verifying that your Agent-based cluster installation runs on {oci}
 
@@ -12,7 +31,8 @@ Verify that your cluster was installed and is running effectively on {oci-first}
 
 * You created all the required {oci} resources and services. See the "Creating OCI infrastructure resources and services" section.
 * You created `install-config.yaml` and `agent-config.yaml` configuration files. See the "Creating configuration files for installing a cluster on OCI" section.
-* You uploaded the agent ISO image to Oracle’s default Object Storage bucket, and you created a compute instance on {oci}. For more information, see "Running a cluster on OCI".
+* You uploaded the agent ISO image to a default Oracle Object Storage bucket, and you created a compute instance on {oci}. For more information, see "Running a cluster on OCI".
+endif::c3[]
 
 .Procedure
 
@@ -68,3 +88,7 @@ baremetal      4.18.0-0    True       False          False      2m42s
 network        4.18.0-0    True       True           False      5m58s  Progressing: …
     …
 ----
+
+ifeval::["{context}" == "installing-c3-agent-based-installer"]
+:!c3:
+endif::[]


### PR DESCRIPTION
[OSDOCS-13355](https://issues.redhat.com/browse/OSDOCS-13355)

Version(s): 4.18+

This PR adds documentation for installing OCP on OCI C3 with the Agent-based Installer

QE review:
- [x] QE has approved this change.

Previews: 

- [Installing a cluster on Oracle Cloud Compute@Customer by using the Agent-based Installer](https://88588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-c3-agent-based-installer)
- [Installing a cluster on Oracle Cloud Infrastructure by using the Agent-based Installer](https://88588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer) (should be unchanged compared to [live version](https://docs.openshift.com/container-platform/4.18/installing/installing_oci/installing-oci-agent-based-installer.html))
