### PR TITLE
OBSDOCS-1392 Remove logging UI warning

### DIFF
--- a/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
@@ -6,11 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[IMPORTANT]
-====
-Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for the logging UI plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the logging UI plugin is ready for GA.
-====
-
 The logging UI plugin surfaces logging data in the {product-title} web console on the *Observe* -> *Logs* page. 
 You can specify filters, queries, time ranges and refresh rates, with the results displayed as a list of collapsed logs, which can then be expanded to show more detailed information for each log.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-1392](https://issues.redhat.com//browse/OBSDOCS-1392)

Link to docs preview:
https://88591--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
