### PR TITLE
OCPBUGS-45750 Fix typo in procedure substep 9.d.5.

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-install.adoc
+++ b/modules/nodes-cma-autoscaling-custom-install.adoc
@@ -126,7 +126,7 @@ spec:
 <2> Specifies the level of verbosity for the Custom Metrics Autoscaler Operator log messages. The allowed values are `debug`, `info`, `error`. The default is `info`.
 <3> Specifies the logging format for the Custom Metrics Autoscaler Operator log messages. The allowed values are `console` or `json`. The default is `console`.
 <4> Optional: Specifies one or more config maps with CA certificates, which the Custom Metrics Autoscaler Operator can use to connect securely to TLS-enabled metrics sources.
-<5> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` or `debug`. The default is `0`.
+<5> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` for `debug`. The default is `0`.
 <6> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section.
 
 .. Click *Create* to create the KEDA controller.

--- a/modules/sd-nodes-cma-autoscaling-custom-install.adoc
+++ b/modules/sd-nodes-cma-autoscaling-custom-install.adoc
@@ -140,7 +140,7 @@ spec:
 <2> Specifies the level of verbosity for the Custom Metrics Autoscaler Operator log messages. The allowed values are `debug`, `info`, `error`. The default is `info`.
 <3> Specifies the logging format for the Custom Metrics Autoscaler Operator log messages. The allowed values are `console` or `json`. The default is `console`.
 <4> Optional: Specifies one or more config maps with CA certificates, which the Custom Metrics Autoscaler Operator can use to connect securely to TLS-enabled metrics sources.
-<5> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` or `debug`. The default is `0`.
+<5> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` for `debug`. The default is `0`.
 <6> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section.
 
 .. Click *Create* to create the KEDA controller.


### PR DESCRIPTION
OCPBUGS-45750 Fix typo in procedure substep 9.d.5.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-45750

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
The typo was present in two modules which are conditionally passed into the nodes-cma-autoscaling-custom-install.adoc assembly based on distribution.
Previews of distributions affected by the change to module nodes-cma-autoscaling-custom-install.adoc:
- [openshift-enterprise](https://88592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-install.html)

Previews of distributions affected by the change to module sd-nodes-cma-autoscaling-custom-install.adoc:
- [openshift-dedicated](https://88592--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-install.html)
- [openshift-rosa](https://88592--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-install.html)
- [openshift-rosa-hcp](https://88592--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/cma/nodes-cma-autoscaling-custom-install.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
