### PR TITLE
OSDOCS-12321_install#adding GCP filestore WIF

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -204,7 +204,7 @@ $ ccoctl gcp create-all \
   --project=<gcp_project_id> \// <3>
   --credentials-requests-dir=<path_to_credentials_requests_directory> <4>
 ----
-<1> Specify the user-defined name for all created GCP resources used for tracking.
+<1> Specify the user-defined name for all created {gcp-short} resources used for tracking. If you plan to install the {gcp-short} Filestore Container Storage Interface (CSI) Driver Operator, retain this value.
 <2> Specify the GCP region in which cloud resources will be created.
 <3> Specify the GCP project ID in which cloud resources will be created.
 <4> Specify the directory containing the files of `CredentialsRequest` manifests to create GCP service accounts.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version:
4.18+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-12321

Link to docs preview:
[Creating GCP resources with the Cloud Credential Operator utility](https://88607--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#cco-ccoctl-creating-at-once_installing-gcp-customizations)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
