### PR TITLE
OCPBUGS-43660: New feature RN only for NTO platform detection

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -700,6 +700,7 @@ For example, the plugin can highlight unexpected differences, such as mismatched
 You can use the `cluster-compare` plugin in development, production, and support scenarios.
 
 For more information about the `cluster-compare` plugin, see xref:../scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.adoc#cluster-compare-overview_understanding-cluster-compare[Overview of the cluster-compare plugin].
+
 [id="ocp-release-notes-node-tuning-operator-deferred-updates_{context}"]
 ==== Node Tuning Operator: Deferred Tuning Updates
 
@@ -716,6 +717,15 @@ With this release, the NUMA Resources Operator no longer creates a custom SELinu
 ====
 In clusters with an existing NUMA-aware scheduler configuration, upgrading to {product-title} 4.18 might result in an additional reboot for each configured node. For further information about how to manage an upgrade in this scenario and limit disruption, see the Red Hat Knowledgebase article link:https://access.redhat.com/articles/7107603[Managing an upgrade to {product-title} 4.18 or later for a cluster with an existing NUMA-aware scheduler configuration]
 ====
+
+[id="ocp-release-notes-scalability-and-performance-nto-platforms_{context}"]
+==== Node Tuning Operator platform detection
+
+With this release, when you apply a performance profile, the Node Tuning Operator detects the platform and configures kernel arguments and other platform-specific options accordingly. This release adds support for detecting the following platforms:
+
+* AMD64
+* AArch64
+* Intel 64
 
 [id="ocp-release-notes-etcd-certificates_{context}"]
 === Security


### PR DESCRIPTION
OCPBUGS-43660: New feature RN only for NTO platform detection

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-43660

Link to docs preview:
(https://88630--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
