### PR TITLE
Fixed a typo in the OpenShift Virtualization Release Notes

### DIFF
--- a/virt/release_notes/virt-4-18-release-notes.adoc
+++ b/virt/release_notes/virt-4-18-release-notes.adoc
@@ -79,7 +79,7 @@ This release adds new features and enhancements related to the following compone
 === Monitoring
 
 //CNV-47048: Release note: announce the availability of new VM metrics
-* You can now view virtual machine (VM) workload metrics for allocated storage, CPU, and network resources. Admins can use these metrics to determine reource allocation and capacity planning.
+* You can now view virtual machine (VM) workload metrics for allocated storage, CPU, and network resources. Admins can use these metrics to determine resource allocation and capacity planning.
 +
 For a complete list of virtualization metrics, see link:https://github.com/kubevirt/monitoring/blob/main/docs/metrics.md[KubeVirt components metrics].
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://88633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-18-release-notes.html#virt-4-18-monitoring
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I initially fixed it as part of #88398 but there is a debate whether it will go out with this release.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
