### PR TITLE
OCPBUGS-50864 - Fixes to the PTP Events v2 documentation

### DIFF
--- a/modules/ptp-events-consumer-application-v2.adoc
+++ b/modules/ptp-events-consumer-application-v2.adoc
@@ -32,9 +32,8 @@ func getEvent(w http.ResponseWriter, req *http.Request) {
   if e != "" {
     processEvent(bodyBytes)
     log.Infof("received event %s", string(bodyBytes))
-  } else {
-    w.WriteHeader(http.StatusNoContent)
   }
+  w.WriteHeader(http.StatusNoContent)
 }
 ----
 
@@ -58,7 +57,7 @@ s5,_:=createsubscription("/cluster/node/<node_name>/sync/ptp-status/clock-class"
 func createSubscription(resourceAddress string) (sub pubsub.PubSub, err error) {
   var status int
   apiPath := "/api/ocloudNotifications/v2/"
-  localAPIAddr := "localhost:8989" // vDU service API address
+  localAPIAddr := "consumer-events-subscription-service.cloud-events.svc.cluster.local:9043" // vDU service API address
   apiAddr := "ptp-event-publisher-service-<node_name>.openshift-ptp.svc.cluster.local:9043" // <1>
   apiVersion := "2.0"
 

--- a/snippets/ptp-event-config-api-v2.adoc
+++ b/snippets/ptp-event-config-api-v2.adoc
@@ -10,9 +10,9 @@ spec:
   daemonNodeSelector:
     node-role.kubernetes.io/worker: ""
   ptpEventConfig:
-    apiVersion: 2.0 <1>
+    apiVersion: "2.0" <1>
     enableEventPublisher: true <2>
 ----
-<1> Enable the PTP events REST API v2 for the PTP event producer by setting the `ptpEventConfig.apiVersion` to 2.0.
-The default value is 1.0.
+<1> Enable the PTP events REST API v2 for the PTP event producer by setting the `ptpEventConfig.apiVersion` to "2.0".
+The default value is "1.0".
 <2> Enable PTP fast event notifications by setting `enableEventPublisher` to `true`.


### PR DESCRIPTION
- apiVersion in the PtpOperatorConfig resource needs to be a string
- getEvent() must write some header and not return HTTP code 200
- In createSubscription(), we need to use a different localAPIAddr to get the events

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-50864

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
