### PR TITLE
OCPBUGS-43730: RN for SELinux policy change

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -694,6 +694,16 @@ In this release, the Node Tuning Operator introduces support for deferring tunin
 
 For more information, see xref:../scalability_and_performance/using-node-tuning-operator.adoc#defer-application-of-tuning-changes_node-tuning-operator[Deferring application of tuning changes].
 
+[id="ocp-release-notes-scalability-and-performance-nrop-policy_{context}"]
+==== NUMA Resources Operator now uses default SELinux policy
+
+With this release, the NUMA Resources Operator no longer creates a custom SELinux policy to enable the installation of Operator components on a target node. Instead, the Operator uses a built-in container SELinux policy. This change removes the additional node reboot that was previously required when applying a custom SELinux policy during an installation. 
+
+[IMPORTANT]
+====
+In clusters with an existing NUMA-aware scheduler configuration, upgrading to {product-title} 4.18 might result in an additional reboot for each configured node. For further information about how to manage an upgrade in this scenario and limit disruption, see the Red Hat Knowledgebase article link:https://access.redhat.com/articles/7107603[Managing an upgrade to {product-title} 4.18 or later for a cluster with an existing NUMA-aware scheduler configuration]
+====
+
 [id="ocp-release-notes-etcd-certificates_{context}"]
 === Security
 


### PR DESCRIPTION
OCPBUGS-43730: RN for SELinux policy change

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-43730

Link to docs preview:
https://88641--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-scalability-and-performance-nrop-policy_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
