### PR TITLE
Minor follow up to OCPBUGS 43762

### DIFF
--- a/modules/nw-ovn-k-day-2-masq-subnet.adoc
+++ b/modules/nw-ovn-k-day-2-masq-subnet.adoc
@@ -26,7 +26,7 @@ $ oc patch networks.operator.openshift.io cluster --type=merge -p '{"spec":{"def
 +
 where:
 
-`ipv4_masquerade_subnet`:: Specifies an IP address to be used as the IPv4 masquerade subnet. This range cannot overlap with any other subnets used by {product-title} or on the host itself. The default value for IPv4 is `169.254.169.0/29`.
+`ipv4_masquerade_subnet`:: Specifies an IP address to be used as the IPv4 masquerade subnet. This range cannot overlap with any other subnets used by {product-title} or on the host itself. In versions of {product-title} earlier than 4.17, the default value for IPv4 was `169.254.169.0/29`, and clusters that were upgraded to version 4.17 maintain this value. For new clusters starting from version 4.17, the default value is `169.254.0.0/17`. 
 
 `ipv6_masquerade_subnet`:: Specifies an IP address to be used as the IPv6 masquerade subnet. This range cannot overlap with any other subnets used by {product-title} or on the host itself. The default value for IPv6 is `fd69::/125`.
 
@@ -39,4 +39,4 @@ $ oc patch networks.operator.openshift.io cluster --type=merge -p '{"spec":{"def
 +
 where:
 
-`ipv4_masquerade_subnet`:: Specifies an IP address to be used as the IPv4 masquerade subnet. This range cannot overlap with any other subnets used by {product-title} or on the host itself. The default value for IPv4 is `169.254.169.0/29`.
+`ipv4_masquerade_subnet`::Specifies an IP address to be used as the IPv4 masquerade subnet. This range cannot overlap with any other subnets used by {product-title} or on the host itself. In versions of {product-title} earlier than 4.17, the default value for IPv4 was `169.254.169.0/29`, and clusters that were upgraded to version 4.17 maintain this value. For new clusters starting from version 4.17, the default value is `169.254.0.0/17`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-50922

Link to docs preview:
https://88642--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
