### PR TITLE
OSSM-8735 Document migration of different gateway deployments

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -40,7 +40,7 @@ Topics:
 - Name: Migrating gateways
   Dir: migrating-gateways
   Topics:
-  - Name: Migrating gateways to Service Mesh 3.0
+  - Name: Migrating gateways from Service Mesh 2 to Service Mesh 3
     File: ossm-migrating-gateways-assembly
 - Name: Completing the migration
   Dir: done

--- a/migrating/migrating-gateways/docinfo.xml
+++ b/migrating/migrating-gateways/docinfo.xml
@@ -1,9 +1,9 @@
-<title>Migrating gateways to Service Mesh 3.0</title>
+<title>Migrating gateways</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
-<subtitle>Migrating gateways</subtitle>
+<subtitle>Migrating gateways from Service Mesh 2 to Service Mesh 3</subtitle>
 <abstract>
-    <para>This document provides important information and step-by-step procedures to migrate gateways from OpenShift Service Mesh 2 to OpenShift Service Mesh 3.
+    <para>This document provides important information about migrating gateways from Service Mesh 2 to Service Mesh 3.
     </para>
 </abstract>
 <authorgroup>

--- a/migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc
+++ b/migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc
@@ -1,8 +1,39 @@
 :_mod-docs-content-type: ASSEMBLY
 [id=ossm-migrating-gateways-assembly]
-= Migrating gateways to Service Mesh 3.0
+= Migrating gateways from Service Mesh 2 to Service Mesh 3
 include::_attributes/common-attributes.adoc[]
 :context: ossm-migrating-gateways-assembly
 
 toc::[]
 
+If you are using gateways with {SMProductName} {SMv2Version} and migrating them to {smproduct} 3.0, you can migrate gateways from {SMProduct} 2 to {SMProduct} 3 just like regular workloads.
+
+Use one of the following two methods for migrating gateways from {SMProductName} 2 to {SMProduct} 3:
+
+* Gateway canary migration
+* Gateway in place migration
+
+include::modules/ossm-migrating-gateways-canary.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../done/ossm-migrating-complete-assembly.adoc[Completing your migration]
+
+include::modules/ossm-migrating-gateways-in-place.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../done/ossm-migrating-complete-assembly.adoc[Completing your migration]
+
+[role="_additional-resources"]
+[id="addition-resources-gateways_{context}"]
+== Additional Resources
+
+* xref:../multitenant/ossm-migrating-multitenant-assembly.adoc[Multitenant migration guide]
+//* Cluster-wide migration guide
+
+//exrefs are being handled by OSSM-8852 for all migration guide content
+
+
+//there is already a Gateways dir that contains 3.0 concept and procedure content for configuring and using gateways in 3.0.
+//named this dir migrating-gateways for clarity

--- a/modules/ossm-migrating-gateways-canary.adoc
+++ b/modules/ossm-migrating-gateways-canary.adoc
@@ -1,0 +1,87 @@
+
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-gateways-canary_{context}"]
+= Gateway canary migration
+
+Use the gateway canary migration method when you want a gradual rollout. It uses multiple gateway versions with maximum control over your gateway rollout.
+
+[NOTE]
+====
+The label for the gateway namespace differs between mulitenant and cluster-wide meshes. To understand which labels to use in your specific migration case and the `maistra.io/ignore-namespace: "true"` label requirement, see the "Multitenant migration guide" or the "Cluster-wide migration guide" section.
+====
+
+.Procedure
+
+. Run the following command to label the gateway namespace to ensure that gateway injection is enabled from the new mesh and add the `maistra.io/ignore-namespace: "true"` label:
++
+[source,terminal]
+----
+$ oc label namespace <gateway_namespace> istio.io/rev=<istio_revision_name> maistra.io/ignore-namespace="true"
+----
++
+.. Remove the `istio-injection=enabled` label, if needed.
+
+. Deploy a canary gateway by using the following example:
++
+.Example YAML for canary gateway
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-ingressgateway-canary
+  namespace: istio-ingress <1>
+  spec:
+     selector:
+       matchLabels:
+         istio: ingressgateway <2>
+     template:
+       metadata:
+         annotations:
+           inject.istio.io/templates: gateway
+         labels:
+           istio: ingressgateway
+           istio.io/rev: canary <3>
+       spec:
+         containers:
+         - name: istio-proxy
+           image: auto
+----
+<1> Your `Deployment` resource must be in in the same namespace as your existing gateway.
+<2> Your `spec.selector.matchlabels.istio` parameter must match your existing gateway service selector.
+<3> Set your {SMProduct} 3.0 control plane revision as the value of the `istio.io/rev` label.
+
+. Ensure that the new gateway deployment is running with the new revision and is handling requests:
++
+.. Check that pods are running and in the `Ready` status.
+
+.. Check that the gateway is running the new revision by running the following command:
++
+[source,terminal]
+----
+$ oc istioctl ps -n istio-ingress
+----
+
+.. Test a sample route through the gateway.
+
+. Gradually shift traffic between deployments:
++
+.. Increase replicas for new gateway by running the following command:
++
+[source,terminal]
+----
+$ oc scale -n istio-ingress deployment/<new_gateway_deployment> --replicas <new_number_of_replicas>
+----
+
+.. Decrease replicas for old gateway by running the following command:
+[source,terminal]
++
+----
+$ oc scale -n istio-ingress deployment/<old_gateway_deployment> --replicas <new_number_of_replicas>
+----
+
+.. Repeat this process, incrementally adjusting replica counts until the new gateway handles all traffic to the gateway Service.

--- a/modules/ossm-migrating-gateways-in-place.adoc
+++ b/modules/ossm-migrating-gateways-in-place.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-gateways-in-place_{context}"]
+= Gateway in place migration
+
+If you need less detailed control over your gateway migration, you can perform gateway in place migration. This method applies to namespaces with dedicated gateways and to environments using a centralized gateway shared across multiple namespaces.
+
+[NOTE]
+====
+The label for the gateway namespace differs between mulitenant and cluster-wide meshes. To understand which labels to use in your specific migration case and the `maistra.io/ignore-namespace: "true"` label requirement, see the "Multitenant migration guide" or the "Cluster-wide migration guide" section.
+====
+.Procedure
+
+. Run the following command to label the gateway namespace to ensure that gateway injection is enabled from the new mesh and add the `maistra.io/ignore-namespace: "true"` label:
++
+[source,terminal]
+----
+$ oc label namespace <gateway_namespace> istio.io/rev=<istio_revision_name> maistra.io/ignore-namespace="true"
+----
+.. Remove the `istio-injection=enabled` label, if needed.
+
+. Restart the gateway deployment by running the following command:
++
+[source,terminal]
+----
+$ oc -n ${app_namespace} rollout restart deployment ${gateway_name}
+----
+
+.Verification
+
+. Check that the gateway is running the new revision by running the following command:
++
+[source,terminal]
+----
+$ oc istioctl ps -n istio-ingress
+----
+
+. Test application-specific routes.


### PR DESCRIPTION
**OSSM 3.0 GA**

**Merge PR to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**And cherry picked to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

This PR also sets up the Gateway dir.

Version(s): 

GA

**Service Mesh 3.0 is moving to the stand alone format and will not be cherry-picked back to OCP core branches.**

Issue:
https://issues.redhat.com/browse/OSSM-8735

https://88648--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/migrating-gateways/ossm-migrating-gateways-assembly.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
