### PR TITLE
OSSM-8862 Migration Hub page content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -11,7 +11,7 @@ Dir: migrating
 Distros: openshift-service-mesh
 Topics:
 - Name: Migrating from Service Mesh 2 to Service Mesh 3 Hub
-  File: ossm-migrating-from-2-to-3-assembly
+  File: ossm-migrating-from-service-mesh-2-to-3-assembly
 #testing use of commenting out
 - Name: Before migrating
   Dir: checklists

--- a/migrating/ossm-migrating-from-2-to-3-assembly.adoc
+++ b/migrating/ossm-migrating-from-2-to-3-assembly.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-from-2-to-3-assembly"]
-= Migrating from Service Mesh 2 to Service Mesh 3
-include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-from-2-to-3-assembly
-
-toc::[]
-
-

--- a/migrating/ossm-migrating-from-service-mesh-2-to-3-assembly.adoc
+++ b/migrating/ossm-migrating-from-service-mesh-2-to-3-assembly.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ossm-migrating-from-service-mesh-2-to-3-assembly"]
+= Migrating from Service Mesh 2 to Service Mesh 3
+include::_attributes/common-attributes.adoc[]
+:context: ossm-migrating-from-2-to-3-assembly
+
+toc::[]
+
+The content in this migration section applies only in the following cases:
+
+* You are an existing {SMProductName} user running {SMProduct} {SMv2Version}.
+* You want to move to {SMProduct} 3.0.
+
+[IMPORTANT]
+====
+If you are not running {SMProduct} {smv2version}, you must update before you can continue. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/service_mesh/service-mesh-2-x#upgrading-ossm[Upgrading Service Mesh].
+====
+
+During the migration process, you might need to reference, or you might be directed to {SMProduct} 2.x content. It can be beneficial to open link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/service_mesh/service-mesh-2-x[OpenShift Service Mesh 2.x] in a new tab or window for easier reference. This can be especially helpful when you move between {SMProduct} 2 `ServiceMeshControlPlane` resource content and {SMProduct} 3 `Istio` resource content.
+
+include::modules/ossm-migrating-hub-recommendations-for-migrating.adoc[leveloffset=+1]
+include::modules/ossm-migrating-hub-how-to-use-migration-guides.adoc[leveloffset=+1]
+include::modules/ossm-migrating-hub-premigration-checklists.adoc[leveloffset=+1]
+include::modules/ossm-migrating-hub-deployment-workloads.adoc[leveloffset=+1]
+include::modules/ossm-migrating-hub-completing-your-migration.adoc[leveloffset=+1]

--- a/modules/ossm-migrating-hub-completing-your-migration.adoc
+++ b/modules/ossm-migrating-hub-completing-your-migration.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/ossm-migrating-from-service-mesh-2-to-3-assembly.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-migrating-hub-completing-your-migration_{context}"]
+= Completing your migration
+
+Depending on your deployment model, you might need to take extra steps to complete the migration. For example, when you migrate with the cert-manager tool, you need to take additional steps before you can remove {SMProduct} 2 resources.
+
+After you complete your migration, you can add new workloads, re-create network policies, and remove {SMProduct} 2 resources.

--- a/modules/ossm-migrating-hub-deployment-workloads.adoc
+++ b/modules/ossm-migrating-hub-deployment-workloads.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/ossm-migrating-from-2-to-3-assembly.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-migrating-hub-deployment-and-workloads_{context}"]
+= Migrating your deployment and workloads
+
+After you complete the premigration checklists, you can migrate your workloads and gateways, based on your deployment model:
+
+* Mulitenant
+* Mulitenant with cert-manager
+* Cluster-wide
+* Cluster-wide with cert-manager

--- a/modules/ossm-migrating-hub-how-to-use-migration-guides.adoc
+++ b/modules/ossm-migrating-hub-how-to-use-migration-guides.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/ossm-migrating-from-2-to-3-assembly.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-migrating-hub-using-migration-guides_{context}"]
+== Using the migration guides
+
+The migration guides are designed to help you move from {SMProduct} {SMv2Version} to {SMProduct} 3.0, based on your deployment model:
+
+* Mulitenant
+* Mulitenant with cert-manager
+* Cluster-wide
+* Cluster-wide with cert-manager
+
+The migration guides use the `bookinfo` application as an example for demonstrations purposes.
+
+You can also migrate gateways.

--- a/modules/ossm-migrating-hub-premigration-checklists.adoc
+++ b/modules/ossm-migrating-hub-premigration-checklists.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/ossm-migrating-from-2-to-3-assembly.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-migrating-hub-premigration-checklists_{context}"]
+= Premigration checklists
+
+Before you can begin your migration, complete the premigration checklists.
+
+These checklists include steps for managing your network policies and configuration updates to set up add ons such as {kialiproduct} and {temposhortname}.
+
+//exrefs handled by OSSM-8852

--- a/modules/ossm-migrating-hub-recommendations-for-migrating.adoc
+++ b/modules/ossm-migrating-hub-recommendations-for-migrating.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/ossm-migrating-from-2-to-3-assembly.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-migrating-hub-recommendations-for-migrating_{context}"]
+= Recommendations for migrating
+
+Consider the following recommendations to limit the risk of misconfigurations or possible conflicts:
+
+* If you have automated updates configured in the {ocp-product-title} web console, change them to **Manual**. By switching to manual updates, you can prevent updates to the {SMProduct} 2 Operator and control planes during your migration.
+
+* Keep the amount of the service mesh configuration changes, such as changes for traffic management or security or adding new workloads or gateways, to a minimum during the migration.
+
+[NOTE]
+====
+If you need to add a new workload namespace during the migration, it must be managed by the {SMProduct} 3 control plane and labeled with `maistra.io/ignore-namespace: "true"` to avoid conflicts between the {SMProduct} 3 control plane and the {SMProduct} 2 `ServiceMeshControlPlane` resource.
+====
+
+* Finish the migration without unnecessary delays.


### PR DESCRIPTION
**OSSM 3.0 GA**

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

**Merge PR to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**And cherry picked to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

This PR also makes changes to the _topic_map .

Version(s): 

GA

**Service Mesh 3.0 is moving to the stand alone format and will not be cherry-picked back to OCP core branches.**

Issue:
https://issues.redhat.com/browse/OSSM-8862

Link to docs preview:
https://88651--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/ossm-migrating-from-service-mesh-2-to-3-assembly.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
