### PR TITLE
OBSDOCS-1682: Port the OpenTelemetry data model chapter

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3014,6 +3014,8 @@ Topics:
       File: log6x-clf-6.2
     - Name: Configuring LokiStack storage
       File: log6x-loki-6.2
+    - Name: OpenTelemetry data model
+      File: log6x-opentelemetry-data-model-6.2
     - Name: Visualization for logging
       File: log6x-visual-6.2
   - Name: Logging 6.1

--- a/observability/logging/logging-6.0/log6x-clf.adoc
+++ b/observability/logging/logging-6.0/log6x-clf.adoc
@@ -80,8 +80,8 @@ Outputs are configured in an array under `spec.outputs`. Each output must have a
 
 azureMonitor:: Forwards logs to Azure Monitor.
 cloudwatch:: Forwards logs to AWS CloudWatch.
-//elasticsearch:: Forwards logs to an external Elasticsearch instance.
 googleCloudLogging:: Forwards logs to Google Cloud Logging.
+elasticsearch:: Forwards logs to an external Elasticsearch instance.
 http:: Forwards logs to a generic HTTP endpoint.
 kafka:: Forwards logs to a Kafka broker.
 loki:: Forwards logs to a Loki logging backend.

--- a/observability/logging/logging-6.1/log6x-clf-6.1.adoc
+++ b/observability/logging/logging-6.1/log6x-clf-6.1.adoc
@@ -81,8 +81,8 @@ Outputs are configured in an array under `spec.outputs`. Each output must have a
 
 azureMonitor:: Forwards logs to Azure Monitor.
 cloudwatch:: Forwards logs to AWS CloudWatch.
-//elasticsearch:: Forwards logs to an external Elasticsearch instance.
 googleCloudLogging:: Forwards logs to Google Cloud Logging.
+elasticsearch:: Forwards logs to an external Elasticsearch instance.
 http:: Forwards logs to a generic HTTP endpoint.
 kafka:: Forwards logs to a Kafka broker.
 loki:: Forwards logs to a Loki logging backend.

--- a/observability/logging/logging-6.2/log6x-clf-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-clf-6.2.adoc
@@ -81,8 +81,8 @@ Outputs are configured in an array under `spec.outputs`. Each output must have a
 
 azureMonitor:: Forwards logs to Azure Monitor.
 cloudwatch:: Forwards logs to AWS CloudWatch.
-//elasticsearch:: Forwards logs to an external Elasticsearch instance.
 googleCloudLogging:: Forwards logs to Google Cloud Logging.
+elasticsearch:: Forwards logs to an external Elasticsearch instance.
 http:: Forwards logs to a generic HTTP endpoint.
 kafka:: Forwards logs to a Kafka broker.
 loki:: Forwards logs to a Loki logging backend.

--- a/observability/logging/logging-6.2/log6x-opentelemetry-data-model-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-opentelemetry-data-model-6.2.adoc
@@ -1,0 +1,383 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="log6x-opentelemetry-data-model-6-2"]
+= OpenTelemetry data model
+include::_attributes/common-attributes.adoc[]
+:context: log6x-opentelemetry-data-model-6-2
+
+toc::[]
+
+This document outlines the protocol and semantic conventions {for} Logging's OpenTelemetry support with {logging-uc} 6.2.
+
+:FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
+include::snippets/technology-preview.adoc[]
+
+[id="forwarding-and-ingestion-protocol_{context}"]
+== Forwarding and ingestion protocol
+
+Red Hat OpenShift {logging-uc} collects and forwards logs to OpenTelemetry endpoints using link:https://opentelemetry.io/docs/specs/otlp/[OTLP Specification]. OTLP encodes, transports, and delivers telemetry data. You can also deploy Loki storage, which provides an OTLP endpont to ingest log streams. This document defines the semantic conventions for the logs collected from various OpenShift cluster sources.
+
+[id="semantic-conventions_{context}"]
+== Semantic conventions
+
+The log collector in this solution gathers the following log streams:
+
+* Container logs
+* Cluster node journal logs
+* Cluster node auditd logs
+* Kubernetes and OpenShift API server logs
+* OpenShift Virtual Network (OVN) logs
+
+You can forward these streams according to the semantic conventions defined by OpenTelemetry semantic attributes. The semantic conventions in OpenTelemetry define a resource as an immutable representation of the entity producing telemetry, identified by attributes. For example, a process running in a container includes attributes such as `container_name`, `cluster_id`, `pod_name`, `namespace`, and possibly `deployment` or `app_name`. These attributes are grouped under the resource object, which helps reduce repetition and optimizes log transmission as telemetry data.
+
+In addition to resource attributes, logs might also contain scope attributes specific to instrumentation libraries and log attributes specific to each log entry. These attributes provide greater detail about each log entry and enhance filtering capabilities when querying logs in storage.
+
+The following sections define the attributes that are generally forwarded.
+
+[id="log-entry-structure_{context}"]
+=== Log entry structure
+
+All log streams include the following link:https://opentelemetry.io/docs/specs/otel/logs/data-model/#log-and-event-record-definition[log data] fields:
+
+The *Applicable Sources* column indicates which log sources each field applies to:
+
+* `all`: This field is present in all logs.
+* `container`: This field is present in Kubernetes container logs, both application and infrastructure.
+* `audit`: This field is present in Kubernetes, OpenShift API, and OVN logs.
+* `auditd`: This field is present in node auditd logs.
+* `journal`: This field is present in node journal logs.
+
+[cols="1,1,1", options="header"]
+|===
+|Name |Applicable Sources |Comment
+
+|`body`
+|all
+|
+
+|`observedTimeUnixNano`
+|all
+|
+
+|`timeUnixNano`
+|all
+|
+
+|`severityText`
+|container, journal
+|
+
+|`attributes`
+|all
+|(Optional) Present when forwarding stream specific attributes
+|===
+
+[id="attributes_{context}"]
+=== Attributes
+
+Log entries include a set of resource, scope, and log attributes based on their source, as described in the following table.
+
+The *Location* column specifies the type of attribute:
+
+* `resource`: Indicates a resource attribute
+* `scope`: Indicates a scope attribute
+* `log`: Indicates a log attribute
+
+The *Storage* column indicates whether the attribute is stored in a LokiStack using the default `openshift-logging` mode and specifies where the attribute is stored:
+
+* `stream label`:
+** Enables efficient filtering and querying based on specific labels.
+** Can be labeled as `required` if the {loki-op} enforces this attribute in the configuration.
+* `structured metadata`:
+** Allows for detailed filtering and storage of key-value pairs.
+** Enables users to use direct labels for streamlined queries without requiring JSON parsing.
+
+With OTLP, users can filter queries directly by labels rather than using JSON parsing, improving the speed and efficiency of queries.
+
+[cols="1,1,1,1,1", options="header"]
+|===
+|Name |Location |Applicable Sources |Storage (LokiStack) |Comment
+
+|`log_source`
+|resource
+|all
+|required stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `openshift.log.source`
+
+|`log_type`
+|resource
+|all
+|required stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `openshift.log.type`
+
+|`kubernetes.container_name`
+|resource
+|container
+|stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `k8s.container.name`
+
+|`kubernetes.host`
+|resource
+|all
+|stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `k8s.node.name`
+
+|`kubernetes.namespace_name`
+|resource
+|container
+|required stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `k8s.namespace.name`
+
+|`kubernetes.pod_name`
+|resource
+|container
+|stream label
+|*(DEPRECATED)* Compatibility attribute, contains same information as `k8s.pod.name`
+
+|`openshift.cluster_id`
+|resource
+|all
+|
+|*(DEPRECATED)* Compatibility attribute, contains same information as `openshift.cluster.uid`
+
+|`level`
+|log
+|container, journal
+|
+|*(DEPRECATED)* Compatibility attribute, contains same information as `severityText`
+
+|`openshift.cluster.uid`
+|resource
+|all
+|required stream label
+|
+
+|`openshift.log.source`
+|resource
+|all
+|required stream label
+|
+
+|`openshift.log.type`
+|resource
+|all
+|required stream label
+|
+
+|`openshift.labels.*`
+|resource
+|all
+|structured metadata
+|
+
+|`k8s.node.name`
+|resource
+|all
+|stream label
+|
+
+|`k8s.namespace.name`
+|resource
+|container
+|required stream label
+|
+
+|`k8s.container.name`
+|resource
+|container
+|stream label
+|
+
+|`k8s.pod.labels.*`
+|resource
+|container
+|structured metadata
+|
+
+|`k8s.pod.name`
+|resource
+|container
+|stream label
+|
+
+|`k8s.pod.uid`
+|resource
+|container
+|structured metadata
+|
+
+|`k8s.cronjob.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`k8s.daemonset.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`k8s.deployment.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`k8s.job.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`k8s.replicaset.name`
+|resource
+|container
+|structured metadata
+|Conditionally forwarded based on creator of pod
+
+|`k8s.statefulset.name`
+|resource
+|container
+|stream label
+|Conditionally forwarded based on creator of pod
+
+|`log.iostream`
+|log
+|container
+|structured metadata
+|
+
+|`k8s.audit.event.level`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.stage`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.user_agent`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.request.uri`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.response.code`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.annotation.*`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.resource`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.name`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.namespace`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.api_group`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.audit.event.object_ref.api_version`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.user.username`
+|log
+|audit
+|structured metadata
+|
+
+|`k8s.user.groups`
+|log
+|audit
+|structured metadata
+|
+
+|`process.executable.name`
+|resource
+|journal
+|structured metadata
+|
+
+|`process.executable.path`
+|resource
+|journal
+|structured metadata
+|
+
+|`process.command_line`
+|resource
+|journal
+|structured metadata
+|
+
+|`process.pid`
+|resource
+|journal
+|structured metadata
+|
+
+|`service.name`
+|resource
+|journal
+|stream label
+|
+
+|`systemd.t.*`
+|log
+|journal
+|structured metadata
+|
+
+|`systemd.u.*`
+|log
+|journal
+|structured metadata
+|
+|===
+
+[NOTE]
+====
+Attributes marked as *Compatibility attribute* support minimal backward compatibility with the ViaQ data model. These attributes are deprecated and function as a compatibility layer to ensure continued UI functionality. These attributes will remain supported until the Logging UI fully supports the OpenTelemetry counterparts in future releases.
+====
+
+Loki changes the attribute names when persisting them to storage. The names will be lowercased, and all characters in the set: (`.`,`/`,`-`) will be replaced by underscores (`_`). For example, `k8s.namespace.name` will become `k8s_namespace_name`.
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://opentelemetry.io/docs/specs/semconv/[Semantic Conventions]
+* link:https://opentelemetry.io/docs/specs/otel/logs/data-model/[Logs Data Model]
+* link:https://opentelemetry.io/docs/specs/semconv/general/logs/[General Logs Attributes]


### PR DESCRIPTION
Version(s): 4.19, 4.18, 4.17,4.16. Note that this needs to be cherry-picked to logging-docs-6.2-4.18, logging-docs-6.2-4.17, logging-docs-6.2-4.16 release branches and not enterprise-4.18, enterprise-4.17 branches.

Issue: https://issues.redhat.com/browse/OBSDOCS-1682
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://88652--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-opentelemetry-data-model-6.2.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR only ports exiting and already published content to a newer release. Content enhancement is beyond the scope of the Jira/PR.

Existing published content: https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.1/log6x-configuring-lokistack-otlp-6.1.html
Existing file that was copied: https://github.com/openshift/openshift-docs/blob/main/observability/logging/logging-6.1/log6x-opentelemetry-data-model-6.1.adoc
