### PR TITLE
OCPBUGS#43475: Drop Ethernet adaptor hardware address requirements

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -218,23 +218,6 @@ If an external NTP time server is configured, you must open UDP port `123`.
 
 |===
 
-ifdef::vsphere[]
-[discrete]
-== Ethernet adaptor hardware address requirements
-
-When provisioning VMs for the cluster, the ethernet interfaces configured for
-each VM must use a MAC address from the VMware Organizationally Unique
-Identifier (OUI) allocation ranges:
-
-* `00:05:69:00:00:00` to `00:05:69:FF:FF:FF`
-* `00:0c:29:00:00:00` to `00:0c:29:FF:FF:FF`
-* `00:1c:14:00:00:00` to `00:1c:14:FF:FF:FF`
-* `00:50:56:00:00:00` to `00:50:56:FF:FF:FF`
-
-If a MAC address outside the VMware OUI is used, the cluster installation will
-not succeed.
-endif::vsphere[]
-
 ifndef::azure,gcp[]
 [discrete]
 == NTP configuration for user-provisioned infrastructure


### PR DESCRIPTION
Version(s):
OCP 4.15+

Issue:
[OCPBUGS-43475](https://issues.redhat.com/browse/OCPBUGS-43475)

Link to docs preview:
* [Network connectivity requirements in installing-bare-metal](https://88687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs#installation-network-connectivity-user-infra_upi-vsphere-installation-reqs)

- [x] SME has approved this change (Kenneth D'souza).
- [x] QE has approved this change (Shang Gao).


Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Drop Ethernet adaptor hardware address requirements as per https://issues.redhat.com/browse/RFE-3104#:~:text=Customers%20can%20use%20any%20mac%20address%20they%20like%20from%204.14


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
