### PR TITLE
OSDOCS#13395: node adding known issue

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -711,7 +711,7 @@ For more information, see xref:../scalability_and_performance/using-node-tuning-
 [id="ocp-release-notes-scalability-and-performance-nrop-policy_{context}"]
 ==== NUMA Resources Operator now uses default SELinux policy
 
-With this release, the NUMA Resources Operator no longer creates a custom SELinux policy to enable the installation of Operator components on a target node. Instead, the Operator uses a built-in container SELinux policy. This change removes the additional node reboot that was previously required when applying a custom SELinux policy during an installation. 
+With this release, the NUMA Resources Operator no longer creates a custom SELinux policy to enable the installation of Operator components on a target node. Instead, the Operator uses a built-in container SELinux policy. This change removes the additional node reboot that was previously required when applying a custom SELinux policy during an installation.
 
 [IMPORTANT]
 ====
@@ -1832,6 +1832,11 @@ In the following tables, features are marked with the following statuses:
 This issue affects CPU load-balancing features, which depend on the CPU Manager releasing CPUs to the available pool. Consequently, non-guaranteed pods might run with a reduced number of CPUs. As a workaround, schedule a pod with a `best-effort` CPU Manager policy on the affected node. This pod will be the last admitted pod and this ensures the resources will be correctly released to the available pool. (link:https://issues.redhat.com/browse/OCPBUGS-46428[*OCPBUGS-46428*])
 
 * When a pod uses the CNI plugin for DHCP address assignment in conjunction with other CNI plugins, the network interface for the pod might be unexpectedly deleted. As a result, when the DHCP lease for the pod expires, the DHCP proxy enters a loop when trying to re-create a new lease, leading to the node becoming unresponsive. There is currently no workaround. (link:https://issues.redhat.com/browse/OCPBUGS-45272[*OCPBUGS-45272*])
+
+[id="ocp-nodes-4-18-known-issues_{context}"]
+
+* When using PXE boot to xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[add a worker node to an on-premise cluster], sometimes the host fails to reboot from the disk properly, preventing the installation from completing.
+As a workaround, you must manually reboot the failed host from the disk. (link:https://issues.redhat.com/browse/OCPBUGS-45116[*OCPBUGS-45116*])
 
 [id="ocp-storage-core-4-18-known-issues_{context}"]
 


### PR DESCRIPTION
[OSDOCS-13395](https://issues.redhat.com/browse/OSDOCS-13395)

Version(s): 4.18

This PR adds a known issue to the release notes for adding nodes to an on-prem cluster

QE review:
- [x] QE has approved this change.

Preview: [Known issue](https://88702--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-known-issues_release-notes)