### PR TITLE
TELCODOCS-2036: Docs and RN: CNF-12678 MLX secure boot: support Disable vendor plugin in SR-IOV operator - Release Notes

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -640,6 +640,13 @@ This is an alternative to explicitly setting an ASN in the `spec.peerASN` field.
 With this release, you can configure a Remote Direct Memory Access (RDMA) Container Network Interface (CNI) on Single Root I/O Virtualization (SR-IOV) to enable high-performance, low-latency communication between containers.
 When you combine RDMA with SR-IOV, you provide a mechanism to expose hardware counters of Mellanox Ethernet devices to be used inside Data Plane Development Kit (DPDK) applications.
 
+[id="ocp-release-notes-networking-sr-iov-mlx-secure-boot_{context}"]
+==== Support configuring the SR-IOV Network Operator on a Secure-Boot-enabled environment for Mellanox cards
+
+With this release, you can configure the Single Root I/O Virtualization (SR-IOV) Network Operator when the system has secure boot enabled. The SR-IOV Operator is configured after you first manually configure the firmware for Mellanox devices. With secure boot enabled, the resilience of your system is enhanced, and a crucial layer of defense for the overall security of your computer is provided.
+
+For more information, see  xref:../networking/hardware_networks/configuring-sriov-device.adoc#nw-sriov-nic-mlx-secure-boot_configuring-sriov-device[Configuring the SR-IOV Network Operator on Mellanox cards when Secure Boot is enabled].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-2036: Docs and RN: [CNF-12678](https://issues.redhat.com//browse/CNF-12678) MLX secure boot: support Disable vendor plugin in SR-IOV operator - Release Notes

Applies to OCP version : 4.18

Preview: [Support configuring the SR-IOV Network Operator on a Secure-Boot-enabled environment for Mellanox cards](https://88705--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-networking-sr-iov-mlx-secure-boot_release-notes)

QE review completed by @evgenLevin
Dev review completed by @SchSeba
Peer review completed by @cbippley @mburke5678 @agantony 

Thank you.