### PR TITLE
TELCODOCS-2069: Telco core bug fix release notes

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1174,6 +1174,17 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-release-note-node-tuning-operator-bug-fixes_{context}"]
 ==== Node Tuning Operator (NTO)
 
+* Previously, if you specified a long string of isolated CPUs in a performance profile, such as `0,1,2,...,512`, the `tuned`, Machine Config Operator, and `rpm-ostree` components failed to process the string as expected. As a consequence, after you applied the performance profile, the expected kernel arguments were missing. The system failed silently with no reported errors. With this release, the string for isolated CPUs in a performance profile is converted to sequential ranges, such as `0-512`. As a result, the kernel arguments are applied as expected in most scenarios. (link:https://issues.redhat.com/browse/OCPBUGS-45264[*OCPBUGS-45264*])
++
+[NOTE]
+====
+The issue might still occur with some combinations of input for isolated CPUs in a performance profile, such as a long list of odd numbers `1,3,5,...,511`.
+====
+
+* Previously, CPU masks for interrupt and network handling CPU affinity were computed incorrectly on machines with more than 256 CPUs. This issue prevented proper CPU isolation and caused `systemd` unit failures during internal node configuration. This fix ensures accurate CPU affinity calculations, enabling correct CPU isolation on machines with more than 256 CPUs. (link:https://issues.redhat.com/browse/OCPBUGS-36431[*OCPBUGS-36431*])
+
+* Previously, entering an invalid value in any `cpuset` field under `spec.cpu` in the `PerformanceProfile` resource caused the webhook validation to crash. With this release, improved error handling for the `PerformanceProfile` validation webhook ensures that invalid values for these fields return an informative error. (link:https://issues.redhat.com/browse/OCPBUGS-45616[*OCPBUGS-45616*])
+
 [discrete]
 [id="ocp-release-note-observability-bug-fixes_{context}"]
 ==== Observability
@@ -1197,6 +1208,8 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [discrete]
 [id="ocp-release-note-scalability-and-performance-bug-fixes_{context}"]
 ==== Scalability and performance
+
+* Previously, you could configure the NUMA Resources Operator to map a `nodeGroup` to more than one `MachineConfigPool`. This implementation is contrary to the intended design of the Operator, which assumed a one-to-one mapping between a `nodeGroup` and a `MachineConfigPool`. With this release, if a `nodeGroup` maps to more than one `MachineConfigPool`, the Operator accepts the configuration, but the Operator state moves to `Degraded`. To retain the previous behavior, you can apply the `config.node.openshift-kni.io/multiple-pools-per-tree: enabled` annotation to the NUMA Resources Operator. However, the ability to assign a `nodeGroup` to more than one `MachineConfigPool` will be removed in a future release. (link:https://issues.redhat.com/browse/OCPBUGS-42523[*OCPBUGS-42523*])
 
 [discrete]
 [id="ocp-release-note-storage-bug-fixes_{context}"]


### PR DESCRIPTION
[TELCODOCS-2069](https://issues.redhat.com//browse/TELCODOCS-2069): Telco core bug fix release notes

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/TELCODOCS-2069

Link to docs preview:
https://88720--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-bug-fixes_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
All RNs have been approved by SME and QE.
