### PR TITLE
OBSDOCS-1646: Document enabling Full In-Cluster OpenTelemetry Support

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3014,6 +3014,8 @@ Topics:
       File: log6x-clf-6.2
     - Name: Configuring LokiStack storage
       File: log6x-loki-6.2
+    - Name: Configuring LokiStack for OTLP
+      File: log6x-configuring-lokistack-otlp-6.2
     - Name: Visualization for logging
       File: log6x-visual-6.2
   - Name: Logging 6.1

--- a/modules/log6x-6-2-0-rn.adoc
+++ b/modules/log6x-6-2-0-rn.adoc
@@ -28,15 +28,17 @@ TOFIX:
 
 * With this update, the new `1x.pico` LokiStack size supports clusters with fewer workloads and lower log volumes (up to 50GB/day). (link:https://issues.redhat.com/browse/LOG-5939[LOG-5939])
 
-[id="logging-release-notes-6-1-0-technology-preview-features"]
+////
+
+[id="logging-release-notes-6-2-0-technology-preview-features_{context}"]
 == Technology Preview
 
 :FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
 include::snippets/technology-preview.adoc[]
 
-* With this update, OpenTelemetry logs can now be forwarded using the `OTel` (OpenTelemetry) data model to a Red Hat Managed LokiStack instance. To enable this feature, add the `observability.openshift.io/tech-preview-otlp-output: "enabled"` annotation to your `ClusterLogForwarder` configuration. For additional configuration information, see link:https://github.com/openshift/cluster-logging-operator/blob/master/docs/features/logforwarding/outputs/opentelemetry-lokistack-forwarding.adoc[OTLP Forwarding].
-
+////
 * With this update, a `dataModel` field has been added to the `lokiStack` output specification. Set the `dataModel` to `Otel` to configure log forwarding using the OpenTelemetry data format. The default is set to `Viaq`. For information about data mapping see link:https://opentelemetry.io/docs/specs/otlp/[OTLP Specification].
+
 ////
 
 [id="logging-release-notes-6-2-0-bug-fixes_{context}"]

--- a/observability/logging/logging-6.1/log6x-configuring-lokistack-otlp-6.1.adoc
+++ b/observability/logging/logging-6.1/log6x-configuring-lokistack-otlp-6.1.adoc
@@ -6,24 +6,24 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Logging 6.1 enables an API endpoint using the OpenTelemetry Protocol (OTLP). As OTLP is a standardized format not specifically designed for Loki, it requires additional configuration on Loki's side to map OpenTelemetry's data format to Loki's data model. OTLP lacks concepts such as _stream labels_ or _structured metadata_. Instead, OTLP provides metadata about log entries as *attributes*, grouped into three categories:
+You can use an API endpoint by using the OpenTelemetry Protocol (OTLP) with Logging 6.1. As OTLP is a standardized format not specifically designed for Loki, OTLP requires an additional Loki configuration to map data format of OpenTelemetry to data model of Loki. OTLP lacks concepts such as _stream labels_ or _structured metadata_. Instead, OTLP provides metadata about log entries as *attributes*, grouped into the following three categories:
 
 * Resource
 * Scope
 * Log
 
-This allows metadata to be set for multiple entries simultaneously or individually as needed.
+You can set metadata for multiple entries simultaneously or individually as needed.
 
 include::modules/log6x-configuring-lokistack-otlp-data-ingestion.adoc[leveloffset=+1]
 
 [id="attribute-mapping_{context}"]
 == Attribute mapping
 
-When the {loki-op} is set to `openshift-logging` mode, it automatically applies a default set of attribute mappings. These mappings align specific OTLP attributes with Loki's stream labels and structured metadata.
+When you set the {loki-op} to the `openshift-logging` mode, {loki-op} automatically applies a default set of attribute mappings. These mappings align specific OTLP attributes with stream labels and structured metadata of Loki.
 
-For typical setups, these default mappings should be sufficient. However, you might need to customize attribute mapping in the following cases:
+For typical setups, these default mappings are sufficient. However, you might need to customize attribute mapping in the following cases:
 
-* Using a custom Collector: If your setup includes a custom collector that generates additional attributes, consider customizing the mapping to ensure these attributes are retained in Loki.
+* Using a custom collector: If your setup includes a custom collector that generates additional attributes, consider customizing the mapping to ensure these attributes are retained in Loki.
 * Adjusting attribute detail levels: If the default attribute set is more detailed than necessary, you can reduce it to essential attributes only. This can avoid excessive data storage and streamline the {logging} process.
 
 [IMPORTANT]
@@ -33,17 +33,15 @@ Attributes that are not mapped to either stream labels or structured metadata ar
 
 [id="custom-attribute-mapping-for-openshift_{context}"]
 === Custom attribute mapping for OpenShift
-
-When using the {loki-op} in `openshift-logging` mode, attribute mapping follow OpenShift defaults, but custom mappings can be configured to adjust these. Custom mappings allow further configurations to meet specific needs.
-
-In `openshift-logging` mode, custom attribute mappings can be configured globally for all tenants or for individual tenants as needed. When custom mappings are defined, they are appended to the OpenShift defaults. If default recommended labels are not required, they can be disabled in the tenant configuration.
+When using the {loki-op} in `openshift-logging` mode, attribute mapping follow OpenShift default values, but you can configure custom mappings to adjust default values. 
+In the `openshift-logging` mode, you can configure custom attribute mappings globally for all tenants or for individual tenants as needed. When you define custom mappings, they are appended to the OpenShift default values. If you do not need default labels, you can disable them in the tenant configuration.
 
 [NOTE]
 ====
-A major difference between the {loki-op} and Loki itself lies in inheritance handling. Loki only copies `default_resource_attributes_as_index_labels` to tenants by default, while the {loki-op} applies the entire global configuration to each tenant in `openshift-logging` mode.
+A major difference between the {loki-op} and Loki lies in inheritance handling. Loki copies only `default_resource_attributes_as_index_labels` to tenants by default, while the {loki-op} applies the entire global configuration to each tenant in the `openshift-logging` mode.
 ====
 
-Within `LokiStack`, attribute mapping configuration is managed through the `limits` setting:
+Within `LokiStack`, attribute mapping configuration is managed through the `limits` setting. See the following example `LokiStack` configuration:
 
 [source,yaml]
 ----
@@ -56,7 +54,7 @@ spec:
       application:
         otlp: {} # <2>
 ----
-<1> Global OTLP attribute configuration.
+<1> Defines global OTLP attribute configuration.
 <2> OTLP attribute configuration for the `application` tenant within `openshift-logging` mode.
 
 [NOTE]
@@ -89,7 +87,7 @@ spec:
     global:
       otlp:
         streamLabels:
-          # ...
+# ...
         structuredMetadata:
           resourceAttributes:
           - name: "process.command_line"

--- a/observability/logging/logging-6.2/log6x-configuring-lokistack-otlp-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-configuring-lokistack-otlp-6.2.adoc
@@ -1,0 +1,142 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="log6x-configuring-lokistack-otlp-6-2"]
+= OTLP data ingestion in Loki
+include::_attributes/common-attributes.adoc[]
+:context: log6x-configuring-lokistack-otlp-6-2
+
+toc::[]
+
+You can use an API endpoint by using the OpenTelemetry Protocol (OTLP) with Logging. As OTLP is a standardized format not specifically designed for Loki, OTLP requires an additional Loki configuration to map data format of OpenTelemetry to data model of Loki. OTLP lacks concepts such as _stream labels_ or _structured metadata_. Instead, OTLP provides metadata about log entries as *attributes*, grouped into the following three categories:
+
+* Resource
+* Scope
+* Log
+
+You can set metadata for multiple entries simultaneously or individually as needed.
+
+include::modules/log6x-configuring-lokistack-otlp-data-ingestion.adoc[leveloffset=+1]
+
+[id="attribute-mapping_{context}"]
+== Attribute mapping
+
+When you set the {loki-op} to the `openshift-logging` mode, {loki-op} automatically applies a default set of attribute mappings. These mappings align specific OTLP attributes with stream labels and structured metadata of Loki.
+
+For typical setups, these default mappings are sufficient. However, you might need to customize attribute mapping in the following cases:
+
+* Using a custom collector: If your setup includes a custom collector that generates additional attributes that you do not want to store, consider customizing the mapping to ensure these attributes are dropped by Loki.
+* Adjusting attribute detail levels: If the default attribute set is more detailed than necessary, you can reduce it to essential attributes only. This can avoid excessive data storage and streamline the {logging} process.
+
+[id="custom-attribute-mapping-for-openshift_{context}"]
+=== Custom attribute mapping for OpenShift
+
+When using the {loki-op} in `openshift-logging` mode, attribute mapping follow OpenShift default values, but you can configure custom mappings to adjust default values. 
+In the `openshift-logging` mode, you can configure custom attribute mappings globally for all tenants or for individual tenants as needed. When you define custom mappings, they are appended to the OpenShift default values. If you do not need default labels, you can disable them in the tenant configuration.
+
+[NOTE]
+====
+A major difference between the {loki-op} and Loki lies in inheritance handling. Loki copies only `default_resource_attributes_as_index_labels` to tenants by default, while the {loki-op} applies the entire global configuration to each tenant in the `openshift-logging` mode.
+====
+
+Within `LokiStack`, attribute mapping configuration is managed through the `limits` setting. See the following example `LokiStack` configuration:
+
+[source,yaml]
+----
+# ...
+spec:
+  limits:
+    global:
+      otlp: {} # <1>
+    tenants:
+      application: # <2>
+        otlp: {}
+----
+<1> Defines global OTLP attribute configuration.
+<2> Defines the OTLP attribute configuration for the `application` tenant within the `openshift-logging` mode. You can also configure `infrastructure` and `audit` tenants in addition to `application` tenants.
+
+[NOTE]
+====
+You can use both global and per-tenant OTLP configurations for mapping attributes to stream labels.
+====
+
+Stream labels derive only from resource-level attributes, which the `LokiStack` resource structure reflects. See the following `LokiStack` example configuration:
+
+[source,yaml]
+----
+spec:
+  limits:
+    global:
+      otlp:
+        streamLabels:
+          resourceAttributes:
+          - name: "k8s.namespace.name"
+          - name: "k8s.pod.name"
+          - name: "k8s.container.name"
+----
+
+You can drop attributes of type resource, scope, or log from the log entry.
+
+[source,yaml]
+----
+# ...
+spec:
+  limits:
+    global:
+      otlp:
+        streamLabels:
+# ...
+        drop:
+          resourceAttributes:
+          - name: "process.command_line"
+          - name: "k8s\\.pod\\.labels\\..+"
+            regex: true
+          scopeAttributes:
+          - name: "service.name"
+          logAttributes:
+          - name: "http.route"
+----
+
+You can use regular expressions by setting `regex: true` to apply a configuration for attributes with similar names.
+
+[IMPORTANT]
+====
+Avoid using regular expressions for stream labels, as this can increase data volume.
+====
+
+Attributes that are not explicitly set as stream labels or dropped from the entry are saved as structured metadata by default.
+
+[id="customizing-openshift-defaults_{context}"]
+=== Customizing OpenShift defaults
+
+In the `openshift-logging` mode, certain attributes are required and cannot be removed from the configuration due to their role in OpenShift functions. Other attributes, labeled *recommended*, might be dropped if performance is impacted. For information about the attributes, see link:https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.1/log6x-opentelemetry-data-model-6.1.html#attributes_log6x-opentelemetry-data-model-6-1[OpenTelemetry data model attributes].
+
+When using the `openshift-logging` mode without custom attributes, you can achieve immediate compatibility with OpenShift tools. If additional attributes are needed as stream labels or some attributes need to be droped, use custom configuration. Custom configurations can merge with default configurations.
+
+[id="removing-recommended-attributes_{context}"]
+=== Removing recommended attributes
+
+To reduce default attributes in the `openshift-logging` mode, disable recommended attributes:
+
+[source,yaml]
+----
+# ...
+spec:
+  tenants:
+    mode: openshift-logging
+    openshift:
+      otlp:
+        disableRecommendedAttributes: true # <1>
+----
+<1> Set `disableRecommendedAttributes: true` to remove recommended attributes, which limits default attributes to the required attributes or stream labels.
++
+[NOTE]
+====
+This setting might negatively impact query performance, as it removes default stream labels. You must pair this option with a custom attribute configuration to retain attributes essential for queries.
+====
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://grafana.com/docs/loki/latest/get-started/labels/[Loki labels] (Grafana documentation)
+* link:https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/[Structured metadata] (Grafana documentation)
+* link:https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.1/log6x-opentelemetry-data-model-6.1.html[OpenTelemetry data model]
+* link:https://opentelemetry.io/docs/specs/otel/common/#attribute[OpenTelemetry attribute] (OpenTelemetry documentation)


### PR DESCRIPTION
Version(s): 4.19, 4.18, 4.17, 4.16. Note that this needs to be cherry-picked to logging-docs-6.2-4.18, logging-docs-6.2-4.17,  logging-docs-6.2-4.16 release branches and not enterprise-4.18, enterprise-4.17 branches.
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1646
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://88721--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-configuring-lokistack-otlp-6.2.html
- https://88721--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-release-notes-6.2.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
There are two parts to this PR.

Part 1:
Port exiting and already published content to a newer release.

- Existing published content: https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.1/log6x-configuring-lokistack-otlp-6.1.html
- Existing file that was copied: https://github.com/openshift/openshift-docs/blob/main/observability/logging/logging-6.1/log6x-configuring-lokistack-otlp-6.1.adoc

Part 2: 

Make the changes required for Logging 6.2 release per [OBSDOCS-1646](https://issues.redhat.com//browse/OBSDOCS-1646). This includes addition of a release note and a few minor changes to the ported content.

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
