### PR TITLE
CNV#45704 4.15 CP: WSFC validation is not working with multipath LUNs

### DIFF
--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -15,6 +15,11 @@ You reserve a LUN through the SCSI persistent reserve options. To enable the res
 . Configure the feature gate option
 . Activate the feature gate option on the LUN disk to issue SCSI device-specific input and output controls (IOCTLs) that the VM requires.
 
+[IMPORTANT]
+====
+{VirtProductName} does not currently support SCSI-3 Persistent Reservations (SCSI-3 PR) over multipath storage. As a workaround, disable multipath or ensure the Windows Server Failover Clustering (WSFC) shared disk is setup from a single device and not part of multipath.
+====
+
 .Prerequisites
 
 * You must have cluster administrator privileges to configure the feature gate option.


### PR DESCRIPTION
**Version(s):**
4.15

**Issue:**
https://issues.redhat.com/browse/CNV-55937

**Link to docs preview:**
https://88723--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.html#virt-configuring-disk-sharing-lun_virt-configuring-shared-volumes-for-vms

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->