### PR TITLE
OSSM-8879 Update docinfo.xml files to use {product-title} and {product-version} for Pantheon

### DIFF
--- a/about/docinfo.xml
+++ b/about/docinfo.xml
@@ -1,6 +1,6 @@
 <title>About</title>
-<productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0.0tp1</productnumber>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
 <subtitle>About OpenShift Service Mesh</subtitle>
 <abstract>
     <para>This document provides an overview of OpenShift Service Mesh features.

--- a/install/docinfo.xml
+++ b/install/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing</title>
-<productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0.0tp1</productnumber>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
 <subtitle>Installing OpenShift Service Mesh</subtitle>
 <abstract>
     <para>This documentation provides information about installing OpenShift Service Mesh.

--- a/migrating/checklists/docinfo.xml
+++ b/migrating/checklists/docinfo.xml
@@ -1,18 +1,9 @@
-<<<<<<< HEAD
-<title>Kiali Differences for Service Mesh 3</title>
-<productname>{product-title}</productname>
-<productnumber>{product-version}</productnumber>
-<subtitle>Kiali Differences for Service Mesh 3</subtitle>
-<abstract>
-    <para>This document provides important updates to Kiali for OpenShift Service Mesh 3.
-=======
 <title>Before migrating</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
 <subtitle>Premigration checklists</subtitle>
 <abstract>
     <para>This document provides information and a set of checklists that must be completed before you can migrate from OpenShift Service Mesh 2.6 to OpenShift Service Mesh 3.
->>>>>>> 12a76b9aec (OSSM-8673 Staging and Testing Migration Guides IA/Content)
     </para>
 </abstract>
 <authorgroup>

--- a/observability/docinfo.xml
+++ b/observability/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Observability</title>
-<productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0.0tp1</productnumber>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
 <subtitle>Observability and Service Mesh</subtitle>
 <abstract>
     <para>This document provides an overview of Red Hat OpenShift Observability integrations with OpenShift Service Mesh.</para>

--- a/observability/kiali/docinfo.xml
+++ b/observability/kiali/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Kiali Operator provided by Red Hat</title>
-<productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0.0tp1</productnumber>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
 <subtitle>Using the Kiali Operator provided by Red Hat</subtitle>
 <abstract>
     <para>This documentation provides information about Kiali Operator provided by Red Hat, and how to view the data that flows through your application.

--- a/observability/metrics/docinfo.xml
+++ b/observability/metrics/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Metrics</title>
-<productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0.0tp1</productnumber>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
 <subtitle>Using metrics with Service Mesh</subtitle>
 <abstract>
     <para>This documentation provides information about how you can monitor the in-cluster health and performance of your applications.

--- a/observability/traces/docinfo.xml
+++ b/observability/traces/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Distributed Tracing</title>
-<productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0.0tp1</productnumber>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
 <subtitle>Using distributed tracing with OpenShift Service Mesh</subtitle>
 <abstract>
     <para>This document provides an overview of distributed tracing in OpenShift Service Mesh, and how to configure distributed tracing for {SMProductShortName}.

--- a/ossm-release-notes/docinfo.xml
+++ b/ossm-release-notes/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Release Notes</title>
 <productname>{product-title}</productname>
-<productnumber>3.0.0tp1</productnumber>
+<productnumber>{product-version}</productnumber>
 <subtitle>OpenShift Service Mesh release notes</subtitle>
 <abstract>
     <para>This documentation provides information about each {product-title} release.

--- a/uninstalling/docinfo.xml
+++ b/uninstalling/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Uninstalling</title>
-<productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0.0tp1</productnumber>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
 <subtitle>Uninstalling OpenShift Service Mesh</subtitle>
 <abstract>
     <para>This documentation provides information about uninstalling OpenShift Service Mesh.

--- a/update/docinfo.xml
+++ b/update/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Updating</title>
-<productname>Red Hat OpenShift Service Mesh</productname>
-<productnumber>3.0.0tp1</productnumber>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
 <subtitle>Updating OpenShift Service Mesh</subtitle>
 <abstract>
     <para>This documentation provides information about how to update OpenShift Service Mesh.


### PR DESCRIPTION
**OSSM 3.0**

[OSSM-8879](https://issues.redhat.com//browse/OSSM-8879) Update docinfo.xml files to use {product-title} and {product-version} for Pantheon

**Merge PR to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

**Service Mesh has moved to the stand alone format and will not be cherry picked back to OCP core branches.**

Issue:
https://issues.redhat.com/browse/OSSM-8879

Link to docs preview:
There are not preview for docinfo.xml files. They are for Pantheon builds.

QE review:
QE review is not required for this PR.

Additional information:
Fixing docinfo.xml files for Pantheon builds.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
