### PR TITLE
OSSM-8520 Document migration of network policies created by 2.x

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -20,8 +20,8 @@ Topics:
     File: ossm-migrating-read-me-assembly
   - Name: Premigration checklists
     File: ossm-migrating-premigration-checklists-assembly
-  - Name: Migrating network policies for security purposes
-    File: ossm-migrating-network-policies-security-assembly
+  - Name: Migrating network policies
+    File: ossm-migrating-network-policies-assembly
   - Name: Kiali differences for Service Mesh 3
     File: ossm-migrating-kiali-differences-assembly
     #Kiali PR https://github.com/openshift/openshift-docs/pull/88193

--- a/migrating/checklists/ossm-migrating-network-policies-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-network-policies-assembly.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ossm-migrating-network-policies-assembly"]
+= Migrating network policies from Service Mesh 2 to Service Mesh 3
+include::_attributes/common-attributes.adoc[]
+:context: ossm-migrating-network-policies-assembly
+
+toc::[]
+
+In {SMProductName} 2, network policies are created by default when the `spec.security.manageNetworkPolicy` field is set to `true` in the `ServiceMeshControlPlane` resource. During the migration to {SMProduct} 3, these policies are removed.
+
+It is recommended to re-create your network policies after you have migrated your deployment and workloads. However, if your security policies require you to keep your network policies, you must re-create them first, and then set the `spec.security.manageNetworkPolicy` field to `false` as outlined in the migration checklists.
+
+include::modules/ossm-migrating-network-policies-setup-during-migration.adoc[leveloffset=+1]
+
+.Next steps
+* In {SMProduct} 2, set the `spec.security.manageNetworkPolicy` field to `false` in your `ServiceMeshControlPlane` resource, and continue with the migration checklists.
+
+//exrefs handled by OSSM-8852
+
+
+//Note to self: migrating-done-network-policies is file name in <done> dir for migrating network policies after completely deployment and workloads migration.

--- a/migrating/checklists/ossm-migrating-network-policies-security-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-network-policies-security-assembly.adoc
@@ -1,8 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-network-policies-security-assembly"]
-= Network policies for security purposes
-include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-network-policies-security-assembly
-
-toc::[]
-

--- a/migrating/done/ossm-migrating-complete-assembly.adoc
+++ b/migrating/done/ossm-migrating-complete-assembly.adoc
@@ -12,7 +12,7 @@ At this stage, you have completed the migration process. It is safe to remove {S
 
 Optionally, if you already have Kiali installed, before you delete {SMProduct} {SMv2Version}, you can verify that all data plane namespaces have been migrated by checking the Kiali **Mesh** page. To learn more about the Kiali **Mesh** page, see "Istio infrastructure status (Kiali.io)".
 
-//include::modules/ossm-migrating-done-network-policies.adoc[leveloffset=+1]
+include::modules/ossm-migrating-done-network-policies.adoc[leveloffset=+1]
 include::modules/ossm-migrating-complete-multitant-cert-manager.adoc[leveloffset=+1]
 
 .Next steps

--- a/modules/ossm-migrating-done-network-policies.adoc
+++ b/modules/ossm-migrating-done-network-policies.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/checklists/ossm-migrating-network-policies.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-network-policies-security_{context}"]
+= Migrating network policies after migrating deployment and workloads
+
+If you did not re-create your network policies before you migrated your deployment and workloads, you can re-create your network policies after migrating.
+
+.Prerequisites
+
+* You have migrated your deployment.
+* You have migrated your workloads.
+
+.Procedure
+
+. Recreate necessary network policies in the new {SMProduct} 3 control plane namespace.
+
+. Recreate network policies for each namespace that was part of the {SMProduct} 2 mesh.
+
+. Update labels.
++
+.. Update corresponding network policy selectors to match the new labels.
++
+[NOTE]
+====
+Use a label scoped specifically to your mesh that you can reuse for discovery selectors.
+====

--- a/modules/ossm-migrating-network-policies-setup-during-migration.adoc
+++ b/modules/ossm-migrating-network-policies-setup-during-migration.adoc
@@ -1,0 +1,228 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/checklists/ossm-migrating-network-policies.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-network-policies-setup-during-migration_{context}"]
+= Set up network policies to use during migration
+
+You can set up network policies to use during your migration.
+
+[IMPORTANT]
+====
+* During the recreation of network policies from {SMProduct} 2 to {SMProduct} 3, both control planes must have access to all workloads and all workloads must have access to control planes.
+
+* The `maistra.io/member-of:` label is removed from the namespaces during migration.
+====
+
+.Prerequisites
+
+* You have deployed {ocp-product-title} 4.14 or later.
+* You are logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
+* You have the {SMProduct} {SMv2Version} Operator installed.
+* You have the `ServiceMeshControlPlane` 2.6 resource installed.
+* In {SMProduct} 2, you have set `spec.security.manageNetworkPolicy=true` in your  `ServiceMeshControlPlane` resource.
+* You have deployed the `bookinfo` and `bookinfo2` applications.
+
+.Procedure
+
+. Label namespaces by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace <app_namespace> service-mesh=enabled
+----
++
+[NOTE]
+====
+Use a label scoped specifically to your mesh that you can reuse for discovery selectors.
+====
+
+. Create your network policies by using the following `NetworkPolicy` example configurations:
++
+.Example of an Istiod network policy in a mesh namespace
+[source,yaml]
+--
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istiod-basic
+  namespace: istio-system
+spec:
+  ingress:
+    - {}
+  podSelector:
+    matchLabels:
+      app: istiod
+      istio.io/rev: basic
+  policyTypes:
+    - Ingress
+--
++
+.Example of an expose route policy in a mesh namespace
+[source,yaml]
+--
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: expose-route-basic
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      maistra.io/expose-route: "true"
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
+--
++
+.Example of a default mesh network policy in a mesh namespace
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-mesh
+  namespace: istio-system
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              service-mesh: enabled
+  podSelector: {}
+  policyTypes:
+    - Ingress
+----
++
+.Example expose route network policy in the `bookinfo` namespace
+[source,yaml]
+--
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-expose-route
+  namespace: bookinfo
+spec:
+  podSelector:
+    matchLabels:
+      maistra.io/expose-route: "true"
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
+--
++
+.Example mesh network policy in the `bookinfo` namespace
+[source,yaml]
+--
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-mesh
+  namespace: bookinfo
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              service-mesh: enabled
+  podSelector: {}
+  policyTypes:
+    - Ingress
+--
++
+.Example expose route network policy in the `bookinfo2` namespace
+[source,yaml]
+--
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-expose-route
+  namespace: bookinfo2
+spec:
+  podSelector:
+    matchLabels:
+      maistra.io/expose-route: "true"
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+
+--
++
+.Example mesh network policy in the `bookinfo2` namespace
+[source,yaml]
+--
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-mesh
+  namespace: bookinfo2
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              service-mesh: enabled
+  podSelector: {}
+  policyTypes:
+    - Ingress
+--
+
+. Disable network policies in {SMProduct} 2 by setting the `spec.security.manageNetworkPolicy` field to `false` in your `ServiceMeshControlPlane` resource.
++
+[NOTE]
+====
+Setting the `spec.security.manageNetworkPolicy` field to `false` in your `ServiceMeshControlPlane` resource removes the network policies created by default in {SMProduct} 2.
+====
+
+. Find your current active revision by running the following command:
++
+[source,terminal]
+----
+$ oc get istios <istio_name>
+----
++
+.Example output
+[source,terminal]
+----
+NAME             REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
+istio-tenant-a   1           1       0        istio-tenant-a    Healthy   v1.24.3   30s
+----
+
+. Copy the active revision name from the output to use for your `istio.io/rev` label in your second Istiod network policy for {SMProduct} 3.
+
+. Create a second Istiod network policy for {SMProduct} 3 by using the following `NetworkPolicy` example configuration:
++
+.Sample policy
++
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-istiod-v3
+  namespace: istio-system
+spec:
+  ingress:
+    - {}
+  podSelector:
+    matchLabels:
+      app: istiod
+      istio.io/rev: istio-tenant-a <1>
+  policyTypes:
+    - Ingress
+----
+<1> Must match your current active revision name.
+
+


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-8520](https://issues.redhat.com//browse/OSSM-8520) Document migration of network policies created by 2.x

**Merge to:** https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick to:** https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

**Service Mesh has moved to the stand alone format and will not be cherry picked back to OCP core**

Issue:
https://issues.redhat.com/browse/OSSM-8520

Link to docs preview:
https://88728--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-network-policies-assembly.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
