### PR TITLE
OSDOCS#13356: Agent Installer with PCA

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -310,6 +310,9 @@ endif::[]
 :oci-c3: Oracle(R) Compute Cloud@Customer
 :oci-c3-no-rt: Oracle Compute Cloud@Customer
 :oci-c3-short: Compute Cloud@Customer
+:oci-pca: Oracle(R) Private Cloud Appliance
+:oci-pca-no-rt: Oracle Private Cloud Appliance
+:oci-pca-short: Private Cloud Appliance
 // Red Hat OpenStack Platform (RHOSP)/OpenStack
 ifndef::openshift-origin[]
 :rh-openstack-first: Red Hat OpenStack Platform (RHOSP)

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -585,6 +585,8 @@ Topics:
     File: installing-oci-agent-based-installer
   - Name: Installing a cluster on Oracle Compute Cloud@Customer by using the Agent-based Installer
     File: installing-c3-agent-based-installer
+  - Name: Installing a cluster on Oracle Private Cloud Appliance by using the Agent-based Installer
+    File: installing-pca-agent-based-installer
 - Name: Installing on VMware vSphere
   Dir: installing_vsphere
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_oci/installing-pca-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-pca-agent-based-installer.adoc
@@ -1,0 +1,70 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="installing-pca-agent-based-installer"]
+= Installing a cluster on {oci-pca-no-rt} by using the Agent-based Installer
+:context: installing-pca-agent-based-installer
+
+toc::[]
+
+You can use the Agent-based Installer to install a cluster on {oci-pca}, so that you can run cluster workloads on on-premise infrastructure while still using {oci-first} services.
+
+////
+Do I need to add a BM/VM support statement like the one below?
+
+Installing a cluster on {oci-pca-short} is supported for virtual-machines (VMs) and bare-metal machines.
+////
+
+[id="abi-oci-pca-process-checklist_{context}"]
+== Installation process workflow
+
+The following workflow describes a high-level outline for the process of installing an {product-title} cluster on {oci-pca-short} using the Agent-based Installer:
+
+. Create {oci-pca-short} resources and services (Oracle).
+. Prepare configuration files for the Agent-based Installer (Red{nbsp}Hat).
+. Generate the agent ISO image (Red{nbsp}Hat).
+. Convert the ISO image to an {oci-first-no-rt} image, upload it to an {oci} Home Region Bucket, and then import the uploaded image to the {oci-pca-short} system (Oracle).
+. Disconnected environments: Prepare a web server that is accessible by {oci} instances (Red{nbsp}Hat).
+. Disconnected environments: Upload the rootfs image to the web server (Red{nbsp}Hat).
+. Configure your firewall for {product-title} (Red{nbsp}Hat).
+. Create control plane nodes and configure load balancers (Oracle).
+. Create compute nodes and configure load balancers (Oracle).
+. Verify that your cluster runs on {oci} (Oracle).
+
+// Creating Private Cloud Appliance infrastructure resources and services
+include::modules/abi-pca-resources-services.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts.htm[Learn About Oracle Cloud Basics (Oracle documentation)]
+
+// Creating configuration files for installing a cluster on OCI
+include::modules/creating-config-files-cluster-install-oci.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#installation-overview_architecture-installation[About {product-title} installation]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing-selecting-cluster-type[Selecting a cluster installation type]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer]
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-retrieve_installing-with-agent-based-installer[Downloading the Agent-based Installer]
+* xref:../../disconnected/mirroring/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red{nbsp}Hat OpenShift]
+* xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository]
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-ztp_installing-with-agent-based-installer[Optional: Using ZTP manifests]
+
+// Configuring your firewall
+include::modules/configuring-firewall.adoc[leveloffset=+1]
+
+// Running your cluster on Private Cloud Appliance
+include::modules/running-cluster-oci-pca-agent-based.adoc[leveloffset=+1]
+
+// Verifying that your Agent-based cluster installation runs on {oci}
+include::modules/verifying-cluster-install-oci-agent-based.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-gather-log_installing-with-agent-based-installer[Gathering log data from a failed Agent-based installation]
+
+* xref:../../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[Adding worker nodes to an on-premise cluster]

--- a/modules/abi-c3-resources-services.adoc
+++ b/modules/abi-c3-resources-services.adoc
@@ -12,9 +12,9 @@ You must create an {oci-c3-short} environment on your virtual machine (VM) or ba
 ====
 To ensure compatibility with {product-title}, you must set `A` as the record type for each DNS record and name records as follows:
 
-* `api.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer.
-* `api-int.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer.
-* `*.apps.<cluster_name>.<base_domain>`, which targets the `ingressVIP` parameter of the Ingress load balancer.
+* `api.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer
+* `api-int.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer
+* `*.apps.<cluster_name>.<base_domain>`, which targets the `ingressVIP` parameter of the Ingress load balancer
 
 The `api.{asterisk}` and `api-int.{asterisk}` DNS records relate to control plane machines, so you must ensure that all nodes in your installed {product-title} cluster can access these DNS records.
 ====

--- a/modules/abi-oci-resources-services.adoc
+++ b/modules/abi-oci-resources-services.adoc
@@ -14,9 +14,9 @@ The Agent-based Installer method for installing an {product-title} cluster on {o
 ====
 To ensure compatibility with {product-title}, you must set `A` as the record type for each DNS record and name records as follows:
 
-* `api.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer.
-* `api-int.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer.
-* `*.apps.<cluster_name>.<base_domain>`, which targets the `ingressVIP` parameter of the Ingress load balancer.
+* `api.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer
+* `api-int.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer
+* `*.apps.<cluster_name>.<base_domain>`, which targets the `ingressVIP` parameter of the Ingress load balancer
 
 The `api.{asterisk}` and `api-int.{asterisk}` DNS records relate to control plane machines, so you must ensure that all nodes in your installed {product-title} cluster can access these DNS records.
 ====

--- a/modules/abi-pca-resources-services.adoc
+++ b/modules/abi-pca-resources-services.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-pca-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="abi-pca-resources-services_{context}"]
+= Creating {oci-pca-no-rt} infrastructure resources and services
+
+You must create an {oci-pca-short} environment on your virtual machine (VM) or bare-metal shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
+
+[IMPORTANT]
+====
+To ensure compatibility with {product-title}, you must set `A` as the record type for each DNS record and name records as follows:
+
+* `api.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer
+* `api-int.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer
+* `*.apps.<cluster_name>.<base_domain>`, which targets the `ingressVIP` parameter of the Ingress load balancer
+
+The `api.{asterisk}` and `api-int.{asterisk}` DNS records relate to control plane machines, so you must ensure that all nodes in your installed {product-title} cluster can access these DNS records.
+====
+
+.Prerequisites
+
+* You configured an {oci} account to host the {product-title} cluster. See "Access and Considerations" in link:https://www.oracle.com/a/otn/docs/private_cloud_appliance_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Private Cloud Appliance] (Oracle documentation).
+
+.Procedure
+
+* Create the required {oci-pca-short} resources and services.
++
+For more information, see "Terraform Script Execution" in link:https://www.oracle.com/a/otn/docs/private_cloud_appliance_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Private Cloud Appliance] (Oracle documentation).

--- a/modules/creating-config-files-cluster-install-oci.adoc
+++ b/modules/creating-config-files-cluster-install-oci.adoc
@@ -1,6 +1,11 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_oci/installing-oci-agent-based-installer.adoc
+// * installing/installing_oci/installing-pca-agent-based-installer.adoc
+
+ifeval::["{context}" == "installing-pca-agent-based-installer"]
+:pca:
+endif::[]
 
 
 ifeval::["{context}" == "installing-c3-agent-based-installer"]
@@ -16,14 +21,20 @@ ifdef::c3[]
 You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
 endif::c3[]
 
-ifndef::c3[]
+ifdef::pca[]
+[id="creating-config-files-cluster-install-pca_{context}"]
+= Creating configuration files for installing a cluster on {oci-pca-short}
+
+You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
+endif::pca[]
+
+ifndef::pca,c3[]
 [id="creating-config-files-cluster-install-oci_{context}"]
 = Creating configuration files for installing a cluster on {oci}
 
 You must create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
 
-At a later stage, you must follow the steps in the Oracle documentation for uploading your generated Agent ISO image to a default Oracle Object Storage bucket, which is the initial step for integrating your {product-title} cluster on {oci-first}.
-endif::c3[]
+endif::pca,c3[]
 
 [NOTE]
 ====
@@ -116,7 +127,7 @@ pullSecret: '<pull_secret>' <6>
 Do not move the `install-config.yaml` or `agent-config.yaml` configuration files to the `openshift` directory.
 ====
 
-ifndef::c3[]
+ifndef::c3,pca[]
 . If you used a stack to provision OCI infrastructure resources: Copy and paste the `dynamic_custom_manifest` output of the OCI stack into a file titled `manifest.yaml` and save the file in the `openshift` directory.
 
 . If you did not use a stack to provision OCI infrastructure resources: Download and prepare custom manifests to create an Agent ISO image:
@@ -127,7 +138,7 @@ ifndef::c3[]
 .. Copy the contents of the `condensed-manifest.yml` file and save it locally to a file in the `openshift` directory.
 
 .. In the `condensed-manifest.yml` file, update the sections marked with `TODO` to specify the compartment {ocid-first}, VCN {ocid}, subnet {ocid} from the load balancer, and the security lists {ocid}.
-endif::c3[]
+endif::c3,pca[]
 
 ifdef::c3[]
 . Configure the Oracle custom manifest files.
@@ -140,6 +151,17 @@ Cloud@Customer] (Oracle documentation).
 
 .. Edit the `oci-ccm.yml` and `oci-csi.yml` files to specify the compartment {ocid-first}, VCN {ocid}, subnet {ocid} from the load balancer, the security lists {ocid}, and the `c3-cert.pem` section.
 endif::c3[]
+
+ifdef::pca[]
+. Configure the Oracle custom manifest files.
+
+.. Go to "Prepare the OpenShift Master Images" in link:https://www.oracle.com/a/otn/docs/private_cloud_appliance_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Private Cloud Appliance] (Oracle documentation).
+
+.. Copy and paste the `oci-ccm.yml`, `oci-csi.yml`, and `machineconfig-ccm.yml` files into your `openshift` directory.
+
+.. Edit the `oci-ccm.yml` and `oci-csi.yml` files to specify the compartment {ocid-first}, VCN {ocid}, subnet {ocid} from the load balancer, the security lists {ocid}, and the `c3-cert.pem` section.
+endif::pca[]
 
 . Configure the `agent-config.yaml` configuration file to meet your organization's requirements.
 +
@@ -197,4 +219,8 @@ Consider that the full ISO image, which is in excess of `1` GB, includes the roo
 
 ifeval::["{context}" == "installing-c3-agent-based-installer"]
 :!c3:
+endif::[]
+
+ifeval::["{context}" == "installing-pca-agent-based-installer"]
+:!pca:
 endif::[]

--- a/modules/running-cluster-oci-pca-agent-based.adoc
+++ b/modules/running-cluster-oci-pca-agent-based.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="running-cluster-oci-pca-agent-based_{context}"]
+= Running a cluster on {oci-pca-short}
+
+To run a cluster on {oci-pca}, you must first convert your generated Agent ISO image into an {oci} image, upload it to an {oci} Home Region Bucket, and then import the uploaded image to the {oci-pca-short} system.
+
+[NOTE]
+====
+{oci-pca-short} supports the following {product-title} cluster topologies:
+
+* Installing an {product-title} cluster on a single node.
+* A highly available cluster that has a minimum of three control plane instances and two compute instances.
+* A compact three-node cluster that has a minimum of three control plane instances.
+====
+
+.Prerequisites
+
+* You generated an Agent ISO image. See the "Creating configuration files for installing a cluster on {oci-pca-short}" section.
+
+.Procedure
+
+. Convert the agent ISO image to an {oci} image, upload it to an {oci} Home Region Bucket, and then import the uploaded image to the {oci-pca-short} system.
+See "Prepare the OpenShift Master Images" in link:https://www.oracle.com/a/otn/docs/private_cloud_appliance_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Private Cloud Appliance (Oracle documentation)] for instructions.
+
+. Create control plane instances on {oci-pca-short}.
+See "Create control plane instances on PCA and Master Node LB Backend Sets" in link:https://www.oracle.com/a/otn/docs/private_cloud_appliance_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Private Cloud Appliance (Oracle documentation)] for instructions.
+
+. Create a compute instance from the supplied base image for your cluster topology.
+See "Add worker nodes" in link:https://www.oracle.com/a/otn/docs/private_cloud_appliance_agent_based_installation.pdf?source=:em:nl:mt::::PCATP[OpenShift Cluster Setup with
+Agent Based Installer on Private Cloud Appliance (Oracle documentation)] for instructions.
++
+[IMPORTANT]
+====
+Before you create the compute instance, check that you have enough memory and disk resources for your cluster. Additionally, ensure that at least one compute instance has the same IP address as the address stated under `rendezvousIP` in the `agent-config.yaml` file.
+====

--- a/modules/verifying-cluster-install-oci-agent-based.adoc
+++ b/modules/verifying-cluster-install-oci-agent-based.adoc
@@ -6,13 +6,17 @@ ifeval::["{context}" == "installing-c3-agent-based-installer"]
 :c3:
 endif::[]
 
+ifeval::["{context}" == "installing-pca-agent-based-installer"]
+:pca:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
 
 ifdef::c3[]
 [id="verifying-cluster-install-oci-agent-based_{context}"]
 = Verifying that your Agent-based cluster installation runs on {oci-c3-short}
 
-Verify that your cluster was installed and is running effectively on {oci-first}.
+Verify that your cluster was installed and is running effectively on {oci-c3-short}.
 
 .Prerequisites
 
@@ -21,7 +25,20 @@ Verify that your cluster was installed and is running effectively on {oci-first}
 * You uploaded the agent ISO image to a default Oracle Object Storage bucket, and you created a compute instance on {oci-c3-short}. For more information, see "Running a cluster on {oci-c3-short}".
 endif::c3[]
 
-ifndef::c3[]
+ifdef::pca[]
+[id="verifying-cluster-install-oci-agent-based_{context}"]
+= Verifying that your Agent-based cluster installation runs on {oci-pca-short}
+
+Verify that your cluster was installed and is running effectively on {oci-pca-short}.
+
+.Prerequisites
+
+* You created all the required {oci-pca} resources and services. See the "Creating {oci-pca-no-rt} infrastructure resources and services" section.
+* You created `install-config.yaml` and `agent-config.yaml` configuration files. See the "Creating configuration files for installing a cluster on {oci-pca-short}" section.
+* You uploaded the agent ISO image to a default Oracle Object Storage bucket, and you created a compute instance on {oci-pca-short}. For more information, see "Running a cluster on {oci-pca-short}".
+endif::pca[]
+
+ifndef::pca,c3[]
 [id="verifying-cluster-install-oci-agent-based_{context}"]
 = Verifying that your Agent-based cluster installation runs on {oci}
 
@@ -32,7 +49,7 @@ Verify that your cluster was installed and is running effectively on {oci-first}
 * You created all the required {oci} resources and services. See the "Creating OCI infrastructure resources and services" section.
 * You created `install-config.yaml` and `agent-config.yaml` configuration files. See the "Creating configuration files for installing a cluster on OCI" section.
 * You uploaded the agent ISO image to a default Oracle Object Storage bucket, and you created a compute instance on {oci}. For more information, see "Running a cluster on OCI".
-endif::c3[]
+endif::pca,c3[]
 
 .Procedure
 
@@ -91,4 +108,8 @@ network        4.18.0-0    True       True           False      5m58s  Progressi
 
 ifeval::["{context}" == "installing-c3-agent-based-installer"]
 :!c3:
+endif::[]
+
+ifeval::["{context}" == "installing-pca-agent-based-installer"]
+:!pca:
 endif::[]


### PR DESCRIPTION
[OSDOCS-13356](https://issues.redhat.com/browse/OSDOCS-13356)

Version(s): 4.18+

This PR adds documentation for installing OCP on OCI PCA with the Agent-based Installer

QE review:
- [x] QE has approved this change. (QE done by @robmurph-coder from Oracle)

Preview: [Installing a cluster on Oracle Private Cloud Appliance by using the Agent-based Installer](https://88729--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-pca-agent-based-installer)
