### PR TITLE
OSSM-8881 docinfo.xml and other strangeness

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -22,8 +22,6 @@ Topics:
     File: ossm-migrating-premigration-checklists-assembly
   - Name: Migrating network policies for security purposes
     File: ossm-migrating-network-policies-security-assembly
-  - Name: Migrating with cert-manager
-    File: ossm-migrating-cert-manager-assembly
   - Name: Kiali differences for Service Mesh 3
     File: ossm-migrating-kiali-differences-assembly
     #Kiali PR https://github.com/openshift/openshift-docs/pull/88193

--- a/migrating/checklists/docinfo.xml
+++ b/migrating/checklists/docinfo.xml
@@ -1,18 +1,9 @@
-<<<<<<< HEAD
-<title>Kiali Differences for Service Mesh 3</title>
-<productname>{product-title}</productname>
-<productnumber>{product-version}</productnumber>
-<subtitle>Kiali Differences for Service Mesh 3</subtitle>
-<abstract>
-    <para>This document provides important updates to Kiali for OpenShift Service Mesh 3.
-=======
 <title>Before migrating</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
 <subtitle>Premigration checklists</subtitle>
 <abstract>
     <para>This document provides information and a set of checklists that must be completed before you can migrate from OpenShift Service Mesh 2.6 to OpenShift Service Mesh 3.
->>>>>>> 12a76b9aec (OSSM-8673 Staging and Testing Migration Guides IA/Content)
     </para>
 </abstract>
 <authorgroup>

--- a/migrating/checklists/ossm-migrating-cert-manager-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-cert-manager-assembly.adoc
@@ -1,7 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-cert-manager-assembly"]
-= Migrating from {SMProduct} 2 to {SMProduct} 3 with cert-manager
-include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-kiali-differences-assembly
-
-toc::[]

--- a/migrating/checklists/ossm-migrating-kiali-differences-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-kiali-differences-assembly.adoc
@@ -1,18 +1,14 @@
-<<<<<<< HEAD
 // This module is used in the following assemblies:
 
 // * migrating/checklists/ossm-kiali-differences-assembly.adoc
 
-=======
->>>>>>> 12a76b9aec (OSSM-8673 Staging and Testing Migration Guides IA/Content)
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-kiali-differences-assembly]
+[id="ossm-migrating-kiali-differences-assembly"]
 = Kiali differences for {SMProductName} 3
 include::_attributes/common-attributes.adoc[]
 :context: ossm-migrating-kiali-differences-assembly
 
 toc::[]
-<<<<<<< HEAD
 
 {kialiproduct} with {SMProductName} 3 introduces the following changes:
 
@@ -63,5 +59,3 @@ The following configuration settings have been renamed:
 |===
 
 These changes reflect evolving capabilities and configuration standards of Kiali within {SMProduct} 3.
-=======
->>>>>>> 12a76b9aec (OSSM-8673 Staging and Testing Migration Guides IA/Content)

--- a/migrating/checklists/ossm-migrating-network-policies-security-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-network-policies-security-assembly.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-network-policies-security-assembly]
+[id="ossm-migrating-network-policies-security-assembly"]
 = Network policies for security purposes
 include::_attributes/common-attributes.adoc[]
 :context: ossm-migrating-network-policies-security-assembly

--- a/migrating/checklists/ossm-migrating-premigration-checklists-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-premigration-checklists-assembly.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-premigration-checklists-assembly]
+[id="ossm-migrating-premigration-checklists-assembly"]
 = Premigration checklists
 include::_attributes/common-attributes.adoc[]
 :context: ossm-migrating-premigration-checklists-assembly

--- a/migrating/checklists/ossm-migrating-read-me-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-read-me-assembly.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-read-me-assembly]
+[id="ossm-migrating-read-me-assembly"]
 = Important information to know if you are migrating from OpenShift Service Mesh 2.6
 include::_attributes/common-attributes.adoc[]
 :context: ossm-migrating-read-me-assembly

--- a/migrating/ossm-migrating-from-2-to-3-assembly.adoc
+++ b/migrating/ossm-migrating-from-2-to-3-assembly.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-from-2-to-3-assembly]
+[id="ossm-migrating-from-2-to-3-assembly"]
 = Migrating from Service Mesh 2 to Service Mesh 3
 include::_attributes/common-attributes.adoc[]
 :context: ossm-migrating-from-2-to-3-assembly


### PR DESCRIPTION
**OSSM 3.0 GA**

**Merge PR to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**And cherry picked**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

This is to fix docinfo.xml and other issues that are causing Pantheon build failures.

Version(s):
GA

**Service Mesh has moved to the stand alone format and will not be cherry picked back to OCP core.**

Issue:
https://issues.redhat.com/browse/OSSM-8881

Link to docs preview:
https://88734--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-kiali-differences-assembly.html
https://88734--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-network-policies-security-assembly.html
https://88734--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-premigration-checklists-assembly.html
https://88734--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-read-me-assembly.html
https://88734--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/ossm-migrating-from-2-to-3-assembly.html

QE review:
QE approval is not required for this PR. Merge conflict resolution commit gone wrong.

Additional information:
This is to fix docinfo.xml and other issues that are causing Pantheon build failures.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
