### PR TITLE
[enterprise-4.16] OSDOCS#12247: Updated GA status for MTO

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -169,16 +169,11 @@ With this release, you can deploy compute nodes on GPU-enabled NVIDIA H100 machi
 === Postinstallation configuration
 
 [id="ocp-4.16-multiarch-tuning-operator_{context}"]
-==== Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator (Technology Preview)
+==== Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator
 
 With this release, you can manage workloads on multi-architecture clusters by using the Multiarch Tuning Operator. This Operator enhances the operational experience within multi-architecture clusters, and single-architecture clusters that are migrating to a multi-architecture compute configuration. It implements the `ClusterPodPlacementConfig` custom resource (CR) to support architecture-aware workload scheduling.
 
 For more information, see xref:../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
-
-[IMPORTANT]
-====
-The Multiarch Tuning Operator is a Technology Preview feature only. It does not support clusters with restricted network scenarios.
-====
 
 [id="ocp-4.16-arm-control-plane-with-x86-compute-machines_{context}"]
 ==== Support for adding 64-bit x86 compute machines to a cluster with 64-bit ARM control plane machines
@@ -2887,7 +2882,7 @@ In the following tables, features are marked with the following statuses:
 |Multiarch Tuning Operator
 |Not available
 |Not available
-|Technology Preview
+|General Availability
 
 |====
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-12247](https://issues.redhat.com/browse/OSDOCS-12247)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Technology Preview features status (Multi-Architecture Technology Preview features)](https://88743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-technology-preview-tables_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Note: Multiarch Tuning Operator is an async Operator. It became GA in 4.16+ post the 4.17 release (4.17.z).