### PR TITLE
TELCODOCS-2210 Add RN to 4.17 regarding Support for Worker Nodes with with AMD EPYC Zen 4 CPUs

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1117,6 +1117,11 @@ In this release, the firmware search path has been updated to copy the contents 
 
 In this release, if your cluster is installed on a bare metal platform, you can scale a cluster control plane up to 5 nodes as a postinstallation task. The etcd Operator scales accordingly to account for the additional control plane nodes. For more information, see xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc#etcd-node-scaling_recommended-etcd-practices[Node scaling for etcd].
 
+[id="ocp-4-17-support-for-compute-nodes-on-amd-cpus_{context}"]
+==== Support for compute nodes with AMD EPYC Zen 4 CPUs
+
+From release 4.17.10, you can use PerformanceProfiles to configure compute nodes on machines equipped with AMD EPYC Zen 4 CPUs such as Genoa and Bergamo. Per-pod power management is currently not supported on AMD.
+
 ////
 [id="ocp-4-17-hcp_{context}"]
 === Hosted control planes


### PR DESCRIPTION
[TELCODOCS-2210]: Add RN to 4.17 regarding Support for Worker Nodes with AMD EPYC Zen 4 CPUs
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2210
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://88746--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-support-for-worker-nodes-on-amd-cpus_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->