### PR TITLE
[enterprise-4.12]OBSDOCS-1392 Remove logging UI warning

### DIFF
--- a/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
@@ -6,10 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The {coo-full}
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
-
 The logging UI plugin surfaces logging data in the {product-title} web console on the *Observe* -> *Logs* page. 
 You can specify filters, queries, time ranges and refresh rates, with the results displayed as a list of collapsed logs, which can then be expanded to show more detailed information for each log.
 


### PR DESCRIPTION

Version(s):
4.12 manual cherry pick

Issue:
[OBSDOCS-1392](https://issues.redhat.com//browse/OBSDOCS-1392)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
