### PR TITLE
[SRVCOM-2510] Configuring request log settings

### DIFF
--- a/modules/serverless-config-request-log.adoc
+++ b/modules/serverless-config-request-log.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/serverless-config-log-settings.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-config-request-log_{context}"]
+= Configuring request log settings
+
+You can configure request logging for your service in the `observability` field of your `KnativeServing` custom resource (CR).
+
+For information about the available parameters for configuring request logging, see "Parameters of request logging".
+
+.Procedure
+
+* Configure request logging for your service by modifying the `observability` field in your `KnativeServing` CR:
++
+.Example `KnativeServing` CR
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+# ...
+spec:
+  config:
+    observability:
+        logging.enable-request-log: true
+        logging.enable-probe-request-log: true
+        logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+# ...
+----

--- a/modules/serverless-request-log-parameters.adoc
+++ b/modules/serverless-request-log-parameters.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/serverless-config-log-settings.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-request-log-parameters_{context}"]
+= Parameters of request logging
+
+The following table describes parameters used to configure request logging.
+
+.Request logging configuration parameters
+[cols=3*,options="header"]
+|===
+|Parameter
+|Type
+|Description
+
+|`logging.enable-request-log`
+|Boolean (`true` or `false`)
+|Set to `true` to enable request logging.
+
+|`logging.enable-probe-request-log`
+|Boolean (`true` or `false`)
+|Set to `true` to enable the queue proxy to log probe requests to stdout. It uses the template specified in `logging.request-log-template`.
+
+|`logging.request-log-template`
+|Go `text/template` string
+|Determine the shape of the request logs. Use a single line to prevent logs from being split into multiple records.
+|===
+
+The `logging.request-log-template` parameter includes the following functions:
+
+* `Request` is an `http.Request` representing an HTTP request received by the server.
+* `Response` represents the HTTP response and includes the following fields:
+** `Code` is the HTTP status code. 
+** `Size` is the response size in bytes.
+** `Latency` is the response latency in seconds.
+* `Revision` contains revision details and includes the following fields: 
+** `Name` is the name of the revision.
+** `Namespace` is the namespace of the revision.
+** `Service` is the name of the service.
+** `Configuration` is the name of the configuration.
+** `PodName` is the name of the pod hosting the revision.
+** `PodIP` is the IP address of the hosting pod.

--- a/observability/cluster-logging/serverless-config-log-settings.adoc
+++ b/observability/cluster-logging/serverless-config-log-settings.adoc
@@ -11,3 +11,7 @@ You can configure logging for OpenShift Serverless Serving and OpenShift Serverl
 include::modules/serverless-config-log-supported-log-levels.adoc[leveloffset=+1]
 
 include::modules/serverless-config-log-settings-serving-eventing.adoc[leveloffset=+1]
+
+include::modules/serverless-config-request-log.adoc[leveloffset=+1]
+
+include::modules/serverless-request-log-parameters.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
serverless-docs-1.34+

Issue:
https://issues.redhat.com/browse/SRVCOM-2510

Link to docs preview:
- https://88783--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/cluster-logging/serverless-config-log-settings.html#serverless-config-request-log_serverless-config-log-setting

QE review:
- [x] QE has approved this change.

Additional information:
