### PR TITLE
[enterprise-4.18] Update 4.18 RN: OLMv0/v1 DEP/REM & TP/GA tables

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -954,6 +954,8 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-release-note-operators-dep-rem_{context}"]
 === Operator lifecycle and development deprecated and removed features
 
+// "Operator lifecycle" refers to OLMv0 and "development" refers to Operator SDK
+
 .Operator lifecycle and development deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
@@ -982,12 +984,12 @@ In the following tables, features are marked with the following statuses:
 |Scaffolding tools for Hybrid Helm-based Operator projects
 |Deprecated
 |Deprecated
-|Deprecated
+|Removed
 
 |Scaffolding tools for Java-based Operator projects
 |Deprecated
 |Deprecated
-|Deprecated
+|Removed
 
 // Do not remove the SQLite database... entry until otherwise directed by the Operator Framework PM
 |SQLite database format for Operator catalogs
@@ -1644,33 +1646,48 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
+[id="ocp-release-notes-extensions-tech-preview_{context}"]
+=== Extensions Technology Preview features
+
+// "Extensions" refers to OLMv1
+
+.Extensions Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.16 |4.17 |4.18
+
+|{olmv1-first}
+|Technology Preview
+|Technology Preview
+|General Availability
+
+|====
+
+[discrete]
 [id="ocp-release-notes-operator-lifecycle-tech-preview_{context}"]
 === Operator lifecycle and development Technology Preview features
+
+// "Operator lifecycle" refers to OLMv0 and "development" refers to Operator SDK
 
 .Operator lifecycle and development Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.16 |4.17 |4.18
 
-|Operator Lifecycle Manager (OLM) v1
+|{olmv1-first}
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|RukPak
-|Technology Preview
-|Removed
-|Removed
+|General Availability
 
 |Scaffolding tools for Hybrid Helm-based Operator projects
 |Deprecated
 |Deprecated
-|Deprecated
+|Removed
 
 |Scaffolding tools for Java-based Operator projects
 |Deprecated
 |Deprecated
-|Deprecated
+|Removed
 
 |====
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-12252

Preview:

[DEP/REM]
* [Operator lifecycle and development deprecated and removed features](https://88784--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-note-operators-dep-rem_release-notes)

[TP/GA]
* [Extensions Technology Preview features](https://88784--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-extensions-tech-preview_release-notes) (new section in 4.18 for OLMv1)
* [Operator lifecycle and development Technology Preview features](https://88784--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-operator-lifecycle-tech-preview_release-notes) (existing section for OLMv0)