### PR TITLE
CNV#56538: RN - Automatic boot source updates when changing the default storage class

### DIFF
--- a/virt/release_notes/virt-4-18-release-notes.adoc
+++ b/virt/release_notes/virt-4-18-release-notes.adoc
@@ -89,6 +89,9 @@ For a complete list of virtualization metrics, see link:https://github.com/kubev
 [id="virt-4-18-notable-technical-changes"]
 === Notable technical changes
 
+//CNV-56538 and 45704: Automatic boot source updates when changing the default storage class
+* Changing the default storage class automatically deletes and re-imports existing boot sources. If boot source images were stored as volume snapshots and no default storage class is set, the snapshots are cleaned up and new data volumes are created but will not import until a default storage class is configured.
+
 [id="virt-4-18-deprecated-removed"]
 == Deprecated and removed features
 //NOTE: Comment out deprecated and removed features (and their IDs) if not used in a release


### PR DESCRIPTION
**Version(s):**
4.18

**Issue:**
https://issues.redhat.com/browse/CNV-56538

**Link to docs preview:**
https://88792--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-18-release-notes.html#virt-4-18-notable-technical-changes

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->