### PR TITLE
OCPBUGS-50855:adds warning for VRF and UDN

### DIFF
--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -11,6 +11,11 @@ After you install the Kubernetes NMState Operator, you can use the Operator to o
 
 For more information about how to install the NMState Operator, see xref:../../networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator].
 
+[WARNING]
+====
+When configuring Virtual Route Forwarding (VRF) users must change their VRFs to a table ID lower than 1000 as higher than 1000 is reserved for {product-title}.
+====
+
 // Viewing the network state of a node by using the CLI
 include::modules/virt-viewing-network-state-of-node.adoc[leveloffset=+1]
 

--- a/networking/metallb/metallb-frr-k8s.adoc
+++ b/networking/metallb/metallb-frr-k8s.adoc
@@ -13,7 +13,10 @@ As a cluster administrator, you can use the `FRRConfiguration` custom resource (
 
 image::695_OpenShift_MetalLB_FRRK8s_integration_0624.png[MetalLB integration with FRR]
 
-
+[WARNING]
+====
+When configuring Virtual Route Forwarding (VRF) users must change their VRFs to a table ID lower than 1000 as higher than 1000 is reserved for {product-title}.
+====
 // FRR configurations
 include::modules/nw-metallb-frr-configurations.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+ for VRF
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-50855
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
