### PR TITLE
OBSDOCS-1161 fix typo in command

### DIFF
--- a/modules/monitoring-creating-a-monitoringstack-object-for-cluster-observability-operator.adoc
+++ b/modules/monitoring-creating-a-monitoringstack-object-for-cluster-observability-operator.adoc
@@ -64,7 +64,7 @@ example-coo-monitoring-stack   81m
 +
 [source,terminal]
 ----
-$ oc -n oc -n ns1-coo exec -c prometheus prometheus-example-coo-monitoring-stack-0 -- curl -s 'http://localhost:9090/api/v1/targets' | jq '.data.activeTargets[].discoveredLabels | select(.__meta_kubernetes_endpoints_label_app=="prometheus-coo-example-app")'
+$ oc -n ns1-coo exec -c prometheus prometheus-example-coo-monitoring-stack-0 -- curl -s 'http://localhost:9090/api/v1/targets' | jq '.data.activeTargets[].discoveredLabels | select(.__meta_kubernetes_endpoints_label_app=="prometheus-coo-example-app")'
 ----
 +
 .Example output


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-1161](https://issues.redhat.com//browse/OBSDOCS-1161)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: not required - typo

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
