### PR TITLE
CNV#56725: Pre-defined instance type table is outdated

### DIFF
--- a/modules/virt-common-instancetypes.adoc
+++ b/modules/virt-common-instancetypes.adoc
@@ -16,59 +16,7 @@ These instance type resources are named according to their series, version, and 
 |===
 ^.^|Use case ^.^|Series ^.^|Characteristics ^.^|vCPU to memory ratio ^.^|Example resource
 
-^.^|Universal
-^.^|U
-a|
-* Burstable CPU performance
-^.^|1:4
-.^a|`u1.medium`::
-* 1 vCPUs
-* 4 Gi memory
-
-^.^|Overcommitted
-^.^|O
-a|
-* Overcommitted memory
-* Burstable CPU performance
-^.^|1:4
-.^a|`o1.small`::
-* 1 vCPU
-* 2Gi memory
-
-^.^|Compute-exclusive
-^.^|CX
-a|
-* Hugepages
-* Dedicated CPU
-* Isolated emulator threads
-* vNUMA
-^.^|1:2
-.^a|`cx1.2xlarge`::
-* 8 vCPUs
-* 16Gi memory
-
-^.^|NVIDIA GPU
-^.^|GN
-a|
-* For VMs that use GPUs provided by the NVIDIA GPU Operator
-* Has predefined GPUs
-* Burstable CPU performance
-^.^|1:4
-.^a|`gn1.8xlarge`::
-* 32 vCPUs
-* 128Gi memory
-
-^.^|Memory-intensive
-^.^|M
-a|
-* Hugepages
-* Burstable CPU performance
-^.^|1:8
-.^a|`m1.large`::
-* 2 vCPUs
-* 16Gi memory
-
-^.^|Network-intensive
+^.^|Network
 ^.^|N
 a|
 * Hugepages
@@ -78,5 +26,46 @@ a|
 ^.^|1:2
 .^a|`n1.medium`::
 * 4 vCPUs
-* 4Gi memory
+* 4GiB Memory
+
+^.^|Overcommitted
+^.^|O
+a|
+* Overcommitted memory
+* Burstable CPU performance
+^.^|1:4
+.^a|`o1.small`::
+* 1 vCPU
+* 2GiB Memory
+
+^.^|Compute Exclusive
+^.^|CX
+a|
+* Hugepages
+* Dedicated CPU
+* Isolated emulator threads
+* vNUMA
+^.^|1:2
+.^a|`cx1.2xlarge`::
+* 8 vCPUs
+* 16GiB Memory
+
+^.^|General Purpose
+^.^|U
+a|
+* Burstable CPU performance
+^.^|1:4
+.^a|`u1.medium`::
+* 1 vCPU
+* 4GiB Memory
+
+^.^|Memory Intensive
+^.^|M
+a|
+* Hugepages
+* Burstable CPU performance
+^.^|1:8
+.^a|`m1.large`::
+* 2 vCPUs
+* 16GiB Memory
 |===


### PR DESCRIPTION
Version(s): 4.18

Issue: [CNV-56725](https://issues.redhat.com/browse/CNV-56725)

Link to docs preview: [Pre-defined instance types](https://88824--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vm/virt-creating-vms-from-instance-types.html#virt-common-instancetypes_virt-creating-vms-from-instance-types)

QE review:
- [x] QE has approved this change.

Additional information:

- I've updated the contents of the table (with the exception of the info in the Characteristics column, which I could not verify) to match what appears in the web console. Note: In a conversation with Matan, he indicated that using **vCPUs** is more accurate than just **CPUs**, so I have followed his advice.
- This update is part of the work done for ContentX (doc effort).

