### PR TITLE
OADP-4883: Added 1.4.3 release notes

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -14,6 +14,7 @@ The release notes for {oadp-first} describe new features and enhancements, depre
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
 ====
 
+include::modules/oadp-1-4-3-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-2-release-notes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/oadp-1-4-3-release-notes.adoc
+++ b/modules/oadp-1-4-3-release-notes.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-3-release-notes_{context}"]
+= {oadp-short} 1.4.3 release notes
+
+The {oadp-first} 1.4.3 release notes lists the following new feature. 
+
+[id="new-features-1-4-3_{context}"]
+== New features
+
+.Notable changes in the `kubevirt` velero plugin in version 0.7.1
+
+With this release, the `kubevirt` velero plugin has been updated to version 0.7.1. Notable improvements include the following bug fix and new features:
+
+* Virtual machine instances (VMIs) are no longer ignored from backup when the owner VM is excluded.
+* Object graphs now include all extra objects during backup and restore operations.
+* Optionally generated labels are now added to new firmware Universally Unique Identifiers (UUIDs) during restore operations.
+* Switching VM run strategies during restore operations is now possible.
+* Clearing a MAC address by label is now supported.
+* The restore-specific checks during the backup operation are now skipped.
+* The `VirtualMachineClusterInstancetype` and `VirtualMachineClusterPreference` custom resource definitions (CRDs) are now supported.
+//link:https://issues.redhat.com/browse/OADP-5551[OADP-5551]


### PR DESCRIPTION
### REASON

* This PR is a copy of https://github.com/openshift/openshift-docs/pull/87964

* This [PR](https://github.com/openshift/openshift-docs/pull/87964) was accidentally merged before a delayed GA.

* OADP 1.4.3 was *shipped live* this morning 

### JIRA

* [OADP-4883](https://issues.redhat.com/browse/OADP-4883)

### VERSIONS

OCP 4.14 - 4.18

### PREVIEW

Link to docs preview: [OADP 1.4.3 release notes](https://88835--ocpdocs-pr.netlify.app/openshift-rosa/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html#oadp-1-4-3-release-notes_oadp-1-4-release-notes)

### QE review:
 
* [X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/87964#issuecomment-2630969113)
.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
