### PR TITLE
OADP-5636: After OADP update to 1.4.2 no backups found

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -61,6 +61,7 @@ include::modules/oadp-configuring-noobaa-for-dr.adoc[leveloffset=+1]
 
 include::modules/about-oadp-update-channels.adoc[leveloffset=+1]
 include::modules/about-installing-oadp-on-multiple-namespaces.adoc[leveloffset=+1]
+include::modules/oadp-support-backup-data-immutability.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/oadp-support-backup-data-immutability.adoc
+++ b/modules/oadp-support-backup-data-immutability.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/installing/about-installing-oadp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="oadp-support-backup-data-immutability_{context}"]
+= OADP does not support backup data immutability
+
+Starting with {oadp-short} 1.3, backups might not function as expected when the target object storage has an immutability option configured. These immutability options are referred to by different names, for example:
+
+* S3 object lock
+* Object retention
+* Bucket versioning
+* Write Once Read Many (WORM) buckets
+
+The primary reason for the absence of support is that {oadp-short} initially saves the state of a backup as _finalizing_ and then scrutinizes whether any asynchronous operations are in progress. 
+
+With versions before {oadp-short} 1.3, object storage with an immutability configuration was also not supported. You might see some problems even though backups are working. For example, version objects are not deleted when a backup is deleted.
+
+[NOTE]
+====
+Depending on the specific provider and configuration, backups might work in some cases.
+====
+
+* AWS S3 service supports backups because an S3 object lock only applies to versioned buckets. You can still update the object data for the new version. However, when backups are deleted, old versions of the objects are not deleted.
+
+* Azure Storage Blob supports both versioned-level immutability and container-level immutability. In a versioned-level situation, data immutability can still work in {oadp-short}, but not at the container level.
+
+* GCP Cloud storage policy only supports bucket-level immutability. Therefore, it is not feasible to implement it in the GCP environment.


### PR DESCRIPTION
### JIRA

 * [OADP-5636](https://issues.redhat.com/browse/OADP-5636)

### VERSIONS

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19

### PREVIEW

* [OADP does not support backup data immutability](https://88849--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-support-backup-data-immutability_about-installing-oadp)

### QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
