### PR TITLE
[OSDOCS#13402] Restore RHOSO monitoring topic to nav

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2999,6 +2999,8 @@ Topics:
     File: troubleshooting-monitoring-issues
   - Name: Config map reference for the Cluster Monitoring Operator
     File: config-map-reference-for-the-cluster-monitoring-operator
+  - Name: Monitoring clusters that run on RHOSO
+    File: shiftstack-prometheus-configuration
 - Name: Logging
   Dir: logging
   Distros: openshift-enterprise,openshift-origin

--- a/observability/monitoring/shiftstack-prometheus-configuration.adoc
+++ b/observability/monitoring/shiftstack-prometheus-configuration.adoc
@@ -17,14 +17,14 @@ include::modules/monitoring-configuring-shiftstack-remotewrite.adoc[leveloffset=
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-remote-write-storage_configuring-the-monitoring-stack[Configuring remote write storage]
-* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#adding-cluster-id-labels-to-metrics_configuring-the-monitoring-stack[Adding cluster ID labels to metrics]
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc#configuring-remote-write-storage_configuring-metrics-uwm[Configuring remote write storage]
+* xref:../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#adding-cluster-id-labels-to-metrics_key-concepts[Adding cluster ID labels to metrics]
 
 include::modules/monitoring-configuring-shiftstack-scraping.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-monitoring-apis-by-using-the-cli[Querying metrics by using the federation endpoint for Prometheus]
+* xref:../../observability/monitoring/accessing-metrics/accessing-monitoring-apis-by-using-the-cli.adoc#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-monitoring-apis-by-using-the-cli[Querying metrics by using the federation endpoint for Prometheus]
 
 include::modules/monitoring-shiftstack-metrics.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13402](https://issues.redhat.com/browse/OSDOCS-13402)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://88850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/shiftstack-prometheus-configuration.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

~QE review:~
~- [ ] QE has approved this change.~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR just re-adds documentation introduced in #86741 to the nav, as well as fixes some links. It was wiped by a re-org force push (or something) after its publication. All content was already peer reviewed.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
