### PR TITLE
OSDOCS-13198: Registry pruning added to ROSA documentation.

### DIFF
--- a/registry/index.adoc
+++ b/registry/index.adoc
@@ -16,6 +16,7 @@ include::modules/registry-integrated-openshift-registry.adoc[leveloffset=+1]
 
 * xref:../registry/configuring-registry-operator.adoc#configuring-registry-operator[Image Registry Operator in {product-title}]
 
+include::modules/pruning-images.adoc[leveloffset=+1]
 include::modules/registry-third-party-registries.adoc[leveloffset=+1]
 
 include::modules/registry-quay-overview.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
`enterprise-4.18+`

Issue:
[OSDOCS-13198](https://issues.redhat.com/browse/OSDOCS-13198)

Link to docs preview:
[Automatically pruning images registry - HCP](https://88853--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/registry/#pruning-images_registry-overview)
[Automatically pruning images registry - ROSA Classic](https://88853--ocpdocs-pr.netlify.app/openshift-rosa/latest/registry/index.html#pruning-images_registry-overview)

The OCP and OSD files still contain the registry pruning information. Here are the previews for OCP and OSD:
[Automatically pruning images registry - OCP](https://88853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/index.html#pruning-images_registry-overview)
[Automatically pruning images registry - OSD](https://88853--ocpdocs-pr.netlify.app/openshift-dedicated/latest/registry/index.html#pruning-images_registry-overview)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
