### PR TITLE
[SRVKS-1289] Timeout seconds for revisions - follow up

### DIFF
--- a/knative-serving/config-applications/configuring-revision-timeouts.adoc
+++ b/knative-serving/config-applications/configuring-revision-timeouts.adoc
@@ -14,6 +14,12 @@ include::modules/configuring-revision-timeout.adoc[leveloffset=+1]
 //Configuring maximum revision timeout
 include::modules/configuring-maximum-revision-timeout.adoc[leveloffset=+1]
 
+//Configuring revision response to start timeout
+include::modules/serverless-configuring-response-start-timeout.adoc[leveloffset=+1]
+
+//Configuring idle revision timeout
+include::modules/serverless-configuring-revision-idle-timeout.adoc[leveloffset=+1]
+
 //Long-running requests
 include::modules/serverless-long-running-requests.adoc[leveloffset=+1]
 

--- a/modules/configuring-maximum-revision-timeout.adoc
+++ b/modules/configuring-maximum-revision-timeout.adoc
@@ -1,25 +1,24 @@
 // Module included in the following assemblies:
 //
 // * knative-serving/config-applications/configuring-revision-timeouts.adoc
-:_content-type: PROCEDURE
+
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-maximum-revision-timeout_{context}"]
 = Configuring maximum revision timeout
 
-By seting the maximum revision timeout, you can ensure that no revision can exceed a specific limit.
+By seting the maximum revision timeout, you can ensure that no revision can exceed a specific limit. The value of your maximum revision timeout must not exceed the `terminationGracePeriodSeconds` value of the activator to prevent in-flight requests being disrupted.
 
 .Prerequisites
 
 * You have installed the {ServerlessOperatorName} and Knative Serving.
-* You have cluster administrator permissions on {ocp-product-title}, or cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* You have the required permissions for your cluster:
+** Cluster administrator permissions on {ocp-product-title}
+** Cluster administrator or dedicated administrator permissions on {rosa-product-title}
+** Cluster administrator or dedicated administrator permissions on {dedicated-product-title}
 
 .Procedure
 
 * To configure the maximum revision timeout, set the `max-revision-timeout-seconds` field in the `KnativeServing` custom resource (CR):
-+
-[NOTE]
-----
-If this value is increased, the activator `terminationGracePeriodSeconds` should also be increased to prevent in-flight requests being disrupted.
-----
 +
 [source,yaml]
 ----
@@ -33,3 +32,11 @@ spec:
     defaults:
       max-revision-timeout-seconds: "600"
 ----
+
++
+[NOTE]
+====
+To set the maximum revision timeout to a value over 600 seconds (10 minutes), you must increase the default {ocp-product-title} route timeout. 
+
+For instructions on how to configure timeouts for requests exceeding the default 600 seconds (10 minutes), see "Long-running requests".
+====

--- a/modules/configuring-revision-timeout.adoc
+++ b/modules/configuring-revision-timeout.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 //
 // * knative-serving/config-applications/configuring-revision-timeouts.adoc
-:_content-type: PROCEDURE
+
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-revision-timeout_{context}"]
 = Configuring revision timeout
 
@@ -10,7 +11,10 @@ You can configure the default number of seconds for the revision timeout based o
 .Prerequisites
 
 * You have installed the {ServerlessOperatorName} and Knative Serving.
-* You have cluster administrator permissions on {ocp-product-title}, or cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* You have the required permissions for your cluster:
+** Cluster administrator permissions on {ocp-product-title}
+** Cluster administrator or dedicated administrator permissions on {rosa-product-title}
+** Cluster administrator or dedicated administrator permissions on {dedicated-product-title}
 
 .Procedure
 
@@ -45,3 +49,11 @@ spec:
       containers:
       - image: ghcr.io/knative/helloworld-go:latest
 ----
+
++
+[NOTE]
+====
+To set the revision timeout to a value over 600 seconds (10 minutes), you must increase the default {ocp-product-title} route timeout and the maximum revision timeout. 
+
+For instructions on how to configure timeouts for requests exceeding the default 600 seconds (10 minutes), see "Long-running requests".
+====

--- a/modules/serverless-configuring-response-start-timeout.adoc
+++ b/modules/serverless-configuring-response-start-timeout.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/configuring-revision-timeouts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-configuring-resoponse-start-timeout_{context}"]
+= Configuring revision response start timeout
+
+By setting the revision response start timeout, you can specify the maximum duration in seconds that Serving waits for a revision to start sending network traffic after a request has been routed to it. The revision response start timeout must not exceed the revision timeout. The default duration is 300 seconds (5 minutes).
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have the required permissions for your cluster:
+** Cluster administrator permissions on {ocp-product-title}
+** Cluster administrator or dedicated administrator permissions on {rosa-product-title}
+** Cluster administrator or dedicated administrator permissions on {dedicated-product-title}
+
+.Procedure
+
+* Choose the appropriate method to configure the revision response start timeout:
+** To configure the timeout globally, set the `revision-response-start-timeout-seconds` field in your `KnativeServing` custom resource (CR). If your required response start timeout exceeds the revision timeout, also adjust the `revision-timeout-seconds` field accordingly:
++
+.Example of revision response start timeout globally set to 300 seconds (5 minutes)
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  config:
+    defaults:
+      revision-timeout-seconds: "600"
+      revision-response-start-timeout-seconds: "300"
+----
++
+** To configure the timeout per revision, set the `responseStartTimeoutSeconds` field in your service definition. If your required response start timeout exceeds the revision timeout, also adjust the `timeoutSeconds` field accordingly:
++
+.Example of a service definition with revision response start timeout set to 300 seconds (5 minutes)
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: my-ns
+spec:
+  template:
+    spec:
+      timeoutSeconds: 600
+      responseStartTimeoutSeconds: 300
+      containers:
+# ...
+----
+
++
+[NOTE]
+====
+To set the revision response start timeout and the revision timeout to a value over 600 seconds (10 minutes), you must increase the default {ocp-product-title} route timeout and the maximum revision timeout. 
+
+For instructions on how to configure timeouts for requests exceeding the default 600 seconds (10 minutes), see "Long-running requests".
+====

--- a/modules/serverless-configuring-revision-idle-timeout.adoc
+++ b/modules/serverless-configuring-revision-idle-timeout.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/configuring-revision-timeouts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-configuring-revision-idle-timeout_{context}"]
+= Configuring revision idle timeout
+
+By setting the revision idle timeout, you can specify the maximum duration in seconds a request is allowed to stay open without receiving data from the application. The default duration is `0` (infinite).
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have the required permissions for your cluster:
+** Cluster administrator permissions on {ocp-product-title}
+** Cluster administrator or dedicated administrator permissions on {rosa-product-title}
+** Cluster administrator or dedicated administrator permissions on {dedicated-product-title}
+
+.Procedure
+
+* Choose the appropriate method to configure the revision idle timeout:
+** To configure the timeout globally, set the `revision-idle-timeout-seconds` field in your `KnativeServing` custom resource (CR):
++
+.Example of revision idle timeout globally set to 300 seconds (5 minutes)
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  config:
+    defaults:
+      revision-idle-timeout-seconds: "300"
+----
++
+** To configure the timeout per revision, set the `idleTimeoutSeconds` field in your service definition:
++
+.Example of a service definition with revision idle timeout set to 300 seconds (5 minutes)
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: my-ns
+spec:
+  template:
+    spec:
+      idleTimeoutSeconds: 300
+      containers:
+# ...
+----

--- a/modules/serverless-long-running-requests.adoc
+++ b/modules/serverless-long-running-requests.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="serverless-long-running-requests_{context}"]
-= Long running requests
+= Long-running requests
 
 To ensure that requests exceeding the default 600 second timeout set by Knative are not prematurely terminated, you need to adjust the timeouts in the following components:
 


### PR DESCRIPTION
Version(s):
serverless-docs-1.34+

Issue:
https://issues.redhat.com/browse/SRVKS-1289

Link to docs preview:
- https://88871--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-applications/configuring-revision-timeouts.html

QE review:
- [x] QE has approved this change.

Additional information:
_Merge AFTER [SRVKS-1306](https://github.com/openshift/openshift-docs/pull/89935)._
