### PR TITLE
OCPBUGS-49826-RN418: Known issues details added

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2013,6 +2013,9 @@ This warning message is a known issue but does not indicate any functionality is
 * When you run Cloud-native Network Functions (CNF) latency tests on an {product-title} cluster, the test can sometimes return results greater than the latency threshold for the test; for example, 20 microseconds for `cyclictest` testing. This results in a test failure.
 (link:https://issues.redhat.com/browse/OCPBUGS-42328[*OCPBUGS-42328*])
 
+* There is a known issue when the grandmaster clock (T-GM) transitions to the `Locked` state too soon. This happens before the Digital Phase-Locked Loop (DPLL) completes its transition to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored.
+(link:https://issues.redhat.com/browse/OCPBUGS-49826[*OCPBUGS-49826*])
+
 [id="ocp-telco-core-4-18-known-issues_{context}"]
 
 * Due to an issue with Kubernetes, the CPU Manager is unable to return CPU resources from the last pod admitted to a node to the pool of available CPU resources. These resources are allocatable if a subsequent pod is admitted to the node. However, this pod then becomes the last pod, and again, the CPU manager cannot return this pod's resources to the available pool.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-49826 T-GM announces "Locked" too fast after holdover - Known Issue Release Note Text

Applies to OCP version : 4.18

Preview: [Known Issues - See OCPBUGS-49826](https://88874--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-known-issues_release-notes)

Dev review completed by @aneeshkp
Peer review completed by @agantony 

Thank you.