### PR TITLE
OSDOCS-13378: 4.16.35 RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3342,6 +3342,37 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.35
+[id="ocp-4-16-35_{context}"]
+=== RHSA-2025:1386 - {product-title} {product-version}.35 bug fix update
+
+Issued: 19 February 2025
+
+{product-title} release {product-version}.35 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1386[RHSA-2025:1386] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:1390[RHBA-2025:1390] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.35 --pullspecs
+----
+
+[id="ocp-4-16-35-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the Bare Metal Operator (BMO) created the `HostFirmwareComponents` custom resource for all `BareMetalHosts` (BMH), including the intelligent platform management interface (IPMI), which does not support the `HostFirmwareComponents` custom resource. With this release, `HostFirmwareComponents` custom resources are only created for BMH. (link:https://issues.redhat.com/browse/OCPBUGS-49703[*OCPBUGS-49703*])
+
+* Previously, importing manifest lists could cause an API crash if the source registry returned an invalid sub-manifest result. With this update, the API flags an error on the imported tag instead of crashing. (link:https://issues.redhat.com/browse/OCPBUGS-49656[*OCPBUGS-49656*])
+
+* Previously, when you used the installation program to install a cluster in a Prism Central environment, the installation failed because a `prism-api` call that loads an {op-system} image timed out. This issue happened because the `prismAPICallTimeout` parameter was set to `5` minutes. With this release, the `prismAPICallTimeout` parameter in the `install-config.yaml` configuration file now defaults to `10` minutes. You can also configure the parameter if you need a longer timeout for a `prism-api` call. (link:https://issues.redhat.com/browse/OCPBUGS-49416[*OCPBUGS-49416*])
+
+* Previously, when you attempted to scale a `DeploymentConfig` object with an admission webhook that the object's `deploymentconfigs/scale` subresource, the `apiserver` failed to handle the request. This impacted the `DeploymentConfig` object as it could not be scaled. With this release, a fix ensures that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-45010[*OCPBUGS-45010*])
+
+[id="ocp-4-16-35-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.16.34
 [id="ocp-4-16-34_{context}"]
 === RHBA-2025:1124 - {product-title} {product-version}.34 bug fix update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-13378](https://issues.redhat.com/browse/OSDOCS-13378)

Link to docs preview:
https://88879--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-35_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (2/19/25)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
