### PR TITLE
OSDOCS-12237-networking: Bug batching 4.18 networking

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -798,6 +798,22 @@ With this release, you can now specify pre-created floating IP addresses in the 
 
 For more information, see xref:../networking/load-balancing-openstack.adoc#nw-osp-specify-floating-ip_load-balancing-openstack[Specifying a floating IP address in the Ingress Controller].
 
+[id="ocp-release-notes-networking-intel-netsec_{context}"]
+==== SR-IOV Network Operator support extension
+
+The SR-IOV Network Operator now supports Intel NetSec Accelerator Cards and Marvell Octeon 10 DPUs. (link:https://issues.redhat.com/browse/OCPBUGS-43451[*OCPBUGS-43451*])
+
+[id="ocp-release-notes-networking-ovnk-linux-bridge_{context}"]
+==== Using a Linux bridge interface as the OVS default port connection
+
+The OVN-Kubernetes plugin can now use a Linux bridge interface as the Open vSwitch (OVS) default port connection. This means that a network interface controller, such as SmartNIC, can now bridge the underlying network with a host. 
+(link:https://issues.redhat.com/browse/OCPBUGS-39226[*OCPBUGS-39226*])
+
+[id="ocp-release-notes-networking-live-migration-cno_{context}"]
+==== Cluster Network Operator exposing network overlap metrics for an issue 
+
+When you start the limited live migration method and an issue exists with network overlap, the Cluster Network Operator (CNO) can now expose network overlap metrics for the issue. This is possible because the `openshift_network_operator_live_migration_blocked` metric now includes the new `NetworkOverlap` label. (link:https://issues.redhat.com/browse/OCPBUGS-39096[*OCPBUGS-39096*])
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 
@@ -1403,8 +1419,6 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 
 * Previously, bonds that were configured in `active-backup` mode would have IPsec Encapsulating Security Payload (ESP) offload active even if underlying links did not support ESP offload. This caused IPsec associations to fail. With this release, ESP offload is disabled for bonds so that IPsec associations pass. (link:https://issues.redhat.com/browse/OCPBUGS-39438[*OCPBUGS-39438*])
 
-* When you start the limited live migration method and an issue exists with network overlap, the Cluster Network Operator (CNO) can now expose network overlap metrics for the issue. This is possible because the `openshift_network_operator_live_migration_blocked` metric now includes the new `NetworkOverlap` label. (link:https://issues.redhat.com/browse/OCPBUGS-39096[*OCPBUGS-39096*])
-
 * Previously, the Machine Config Operator (MCO)'s vSphere `resolve-prepender` script used `systemd` directives that were incompatible with old bootimage versions used in {product-title} 4. With this release, nodes can scale using newer bootimage versions {product-version} 4.13 and above, through manual intervention, or by upgrading to a release that includes this fix. (link:https://issues.redhat.com/browse/OCPBUGS-38012[*OCPBUGS-38012*])
 
 * Previously, the Ingress Controller status incorrectly displayed as `Degraded=False` because of a migration time issue with the `CanaryRepetitiveFailures` condition. With this release, the Ingress Controller status is correctly marked as `Degraded=True` for the appropriate length of time that the `CanaryRepetitiveFailures` condition exists. (link:https://issues.redhat.com/browse/OCPBUGS-37491[*OCPBUGS-37491*])
@@ -1417,13 +1431,30 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 
 * Previously, for an Ingress resource with an `IngressWithoutClassName` alert, the Ingress Controller did not delete the alert along with deletion of the resource. The alert continued to show on the {product-title} web console. With this release, the Ingress Controller resets the `openshift_ingress_to_route_controller_ingress_without_class_name` metric to `0` before the controller deletes the Ingress resource, so that the alert is deleted and no longer shows on the web console. (link:https://issues.redhat.com/browse/OCPBUGS-13181[*OCPBUGS-13181*])
 
-* Previously, when the live migration to OVN-Kubernetes was employed on clusters using the subnet 100.88.0.0/16 for either the `clusterNetwork` or `serviceNetwork` IP address pools, the `ovnkube-node` pod would crash after migration. With this update, the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-43740[*OCPBUGS-43740*])
+* Previously, when either  the `clusterNetwork` or `serviceNetwork` IP address pools overlapped with the default `transit_switch_subnet` `100.88.0.0/16` IP address and the custom value of `transit_switch_subnet` did not take effect, `ovnkube-node` pods crashed after the live migration operation. With this release, the custom value of `transit_switch_subnet` can be passed to `ovnkube node` pods, so that this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-43740[*OCPBUGS-43740*])
 
 * Previously, a change in OVN-Kubernetes that standardized the `appProtocol` value `h2c` to `kubernetes.io/h2c` was not recognized by OpenShift router. Consequently, specifying `appProtocol: kubernetes.io/h2c` on a service did not cause OpenShift router to use clear-text HTTP/2 to connect to the service endpoints. With this release, OpenShift router was changed to handle `appProtocol: kubernetes.io/h2c` the same way as it handles `appProtocol: h2c` resolving the issue. (link:https://issues.redhat.com/browse/OCPBUGS-42972[*OCPBUGS-42972*])
 
 * Previously, instructions that guided the user after changing the `LoadBalancer` parameter from `External` to `Internal` were missing for {ibm-power-server-title}, {alibaba}, and {rh-openstack-first}. This caused the Ingress Controller to be put in a permanent `Progressing` state. With this release the message `The IngressController scope was changed from Internal to External` is followed by `To effectuate this change, you must delete the service` resolving the permanent `Progressing` state. (link:https://issues.redhat.com/browse/OCPBUGS-39151[*OCPBUGS-39151*])
 
 * Previously, there was no event logged when an error occurred from failed conversion from ingress to route conversion. With this update, this error appear in the event logs. (link:https://issues.redhat.com/browse/OCPBUGS-29354[*OCPBUGS-29354*])
+
+* Previously, an `ovnkube-node` pod on a node that uses cgroup v1 was failing because it could not find the kubelet cgroup path. With this release, an `ovnkube-node` pod no longer fails if the node uses cgroup v1. However, the OVN-Kubernetes network plugin outputs an `UDNKubeletProbesNotSupported` event notification. If you enable cgroup v2 for each node, OVN-Kubernetes no longer outputs the event notification.(link:https://issues.redhat.com/browse/OCPBUGS-50513[*OCPBUGS-50513*])
+
+* Previously, when you finished the live migration for a kubevirt virtual machine (VM) that uses the Layer 2 topology, an old node still transmits IPv4 egress traffic to the virtual machine. With this release, the OVN-Kubernetes plugin updates the gateway MAC address for a  kubevirt virtual machine (VM) during the live migration process so that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-49857[*OCPBUGS-49857*])
+
+* Previously, the DNS-based egress firewall incorrectly prevented creation of a firewall rule that contained a DNS name in uppercase characters. With this release, an fix to the egress firewall no longer prevents creation of a firewall rule that contains a DNS name in uppercase characters. (link:https://issues.redhat.com/browse/OCPBUGS-49589[*OCPBUGS-49589*])
+
+* Previously, when you attempted to use the Cluster Network Operator (CNO) to upgrade a cluster with existing `localnet` networks, `ovnkube-control-plane` pods failed to run. This happened because the `ovnkube-cluster-manager` container could not process an OVN-Kubernetes `localnet` topology network that did not have subnets defined. With this release, a fix ensures that the `ovnkube-cluster-manager` container can process an OVN-Kubernetes `localnet` topology network that does not have subnets defined. (link:https://issues.redhat.com/browse/OCPBUGS-44195[*OCPBUGS-44195*])
+
+* Previously, the SR-IOV Network Operator could not retrieve metadata when cloud-native network (CNF) workers were deployed with a configuration drive on {rh-openstack-first}. A configuration drive is often unmounted after a boot operation on immutable systems, so now the Operator dynamically mounts a configuration drive when required. The Operator can now retrieve the metadata and then unmount the configuration drive. This means that you no longer need to manually mount and unmount the configuration drive. (link:https://issues.redhat.com/browse/OCPBUGS-41829[*OCPBUGS-41829*])
+
+* Previously, when you switched your cluster to use a different load balancer, the Ingress Operator did not remove the values from the `classicLoadBalancer` and `networkLoadBalancer` parameters in the `IngressController` custom resource (CR) status. This situation caused the status of the CR to report wrong information from the `classicLoadBalancer` and `networkLoadBalancer` parameters. With this release, after you switch your cluster to use a different load balancer, the Ingress Operator removes values from these parameters so that the CR reports a more accurate and less confusing message status. (link:https://issues.redhat.com/browse/OCPBUGS-38217[*OCPBUGS-38217*])
+
+* Previously, a duplicate feature gate, `ExternalRouteCertificate`, was added to the `FeatureGate` CR. With this release, `ExternalRouteCertificate` is removed because a {product-title} cluster does not use this feature gate. (link:https://issues.redhat.com/browse/OCPBUGS-36479[*OCPBUGS-36479*])
+
+* Previously, after a user created a route, the user needed both `create` and `update` permissions on the `routes/custom-host` sub-resource to edit the `.spec.tls.externalCertificate` field of a route. With this release, this permission requirement has been fixed, so that a user only needs the `create` permission to edit the `.spec.tls.externalCertificate` field of a route. The `update` permission is now marked as an optional permission. (link:https://issues.redhat.com/browse/OCPBUGS-34373[*OCPBUGS-34373*])
+
 
 [discrete]
 [id="ocp-release-note-node-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12237](https://issues.redhat.com/browse/OSDOCS-12237)

Link to docs preview:
* [Bug fixes](https://88882--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-bug-fixes_release-notes)
