### PR TITLE
OSDOCS-13410: added new DPU/Accelerator NICs

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -77,6 +77,31 @@
 |8086
 |1593
 
+|Intel
+|Ice E810-XXV Backplane
+|8086
+|1599
+
+|Intel
+|Ice E823L Backplane
+|8086
+|124c
+
+|Intel
+|Ice E823L SFP
+|8086
+|124d
+
+|Marvell
+|OCTEON Fusion CNF105XX
+|177d
+|ba00
+
+|Marvell
+|OCTEON10 CN10XXX
+|1177d
+|b900
+
 |Mellanox
 |MT27700 Family [ConnectX&#8209;4]
 |15b3


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-13410

Link to docs preview:
https://88883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
