### PR TITLE
OSDOCS#13379: Update the 4.14.48 z-stream RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3399,6 +3399,33 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+// 4.14.48
+[id="ocp-4-14-48_{context}"]
+=== RHSA-2025:1451 - {product-title} 4.14.48 bug fix and security update
+
+Issued: 19 February 2025
+
+{product-title} release 4.14.48, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1451[RHSA-2025:1451] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1453[RHSA-2025:1453] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.48 --pullspecs
+----
+
+[id="ocp-4-14-48-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, an invalid or unreachable identity provider (IDP) blocked updates to {hcp}. With this release, the `ValidIDPConfiguration` condition in the `HostedCluster` object now reports any IDP errors so that these errors do not block updates to {hcp}. (link:https://issues.redhat.com/browse/OCPBUGS-49405[*OCPBUGS-49405*])
+
+[id="ocp-4-14-48-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.46
 [id="ocp-4-14-46_{context}"]
 === RHSA-2025:0840 - {product-title} 4.14.46 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-13379](https://issues.redhat.com//browse/OSDOCS-13379)

Link to docs preview:
[4.14.48](https://88885--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-48_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
The errata URLs will return 404 until the go-live date of 02/19/25.
