### PR TITLE
CNV#45704 4.17: Configuring a storage class for custom boot source updates

### DIFF
--- a/modules/virt-configuring-default-and-virt-default-storage-class.adoc
+++ b/modules/virt-configuring-default-and-virt-default-storage-class.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assembly:
+//
+// * virt/storage/virt-automatic-bootsource-updates.adoc
+//
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-default-and-virt-default-storage-class_{context}"]
+= Configuring the default and virt-default storage classes
+
+A storage class determines how persistent storage is provisioned for workloads. In {VirtProductName}, the virt-default storage class takes precedence over the cluster default storage class and is used specifically for virtualization workloads. Only one storage class should be set as virt-default or cluster default at a time. If multiple storage classes are marked as default, the virt-default storage class overrides the cluster default. To ensure consistent behavior, configure only one storage class as the default for virtualization workloads.
+
+[IMPORTANT]
+====
+Boot sources are created using the default storage class. If your cluster does not have a default storage class, you must define one.
+====
+
+.Procedure
+
+. Patch the current virt-default or a cluster default storage class to false:
+.. Identify all storage classes currently marked as virt-default by running the following command:
++
+[source,terminal]
+----
+$ oc get sc -o json| jq '.items[].metadata|select(.annotations."storageclass.kubevirt.io/is-default-virt-class"=="true")|.name'
+----
++
+.. For each storage class returned, remove the virt-default annotation by running the following command:
++
+[source,terminal]
+----
+$ oc patch storageclass <storage_class_name> -p '{"metadata": {"annotations": {"storageclass.kubevirt.io/is-default-virt-class": "false"}}}'
+----
++
+.. Identify all storage classes currently marked as cluster default by running the following command:
++
+[source,terminal]
+----
+$ oc get sc -o json| jq '.items[].metadata|select(.annotations."storageclass.kubernetes.io/is-default-class"=="true")|.name'
+----
++
+.. For each storage class returned, remove the cluster default annotation by running the following command:
++
+[source,terminal]
+----
+$ oc patch storageclass <storage_class_name> -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "false"}}}'
+----
+
+. Set a new default storage class:
+.. Assign the virt-default role to a storage class by running the following command:
++
+[source,terminal]
+----
+$ oc patch storageclass <storage_class_name> -p '{"metadata": {"annotations": {"storageclass.kubevirt.io/is-default-virt-class": "true"}}}'
+----
++
+.. Alternatively, assign the cluster default role to a storage class by running the following command:
++
+[source,terminal]
+----
+$ oc patch storageclass <storage_class_name> -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "true"}}}'
+----
+
+. Delete any outdated `DataVolume` and `VolumeSnapshot` objects from the `openshift-virtualization-os-images` namespace by running the following command.
++
+[source,terminal]
+----
+$ oc delete DataVolume,VolumeSnapshot -n openshift-virtualization-os-images --selector=cdi.kubevirt.io/dataImportCron
+----
+
+. Wait for all `DataSource` objects to reach a "Ready - True" status. Data sources can reference either a PersistentVolumeClaim (PVC) or a VolumeSnapshot. To check the expected source format, run the following command:
++
+[source,terminal]
+----
+$ oc get storageprofile <storage_class_name> -o json | jq .status.dataImportCronSourceFormat
+----

--- a/modules/virt-configuring-storage-class-bootsource-update.adoc
+++ b/modules/virt-configuring-storage-class-bootsource-update.adoc
@@ -5,13 +5,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-configuring-storage-class-bootsource-update_{context}"]
-= Configuring a storage class for custom boot source updates
+= Configuring a storage class for boot source images
 
-You can override the default storage class by editing the `HyperConverged` custom resource (CR).
+You can configure a specific storage class in the `HyperConverged` resource.
 
 [IMPORTANT]
 ====
-Boot sources are created from storage using the default storage class. If your cluster does not have a default storage class, you must define one before configuring automatic updates for custom boot sources.
+To ensure stable behavior and avoid unnecessary re-importing, you can specify the `storageClassName` in the `dataImportCronTemplates` section of the `HyperConverged` resource.
 ====
 
 .Procedure
@@ -23,7 +23,7 @@ Boot sources are created from storage using the default storage class. If your c
 $ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
-. Define a new storage class by entering a value in the `storageClassName` field:
+. Add the `dataImportCronTemplate` to the spec section of the `HyperConverged` resource and set the `storageClassName`:
 +
 [source,yaml]
 ----
@@ -34,11 +34,12 @@ metadata:
 spec:
   dataImportCronTemplates:
   - metadata:
-      name: rhel8-image-cron
+      name: rhel9-image-cron
     spec:
       template:
         spec:
-          storageClassName: <new_storage_class> <1>
+          storage:
+            storageClassName: <storage_class> <1>
       schedule: "0 */12 * * *" <2>
       managedDataSource: <data_source> <3>
 # ...
@@ -47,43 +48,23 @@ spec:
 <2> Required: Schedule for the job specified in cron format.
 <3> Required: The data source to use.
 +
---
 [NOTE]
-----
+====
 For the custom image to be detected as an available boot source, the value of the `spec.dataVolumeTemplates.spec.sourceRef.name` parameter in the VM template must match this value.
-----
---
+====
 
-. Remove the `storageclass.kubernetes.io/is-default-class` annotation from the current default storage class.
-.. Retrieve the name of the current default storage class by running the following command:
+. Wait for the HyperConverged Operator (HCO) and Scheduling, Scale, and Performance (SSP) resources to complete reconciliation.
+
+. Delete any outdated `DataVolume` and `VolumeSnapshot` objects from the `openshift-virtualization-os-images` namespace.
 +
 [source,terminal]
 ----
-$ oc get storageclass
+$ oc delete DataVolume,VolumeSnapshot -n openshift-virtualization-os-images --selector=cdi.kubevirt.io/dataImportCron
 ----
-+
-.Example output
-[source,text]
-----
-NAME                          PROVISIONER                      RECLAIMPOLICY  VOLUMEBINDINGMODE    ALLOWVOLUMEEXPANSION  AGE
-csi-manila-ceph               manila.csi.openstack.org         Delete         Immediate            false                 11d
-hostpath-csi-basic (default)  kubevirt.io.hostpath-provisioner Delete         WaitForFirstConsumer false                 11d <1>
-----
-+
-<1> In this example, the current default storage class is named `hostpath-csi-basic`.
 
-.. Remove the annotation from the current default storage class by running the following command:
+. Wait for all `DataSource` objects to reach a "Ready - True" status. Data sources can reference either a PersistentVolumeClaim (PVC) or a VolumeSnapshot. To check the expected source format, run the following command:
 +
 [source,terminal]
 ----
-$ oc patch storageclass <current_default_storage_class> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}' <1>
+$ oc get storageprofile <storage_class_name> -o json | jq .status.dataImportCronSourceFormat
 ----
-<1> Replace `<current_default_storage_class>` with the `storageClassName` value of the default storage class.
-
-. Set the new storage class as the default by running the following command:
-+
-[source,terminal]
-----
-$ oc patch storageclass <new_storage_class> -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}' <1>
-----
-<1> Replace `<new_storage_class>` with the `storageClassName` value that you added to the `HyperConverged` CR.

--- a/virt/storage/virt-automatic-bootsource-updates.adoc
+++ b/virt/storage/virt-automatic-bootsource-updates.adoc
@@ -41,6 +41,8 @@ You must configure a storage profile. Otherwise, the cluster cannot receive auto
 ====
 endif::openshift-rosa,openshift-dedicated[]
 
+include::modules/virt-configuring-default-and-virt-default-storage-class.adoc[leveloffset=+2]
+
 include::modules/virt-configuring-storage-class-bootsource-update.adoc[leveloffset=+2]
 
 include::modules/virt-autoupdate-custom-bootsource.adoc[leveloffset=+2]


### PR DESCRIPTION
**Version(s):**
4.17

**Issue:**
https://issues.redhat.com/browse/CNV-45704

**Link to docs preview:**
https://88890--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-automatic-bootsource-updates.html

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
Most of the reviewing was done in https://github.com/openshift/openshift-docs/pull/88579 for 4.18, but there are some slight deviations in the 4.17 that warranted a new PR. But feel free to use that for reference.