### PR TITLE
OSDOCS-12237-mco-insights-reg: Bug batching 4.18 MCO+

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1363,6 +1363,24 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-release-note-image-registry-bug-fixes_{context}"]
 ==== Image Registry
 
+* Previously, you could not install a cluster on {aws-short} in the `ap-southeast-5` region or other regions because the {product-title} internal registry did not support these regions. With this release, the internal registry is updated to include the following regions so that this issue no longer occurs:
++
+** `ap-southeast-5`
+** `ap-southeast-7`
+** `ca-west-1`
+** `il-central-1`
+** `mx-central-1`
++
+(link:https://issues.redhat.com/browse/OCPBUGS-49693[*OCPBUGS-49693*])
+
+* Previously, when the Image Registry Operator was configured with `networkAccess: Internal` in {azure-first}, it would not be possible to successfully set `managementState` to `Removed` in the Operator configuration. This occurred because of an authorization error when the Operator tried to delete the storage container. With this update, the Image Registry Operator continues with the deletion of the storage account, which automatically deletes the storage container, resulting in a successful change into the `Removed` state. (link:https://issues.redhat.com/browse/OCPBUGS-42732[*OCPBUGS-42732*])
+
+* Previously, when configuring the image registry to use an {azure-first} storage account located in a resource group other than the cluster's resource group, the Image Registry Operator would become degraded due to a validation error. This update changes the Image Registry Operator to allow for authentication by only storage account key without validating for other authentication requirements. (link:https://issues.redhat.com/browse/OCPBUGS-42514[*OCPBUGS-42514*])
+
+* Previously, installation with the OpenShift installer used the cluster API. Virtual networks created by the cluster API use a different tag template. Consequently, setting `.spec.storage.azure.networkAccess.type: Internal` in the Image Registry Operator's `config.yaml` file resulted in the Image Registry Operator unable to discover the virtual network. With this update, the Image Registry Operator searches for both new and old tag templates, resolving the issue. (link:https://issues.redhat.com/browse/OCPBUGS-42196[*OCPBUGS-42196*])
+
+* Previously, the image registry would, in some cases, panic when attempting to purge failed uploads from s3-compatible storage providers. This was caused by the image registry's s3 driver mishandling empty directory paths. With this update, the image registry properly handles empty directory paths, fixing the panic. (link:https://issues.redhat.com/browse/OCPBUGS-39108[*OCPBUGS-39108*])
+
 [discrete]
 [id="ocp-release-note-installer-bug-fixes_{context}"]
 ==== Installer
@@ -1382,6 +1400,10 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [discrete]
 [id="ocp-release-note-machine-config-operator-bug-fixes_{context}"]
 ==== Machine Config Operator
+
+* Previously, {op-system-base-full} CoreOS templates that were shipped by the  Machine Config Operator (MCO) caused node scaling to fail on {rh-openstack-first}. This issue happened because of an issue with `systemd` and the presence of a legacy boot image from older versions of {product-title}. With this release, a patch fixes the issue with `systemd` and removes the legacy boot image, so that node scaling can continue as expected. (link:https://issues.redhat.com/browse/OCPBUGS-42324[*OCPBUGS-42324*])
+
+* Previously, if you enabled on-cluster layering for your cluster and you attempted to configure kernel arguments in the machine configuration, machine config pools (MCPs) and nodes entered a degraded state. This happened because of a configuration mismatch. With this release, a check for kernel arguments for a cluster with OCL-enabled ensures that the arguments are configured and applied to nodes in the cluster. This update prevents any mismatch that previously occurred between the machine configuration and the node configuration. (link:https://issues.redhat.com/browse/OCPBUGS-34647[*OCPBUGS-34647*])
 
 [discrete]
 [id="ocp-release-note-management-console-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12237](https://issues.redhat.com/browse/OSDOCS-12237)

Link to docs preview:
* [Bug fixes](https://88892--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-bug-fixes_release-notes)
