### PR TITLE
OSDOCS#11325: updating 4.18 RHEL update version numbers

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -52,7 +52,7 @@ By default, the base OS RHEL with "Minimal" installation option enables firewall
 +
 [source,terminal,subs="attributes+"]
 ----
-# subscription-manager repos --disable=rhocp-4.16-for-rhel-8-x86_64-rpms \
+# subscription-manager repos --disable=rhocp-4.17-for-rhel-8-x86_64-rpms \
                              --enable=rhocp-{product-version}-for-rhel-8-x86_64-rpms
 ----
 +
@@ -72,7 +72,7 @@ As of {product-title} 4.11, the Ansible playbooks are provided only for {op-syst
 +
 [source,terminal,subs="attributes+"]
 ----
-# subscription-manager repos --disable=rhocp-4.16-for-rhel-8-x86_64-rpms \
+# subscription-manager repos --disable=rhocp-4.17-for-rhel-8-x86_64-rpms \
                              --enable=rhocp-{product-version}-for-rhel-8-x86_64-rpms
 ----
 


### PR DESCRIPTION
[OSDOCS-11325](https://issues.redhat.com/browse/OSDOCS-11325)

Version(s): 4.18+

This PR updates the RHEL update version numbers for the 4.18 docs.

QE review:
- [x] QE has approved this change.

Preview: [Updating RHEL compute machines in your cluster](https://88896--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-rhel-compute.html#rhel-compute-updating-minor_updating-cluster-rhel-compute)