### PR TITLE
4.15 - OADP-4883: Added 1.4.3 release notes

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -14,6 +14,7 @@ The release notes for {oadp-first} describe new features and enhancements, depre
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
 ====
 
+include::modules/oadp-1-4-3-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-2-release-notes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -25,9 +26,12 @@ include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]
 include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+3]
 
+// TODO: Include this xref when the Operators book is added to the ROSA HCP docs.
+ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
+endif::openshift-rosa-hcp[]
 
 [id="oadp-converting-dpa-to-new-version-1-4-0_{context}"]
 === Converting DPA to the new version
@@ -35,4 +39,3 @@ include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+3]
 To upgrade from OADP 1.3 to 1.4, no Data Protection Application (DPA) changes are required.
 
 include::modules/oadp-verifying-upgrade-1-4-0.adoc[leveloffset=+2]
-

--- a/modules/oadp-1-4-3-release-notes.adoc
+++ b/modules/oadp-1-4-3-release-notes.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-3-release-notes_{context}"]
+= {oadp-short} 1.4.3 release notes
+
+The {oadp-first} 1.4.3 release notes lists the following new feature. 
+
+[id="new-features-1-4-3_{context}"]
+== New features
+
+.Notable changes in the `kubevirt` velero plugin in version 0.7.1
+
+With this release, the `kubevirt` velero plugin has been updated to version 0.7.1. Notable improvements include the following bug fix and new features:
+
+* Virtual machine instances (VMIs) are no longer ignored from backup when the owner VM is excluded.
+* Object graphs now include all extra objects during backup and restore operations.
+* Optionally generated labels are now added to new firmware Universally Unique Identifiers (UUIDs) during restore operations.
+* Switching VM run strategies during restore operations is now possible.
+* Clearing a MAC address by label is now supported.
+* The restore-specific checks during the backup operation are now skipped.
+* The `VirtualMachineClusterInstancetype` and `VirtualMachineClusterPreference` custom resource definitions (CRDs) are now supported.
+//link:https://issues.redhat.com/browse/OADP-5551[OADP-5551]


### PR DESCRIPTION
### Cherry picked

 * Cherry Picked from b0de1484302d98a4e24c6d87da2170fb74cd00f7 xref: https://github.com/openshift/openshift-docs/pull/88835

### REASON

* This PR is a copy of https://github.com/openshift/openshift-docs/pull/87964

* This [PR](https://github.com/openshift/openshift-docs/pull/87964) was accidentally merged before a delayed GA.

* OADP 1.4.3 was *shipped live* this morning 

### JIRA

* [OADP-4883](https://issues.redhat.com/browse/OADP-4883)

### VERSIONS

* OCP 4.15 

### PREVIEW

Link to docs preview: [OADP 1.4.3 release notes](https://88904--ocpdocs-pr.netlify.app/openshift-rosa/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html#oadp-1-4-3-release-notes_oadp-1-4-release-notes)

### QE review:
 
* [X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/87964#issuecomment-2630969113)

### Meld diff check

![image](https://github.com/user-attachments/assets/c24270ff-b907-44c6-b57d-e59c10f3aa0d)

Validated by Ben Hardesty - *Hi Andy - I added this conditional for ROSA, so it wouldn't have been applied to any branches previous to 4.17. I don't think it would hurt to add the block to 4.15, but it wouldn't be necessary since the ROSA docs are versionless (they're built from the current OCP version number, which would be 4.17). Alternatively, you could simply ignore that conditional for 4.15 since, again, it won't affect the ROSA docs.
All that to say, to resolve this merge conflict, you should be fine either accepting the incoming or the current since it involves an older OpenShift version that isn't published for ROSA.*

