### PR TITLE
crun release note minor rewording

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -798,7 +798,7 @@ For more information, see xref:../networking/load-balancing-openstack.adoc#nw-os
 ==== crun is now the default container runtime
 crun is now the default container runtime for new containers created in {product-title}. The runC runtime is still supported and you can change the default runtime to runC, if needed. For more information on crun, see xref:../nodes/containers/nodes-containers-using.adoc#nodes-containers-runtimes[About the container engine and container runtime]. For information on changing the default to runC, see xref:../machine_configuration/machine-configs-custom.adoc#create-a-containerruntimeconfig_machine-configs-custom[Creating a ContainerRuntimeConfig CR to edit CRI-O parameters].
 
-After updating from {product-title} 4.17.z to {product-title} {product-version}, the container runtime configured as the default is respected in {product-version}.
+Updating from {product-title} 4.17.z to {product-title} {product-version} does not change your container runtime.
 
 [id="ocp-release-notes-nodes-crun-sigstore_{context}"]
 ==== sigstore support (Technology Preview)


### PR DESCRIPTION
Per @wking in [Slack](https://redhat-internal.slack.com/archives/CEKNRGF25/p1740001310299409?thread_ts=1740000049.251399&cid=CEKNRGF25).

Preview: https://88923--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-nodes-crun-default_release-notes

Minor work change. No QE needed.