### PR TITLE
[OSDOCS-12242]: HCP updates for OCP 4.18 release notes

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -146,6 +146,8 @@ For more information about the SiteConfig Operator, see link:https://docs.redhat
 [id="ocp-release-notes-hcp_{context}"]
 === Hosted control planes
 
+Because {hcp} releases asynchronously from {product-title}, it has its own release notes. For more information, see xref:../hosted_control_planes/hosted-control-planes-release-notes.adoc#hosted-control-planes-release-notes[{hcp-capital} release notes].
+
 [id="ocp-release-notes-ibm-z_{context}"]
 === {ibm-z-title} and {ibm-linuxone-title}
 
@@ -1358,10 +1360,6 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 ==== etcd Cluster Operator
 
 [discrete]
-[id="ocp-release-note-hosted-control-planes-bug-fixes_{context}"]
-==== Hosted control planes
-
-[discrete]
 [id="ocp-release-note-image-registry-bug-fixes_{context}"]
 ==== Image Registry
 
@@ -1530,42 +1528,6 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 |Technology Preview
-
-|====
-
-[discrete]
-[id="ocp-release-notes-hcp-tech-preview_{context}"]
-=== Hosted control planes Technology Preview features
-
-.Hosted control planes Technology Preview tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.16 |4.17 |4.18
-
-|{hcp-capital} for {product-title} using non-bare metal agent machines
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|{hcp-capital} for an ARM64 {product-title} cluster on {aws-full}
-|Technology Preview
-|General Availability
-|General Availability
-
-|{hcp-capital} for {product-title} on {ibm-power-title}
-|Technology Preview
-|General Availability
-|General Availability
-
-|{hcp-capital} for {product-title} on {ibm-z-title}
-|Technology Preview
-|General Availability
-|General Availability
-
-|{hcp-capital} for {product-title} on {rh-openstack}
-|Not Available
-|Not Available
-|Developer Preview
 
 |====
 
@@ -2171,8 +2133,6 @@ This issue affects CPU load-balancing features, which depend on the CPU Manager 
 As a workaround, you must manually reboot the failed host from the disk. (link:https://issues.redhat.com/browse/OCPBUGS-45116[*OCPBUGS-45116*])
 
 [id="ocp-storage-core-4-18-known-issues_{context}"]
-
-[id="ocp-hosted-control-planes-4-18-known-issues_{context}"]
 
 [id="ocp-4-18-asynchronous-errata-updates_{context}"]
 == Asynchronous errata updates


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12259
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://88924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-hcp_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: As discussed with Kathryn, this PR adds a pointer to the hosted control planes release notes. It also removes from the OCP release notes the TP/GA tracker table for hosted control planes and the headings for bug fixes and known issues for hosted control planes.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
