### PR TITLE
OSDOCS#10370: More OLMv1 and OSDK RNs for OCP 4.18

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -230,11 +230,11 @@ endif::[]
 //Version-agnostic OLM
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-//Initial version of OLM that shipped with OCP 4, aka "v0"
-:olmv0: existing OLM
-:olmv0-caps: Existing OLM
-:olmv0-first: existing Operator Lifecycle Manager (OLM)
-:olmv0-first-caps: Existing Operator Lifecycle Manager (OLM)
+//Initial version of OLM that shipped with OCP 4, aka "v0" and f/k/a "existing" during OLM v1's pre-4.18 TP phase
+:olmv0: OLM (Classic)
+:olmv0-caps: OLM (Classic)
+:olmv0-first: Operator Lifecycle Manager (OLM) Classic
+:olmv0-first-caps: Operator Lifecycle Manager (OLM) Classic
 //Next-gen (OCP 4.14+) Operator Lifecycle Manager, f/k/a "1.0"
 :olmv1: OLM v1
 :olmv1-first: Operator Lifecycle Manager (OLM) v1

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -80,21 +80,27 @@ For more information, see xref:../backup_and_restore/hibernating-cluster.adoc#hi
 [id="ocp-release-notes-extensions_{context}"]
 === Extensions ({olmv1})
 
-Operator Lifecycle Manager (OLM) has been included with {product-title} 4 since its initial release and has helped grow and enable a substantial ecosystem of solutions and advanced workloads running as Operators. {product-title} {product-version} introduces {olmv1}, the next-generation Operator Lifecycle Manager, as a General Availability feature, designed to improve how you manage Operators on {product-title}.
+[id="ocp-release-notes-extensions-olmv1-ga_{context}"]
+==== {olmv1-first} (General Availability)
 
-Previously available as a Technology Preview feature only, this updated framework evolves many of the concepts that have been part of previous versions of {olmv0} by simplifying Operator management, enhancing secrutiy, and boosting reliability.
+Operator Lifecycle Manager (OLM) has been included with {product-title} 4 since its initial release and has helped enable and grow a substantial ecosystem of solutions and advanced workloads running as Operators.
 
-[NOTE]
+{product-title} {product-version} introduces _{olmv1}_, the next-generation Operator Lifecycle Manager, as a General Availability (GA) feature, designed to improve how you manage Operators on {product-title}.
+
+With {olmv1} now generally available, starting in {product-title} {product-version}, the existing version of OLM that has been included since the launch of {product-title} 4 is now known as _{olmv0}_.
+
+Previously available as a Technology Preview feature only, the updated framework in {olmv1} evolves many of the concepts that have been part of {olmv0} by simplifying Operator management, enhancing security, and boosting reliability.
+
+[IMPORTANT]
 ====
-The documentation for {olmv1} exists as a stand-alone guide called xref:../extensions/index.adoc#olmv1-about[Extensions]. Previously, {olmv1} documentation was a subsection of the xref:../operators/index.adoc#operators-overview[Operators] guide, which otherwise documents the {olmv0} feature set.
-
-The updated location and guide name reflect a more focused documentation experience and aims to differentiate between {olmv1} and {olmv0}.
+* Starting in {product-title} {product-version}, {olmv1} is now enabled by default, alongside {olmv0}. {olmv1} is a xref:../installing/overview/cluster-capabilities.adoc#cluster-operators-ref-olmv1_cluster-capabilities[cluster capability] that administrators can optionally disable before installation of {product-title}.
+* {olmv0} remains fully supported throughout the {product-title} 4 lifecycle.
 ====
 
 Simplified API::
 {olmv1} simplifies Operator management with a new, user-friendly API: xref:../extensions/arch/operator-controller.adoc#olmv1-clusterextension-api_operator-controller[the `ClusterExtension` object]. By managing Operators as integral extensions of the cluster, {olmv1} caters to the special lifecycle requirements of custom resource definition (CRDs). This design aligns more closely with Kubernetes principles, treating Operators, which consist of custom controllers and CRDs, as cluster-wide singletons. 
 +
-{product-title} continues to give you access to the latest Operator packages, patches, and updates through default xref:../extensions/catalogs/rh-catalogs.adoc#rh-catalogs[Red Hat Operator catalogs]. With {olmv1}, you can install an Operator package by creating and applying a `ClusterExtension` API object in your cluster. By interacting with `ClusterExtension` objects, you can manage the lifecycle of Operator packages, quickly understand their status, and troubleshoot issues.
+{product-title} continues to give you access to the latest Operator packages, patches, and updates through default xref:../extensions/catalogs/rh-catalogs.adoc#rh-catalogs[Red Hat Operator catalogs], which are enabled by default for {olmv1} in {product-title} {product-version}. With {olmv1}, you can install an Operator package by creating and applying a `ClusterExtension` API object in your cluster. By interacting with `ClusterExtension` objects, you can manage the lifecycle of Operator packages, quickly understand their status, and troubleshoot issues.
 
 Streamlined declarative workflows::
 Leveraging the simplified API, you can define your desired Operator states in a declarative way and, when integrating with tools like Git and Zero Touch Provisioning, let {olmv1} automatically maintain those states. This minimizes human error and unlocks a wider range of use cases.
@@ -109,13 +115,71 @@ With granular update control, you can select a specific Operator version or defi
 +
 Alternatively, automatic z-stream updates provide a seamless and secure experience by automatically applying security fixes without manual intervention, minimizing operational disruptions.
 
-Enhanced security with user-provided `ServiceAccount` objects::
-{olmv1} prioritizes security by minimizing its permission requirements and providing greater control over access. By using user-provided `ServiceAccount` objects for Operator lifecycle operations, {olmv1} access is restricted to only the necessary permissions, significantly reducing the control plane attack surface and improving overall security. In this way, {olmv1} adopts a least-privilege model to minimize the impact of a compromise.
+Enhanced security with user-provided service accounts::
+{olmv1} prioritizes security by minimizing its permission requirements and providing greater control over access. By using xref:../extensions/ce/managing-ce.adoc#olmv1-cluster-extension-permissions_managing-ce[user-provided `ServiceAccount` objects for Operator lifecycle operations], {olmv1} access is restricted to only the necessary permissions, significantly reducing the control plane attack surface and improving overall security. In this way, {olmv1} adopts a least-privilege model to minimize the impact of a compromise.
+
+[NOTE]
+====
+The documentation for {olmv1} exists as a stand-alone guide called xref:../extensions/index.adoc#olmv1-about[Extensions]. Previously, {olmv1} documentation was a subsection of the xref:../operators/index.adoc#operators-overview[Operators] guide, which otherwise documents the {olmv0} feature set.
+
+The updated location and guide name reflect a more focused documentation experience and aims to differentiate between {olmv1} and {olmv0}.
+====
 
 [id="ocp-4-18-extensions-supported-extensions_{context}"]
-==== {olmv1} supported extensions and known issue
+==== {olmv1} supported extensions
 
 include::snippets/olmv1-tp-extension-support.adoc[]
+
+[id="ocp-4-18-extensions-disconnected_{context}"]
+==== Disconnected environment support in {olmv1}
+
+To support cluster administrators that prioritize high security by running their clusters in internet-disconnected environments, especially for mission-critical production workloads, {olmv1} supports these disconnected environments, starting in {product-title} {product-version}.
+
+After using the oc-mirror plugin for the {oc-first} to mirror the images required for your cluster to a mirror registry in your fully or partially disconnected environments, {olmv1} can function properly in these environments by utilizing the sets of resources generated by either oc-mirror plugin v1 or v2.
+
+For more information, see xref:../extensions/catalogs/disconnected-catalogs.adoc#disconnected-catalogs[Disconnected environment support in {olmv1}].
+
+[id="ocp-4-18-extensions-catalog-selection_{context}"]
+==== Improved catalog selection in {olmv1}
+
+With this release, you can perform the following actions to control the selection of catalog content when you install or update a cluster extension:
+
+* Specify labels to select the catalog
+* Use match expressions to filter across catalogs
+* Set catalog priority
+
+For more information, see xref:../extensions/catalogs/catalog-content-resolution.adoc#catalog-content-resolution[Catalog content resolution].
+
+[id="ocp-4-18-extensions-proxy-and-trustedCA_{context}"]
+==== Basic support for proxied environments and trusted CA certificates
+
+With this release, Operator Controller and catalogd can now run in proxied environments and include basic support for trusted CA certificates.
+
+[id="ocp-4-18-extensions-maxopenshiftversion_{context}"]
+==== Compatibility with {product-title} versions
+
+Before cluster administrators can update their {product-title} cluster to its next minor version, they must ensure that all installed Operators are updated to a bundle version that is compatible with the next minor version (4.y+1) of a cluster.
+
+Starting in {product-title} {product-version}, {olmv1} supports the `olm.maxOpenShiftVersion` annotation in the cluster service version (CSV) of an Operator, similar to the behavior in {olmv0}, to prevent administrators from updating the cluster before updating the installed Operator to a compatible version.
+
+For more information, see xref:../extensions/ce/update-paths.adoc#olmv1-ocp-compat_update-paths[Compatibility with {product-title} versions].
+
+[id="ocp-4-18-extensions-user-access-resources_{context}"]
+==== User access to extension resources
+
+After a cluster extension has been installed and is being managed by {olmv1-first}, the extension can often provide `CustomResourceDefinition` objects (CRDs) that expose new API resources on the cluster. Cluster administrators typically have full management access to these resources by default, whereas non-cluster administrator users, or _regular users_, might lack sufficient permissions.
+
+{olmv1} does not automatically configure or manage role-based access control (RBAC) for regular users to interact with the APIs provided by installed extensions. Cluster administrators must define the required RBAC policy to create, view, or edit these custom resources (CRs) for such users.
+
+For more information, see xref:../extensions/ce/user-access-resources.adoc#user-access-resources[User access to extension resources].
+
+[id="ocp-4-18-extensions-sigstore_{context}"]
+==== Runtime validation of container images using sigstore signatures in {olmv1} (Technology Preview)
+
+Starting in {product-title} {product-version}, {olmv1} support for handling runtime validation of sigstore signatures for container images is available as a Technology Preview (TP) feature.
+
+[id="ocp-4-18-extensions-known-issues_{context}"]
+==== {olmv1} known issues
 
 include::snippets/olmv1-operator-conditions-support.adoc[]
 
@@ -594,8 +658,19 @@ For more information, see xref:../installing/installing_with_agent_based_install
 [id="ocp-release-notes-olm_{context}"]
 === Operator lifecycle
 
-[id="ocp-release-notes-osdk_{context}"]
-=== Operator development
+[id="ocp-release-notes-olm-classic-rename_{context}"]
+==== Existing version of Operator Lifecycle Manager now known as {olmv0}
+
+With the release of {olmv1-first} as a General Availability (GA) feature, starting in {product-title} {product-version}, the existing version of OLM that has been included since the launch of {product-title} 4 is now known as _{olmv0}_.
+
+[NOTE]
+====
+{olmv0} remains enabled by default and fully supported throughout the {product-title} 4 lifecycle.
+====
+
+For more information on the GA release of {olmv1}, see the xref:../release_notes/ocp-4-18-release-notes.adoc#ocp-release-notes-extensions_release-notes[Extensions ({olmv1})] release note sections. For full documentation focused on {olmv1}, see the stand-alone xref:../extensions/index.adoc#olmv1-about[Extensions] guide.
+
+For full documentation focused on {olmv0}, continue referring to the xref:../operators/index.adoc#operators-overview[Operators] guide.
 
 [id="ocp-release-notes-openshift-cli_{context}"]
 === OpenShift CLI (oc)
@@ -960,10 +1035,34 @@ From {product-title} {product-version}, to successfully uninstall the SR-IOV Net
 
 For more information, see xref:../networking/networking_operators/sr-iov-operator/uninstalling-sriov-operator.adoc#nw-sriov-operator-uninstall_uninstalling-sr-iov-operator[Uninstalling the SR-IOV Network Operator].
 
+[discrete]
 [id="ocp-4-18-rhcos-iscsi-initiator_{context}"]
 === Changes to the iSCSI initiator name and service
 
 Previously, the `/etc/iscsi/initiatorname.iscsi` file was present by default on {op-system} images. With this release, the `initiatorname.iscsi` file is no longer present by default. Instead, it is created at run time when the `iscsi.service` and subsequent `iscsi-init.service` services start. This service is not enabled by default and might affect any CSI drivers that rely on reading the contents of the `initiatorname.iscsi` file prior to starting the service.
+
+[discrete]
+[id="ocp-4-18-operator-sdk-1-38-0_{context}"]
+=== Operator SDK 1.38.0
+
+{product-title} {product-version} supports Operator SDK 1.38.0. See xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Installing the Operator SDK CLI] to install or update to this latest version.
+
+Operator SDK 1.38.0 now supports Kubernetes 1.30 and uses Kubebuilder v4.
+
+Metrics endpoints are now secured using native Kubebuilder link:https://book.kubebuilder.io/reference/metrics[metrics configuration] instead of `kube-rbac-proxy`, which is now removed.
+
+The following support has also been removed from Operator SDK:
+
+* Scaffolding tools for Hybrid Helm-based Operator projects
+* Scaffolding tools for Java-based Operator projects
+
+If you have Operator projects that were previously created or maintained with Operator SDK 1.36.1, update your projects to keep compatibility with Operator SDK 1.38.0:
+
+* xref:../operators/operator_sdk/golang/osdk-golang-updating-projects.adoc#osdk-upgrading-projects_osdk-golang-updating-projects[Updating Go-based Operator projects]
+
+* xref:../operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc#osdk-upgrading-projects_osdk-ansible-updating-projects[Updating Ansible-based Operator projects]
+
+* xref:../operators/operator_sdk/helm/osdk-helm-updating-projects.adoc#osdk-upgrading-projects_osdk-helm-updating-projects[Updating Helm-based Operator projects]
 
 [id="ocp-4-18-deprecated-removed-features_{context}"]
 == Deprecated and removed features
@@ -1913,6 +2012,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 |General Availability
+
+|{olmv1} runtime validation of container images using sigstore signatures
+|Not Available
+|Not Available
+|Technology Preview
 
 |====
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10370

Version: 4.18

Preview: [New features and enhancements -> Extensions (OLMv1)](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-extensions_release-notes)

**[Note for reviewers] If you see any instances of "Branch Build" in the previews, those will be rendered as "4.18" after merge in the final publication.**

* Follow-up to https://github.com/openshift/openshift-docs/pull/88834 (which added the intro matter for the ["Operator Lifecycle Manager (OLM) v1 (General Availability)"](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-extensions-olmv1-ga_release-notes) announcement / feature note, reviewed by PM).
  * Reviewers, feel free to add in-line comments in that previous PR too if the content is not represented in this PR, or just leave a general comment in this one.

* Consumes content from https://github.com/openshift/openshift-docs/pull/88905
  * ["Improved catalog selection in OLM v1"](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-extensions-catalog-selection_release-notes) feature note
  * ["Basic support for proxied environments and trusted CA certificates"](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-extensions-proxy-and-trustedCA_release-notes) feature note
* Adds ["Disconnected environment support in OLM v1"](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-extensions-disconnected_release-notes) feature note
* Adds ["Compatibility with OpenShift Container Platform versions"](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-extensions-maxopenshiftversion_release-notes) feature note
* Adds ["User access to extension resources"](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-extensions-user-access-resources_release-notes) feature note
* Adds ["Runtime validation of container images using sigstore signatures in OLM v1 (Technology Preview)"](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-extensions-sigstore_release-notes) feature note
  * Updated the [Extensions Technology Preview tracker](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-extensions-tech-preview_release-notes) table to include this as well

* Adds "Notable technical changes" entry for [Operator SDK 1.38.0](https://88927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-operator-sdk-1-38-0_release-notes)