### PR TITLE
OSSM-8459 [DOCS] Change PodMonitor creation instructions

### DIFF
--- a/modules/ossm-config-openshift-monitoring-only.adoc
+++ b/modules/ossm-config-openshift-monitoring-only.adoc
@@ -84,16 +84,27 @@ spec:
       replacement: '$2:$1'
       sourceLabels: ["__meta_kubernetes_pod_annotation_prometheus_io_port","__meta_kubernetes_pod_ip"]
       targetLabel: "__address__"
-    - action: labeldrop
-      regex: "__meta_kubernetes_pod_label_(.+)"
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_name","__meta_kubernetes_pod_label_app"]
+      separator: ";"
+      targetLabel: "app"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "${1}${2}"
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_version","__meta_kubernetes_pod_label_version"]
+      separator: ";"
+      targetLabel: "version"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "${1}${2}"
     - sourceLabels: ["__meta_kubernetes_namespace"]
       action: replace
       targetLabel: namespace
-    - sourceLabels: ["__meta_kubernetes_pod_name"]
-      action: replace
-      targetLabel: pod_name
+    - action: replace
+      replacement: "the-mesh-identification-string" # <2>
+      targetLabel: mesh_id 
 ----
-<1> Because {ocp-product-title} monitoring ignores the `namespaceSelector` spec in `ServiceMonitor` and `PodMonitor` objects, you must apply the `PodMonitor` object in all mesh namespaces, including the Istio control plane namespace.
+<1> Specifies that the `PodMonitor` object must be applied in all mesh namespaces, including the Istio control plane namespace, because {ocp-product-title} monitoring ignores the `namespaceSelector` spec in `ServiceMonitor` and `PodMonitor` objects.
+<2> Specify the actual mesh ID.
 
 . Apply the YAML file by running the following command:
 +


### PR DESCRIPTION
Change type: Doc update; Change PodMonitor creation instructions

Doc JIRA: https://issues.redhat.com/browse/OSSM-8459

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://88930--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/metrics/ossm-metrics-assembly.html#ossm-config-openshift-monitoring-only_ossm-metrics-assembly

SME Review/QE Review: @jmazzitelli @sridhargaddam 
Peer Review: 