### PR TITLE
OBSDOCS-1720: remove the additional spaces to see if it causes the d.r.c breaks

### DIFF
--- a/modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc
+++ b/modules/monitoring-about-specifying-limits-and-requests-for-monitoring-components.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: CONCEPT
-
 [id="about-specifying-limits-and-requests-for-monitoring-components_{context}"]
 = About specifying limits and requests for monitoring components
 

--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="assigning-tolerations-to-monitoring-components_{context}"]
 = Assigning tolerations to monitoring components
 

--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="attaching-additional-labels-to-your-time-series-and-alerts_{context}"]
 = Attaching additional labels to your time series and alerts
 

--- a/modules/monitoring-configurable-monitoring-components.adoc
+++ b/modules/monitoring-configurable-monitoring-components.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: REFERENCE
-
 [id="configurable-monitoring-components_{context}"]
 = Configurable monitoring components
 

--- a/modules/monitoring-configuring-a-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-persistent-volume-claim.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="configuring-a-persistent-volume-claim_{context}"]
 = Configuring a persistent volume claim
 

--- a/modules/monitoring-configuring-external-alertmanagers.adoc
+++ b/modules/monitoring-configuring-external-alertmanagers.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="monitoring-configuring-external-alertmanagers_{context}"]
 = Configuring external Alertmanager instances
 

--- a/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
+++ b/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="configuring-pod-topology-spread-constraints_{context}"]
 = Configuring pod topology spread constraints
 

--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="configuring-remote-write-storage_{context}"]
 = Configuring remote write storage
 

--- a/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
+++ b/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="creating-cluster-id-labels-for-metrics_{context}"]
 = Creating cluster ID labels for metrics
 

--- a/modules/monitoring-example-remote-write-authentication-settings.adoc
+++ b/modules/monitoring-example-remote-write-authentication-settings.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: REFERENCE
-
 [id="example-remote-write-authentication-settings_{context}"]
 = Example remote write authentication settings
 

--- a/modules/monitoring-example-remote-write-queue-configuration.adoc
+++ b/modules/monitoring-example-remote-write-queue-configuration.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: REFERENCE
-
 [id="example-remote-write-queue-configuration_{context}"]
 = Example remote write queue configuration
 

--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="modifying-retention-time-and-size-for-prometheus-metrics-data_{context}"]
 = Modifying retention time and size for Prometheus metrics data
 

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="moving-monitoring-components-to-different-nodes_{context}"]
 = Moving monitoring components to different nodes
 

--- a/modules/monitoring-resizing-a-persistent-volume.adoc
+++ b/modules/monitoring-resizing-a-persistent-volume.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="resizing-a-persistent-volume_{context}"]
 = Resizing a persistent volume
 

--- a/modules/monitoring-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: CONCEPT
-
 [id="retention-time-and-size-for-prometheus-metrics-data_{context}"]
 = Retention time and size for Prometheus metrics
 

--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="setting-log-levels-for-monitoring-components_{context}"]
 = Setting log levels for monitoring components
 

--- a/modules/monitoring-setting-query-log-file-for-prometheus.adoc
+++ b/modules/monitoring-setting-query-log-file-for-prometheus.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="setting-query-log-file-for-prometheus_{context}"]
 = Enabling the query log file for Prometheus
 

--- a/modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc
+++ b/modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc
@@ -3,7 +3,6 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="specifying-limits-and-resource-requests-for-monitoring-components_{context}"]
 = Specifying limits and requests
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 and later
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OBSDOCS-1720
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: `n/a`
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is to see if maybe the additional space causes the monitoring pages to render wrong in d.r.c
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
