### PR TITLE
OSDOCS-12237-oc: Bug batching oc-mirror

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1449,6 +1449,11 @@ In the following tables, features are marked with the following statuses:
 ==== The Shared Resource CSI Driver is removed
 The Shared Resource CSI Driver feature was deprecated in {product-title} 4.17, and is now removed from {product-title} 4.18. This feature is now generally available in Builds for Red Hat OpenShift 1.1. To use this feature, ensure you are using Builds for Red Hat OpenShift 1.1 or later.
 
+[id="ocp-4-18-selected-bundled-removed_{context}"]
+==== The selected bundles feature is removed in oc-mirror v2
+
+The selected bundles feature is removed from the oc-mirror v2 Generally Available release. This change prevents issues where specifying the wrong Operator bundle version could break the Operators in a cluster. (link:https://issues.redhat.com/browse/OCPBUGS-49419[*OCPBUGS-49419*])
+
 [id="ocp-4-18-future-deprecation_{context}"]
 === Notice of future deprecation
 
@@ -1762,8 +1767,58 @@ If these values are not defined in a failure domain configuration, for instance 
 
 
 [discrete]
+[id="ocp-release-note-oc-mirror-bug-fixes_{context}"]
+==== oc-mirror
+
+* Previously, when using `oc-mirror --v2 delete --generate` command, the contents of the `working-dir/cluster-resources` directory were cleared. With this fix, the `working-dir/cluster-resources` directory is not cleaned when the delete feature is used. (link:https://issues.redhat.com/browse/OCPBUGS-48430[*OCPBUGS-48430*])
+
+* Previously, release images were signed using a `SHA-1` key. On {op-system-base} 9 FIPS STIG-compliant machines, verification of release signatures using the old `SHA-1` key failed due to security restrictions on weak keys. With this release, release images are signed using a new `SHA-256` trusted key so that the release signatures no longer fail. (link:https://issues.redhat.com/browse/OCPBUGS-48314[*OCPBUGS-48314*])
+
+// Subhashini to confirm the TP status on these bugs
+////
+
+* Previously, when running oc-mirror v2 Technology Preview in mirror-to-disk mode within an disconnected environment, the tool attempted to download `graph.tar.gz` from `api.openshift.com`, causing the mirroring process to fail.
++
+With this release, when the `UPDATE_URL_OVERRIDE` environment variable is set, oc-mirror first checks for the graph image in the oc-mirror cache. If the image is not found, `oc-mirror` skips it without failing, ensuring successful mirroring in air-gapped environments. (link:https://issues.redhat.com/browse/OCPBUGS-38037[*OCPBUGS-38037*])
+
+* Previously, oc-mirror v2 Technology Preview did not support images referenced by both `tag` and `digest`. These images were excluded from the archive during the mirror-to-disk workflow, causing failures when mirroring from the archive to a disconnected mirror registry. With this fix, oc-mirror v2 includes these images in the archive by pulling the source image by `digest` while retaining the `tag` for reference. A warning message is displayed to inform users of this behavior. (link:https://issues.redhat.com/browse/OCPBUGS-37867[*OCPBUGS-37867*])
+
+* Previously, when running oc-mirror v2 Technology Preview in mirror-to-disk mode within an disconnected environment, the tool attempted to download `graph.tar.gz` from `api.openshift.com`, causing the mirroring process to fail. With this fix, when the `UPDATE_URL_OVERRIDE` environment variable is set, oc-mirror first checks for the graph image in the oc-mirror cache. If the image is not found, oc-mirror skips it without failing, ensuring successful mirroring in air-gapped environments. (link:https://issues.redhat.com/browse/OCPBUGS-38037[*OCPBUGS-38037*])
+
+* Previously, oc-mirror v2 Technology Preview did not support images referenced by both `tag` and `digest`. These images were excluded from the archive during the mirror-to-disk workflow, causing failures when mirroring from the archive to a disconnected mirror registry. With this fix, oc-mirror v2 includes these images in the archive by pulling the source image by `digest` while retaining the `tag` for reference. A warning message is displayed to inform users of this behavior.  (link:https://issues.redhat.com/browse/OCPBUGS-37867[*OCPBUGS-37867*])
+
+* Previously, mirroring a release that used a digest instead of a tag did not work as expected. This issue has been fixed, ensuring successful mirroring for releases that use digests. (link:https://issues.redhat.com/browse/OCPBUGS-45249[*OCPBUGS-45249*])
+
+* Previously, API calls to Cincinnati that encountered errors did not fail immediately, potentially leading to inconsistencies. With this update, errors related to Cincinnati are now considered severe and cause an immediate failure. (link:https://issues.redhat.com/browse/OCPBUGS-38461[*OCPBUGS-38461*])
+
+* When you used oc-mirror v2 Technology Preview in a mirror-to-mirror workflow, logs displayed catalog images twice. This could mislead users into thinking the catalog image was mirrored twice. In reality, the image was copied once to the destination registry and once to the oc-mirror local cache. This issue has been fixed to ensure logs accurately reflect the mirroring process. (link:https://issues.redhat.com/browse/OCPBUGS-41331[*OCPBUGS-41331*])
+////
+
+* Previously, when using the `--force-cache-delete` flag to delete images from a remote registry, the deletion process did not work as expected. With this update, the issue has been resolved, ensuring that images are deleted properly when the flag is used. (link:https://issues.redhat.com/browse/OCPBUGS-47690[*OCPBUGS-47690*])
+
+* Previously, oc-mirror plugin v2 could not delete the graph image when the mirroring uses a partially disconnected mirroring workflow (mirror-to-mirror). With this update, graph images can now be deleted regardless of the mirroring workflow used. (link:https://issues.redhat.com/browse/OCPBUGS-46145[*OCPBUGS-46145*])
+
+* Previously, if the same image was used by multiple {product-title} release components, oc-mirror plugin v2 attempted to delete the image multiple times, but failed after the first attempt. This issue has been resolved by ensuring oc-mirror plugin v2 generates a list of unique images during the delete `--generate` phase. (link:https://issues.redhat.com/browse/OCPBUGS-45299[*OCPBUGS-45299*])
+
+* Previously, `oci` catalogs on disk were not mirrored correctly in the oc-mirror plugin v2. With this update, `oci` catalogs are now successfully mirrored. (link:https://issues.redhat.com/browse/OCPBUGS-44225[*OCPBUGS-44225*])
+
+* Previously, if you reran the `oc-mirror` command, the rebuild of the `oci` catalog failed and an error was generated. With this release, if you rerun the `oc-mirror` command, the wrokspace file is deleted so that the failed catalog issue does not happen. (link:https://issues.redhat.com/browse/OCPBUGS-45171[*OCPBUGS-45171*])
+
+* Previously, if you ran the `oc adm node-image create` command on the first attempt, sometimes an `image can't be pulled` error message was generated. With this release, a retry mechanism addresses temporary failures when pulling the image from the release payload. (link:https://issues.redhat.com/browse/OCPBUGS-44388[*OCPBUGS-44388*])
+
+* Previously, `oci` catalogs on disk were not mirrored correctly in oc-mirror plugin v2. With this update, `oci` catalogs are now successfully mirrored. (link:https://issues.redhat.com/browse/OCPBUGS-44225[*OCPBUGS-44225*])
+
+* Previously, duplicate entries could appear in the signature `ConfigMap YAML` and `JSON` files created in the `clusterresource` object, leading to issues when applying them to the cluster. This update ensures that the generated files do not contain duplicates. (link:https://issues.redhat.com/browse/OCPBUGS-42428[*OCPBUGS-42428*])
+
+* Previously, the release signature `ConfigMap` for oc-mirror plugin v2 was incorrectly stored in an archived TAR file instead of in the `cluster-resources` folder. This caused `mirror2disk` to fail. With this release. the release signature `ConfigMap` for oc-mirror plugin v2 that is in JSON format or YAML format, compatible with oc-mirror plugin v1, now get stored in the `cluster-resources` folder. (link:https://issues.redhat.com/browse/OCPBUGS-38343[*OCPBUGS-38343*]) and (link:https://issues.redhat.com/browse/OCPBUGS-38233[*OCPBUGS-38233*])
+
+* Previously, using an invalid log-level flag caused oc-mirror plugin v2 to panic. This update ensures that the oc-mirror plugin v2 handles invalid log levels gracefully. Additionally, the `loglevel` flag has been renamed to `log-level` to align with tools like Podman for the convenience of the user. (link:https://issues.redhat.com/browse/OCPBUGS-37740[*OCPBUGS-37740*])
+
+[discrete]
 [id="ocp-release-note-openshift-cli-bug-fixes_{context}"]
 ==== OpenShift CLI (oc)
+
+* Previously, the `oc adm node-image create --pxe generated` command did not create only the Preboot Execution Environment (PXE) artifacts. Instead, the command created the PXE artifacts with other artifacts from a `node-joiner` pod and stored them all in the wrong subdirectory. Additionally, the PXE artifacts were incorrectly prefixed with `agent` instead of `node`. With this release, generated PXE artifacts are stored in the correct directory and receive the correct prefix. (link:https://issues.redhat.com/browse/OCPBUGS-46449[*OCPBUGS-46449*])
 
 [discrete]
 [id="ocp-release-note-olm-bug-fixes_{context}"]
@@ -2411,6 +2466,8 @@ In the following tables, features are marked with the following statuses:
 
 [id="ocp-4-18-known-issues_{context}"]
 == Known issues
+
+* oc-mirror plugin v2 currently returns an exit status of `0`, meaning "success", even when mirroring errors occur. As a result, do not rely on the exit status in automated workflows. Until this issue is resolved, manually check the `mirroring_errors_XXX_XXX.txt` file generated by `oc-mirror` for errors. (link:https://issues.redhat.com/browse/OCPBUGS-49880[*OCPBUGS-49880*])
 
 * The DNF package manager included in {op-system-first} images cannot be used at runtime, because DNF relies on additional packages to access entitled nodes in a cluster that are under a Red Hat subscription. As a workaround, use the `rpm-ostree` command instead. (link:https://issues.redhat.com/browse/OCPBUGS-35247[*OCPBUGS-35247*])
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12237](https://issues.redhat.com/browse/OSDOCS-12237)

Link to docs preview:
* [Bug fixes](https://88938--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-bug-fixes_release-notes)
