### PR TITLE
OSDOCS-12240: Updated the advisory info for the 4.18 RN doc

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -14,7 +14,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update with the relevant information closer to release.
-{product-title} (link:https://access.redhat.com/errata/RHSA-2024:xxxx[RHSA-2024:xxxx]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md[Kubernetes 1.31] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2024:6122[RHSA-2024:6122]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md[Kubernetes 1.31] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. From the {hybrid-console}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
@@ -2694,12 +2694,12 @@ For any {product-title} release, always review the instructions on xref:../updat
 ====
 
 //Update with relevant advisory information
-[id="ocp-4-18-0-ga_{context}"]
-=== RHSA-2024:XXXX - {product-title} {product-version}.0 image release, bug fix, and security update advisory
+[id="ocp-4-18-1-ga_{context}"]
+=== RHSA-2024:6122 - {product-title} {product-version}.1 image release, bug fix, and security update advisory
 
-Issued: TBD
+Issued: 25 February 2025
 
-{product-title} release {product-version}.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:XXXX[RHSA-2024:XXXX] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3722[RHSA-2024:XXXX] advisory.
+{product-title} release {product-version}.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:6122[RHSA-2024:6122] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2024:6126[RHEA-2024:6126] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -2707,10 +2707,10 @@ You can view the container images in this release by running the following comma
 
 [source,terminal]
 ----
-$ oc adm release info 4.18.0 --pullspecs
+$ oc adm release info 4.18.1 --pullspecs
 ----
 
-[id="ocp-4-18-0-updating_{context}"]
+[id="ocp-4-18-1-updating_{context}"]
 ==== Updating
 To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12240](https://issues.redhat.com/browse/OSDOCS-12240)

Link to docs preview:


ART ticket: https://issues.redhat.com/browse/ART-10610
