### PR TITLE
CNV-47369: Update the Getting Started page links

### DIFF
--- a/modules/migrating-to-virt.adoc
+++ b/modules/migrating-to-virt.adoc
@@ -14,7 +14,7 @@ To migrate virtual machines from an external provider such as {vmw-first}, {rh-o
 ====
 
 .Prerequisites
-* The {mtv-full} Operator link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{mtv-version}/html/installing_and_using_the_migration_toolkit_for_virtualization/installing-the-operator_mtv[is installed].
+* The {mtv-full} Operator link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{mtv-version}/html/installing_and_using_the_migration_toolkit_for_virtualization/installing-the-operator_mtv#installing-the-operator_mtv[is installed].
 
 .Procedure
 . link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/{mtv-version}/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-vms-web-console_mtv#adding-source-providers[Configure the source provider].

--- a/virt/getting_started/virt-getting-started.adoc
+++ b/virt/getting_started/virt-getting-started.adoc
@@ -38,7 +38,7 @@ Quick start tours are available for several {VirtProductName} features. To acces
 . Click the *Help* icon *?* in the menu bar on the header of the {product-title} web console.
 . Select *Quick Starts*.
 
-You can filter the available tours by entering the keyword `virtualization` in the *Filter* field.
+You can filter the available tours by entering the keyword `virtual` in the *Filter* field.
 endif::openshift-rosa,openshift-dedicated[]
 
 [id="planning-and-installing-virt_{context}"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-47369](https://issues.redhat.com/browse/CNV-47369)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Steps I took to review the Getting Started page:

- [x] Retested the _Tours and quick starts_ procedures in the QE environment
- [x] Reviewed all links and ensured they point to the right sections after content reorganization
- [x] Reviewed all documentation changes between the _enterprise-4.17_ and _enterprise-4.18_ and checked that no new links need to be added

Changes in this pull request:

- [x] Added an anchor to the link to Migration Toolkit for Virtualization documentation. While not strictly needed for an external link, it is consistent with the other links and takes the readers to the exact section on the page.
- [x] Adjusted the instruction for filtering quick starts as on OpenShift 4.18, typing in "virtualization" in the filter field eliminates all relevant results. Changing the keyword to "virual" ensures that quick start documents like "Create a virtual machine from a template" or "Update a boot source" that has "virtual machines" in the description show up in the results.

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
