### PR TITLE
OCPBUGS-153889a added the word mirror to comment 12

### DIFF
--- a/modules/images-configuration-registry-mirror-configuring.adoc
+++ b/modules/images-configuration-registry-mirror-configuring.adoc
@@ -119,9 +119,9 @@ spec:
 ** `NeverContactSource`: Prevents continued attempts to pull the image from the source repository.
 <8> Optional: Indicates a namespace inside a registry, which allows you to use any image in that namespace. If you use a registry domain as a source, the object is applied to all repositories from the registry.
 <9> Optional: Indicates a registry, which allows you to use any image in that registry. If you specify a registry name, the object is applied to all repositories from a source registry to a mirror registry.
-<10> Pulls the image `registry.example.com/example/myimage@sha256:...` from the mirror `mirror.example.net/image@sha256:..`.
+<10> Pulls the image `registry.example.com/example/myimage@sha256:...` from the mirror `mirror.example.net/image@sha256:...`.
 <11> Pulls the image `registry.example.com/example/image@sha256:...` in the source registry namespace from the mirror `mirror.example.net/image@sha256:...`.
-<12> Pulls the image `registry.example.com/myimage@sha256` from the mirror registry `example.net/registry-example-com/myimage@sha256:...`.
+<12> Pulls the image `registry.example.com/myimage@sha256` from the mirror registry `mirror.example.net/registry-example-com/myimage@sha256:...`.
 
 * Create an `ImageContentSourcePolicy` custom resource, replacing the source and mirrors with your own registry and repository pairs and images:
 +


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-15389

Link to docs preview:
https://88962--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-configuration.html
https://88962--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/updating/disconnected-update.html
https://88962--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html
https://88962--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html
https://88962--ocpdocs-pr.netlify.app/openshift-rosa/latest/openshift_images/image-configuration.html


QE review:
- [x] QE has approved this change.


Additional information:
This is a redo from PR https://github.com/openshift/openshift-docs/pull/84176. Although the PR was reviewed and merged, the updates never made it to the document so this is a new PR to get those updates into the document.


