### PR TITLE
OSDOCS-11950: updates release notes z 4.18 MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -133,11 +133,11 @@ Red{nbsp}Hat Customer Portal user accounts must have systems registered and cons
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
-[id="microshift-4-18-0-dp_{context}"]
-=== RHSA-2024:6124 - {microshift-short} 4.18.0 bug fix and security update advisory
+[id="microshift-4-18-1-dp_{context}"]
+=== RHSA-2024:6124 - {microshift-short} 4.18.1 bug fix and security update advisory
 
 Issued: 25 February 2025
 
-{product-title} release 4.18.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2024:6124[RHSA-2024:6124] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2024:6122[RHEA-2024:6122] advisory.
+{product-title} release 4.18.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2024:6124[RHSA-2024:6124] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2024:6122[RHEA-2024:6122] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-11950](https://issues.redhat.com/browse/OSDOCS-11950)

Link to docs preview:
[microshift-4-18-1-release-notes](https://88968--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-1-dp_release-notes)

QE review:
- N/A, stock text update

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
