### PR TITLE
OSDOCS-12237-OLM: Bug batching for OLM 4.18

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1769,6 +1769,24 @@ If these values are not defined in a failure domain configuration, for instance 
 [id="ocp-release-note-olm-bug-fixes_{context}"]
 ==== Operator Lifecycle Manager (OLM)
 
+* Previously, concurrent reconciliation of the same namespace in {olmv0-first} led to `ConstraintsNotSatisfiable` errors on subscriptions. This update resolves the issue. (link:https://issues.redhat.com/browse/OCPBUGS-48660[*OCPBUGS-48660*])
+
+* Previously, excessive catalog source snapshots caused severe performance regressions. This update fixes the issue. (link:https://issues.redhat.com/browse/OCPBUGS-48644[*OCPBUGS-48644*])
+
+* Previously, when the kubelet terminated catalog registry pods with the `TerminationByKubelet` message, the registry pods were not recreated by the catalog Operator. This update fixes the issue. (link:https://issues.redhat.com/browse/OCPBUGS-46474[*OCPBUGS-46474*])
+
+* Previously, {olmv0} failed to upgrade Operator cluster service versions (CSVs) due to a TLS validation error. This update fixes the issue. (link:https://issues.redhat.com/browse/OCPBUGS-43581[*OCPBUGS-43581*])
+
+* Previously, service account tokens for Operator groups failed to generate automatically in {olmv0-first}. This update fixes the issue. (link:https://issues.redhat.com/browse/OCPBUGS-42360[*OCPBUGS-42360*])
+
+* Previously when {olmv1-first} validated custom resource definition (CRD) upgrades, the message output when detecting changed default values was rendered in bytes instead of human-readable language. With this update, related messages are now updated to show human-readable values. (link:https://issues.redhat.com/browse/OCPBUGS-41726[*OCPBUGS-41726*])
+
+* Previously, the status update function did not return an error when a connection error occurred in the Catalog Operator. As a result, the Operator might crash because the IP address returned a `nil` status. This update resolves the issue so that an errro message is returned and the Operator no longer crashes. (link:https://issues.redhat.com/browse/OCPBUGS-37637[*OCPBUGS-37637*])
+
+* Previously, catalog source registry pods did not recover from cluster node failures. This update fixes the issue. (link:https://issues.redhat.com/browse/OCPBUGS-36661[*OCPBUGS-36661*])
+
+* Previously, Operators with many custom resources (CRs) exceeded API server timeouts. As a result, the install plan for the Operator got stuck in a pending state. This update fixes the issue by adding a page view for list CRs deployed on the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-35358[*OCPBUGS-35358*])
+
 [discrete]
 [id="ocp-release-note-openshift-api-server-bug-fixes_{context}"]
 ==== OpenShift API server


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12237](https://issues.redhat.com/browse/OSDOCS-12237)

Link to docs preview:
* [Bug fixes](https://88969--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html)
