### PR TITLE
OBSDOCS-1693: Remove Logging 6.0 docs from OpenShift 4.18

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3003,23 +3003,6 @@ Topics:
 #      File: logging-5-8-release-notes
 #    - Name: Logging 5.7
 #      File: logging-5-7-release-notes
-  - Name: Logging 6.0
-    Dir: logging-6.0
-    Topics:
-      - Name: Release notes
-        File: log6x-release-notes
-      - Name: About logging 6.0
-        File: log6x-about
-      - Name: Upgrading to Logging 6.0
-        File: log6x-upgrading-to-6
-      - Name: Configuring log forwarding
-        File: log6x-clf
-      - Name: Configuring LokiStack storage
-        File: log6x-loki
-      - Name: Visualization for logging
-        File: log6x-visual
-#      - Name: API reference 6.0
-#        File: log6x-api-reference
   - Name: Logging 6.1
     Dir: logging-6.1
     Topics:

--- a/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-design-components.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-design-components.adoc
@@ -69,7 +69,8 @@ include::modules/telco-core-logging.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../observability/logging/logging-6.0/log6x-about.adoc#log6x-about[About logging]
+//* xref:../../../observability/logging/logging-6.0/log6x-about.adoc#log6x-about[About logging]
+* link:https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.0/log6x-about.html[About logging]
 
 include::modules/telco-core-power-management.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.adoc
+++ b/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.adoc
@@ -48,7 +48,8 @@ include::modules/telco-ran-logging.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../observability/logging/logging-6.0/log6x-about.adoc#log6x-about[About logging]
+//* xref:../../../observability/logging/logging-6.0/log6x-about.adoc#log6x-about[About logging]
+* link:https://docs.openshift.com/container-platform/4.17/observability/logging/logging-6.0/log6x-about.html[About logging]
 
 include::modules/telco-ran-sriov-fec-operator.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.18

Issue: https://issues.redhat.com/browse/OBSDOCS-1693
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://88978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-release-notes-6.1 (This links just shows that Logging 6.0 is not visible, which is what we want)
- https://88978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-design-components.html
- https://88978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-components.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required because the changes do not impact the meaning of the docs.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->