### PR TITLE
OCI C3 and PCA GA docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -307,6 +307,12 @@ endif::[]
 :ocid: OCID
 :ocvs-first: Oracle(R) Cloud VMware Solution (OCVS)
 :ocvs: OCVS
+:oci-c3: Oracle(R) Compute Cloud@Customer
+:oci-c3-no-rt: Oracle Compute Cloud@Customer
+:oci-c3-short: Compute Cloud@Customer
+:oci-pca: Oracle(R) Private Cloud Appliance
+:oci-pca-no-rt: Oracle Private Cloud Appliance
+:oci-pca-short: Private Cloud Appliance
 // Red Hat OpenStack Platform (RHOSP)/OpenStack
 ifndef::openshift-origin[]
 :rh-openstack-first: Red Hat OpenStack Platform (RHOSP)

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -581,6 +581,10 @@ Topics:
     File: installing-oci-assisted-installer
   - Name: Installing a cluster on Oracle Cloud Infrastructure by using the Agent-based Installer
     File: installing-oci-agent-based-installer
+  - Name: Installing a cluster on Oracle Compute Cloud@Customer
+    File: installing-c3-agent-based-installer
+  - Name: Installing a cluster on Oracle Private Cloud Appliance
+    File: installing-pca-agent-based-installer
 - Name: Installing on VMware vSphere
   Dir: installing_vsphere
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_oci/installing-c3-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-c3-agent-based-installer.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="installing-c3-agent-based-installer"]
+= Installing a cluster on {oci-c3-no-rt}
+:context: installing-c3-agent-based-installer
+
+toc::[]
+
+You can install an {product-title} cluster on {oci-c3} using either the Agent-based Installer or the Assisted Installer, so that you can run cluster workloads on on-premise infrastructure while still utilizing {oci-first} services.
+
+For instructions on installing a cluster on {oci-c3}, see (link here) for more information.

--- a/installing/installing_oci/installing-pca-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-pca-agent-based-installer.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="installing-pca-agent-based-installer"]
+= Installing a cluster on {oci-pca-no-rt}
+:context: installing-pca-agent-based-installer
+
+toc::[]
+
+You can install an {product-title} cluster on {oci-pca} using either the Agent-based Installer or the Assisted Installer, so that you can run cluster workloads on on-premise infrastructure while still utilizing {oci-first} services.
+
+For instructions on installing a cluster on {oci-pca}, see (link here) for more information.


### PR DESCRIPTION
Version(s): 4.18+

This PR documents the GA of installing a cluster on Oracle Compute Cloud@Customer and Private Cloud Appliance for both the Agent-based Installer and the Assisted Installer. The goal here is to provide temporary links to where Oracle will be hosting end-to-end guides of the process.

At a later time, these docs will be replaced with more fleshed out procedures that Red Hat owns and links to webpages for procedures that Oracle owns.

QE review:
- [ ] QE has approved this change.

Previews:

- [Installing a cluster on Oracle Compute Cloud@Customer](https://88988--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-c3-agent-based-installer)
- [Installing a cluster on Oracle Private Cloud Appliance](https://88988--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-pca-agent-based-installer)