### PR TITLE
OCI C3 and PCA Release Note

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1043,14 +1043,14 @@ For full documentation focused on {olmv0}, continue referring to the xref:../ope
 
 With this release, you can install an {product-title} cluster on {oci-c3} by using either the Assisted Installer or the Agent-based Installer.
 
-For more information, see (xref here).
+For more information, see xref:../installing/installing_oci/installing-c3-agent-based-installer.adoc#installing-c3-agent-based-installer[Installing a cluster on {oci-c3-no-rt} by using the Agent-based Installer].
 
 [id="ocp-release-notes-oci-pca_{context}"]
 ==== {product-title} support on {oci-pca}
 
 With this release, you can install an {product-title} cluster on {oci-pca} by using either the Assisted Installer or the Agent-based Installer.
 
-For more information, see (xref here).
+For more information, see xref:../installing/installing_oci/installing-pca-agent-based-installer.adoc#installing-pca-agent-based-installer[Installing a cluster on {oci-pca-no-rt} by using the Agent-based Installer].
 
 [id="ocp-4.18-postinstallation-configuration_{context}"]
 === Postinstallation configuration
@@ -2347,12 +2347,12 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-|{product-title} on Oracle Compute Cloud@Customer (C3)
+|{product-title} on Oracle Compute Cloud@Customer
 |Not Available
 |Not Available
 |General Availability
 
-|{product-title} on Oracle Private Cloud Appliance (PCA)
+|{product-title} on Oracle Private Cloud Appliance
 |Not Available
 |Not Available
 |General Availability

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1038,6 +1038,20 @@ For full documentation focused on {olmv0}, continue referring to the xref:../ope
 * xref:../installing/installing_oci/installing-oci-assisted-installer.adoc#installing-oci-assisted-installer[Installing a cluster on {oci-first-no-rt} by using the {ai-full}]
 * xref:../installing/installing_oci/installing-oci-agent-based-installer.adoc#installing-oci-agent-based-installer[Installing a cluster on {oci-first-no-rt} by using the Agent-based Installer]
 
+[id="ocp-release-notes-oci-c3_{context}"]
+==== {product-title} support on {oci-c3}
+
+With this release, you can install an {product-title} cluster on {oci-c3} by using either the Assisted Installer or the Agent-based Installer.
+
+For more information, see (xref here).
+
+[id="ocp-release-notes-oci-pca_{context}"]
+==== {product-title} support on {oci-pca}
+
+With this release, you can install an {product-title} cluster on {oci-pca} by using either the Assisted Installer or the Agent-based Installer.
+
+For more information, see (xref here).
+
 [id="ocp-4.18-postinstallation-configuration_{context}"]
 === Postinstallation configuration
 


### PR DESCRIPTION
Version(s): 4.18

This PR adds release note entries for OCP installations on Oracle Compute Cloud@Customer and Private Cloud Appliance for both the Agent-based Installer and the Assisted Installer. 

QE review:
- [ ] QE has approved this change.

Preview: https://88989--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-oci-c3_release-notes