### PR TITLE
MCO removing extensions from OCL docs

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -191,11 +191,14 @@ include::modules/coreos-layering-configuring-on-modifying.adoc[leveloffset=+2]
 .Additional resources
 * xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools]
 
+////
+Hiding extensions, not in 4.18. Maybe 4.19?
 include::modules/coreos-layering-configuring-on-extensions.adoc[leveloffset=+2]
 
 .Additional resources
 * xref:../machine_configuration/machine-configs-configure.html#rhcos-add-extensions_machine-configs-configure[Adding extensions to RHCOS]
 * xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools]
+////
 
 // Not in 4.18; maybe 4.19
 // include::modules/coreos-layering-configuring-on-rebuild.adoc[leveloffset=+2] 


### PR DESCRIPTION
Per conversation in Slack with @dkhater-redhat, support for installing extensions using an OCL is not supported for 4.18. This PR hides the include in the mco-coreos-layering.adoc assembly that adds the extensions module. The module can remain in the repo, as it has been reviewed multiple times and should be used in the future. 

[Current 4.18 docs](https://docs.openshift.com/container-platform/4.18/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on_mco-coreos-layering)
[Updated docs](https://88993--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on_mco-coreos-layering)


QE review: No QE needed
