### PR TITLE
Bug bashing: Add Node Tuning Operator 4.18 RN

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -873,6 +873,14 @@ Available as a Technology Preview, you can use the sigstore project with {produc
 Enhancements have been added to the process for xref:../nodes/nodes/nodes-nodes-adding-node-iso.adoc#adding-node-iso[adding worker nodes to an on-premise cluster] that was introduced in {product-title} 4.17.
 With this release, you can now generate Preboot Execution Environment (PXE) assets instead of an ISO image file, and you can configure reports to be generated regardless of whether the node creation process fails or not.
 
+[id="ocp-release-notes-nodes-select-kernel-arguments_{context}"]
+==== Node Tuning Operator properly selects kernel arguments
+The Node Tuning Operator can now properly select kernel arguments and management options for Intel and AMD CPUs. (link:https://issues.redhat.com/browse/OCPBUGS-43664[*OCPBUGS-43664*])
+
+[id="ocp-release-notes-nodes-default-container-runtime_{context}"]
+==== Default container runtime is not always set properly
+The default container runtime that is set by the cluster Node Tuning Operator is always inherited from the cluster, and is not hard-coded by the Operator. Starting with this release, the default value is `crun`. (link:https://issues.redhat.com/browse/OCPBUGS-45450[*OCPBUGS-45450*])
+
 [id="ocp-release-notes-postinstallation-configuration_{context}"]
 === Postinstallation configuration
 
@@ -1723,6 +1731,12 @@ If these values are not defined in a failure domain configuration, for instance 
 * Previously, CPU masks for interrupt and network handling CPU affinity were computed incorrectly on machines with more than 256 CPUs. This issue prevented proper CPU isolation and caused `systemd` unit failures during internal node configuration. This fix ensures accurate CPU affinity calculations, enabling correct CPU isolation on machines with more than 256 CPUs. (link:https://issues.redhat.com/browse/OCPBUGS-36431[*OCPBUGS-36431*])
 
 * Previously, entering an invalid value in any `cpuset` field under `spec.cpu` in the `PerformanceProfile` resource caused the webhook validation to crash. With this release, improved error handling for the `PerformanceProfile` validation webhook ensures that invalid values for these fields return an informative error. (link:https://issues.redhat.com/browse/OCPBUGS-45616[*OCPBUGS-45616*])
+
+* Previously, users could enter an invalid string for any CPU set in the performance profile, resulting in a broken cluster. With this release, the fix ensures that only valid strings can be entered, eliminating the risk of cluster breakage. (link:https://issues.redhat.com/browse/OCPBUGS-47678[*OCPBUGS-47678*])
+
+* Previously, configuring the Node Tuning Operator (NTO) using `PerformanceProfiles` created the `ocp-tuned-one-shot` `systemd` service, which ran before kubelet and blocked its execution. The `systemd` service invoked Podman, which used the NTO image. When the NTO image was not present, Podman tried to fetch the image. With this release, support for cluster-wide proxy environment variables defined in `/etc/mco/proxy.env` is added. This support allows Podman to pull the NTO image in environments that need to use `http(s)` proxy for out-of-cluster connections. (link:https://issues.redhat.com/browse/OCPBUGS-39005[*OCPBUGS-39005*])
+
+* Previously, CPU masks for interrupt and network handling CPU affinity were computed incorrectly on machines with more than 256 CPUs. This issue prevented proper CPU isolation and caused `systemd` unit failures during internal node configuration. With this release, a fix ensures accurate CPU affinity calculations, enabling correct CPU isolation on machines with more than 256 CPUs. (link:https://issues.redhat.com/browse/OCPBUGS-36431[*OCPBUGS-36431*])
 
 [discrete]
 [id="ocp-release-note-observability-bug-fixes_{context}"]


### PR DESCRIPTION
[OSDOCS-12234](https://issues.redhat.com/browse/OSDOCS-12234)

Version(s):
4.18

Link to docs preview:
[New features and enhancements](https://88994--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-nodes_release-notes)
[Bug fixes](https://88994--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-bug-fixes_release-notes)

QE review:
- [ ] QE has approved this change.
N/A