### PR TITLE
Just moving the content down to the correct postinstall section

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -92,7 +92,7 @@ The updated location and guide name reflect a more focused documentation experie
 ====
 
 Simplified API::
-{olmv1} simplifies Operator management with a new, user-friendly API: xref:../extensions/arch/operator-controller.adoc#olmv1-clusterextension-api_operator-controller[the `ClusterExtension` object]. By managing Operators as integral extensions of the cluster, {olmv1} caters to the special lifecycle requirements of custom resource definition (CRDs). This design aligns more closely with Kubernetes principles, treating Operators, which consist of custom controllers and CRDs, as cluster-wide singletons. 
+{olmv1} simplifies Operator management with a new, user-friendly API: xref:../extensions/arch/operator-controller.adoc#olmv1-clusterextension-api_operator-controller[the `ClusterExtension` object]. By managing Operators as integral extensions of the cluster, {olmv1} caters to the special lifecycle requirements of custom resource definition (CRDs). This design aligns more closely with Kubernetes principles, treating Operators, which consist of custom controllers and CRDs, as cluster-wide singletons.
 +
 {product-title} continues to give you access to the latest Operator packages, patches, and updates through default xref:../extensions/catalogs/rh-catalogs.adoc#rh-catalogs[Red Hat Operator catalogs]. With {olmv1}, you can install an Operator package by creating and applying a `ClusterExtension` API object in your cluster. By interacting with `ClusterExtension` objects, you can manage the lifecycle of Operator packages, quickly understand their status, and troubleshoot issues.
 
@@ -599,26 +599,6 @@ With this release, the Agent-based Installer supports creating assets that can b
 
 For more information, see xref:../installing/installing_with_agent_based_installer/installing-using-iscsi.adoc#installing-using-iscsi[Preparing installation assets for iSCSI booting].
 
-[id="ocp-4.18-postinstallation-configuration_{context}"]
-=== Postinstallation configuration
-
-[id="ocp-4.18-migrate-x86-cp-to-arm-arch_{context}"]
-==== Migrating the x86 control plane to arm64 architecture on {aws-full}
-
-With this release, you can migrate the control plane in your cluster from `x86` to `arm64` architecture on {aws-first}. For more information, see xref:../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-from-x86-to-arm64-cp_updating-clusters-overview[Migrating the x86 control plane to arm64 architecture on Amazon Web Services].
-
-[id="ocp-4.18-support-for-config-image-stream-import-beh_{context}"]
-==== Configuring the image stream import mode behavior (Technology Preview)
-
-This feature introduces a new field, `imageStreamImportMode`, in the `image.config.openshift.io/cluster` resource. The `imageStreamImportMode` field controls the import mode behavior of image streams. You can set the `imageStreamImportMode` field to either of the following values:
-
-* `Legacy`
-* `PreserveOriginal`
-
-For more information, see xref:../openshift_images/image-configuration.adoc#images-configuration-parameters_image-configuration[Image controller configuration parameters].
-
-You must enable the `TechPreviewNoUpgrade` feature set in the `FeatureGate` custom resource (CR) to enable the `imageStreamImportMode` feature. For more information, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates].
-
 [id="ocp-release-notes-olm_{context}"]
 === Operator lifecycle
 
@@ -692,7 +672,7 @@ For more information, see xref:../machine_management/cluster_api_machine_managem
 === Management console
 
 [id="ocp-4-18-checkbox-cluster-monitoring_{context}"]
-==== Checkbox for enabling cluster monitoring is marked by default 
+==== Checkbox for enabling cluster monitoring is marked by default
 
 With this update, the checkbox for enabling cluster monitoring is now checked by default when installing the {ols} Operator. (link:https://issues.redhat.com/browse/OCPBUGS-42381[*OCPBUGS-42381*])
 
@@ -866,11 +846,11 @@ The SR-IOV Network Operator now supports Intel NetSec Accelerator Cards and Marv
 [id="ocp-release-notes-networking-ovnk-linux-bridge_{context}"]
 ==== Using a Linux bridge interface as the OVS default port connection
 
-The OVN-Kubernetes plugin can now use a Linux bridge interface as the Open vSwitch (OVS) default port connection. This means that a network interface controller, such as SmartNIC, can now bridge the underlying network with a host. 
+The OVN-Kubernetes plugin can now use a Linux bridge interface as the Open vSwitch (OVS) default port connection. This means that a network interface controller, such as SmartNIC, can now bridge the underlying network with a host.
 (link:https://issues.redhat.com/browse/OCPBUGS-39226[*OCPBUGS-39226*])
 
 [id="ocp-release-notes-networking-live-migration-cno_{context}"]
-==== Cluster Network Operator exposing network overlap metrics for an issue 
+==== Cluster Network Operator exposing network overlap metrics for an issue
 
 When you start the limited live migration method and an issue exists with network overlap, the Cluster Network Operator (CNO) can now expose network overlap metrics for the issue. This is possible because the `openshift_network_operator_live_migration_blocked` metric now includes the new `NetworkOverlap` label. (link:https://issues.redhat.com/browse/OCPBUGS-39096[*OCPBUGS-39096*])
 
@@ -895,6 +875,23 @@ With this release, you can now generate Preboot Execution Environment (PXE) asse
 
 [id="ocp-release-notes-postinstallation-configuration_{context}"]
 === Postinstallation configuration
+
+[id="ocp-4.18-migrate-x86-cp-to-arm-arch_{context}"]
+==== Migrating the x86 control plane to arm64 architecture on {aws-full}
+
+With this release, you can migrate the control plane in your cluster from `x86` to `arm64` architecture on {aws-first}. For more information, see xref:../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-from-x86-to-arm64-cp_updating-clusters-overview[Migrating the x86 control plane to arm64 architecture on Amazon Web Services].
+
+[id="ocp-4.18-support-for-config-image-stream-import-beh_{context}"]
+==== Configuring the image stream import mode behavior (Technology Preview)
+
+This feature introduces a new field, `imageStreamImportMode`, in the `image.config.openshift.io/cluster` resource. The `imageStreamImportMode` field controls the import mode behavior of image streams. You can set the `imageStreamImportMode` field to either of the following values:
+
+* `Legacy`
+* `PreserveOriginal`
+
+For more information, see xref:../openshift_images/image-configuration.adoc#images-configuration-parameters_image-configuration[Image controller configuration parameters].
+
+You must enable the `TechPreviewNoUpgrade` feature set in the `FeatureGate` custom resource (CR) to enable the `imageStreamImportMode` feature. For more information, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates].
 
 [id="ocp-release-notes-registry_{context}"]
 === Registry
@@ -1003,7 +1000,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 [id="ocp-4-18-release-notes-storage-secret-csi-driver_{context}"]
 ==== Secret Store CSI Driver Operator is generally available
-The Secrets Store Container Storage Interface (CSI) Driver Operator, `secrets-store.csi.k8s.io`, allows {product-title} to mount multiple secrets, keys, and certificates stored in enterprise-grade external secrets stores into pods as an inline ephemeral volume. The Secrets Store CSI Driver Operator communicates with the provider using gRPC to fetch the mount contents from the specified external secrets store. After the volume is attached, the data in it is mounted into the container’s file system. The Secrets Store CSI Driver Operator was available in {product-title} 4.14 as a Technology Preview feature. {product-title} 4.18 introduces this feature as generally available. 
+The Secrets Store Container Storage Interface (CSI) Driver Operator, `secrets-store.csi.k8s.io`, allows {product-title} to mount multiple secrets, keys, and certificates stored in enterprise-grade external secrets stores into pods as an inline ephemeral volume. The Secrets Store CSI Driver Operator communicates with the provider using gRPC to fetch the mount contents from the specified external secrets store. After the volume is attached, the data in it is mounted into the container’s file system. The Secrets Store CSI Driver Operator was available in {product-title} 4.14 as a Technology Preview feature. {product-title} 4.18 introduces this feature as generally available.
 
 For more information about the Secrets Store CSI driver, see xref:../storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc#persistent-storage-csi-secrets-store[Secrets Store CSI Driver Operator].
 
@@ -1039,7 +1036,7 @@ For more information, see xref:../storage/persistent_storage/persistent_storage_
 
 [id="ocp-4-18-release-notes-storage-volume-group-snapshots_{context}"]
 ==== CSI volume group snapshots (Technology Preview)
-{product-title} 4.18 introduces Container Storage Interface (CSI) volume group snapshots as a Technology Preview feature. This feature needs to be supported by the CSI driver. CSI volume group snapshots use a label selector to group multiple persistent volume claims (PVCs) for snapshotting. A volume group snapshot represents copies from multiple volumes that are taken at the same point-in-time. This can be useful for applications that contain multiple volumes. 
+{product-title} 4.18 introduces Container Storage Interface (CSI) volume group snapshots as a Technology Preview feature. This feature needs to be supported by the CSI driver. CSI volume group snapshots use a label selector to group multiple persistent volume claims (PVCs) for snapshotting. A volume group snapshot represents copies from multiple volumes that are taken at the same point-in-time. This can be useful for applications that contain multiple volumes.
 
 {rh-storage} supports volume group snapshots.
 
@@ -1049,7 +1046,7 @@ For more information about CSI volume group snapshots, see xref:../storage/conta
 ==== GCP PD CSI driver supports the C3 instance type for bare metal and N4 machine series is generally available
 The Google Cloud Platform Persistent Disk (GCP PD) Container Storage Interface (CSI) driver supports the C3 instance type for bare metal and N4 machine series. The C3 instance type and N4 machine series support the hyperdisk-balanced disks.
 
-Additionally, hyperdisk storage pools are supported for large-scale storage. A hyperdisk storage pool is a purchased collection of capacity, throughput, and IOPS, which you can then provision for your applications as needed. 
+Additionally, hyperdisk storage pools are supported for large-scale storage. A hyperdisk storage pool is a purchased collection of capacity, throughput, and IOPS, which you can then provision for your applications as needed.
 
 For {product-title} 4.18, this feature is generally available.
 
@@ -1489,7 +1486,7 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-release-note-api-auth-bug-fixes_{context}"]
 ==== API Server and Authentication
 
-* Previously, API validation did not prevent an authorized client from decreasing the current revision of a static pod operand, such as kube-apiserver, or prevent the operand from progressing concurrently on two nodes. With this release, requests that attempt to do either are now rejected. (link:https://issues.redhat.com/browse/OCPBUGS-48502[*OCPBUGS-48502*]) 
+* Previously, API validation did not prevent an authorized client from decreasing the current revision of a static pod operand, such as kube-apiserver, or prevent the operand from progressing concurrently on two nodes. With this release, requests that attempt to do either are now rejected. (link:https://issues.redhat.com/browse/OCPBUGS-48502[*OCPBUGS-48502*])
 
 * Previously, the oauth-server would crash when configuring an oath identity provider (IDP) with a callback path that contained spaces. With this release, the issue is resolved.(link:https://issues.redhat.com/browse/OCPBUGS-44099[*OCPBUGS-44099*])
 
@@ -1560,7 +1557,7 @@ If these values are not defined in a failure domain configuration, for instance 
 
 * Previously, a custom security context constraint (SCC) impacted any pod that was generated by the Cluster Version Operator from receiving a cluster version upgrade. With this release, {product-title} now sets a default SCC to each pod, so that any custom SCC created does not impact a pod.  (link:https://issues.redhat.com/browse/OCPBUGS-46410[*OCPBUGS-46410*])
 
-* Previously, the Cluster Version Operator (CVO) did not filter internal errors that were propogated to the "ClusterVersion Failing" condition message. As a result, errors that did not negatively impact the update were shown in the "ClusterVersion Failing" condition message. With this release, the errors that are propogated to the "ClusterVersion Failing" condition message are filtered. (link:https://issues.redhat.com/browse/OCPBUGS-15200[*OCPBUGS-15200*]) 
+* Previously, the Cluster Version Operator (CVO) did not filter internal errors that were propogated to the "ClusterVersion Failing" condition message. As a result, errors that did not negatively impact the update were shown in the "ClusterVersion Failing" condition message. With this release, the errors that are propogated to the "ClusterVersion Failing" condition message are filtered. (link:https://issues.redhat.com/browse/OCPBUGS-15200[*OCPBUGS-15200*])
 
 [discrete]
 [id="ocp-release-note-dev-console-bug-fixes_{context}"]
@@ -2183,7 +2180,7 @@ In the following tables, features are marked with the following statuses:
 |oc-mirror plugin v2
 |Technology Preview
 |Technology Preview
-|General Availability 
+|General Availability
 
 |oc-mirror plugin v2 enclave support
 |Technology Preview


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18 only

Issue:
N/A

Link to docs preview:
https://88998--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-postinstallation-configuration_release-notes

QE review:
N/A - no actual content change

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Note to reviewer: No actual content changed. This is just moving the content from the duplicate postinstall section from #88745 down to the right section.
