### PR TITLE
MCO OCL remove wording around layered MCP

### DIFF
--- a/modules/coreos-layering-configuring-on-extensions.adoc
+++ b/modules/coreos-layering-configuring-on-extensions.adoc
@@ -31,7 +31,7 @@ apiVersion: machineconfiguration.openshift.io/v1 <1>
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: layered <2>
+    machineconfiguration.openshift.io/role: worker <2>
   name: 80-worker-extensions
 spec:
   config:
@@ -80,9 +80,8 @@ $ oc get machineconfigpools
 [source,terminal]
 ----
 NAME      CONFIG                                              UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
-layered   rendered-layered-221507009cbcdec0eec8ab3ccd789d18   False     True       False      1              0                   0                     0                      167m <1>
 master    rendered-master-a0b404d061a6183cc36d302363422aba    True      False      False      3              3                   3                     0                      3h38m
-worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    True      False      False      2              2                   2                     0                      3h38m
+worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    False     True       False      2              2                   2                     0                      3h38m <1>
 ----
 <1> The value `FALSE` in the `UPDATED` column indicates that the `MachineOSBuild` object is building. When the `UPDATED` column reports `FALSE`, the new custom layered image has rolled out to the nodes.
 

--- a/modules/coreos-layering-configuring-on-modifying.adoc
+++ b/modules/coreos-layering-configuring-on-modifying.adoc
@@ -27,10 +27,10 @@ include::snippets//coreos-layering-configuring-on-pause.adoc[]
 apiVersion: machineconfiguration.openshift.io/v1alpha1
 kind: MachineOSConfig
 metadata:
-  name: layered-alpha1
+  name: layered
 spec:
   machineConfigPool:
-    name: layered
+    name: worker
   buildInputs:
     containerFile:
     - containerfileArch: noarch
@@ -92,9 +92,8 @@ $ oc get machineconfigpools
 [source,terminal]
 ----
 NAME      CONFIG                                              UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
-layered   rendered-layered-221507009cbcdec0eec8ab3ccd789d18   False     True       False      1              0                   0                     0                      167m <1>
 master    rendered-master-a0b404d061a6183cc36d302363422aba    True      False      False      3              3                   3                     0                      3h38m
-worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    True      False      False      2              2                   2                     0                      3h38m
+worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    False     True       False      2              2                   2                     0                      3h38m <1>
 ----
 <1> The value `FALSE` in the `UPDATED` column indicates that the `MachineOSBuild` object is building. When the `UPDATED` column reports `FALSE`, the new custom layered image has rolled out to the nodes.
 

--- a/modules/coreos-layering-configuring-on-revert.adoc
+++ b/modules/coreos-layering-configuring-on-revert.adoc
@@ -45,7 +45,6 @@ $ oc get mcp
 [source,terminal]
 ----
 NAME      CONFIG                                              UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
-layered   rendered-layered-bde4e4206442c0a48b1a1fb35ba56e85   True      False      False      0              0                   0                     0                      4h46m
 master    rendered-master-8332482204e0b76002f15ecad15b6c2d    True      False      False      3              3                   3                     0                      5h26m
 worker    rendered-worker-bde4e4206442c0a48b1a1fb35ba56e85    False     True       False      3              2                   2                     0                      5h26m <1>
 ----

--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -29,7 +29,12 @@ NAME                                                READY   STATUS      RESTARTS
 build-layered-c8765e26ebc87e1e17a7d6e0a78e8bae      2/2     Running     0               11m
 ----
 
-When the build is complete, the MCO pushes the new custom layered image to your repository for use when deploying new nodes. You can see the digested image pull spec for the new custom layered image in the `MachineOSBuild` object and `machine-os-builder` pod.
+When the build is complete, the MCO pushes the new custom layered image to your repository and rolled out to the nodes in the associated machine config pool. You can see the digested image pull spec for the new custom layered image in the `MachineOSBuild` object and `machine-os-builder` pod.
+
+[TIP]
+====
+You can test a `MachineOSBuild` object to make sure it builds correctly without rolling out the custom layered image to active nodes by using a custom machine config pool that contains non-production nodes. Alternatively, you can use a custom machine config pool that has no nodes. The `MachineOSBuild` object builds even if there are no nodes for the MCO to deploy the custom layered image onto.
+====
 
 You should not need to interact with these new objects or the `machine-os-builder` pod. However, you can use all of these resources for troubleshooting, if necessary.
 
@@ -99,7 +104,7 @@ metadata:
   name: layered <2>
 spec:
   machineConfigPool:
-    name: <mcp_name> <3>
+    name: worker <3>
   buildInputs:
     containerFile: <4>
     - containerfileArch: noarch
@@ -120,7 +125,7 @@ spec:
 ----
 <1> Specifies the `machineconfiguration.openshift.io/v1` API that is required for `MachineConfig` CRs.
 <2> Specifies a name for the `MachineOSConfig` object. This name is used with other on-cluster layering resources. The examples in this documentation use the name `layered`. 
-<3> Specifies the name of the machine config pool associated with the nodes where you want to deploy the custom layered image.
+<3> Specifies the name of the machine config pool associated with the nodes where you want to deploy the custom layered image. The examples in this documentation use the `worker` machine config pool.
 <4> Specifies the Containerfile to configure the custom layered image.
 <5> Specifies the name of the image builder to use. This must be `PodImageBuilder`.
 <6> Specifies the name of the pull secret that the MCO needs in order to pull the base operating system image from the registry.
@@ -223,7 +228,7 @@ Spec:
   Desired Config:
     Name:  rendered-layered-ad5a3cad36303c363cf458ab0524e7c0
   Machine OS Config:
-    Name:                   layered-alpha1
+    Name:                   layered
   Rendered Image Pushspec:  image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-images:layered-ad5a3cad36303c363cf458ab0524e7c0
 # ...
     Last Transition Time:  2025-02-12T19:21:28Z

--- a/snippets/coreos-layering-configuring-on-pause.adoc
+++ b/snippets/coreos-layering-configuring-on-pause.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: SNIPPET
 
-Making certain changes to a `MachineOSConfig` object triggers an automatic rebuild of the associated custom layered image. You can mitigate the effects of the rebuild by pausing the machine config pool where the custom layered image is applied as described in "Pausing the machine config pools." For example, if you want to remove and replace a `MachineOSCOnfig` object, pausing the machine config pools before making the change prevents the MCO from reverting the associated nodes to the base image, reducing the number of reboots needed. 
+Making certain changes to a `MachineOSConfig` object triggers an automatic rebuild of the associated custom layered image. You can mitigate the effects of the rebuild by pausing the machine config pool where the custom layered image is applied as described in "Pausing the machine config pools." For example, if you want to remove and replace a `MachineOSCOnfig` object, pausing the machine config pools before making the change prevents the MCO from reverting the associated nodes to the base image, reducing the number of reboots needed.
 
 When a machine config pool is paused, the `oc get machineconfigpools` reports the following status:
 
@@ -13,10 +13,9 @@ When a machine config pool is paused, the `oc get machineconfigpools` reports th
 [source,terminal]
 ----
 NAME      CONFIG                                              UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
-layered   rendered-layered-221507009cbcdec0eec8ab3ccd789d18   False     False      False      1              0                   0                     0                      3h23m <1>
 master    rendered-master-a0b404d061a6183cc36d302363422aba    True      False      False      3              3                   3                     0                      4h14m
-worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    True      False      False      2              2                   2                     0                      4h14m
+worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    False     False      False      2              2                   2                     0                      4h14m <1>
 ----
-<1> The `layered` machine config pool is paused, as indicated by the three `False` statuses and the `READYMACHINECOUNT` at `0`.
+<1> The `worker` machine config pool is paused, as indicated by the three `False` statuses and the `READYMACHINECOUNT` at `0`.
 
 After the changes have been rolled out, you can unpause the machine config pool.


### PR DESCRIPTION
Based on conversations with Mark Russell, we want to add a statement that users can deploy a MOSB to an empty or test custom machine config pool in order to test the MOSB build without concerns about deploying the resulting image or incurring node restarts. Also, I removed from the examples my use of a custom machine config pool, per Mark's request, as this is likely not the typical use case. 

QE review: No QE needed, wording changes only.