### PR TITLE
OCPBUGS-51127: Removing unsupported netobserv cli options

### DIFF
--- a/modules/network-observability-netobserv-cli-reference.adoc
+++ b/modules/network-observability-netobserv-cli-reference.adoc
@@ -57,11 +57,9 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 | Option | Description | Default
 |--enable_all|                enable all eBPF features                   | false
 |--enable_dns|                enable DNS tracking                        | false
-|--enable_network_events|     enable network events monitoring           | false
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
-|--enable_udn_mapping|        enable User Defined Network mapping | false
 |--get-subnets|               get subnets information                   | false
 |--background|                run in background                          | false
 |--copy|                      copy the output files locally              | prompt
@@ -157,11 +155,9 @@ $ oc netobserv metrics [<option>]
 | Option | Description | Default
 |--enable_all|                enable all eBPF features                   | false
 |--enable_dns|                enable DNS tracking                        | false
-|--enable_network_events|     enable network events monitoring           | false
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
-|--enable_udn_mapping|        enable User Defined Network mapping | false
 |--get-subnets|               get subnets information                   | false
 |--action|                    filter action                              | Accept
 |--cidr|                      filter CIDR                                | 0.0.0.0/0


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Merge only to `no-1.8`, which will be incorporated to 4.12+ on 2/25/25, Network Observability GA. 
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-51127
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://89007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-reference.html
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
