### PR TITLE
OLMv1 capability and xref fixes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -229,11 +229,11 @@ endif::[]
 //Version-agnostic OLM
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-//Initial version of OLM that shipped with OCP 4, aka "v0"
-:olmv0: existing OLM
-:olmv0-caps: Existing OLM
-:olmv0-first: existing Operator Lifecycle Manager (OLM)
-:olmv0-first-caps: Existing Operator Lifecycle Manager (OLM)
+//Initial version of OLM that shipped with OCP 4, aka "v0" and f/k/a "existing" during OLM v1's pre-4.18 TP phase
+:olmv0: OLM (Classic)
+:olmv0-caps: OLM (Classic)
+:olmv0-first: Operator Lifecycle Manager (OLM) Classic
+:olmv0-first-caps: Operator Lifecycle Manager (OLM) Classic
 //Next-gen (OCP 4.14+) Operator Lifecycle Manager, f/k/a "1.0"
 :olmv1: OLM v1
 :olmv1-first: Operator Lifecycle Manager (OLM) v1

--- a/extensions/ce/user-access-resources.adoc
+++ b/extensions/ce/user-access-resources.adoc
@@ -17,7 +17,7 @@ The RBAC permissions described for user access to extension resources are differ
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../extensions/ce/managing-ce.adoc#managing-ce["Managing extensions" -> "Cluster extension permissions"]
+* xref:../../extensions/ce/managing-ce.adoc#olmv1-cluster-extension-permissions_managing-ce["Managing extensions" -> "Cluster extension permissions"]
 
 include::modules/olmv1-default-cluster-roles-users.adoc[leveloffset=+1]
 

--- a/modules/olm-overview.adoc
+++ b/modules/olm-overview.adoc
@@ -11,28 +11,31 @@ ifeval::["{context}" == "cluster-capabilities"]
 :cluster-caps:
 endif::[]
 
-
 :_mod-docs-content-type: CONCEPT
 [id="olm-overview_{context}"]
 ifndef::operators[]
 ifndef::cluster-caps[]
-= What is Operator Lifecycle Manager?
+= What is {olmv0-first}?
 endif::[]
 endif::[]
 ifdef::operators[]
 = Purpose
 endif::[]
 ifdef::cluster-caps[]
-= Operator Lifecycle Manager capability
+= {olmv0-first} capability
 
 [discrete]
 == Purpose
 endif::[]
 
-_Operator Lifecycle Manager_ (OLM) helps users install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running across their {product-title} clusters. It is part of the link:https://operatorframework.io/[Operator Framework], an open source toolkit designed to manage Operators in an effective, automated, and scalable way.
+ifdef::cluster-caps[]
+{olmv0} provides the features for the `OperatorLifecycleManager` capability.
+endif::[]
+
+{olmv0-first} helps users install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running across their {product-title} clusters. It is part of the link:https://operatorframework.io/[Operator Framework], an open source toolkit designed to manage Operators in an effective, automated, and scalable way.
 
 ifndef::cluster-caps[]
-.Operator Lifecycle Manager workflow
+.{olmv0} workflow
 image::olm-workflow.png[]
 
 OLM runs by default in {product-title} {product-version}, which aids

--- a/modules/olmv1-clusteroperator.adoc
+++ b/modules/olmv1-clusteroperator.adoc
@@ -3,14 +3,31 @@
 // * operators/operator-reference.adoc
 // * installing/overview/cluster-capabilities.adoc
 
+ifeval::["{context}" == "cluster-operators-ref"]
+:operators:
+endif::[]
+ifeval::["{context}" == "cluster-capabilities"]
+:cluster-caps:
+endif::[]
+
 :_mod-docs-content-type: CONCEPT
+
 [id="cluster-operators-ref-olmv1_{context}"]
+ifdef::operators[]
 = {olmv1-first} Operator
+endif::[]
+ifdef::cluster-caps[]
+= {olmv1-first} capability
+endif::[]
 
 [discrete]
 == Purpose
 
-Starting in {product-title} 4.18, {olmv1-first} is enabled by default alongside the {olmv0}. This next-generation iteration provides an updated framework that evolves many of the {olmv0} concepts that enable cluster administrators to extend capabilities for their users.
+ifdef::cluster-caps[]
+{olmv1} provides the features for the `OperatorLifecycleManagerV1` capability.
+endif::[]
+
+Starting in {product-title} 4.18, {olmv1} is enabled by default alongside {olmv0}. This next-generation iteration provides an updated framework that evolves many of {olmv0} concepts that enable cluster administrators to extend capabilities for their users.
 
 {olmv1} manages the lifecycle of the new `ClusterExtension` object, which includes Operators via the `registry+v1` bundle format, and controls installation, upgrade, and role-based access control (RBAC) of extensions within a cluster.
 

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -135,11 +135,11 @@ include::modules/openshift-apiserver-operator.adoc[leveloffset=+1]
 include::modules/cluster-openshift-controller-manager-operators.adoc[leveloffset=+1]
 
 [id="cluster-operators-ref-olm"]
-== Operator Lifecycle Manager (OLM) Operators
+== {olmv0-first} Operators
 
 [NOTE]
 ====
-The following sections pertain to the {olmv0-first} that has been included with {product-title} 4 since its initial release. For {olmv1}, see xref:../operators/operator-reference.adoc#cluster-operators-ref-olmv1_cluster-operators-ref[{olmv1-first} Operators].
+The following sections pertain to {olmv0-first} that has been included with {product-title} 4 since its initial release. For {olmv1}, see xref:../operators/operator-reference.adoc#cluster-operators-ref-olmv1_cluster-operators-ref[{olmv1-first} Operators].
 ====
 
 [discrete]


### PR DESCRIPTION
4.18

This fixes an `xref` to go to the intended deep-linked section, and adds `ifdef`s in the OLM (Classic) and OLM v1 modules that are shared between the "Cluster Operators reference" assembly and the "Cluster capabilities" assembly to have different titles.

Preview:

* Fixed link (first "Additional resources" entry): https://89011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/user-access-resources
* "Cluster Operators reference" assembly:
  * [OLM (Classic) section](https://89011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-operators-ref-olm)
  * [OLM v1 section](https://89011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-operators-ref-olmv1_cluster-operators-ref)
* "Cluster capabilities" assembly:
  * [OLM (Classic) section](https://89011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities#olm-overview_cluster-capabilities)
  * [OLM v1 section](https://89011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities#cluster-operators-ref-olmv1_cluster-capabilities)

Note: This is also the PR that introduces the new "OLM (Classic)" naming into the `common-attributes.adoc` file, for `main`. Technically, on `enterprise-4.18` it was originally already added earlier today via https://github.com/openshift/openshift-docs/pull/88927, so it landed a little backwards.