### PR TITLE
Cluster Autoscaler for ROSA HCP

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -607,6 +607,9 @@ Topics:
     File: dedicated-aws-dc
 - Name: Cluster autoscaling
   File: rosa-cluster-autoscaling
+- Name: Cluster autoscaling for ROSA HCP
+  File: rosa-cluster-autoscaling-hcp
+  # Remove cluster autoscaling for ROSA HCP once the HCP docs are published
 - Name: Manage nodes using machine pools
   Dir: rosa_nodes
   Distros: openshift-rosa

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -374,6 +374,8 @@ Topics:
     File: dedicated-aws-vpn
   - Name: Configuring AWS Direct Connect
     File: dedicated-aws-dc
+- Name: Cluster autoscaling
+  File: rosa-cluster-autoscaling
 - Name: Manage nodes using machine pools
   Dir: rosa_nodes
   Topics:

--- a/modules/rosa-cluster-autoscaler-cli-after.adoc
+++ b/modules/rosa-cluster-autoscaler-cli-after.adoc
@@ -6,16 +6,18 @@
 [id="rosa-enable-cluster-autoscale-cli-after_{context}"]
 = Enable autoscaling after cluster creation with the ROSA CLI
 
+////
 [IMPORTANT]
 ====
 The following procedure is only supported for ROSA Classic clusters. To enable autoscaling after cluster creation for ROSA with HCP clusters, see link:https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.html#nodes-enabling-autoscaling-nodes[Enabling autoscaling nodes on a cluster].
 ====
+////
 
 You can use the ROSA CLI (`rosa`) to set cluster-wide autoscaling after cluster creation.
 
 .Procedure
-
-- After you have created a cluster, create the autoscaler:
+ 
+* After you have created a cluster, create the autoscaler:
 +
 .Example
 [source,terminal]
@@ -23,7 +25,7 @@ You can use the ROSA CLI (`rosa`) to set cluster-wide autoscaling after cluster 
 $ rosa create autoscaler --cluster=<mycluster>
 ----
 +
-.. You can also create the autoscaler with specific parameters using the following command:
+** You can also create the autoscaler with specific parameters using the following command:
 +
 .Example
 [source,terminal]

--- a/modules/rosa-cluster-autoscaler-cli-delete.adoc
+++ b/modules/rosa-cluster-autoscaler-cli-delete.adoc
@@ -8,7 +8,9 @@
 
 You can delete the cluster autoscaler if you no longer want to use it.
 
-- To delete the cluster autoscaler, run the following command:
+.Procedure
+
+* To delete the cluster autoscaler, run the following command:
 +
 .Example
 [source,terminal]

--- a/modules/rosa-cluster-autoscaler-cli-describe.adoc
+++ b/modules/rosa-cluster-autoscaler-cli-describe.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-cluster-autoscaler-cli-describe_{context}"]
+= View autoscaler configurations with the ROSA CLI
+
+You can view your cluster autoscaler configurations using the `rosa describe autoscaler` command.
+
+//ROSA HCP procedure
+ifdef::openshift-rosa-hcp[]
+.Procedure
+
+* To view cluster autoscaler configurations, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa describe autoscaler -h --cluster=<mycluster>
+----
+endif::openshift-rosa-hcp[]
+
+//ROSA Classic procedure
+ifdef::openshift-rosa[]
+.Procedure
+
+* To view cluster autoscaler configurations, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa describe autoscaler --cluster=<mycluster>
+----
+endif::openshift-rosa[]

--- a/modules/rosa-cluster-autoscaler-cli-edit.adoc
+++ b/modules/rosa-cluster-autoscaler-cli-edit.adoc
@@ -8,7 +8,30 @@
 
 You can edit any specific parameters of the cluster autoscaler after creating the autoscaler.
 
-- To edit the cluster autoscaler, run the following command:
+.Procedure
+
+//ROSA HCP procedure
+ifdef::openshift-rosa-hcp[]
+* To edit the cluster autoscaler, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa edit autoscaler -h --cluster=<mycluster>
+----
++
+** To edit a specific parameter, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa edit autoscaler -h --cluster=<mycluster> <parameter>
+----
+endif::openshift-rosa-hcp[]
+
+//ROSA Classic procedure
+ifdef::openshift-rosa[]
+* To edit the cluster autoscaler, run the following command:
 +
 .Example
 [source,terminal]
@@ -16,10 +39,11 @@ You can edit any specific parameters of the cluster autoscaler after creating th
 $ rosa edit autoscaler --cluster=<mycluster>
 ----
 +
-.. To edit a specific parameter, run the following command:
+** To edit a specific parameter, run the following command:
 +
 .Example
 [source,terminal]
 ----
 $ rosa edit autoscaler --cluster=<mycluster> <parameter>
 ----
+endif::openshift-rosa[]

--- a/modules/rosa-cluster-autoscaler-cli-settings.adoc
+++ b/modules/rosa-cluster-autoscaler-cli-settings.adoc
@@ -17,6 +17,8 @@ You can add the following parameters to the cluster creation command to configur
 |Type or Range
 |Example/Instruction
 
+ifdef::openshift-rosa[]
+//Classic only
 |`--autoscaler-balance-similar-node-groups`
 |Identify node groups with the same instance type and label set, and try to balance respective sizes of those node groups.
 |`boolean`
@@ -31,17 +33,22 @@ You can add the following parameters to the cluster creation command to configur
 |Autoscaler log level. Replace _int_ in the command with the number you want to use.
 |`integer`
 |`--autoscaler-log-verbosity 4`
+endif::openshift-rosa[]
 
+//Both Classic and HCP
 |`--autoscaler-max-pod-grace-period _int_`
 |Gives pods graceful termination time before scaling down, measured in seconds. Replace _int_ in the command with the number of seconds you want to use.
 |`integer`
 |`--autoscaler-max-pod-grace-period 0`
 
+//Both Classic and HCP
 |`--autoscaler-pod-priority-threshold _int_`
 |The priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Replace _int_ in the command with the number you want to use, can be negative.
 |`integer`
 |`--autoscaler-pod-priority-threshold -10`
 
+ifdef::openshift-rosa[]
+//Classic only
 |`--autoscaler-gpu-limit _stringArray_`
 |Minimum and maximum number of different GPUs in cluster. Cluster autoscaler does not scale the cluster less than or greater than these numbers. The format must be a comma-separated list of "<gpu_type>,<min>,<max>".
 |`array`
@@ -51,22 +58,30 @@ You can add the following parameters to the cluster creation command to configur
 |If set, the cluster-autoscaler ignores daemon set pods when calculating resource utilization for scaling down.
 |`boolean`
 |Add it to set to true, omit the option to set to false.
+endif::openshift-rosa[]
 
+//Both Classic and HCP
 |`--autoscaler-max-node-provision-time _string_`
 |Maximum time that the cluster autoscaler waits for a node to be provisioned. Replace _string_ in the command with an integer and time unit (ns,us,µs,ms,s,m,h).
 |`string`
 |`--autoscaler-max-node-provision-time 35m`
 
+ifdef::openshift-rosa[]
+//Classic only
 |`--autoscaler-balancing-ignored-labels _strings_`
 |A comma-separated list of label keys that the cluster autoscaler should ignore when comparing node groups for similarity. Replace _strings_ in the command with the relevant labels..
 |`string`
 |`--autoscaler-balancing-ignored-labels topology.ebs.csi.aws.com/zone,alpha.eksctl.io/instance-id`
+endif::openshift-rosa[]
 
+//Both Classic and HCP
 |`--autoscaler-max-nodes-total _int_`
 |Maximum amount of nodes in the cluster, including the autoscaled nodes. Replace _int_ in the command with the number you want to use.
 |`integer`
 |`--autoscaler-max-nodes-total 180`
 
+ifdef::openshift-rosa[]
+//Classic only
 |`--autoscaler-min-cores _int_`
 |Minimum number of cores to deploy in the cluster. Replace _int_ in the command with the number you want to use.
 |`integer`
@@ -116,5 +131,6 @@ You can add the following parameters to the cluster creation command to configur
 |How long after scale down failure that scale down evaluation resumes. Replace _string_ in the command with an integer and time unit (ns,us,µs,ms,s,m,h).
 |`string`
 |`--autoscaler-scale-down-delay-after-failure 1h`
+endif::openshift-rosa[]
 
 |===

--- a/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+++ b/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
@@ -1,50 +1,30 @@
-// Module included in the following assemblies:
-//
-// * nodes/nodes-about-autoscaling-nodes.adoc
-// * machine_management/applying-autoscaling.adoc
-// * osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.adoc
-// * osd_cluster_admin/osd-cluster-autoscaling.adoc
-// * rosa_cluster_admin/rosa-cluster-autoscaling.adoc
-// * rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc (temporary)
+:_mod-docs-content-type: ASSEMBLY
+[id="rosa-cluster-autoscaling-hcp"]
+= Cluster autoscaling for ROSA HCP 
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-cluster-autoscaling-hcp
 
+toc::[]
 
-:_mod-docs-content-type: CONCEPT
+//This is a temporary assembly. Remove when the ROSA HCP docs are published.
+
+Applying autoscaling to {hcp-title-first} clusters involves configuring one or more machine pools with autoscaling. You can use the Cluster Autoscaler to further configure cluster-wide autoscaling that is applicable to all of the machine pools that are autoscaling.
+
+//The includes reference modules that are included in rosa-cluster-autoscaling.adoc. They are conditionalized to reflect the applicable information for ROSA Classic and ROSA HCP. Because this is a temporary assembly, I am putting the content directly here rather that creating three duplicate files that would have to be removed in the near future. 
+
+//include::modules/cluster-autoscaler-about.adoc[leveloffset=+1]
 [id="cluster-autoscaler-about_{context}"]
-= About the cluster autoscaler
+== About the cluster autoscaler
 
-The cluster autoscaler adjusts the size of an {product-title} cluster to meet its current deployment needs. It uses declarative, Kubernetes-style arguments to provide infrastructure management that does not rely on objects of a specific cloud provider. The cluster autoscaler has a cluster scope, and is not associated with a particular namespace.
-ifdef::openshift-rosa-hcp[]
-In {product-title}, the Cluster Autoscaler is fully managed, which means it is hosted along with the control plane.
-endif::openshift-rosa-hcp[]
-
+The cluster autoscaler adjusts the size of a {hcp-title} cluster to meet its current deployment needs. It uses declarative, Kubernetes-style arguments to provide infrastructure management that does not rely on objects of a specific cloud provider. The cluster autoscaler has a cluster scope, and is not associated with a particular namespace. In {hcp-title}, the Cluster Autoscaler is fully managed, which means it is hosted along with the control plane.
 
 The cluster autoscaler increases the size of the cluster when there are pods that fail to schedule on any of the current worker nodes due to insufficient resources or when another node is necessary to meet deployment needs. The cluster autoscaler does not increase the cluster resources beyond the limits that you specify.
 
-ifdef::openshift-rosa-hcp[]
-The cluster autoscaler computes the total memory, CPU, and GPU only on the nodes that belong to autoscaling machine pools. All of the machine pool nodes that are not autoscaling are excluded from this aggregation. For example, if you set the `maxNodesTotal` to `50` on a {product-title} cluster with three machine pools in which a single machine pool is not autoscaling, the cluster autoscaler restricts the total nodes to `50` in only those two machine pools that are autoscaling. The single manually scaling machine pool can have additional nodes, making the overall cluster nodes total more than `50`.
-endif::openshift-rosa-hcp[]
-
-ifndef::openshift-rosa-hcp[]
-The cluster autoscaler computes the total
-ifndef::openshift-dedicated,openshift-rosa[]
-memory, CPU, and GPU
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-memory and CPU
-endif::openshift-dedicated,openshift-rosa[]
-on all nodes the cluster, even though it does not manage the control plane nodes. These values are not single-machine oriented. They are an aggregation of all the resources in the entire cluster. For example, if you set the maximum memory resource limit, the cluster autoscaler includes all the nodes in the cluster when calculating the current memory usage. That calculation is then used to determine if the cluster autoscaler has the capacity to add more worker resources.
-endif::openshift-rosa-hcp[]
-
-ifndef::openshift-rosa-hcp[]
-[IMPORTANT]
-====
-Ensure that the `maxNodesTotal` value in the `ClusterAutoscaler` resource definition that you create is large enough to account for the total possible number of machines in your cluster. This value must encompass the number of control plane machines and the possible number of compute machines that you might scale to.
-====
-endif::openshift-rosa-hcp[]
+The cluster autoscaler computes the total memory, CPU, and GPU only on the nodes that belong to autoscaling machine pools. All of the machine pool nodes that are not autoscaling are excluded from this aggregation. For example, if you set the `maxNodesTotal` to `50` on a {hcp-title} cluster with three machine pools in which a single machine pool is not autoscaling, the cluster autoscaler restricts the total nodes to `50` in only those two machine pools that are autoscaling. The single manually scaling machine pool can have additional nodes, making the overall cluster nodes total more than `50`.
 
 [discrete]
 [id="cluster-autoscaler-scale-down_{context}"]
-== Automatic node removal
+=== Automatic node removal
 
 Every 10 seconds, the cluster autoscaler checks which nodes are unnecessary in the cluster and removes them. The cluster autoscaler considers a node for removal if the following conditions apply:
 
@@ -66,7 +46,7 @@ For example, you set the maximum CPU limit to 64 cores and configure the cluster
 
 [discrete]
 [id="cluster-autoscaler-limitations_{context}"]
-== Limitations
+=== Limitations
 
 If you configure the cluster autoscaler, additional usage restrictions apply:
 
@@ -84,7 +64,7 @@ If the available node types cannot meet the requirements for a pod request, or i
 
 [discrete]
 [id="cluster-autoscaler-interaction_{context}"]
-== Interaction with other scheduling features
+=== Interaction with other scheduling features
 
 The horizontal pod autoscaler (HPA) and the cluster autoscaler modify cluster resources in different ways. The HPA changes the deployment's or replica set's number of replicas based on the current CPU load. If the load increases, the HPA creates new replicas, regardless of the amount of resources available to the cluster. If there are not enough resources, the cluster autoscaler adds resources so that the HPA-created pods can run. If the load decreases, the HPA stops some replicas. If this action causes some nodes to be underutilized or completely empty, the cluster autoscaler deletes the unnecessary nodes.
 
@@ -95,3 +75,85 @@ Pods with priority lower than the cutoff value do not cause the cluster to scale
 ////
 Default priority cutoff is 0. It can be changed using `--expendable-pods-priority-cutoff` flag, but we discourage it. cluster autoscaler also doesn't trigger scale-up if an unschedulable Pod is already waiting for a lower priority Pod preemption.
 ////
+
+//::modules/rosa-cluster-autoscaler-cli-edit.adoc[leveloffset=+1]
+[id="rosa-edit-cluster-autoscale-cli_{context}"]
+== Edit autoscaling after cluster creation with the ROSA CLI
+
+You can edit any specific parameters of the cluster autoscaler after creating the autoscaler.
+
+.Procedure
+
+. To edit the cluster autoscaler, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa edit autoscaler -h --cluster=<mycluster>
+----
++
+.. To edit a specific parameter, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa edit autoscaler -h --cluster=<mycluster> <parameter>
+----
+
+//::modules/rosa-cluster-autoscaler-cli-describe.adoc[leveloffset=+1]
+[id="rosa-cluster-autoscaler-cli-describe_{context}"]
+== View autoscaler configurations with the ROSA CLI
+
+You can view your cluster autoscaler configurations using the `rosa describe autoscaler` command.
+
+.Procedure
+
+* To view cluster autoscaler configurations, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa describe autoscaler -h --cluster=<mycluster>
+----
+
+//include::modules/rosa-cluster-autoscaler-cli-settings.adoc[leveloffset=+1]
+[id="rosa-cluster-cli-autoscale-parameters_{context}"]
+== Cluster autoscaling parameters using the ROSA CLI
+
+You can add the following parameters to the cluster creation command to configure autoscaler parameters when using the ROSA CLI (`rosa`).
+
+.Configurable autoscaler parameters available with the ROSA CLI (`rosa`)
+
+[cols="4",options="header"]
+|===
+|Setting
+|Description
+|Type or Range
+|Example/Instruction
+
+//Both Classic and HCP
+|`--autoscaler-max-pod-grace-period _int_`
+|Gives pods graceful termination time before scaling down, measured in seconds. Replace _int_ in the command with the number of seconds you want to use.
+|`integer`
+|`--autoscaler-max-pod-grace-period 0`
+
+//Both Classic and HCP
+|`--autoscaler-pod-priority-threshold _int_`
+|The priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Replace _int_ in the command with the number you want to use, can be negative.
+|`integer`
+|`--autoscaler-pod-priority-threshold -10`
+
+//Both Classic and HCP
+|`--autoscaler-max-node-provision-time _string_`
+|Maximum time that the cluster autoscaler waits for a node to be provisioned. Replace _string_ in the command with an integer and time unit (ns,us,µs,ms,s,m,h).
+|`string`
+|`--autoscaler-max-node-provision-time 35m`
+
+//Both Classic and HCP
+|`--autoscaler-max-nodes-total _int_`
+|Maximum amount of nodes in the cluster, including the autoscaled nodes. Replace _int_ in the command with the number you want to use.
+|`integer`
+|`--autoscaler-max-nodes-total 180`
+
+|===
+

--- a/rosa_cluster_admin/rosa-cluster-autoscaling.adoc
+++ b/rosa_cluster_admin/rosa-cluster-autoscaling.adoc
@@ -6,17 +6,30 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Applying autoscaling to {product-title} clusters involves configuring a cluster autoscaler and then configuring a machine autoscaler for at least one machine pool in your cluster.
+//Adding ROSA HCP commands 
 
+ifdef::openshift-rosa[]
+Applying autoscaling to {rosa-classic-first} clusters involves configuring a cluster autoscaler and then configuring a machine autoscaler for at least one machine pool in your cluster.
+endif::openshift-rosa[]
+
+ifdef::openshift-rosa-hcp[]
+Applying autoscaling to {product-title} clusters involves configuring one or more machine pools with autoscaling. You can use the Cluster Autoscaler to further configure cluster-wide autoscaling that is applicable to all of the machine pools that are autoscaling.
+endif::openshift-rosa-hcp[]
+
+//Machine API is not available or applicable in ROSA HCP.
+ifdef::openshift-rosa[]
 [IMPORTANT]
 ====
 You can configure the cluster autoscaler only in clusters where the machine API is operational.
 
 Only one cluster autoscaler can be created per cluster.
 ====
+endif::openshift-rosa[]
 
 include::modules/cluster-autoscaler-about.adoc[leveloffset=+1]
 
+//Need verification if the UI and interactive procedures match for ROSA HCP. Until then, they will only build on ROSA Classic. 
+ifdef::openshift-rosa[]
 include::modules/rosa-cluster-autoscaler-ui-during.adoc[leveloffset=+1]
 
 include::modules/rosa-cluster-autoscaler-ui-after.adoc[leveloffset=+1]
@@ -25,14 +38,19 @@ include::modules/rosa-cluster-autoscaler-ui-settings.adoc[leveloffset=+1]
 
 include::modules/rosa-cluster-autoscaler-cli-interactive-during.adoc[leveloffset=+1]
 
-include::modules/rosa-cluster-autoscaler-cli-interactive-after.adoc[leveloffset=+2]
+include::modules/rosa-cluster-autoscaler-cli-interactive-after.adoc[leveloffset=+1]
 
 include::modules/rosa-cluster-autoscaler-cli-during.adoc[leveloffset=+1]
 
-include::modules/rosa-cluster-autoscaler-cli-after.adoc[leveloffset=+2]
+include::modules/rosa-cluster-autoscaler-cli-after.adoc[leveloffset=+1]
+endif::openshift-rosa[]
 
-include::modules/rosa-cluster-autoscaler-cli-edit.adoc[leveloffset=+2]
+include::modules/rosa-cluster-autoscaler-cli-edit.adoc[leveloffset=+1]
 
-include::modules/rosa-cluster-autoscaler-cli-delete.adoc[leveloffset=+2]
+include::modules/rosa-cluster-autoscaler-cli-describe.adoc[leveloffset=+1]
+
+ifdef::openshift-rosa[]
+include::modules/rosa-cluster-autoscaler-cli-delete.adoc[leveloffset=+1]
+endif::openshift-rosa[]
 
 include::modules/rosa-cluster-autoscaler-cli-settings.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13349

Link to docs preview:
**ROSA HCP Cluster Autoscaling:** https://89029--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa-cluster-autoscaling.html#rosa-enable-cluster-autoscale-cli-after_rosa-cluster-autoscaling

**(Temporary) ROSA Cluster Autoscaling on in the classic docs:** https://89029--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.html

- This is a temporary assembly to allow the HCP content to build in Classic. It will be removed when the HCP docs are published.

**ROSA Classic Cluster Autoscaling:** https://89029--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-cluster-autoscaling.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
