### PR TITLE
Adding note section for rolloutStrategy set to recreate for RWO

### DIFF
--- a/modules/installation-registry-osp-creating-custom-pvc.adoc
+++ b/modules/installation-registry-osp-creating-custom-pvc.adoc
@@ -12,7 +12,6 @@ After you install a cluster on {rh-openstack-first}, you can use a Cinder volume
 
 . Enter the following command to set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy, and runs with only one (1) replica:
 +
-+
 ----
 $ oc patch config.imageregistry.operator.openshift.io/cluster --type=merge -p '{"spec":{"rolloutStrategy":"Recreate","replicas":1}}'
 ----

--- a/modules/installation-registry-osp-creating-custom-pvc.adoc
+++ b/modules/installation-registry-osp-creating-custom-pvc.adoc
@@ -12,6 +12,7 @@ After you install a cluster on {rh-openstack-first}, you can use a Cinder volume
 
 . Enter the following command to set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy, and runs with only one (1) replica:
 +
++
 ----
 $ oc patch config.imageregistry.operator.openshift.io/cluster --type=merge -p '{"spec":{"rolloutStrategy":"Recreate","replicas":1}}'
 ----

--- a/modules/installation-registry-osp-creating-custom-pvc.adoc
+++ b/modules/installation-registry-osp-creating-custom-pvc.adoc
@@ -11,6 +11,7 @@ After you install a cluster on {rh-openstack-first}, you can use a Cinder volume
 .Procedure
 
 . Enter the following command to set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy, and runs with only one (1) replica:
++
 ----
 $ oc patch config.imageregistry.operator.openshift.io/cluster --type=merge -p '{"spec":{"rolloutStrategy":"Recreate","replicas":1}}'
 ----

--- a/modules/installation-registry-osp-creating-custom-pvc.adoc
+++ b/modules/installation-registry-osp-creating-custom-pvc.adoc
@@ -10,6 +10,11 @@ After you install a cluster on {rh-openstack-first}, you can use a Cinder volume
 
 .Procedure
 
+. Enter the following command to set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy, and runs with only one (1) replica:
+----
+$ oc patch config.imageregistry.operator.openshift.io/cluster --type=merge -p '{"spec":{"rolloutStrategy":"Recreate","replicas":1}}'
+----
+
 . Create a YAML file that specifies the storage class and availability zone to use. For example:
 +
 [source,yaml]
@@ -80,11 +85,6 @@ $ oc apply -f <pvc_file_name>
 persistentvolumeclaim/csi-pvc-imageregistry created
 ----
 +
-[NOTE]
-====
-RWO accèss mode requires rolloutStrategy  set to recreate and replica count set to 1.
-====
-
 
 . Replace the original persistent volume claim in the image registry configuration with the new claim:
 +

--- a/modules/installation-registry-osp-creating-custom-pvc.adoc
+++ b/modules/installation-registry-osp-creating-custom-pvc.adoc
@@ -82,7 +82,7 @@ persistentvolumeclaim/csi-pvc-imageregistry created
 +
 [NOTE]
 ====
-RWO accèss modes needs rolloutStrategy  set as recreate and replica count must be set as 1.
+RWO accèss mode requires rolloutStrategy  set to recreate and replica count set to 1.
 ====
 
 

--- a/modules/installation-registry-osp-creating-custom-pvc.adoc
+++ b/modules/installation-registry-osp-creating-custom-pvc.adoc
@@ -79,6 +79,12 @@ $ oc apply -f <pvc_file_name>
 ----
 persistentvolumeclaim/csi-pvc-imageregistry created
 ----
++
+[NOTE]
+====
+RWO accèss modes needs rolloutStrategy  set as recreate and replica count must be set as 1.
+====
+
 
 . Replace the original persistent volume claim in the image registry configuration with the new claim:
 +


### PR DESCRIPTION
Adding note for set  rolloutStrategy as recreate and replicas as 1 for RWO access modes of volume. 

In doc[1] its not mention to use correct rolloutStrategy and replica. 

[1]  https://docs.openshift.com/container-platform/4.17/registry/configuring_registry_storage/configuring-registry-storage-osp.html#installation-registry-osp-creating-custom-pvc_configuring-registry-storage-openstack