### PR TITLE
GH-81519: Update mirroring instructions for OKD

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -33,8 +33,14 @@ endif::[]
 Complete the following steps on the mirror host:
 
 . Review the
+ifndef::openshift-origin[]
 link:https://access.redhat.com/downloads/content/290/[{product-title} downloads page]
 to determine the version of {product-title} that you want to install and determine the corresponding tag on the link:https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags[Repository Tags] page.
+endif::[]
+ifdef::openshift-origin[]
+link:https://github.com/okd-project/okd/releases/[{product-title} releases page]
+to determine the version and tag of {product-title} that you want to install.
+endif::[]
 
 . Set the required environment variables:
 .. Export the release version:
@@ -81,7 +87,7 @@ endif::[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ PRODUCT_REPO='openshift'
+$ PRODUCT_REPO='okd'
 ----
 endif::[]
 
@@ -107,7 +113,7 @@ endif::[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ RELEASE_NAME="okd"
+$ RELEASE_NAME="scos-release"
 ----
 endif::[]
 

--- a/modules/ipi-install-mirroring-for-disconnected-registry.adoc
+++ b/modules/ipi-install-mirroring-for-disconnected-registry.adoc
@@ -24,8 +24,14 @@ endif::[]
 .Procedure
 
 . Review the
+ifndef::openshift-origin[]
 link:https://access.redhat.com/downloads/content/290/[{product-title} downloads page]
 to determine the version of {product-title} that you want to install and determine the corresponding tag on the link:https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags[Repository Tags] page.
+endif::[]
+ifdef::openshift-origin[]
+link:https://github.com/okd-project/okd/releases/[{product-title} releases page]
+to determine the version and tag of {product-title} that you want to install.
+endif::[]
 
 . Set the required environment variables:
 .. Export the release version:
@@ -72,7 +78,7 @@ endif::[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ PRODUCT_REPO='openshift'
+$ PRODUCT_REPO='okd'
 ----
 endif::[]
 
@@ -98,7 +104,7 @@ endif::[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ RELEASE_NAME="okd"
+$ RELEASE_NAME="scos-release"
 ----
 endif::[]
 


### PR DESCRIPTION
This PR updates the instructions for performing a repository mirror of the OKD (ex. "OpenShift Origin") release payload.
Specifically, the location where releases can be found (https://github.com/okd-project/okd/releases/) and the location where images are located (`quay.io/okd/scos-release`) are being updated.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):

main / 4.16 / 4.17

Issue:

closes https://github.com/openshift/openshift-docs/issues/81519

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
