### PR TITLE
OSDOCS-12165: adds 4.15.46 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -532,3 +532,14 @@ Issued: 15 January 2025
 {product-title} release 4.15.43 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:0123[RHBA-2025:0123] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0121[RHSA-2025:0121] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-46-dp_{context}"]
+=== RHBA-2025:1719 - {microshift-short} 4.15.46 bug fix and enhancement advisory
+
+Issued: 27 February 2025
+
+{product-title} release 4.15.46 is now available. With this release, {microshift-short} introduces a priority-based release cadence to provide the most important updates with the least disruption.
+
+The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:1719[RHBA-2025:1719] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1711[RHSA-2025:1711] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-12165](https://issues.redhat.com/browse/OSDOCS-12165)

Link to docs preview:
[4-15-46-dp_release-notes](https://89052--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-46-dp_release-notes)

QE review:
- [x] QE has approved this change. 
Stock text update. No other changes.
