### PR TITLE
ROX-27332,ROX-27333: Overlays for configmaps

### DIFF
--- a/modules/customize-installation-operator-overlays.adoc
+++ b/modules/customize-installation-operator-overlays.adoc
@@ -39,21 +39,21 @@ The following example shows the structure of an overlay:
 [source,yaml]
 ----
 overlays:
-- apiVersion: v1     # <1>
-  kind: ConfigMap    # <2>
-  name: my-configmap # <3>
+- apiVersion: v1         # <1>
+  kind: ExampleKind      # <2>
+  name: my-resource      # <3>
   patches:
-    - path: .data    # <4>
-      value: |       # <5>
+    - path: .some.field  # <4>
+      value: |           # <5>
         key1: data2
         key2: data2
 ----
 
 <1> Targeted Kubernetes resource ApiVersion, for example `apps/v1`, `v1`, `networking.k8s.io/v1`
 <2> Resource type (e.g., Deployment, ConfigMap, NetworkPolicy)
-<3> Name of the resource, for example `my-configmap`
+<3> Name of the resource, for example `my-resource`
 <4> JSONPath expression to the field, for example `spec.template.spec.containers[name:central].env[-1]`
-<5> YAML string for the new field value
+<5> YAML string for the new field value. If you do not want to use YAML parsing, you can use the `verbatim` key as shown in the following ConfigMap example.
 
 [id="adding-an-overlay_{context}"]
 === Adding an overlay
@@ -157,11 +157,20 @@ spec:
       kind: ConfigMap
       name: central-endpoints
       patches:
-      - path: data
-        value: |
-          endpoints.yaml: |
-            disableDefault: false
+      - path: data.endpoints\.yaml
+        verbatim: |
+          disableDefault: false
+          # another line
 ----
+
+This example shows how to override only a single item (file) under `data`.
+
+Follow this example by taking these steps:
+
+* Use the `verbatim` key, rather than `value`.
+This helps pass through characters such as newlines or quotes so that they are unaffected.
+* You must escape the dot in the filename in the `path` key as shown, or
+ you can write the path as `data["endpoints.yaml"]`.
 
 [id="adding-a-container-to-a-deployment_{context}"]
 === Adding a container to the `Central` deployment


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): RH ACS 4.8
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
- https://issues.redhat.com/browse/ROX-27332
- https://issues.redhat.com/browse/ROX-27333

Links to docs previews:

[89058--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp.html](https://89058--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp.html)
[89058--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html](https://89058--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This:
- changes the overall overlay structure example at the top to be generic rather than specific to config maps, because config maps are a bit special
- changes the configmap-specific example to show how to:
  - override just one `data` field rather than all of them
  - use the new `verbatim` field and why

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
