### PR TITLE
OSSM 8936 Fix SMv2Version attribute in service-mesh-docs-3.0

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -21,7 +21,7 @@
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.6
-//SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version.
+//SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. 02/24/2025: updating for service-mesh-docs-3.0 branch only.
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat
 //Kiali Server

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -20,8 +20,8 @@ Topics:
     File: ossm-migrating-read-me-assembly
   - Name: Premigration checklists
     File: ossm-migrating-premigration-checklists-assembly
-  - Name: Migrating network policies for security purposes
-    File: ossm-migrating-network-policies-security-assembly
+  - Name: Migrating network policies
+    File: ossm-migrating-network-policies-assembly
   - Name: Kiali differences for Service Mesh 3
     File: ossm-migrating-kiali-differences-assembly
     #Kiali PR https://github.com/openshift/openshift-docs/pull/88193

--- a/migrating/checklists/ossm-migrating-network-policies-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-network-policies-assembly.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In OpenShift {SMProductName} 2, network policies are created by default when `spec.security.manageNetworkPolicy` is set to `true` in the `ServiceMeshControlPlane` resource. During migration to {SMProduct} 3, these policies are removed.
+In OpenShift {SMProductName} 2, network policies are created by default when `spec.security.manageNetworkPolicy` is set to `true` in the `ServiceMeshControlPlane` resource. During the migration to {SMProduct} 3, these policies are removed.
 
 It is recommended to recreate your network policies after you have migrated your deployment and workloads. However, for security reasons, you may need to recreate them now, and then set `spec.security.manageNetworkPolicy` to `false` as outlined in the migration checklists.
 

--- a/migrating/checklists/ossm-migrating-network-policies-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-network-policies-assembly.adoc
@@ -6,9 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In OpenShift {SMProductName} 2, network policies are created by default when `spec.security.manageNetworkPolicy=` is set to `true` in the `ServiceMeshControlPlane` resource. During migration to {SMProduct} 3, these policies are removed.
+In OpenShift {SMProductName} 2, network policies are created by default when `spec.security.manageNetworkPolicy` is set to `true` in the `ServiceMeshControlPlane` resource. During migration to {SMProduct} 3, these policies are removed.
 
-It is recommended to recreate your network policies after you have migrated your deployment and workloads. However, for security reasons, you may need to recreate them now, and then set `spec.security.manageNetworkPolicy=` to `false` as outlined in the migration checklists.
+It is recommended to recreate your network policies after you have migrated your deployment and workloads. However, for security reasons, you may need to recreate them now, and then set `spec.security.manageNetworkPolicy` to `false` as outlined in the migration checklists.
 
 include::modules/ossm-migrating-network-policies-security.adoc[leveloffset=+1]
 
@@ -16,8 +16,6 @@ include::modules/ossm-migrating-network-policies-security.adoc[leveloffset=+1]
 * In your {SMProduct} 2 `ServiceMeshControlPlane` resource, set `spec.security.manageNetworkPolicy=` to `false` and continue with migration checklists.
 
 //exrefs handled by OSSM-8852
-
-
 
 
 //Note to self: migrating-done-network-policies is file name in <done> dir for migrating network policies after completely deployment and workloads migration.

--- a/migrating/checklists/ossm-migrating-network-policies-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-network-policies-assembly.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: ASSEMBLY
+[id=ossm-migrating-network-policies-assembly]
+= Migrating network policies from Service Mesh 2 to Service Mesh 3
+include::_attributes/common-attributes.adoc[]
+:context: ossm-migrating-network-policies-assembly
+
+toc::[]
+
+In OpenShift {SMProductName} 2, network policies are created by default when `spec.security.manageNetworkPolicy=` is set to `true` in the `ServiceMeshControlPlane` resource. During migration to {SMProduct} 3, these policies are removed.
+
+It is recommended to recreate your network policies after you have migrated your deployment and workloads. However, for security reasons, you may need to recreate them now, and then set `spec.security.manageNetworkPolicy=` to `false` as outlined in the migration checklists.
+
+include::modules/ossm-migrating-network-policies-security.adoc[leveloffset=+1]
+
+.Next step
+* In your {SMProduct} 2 `ServiceMeshControlPlane` resource, set `spec.security.manageNetworkPolicy=` to `false` and continue with migration checklists.
+
+//exrefs handled by OSSM-8852
+
+
+
+
+//Note to self: migrating-done-network-policies is file name in <done> dir for migrating network policies after completely deployment and workloads migration.

--- a/migrating/checklists/ossm-migrating-network-policies-security-assembly.adoc
+++ b/migrating/checklists/ossm-migrating-network-policies-security-assembly.adoc
@@ -1,8 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-network-policies-security-assembly"]
-= Network policies for security purposes
-include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-network-policies-security-assembly
-
-toc::[]
-

--- a/migrating/done/ossm-migrating-complete-assembly.adoc
+++ b/migrating/done/ossm-migrating-complete-assembly.adoc
@@ -12,7 +12,7 @@ At this stage, you have completed the migration process. It is safe to remove {S
 
 Optionally, if you already have Kiali installed, before you delete {SMProduct} {SMv2Version}, you can verify that all data plane namespaces have been migrated by checking the Kiali **Mesh** page. To learn more about the Kiali **Mesh** page, see "Istio infrastructure status (Kiali.io)".
 
-//include::modules/ossm-migrating-done-network-policies.adoc[leveloffset=+1]
+include::modules/ossm-migrating-done-network-policies.adoc[leveloffset=+1]
 include::modules/ossm-migrating-complete-multitant-cert-manager.adoc[leveloffset=+1]
 
 .Next steps

--- a/modules/ossm-migrating-done-network-policies.adoc
+++ b/modules/ossm-migrating-done-network-policies.adoc
@@ -10,8 +10,8 @@ This procedure applies after you have migrated your deployment and workloads.
 
 .Prerequisites
 
-* You have migrated your deployment
-* You have migrated your workloads
+* You have migrated your deployment.
+* You have migrated your workloads.
 
 [NOTE]
 ====
@@ -27,4 +27,3 @@ Use a label scoped specifically to your mesh that can be reused for discovery se
 . Update labels.
 +
 .. Update corresponding network policy selectors to match the new labels.
-

--- a/modules/ossm-migrating-done-network-policies.adoc
+++ b/modules/ossm-migrating-done-network-policies.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/checklists/ossm-migrating-network-policies.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-network-policies-security_{context}"]
+= Migrating network policies after migrating deployment and workloads
+
+This procedure applies after you have migrated your deployment and workloads.
+
+.Prerequisites
+
+* You have migrated your deployment
+* You have migrated your workloads
+
+[NOTE]
+====
+Use a label scoped specifically to your mesh that can be reused for discovery selectors.
+====
+
+.Procedure
+
+. Recreate necessary network policies in the new {SMProduct} 3 control plane namespace.
+
+. Recreate network policies for each namespace that was part of the {SMProduct} 2 mesh.
+
+. Update labels.
++
+.. Update corresponding network policy selectors to match the new labels.
+

--- a/modules/ossm-migrating-network-policies-security.adoc
+++ b/modules/ossm-migrating-network-policies-security.adoc
@@ -17,6 +17,10 @@ During the recreation of network policies from {SMProduct} 2 to {SMProduct} 3, b
 
 * You have deployed {ocp-product-title} 4.14 or later.
 * You are logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
+* You have the {SMProduct} {SMv2Version} Operator installed.
+* You have the `ServiceMeshControlPlane` 2.6 resource installed.
+* The `manageNetworkPolicy` in your `ServiceMeshControlPlane` resource set to `true`.
+* You have deployed the `bookinfo` and `bookinfo2` applications.
 
 [IMPORTANT]
 ====
@@ -105,7 +109,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: istio-expose-route
-  namespace: httpbin-2
+  namespace: bookinfo
 spec:
   podSelector:
     matchLabels:
@@ -126,7 +130,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: istio-mesh
-  namespace: httpbin-2
+  namespace: bookinfo
 spec:
   ingress:
     - from:
@@ -145,7 +149,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: istio-expose-route
-  namespace: httpbin-3
+  namespace: bookinfo2
 spec:
   podSelector:
     matchLabels:
@@ -166,7 +170,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: istio-mesh
-  namespace: httpbin-3
+  namespace: bookinfo2
 spec:
   ingress:
     - from:
@@ -179,6 +183,27 @@ spec:
 --
 
 . Disable network policies in {SMProduct} 2 by setting `spec.security.manageNetworkPolicy` to `false` in your `ServiceMeshConrolPlane` resource.
++
+[NOTE]
+====
+Setting setting `spec.security.manageNetworkPolicy` to `false` in your `ServiceMeshConrolPlane` resource removes the network policies created by default in {SMProduct} 2.
+====
+
+. Find your current active revision by running the following command:
++
+[source,terminal]
+----
+$ oc get istios <istio-name>
+----
++
+.Example output
+[source,terminal]
+----
+NAME             REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
+istio-tenant-a   1           1       0        istio-tenant-a    Healthy   v1.24.3   30s
+----
+
+. Copy the ACTIVE REVISION to use as your `istio.io/rev` label in your second Istiod
 
 . Create a second Istiod network policy for {SMProduct} 3:
 +
@@ -197,14 +222,10 @@ spec:
   podSelector:
     matchLabels:
       app: istiod
-      istio.io/rev: v3 <1>
+      istio.io/rev: istio-tenant-a <1>
   policyTypes:
     - Ingress
 ----
-<1> Must be your current active revision. You can find it by running the following command:
-+
-[source,terminal]
-----
-$ oc get istios <istio-name>
-----
+<1> Must be your current active revision.
+
 

--- a/modules/ossm-migrating-network-policies-security.adoc
+++ b/modules/ossm-migrating-network-policies-security.adoc
@@ -19,7 +19,7 @@ During the recreation of network policies from {SMProduct} 2 to {SMProduct} 3, b
 * You are logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
 * You have the {SMProduct} {SMv2Version} Operator installed.
 * You have the `ServiceMeshControlPlane` 2.6 resource installed.
-* The `manageNetworkPolicy` in your `ServiceMeshControlPlane` resource set to `true`.
+* You have `spec.security.manageNetworkPolicy=true` in your {SMProduct} 2 `ServiceMeshControlPlane` resource.
 * You have deployed the `bookinfo` and `bookinfo2` applications.
 
 [IMPORTANT]

--- a/modules/ossm-migrating-network-policies-security.adoc
+++ b/modules/ossm-migrating-network-policies-security.adoc
@@ -1,0 +1,199 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/checklists/ossm-migrating-network-policies.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-network-policies-security_{context}"]
+= Migrating network policies for security reasons
+
+This procedure applies only if you must recreate your network policies first for security reasons.
+
+.Prerequisites
+
+* You have deployed {ocp-product-title} 4.14 or later.
+* You are logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
+
+[IMPORTANT]
+====
+The `maistra.io/member-of: istio-system` label will be removed from the namespaces during migration.
+====
+
+.Procedure
+
+[IMPORTANT]
+====
+During the recreation of network policies from {SMProduct} 2 to {SMProduct} 3, both control planes must have access to all workloads and vice versa.
+====
+
+. Label namespaces.
++
+[NOTE]
+====
+Use a label scoped specifically to your mesh that can be reused for discovery selectors.
+====
+
+. Create your network policies:
++
+.Example of an Istiod network policy in a mesh namespace
+[source,yaml]
+--
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: istiod-basic
+      namespace: istio-system
+    spec:
+      ingress:
+        - {}
+      podSelector:
+        matchLabels:
+          app: istiod
+          istio.io/rev: basic
+      policyTypes:
+        - Ingress
+--
++
+.Example of an expose route policy in a mesh namespace
+[source,yaml]
+--
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: expose-route-basic
+      namespace: istio-system
+    spec:
+      podSelector:
+        matchLabels:
+          maistra.io/expose-route: "true"
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  network.openshift.io/policy-group: ingress
+      policyTypes:
+        - Ingress
+--
++
+.Example of a default mesh network policy in a mesh namespace
+[source,yaml]
+--
+
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: istio-mesh
+      namespace: istio-system
+    spec:
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  service-mesh: enabled
+      podSelector: {}
+      policyTypes:
+        - Ingress
+--
++
+.Example expose route network policy in a httpbin-2 namespace
+[source,yaml]
+--
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: istio-expose-route
+      namespace: httpbin-2
+    spec:
+      podSelector:
+        matchLabels:
+          maistra.io/expose-route: "true"
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  network.openshift.io/policy-group: ingress
+      policyTypes:
+        - Ingress
+--
++
+.Example mesh network policy in a httpbin-2 namespace
+[source,yaml]
+--
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: istio-mesh
+      namespace: httpbin-2
+    spec:
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  service-mesh: enabled
+      podSelector: {}
+      policyTypes:
+        - Ingress
+--
++
+.Example expose route network policy iin a httpbin-3 namespace
+[source,yaml]
+--
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: istio-expose-route
+      namespace: httpbin-3
+    spec:
+      podSelector:
+        matchLabels:
+          maistra.io/expose-route: "true"
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  network.openshift.io/policy-group: ingress
+      policyTypes:
+        - Ingress
+--
++
+.Example mesh network policy in a httpbin-3 namespace
+[source,yaml]
+--
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: istio-mesh
+      namespace: httpbin-3
+    spec:
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  service-mesh: enabled
+      podSelector: {}
+      policyTypes:
+        - Ingress
+--
+
+. Disable network policies in {SMProduct} 2 by setting `spec.security.manageNetworkPolicy` to `false` in your `ServiceMeshConrolPlane` resource.
+
+. Create a second Istiod network policy for {SMProduct} 3:
++
+.Example of a second Istiod network policy for {SMProduct} 3
++
+[source,yaml]
+----
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: istio-istiod-v3
+      namespace: istio-system
+    spec:
+      ingress:
+        - {}
+      podSelector:
+        matchLabels:
+          app: istiod
+          istio.io/rev: v3
+      policyTypes:
+        - Ingress
+----

--- a/modules/ossm-migrating-network-policies-security.adoc
+++ b/modules/ossm-migrating-network-policies-security.adoc
@@ -203,7 +203,7 @@ NAME             REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSIO
 istio-tenant-a   1           1       0        istio-tenant-a    Healthy   v1.24.3   30s
 ----
 
-. Copy the ACTIVE REVISION to use as your `istio.io/rev` label in your second Istiod network policy for {SMProduct} 3.
+. Copy the ACTIVE REVISION to use as your `istio.io/rev` label when creating your second Istiod network policy for {SMProduct} 3.
 
 . Create a second Istiod network policy for {SMProduct} 3:
 +

--- a/modules/ossm-migrating-network-policies-security.adoc
+++ b/modules/ossm-migrating-network-policies-security.adoc
@@ -203,7 +203,7 @@ NAME             REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSIO
 istio-tenant-a   1           1       0        istio-tenant-a    Healthy   v1.24.3   30s
 ----
 
-. Copy the ACTIVE REVISION to use as your `istio.io/rev` label in your second Istiod
+. Copy the ACTIVE REVISION to use as your `istio.io/rev` label in your second Istiod network policy for {SMProduct} 3.
 
 . Create a second Istiod network policy for {SMProduct} 3:
 +

--- a/modules/ossm-migrating-network-policies-security.adoc
+++ b/modules/ossm-migrating-network-policies-security.adoc
@@ -8,6 +8,11 @@
 
 This procedure applies only if you must recreate your network policies first for security reasons.
 
+[IMPORTANT]
+====
+During the recreation of network policies from {SMProduct} 2 to {SMProduct} 3, both control planes must have access to all workloads and vice versa.
+====
+
 .Prerequisites
 
 * You have deployed {ocp-product-title} 4.14 or later.
@@ -15,17 +20,17 @@ This procedure applies only if you must recreate your network policies first for
 
 [IMPORTANT]
 ====
-The `maistra.io/member-of: istio-system` label will be removed from the namespaces during migration.
+The `maistra.io/member-of:` label will be removed from the namespaces during migration.
 ====
 
 .Procedure
 
-[IMPORTANT]
-====
-During the recreation of network policies from {SMProduct} 2 to {SMProduct} 3, both control planes must have access to all workloads and vice versa.
-====
-
-. Label namespaces.
+. Label namespaces by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace <app-namespace> service-mesh=enabled
+----
 +
 [NOTE]
 ====
@@ -37,141 +42,140 @@ Use a label scoped specifically to your mesh that can be reused for discovery se
 .Example of an Istiod network policy in a mesh namespace
 [source,yaml]
 --
-    apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: istiod-basic
-      namespace: istio-system
-    spec:
-      ingress:
-        - {}
-      podSelector:
-        matchLabels:
-          app: istiod
-          istio.io/rev: basic
-      policyTypes:
-        - Ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istiod-basic
+  namespace: istio-system
+spec:
+  ingress:
+    - {}
+  podSelector:
+    matchLabels:
+      app: istiod
+      istio.io/rev: basic
+  policyTypes:
+    - Ingress
 --
 +
 .Example of an expose route policy in a mesh namespace
 [source,yaml]
 --
-    apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: expose-route-basic
-      namespace: istio-system
-    spec:
-      podSelector:
-        matchLabels:
-          maistra.io/expose-route: "true"
-      ingress:
-        - from:
-            - namespaceSelector:
-                matchLabels:
-                  network.openshift.io/policy-group: ingress
-      policyTypes:
-        - Ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: expose-route-basic
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      maistra.io/expose-route: "true"
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
 --
 +
 .Example of a default mesh network policy in a mesh namespace
 [source,yaml]
---
-
-    apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: istio-mesh
-      namespace: istio-system
-    spec:
-      ingress:
-        - from:
-            - namespaceSelector:
-                matchLabels:
-                  service-mesh: enabled
-      podSelector: {}
-      policyTypes:
-        - Ingress
---
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-mesh
+  namespace: istio-system
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              service-mesh: enabled
+  podSelector: {}
+  policyTypes:
+    - Ingress
+----
 +
 .Example expose route network policy in a httpbin-2 namespace
 [source,yaml]
 --
-    apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: istio-expose-route
-      namespace: httpbin-2
-    spec:
-      podSelector:
-        matchLabels:
-          maistra.io/expose-route: "true"
-      ingress:
-        - from:
-            - namespaceSelector:
-                matchLabels:
-                  network.openshift.io/policy-group: ingress
-      policyTypes:
-        - Ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-expose-route
+  namespace: httpbin-2
+spec:
+  podSelector:
+    matchLabels:
+      maistra.io/expose-route: "true"
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+    - Ingress
 --
 +
 .Example mesh network policy in a httpbin-2 namespace
 [source,yaml]
 --
-    apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: istio-mesh
-      namespace: httpbin-2
-    spec:
-      ingress:
-        - from:
-            - namespaceSelector:
-                matchLabels:
-                  service-mesh: enabled
-      podSelector: {}
-      policyTypes:
-        - Ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-mesh
+  namespace: httpbin-2
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              service-mesh: enabled
+  podSelector: {}
+  policyTypes:
+    - Ingress
 --
 +
 .Example expose route network policy iin a httpbin-3 namespace
 [source,yaml]
 --
-    apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: istio-expose-route
-      namespace: httpbin-3
-    spec:
-      podSelector:
-        matchLabels:
-          maistra.io/expose-route: "true"
-      ingress:
-        - from:
-            - namespaceSelector:
-                matchLabels:
-                  network.openshift.io/policy-group: ingress
-      policyTypes:
-        - Ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-expose-route
+  namespace: httpbin-3
+spec:
+  podSelector:
+    matchLabels:
+      maistra.io/expose-route: "true"
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  policyTypes:
+
 --
 +
 .Example mesh network policy in a httpbin-3 namespace
 [source,yaml]
 --
-    apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: istio-mesh
-      namespace: httpbin-3
-    spec:
-      ingress:
-        - from:
-            - namespaceSelector:
-                matchLabels:
-                  service-mesh: enabled
-      podSelector: {}
-      policyTypes:
-        - Ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-mesh
+  namespace: httpbin-3
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              service-mesh: enabled
+  podSelector: {}
+  policyTypes:
+    - Ingress
 --
 
 . Disable network policies in {SMProduct} 2 by setting `spec.security.manageNetworkPolicy` to `false` in your `ServiceMeshConrolPlane` resource.
@@ -182,18 +186,25 @@ Use a label scoped specifically to your mesh that can be reused for discovery se
 +
 [source,yaml]
 ----
-    apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: istio-istiod-v3
-      namespace: istio-system
-    spec:
-      ingress:
-        - {}
-      podSelector:
-        matchLabels:
-          app: istiod
-          istio.io/rev: v3
-      policyTypes:
-        - Ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: istio-istiod-v3
+  namespace: istio-system
+spec:
+  ingress:
+    - {}
+  podSelector:
+    matchLabels:
+      app: istiod
+      istio.io/rev: v3 <1>
+  policyTypes:
+    - Ingress
 ----
+<1> Must be your current active revision. You can find it by running the following command:
++
+[source,terminal]
+----
+$ oc get istios <istio-name>
+----
+


### PR DESCRIPTION
**OSSM 3.0 GA**

**Merge PR to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main
**Cherry pick to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

**Service Mesh has moved to the stand alone format and is no longer cherry-picked to OCP core.**

Issue:
https://issues.redhat.com/browse/OSSM-8936 

Link to docs preview:
Update to _attributes, no preview available

QE review:
QE is not required for this change.

Additional information:
Updated attribute missing from service-mesh-docs-3.0 branch so the wrong version is showing on docs.redhat.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
