### PR TITLE
OSSM-8937 Fix SMv2Version attribute in service-mesh-docs-3.0

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -21,7 +21,7 @@
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.6
-//SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version.
+//SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat
 //Kiali Server


### PR DESCRIPTION
**OSSM 3.0 GA**

**Merge PR to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**And cherry picked to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

[OSSM-8937](https://issues.redhat.com//browse/OSSM-8937) Fix SMv2Version attribute in service-mesh-docs-3.0

Version(s):

GA

**Service Mesh has moved to the stand alone doc format and is no longer cherry-picked to OCP core.**

Issue:
https://issues.redhat.com/browse/OSSM-8937

Link to docs preview:
Attribute update; no preview available.

QE review:
QE is not required for this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
