### PR TITLE
OSDOCS-13414#Fix docs for non-graceful node shutdown

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1775,8 +1775,6 @@ Topics:
     File: persistent-storage-csi-sc-manage
   - Name: CSI automatic migration
     File: persistent-storage-csi-migration
-  - Name: Detach CSI volumes after non-graceful node shutdown
-    File: persistent-storage-csi-vol-detach-non-graceful-shutdown
   - Name: AWS Elastic Block Store CSI Driver Operator
     File: persistent-storage-csi-ebs
   - Name: AWS Elastic File Service CSI Driver Operator
@@ -1814,6 +1812,9 @@ Topics:
 - Name: Dynamic provisioning
   File: dynamic-provisioning
   Distros: openshift-enterprise,openshift-origin
+- Name: Detach volumes after non-graceful node shutdown
+  File: persistent-storage-csi-vol-detach-non-graceful-shutdown
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 ---
 Name: Registry
 Dir: registry

--- a/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
+++ b/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
@@ -32,6 +32,12 @@ If the node is not completely shut down, do not proceed with tainting the node. 
 +
 . Taint the corresponding node object by running the following command:
 +
+[IMPORTANT]
+====
+Tainting a node this way deletes all pods on that node. This also causes any pods that are backed by 
+statefulsets to be evicted, and replacement pods to be created on a different node.
+====
++
 [source,terminal]
 ----
 oc adm taint node <node name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute <1>

--- a/storage/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
+++ b/storage/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ephemeral-storage-csi-vol-detach-non-graceful-shutdown"]
-= Detach CSI volumes after non-graceful node shutdown
+= Detach volumes after non-graceful node shutdown
 include::_attributes/common-attributes.adoc[]
 :context: ephemeral-storage-csi-vol-detach-non-graceful-shutdown
 
 toc::[]
 
-This feature allows Container Storage Interface (CSI) drivers to automatically detach volumes when a node goes down non-gracefully.
+This feature allows drivers to automatically detach volumes when a node goes down non-gracefully.
 
 include::modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13414
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://89067--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent-storage-csi-vol-detach-non-graceful-shutdown
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

PTAL: @gcharot @gnufied @radeore 
