### PR TITLE
OSDOCS-13428: Documented the 4.16.36 z-stream notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3347,6 +3347,31 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.16.36
+[id="ocp-4-16-36_{context}"]
+=== RHSA-2025:1707 - {product-title} {product-version}.36 bug fix and security update
+
+Issued: 27 February 2025
+
+{product-title} release {product-version}.36 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1707[RHSA-2025:1707] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:1709[RHBA-2025:1709] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.36 --pullspecs
+----
+
+[id="ocp-4-16-36-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, certain {product-title} clusters with hundreds of nodes and network policies caused the live migration from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin to fail. The live migration operation failed because of excess RAM consumption. With this release, a fix means that the live migration operation no longer fails for these cluster configurations. (link:https://issues.redhat.com/browse/OCPBUGS-46493[*OCPBUGS-46493*])
+
+[id="ocp-4-16-36-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.16.35
 [id="ocp-4-16-35_{context}"]
 === RHSA-2025:1386 - {product-title} {product-version}.35 bug fix update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-13428](https://issues.redhat.com/browse/OSDOCS-13428)

Link to docs preview:
[4.16.36](https://89069--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-36_release-notes)
