### PR TITLE
OLS-1427: after updating OLS, Operator cannot watch all namespaces

### DIFF
--- a/modules/ols-release-0-3-0-known-issues.adoc
+++ b/modules/ols-release-0-3-0-known-issues.adoc
@@ -16,6 +16,6 @@ Workaround: The LLM provider secret must be created before the `OLSConfig` custo
 +
 Workaround: There are two ways to address this issue:
 +
-Add the `targetNamespace` parameter to the `OperatorGroup` for the {ols-long} Operator. Set the `targetNamespace` parameter to the namespace where the {ols-short} Operator runs. Then, delete the old version of the {ols-short} Operator, and wait for the new {ols-short} Operator to deploy. 
+Add the `targetNamespace` field to the `OperatorGroup` resource for the {ols-long} Operator. Set the `targetNamespace` field to the namespace where the {ols-short} Operator runs. Then, delete the old version of the {ols-short} Operator, and wait for the new {ols-short} Operator to deploy. 
 +
-Alternatively, copy the `OLSConfig` custom resource (CR) and API token secrets to local file, and delete the {ols-short} Operator and the operator group. Then, reinstall the {ols-short} Operator and restore the API token secrets and `OLSConfig` CR using the local file.
+Alternatively, copy the `OLSConfig` custom resource (CR) and API token secrets to local file. Delete the {ols-short} Operator and the operator group. Then, reinstall the {ols-short} Operator and restore the API token secrets and `OLSConfig` CR using the file that was created locally.

--- a/modules/ols-release-0-3-0-known-issues.adoc
+++ b/modules/ols-release-0-3-0-known-issues.adoc
@@ -18,4 +18,4 @@ Workaround: There are two ways to address this issue:
 +
 Add the `targetNamespace` field to the `OperatorGroup` resource for the {ols-long} Operator. Set the `targetNamespace` field to the namespace where the {ols-short} Operator runs. Then, delete the old version of the {ols-short} Operator, and wait for the new {ols-short} Operator to deploy. 
 +
-Alternatively, copy the `OLSConfig` custom resource (CR) and API token secrets to local file. Delete the {ols-short} Operator and the operator group. Then, reinstall the {ols-short} Operator and restore the API token secrets and `OLSConfig` CR using the file that was created locally.
+Alternatively, you can delete and then reinstall the {ols-short} Operator. Prior to deleting the Operator, copy the `OLSConfig` custom resource (CR) and API token secrets to local file. Delete the Operator and the operator group. Then, reinstall the {ols-short} Operator and restore the API token secrets and `OLSConfig` CR using the file that was created locally.

--- a/modules/ols-release-0-3-0-known-issues.adoc
+++ b/modules/ols-release-0-3-0-known-issues.adoc
@@ -11,3 +11,11 @@ The following issues are identified with {ols-official} 0.3.0:
 * If the {ols-long} Operator is installed in a namespace other than `openshift-lightspeed`, the Operator cannot reconcile the secret used to authenticate the Large Language Model (LLM) provider. 
 +
 Workaround: The LLM provider secret must be created before the `OLSConfig` custom resource is created. Then, the Operator can reconcile the secret. link:https://issues.redhat.com/browse/OLS-1426[OLS-1426]. 
+
+* After updating to to version 0.3.0 of the {ols-long} Operator, the `AllNamespaces` `InstallModeType` is not supported, and the Operator cannot watch all namespaces.link:https://issues.redhat.com/browse/OLS-1427[OLS-1427].
++
+Workaround: There are two ways to address this issue:
++
+Add the `targetNamespace` parameter to the `OperatorGroup` for the {ols-long} Operator. Set the `targetNamespace` parameter to the namespace where the {ols-short} Operator runs. Then, delete the old version of the {ols-short} Operator, and wait for the new {ols-short} Operator to deploy. 
++
+Alternatively, copy the `OLSConfig` custom resource (CR) and API token secrets to local file, and delete the {ols-short} Operator and the operator group. Then, reinstall the {ols-short} Operator and restore the API token secrets and `OLSConfig` CR using the local file.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): TP
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-1427
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://89083--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-release-0-3-known-issues_ols-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
