### PR TITLE
CNV-56370: Fixed indentation of the example manifest

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4640,6 +4640,8 @@ Topics:
     Topics:
     - Name: Working with resource quotas for virtual machines
       File: virt-working-with-resource-quotas-for-vms
+    - Name: Configuring the Application-Aware Quota Operator
+      File: virt-understanding-aaq-operator
     - Name: Specifying nodes for virtual machines
       File: virt-specifying-nodes-for-vms
     - Name: Configuring the default CPU model
@@ -4658,6 +4660,8 @@ Topics:
       File: virt-configuring-pci-passthrough
     - Name: Configuring virtual GPUs
       File: virt-configuring-virtual-gpus
+    - Name: Configuring USB host passthrough
+      File: virt-configuring-usb-host-passthrough
     - Name: Enabling descheduler evictions on virtual machines
       File: virt-enabling-descheduler-evictions
     - Name: About high availability for virtual machines

--- a/modules/virt-about-aaq-operator.adoc
+++ b/modules/virt-about-aaq-operator.adoc
@@ -51,10 +51,10 @@ metadata:
 spec:
   quota:
     hard:
-    requests.memory: 1Gi
-    limits.memory: 1Gi
-    requests.cpu/vmi: "1"
-    requests.memory/vmi: 1Gi
+      requests.memory: 1Gi
+      limits.memory: 1Gi
+      requests.cpu/vmi: "1"
+      requests.memory/vmi: 1Gi
   selector:
     annotations: null
     labels:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-56370](https://issues.redhat.com/browse/CNV-56370)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://89089--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-understanding-aaq-operator.html#aaq-controller-and-crds_virt-understanding-aaq-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This fixes a trivial problem with incorrect indentation of a YAML file example.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
