### PR TITLE
[OCP][4.12] Fix the patch command for OVN customization

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -178,7 +178,7 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
         "ovnKubernetesConfig":{
           "mtu":<mtu>,
           "genevePort":<port>,
-          "v4InternalSubnet":"<ipv4_subnet>",
+          "v4InternalSubnet":"<ipv4_subnet>"
     }}}}'
 ----
 +


### PR DESCRIPTION
In [OCP 4.12 documentation](https://docs.openshift.com/container-platform/4.12/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn) , the last comma is not necessary and blocks the patch command at step 6

Version(s):
4.12

Issue: https://issues.redhat.com/browse/OCPBUGS-51201

Link to docs preview:
Original: https://docs.openshift.com/container-platform/4.12/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn

Updated: https://89091--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/rollback-to-ovn-kubernetes.html#nw-ovn-kubernetes-migration_roll-back-to-ovn-kubernetes