### PR TITLE
OCPBUGS50932: ClusterResourceOverride Operator modifies the pod resources even if resource requests and limits are defined

### DIFF
--- a/modules/nodes-cluster-resource-override.adoc
+++ b/modules/nodes-cluster-resource-override.adoc
@@ -3,13 +3,19 @@
 // * nodes/clusters/nodes-cluster-overcommit.adoc
 // * post_installation_configuration/node-tasks.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="nodes-cluster-resource-override_{context}"]
 = Cluster-level overcommit using the Cluster Resource Override Operator
 
 The Cluster Resource Override Operator is an admission webhook that allows you to control the level of overcommit and manage
 container density across all the nodes in your cluster. The Operator controls how nodes in specific projects can exceed defined memory and CPU limits.
 
-You must install the Cluster Resource Override Operator using the {product-title} console or CLI as shown in the following sections.
+// Paragraph taken from 3.11 docs and modified. 
+// https://docs.openshift.com/container-platform/3.11/admin_guide/overcommit.html#configuring-masters-for-overcommitment
+The Operator modifies the ratio between the requests and limits that are set on developer containers. In conjunction with a per-project limit range that specifies limits and defaults, you can achieve the desired level of overcommit.
+
+You must install the Cluster Resource Override Operator by using the {product-title} console or CLI as shown in the following sections. After you deploy the Cluster Resource Override Operator, the Operator modifies all new pods in specific namespaces. The Operator does not edit pods that existed before you deployed the Operator. 
+
 During the installation, you create a `ClusterResourceOverride` custom resource (CR), where you set the level of overcommit, as shown in the
 following example:
 
@@ -39,8 +45,7 @@ been set on containers. Create a `LimitRange` object with default limits per ind
 or configure limits in `Pod` specs for the overrides to apply.
 ====
 
-When configured, overrides can be enabled per-project by applying the following
-label to the Namespace object for each project:
+When configured, you can enable overrides on a per-project basis by applying the following label to the `Namespace` object for each project where you want the overrides to apply. For example, you can configure override so that infrastructure components are not subject to the overrides.
 
 [source,yaml]
 ----
@@ -57,3 +62,53 @@ metadata:
 ----
 
 The Operator watches for the `ClusterResourceOverride` CR and ensures that the `ClusterResourceOverride` admission webhook is installed into the same namespace as the operator.
+
+// Examples take from: https://github.com/openshift/cluster-resource-override-admission-operator?tab=readme-ov-file#test-pod-resource-override
+For example, a pod has the following resources limits:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: my-namespace
+# ...
+spec:
+  containers:
+    - name: hello-openshift
+      image: openshift/hello-openshift
+      resources:
+        limits:
+          memory: "512Mi"
+          cpu: "2000m"
+# ...
+----
+
+The Cluster Resource Override Operator intercepts the original pod request, then overrides the resources according to the configuration set in the `ClusterResourceOverride` object.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: my-namespace
+# ...
+spec:
+  containers:
+  - image: openshift/hello-openshift
+    name: hello-openshift
+    resources:
+      limits:
+        cpu: "1" <1>
+        memory: 512Mi
+      requests:
+        cpu: 250m <2>
+        memory: 256Mi
+# ...
+----
+<1> The CPU limit has been overridden to `1` because the `limitCPUToMemoryPercent` parameter is set to `200` in the `ClusterResourceOverride` object. As such, 200% of the memory limit, 512Mi in CPU terms, is 1 CPU core. 
+<2> The CPU request is now `250m` because the `cpuRequestToLimit` is set to `25` in the `ClusterResourceOverride` object. As such, 25% of the 1 CPU core is 250m.
+
+

--- a/nodes/clusters/nodes-cluster-overcommit.adoc
+++ b/nodes/clusters/nodes-cluster-overcommit.adoc
@@ -21,10 +21,8 @@ resource requests and nodes' available capacity into consideration.
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 {product-title} administrators can control the level of overcommit and manage
-container density on nodes. You can configure cluster-level overcommit using
-the xref:#nodes-cluster-resource-override_nodes-cluster-overcommit[ClusterResourceOverride Operator]
-to override the ratio between requests and limits set on developer containers.
-In conjunction with xref:#nodes-cluster-node-overcommit_nodes-cluster-overcommit[node overcommit], you can adjust the resource limit and request to achieve the desired level of overcommit.
+container density on developer containers by using
+the xref:#nodes-cluster-resource-override_nodes-cluster-overcommit[ClusterResourceOverride Operator].
 
 [NOTE]
 ====


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-50932

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
