### PR TITLE
OSSM-8942 Update istio-latest attribute to 1.24.3

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -22,6 +22,10 @@
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.6
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
+//Istio
+:istio: Istio
+:istio-latest: 1.24.3
+//update istio-latest as necessary
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat
 //Kiali Server
@@ -55,9 +59,7 @@
 //pipelines
 :pipelines-title: Red{nbsp}Hat OpenShift Pipelines
 :pipelines-shortname: OpenShift Pipelines
-//Istio
-:istio: Istio
-:istio-latest: 1.24.1
+
 //Used infrequently
 //ROSA
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-8942](https://issues.redhat.com//browse/OSSM-8942) Update istio-latest attribute to 1.24.3

**Merge PR to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**And cherry picked to**:  https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

02/25/2025: user error. Should be cp'd to service-mesh-docs-3.0 and not 3.0.0tp1

Version(s):

GA

**Service Mesh has moved to the stand alone format and is no longer cherry-picked back to OCP core.**

Issue:
https://issues.redhat.com/browse/OSSM-8942

Link to docs preview:
No preview, attribute update

QE review:
QE approval is not required for this change.

Additional information:
Also moved attribute up in the order to be closer to other version updates to make it easier to remember to update it as necessary. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
