### PR TITLE
Fix incorrect nesting of monitoring docs

### DIFF
--- a/observability/monitoring/configuring-core-platform-monitoring/configuring-alerts-and-notifications.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/configuring-alerts-and-notifications.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can configure a local or external Alertmanager instance to route alerts from Prometheus to endpoint receivers. You can also attach custom labels to all time series and alerts to add useful metadata information.
 
 //Configuring external Alertmanager instances
-include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=1,tags=**;CPM;!UWM]
+include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=+1,tags=**;CPM;!UWM]
 
 // Disabling the local Alertmanager
 include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+2]
@@ -21,9 +21,9 @@ include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+2
 * xref:../../../observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc#managing-alerts-as-an-administrator[Managing alerts as an Administrator]
 
 //Configuring secrets for Alertmanager
-include::modules/monitoring-configuring-secrets-for-alertmanager.adoc[leveloffset=1]
+include::modules/monitoring-configuring-secrets-for-alertmanager.adoc[leveloffset=+1]
 
-include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc[leveloffset=2,tags=**;CPM;!UWM]
+include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc[leveloffset=+2,tags=**;CPM;!UWM]
 
 //Attaching additional labels to your time series and alerts
 include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1,tags=**;CPM;!UWM]

--- a/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
@@ -80,7 +80,7 @@ include::modules/monitoring-choosing-a-metrics-collection-profile.adoc[leveloffs
 * xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
 
 //Configuring pod topology spread constraints for core platform monitoring
-include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=1,tags=**;CPM;!UWM]
+include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=+1,tags=**;CPM;!UWM]
 
 [role="_additional-resources"]
 .Additional resources

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -297,14 +297,14 @@ endif::openshift-dedicated,openshift-rosa[]
 
 //Configuring external Alertmanager instances
 // The following module should only include monitoring for user-defined projects (UWM tags)
-include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=1,tags=**;!CPM;UWM]
+include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
 //Configuring secrets for Alertmanager
-include::modules/monitoring-configuring-secrets-for-alertmanager.adoc[leveloffset=1]
+include::modules/monitoring-configuring-secrets-for-alertmanager.adoc[leveloffset=+1]
 
 // Adding a secret to the Alertmanager configuration
 // The following module should only include monitoring for user-defined projects (UWM tags)
-include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc[leveloffset=2,tags=**;!CPM;UWM]
+include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
 //Attaching additional labels to your time series and alerts
 // The following module should only include monitoring for user-defined projects (UWM tags)
@@ -319,7 +319,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 endif::openshift-dedicated,openshift-rosa[]
 
 // Using topology spread constraints for monitoring components
-include::modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc[leveloffset=1]
+include::modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -332,7 +332,7 @@ endif::openshift-dedicated,openshift-rosa[]
 
 // Configuring pod topology spread constraints
 // The following module should only include monitoring for user-defined projects (UWM tags)
-include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=2,tags=**;!CPM;UWM]
+include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
 // Setting log levels for monitoring components
 // The following module should only include monitoring for user-defined projects (UWM tags)

--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm.adoc
@@ -9,12 +9,12 @@ toc::[]
 You can configure a local or external Alertmanager instance to route alerts from Prometheus to endpoint receivers. You can also attach custom labels to all time series and alerts to add useful metadata information.
 
 //Configuring external Alertmanager instances
-include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=1,tags=**;!CPM;UWM]
+include::modules/monitoring-configuring-external-alertmanagers.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
 //Configuring secrets for Alertmanager
-include::modules/monitoring-configuring-secrets-for-alertmanager.adoc[leveloffset=1]
+include::modules/monitoring-configuring-secrets-for-alertmanager.adoc[leveloffset=+1]
 
-include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc[leveloffset=2,tags=**;!CPM;UWM]
+include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
 //Attaching additional labels to your time series and alerts
 include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1,tags=**;!CPM;UWM]

--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
@@ -88,7 +88,7 @@ include::modules/monitoring-setting-scrape-and-evaluation-intervals-limits-for-u
 include::modules/monitoring-creating-scrape-sample-alerts.adoc[leveloffset=+2]
 
 //Configuring pod topology spread constraints for monitoring of user-defined projects
-include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=1,tags=**;!CPM;UWM]
+include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
 [role="_additional-resources"]
 .Additional resources

--- a/observability/monitoring/managing-alerts.adoc
+++ b/observability/monitoring/managing-alerts.adoc
@@ -18,15 +18,15 @@ The alerts, silences, and alerting rules that are available in the Alerting UI r
 ====
 
 // Accessing the Alerting UI in the Administrator and Developer perspectives
-include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=1,tags=**;ADM;!DEV]
-include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=1,tags=**;DEV;!ADM]
+include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=+1,tags=**;ADM;!DEV]
+include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=+1,tags=**;DEV;!ADM]
 
 // Searching and filtering alerts, silences, and alerting rules
 include::modules/monitoring-searching-alerts-silences-and-alerting-rules.adoc[leveloffset=+1]
 
 // Getting information about alerts, silences and alerting rules
-include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=1,tags=**;ADM;!DEV]
-include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=1,tags=**;DEV;!ADM]
+include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=+1,tags=**;ADM;!DEV]
+include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=+1,tags=**;DEV;!ADM]
 
 [role="_additional-resources"]
 .Additional resources

--- a/observability/monitoring/managing-alerts/managing-alerts-as-a-developer.adoc
+++ b/observability/monitoring/managing-alerts/managing-alerts-as-a-developer.adoc
@@ -14,7 +14,7 @@ The alerts, silences, and alerting rules that are available in the Alerting UI r
 ====
 
 // Accessing the Alerting UI from the Developer perspective
-include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=1,tags=**;DEV;!ADM]
+include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=+1,tags=**;DEV;!ADM]
 
 [role="_additional-resources"]
 .Additional resources
@@ -22,7 +22,7 @@ include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=1,tags=**
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#searching-alerts-silences-and-alerting-rules_key-concepts[Searching and filtering alerts, silences, and alerting rules]
 
 // Getting information about alerts, silences and alerting rules from the Developer perspective
-include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=1,tags=**;DEV;!ADM]
+include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=+1,tags=**;DEV;!ADM]
 
 [role="_additional-resources"]
 .Additional resources

--- a/observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc
+++ b/observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc
@@ -14,7 +14,7 @@ The alerts, silences, and alerting rules that are available in the Alerting UI r
 ====
 
 // Accessing the Alerting UI from the Administrator perspective
-include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=1,tags=**;ADM;!DEV]
+include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=+1,tags=**;ADM;!DEV]
 
 [role="_additional-resources"]
 .Additional resources
@@ -22,7 +22,7 @@ include::modules/monitoring-accessing-the-alerting-ui.adoc[leveloffset=1,tags=**
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#searching-alerts-silences-and-alerting-rules_key-concepts[Searching and filtering alerts, silences, and alerting rules]
 
 // Getting information about alerts, silences and alerting rules from the Administrator perspective
-include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=1,tags=**;ADM;!DEV]
+include::modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc[leveloffset=+1,tags=**;ADM;!DEV]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): `enterprise-4.14` and later 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1720
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: `n/a`
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: To fix the rendering issue on **docs.redhat.com** ([example](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/monitoring/configuring-pod-topology-spread-constraints_configuring-performance-and-scalability))
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
