### PR TITLE
OCPBUGS-43109: Moved AWS Outpost note to deprecated section

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -696,13 +696,6 @@ You can now move etcd from a root volume (Cinder) to a dedicated ephemeral local
 
 For more information, see xref:../installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.adoc#deploying-openstack-with-rootvolume-etcd-on-local-disk[Deploying on OpenStack with rootVolume and etcd on local disk].
 
-[id="ocp-4-17-installation-aws-outposts-deprecated_{context}"]
-==== Announcement of the deprecation of extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud
-
-With this release, extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud is deprecated. The ability to deploy compute nodes into AWS Outposts after installation, as an extension of an existing {product-title} cluster operating in a public AWS region, will be removed with the release of {product-title} version 4.20.
-
-For more information, see xref:../installing/installing_aws/ipi/installing-aws-outposts.html#installing-aws-outposts[Extending an AWS VPC cluster into an AWS Outpost].
-
 [id="ocp-4-17-olm_{context}"]
 === Operator lifecycle
 
@@ -1580,6 +1573,13 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-17-deprecated-features_{context}"]
 === Deprecated features
 
+[id="ocp-4-17-installation-aws-outposts-deprecated_{context}"]
+==== Announcement of the deprecation of extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud
+
+With this release, extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud is deprecated. The ability to deploy compute nodes into AWS Outposts after installation, as an extension of an existing {product-title} cluster operating in a public AWS region, will be removed with the release of {product-title} version 4.20.
+
+For more information, see xref:../installing/installing_aws/ipi/installing-aws-outposts.html#installing-aws-outposts[Extending an AWS VPC cluster into an AWS Outpost].
+
 [id="ocp-4-17-preserveBootstrapIgnition-deprecated_{context}"]
 ==== The preserveBootstrapIgnition parameter for {aws-short}
 
@@ -2043,7 +2043,7 @@ With this update, the plugin checks the local cache during the disk-to-mirror pr
 +
 [source,terminal]
 ----
-[ERROR]: Detected a v2 `ImageSetConfiguration`, please use `--v2` instead of `-v2`.
+[ERROR]: Detected a v2 ImageSetConfiguration, please use --v2 instead of -v2.
 ----
 +
 (link:https://issues.redhat.com/browse/OCPBUGS-33121[*OCPBUGS-33121*])
@@ -3455,7 +3455,7 @@ $ oc adm release info 4.17.3 --pullspecs
 
 * Previously, a regression was introduced to the OpenShift installer during a Power VS deployment. As a result, the security group rules required for OpenShift Install were not created. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-43547[*OCPBUGS-43547*])
 
-* Previously, if an image registry Operator was configured with the`networkAccess` field set to `Internal` in Azure, an authorization error prevented the image registry Operator from deleting the storage container, and the `managementState` field from being set to `Removed`. With this release, the Operator can delete the storage account and storage container, and the `managementState` field can successfully set to `Removed`. (link:https://issues.redhat.com/browse/OCPBUGS-43350[*OCPBUGS-43350*])
+* Previously, if an image registry Operator was configured with the `networkAccess` field set to `Internal` in Azure, an authorization error prevented the image registry Operator from deleting the storage container, and the `managementState` field from being set to `Removed`. With this release, the Operator can delete the storage account and storage container, and the `managementState` field can successfully set to `Removed`. (link:https://issues.redhat.com/browse/OCPBUGS-43350[*OCPBUGS-43350*])
 
 * Previously, both active and passive high-availability (HA) deployments ran three replicas instead of the required two. As a result, control planes contained more pods than required, which led to scaling issues. With this release, the number of replicas in active and passive HA deployments is reduced from three to two. (link:https://issues.redhat.com/browse/OCPBUGS-42704[*OCPBUGS-42704*])
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OCPBUGS-43109](https://issues.redhat.com/browse/OCPBUGS-43109)

Link to docs preview:
[4.17](https://89113--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-deprecated-features_release-notes)

