### PR TITLE
4.14: OADP-5658 Release Notes for OADP 1.3.6

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -40,7 +40,7 @@ endif::[]
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
 :oadp-version: 1.4.2
-:oadp-version-1-3: 1.3.5
+:oadp-version-1-3: 1.3.6
 :oadp-version-1-4: 1.4.2
 :oadp-bsl-api: backupstoragelocations.velero.io
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -9,6 +9,7 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-3-6.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-5.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-4.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-3.adoc[leveloffset=+1]

--- a/modules/oadp-release-notes-1-3-6.adoc
+++ b/modules/oadp-release-notes-1-3-6.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="oadp-release-notes-1-3-6_{context}"]
+= {oadp-short} 1.3.6 release notes
+
+{oadp-first} 1.3.6 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.3.5.


### PR DESCRIPTION
### JIRA

* [OADP-5658 Release Notes for OADP 1.3.6](https://issues.redhat.com/browse/OADP-5658)

### Version(s):

* OCP 4.12, 4.13, 4.14, 4.15

Related to #89112 
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
