### PR TITLE
OCPBUGS-25761: Clarified relationship between rules and profiles

### DIFF
--- a/modules/compliance-profile-types.adoc
+++ b/modules/compliance-profile-types.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/co-concepts/compliance-operator-understanding.adoc
+// * security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="compliance_profile_types_{context}"]
+= Compliance Operator profile types
+
+Compliance Operator rules are organized into profiles. Profiles can target the Platform or Nodes for {product-title}, and some benchmarks include `rhcos4` Node profiles.
+
+Platform:: Platform profiles evaluate your {product-title} cluster components. For example, a Platform-level rule can confirm whether APIServer configurations are using strong encryption cyphers.
+
+Node:: Node profiles evaluate the OpenShift or {op-system} configuration of each host. You can use two Node profiles: `ocp4` Node profiles and `rhcos4` Node profiles. The `ocp4` Node profiles evaluate the OpenShift configuration of each host. For example, they can confirm whether `kubeconfig` files have the correct permissions to meet a compliance standard. The `rhcos4` Node profiles evaluate the {op-system-first} configuration of each host. For example, they can confirm whether the SSHD service is configured to disable password logins.
+
+[IMPORTANT]
+====
+For benchmarks that have Node and Platform profiles, such as PCI-DSS, you must run both profiles in your {product-title} environment.
+
+For benchmarks that have `ocp4` Platform, `ocp4` Node, and `rhcos4` Node profiles, such as FedRAMP High, you must run all three profiles in your {product-title} environment.
+====
+
+[NOTE]
+====
+In a cluster with many Nodes, both `ocp4` Node and `rhcos4` Node scans might take a long time to complete.
+====

--- a/modules/compliance-profiles.adoc
+++ b/modules/compliance-profiles.adoc
@@ -215,17 +215,3 @@ warning: Manual editing of these files may indicate nefarious activity, such as 
   attacker attempting to remove evidence of an intrusion.
 ----
 ====
-
-[id="compliance_profile_types_{context}"]
-== Compliance Operator profile types
-
-There are two types of compliance profiles available: Platform and Node.
-
-Platform:: Platform scans target your {product-title} cluster.
-
-Node:: Node scans target the nodes of the cluster.
-
-[IMPORTANT]
-====
-For compliance profiles that have Node and Platform applications, such as `pci-dss` compliance profiles, you must run both in your {product-title} environment.
-====

--- a/security/compliance_operator/co-concepts/compliance-operator-understanding.adoc
+++ b/security/compliance_operator/co-concepts/compliance-operator-understanding.adoc
@@ -15,8 +15,4 @@ The Compliance Operator is available for {op-system-first} deployments only.
 
 include::modules/compliance-profiles.adoc[leveloffset=+1]
 
-[id="additional-resources_compliance-operator-understanding"]
-[role="_additional-resources"]
-== Additional resources
-
-* xref:../../../security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[Supported compliance profiles]
+include::modules/compliance-profile-types.adoc[leveloffset=+2]

--- a/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
+++ b/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
@@ -27,8 +27,4 @@ The Compliance Operator might report incorrect results on some managed platforms
 
 include::modules/compliance-supported-profiles.adoc[leveloffset=+1]
 
-[id="additional-resources-compliance-operator-"]
-[role="_additional-resources"]
-== Additional resources
-
-* xref:../../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#compliance_profile_types_understanding-compliance[Compliance Operator profile types]
+include::modules/compliance-profile-types.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-25761

Link to docs preview:
[Compliance Operator profile types](https://89115--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-supported-profiles.html#compliance_profile_types_compliance-operator-supported-profiles)

QE review:
- [x] QE has approved this change.


Additional information:
This PR moves, rearranges, and provides more detail regarding the complex relationship of Compliance Operator scans, rules, and available profiles. 
