### PR TITLE
OADP-5647 Independent BSL conflict

### DIFF
--- a/modules/oadp-configuring-dpa-multiple-bsl.adoc
+++ b/modules/oadp-configuring-dpa-multiple-bsl.adoc
@@ -7,7 +7,14 @@
 [id="oadp-configuring-dpa-multiple-bsl_{context}"]
 = Configuring the DPA with more than one BSL
 
-You can configure the DPA with more than one BSL and specify the credentials provided by the cloud provider.  
+You can configure the `DataProtectionApplication` (DPA) custom resource (CR) with more than one `BackupStorageLocation` (BSL) CR and specify the credentials provided by the cloud provider.
+
+For example, where you have configured the following two BSLs:
+
+* Configured one BSL in the DPA and set it as the default BSL.
+* Created another BSL independently by using the `BackupStorageLocation` CR.
+
+As you have already set the BSL created through the DPA as the default, you cannot set the independently created BSL again as the default. This means, at any given time, you can set only one BSL as the default BSL.
 
 .Prerequisites
 
@@ -16,7 +23,7 @@ You can configure the DPA with more than one BSL and specify the credentials pro
 
 .Procedure
 
-. Configure the DPA with more than one BSL. See the following example.
+. Configure the `DataProtectionApplication` CR with more than one `BackupStorageLocation` CR. See the following example:
 +
 .Example DPA
 [source,yaml]


### PR DESCRIPTION
## Jira 

* [OADP-5647](https://issues.redhat.com/browse/OADP-5647)

Added a note for two BSLs scenario

##  Version

* OCP 4.14 → OCP 4.19

## Preview

I have added the note in the module and it will be shown in all cloud provider sections.

* [Note for setting more than 1 BSL as default](https://89116--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.html#oadp-configuring-dpa-multiple-bsl_configuring-oadp-multiple-bsl)

## QE Review

* [x] QE has approved this change.
