### PR TITLE
OCPBUGS#43947: Updated the OPENSHIFT_HA_NETWORK_INTERFACE description

### DIFF
--- a/modules/nw-ipfailover-environment-variables.adoc
+++ b/modules/nw-ipfailover-environment-variables.adoc
@@ -19,7 +19,9 @@ The following table contains the variables used to configure IP failover.
 
 |`OPENSHIFT_HA_NETWORK_INTERFACE`
 |
-|The interface name that IP failover uses to send Virtual Router Redundancy Protocol (VRRP) traffic. The default value is `eth0`.
+|The interface name that IP failover uses to send Virtual Router Redundancy Protocol (VRRP) traffic. The default value is `eth0`. 
+
+If your cluster uses the OVN-Kubernetes network plugin, set this value to `br-ex` to avoid packet loss. For a cluster that uses the OVN-Kubernetes network plugin, all listening interfaces do not serve VRRP but instead expect inbound traffic over a `br-ex` bridge.
 
 |`OPENSHIFT_HA_REPLICA_COUNT`
 |`2`


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-43947](https://issues.redhat.com/browse/OCPBUGS-43947)

Link to docs preview:
[IP failover environment variables](https://89118--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring-ipfailover.html#nw-ipfailover-environment-variables_configuring-ipfailover)

Reviews:

* [x] SME (Will Russell)
* [x] QE (Asked ne-qe-team: Melvin Joseph)
