### PR TITLE
OCPBUGS44935: WMCO uninstall should describe procedure of uninstalling the operator and deleteing the namespace

### DIFF
--- a/modules/deleting-wmco-namespace.adoc
+++ b/modules/deleting-wmco-namespace.adoc
@@ -17,12 +17,17 @@ After removing the Windows Machine Config Operator, it is recommended that you r
 
 This procedure assumes that you are using the default `openshift-windows-machine-config-operator` namespace.
 
-. Remove all resources that were created in the `openshift-windows-machine-config-operator` namespace by using the following command:
+. Remove all WMCO resources that were created in the `openshift-windows-machine-config-operator` namespace by using the following command:
 +
 [source,terminal]
 ----
 $ oc delete --all pods --namespace=openshift-windows-machine-config-operator
 ----
++
+[NOTE]
+====
+The `openshift-windows-machine-config-operator` namespace is reserved for WMCO resources. There should be no Windows workloads or pods in the namespace.
+====
 
 . Verify that all pods in the `openshift-windows-machine-config-operator` namespace are deleted or are reporting a terminating state by using the following command:
 +
@@ -31,18 +36,45 @@ $ oc delete --all pods --namespace=openshift-windows-machine-config-operator
 $ oc get pods --namespace openshift-windows-machine-config-operator
 ----
 
-. Delete the subscription by using the following command:
+. Delete the subscription and CSV: by using the following command:
+
+.. Ensure the latest version of the subscribed operator is identified in the `currentCSV` field by using the following command:
 +
 [source,terminal]
 ----
-$ oc delete subscription -n openshift-windows-machine-config-operator windows-machine-config-operator
+$ oc get subscription.operators.coreos.com windows-machine-config-operator -n openshift-windows-machine-config-operator -o yaml | grep currentCSV
+----
++
+.Example output
+[source,terminal]
+----
+  currentCSV: openshift-windows-machine-config-operator
 ----
 
-. Delete the CSV by using the following command:
+.. Delete the subscription by using the following command:
 +
 [source,terminal]
 ----
-$ oc delete csv -n openshift-windows-machine-config-operator ${WMCO_CSV}
+$ oc delete subscription.operators.coreos.com windows-machine-config-operator -n openshift-windows-machine-config-operator
+----
++
+.Example output
+[source,terminal]
+----
+subscription.operators.coreos.com "windows-machine-config-operator" deleted
+----
+
+.. Delete the CSV for the Operator in the target namespace  by using the following command with the `currentCSV` value from the previous step:
++
+[source,terminal]
+----
+$ oc delete clusterserviceversion windows-machine-config-operator -n openshift-windows-machine-config-operator
+----
++
+.Example output
+[source,terminal]
+----
+clusterserviceversion.operators.coreos.com "serverless-operator.v1.28.0" deleted
 ----
 
 . Delete RBAC resources by using the following command:

--- a/modules/deleting-wmco-namespace.adoc
+++ b/modules/deleting-wmco-namespace.adoc
@@ -35,46 +35,11 @@ The `openshift-windows-machine-config-operator` namespace is reserved for WMCO r
 ----
 $ oc get pods --namespace openshift-windows-machine-config-operator
 ----
-
-. Delete the subscription and CSV: by using the following command:
-
-.. Ensure the latest version of the subscribed operator is identified in the `currentCSV` field by using the following command:
-+
-[source,terminal]
-----
-$ oc get subscription.operators.coreos.com windows-machine-config-operator -n openshift-windows-machine-config-operator -o yaml | grep currentCSV
-----
 +
 .Example output
 [source,terminal]
 ----
-  currentCSV: openshift-windows-machine-config-operator
-----
-
-.. Delete the subscription by using the following command:
-+
-[source,terminal]
-----
-$ oc delete subscription.operators.coreos.com windows-machine-config-operator -n openshift-windows-machine-config-operator
-----
-+
-.Example output
-[source,terminal]
-----
-subscription.operators.coreos.com "windows-machine-config-operator" deleted
-----
-
-.. Delete the CSV for the Operator in the target namespace  by using the following command with the `currentCSV` value from the previous step:
-+
-[source,terminal]
-----
-$ oc delete clusterserviceversion windows-machine-config-operator -n openshift-windows-machine-config-operator
-----
-+
-.Example output
-[source,terminal]
-----
-clusterserviceversion.operators.coreos.com "serverless-operator.v1.28.0" deleted
+No resources found in openshift-windows-machine-config-operator namespace.
 ----
 
 . Delete RBAC resources by using the following command:

--- a/modules/deleting-wmco-namespace.adoc
+++ b/modules/deleting-wmco-namespace.adoc
@@ -4,28 +4,45 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="deleting-wmco-namespace_{context}"]
-= Deleting the Windows Machine Config Operator namespace
+= Deleting the Windows Machine Config Operator namespace and operands
 
-You can delete the namespace that was generated for the Windows Machine Config Operator (WMCO) by default.
+After removing the Windows Machine Config Operator, it is recommended that you remove the other components associated with the Operator to avoid potential issues.
 
 .Prerequisites
 
+* The Windows `Machine` objects that hosted your Windows workloads are removed from your cluster.
 * The WMCO is removed from your cluster.
 
 .Procedure
 
-. Remove all Windows workloads that were created in the `openshift-windows-machine-config-operator` namespace:
+This procedure assumes that you are using the default `openshift-windows-machine-config-operator` namespace.
+
+// Removing the workloads and pods steps, as these should have been done as a prereq for removing the Operator
+
+. Delete the subscription
 +
 [source,terminal]
 ----
-$ oc delete --all pods --namespace=openshift-windows-machine-config-operator
+$ oc delete subscription -n openshift-windows-machine-config-operator windows-machine-config-operator
 ----
 
-. Verify that all pods in the `openshift-windows-machine-config-operator` namespace are deleted or are reporting a terminating state:
+. Delete the CSV
 +
 [source,terminal]
 ----
-$ oc get pods --namespace openshift-windows-machine-config-operator
+$ oc delete csv -n openshift-windows-machine-config-operator ${WMCO_CSV}
+----
+
+. Delete RBAC resources
++
+[source,terminal]
+----
+$ oc delete clusterrolebinding windows-instance-config-daemon
+----
++
+[source,terminal]
+----
+$ oc delete clusterroles windows-instance-config-daemon
 ----
 
 . Delete the `openshift-windows-machine-config-operator` namespace:

--- a/modules/deleting-wmco-namespace.adoc
+++ b/modules/deleting-wmco-namespace.adoc
@@ -17,23 +17,35 @@ After removing the Windows Machine Config Operator, it is recommended that you r
 
 This procedure assumes that you are using the default `openshift-windows-machine-config-operator` namespace.
 
-// Removing the workloads and pods steps, as these should have been done as a prereq for removing the Operator
+. Remove all resources that were created in the `openshift-windows-machine-config-operator` namespace by using the following command:
++
+[source,terminal]
+----
+$ oc delete --all pods --namespace=openshift-windows-machine-config-operator
+----
 
-. Delete the subscription
+. Verify that all pods in the `openshift-windows-machine-config-operator` namespace are deleted or are reporting a terminating state by using the following command:
++
+[source,terminal]
+----
+$ oc get pods --namespace openshift-windows-machine-config-operator
+----
+
+. Delete the subscription by using the following command:
 +
 [source,terminal]
 ----
 $ oc delete subscription -n openshift-windows-machine-config-operator windows-machine-config-operator
 ----
 
-. Delete the CSV
+. Delete the CSV by using the following command:
 +
 [source,terminal]
 ----
 $ oc delete csv -n openshift-windows-machine-config-operator ${WMCO_CSV}
 ----
 
-. Delete RBAC resources
+. Delete RBAC resources by using the following command:
 +
 [source,terminal]
 ----
@@ -45,7 +57,7 @@ $ oc delete clusterrolebinding windows-instance-config-daemon
 $ oc delete clusterroles windows-instance-config-daemon
 ----
 
-. Delete the `openshift-windows-machine-config-operator` namespace:
+. Delete the `openshift-windows-machine-config-operator` namespace by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/uninstalling-wmco.adoc
+++ b/modules/uninstalling-wmco.adoc
@@ -14,7 +14,7 @@ You can uninstall the Windows Machine Config Operator (WMCO) from your cluster.
 
 .Procedure
 
-. From the *Operators -> OperatorHub* page, use the *Filter by keyword* box to search for `Red Hat Windows Machine Config Operator`.
+. From the *Operators -> OperatorHub* page, use the *Filter by keyword* box to search for `Windows Machine Config Operator`.
 
 . Click the *Red Hat Windows Machine Config Operator* tile. The Operator tile indicates it is installed.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-44935

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
