### PR TITLE
OSDOCS-13448:Moved egress tech preview note into correct bullet point.

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-whats-new"]
 = What's new with {product-title}
+include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-whats-new
 
@@ -39,26 +40,25 @@ If your cluster uses the OpenShift SDN network plugin, you cannot upgrade to fut
 +
 For more information about migrating to OVN-Kubernetes, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#migrate-from-openshift-sdn[Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin].
 +
-[IMPORTANT]
-====
-Egress lockdown is a Technology Preview feature.
-====
-+
 * **Egress lockdown is now available as a Technology Preview on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-lockdown-install.adoc#rosa-hcp-egress-lockdown-install[Creating a {product-title} cluster with egress lockdown].
-
++
+--
+:FeatureName: Egress lockdown
+include::snippets/technology-preview.adoc[]
+--
 * **ROSA with HCP now creates independent security groups for the AWS PrivateLink endpoint and worker nodes.** {hcp-title} clusters version 4.17.2 and greater can now add additional AWS security groups to the AWS PrivateLink endpoint to allow additional ingress traffic to the cluster's API. For more information, see xref:../rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc#rosa-hcp-aws-private-security-groups_rosa-hcp-aws-private-creating-cluster[Adding additional AWS security groups to the AWS PrivateLink endpoint].
 
 * **Red{nbsp}Hat SRE log-based alerting endpoints have been updated.** {rosa-classic} customers who are using a firewall to control egress traffic can now remove all references to `*.osdsecuritylogs.splunkcloud.com:9997` from your firewall allowlist. {rosa-classic} clusters still require the `http-inputs-osdsecuritylogs.splunkcloud.com:443` log-based alerting endpoint to be accessible from the cluster.
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 * **ROSA with HCP now creates independent security groups for the AWS PrivateLink endpoint and worker nodes.** {hcp-title} clusters version 4.17.2 and greater can now add additional AWS security groups to the AWS PrivateLink endpoint to allow additional ingress traffic to the cluster's API. For more information, see xref:../rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc#rosa-hcp-aws-private-security-groups_rosa-hcp-aws-private-creating-cluster[Adding additional AWS security groups to the AWS PrivateLink endpoint].
-+
-[IMPORTANT]
-====
-Egress lockdown is a Technology Preview feature.
-====
-+
+
 * **Egress lockdown is now available as a Technology Preview on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-lockdown-install.adoc#rosa-hcp-egress-lockdown-install[Creating a {product-title} cluster with egress lockdown].
++
+--
+:FeatureName: Egress lockdown
+include::snippets/technology-preview.adoc[]
+--
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa[]
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13448

Link to docs preview:

- https://89156--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html

- https://89156--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html

Peer review:
- [x] Peer reviewer has approved this change.

**QE approval is not required**

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
