### PR TITLE
OCPBUGS#50931: Dropped the live migration section from 4.14 to 4.12 docs

### DIFF
--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -8,18 +8,7 @@ toc::[]
 
 As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the OpenShift SDN network plugin.
 
-The following methods exist for migrating from the OpenShift SDN network plugin to the OVN-Kubernetes plugin:
-
-Limited live migration (preferred method)::
-This is an automated process that migrates your cluster from OpenShift SDN to OVN-Kubernetes.
-
-Offline migration::
-This is a manual process that includes some downtime. This method is primarily used for self-managed {product-title} deployments, and consider using this method when you cannot perform a limited live migration to the OVN-Kubernetes network plugin.
-
-[WARNING]
-==== 
-For the limited live migration method only, do not automate the migration from OpenShift SDN to OVN-Kubernetes with a script or another tool such as Red{nbsp}Hat Ansible Automation Platform. This might cause outages or crash your {product-title} cluster.
-====
+You can use the offline migration method for migrating from the OpenShift SDN network plugin to the OVN-Kubernetes plugin. The offline migration method is a manual process that includes some downtime.
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-50931](https://issues.redhat.com/browse/OCPBUGS-50931)

Link to docs preview:
[Migrating from the OpenShift SDN network plugin](https://89157--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)


- [x] SME has approved this change (Andre Costa).
- [x] QE has approved this change. (Zhanqi Zhao)


4.14 plan to support live migration: https://issues.redhat.com/browse/NP-1076
