### PR TITLE
OCPBUGS50980 Need to make changes in the garbage collection documentation

### DIFF
--- a/modules/nodes-nodes-garbage-collection-configuring.adoc
+++ b/modules/nodes-nodes-garbage-collection-configuring.adoc
@@ -117,8 +117,8 @@ spec:
 For `evictionHard` you must specify all of these parameters.  If you do not specify all parameters, only the specified parameters are applied and the garbage collection will not function properly.
 <7> For container garbage collection: The duration to wait before transitioning out of an eviction pressure condition. Setting the `evictionPressureTransitionPeriod` parameter to `0` configures the default value of 5 minutes.
 <8> For image garbage collection: The minimum age for an unused image before the image is removed by garbage collection.
-<9> For image garbage collection: The percent of disk usage (expressed as an integer) that triggers image garbage collection.
-<10> For image garbage collection: The percent of disk usage (expressed as an integer) that image garbage collection attempts to free.
+<9> For image garbage collection: Image garbage collection is triggered at the specified percent of disk usage (expressed as an integer). This value must be greater than the `imageGCLowThresholdPercent` value.
+<10> For image garbage collection: Image garbage collection attempts to free resources to the specified percent of disk usage (expressed as an integer). This value must be less than the `imageGCHighThresholdPercent` value.
 
 . Run the following command to create the CR:
 +

--- a/modules/nodes-nodes-garbage-collection-images.adoc
+++ b/modules/nodes-nodes-garbage-collection-images.adoc
@@ -34,11 +34,11 @@ a custom resource.
 
 |`imageGCHighThresholdPercent`
 |The percent of disk usage, expressed as an integer, which triggers image
-garbage collection. The default is *85*.
+garbage collection. The default is *85*. This value must be greater than the `imageGCLowThresholdPercent` value.
 
 |`imageGCLowThresholdPercent`
 |The percent of disk usage, expressed as an integer, to which image garbage
-collection attempts to free. The default is *80*.
+collection attempts to free. The default is *80*. This value must be less than the `imageGCHighThresholdPercent` value.
 |===
 
 Two lists of images are retrieved in each garbage collector run:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-50980

mention that the  `imageGCHighThresholdPercent` and  `imageGCLowThresholdPercent` should have different values, when they are provided with the same values the kubelet  crashes and node goes to NotReady state.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

