### PR TITLE
OSDOCS#5627: Fix serviceAccountName field for OperatorGroup

### DIFF
--- a/modules/olm-operatorgroups-provided-apis-annotations.adoc
+++ b/modules/olm-operatorgroups-provided-apis-annotations.adoc
@@ -21,7 +21,7 @@ metadata:
   ...
 spec:
   selector: {}
-  serviceAccount:
+  serviceAccountName:
     metadata:
       creationTimestamp: null
   targetNamespaces:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5627

Versions: 4.12+

Preview: https://89166--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-provided-apis-annotation_olm-understanding-operatorgroups