### PR TITLE
OCPBUGS#31429: Fix ose-operator-registry-rhel9 pull specs

### DIFF
--- a/modules/olm-filtering-fbc.adoc
+++ b/modules/olm-filtering-fbc.adoc
@@ -6,7 +6,7 @@ ifdef::openshift-origin[]
 :registry-image: quay.io/operator-framework/opm:latest
 endif::[]
 ifndef::openshift-origin[]
-:registry-image: registry.redhat.io/openshift4/ose-operator-registry:v{product-version}
+:registry-image: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v{product-version}
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/olm-migrating-sqlite-catalog-to-fbc.adoc
+++ b/modules/olm-migrating-sqlite-catalog-to-fbc.adoc
@@ -34,7 +34,7 @@ $ opm migrate <registry_image> <fbc_directory>
 ----
 $ opm generate dockerfile <fbc_directory> \
   --binary-image \
-  registry.redhat.io/openshift4/ose-operator-registry:v{product-version}
+  registry.redhat.io/openshift4/ose-operator-registry-rhel9:v{product-version}
 ----
 
 .Next steps

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -7,7 +7,7 @@ ifdef::openshift-origin[]
 :catalog-name: catalog
 :index-image-pullspec: quay.io/operatorhubio/catalog:latest
 :index-image: catalog:latest
-:registry-image: quay.io/openshift/origin-operator-registry:4.9.0
+:registry-image: quay.io/openshift/origin-operator-registry:{product-version}
 :package1: couchdb-operator
 :package2: eclipse-che
 :package3: etcd
@@ -16,7 +16,7 @@ ifndef::openshift-origin[]
 :catalog-name: redhat-operators
 :index-image-pullspec: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
 :index-image: redhat-operator-index:v{product-version}
-:registry-image: registry.redhat.io/openshift4/ose-operator-registry:v4.9
+:registry-image: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v{product-version}
 :package1: advanced-cluster-management
 :package2: jaeger-product
 :package3: quay-operator

--- a/modules/olm-updating-sqlite-catalog-to-a-new-opm-version.adoc
+++ b/modules/olm-updating-sqlite-catalog-to-a-new-opm-version.adoc
@@ -26,7 +26,7 @@ endif::openshift-dedicated,openshift-rosa[]
 [source,terminal,subs="attributes+"]
 ----
 $ opm index add --binary-image \
-  registry.redhat.io/openshift4/ose-operator-registry:v{product-version} \
+  registry.redhat.io/openshift4/ose-operator-registry-rhel9:v{product-version} \
   --from-index <your_registry_image> \
   --bundles "" -t \<your_registry_image>
 ----

--- a/modules/olmv1-creating-fbc.adoc
+++ b/modules/olmv1-creating-fbc.adoc
@@ -6,7 +6,7 @@ ifdef::openshift-origin[]
 :registry-image: quay.io/operator-framework/opm:latest
 endif::[]
 ifndef::openshift-origin[]
-:registry-image: registry.redhat.io/openshift4/ose-operator-registry:v{product-version}
+:registry-image: registry.redhat.io/openshift4/ose-operator-registry-rhel9:v{product-version}
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/opm-cli-ref-generate.adoc
+++ b/modules/opm-cli-ref-generate.adoc
@@ -70,6 +70,6 @@ $ opm generate dockerfile <dcRootDir> [<flags>]
 ifndef::openshift-origin[]
 [NOTE]
 ====
-To build with the official Red Hat image, use the `registry.redhat.io/openshift4/ose-operator-registry:v{product-version}` value with the `-i` flag.
+To build with the official Red Hat image, use the `registry.redhat.io/openshift4/ose-operator-registry-rhel9:v{product-version}` value with the `-i` flag.
 ====
 endif::[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-31429

Versions: 4.15+

Adding `-rhel9` to the end of the image pull specs.

Preview:

- [89177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-ref.html](https://89177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-ref.html)
- [89177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/catalogs/creating-catalogs.html](https://89177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/catalogs/creating-catalogs.html)
- [89177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html](https://89177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html)