### PR TITLE
OSDOCS-11245 OSD minimum bandwidth

### DIFF
--- a/modules/mos-network-prereqs-min-bandwidth.adoc
+++ b/modules/mos-network-prereqs-min-bandwidth.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
 // * rosa_planning/rosa-sts-aws-prereqs.adoc
+// * rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
+// * rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
 
 [id="mos-network-prereqs-min-bandwidth_{context}"]
 = Minimum bandwidth

--- a/osd_planning/aws-ccs.adoc
+++ b/osd_planning/aws-ccs.adoc
@@ -10,12 +10,23 @@ toc::[]
 {product-title} provides a Customer Cloud Subscription (CCS) model that allows Red Hat to deploy and manage clusters into a customer’s existing Amazon Web Service (AWS) account.
 
 include::modules/ccs-aws-understand.adoc[leveloffset=+1]
+
 include::modules/ccs-aws-customer-requirements.adoc[leveloffset=+1]
+
 include::modules/ccs-aws-customer-procedure.adoc[leveloffset=+1]
+
 include::modules/ccs-aws-scp.adoc[leveloffset=+1]
+
 include::modules/ccs-aws-iam.adoc[leveloffset=+1]
+
 include::modules/ccs-aws-provisioned.adoc[leveloffset=+1]
-include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
+
+[id="aws-ccs-networking-prereqs_{context}"]
+== Networking prerequisites
+
+include::modules/mos-network-prereqs-min-bandwidth.adoc[leveloffset=+2]
+
+include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s): 4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-11245

Link to docs preview:
OSD:
- https://89189--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs.html

ROSA (unchanged, header comments updated to indicate correct assemblies):
- https://89189--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-cloud-expert-prereq-checklist.html
- https://89189--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-aws-prereqs.html
- https://89189--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html
- https://89189--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-cloud-expert-prereq-checklist.html
- https://89189--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html

QE review: N/A, approved previously for OSD, ROSA, and ROSA with HCP