### PR TITLE
TELCODOCS-2216: Enabling SR-IOV metrics backport

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -22,6 +22,8 @@ spec:
   enableInjector: true
   enableOperatorWebhook: true
   logLevel: 2
+  featureGates:
+    metricsExporter: false
 ----
 +
 [NOTE]
@@ -85,6 +87,14 @@ By default, this field is set to `true`.
 |Specifies the log verbosity level of the Operator.
 Set to `0` to show only the basic logs. Set to `2` to show all the available logs.
 By default, this field is set to `2`.
+
+|`spec.featureGates`
+|`map[string]bool`
+|Specifies whether to enable or disable the optional features. For example, `metricsExporter`.
+
+|`spec.featureGates.metricsExporter`
+|`boolean`
+|Specifies whether to enable or disable the SR-IOV Network Operator metrics. By default, this field is set to `false`.
 
 |====
 

--- a/modules/sriov-network-metrics-exporter.adoc
+++ b/modules/sriov-network-metrics-exporter.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="sriov-network-metrics-exporter_{context}"]
+= About the SR-IOV network metrics exporter
+
+The Single Root I/O Virtualization (SR-IOV) network metrics exporter reads the metrics for SR-IOV virtual functions (VFs) and exposes these VF metrics in Prometheus format. When the SR-IOV network metrics exporter is enabled, you can query the SR-IOV VF metrics by using the {product-title} web console to monitor the networking activity of the SR-IOV pods.
+
+When you query the SR-IOV VF metrics by using the web console, the SR-IOV network metrics exporter fetches and returns the VF network statistics along with the name and namespace of the pod that the VF is attached to.
+
+The SR-IOV VF metrics that the metrics exporter reads and exposes in Prometheus format are described in the following table:
+
+.SR-IOV VF metrics
+[%autowidth,options="header"]
+|====
+|Metric| Description |Example PromQL query to examine the VF metric
+
+|`sriov_vf_rx_bytes` |Received bytes per virtual function. |`sriov_vf_rx_bytes * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_tx_bytes` |Transmitted bytes per virtual function. |`sriov_vf_tx_bytes * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_rx_packets` |Received packets per virtual function. |`sriov_vf_rx_packets * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_tx_packets` |Transmitted packets per virtual function. |`sriov_vf_tx_packets * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_rx_dropped` |Dropped packets upon receipt per virtual function. |`sriov_vf_rx_dropped * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_tx_dropped` |Dropped packets during transmission per virtual function. |`sriov_vf_tx_dropped * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_rx_multicast` |Received multicast packets per virtual function. |`sriov_vf_rx_multicast * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_vf_rx_broadcast` |Received broadcast packets per virtual function. |`sriov_vf_rx_broadcast * on (pciAddr,node) group_left(pod,namespace,dev_type) sriov_kubepoddevice`
+|`sriov_kubepoddevice` |Virtual functions linked to active pods. |-
+
+|====
+
+You can also combine these queries with the kube-state-metrics to get more information about the SR-IOV pods. For example, you can use the following query to get the VF network statistics along with the application name from the standard Kubernetes pod label:
+
+[source,terminal]
+----
+(sriov_vf_tx_packets * on (pciAddr,node)  group_left(pod,namespace)  sriov_kubepoddevice) * on (pod,namespace) group_left (label_app_kubernetes_io_name) kube_pod_labels
+----

--- a/modules/sriov-operator-metrics.adoc
+++ b/modules/sriov-operator-metrics.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="sriov-operator-metrics_{context}"]
+= Enabling the SR-IOV network metrics exporter
+
+The Single Root I/O Virtualization (SR-IOV) network metrics exporter is disabled by default. To enable the metrics exporter, you must set the `spec.featureGates.metricsExporter` field to `true`.
+
+[IMPORTANT]
+====
+When the metrics exporter is enabled, the SR-IOV Network Operator deploys the metrics exporter only on nodes with SR-IOV capabilities.
+====
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+* You have logged in as a user with `cluster-admin` privileges.
+* You have installed the SR-IOV Network Operator.
+
+.Procedure
+
+. Enable cluster monitoring by running the following command:
++
+[source,terminal]
+----
+$ oc label ns/openshift-sriov-network-operator openshift.io/cluster-monitoring=true
+----
++
+To enable cluster monitoring, you must add the `openshift.io/cluster-monitoring=true` label in the namespace where you have installed the SR-IOV Network Operator.
+
+. Set the `spec.featureGates.metricsExporter` field to `true` by running the following command:
++
+[source,terminal]
+----
+$ oc patch -n openshift-sriov-network-operator sriovoperatorconfig/default \
+    --type='merge' -p='{"spec": {"featureGates": {"metricsExporter": true}}}'
+----
+
+.Verification
+
+. Check that the SR-IOV network metrics exporter is enabled by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-sriov-network-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                     READY   STATUS    RESTARTS   AGE
+operator-webhook-hzfg4                   1/1     Running   0          5d22h
+sriov-network-config-daemon-tr54m        1/1     Running   0          5d22h
+sriov-network-metrics-exporter-z5d7t     1/1     Running   0          10s
+sriov-network-operator-cc6fd88bc-9bsmt   1/1     Running   0          5d22h
+----
++
+The `sriov-network-metrics-exporter` pod must be in the `READY` state.
+
+. Optional: Examine the SR-IOV virtual function (VF) metrics by using the {product-title} web console. For more information, see "Querying metrics".

--- a/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc
+++ b/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc
@@ -12,9 +12,18 @@ include::modules/nw-sriov-configuring-operator.adoc[leveloffset=+1]
 
 include::modules/sriov-operator-hosted-control-planes.adoc[leveloffset=+2]
 
+include::modules/sriov-network-metrics-exporter.adoc[leveloffset=+1]
+
+include::modules/sriov-operator-metrics.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc#querying-metrics-for-all-projects-with-mon-dashboard_accessing-metrics-as-an-administrator[Querying metrics for all projects with the monitoring dashboard]
+* xref:../../../observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer.adoc#querying-metrics-for-user-defined-projects-with-mon-dashboard_accessing-metrics-as-a-developer[Querying metrics for user-defined projects as a developer]
+
 [id="configuring-sriov-operator-next-steps"]
 == Next steps
 
 * xref:../../../networking/hardware_networks/configuring-sriov-device.adoc#configuring-sriov-device[Configuring an SR-IOV network device]
 * Optional: xref:../../../networking/networking_operators/sr-iov-operator/uninstalling-sriov-operator.adoc#uninstalling-sriov-operator[Uninstalling the SR-IOV Network Operator]
-

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -699,6 +699,13 @@ For more information, see xref:../post_installation_configuration/changing-cloud
 [id="ocp-4-16-networking_{context}"]
 === Networking
 
+[id="ocp-4-16-sr-iov-network-metrics-exporter_{context}"]
+==== Enabling the SR-IOV network metrics exporter
+
+Starting in 4.16.38, you can query the Single Root I/O Virtualization (SR-IOV) virtual function (VF) metrics by using the {product-title} web console to monitor the networking activity of the SR-IOV pods. When you query the SR-IOV VF metrics by using the web console, the SR-IOV network metrics exporter fetches and returns the VF network statistics along with the name and namespace of the pod that the VF is attached to.
+
+For more information, see xref:../networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc#sriov-operator-metrics_configuring-sriov-operator[Enabling the SR-IOV network metrics exporter].
+
 [id="ocp-4-16-networking-openshift-sdn-upgrade-block_{context}"]
 ==== OpenShift SDN network plugin blocks future major upgrades
 


### PR DESCRIPTION
Version(s):
4.16.38+ only

Issue:
https://issues.redhat.com/browse/TELCODOCS-2216

Link to docs preview:

[Enabling the SR-IOV network metrics exporter (release notes update)](https://89198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-sr-iov-network-metrics-exporter_release-notes)

[About the SR-IOV network metrics exporter (conceptual and procedural information)](https://89198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.html#sriov-network-metrics-exporter_configuring-sriov-operator)

QE review:
- [x] QE has approved this change.

Additional information:
This is a manual cherrypick from 4.17. To be released alongside the 4.16.38 z-stream (subject to change).

This pull request adds to the 4.16 release notes, and so will the z-stream release - so this will likely require a rebase prior to merging. 