### PR TITLE
CNV-39489: Add the missing namespace definition to the example

### DIFF
--- a/modules/virt-configuring-secondary-network-vm-live-migration.adoc
+++ b/modules/virt-configuring-secondary-network-vm-live-migration.adoc
@@ -50,18 +50,19 @@ spec:
 +
 [source,terminal,subs="attributes+"]
 ----
-oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the name of the `NetworkAttachmentDefinition` object to the `spec.liveMigrationConfig` stanza of the `HyperConverged` CR:
 +
 .Example `HyperConverged` manifest
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
+  namespace: {CNVNamespace}
 spec:
   liveMigrationConfig:
     completionTimeoutPerGiB: 800


### PR DESCRIPTION
In addition, I noticed that the command in the previous step was missing the prompt so I added it to ensure it is formated the same way as other commands.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-39489](https://issues.redhat.com/browse/CNV-39489)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://89201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config.html#clipboard-3
- https://89201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-dedicated-network-live-migration.html#clipboard-2
- https://89201--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/post_installation_configuration/virt-post-install-network-config.html#clipboard-3
- https://89201--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/vm_networking/virt-dedicated-network-live-migration.html#clipboard-2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The `oc edit` command from the preceding step defines the namespace as one of its arguments, I verified that it is propagated to the YAML file and should therefore be included. I also noticed that the `oc` command was missing the command prompt and added it.

This issue is present in the documentation for OpenShift 4.14 and later.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
