### PR TITLE
TELCODOCS-2045 - flattening telco RDS TOC

### DIFF
--- a/scalability_and_performance/telco_reference_design_specs/telco-core-rds.adoc
+++ b/scalability_and_performance/telco_reference_design_specs/telco-core-rds.adoc
@@ -13,9 +13,9 @@ include::modules/telco-core-rds-product-version-use-model-overview.adoc[leveloff
 
 include::modules/telco-core-about-the-telco-core-cluster-use-model.adoc[leveloffset=+1]
 
-include::modules/telco-ran-core-ref-design-spec.adoc[leveloffset=+2]
+include::modules/telco-ran-core-ref-design-spec.adoc[leveloffset=+1]
 
-include::modules/telco-deviations-from-the-ref-design.adoc[leveloffset=+2]
+include::modules/telco-deviations-from-the-ref-design.adoc[leveloffset=+1]
 
 include::modules/telco-core-common-baseline-model.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/telco_reference_design_specs/telco-ran-du-rds.adoc
+++ b/scalability_and_performance/telco_reference_design_specs/telco-ran-du-rds.adoc
@@ -12,13 +12,13 @@ It captures the recommended, tested, and supported configurations to get reliabl
 
 include::modules/telco-ref-design-overview.adoc[leveloffset=+1]
 
-include::modules/telco-ran-core-ref-design-spec.adoc[leveloffset=+2]
+include::modules/telco-ran-core-ref-design-spec.adoc[leveloffset=+1]
 
-include::modules/telco-deviations-from-the-ref-design.adoc[leveloffset=+2]
+include::modules/telco-deviations-from-the-ref-design.adoc[leveloffset=+1]
 
-include::modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc[leveloffset=+2]
+include::modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc[leveloffset=+1]
 
-include::modules/telco-ran-du-application-workloads.adoc[leveloffset=+2]
+include::modules/telco-ran-du-application-workloads.adoc[leveloffset=+1]
 
 include::modules/telco-ran-du-reference-design-components.adoc[leveloffset=+1]
 
@@ -113,7 +113,7 @@ include::modules/telco-ran-red-hat-advanced-cluster-management-rhacm.adoc[levelo
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes[Red Hat Advanced Cluster Management for Kubernetes]
 
-include::modules/telco-ran-siteconfig-operator.adoc[leveloffset=+1]
+include::modules/telco-ran-siteconfig-operator.adoc[leveloffset=+2]
 
 include::modules/telco-ran-topology-aware-lifecycle-manager-talm.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Correcting TOC level errors in the telco RDS.

Version(s):
enterprise-4.18, enterprise-4.19

Issue:
https://issues.redhat.com/browse/TELCODOCS-2045

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE review not required.
