### PR TITLE
OSDOCS-13435:refactor of UDN docs

### DIFF
--- a/modules/nw-cudn-about.adoc
+++ b/modules/nw-cudn-about.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-cudn_{context}"]
+= About the ClusterUserDefinedNetwork CR
+
+The `ClusterUserDefinedNetwork` (UDN) custom resource (CR) provides cluster-scoped network segmentation and isolation for administrators only.
+
+The following diagram demonstrates how a cluster administrator can use the `ClusterUserDefinedNetwork` CR to create network isolation between tenants. This network configuration allows a network to span across many namespaces. In the diagram, network isolation is achieved through the creation of two user-defined networks, `udn-1` and `udn-2`. These networks are not connected and the `spec.namespaceSelector.matchLabels` field is used to select different namespaces. For example, `udn-1` configures and isolates communication for `namespace-1` and `namespace-2`, while `udn-2` configures and isolates communication for `namespace-3` and `namespace-4`. Isolated tenants (Tenants 1 and Tenants 2) are created by separating namespaces while also allowing pods in the same namespace to communicate.
+
+.Tenant isolation using ClusterUserDefinedNetwork CR
+image::528-OpenShift-multitenant-0225.png[The tenant isolation concept in a user-defined network (UDN)]

--- a/modules/nw-udn-about.adoc
+++ b/modules/nw-udn-about.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-udn_{context}"]
+= About the UserDefinedNetwork CR
+
+The `UserDefinedNetwork` (UDN) custom resource (CR) provides advanced network segmentation and isolation for users and administrators.
+
+The following diagram shows four cluster namespaces, where each namespace has a single assigned user-defined network (UDN), and each UDN has an assigned custom subnet for its pod IP allocations. The OVN-Kubernetes handles any overlapping UDN subnets. Without using the Kubernetes network policy, a pod attached to a UDN can communicate with other pods in that UDN. By default, these pods are isolated from communicating with pods that exist in other UDNs. For microsegmentation, you can apply network policy within a UDN. You can assign one or more UDNs to a namespace, with a limitation of only one primary UDN to a namespace, and one or more namespaces to a UDN.
+
+.Namespace isolation using UserDefinedNetwork CR
+image::527-OpenShift-UDN-isolation-012025.png[The namespace isolation concept in a user-defined network (UDN)]

--- a/networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
+++ b/networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
@@ -6,14 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+Before the implementation of user-defined networks (UDN), the OVN-Kubernetes CNI plugin for {product-title} only supported a Layer 3 topology on the primary or _main_ network. Due to Kubernetes design principles: all pods are attached to the main network, all pods communicate with each other by their IP addresses, and inter-pod traffic is restricted according to network policy.
 
-Before the implementation of user-defined networks (UDNs) in the default the OVN-Kubernetes CNI plugin for {product-title}, the Kubernetes Layer 3 topology was supported as the primary network, or _main_ network, to where all pods attach. The Kubernetes design principle requires that all pods communicate with each other by their IP addresses, and Kubernetes restricts inter-pod traffic according to the Kubernetes network policy. While the Kubernetes design is useful for simple deployments, the Layer 3 topology restricts customization of primary network segment configurations, especially for modern multi-tenant deployments.
+While the Kubernetes design is useful for simple deployments, this Layer 3 topology restricts customization of primary network segment configurations, especially for modern multi-tenant deployments.
 
 UDN improves the flexibility and segmentation capabilities of the default Layer 3 topology for a Kubernetes pod network by enabling custom Layer 2, Layer 3, and localnet network segments, where all these segments are isolated by default. These segments act as either primary or secondary networks for container pods and virtual machines that use the default OVN-Kubernetes CNI plugin. UDNs enable a wide range of network architectures and topologies, enhancing network flexibility, security, and performance. You can build a UDN by using a Virtual Router Function (VRF).
-
-The following diagram shows four cluster namespaces, where each namespace has a single assigned UDN, and each UDN has an assigned custom subnet for its pod IP allocations. The OVN-Kubernetes handles any overlapping UDN subnets. Without using the Kubernetes network policy, a pod attached to a UDN can communicate with other pods in that UDN. By default, these pods are isolated from communicating with pods that exist in other UDNs. For microsegmentation, you can apply the Kubernetes network policy within a UDN. You can assign one or more UDNs to a namespace, with a limitation of only one primary UDN to a namespace, and one or more namespaces to a UDN.
-
-image::527-OpenShift-UDN-isolation-012025.png[The namespace isolation concept in a user-defined network (UDN)]
 
 [NOTE]
 ====
@@ -21,10 +18,6 @@ Nodes that use `cgroupv1` Linux Control Groups (cgroup) must be reconfigured fro
 ====
 
 A cluster administrator can use a user-defined network to create and define additional networks that span multiple namespaces at the cluster level by leveraging the `ClusterUserDefinedNetwork` custom resource (CR). Additionally, a cluster administrator or a cluster user can use a user-defined network to define additional networks at the namespace level with the `UserDefinedNetwork` CR.
-
-The following diagram shows tenant isolation that a cluster administrator created by defining a `ClusterUserDefinedNetwork` CR for each tenant. This network configuration allows a network to span across many namespaces. In the diagram, the `udn-1` disconnected network selects `namespace-1` and `namespace-2`, while the `udn-2` disconnected network selects `namespace-3` and `namespace-4`. A tenant acts as a disconnected network that is isolated from other tenants' networks. Pods from a namespace can communicate with pods in another namespace only if those namespaces exist in the same tenant network.
-
-image::528-OpenShift-multitenant-0225.png[The tenant isolation concept in a user-defined network (UDN)]
 
 The following sections further emphasize the benefits and limitations of user-defined networks, the best practices when creating a `ClusterUserDefinedNetwork` or `UserDefinedNetwork` CR, how to create the CR, and additional configuration details that might be relevant to your deployment.
 
@@ -34,24 +27,30 @@ include::modules/nw-udn-benefits.adoc[leveloffset=+1]
 //Limitations that users should consider for UDN.
 include::modules/nw-udn-limitations.adoc[leveloffset=+1]
 
+//About CUDN CR
+include::modules/nw-cudn-about.adoc[leveloffset=+1]
+
 //Best practices for using CUDN.
-include::modules/nw-cudn-best-practices.adoc[leveloffset=+1]
+include::modules/nw-cudn-best-practices.adoc[leveloffset=+2]
 
 //How to implement the CUDN API on a cluster.
-include::modules/nw-cudn-cr.adoc[leveloffset=+1]
+include::modules/nw-cudn-cr.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.adoc#configuring-pods-static-ip_configuring-additional-network-ovnk[Configuring pods with a static IP address]
 
+// About the UDN CR
+include::modules/nw-udn-about.adoc[leveloffset=+1]
+
 //Best practices for using UDN.
-include::modules/nw-udn-best-practices.adoc[leveloffset=+1]
+include::modules/nw-udn-best-practices.adoc[leveloffset=+2]
 
 //How to implement the UDN API on a cluster.
-include::modules/nw-udn-cr.adoc[leveloffset=+1]
+include::modules/nw-udn-cr.adoc[leveloffset=+2]
 
 //Explanation of optional config details
-include::modules/nw-udn-additional-config-details.adoc[leveloffset=+1]
+include::modules/nw-udn-additional-config-details.adoc[leveloffset=+2]
 
 //UDN/CUDN status conditions
 include::modules/cudn-status-conditions.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-13435
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
For reviewers this is a refractor with very minor wording changes that are focused on minimalism. The [modules/nw-cudn-about.adoc](https://github.com/openshift/openshift-docs/pull/89210/files#diff-a462cc0c5c98634f723a2d1038e9d1cb3d755d9ad182a5837c6252c22f0c58ab) looks entirely new because of our modularization. The updates move the UDN [diagram](https://github.com/openshift/openshift-docs/pull/89210/files#diff-3b931ff4d98ce8b85a1482e4b33a95a0ca205fb5868b95611ec0a0073ae7584dL14-L17) and the CUDN [diagram](https://github.com/openshift/openshift-docs/pull/89210/files#diff-3b931ff4d98ce8b85a1482e4b33a95a0ca205fb5868b95611ec0a0073ae7584dL25-L28) into new modules with minor wording changes. This achieves a better ux in the sidebar navigation through a more symmetrical organizational structure in the docs. 

- CUDN CR about the [Original](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/multiple-networks#about-user-defined-networks:~:text=A%20cluster%20administrator,same%20tenant%20network.) vs [New](https://89210--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html#about-cudn_about-user-defined-networks)
- UDN CR about the [Original](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/multiple-networks#about-user-defined-networks:~:text=The%20following%20diagram,to%20a%20UDN.) vs [New](https://89210--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html#about-udn_about-user-defined-networks)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
