### PR TITLE
OCPBUGS-44464: Fixed the TAP note

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -892,7 +892,7 @@ For further information about all-multicast mode, see xref:../networking/hardwar
 [id="ocp-4-14-tap-device-plugin"]
 ==== Enhance network flexibility by using the TAP device plugin
 
-This release introduces a new Container Network Interface (CNI) network plugin type: the Tanzu Application Platform (TAP) device plugin. You can use this plugin to create TAP devices within containers, which enables user-space programs to handle network frames and act as an interface that receives frames from and that sends frames to user-space applications instead of through traditional network interfaces. For more information, see xref:../networking/multiple_networks/configuring-additional-network.html#nw-multus-tap-object_configuring-additional-network[Configuration for a TAP additional network].
+This release introduces a new Container Network Interface (CNI) network plugin type: the TAP device plugin. You can use this plugin to create TAP devices within containers, which enables user-space programs to handle network frames and act as an interface that receives frames from and that sends frames to user-space applications instead of through traditional network interfaces. For more information, see xref:../networking/multiple_networks/configuring-additional-network.html#nw-multus-tap-object_configuring-additional-network[Configuration for a TAP additional network].
 
 [id="ocp-4-14-non-root-dpdk"]
 ==== Support for running rootless DPDK workloads with kernel access by using the TAP CNI plugin


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OCPBUGS-44464](https://issues.redhat.com/browse/OCPBUGS-44464)

Link to docs preview:
https://89211--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-tap-device-plugin

