### PR TITLE
CNV#56500: [Docs] Incorrect yaml for HostPathProvisioner

### DIFF
--- a/modules/virt-creating-hpp-basic-storage-pool.adoc
+++ b/modules/virt-creating-hpp-basic-storage-pool.adoc
@@ -33,9 +33,9 @@ spec:
   storagePools: <1>
   - name: any_name
     path: "/var/myvolumes" <2>
-workload:
-  nodeSelector:
-    kubernetes.io/os: linux
+  workload:
+    nodeSelector:
+      kubernetes.io/os: linux
 ----
 <1> The `storagePools` stanza is an array to which you can add multiple entries.
 <2> Specify the storage pool directories under this node path.


### PR DESCRIPTION
Version(s): 4.17+

Issue: [CNV-56500](https://issues.redhat.com/browse/CNV-56500)

Link to docs preview: [Creating a hostpath provisioner with a basic storage pool](https://89234--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-local-storage-with-hpp.html)

QE review:
- [x] QE has approved this change.

