### PR TITLE
OCPBUGS#38094: Correcting the image name for cluster node tuning operator

### DIFF
--- a/modules/cnf-configuring-power-saving-for-nodes.adoc
+++ b/modules/cnf-configuring-power-saving-for-nodes.adoc
@@ -24,7 +24,7 @@ The feature is supported on Intel Ice Lake and later generations of Intel CPUs. 
 [source,terminal,subs="attributes+"]
 ----
 $ podman run --entrypoint performance-profile-creator -v \
-/must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v{product-version} \
+/must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} \
 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true \
 --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node \
 --must-gather-dir-path /must-gather --power-consumption-mode=low-latency \ <1>


### PR DESCRIPTION
OCPBUGS#38094: Correcting the image name for cluster node tuning operator in one of the procedures

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-38094

Link to docs preview:
https://89235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html#cnf-configuring-power-saving-for-nodes_cnf-low-latency-perf-profile 

QE review:
- [x] QE has approved this change.
