### PR TITLE
OSDOCS-13429: 4.17.18 RN

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2879,6 +2879,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.18
+[id="ocp-4-17-18_{context}"]
+=== RHSA-2025:1703 - {product-title} {product-version}.18 bug fix, and security update advisory
+
+Issued: 26 February 2025
+
+{product-title} release {product-version}.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1703[RHSA-2025:1703] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:1706[RHBA-2025:1706] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.18 --pullspecs
+----
+
+[id="ocp-4-17-18-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the control plane Operator did not honor the set PROXY environment variables when it checked the API endpoint availability. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-50596[*OCPBUGS-50596*]) 
+
+* Previously, when installing a cluster on {aws-first} in existing subnets that were located in edge zones, such as a AWS Local Zone or a Wavelength Zone, the `kubernetes.io/cluster/<InfraID>:shared` tag was missing in the subnet resources of the edge zone. With this release, a fix ensures that all subnets that are used in the `install-config.yaml` configuration file have the required tag. (link:https://issues.redhat.com/browse/OCPBUGS-49975[*OCPBUGS-49975*])
+
+* Previously, incorrect addresses were being passed to the Kubernetes `EndpointSlice` on a cluster, and this issue prevented the installation of the MetalLB Operator on an Agent-based cluster in an IPv6 disconnected environment. With this release, a fix modifies the address evaluation method. Red{nbsp}Hat Marketplace pods can now successfully connect to the cluster API server, so that the installation of MetalLB Operator and handling of ingress traffic in IPv6 disconnected environments can occur. (link:https://issues.redhat.com/browse/OCPBUGS-46665[*OCPBUGS-46665*])
+
+* Previously, the method to validate the container image architecture did not go through the image metadata provider. As a consequence, the image overrides did not take effect. With this release, the methods on the image metadata provider were modified to allow multi-architecture validations, and those methods were propagated through all components for image validation steps. As a result, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-46664[*OCPBUGS-46664*])
+
+[id="ocp-4-17-18-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.17
 [id="ocp-4-17-17_{context}"]
 === RHSA-2025:1403 - {product-title} {product-version}.17 bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13429](https://issues.redhat.com/browse/OSDOCS-13429)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A

Additional information:
Errata urls will return 404 until go-live (2/26)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
