### PR TITLE
OCPBUGS#14747: Removing redhat-support-tool since it no longer ships …

### DIFF
--- a/modules/about-toolbox.adoc
+++ b/modules/about-toolbox.adoc
@@ -7,7 +7,7 @@
 = About `toolbox`
 
 ifndef::openshift-origin[]
-`toolbox` is a tool that starts a container on a {op-system-first} system. The tool is primarily used to start a container that includes the required binaries and plugins that are needed to run commands such as `sosreport` and `redhat-support-tool`.
+`toolbox` is a tool that starts a container on a {op-system-first} system. The tool is primarily used to start a container that includes the required binaries and plugins that are needed to run commands such as `sosreport`.
 
 The primary purpose for a `toolbox` container is to gather diagnostic information and to provide it to Red Hat Support. However, if additional diagnostic tools are required, you can add RPM packages or run an image that is an alternative to the standard support tools image.
 endif::openshift-origin[]

--- a/modules/support-collecting-network-trace.adoc
+++ b/modules/support-collecting-network-trace.adoc
@@ -109,15 +109,6 @@ $ tcpdump -nn -s 0 -i ens5 -w /host/var/tmp/my-cluster-node_$(date +%d_%m_%Y-%H_
 
 . Provide the `tcpdump` capture file to Red Hat Support for analysis, using one of the following methods.
 +
-* Upload the file to an existing Red Hat support case directly from an {product-title} cluster.
-.. From within the toolbox container, run `redhat-support-tool` to attach the file directly to an existing Red Hat Support case. This example uses support case ID `01234567`:
-+
-[source,terminal]
-----
-# redhat-support-tool addattachment -c 01234567 /host/var/tmp/my-tcpdump-capture-file.pcap <1>
-----
-<1> The toolbox container mounts the host's root directory at `/host`. Reference the absolute path from the toolbox container's root directory, including `/host/`, when specifying files to upload through the `redhat-support-tool` command.
-+
 * Upload the file to an existing Red Hat support case.
 
 .. Concatenate the `sosreport` archive by running the `oc debug node/<node_name>` command and redirect the output to a file. This command assumes you have exited the previous `oc debug` session:

--- a/modules/support-generating-a-sosreport-archive.adoc
+++ b/modules/support-generating-a-sosreport-archive.adoc
@@ -114,15 +114,6 @@ The checksum is: 382ffc167510fd71b4f12a4f40b97a4e
 
 . Provide the `sosreport` archive to Red Hat Support for analysis, using one of the following methods.
 +
-* Upload the file to an existing Red Hat support case directly from an {product-title} cluster.
-.. From within the toolbox container, run `redhat-support-tool` to attach the archive directly to an existing Red Hat support case. This example uses support case ID `01234567`:
-+
-[source,terminal]
-----
-# redhat-support-tool addattachment -c 01234567 /host/var/tmp/my-sosreport.tar.xz <1>
-----
-<1> The toolbox container mounts the host's root directory at `/host`. Reference the absolute path from the toolbox container's root directory, including `/host/`, when specifying files to upload through the `redhat-support-tool` command.
-+
 * Upload the file to an existing Red Hat support case.
 .. Concatenate the `sosreport` archive by running the `oc debug node/<node_name>` command and redirect the output to a file. This command assumes you have exited the previous `oc debug` session:
 +

--- a/modules/support-providing-diagnostic-data-to-red-hat.adoc
+++ b/modules/support-providing-diagnostic-data-to-red-hat.adoc
@@ -6,7 +6,7 @@
 [id="support-providing-diagnostic-data-to-red-hat_{context}"]
 = Providing diagnostic data to Red Hat Support
 
-When investigating {product-title} issues, Red Hat Support might ask you to upload diagnostic data to a support case. Files can be uploaded to a support case through the Red Hat Customer Portal, or from an {product-title} cluster directly by using the `redhat-support-tool` command.
+When investigating {product-title} issues, Red Hat Support might ask you to upload diagnostic data to a support case. Files can be uploaded to a support case through the Red Hat Customer Portal.
 
 .Prerequisites
 

--- a/support/index.adoc
+++ b/support/index.adoc
@@ -54,7 +54,6 @@ ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * *Cluster node journal logs*: Gather `journald` unit logs and logs within `/var/log` on individual cluster nodes to troubleshoot node-related issues.
 * *A network trace*: Provide a network packet trace from a specific {product-title} cluster node or a container to Red Hat Support to help troubleshoot network-related issues.
-* *Diagnostic data*: Use the `redhat-support-tool` command to gather(?) diagnostic data about your cluster.
 
 [id='support-overview-troubleshooting-issues']
 == Troubleshooting issues


### PR DESCRIPTION
…with RHEL 9

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-14747

Link to docs preview:
* https://89251--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html
* https://89251--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/index.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
