### PR TITLE
OSDOCS-13349: What's new entry cluster autoscaling for ROSA HCP

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -18,6 +18,15 @@ toc::[]
 === Q1 2025
 
 ifdef::openshift-rosa[]
+//Remove when ROSA HCP is published.
+* **Cluster autoscaling is now available for {hcp-title}.** You can configure cluster autoscaling for {hcp-title}. For more information, see xref:../rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc#rosa-cluster-autoscaling-hcp[Cluster autoscaling].
+endif::openshift-rosa[]
+
+ifdef::openshift-rosa-hcp[]
+* **Cluster autoscaling is now available for {product-title}.** You can configure cluster autoscaling for {product-title}. For more information, see xref:../rosa_cluster_admin/rosa-cluster-autoscaling.adoc#rosa-cluster-autoscaling[Cluster autoscaling].
+endif::openshift-rosa-hcp[]
+
+ifdef::openshift-rosa[]
 * **New version of {product-title} available.** {product-title} version 4.18 is now available. For more information about upgrading to this latest version, see xref:../upgrading/rosa-upgrading-sts.adoc#rosa-upgrading-sts[Upgrading ROSA (classic architecture) clusters].
 endif::openshift-rosa[]
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13349

Link to docs preview:
**HCP:** https://89253--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html
**Classic:** https://89253--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
