### PR TITLE
OSDOCS#13430: Update the z-stream RN for 4.15.46

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2779,6 +2779,36 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.46
+[id="ocp-4-15-46_{context}"]
+=== RHSA-2025:1711 - {product-title} 4.15.46 bug fix and security update
+
+Issued: 27 February 2025
+
+{product-title} release 4.15.46, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1711[RHSA-2025:1711] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1713[RHSA-2025:1713] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.46 --pullspecs
+----
+
+[id="ocp-4-15-46-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, if you tried to rerun a resolver-based `PipelineRun` from the {product-title} console, the `Invalid PipelineRun configuration, unable to start Pipeline` UI message was displayed. With this release, you can rerun a resolver-based `PipelineRun` with no problem. (link:https://issues.redhat.com/browse/OCPBUGS-48593[*OCPBUGS-48593*])
+
+* Previously, a bug caused requests to update the `deploymentconfigs/scale` sub resource to fail when a matching admission webhook was configured. With this release, you can update to continue without an error. (link:https://issues.redhat.com/browse/OCPBUGS-47766[*OCPBUGS-47766*])
+
+* Previously, the installation program did not validate the maximum transmission unit (MTU) for custom networks on Red{nbsp}Hat OpenStack platforms, which led to an installation failure when the MTU was too small. For IPv6, the minimum MTU is 1280 and 100 for OVN-Kubernetes. With this release, the installation program validates the MTU of Red{nbsp}Hat OpenStack custom networks. (link:https://issues.redhat.com/browse/OCPBUGS-41815[*OCPBUGS-41815*])
+
+[id="ocp-4-15-46-updating_{context}"]
+==== Updating
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.15.45
 [id="ocp-4-15-45_{context}"]
 === RHSA-2025:1128 - {product-title} 4.15.45 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-13430](https://issues.redhat.com/browse/OSDOCS-13430)

Link to docs preview:
[4.15.46](https://89262--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-46_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 02/27/25.
