### PR TITLE
OCPBUGS#49922: Deleted pod examples from nmstate-deploying-nmstate-CL…

### DIFF
--- a/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
+++ b/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
@@ -77,7 +77,7 @@ $ oc get clusterserviceversion -n openshift-nmstate \
 [source, terminal,subs="attributes+"]
 ----
 Name                                             Phase
-kubernetes-nmstate-operator.4.18.0-202210210157   Succeeded
+kubernetes-nmstate-operator.4.18.0-202210210157  Succeeded
 ----
 
 . Create an instance of the `nmstate` Operator:
@@ -92,7 +92,7 @@ metadata:
 EOF
 ----
 
-. Verify the pods for NMState Operator are running:
+. Verify that all pods for the NMState Operator are in a `Running` state:
 +
 [source,terminal]
 ----
@@ -103,15 +103,8 @@ $ oc get pod -n openshift-nmstate
 [source, terminal,subs="attributes+"]
 ----
 Name                                      Ready   Status  Restarts  Age
-pod/nmstate-cert-manager-5b47d8dddf-5wnb5   1/1   Running  0         77s
-pod/nmstate-console-plugin-d6b76c6b9-4dcwm  1/1   Running  0         77s
-pod/nmstate-handler-6v7rm                   1/1   Running  0         77s
-pod/nmstate-handler-bjcxw                   1/1   Running  0         77s
-pod/nmstate-handler-fv6m2                   1/1   Running  0         77s
-pod/nmstate-handler-kb8j6                   1/1   Running  0         77s
-pod/nmstate-handler-wn55p                   1/1   Running  0         77s
-pod/nmstate-operator-f6bb869b6-v5m92        1/1   Running  0        4m51s
-pod/nmstate-webhook-66d6bbd84b-6n674        1/1   Running  0         77s
-pod/nmstate-webhook-66d6bbd84b-vlzrd        1/1   Running  0         77s
+pod/nmstate-handler-wn55p                 1/1     Running  0        77s
+pod/nmstate-operator-f6bb869b6-v5m92      1/1     Running  0        4m51s
+...
 ----
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-49922](https://issues.redhat.com/browse/OCPBUGS-49922)

Link to docs preview:
https://89282--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html#installing-the-kubernetes-nmstate-operator-CLI_k8s-nmstate-operator


- [x] SME has approved this change.
- [x] QE has approved this change.

