### PR TITLE
TELCODOCS-2215: Clarifying extra manifest order of application

### DIFF
--- a/modules/cnf-image-based-upgrade-prep-extramanifests.adoc
+++ b/modules/cnf-image-based-upgrade-prep-extramanifests.adoc
@@ -8,6 +8,11 @@
 
 Create additional manifests that you want to apply to the target cluster.
 
+[NOTE]
+====
+If you add more than one extra manifest, and the manifests must be applied in a specific order, you must prefix the filenames of the manifests with numbers that represent the required order. For example, `00-namespace.yaml`, `01-sriov-extra-manifest.yaml`, and so on.
+====
+
 .Procedure
 
 . Create a YAML file that contains your extra manifests, such as SR-IOV.

--- a/modules/ibi-extra-manifests-configmap.adoc
+++ b/modules/ibi-extra-manifests-configmap.adoc
@@ -83,6 +83,11 @@ $ oc create configmap sr-iov-extra-manifest --from-file=sriov-extra-manifest.yam
 ----
 configmap/sr-iov-extra-manifest created
 ----
++
+[NOTE]
+====
+If you add more than one extra manifest, and the manifests must be applied in a specific order, you must prefix the filenames of the manifests with numbers that represent the required order. For example, `00-namespace.yaml`, `01-sriov-extra-manifest.yaml`, and so on.
+====
 
 . Reference the `ConfigMap` resource in the `spec.extraManifestsRefs` field of the `ImageClusterInstall` resource:
 +

--- a/modules/ibi-extra-manifests-standalone.adoc
+++ b/modules/ibi-extra-manifests-standalone.adoc
@@ -21,6 +21,11 @@ You can create a resource in the `extra-manifests` folder of your working direct
 
 The following example adds an single-root I/O virtualization (SR-IOV) network to the deployment.
 
+[NOTE]
+====
+If you add more than one extra manifest, and the manifests must be applied in a specific order, you must prefix the filenames of the manifests with numbers that represent the required order. For example, `00-namespace.yaml`, `01-sriov-extra-manifest.yaml`, and so on.
+====
+
 .Prerequisites
 
 * You created a working directory with the `install-config.yaml` and `image-based-config.yaml` manifests


### PR DESCRIPTION
[TELCODOCS-2215](https://issues.redhat.com//browse/TELCODOCS-2215): Clarifying extra manifest order of application

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2215

Link to docs preview:
https://89296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install.html#ibi-create-extra-manifest-configmap_ibi-edge-image-based-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
