### PR TITLE
TELCODOCS-2105: Moving from TP to GA for EgressService and Metalb VRF features

### DIFF
--- a/modules/nw-egress-service-ovn.adoc
+++ b/modules/nw-egress-service-ovn.adoc
@@ -15,6 +15,7 @@ The following example configures the egress traffic to have the same source IP a
 * Install the OpenShift CLI (`oc`).
 * Log in as a user with `cluster-admin` privileges.
 * You configured MetalLB `BGPPeer` resources.
+* You use OVN-Kubernetes configured with the `gatewayConfig.routingViaHost` specification set to `true` only.
 
 .Procedure
 

--- a/modules/nw-metallb-configure-return-traffic-proc.adoc
+++ b/modules/nw-metallb-configure-return-traffic-proc.adoc
@@ -10,11 +10,11 @@ You can configure symmetric network routing for applications behind a MetalLB se
 
 This example associates a VRF routing table with MetalLB and an egress service to enable symmetric routing for ingress and egress traffic for pods behind a `LoadBalancer` service.
 
-[NOTE]
+[IMPORTANT]
 ====
 * If you use the `sourceIPBy: "LoadBalancerIP"` setting in the `EgressService` CR, you must specify the load-balancer node in the `BGPAdvertisement` custom resource (CR).
 
-* You can use the `sourceIPBy: "Network"` setting on clusters that use OVN-Kubernetes configured with the `gatewayConfig.routingViaHost` specification set to `true` only. Additionally, if you use the `sourceIPBy: "Network"` setting, you must schedule the application workload on nodes configured with the network VRF instance.
+* To configure an egress service for pods behind a load balancer service, you must configure OVN-Kubernetes with the `gatewayConfig.routingViaHost` specification set to `true`. For more information about this configuration, see "Cluster Network Operator in {product-title}" in _Networking Operators_.
 ====
 
 .Prerequisites

--- a/modules/nw-metallb-configure-vrf-bgppeer.adoc
+++ b/modules/nw-metallb-configure-vrf-bgppeer.adoc
@@ -8,9 +8,6 @@
 
 You can expose a service through a virtual routing and forwarding (VRF) instance by associating a VRF on a network interface with a BGP peer.
 
-:FeatureName: Exposing a service through a VRF on a BGP peer
-include::snippets/technology-preview.adoc[]
-
 By using a VRF on a network interface to expose a service through a BGP peer, you can segregate traffic to the service, configure independent routing decisions, and enable multi-tenancy support on a network interface.
 
 [NOTE]

--- a/networking/metallb/metallb-configure-return-traffic.adoc
+++ b/networking/metallb/metallb-configure-return-traffic.adoc
@@ -10,9 +10,6 @@ As a cluster administrator, you can effectively manage traffic for pods behind a
 
 To achieve this functionality, learn how to implement virtual routing and forwarding (VRF) instances with MetalLB, and configure egress services.
 
-:FeatureName: Configuring symmetric traffic by using a VRF instance with MetalLB and an egress service
-include::snippets/technology-preview.adoc[]
-
 [id="challenges-of-managing-symmetric-routing-with-metallb"]
 == Challenges of managing symmetric routing with MetalLB
 
@@ -62,3 +59,5 @@ include::modules/nw-metallb-configure-return-traffic-proc.adoc[leveloffset=+1]
 * xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-host-vrf_k8s-nmstate-updating-node-network-config[Example: Network interface with a VRF instance node network configuration policy]
 
 * xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc#configuring-egress-traffic-loadbalancer-services[Configuring an egress service]
+
+* xref:../../networking/networking_operators/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator configuration object]

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc
@@ -8,8 +8,10 @@ toc::[]
 
 As a cluster administrator, you can configure egress traffic for pods behind a load balancer service by using an egress service.
 
-:FeatureName: Egress service
-include::snippets/technology-preview.adoc[]
+[NOTE]
+====
+To configure an egress service for pods behind a load balancer service, you must configure OVN-Kubernetes with the `gatewayConfig.routingViaHost` specification set to `true`. For more information about this configuration, see xref:../../networking/networking_operators/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator configuration object] in _Networking Operators_.
+====
 
 You can use the `EgressService` custom resource (CR) to manage egress traffic in the following ways:
 


### PR DESCRIPTION
[TELCODOCS-2105](https://issues.redhat.com//browse/TELCODOCS-2105): Moving from TP to GA for EgressService and Metalb VRF features.

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2105
https://issues.redhat.com/browse/TELCODOCS-2106

Link to docs preview:
- https://89322--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-bgp-peer-vrf_configure-metallb-bgp-peers
- https://89322--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-return-traffic.html
- https://89322--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
