### PR TITLE
OCPBUGS-27077:updates routingViaHost limitations

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -355,6 +355,10 @@ One of the following additional audit log targets:
 |`routingViaHost`
 |`boolean`
 |Set this field to `true` to send egress traffic from pods to the host networking stack.
+[NOTE]
+====
+In {product-title} {version}, egress IP is only assigned to the primary interface. Consequentially, setting `routingViaHost` to `true` will not work for egress IP in {product-title} {version}.
+====
 For highly-specialized installations and applications that rely on manually configured routes in the kernel routing table, you might want to route egress traffic to the host networking stack.
 By default, egress traffic is processed in OVN to exit the cluster and is not affected by specialized routes in the kernel routing table.
 The default value is `false`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-27077
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://github.com/openshift/openshift-docs/pull/89326/files#:~:text=89326%2D%2Docpdocs%2Dpr.netlify.app/openshift%2Denterprise/latest/networking/cluster%2Dnetwork%2Doperator%23nw%2Doperator%2Dcr_cluster%2Dnetwork%2Doperator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
