### PR TITLE
OCPBUGS-36534: Updated the CurrentImagePullSecret note

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -4789,7 +4789,7 @@ $ oc adm release info 4.16.1 --pullspecs
 
 * Previously, the Source-to-Image (S2I) build strategy needed to be explicitly added to the `func.yaml` in order to create the Serverless function. Additionally, the error message did not indicate the problem. With this release, if S2I is not added, users can still create the Serverless function. However, if it is not S2I, users cannot create the function. Additionally, the error messages have been updated to provide more information. (link:https://issues.redhat.com/browse/OCPBUGS-34717[*OCPBUGS-34717*])
 
-* Previously, the `CurrentImagePullSecret` field on the `MachineOSConfig` object was not being used in when rolling out new on-cluster layering build images.. With this release, the `CurrentImagePullSecret` field on the `MachineOSConfig` object is allowed to be used by the image rollout process. (link:https://issues.redhat.com/browse/OCPBUGS-34261[*OCPBUGS-34261*])
+* Previously, the `CurrentImagePullSecret` field on the `MachineOSConfig` object was not being used when rolling out new on-cluster layering build images. With this release, the `CurrentImagePullSecret` field on the `MachineOSConfig` object is allowed to be used by the image rollout process. (link:https://issues.redhat.com/browse/OCPBUGS-34261[*OCPBUGS-34261*])
 
 * Previously, when sending multiple failing port-forwarding requests, CRI-O memory usage increases until the node dies. With this release, the memory leakage when sending a failing port-forward request is fixed and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-30978[*OCPBUGS-30978*])
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OCPBUGS-36534](https://issues.redhat.com/browse/OCPBUGS-36534)

Link to docs preview:
https://89327--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-1_release-notes
