### PR TITLE
CNV#40962: Documentation Issue in Regards to SSP Operator

### DIFF
--- a/modules/virt-connecting-vm-virtctl.adoc
+++ b/modules/virt-connecting-vm-virtctl.adoc
@@ -41,6 +41,7 @@ $ virtctl console <vm_name>
 . Press `Ctrl+]` to end the console session.
 endif::[]
 ifdef::vnc-console[]
++
 [source,terminal]
 ----
 $ virtctl vnc <vm_name>

--- a/modules/virt-temporary-token-VNC.adoc
+++ b/modules/virt-temporary-token-VNC.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/virt-accessing-vm-consoles.adoc
+// * virt/managing_vms/virt-accessing-vm-consoles.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-temporary-token-VNC_{context}"]
@@ -15,7 +15,7 @@ Kubernetes also supports authentication using client certificates, instead of a 
 
 .Prerequisites
 
-* A running VM with {VirtProductName} 4.14 or later and xref:../../virt/about-virt/virt-architecture#virt-about-ssp-operator_virt-architecture[`ssp-operator`] 4.14 or later
+* A running VM with {VirtProductName} 4.14 or later and `ssp-operator` 4.14 or later.
 
 .Procedure
 

--- a/virt/managing_vms/virt-accessing-vm-consoles.adoc
+++ b/virt/managing_vms/virt-accessing-vm-consoles.adoc
@@ -21,15 +21,14 @@ You can connect to the VNC console of a virtual machine by using the {product-ti
 :context: vnc-console
 include::modules/virt-connecting-to-vm-console-web.adoc[leveloffset=+2]
 include::modules/virt-connecting-vm-virtctl.adoc[leveloffset=+2]
-:!vnc-console:
-
-:context: vnc-console
 include::modules/virt-temporary-token-VNC.adoc[leveloffset=+2]
-:!vnc-console:
 
-:context: vnc-console
+[role="_additional-resources"]
+.Additional resources
+* xref:../../virt/about_virt/virt-architecture.adoc#virt-about-ssp-operator_virt-architecture[About the Scheduling, Scale, and Performance (SSP) Operator]
+
 include::modules/virt-cluster-role-VNC.adoc[leveloffset=+3]
-:!vnc-console:
+:context: virt-accessing-vm-consoles
 
 [id="serial-console_virt-accessing-vm-consoles"]
 == Connecting to the serial console
@@ -44,7 +43,7 @@ Running concurrent VNC connections to a single virtual machine is not currently 
 :context: serial-console
 include::modules/virt-connecting-to-vm-console-web.adoc[leveloffset=+2]
 include::modules/virt-connecting-vm-virtctl.adoc[leveloffset=+2]
-:!serial-console:
+:context: virt-accessing-vm-consoles
 
 [id="desktop-viewer_virt-accessing-vm-consoles"]
 == Connecting to the desktop viewer
@@ -53,4 +52,4 @@ You can connect to a Windows virtual machine (VM) by using the desktop viewer an
 
 :context: desktop-viewer
 include::modules/virt-connecting-to-vm-console-web.adoc[leveloffset=+2]
-:!desktop-viewer:
+:context: virt-accessing-vm-consoles


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/CNV-50962

Link to docs preview:
https://89338--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-accessing-vm-consoles.html#virt-temporary-token-VNC_vnc-console

QE review:
- [x] QE has approved this change.

Additional information:
Along with fixing the broken link, we did some cleaning up on the assembly file to be more consistent with our guidelines. Also this is for the 4.18+ docs and #89344 is for the 4.14-4.17 docs. This is necessary due to a major refactoring that took place.
