### PR TITLE
OSDOCS-13225 Admonition note for HighNodeUtilization

### DIFF
--- a/modules/nodes-scheduler-profiles-about.adoc
+++ b/modules/nodes-scheduler-profiles-about.adoc
@@ -14,4 +14,9 @@ The following scheduler profiles are available:
 
 `HighNodeUtilization`:: This profile attempts to place as many pods as possible on to as few nodes as possible. This minimizes node count and has high resource usage per node.
 
+[NOTE]
+====
+Switching to the `HighNodeUtilization` scheduler profile will result in all pods of a `ReplicaSet` object being scheduled on the same node. This will add an increased risk for pod failure if the node fails.
+====
+
 `NoScoring`:: This is a low-latency profile that strives for the quickest scheduling cycle by disabling all score plugins. This might sacrifice better scheduling decisions for faster ones.


### PR DESCRIPTION
Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13225](https://issues.redhat.com/browse/OSDOCS-13225)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://89339--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-profiles.html#nodes-scheduler-profiles-about_nodes-scheduler-profiles 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
