### PR TITLE
OSDOCS-13469: Created a 4.19 release note stump file

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ocp-4-19-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/common-attributes.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch that they are relevant for.
+
+Release note changes should be added or edited in their own PR.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
Version(s):
main only- separate PR for 4.19

Issue:
[OSDOCS-13469](https://issues.redhat.com/browse/OSDOCS-13469)

Link to docs preview:

* No preview as the file will not be published but is needed for build reasons.
