### PR TITLE
OSDOCS-13295: update RHDE page for Microshift 4.19

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -10,11 +10,11 @@
 :op-system-base: RHEL
 :op-system-ostree-first: Red Hat Enterprise Linux (RHEL) for Edge
 :op-system-ostree: RHEL for Edge
-:op-system-version: 9.4
+:op-system-version: 9.6
 :op-system-version-major: 9
 :microshift-first: Red Hat build of MicroShift (MicroShift)
 :microshift-short: MicroShift
-:microshift-version: 4.18
+:microshift-version: 4.19
 :rhde: Red Hat Device Edge
 :ansible: Red Hat Ansible Automation Platform
 :ansible-version: 2.5

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -23,18 +23,20 @@ The latest release notes for each product that is part of {product-title} are av
 
 * link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{microshift-version}/html/red_hat_build_of_microshift_release_notes/index[{microshift-first}]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.2_release_notes/index[{op-system-ostree-first}] 9.2 release notes contain details about {op-system-ostree}
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.2_release_notes/index[{op-system-first}] 9.2 release notes.
 
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.3_release_notes/index[{op-system-ostree-first}] 9.3 release notes contain details about {op-system-ostree}
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.3_release_notes/index[{op-system-first}] 9.3 release notes.
 
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.4_release_notes/index[{op-system-ostree-first}] 9.4 release notes contain details about {op-system-ostree}
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.4_release_notes/index[{op-system-first}] 9.4 release notes.
 
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/release_notes/index[{ansible} Release Notes]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.6_release_notes/index[{op-system-first}] 9.6 release notes.
+
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{ansible-version}/html/red_hat_ansible_automation_platform_release_notes/index[{ansible} Release Notes]
 
 [id="device-edge-compatibility_{context}"]
 == {product-title} product release compatibility matrix
 
-{op-system-base} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.14 to 4.16 requires a {op-system-base} update. Supported configurations of {product-title} use verified releases for each together as listed in the following table:
+{op-system-base} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.14 to 4.16 or an update from 4.18 to 4.19 requires a {op-system-base} update. Supported configurations of {product-title} use verified releases for each together as listed in the following table:
 
 [%header,cols="3",cols="1,1,2"]
 |===
@@ -42,9 +44,13 @@ The latest release notes for each product that is part of {product-title} are av
 ^|*{microshift-short} Version*
 ^|*Supported {microshift-short} Version{nbsp}&#8594;{nbsp}Version Updates*
 
+^|9.6
+^|4.19
+^|4.19.0{nbsp}&#8594;{nbsp}4.19.z
+
 ^|9.4
 ^|4.18
-^|4.18.0{nbsp}&#8594;{nbsp}4.18.z
+^|4.18.0{nbsp}&#8594;{nbsp}4.18.z, 4.18{nbsp}&#8594;{nbsp}4.19 on {op-system-base} 9.6
 
 ^|9.4
 ^|4.17
@@ -56,11 +62,11 @@ The latest release notes for each product that is part of {product-title} are av
 
 ^|9.2, 9.3
 ^|4.15
-^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16 on {op-system} 9.4
+^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
 
 ^|9.2, 9.3
 ^|4.14
-^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15, 4.14{nbsp}&#8594;{nbsp}4.16 on {op-system} 9.4
+^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15, 4.14{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
 |===
 
 [id="device-edge-compatibility-ansible_{context}"]

--- a/overview/rhde-overview.adoc
+++ b/overview/rhde-overview.adoc
@@ -3,6 +3,6 @@
 include::_attributes/common-attributes.adoc[]
 :context: device-edge-overview
 
-{product-title} delivers an enterprise-ready distribution of the Red Hat-led open source community project {microshift-first}. {microshift} is a lightweight Kubernetes orchestration solution built from the edge capabilities of {OCP}, along with an edge-optimized operating system built from {op-system-first}.
+{product-title} delivers an enterprise-ready distribution of the Red Hat-led open source community project {microshift-first}. {microshift-short} is a lightweight Kubernetes orchestration solution built from the edge capabilities of {OCP}, along with an edge-optimized operating system built from {op-system-first}.
 
 include::modules/about-rhde.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
RHDE 4

Issue:
[OSDOCS-13295](https://issues.redhat.com/browse/OSDOCS-13295)

Link to docs preview:
[RHDE overview](https://89360--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

QE review:
- [x] QE has approved this change.

Additional information:
OK to merge, but NOT to sync and publish until 4.19 is released.

