### PR TITLE
OSDOCS-13297: updates attributes and compatibility table in MicroShift

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,14 +4,14 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.18
+:ocp-version: 4.19
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 //OpenShift Kubernetes Engine
 :oke: OpenShift Kubernetes Engine
 :product-title-first: Red Hat build of MicroShift (MicroShift)
 :microshift-short: MicroShift
 :product-registry: OpenShift image registry
-:product-version: 4.18
+:product-version: 4.19
 :rhel-major: rhel-9
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system-base: RHEL
@@ -20,9 +20,9 @@
 :op-system-rt-kernel: Red Hat Enterprise Linux for Real Time (real-time kernel)
 :op-system-rtk: real-time kernel
 :op-system-image: image mode for RHEL
-:op-system-version: 9.4
+:op-system-version: 9.6
 :op-system-version-major: 9
 :op-system-bundle: Red Hat Device Edge
-:rpm-repo-version: rhocp-4.18
+:rpm-repo-version: rhocp-4.19
 :rhde-version: 4
 :VirtProductName: OpenShift Virtualization

--- a/microshift_cli_ref/microshift-usage-oc-kubectl.adoc
+++ b/microshift_cli_ref/microshift-usage-oc-kubectl.adoc
@@ -35,7 +35,7 @@ The additional command `oc new-app`, for example, makes it easier to get new app
 If you installed an earlier version of `oc`, you might not be able use it to complete all of the commands in {microshift-short} {product-version}. If you want the latest features, you must download and install the latest version of `oc` that corresponds with your {microshift-short} version.
 ====
 
-Using new capabilities often requires the latest `oc` binary. A 4.18 server might have additional capabilities that a 4.16 `oc` binary cannot use and a 4.18 `oc` binary might have additional capabilities that are unsupported by a 4.15 server.
+Using new capabilities often requires the latest `oc` binary. A 4.19 server might have additional capabilities that a 4.16 `oc` binary cannot use and a 4.19 `oc` binary might have additional capabilities that are unsupported by a 4.15 server.
 
 .Compatibility Matrix
 

--- a/microshift_networking/microshift_multiple_networks/microshift-cni-multus-using.adoc
+++ b/microshift_networking/microshift_multiple_networks/microshift-cni-multus-using.adoc
@@ -26,4 +26,4 @@ include::modules/microshift-cni-multus-troubleshoot.adoc[leveloffset=+1]
 == Additional resources
 * xref:../../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-cni-multus[About using multiple networks]
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.18/html/networking/multiple-networks#nw-multus-ipam-object_configuring-additional-network[Configuration of IP address assignment for an additional network]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking/multiple-networks#nw-multus-ipam-object_configuring-additional-network[Configuration of IP address assignment for an additional network]

--- a/microshift_updating/microshift-update-rpms-manually.adoc
+++ b/microshift_updating/microshift-update-rpms-manually.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Updating {product-title} for non-OSTree systems such as {op-system-base-full} requires updating the RPMs. For patch releases, such as 4.18.1 to 4.18.2, simply update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
+Updating {product-title} for non-OSTree systems such as {op-system-base-full} requires updating the RPMs. For patch releases, such as 4.19.1 to 4.19.2, simply update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
 
 [NOTE]
 ====

--- a/microshift_updating/microshift-update-rpms-ostree.adoc
+++ b/microshift_updating/microshift-update-rpms-ostree.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Updating {microshift-short} on an `rpm-ostree` system such as {op-system-ostree-first} requires building a new {op-system-ostree} image containing the new version of {microshift-short} and any associated optional RPMs. After you have the `rpm-ostree` image with {microshift-short} embedded, direct your system to boot into that operating system image.
 
-The procedures are the same for minor-version and patch updates. For example, use the same steps to upgrade from 4.17 to 4.18 or from 4.18.2 to 4.18.3.
+The procedures are the same for minor-version and patch updates. For example, use the same steps to upgrade from 4.18 to 4.19 or from 4.19.2 to 4.19.3.
 
 [NOTE]
 ====

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -37,7 +37,7 @@ groups = []
 
 [[packages]]
 name = "microshift"
-version = "4.18.1" <3>
+version = "4.19.1" <3>
 
 [customizations.services]
 enabled = ["microshift"]
@@ -45,7 +45,7 @@ EOF
 ----
 <1> The name of the TOML file.
 <2> The name of the blueprint.
-<3> Substitute the value for the version you want. For example, insert `4.18.1` to download the {microshift-short} 4.18.1 RPMs.
+<3> Substitute the value for the version you want. For example, insert `4.19.1` to download the {microshift-short} 4.19.1 RPMs.
 
 . Optional. Use the blueprint installed in the `/usr/share/microshift/blueprint` directory that is specific to your platform architecture. See the following example snippet for an explanation of the blueprint sections:
 +

--- a/modules/microshift-embed-microshift-image-offline-deploy.adoc
+++ b/modules/microshift-embed-microshift-image-offline-deploy.adoc
@@ -25,11 +25,11 @@ You can use image builder to create {op-system-ostree} images with embedded {mic
 
 .. Install the `microshift-release-info` RPM package by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo dnf install -y microshift-release-info-<release_version>
+$ sudo dnf install -y microshift-release-info-_<release_version>_
 ----
-Replace `<release_version>` with the numerical value of the release you are deploying, using the entire version number, such as `4.18.1`.
+Replace `_<release_version>_` with the numerical value of the release you are deploying, using the entire version number, such as `4.19.1`.
 
 .. List the contents of the `/usr/share/microshift/release` directory to verify the presence of the release information files by running the following command:
 +
@@ -55,7 +55,7 @@ If you installed the `microshift-release-info` RPM, proceed to step 4.
 ----
 $ sudo dnf download microshift-release-info-_<release_version>_ # <1>
 ----
-<1> Replace `_<release_version>_` with the numerical value of the release you are deploying, using the entire version number, such as `4.18.1`.
+<1> Replace `_<release_version>_` with the numerical value of the release you are deploying, using the entire version number, such as `4.19.1`.
 +
 .Example RPM output
 [source,terminal,subs="+quotes"]

--- a/modules/microshift-install-rpms.adoc
+++ b/modules/microshift-install-rpms.adoc
@@ -20,30 +20,30 @@ Use the following procedure to install {microshift-short} from an RPM package.
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-<4.18>-for-<9>-$(uname -m)-rpms \ # <1>
-    --enable fast-datapath-for-<9>-$(uname -m)-rpms # <2>
+    --enable rhocp-_<4.19>_-for-_<9>_-$(uname -m)-rpms \ # <1>
+    --enable fast-datapath-for-_<9>_-$(uname -m)-rpms # <2>
 ----
-<1> Replace _<4.18>_ and _<9>_ with the compatible versions of your {microshift-short} and {op-system-base-full}.
-<2> Replace  _<9>_ with the compatible version of {op-system-base}.
+<1> Replace `_<4.19>_` and `_<9>_` with the compatible versions of your {microshift-short} and {op-system-base-full}.
+<2> Replace  `_<9>_` with the compatible version of {op-system-base}.
 
 . For extended support (EUS) releases, also enable the EUS repositories by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 `$ sudo subscription-manager repos \
-    --enable rhel-<9>-for-x86_64-appstream-eus-rpms \ # <1>
-    --enable rhel-<9>-for-x86_64-baseos-eus-rpms` # <2>
+    --enable rhel-_<9>_-for-x86_64-appstream-eus-rpms \ # <1>
+    --enable rhel-_<9>_-for-x86_64-baseos-eus-rpms` # <2>
 ----
-<1> Replace _<9>_ with the compatible major version number of {op-system-base}.
-<2> Replace _<9>_ with the compatible major version number of {op-system-base}.
+<1> Replace `_<9>_` with the compatible major version number of {op-system-base}.
+<2> Replace `_<9>_` with the compatible major version number of {op-system-base}.
 
 . Avoid unintended future updates into an unsupported configuration by locking your operating system version with the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo subscription-manager release --set=<9.4> command. # <1>
+$ sudo subscription-manager release --set=_<9.6>_ command. # <1>
 ----
-<1> Replace _<9.4>_ with the major and minor version of your compatible {op-system-base} system.
+<1> Replace `_<9.6>_` with the major and minor version of your compatible {op-system-base} system.
 
 . Install {microshift-short} by running the following command:
 +

--- a/modules/microshift-oc-mirror-creating-imageset-config.adoc
+++ b/modules/microshift-oc-mirror-creating-imageset-config.adoc
@@ -43,10 +43,10 @@ storageConfig:
 mirror:
   platform: # <1>
     channels:
-    - name: stable-4.18
+    - name: stable-4.19
       type: ocp
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
     packages:
     - name: serverless-operator
       channels:
@@ -72,7 +72,7 @@ storageConfig: <1>
     skipTLS: false
 mirror:
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18 <3>
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19 <3>
     packages:
     - name: amq-broker-rhel8 <4>
       channels:

--- a/modules/microshift-updates-troubleshooting.adoc
+++ b/modules/microshift-updates-troubleshooting.adoc
@@ -22,17 +22,6 @@ Check the following compatibility table:
 
 include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+2]
 
-[id="microshift-version-compatibility_{context}"]
-=== Version compatibility
-Check the following update paths:
-
-*{product-title} update paths*
-
-* Generally Available Version 4.18.0 to 4.18.z on {op-system-base} 9.4
-* Generally Available Version 4.17.1 to 4.17.z on {op-system-base} 9.4
-* Generally Available Version 4.15.0 from {op-system-base} 9.2 to 4.16.0 on {op-system-base} 9.4
-* Generally Available Version 4.14.0 from {op-system-base} 9.2 to 4.15.0 on {op-system-base} 9.4
-
 [id="microshift-ostree-update-failed_{context}"]
 == OSTree update failed
 If you updated on an OSTree system, the Greenboot health check automatically logs and acts on system health. A failure can be indicated by a system rollback by Greenboot. In cases where the update failed, but Greenboot did not complete a system rollback, you can troubleshoot using the {op-system-ostree} documentation linked in the "Additional resources" section that follows this content.

--- a/modules/microshift-updating-rpms-z.adoc
+++ b/modules/microshift-updating-rpms-z.adoc
@@ -6,7 +6,7 @@
 [id="microshift-applying-patch-updates-rpms_{context}"]
 = Applying patch updates using RPMs
 
-Updating {microshift-short} on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to upgrade from 4.18.1 to 4.18.2.
+Updating {microshift-short} on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to upgrade from 4.19.1 to 4.19.2.
 
 .Prerequisites
 * The system requirements for installing {microshift-short} have been met.

--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -7,7 +7,7 @@
 
 .{op-system-bundle} release compatibility matrix
 
-{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
+{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.14 to 4.16 or an update from 4.18 to 4.19 requires a {op-system-base-full} update. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
 
 [%header,cols="3",cols="1,1,2"]
 |===
@@ -15,9 +15,13 @@
 ^|*{microshift-short} Version*
 ^|*Supported {microshift-short} Version{nbsp}&#8594;{nbsp}Version Updates*
 
+^|9.6
+^|4.19
+^|4.19.0{nbsp}&#8594;{nbsp}4.19.z
+
 ^|9.4
 ^|4.18
-^|4.18.0{nbsp}&#8594;{nbsp}4.18.z
+^|4.18.0{nbsp}&#8594;{nbsp}4.18.z, 4.18{nbsp}&#8594;{nbsp}4.19 on {op-system-base} 9.6
 
 ^|9.4
 ^|4.17


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-13297](https://issues.redhat.com/browse/OSDOCS-13297)

Link to docs preview:
[Compatibility table](https://89382--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready#get-ready-install-rhde-compatibility-table_microshift-install-get-ready)
[The oc CLI tool](https://89382--ocpdocs-pr.netlify.app/microshift/latest/microshift_cli_ref/microshift-usage-oc-kubectl)
[Additional resources](https://89382--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus-using#additional-resources_microshift-cni-multus-using_microshift-cni-multus-using)
[Applying patch updates using RPMs](https://89382--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually#microshift-applying-patch-updates-rpms_microshift-update-rpms-manually)
[Updating RPMs on an OSTree system](https://89382--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-ostree)
[Troubleshooting updates versions](https://89382--ocpdocs-pr.netlify.app/microshift/latest/microshift_troubleshooting/microshift-troubleshoot-updates)
[Installing MicroShift from an RPM package](https://89382--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm/microshift-install-rpm#installing-microshift-from-rpm-package_microshift-install-rpm)
[System requirements for installing MicroShift](https://89382--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready#microshift-install-system-requirements_microshift-install-get-ready)

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
- Refer to the PR #[89360](https://github.com/openshift/openshift-docs/pull/89360) for QE approval on the compatibility table changes.

