### PR TITLE
OSDOCS10896: Update Custom Metrics Autoscaler documentation for ClusterTriggerAuthentication implementation

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
+++ b/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
@@ -8,6 +8,8 @@
 
 You can use the installed {product-title} Prometheus monitoring as a source for the metrics used by the custom metrics autoscaler. However, there are some additional configurations you must perform.
 
+For your scaled objects to be able to read the {product-title} Prometheus metrics, you must use a trigger authentication or a cluster trigger authentication in order to provide the authentication information required. The following procedure differs depending on which trigger authentication method you use. For more information on trigger authentications, see "Understanding custom metrics autoscaler trigger authentications". 
+
 [NOTE]
 ====
 These steps are not required for an external Prometheus source.
@@ -32,12 +34,16 @@ You must perform the following tasks, as described in this section:
 
 .Procedure
 
-. Change to the project with the object you want to scale:
+. Change to the appropriate project:
 +
 [source,terminal]
 ----
-$ oc project my-project
+$ oc project <project_name> <1>
 ----
+<1> Specifies one of the following projects:
++
+*  If you are using a trigger authentication, specify the project with the object you want to scale.
+*  If you are using a cluster trigger authentication, specify the `openshift-keda` project.
 
 . Create a service account and token, if your cluster does not have one:
 
@@ -47,7 +53,6 @@ $ oc project my-project
 ----
 $ oc create serviceaccount thanos <1>
 ----
-+
 <1> Specifies the name of the service account.
 
 .. Create a `secret` YAML to generate a service account token:
@@ -62,7 +67,6 @@ metadata:
     kubernetes.io/service-account.name: thanos <1>
 type: kubernetes.io/service-account-token
 ----
-+
 <1> Specifies the name of the service account.
 
 .. Create the secret object by using the following command:
@@ -86,7 +90,7 @@ $ oc describe serviceaccount thanos <1>
 [source,terminal]
 ----
 Name:                thanos
-Namespace:           my-project
+Namespace:           <namespace_name>
 Labels:              <none>
 Annotations:         <none>
 Image pull secrets:  thanos-dockercfg-nnwgj
@@ -105,22 +109,27 @@ Events:              <none>
 [source,yaml]
 ----
 apiVersion: keda.sh/v1alpha1
-kind: TriggerAuthentication
+kind: <authentication_method> <1>
 metadata:
   name: keda-trigger-auth-prometheus
 spec:
-  secretTargetRef: <1>
-  - parameter: bearerToken <2>
-    name: thanos-token <3>
-    key: token <4>
+  secretTargetRef: <2>
+  - parameter: bearerToken <3>
+    name: thanos-token <4>
+    key: token <5>
   - parameter: ca
     name: thanos-token
     key: ca.crt
 ----
-<1> Specifies that this object uses a secret for authorization.
-<2> Specifies the authentication parameter to supply by using the token.
-<3> Specifies the name of the token to use.
-<4> Specifies the key in the token to use with the specified parameter.
+<1> Specifies one of the following trigger authentication methods:
++
+*  If you are using a trigger authentication, specify `TriggerAuthentication`. This example configures a trigger authentication.
+*  If you are using a cluster trigger authentication, specify `ClusterTriggerAuthentication`.
++
+<2> Specifies that this object uses a secret for authorization.
+<3> Specifies the authentication parameter to supply by using the token.
+<4> Specifies the name of the token to use.
+<5> Specifies the key in the token to use with the specified parameter.
 
 .. Create the CR object:
 +
@@ -171,23 +180,32 @@ $ oc create -f <file-name>.yaml
 [source,yaml]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: <binding_type> <1>
 metadata:
-  name: thanos-metrics-reader <1>
-  namespace: my-project <2>
+  name: thanos-metrics-reader <2>
+  namespace: my-project <3>
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: thanos-metrics-reader
 subjects:
 - kind: ServiceAccount
-  name: thanos <3>
-  namespace: my-project <4>
+  name: thanos <4>
+  namespace: <namespace_name> <5>
 ----
-<1> Specifies the name of the role you created.
-<2> Specifies the namespace of the object you want to scale.
-<3> Specifies the name of the service account to bind to the role.
-<4> Specifies the namespace of the object you want to scale.
+<1> Specifies one of the following object types:
++
+*  If you are using a trigger authentication, specify `RoleBinding`.
+*  If you are using a cluster trigger authentication, specify `ClusterRoleBinding`.
++
+<2> Specifies the name of the role you created.
+<3> Specifies one of the following projects:
++
+*  If you are using a trigger authentication, specify the project with the object you want to scale.
+*  If you are using a cluster trigger authentication, specify the `openshift-keda` project.
++
+<4> Specifies the name of the service account to bind to the role.
+<5> Specifies the project where you previously created the service account.
 
 .. Create the CR object:
 +

--- a/nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc
@@ -23,6 +23,11 @@ You can configure a certificate authority xref:../../nodes/cma/nodes-cma-autosca
 
 include::modules/nodes-cma-autoscaling-custom-trigger-prom.adoc[leveloffset=+1]
 include::modules/nodes-cma-autoscaling-custom-prometheus-config.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc#nodes-cma-autoscaling-custom-trigger-auth[Understanding custom metrics autoscaler trigger authentications]
+
 include::modules/nodes-cma-autoscaling-custom-trigger-cpu.adoc[leveloffset=+1]
 include::modules/nodes-cma-autoscaling-custom-trigger-memory.adoc[leveloffset=+1]
 include::modules/nodes-cma-autoscaling-custom-trigger-kafka.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10896

Preview:
[Configuring the custom metrics autoscaler to use OpenShift Container Platform monitoring](https://89402--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger.html#nodes-cma-autoscaling-custom-prometheus-config_nodes-cma-autoscaling-custom-trigger) -- Myriad changes, including: 
* new 2nd paragraph; 
* Procedure step 1; 
* Procedure 2d; 
* Procedure 3a callout 1 only;  
* Procedure 5a callouts 1, 3 and 5 only; 
* Additional resources at end of module. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
