### PR TITLE
OSDOCS-12564: Adds all of the Observability book to HCP

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1238,6 +1238,37 @@ Name: Observability
 Dir: observability
 Distros: openshift-rosa-hcp
 Topics:
+- Name: Observability overview
+  Dir: overview
+  Topics:
+  - Name: About Observability
+    File: index
+- Name: Monitoring
+  Dir: monitoring
+  Distros: openshift-rosa-hcp
+  Topics:
+  - Name: Monitoring overview
+    File: monitoring-overview
+  - Name: Accessing monitoring for user-defined projects
+    File: sd-accessing-monitoring-for-user-defined-projects
+  - Name: Configuring the monitoring stack
+    File: configuring-the-monitoring-stack
+  - Name: Disabling monitoring for user-defined projects
+    File: sd-disabling-monitoring-for-user-defined-projects
+  - Name: Enabling alert routing for user-defined projects
+    File: enabling-alert-routing-for-user-defined-projects
+  - Name: Managing metrics
+    File: managing-metrics
+  - Name: Managing alerts
+    File: managing-alerts
+  - Name: Reviewing monitoring dashboards
+    File: reviewing-monitoring-dashboards
+  - Name: Accessing third-party monitoring APIs
+    File: accessing-third-party-monitoring-apis
+  - Name: Troubleshooting monitoring issues
+    File: troubleshooting-monitoring-issues
+  - Name: Config map reference for the Cluster Monitoring Operator
+    File: config-map-reference-for-the-cluster-monitoring-operator
 - Name: Logging
   Dir: logging
   Distros: openshift-rosa-hcp

--- a/observability/monitoring/accessing-third-party-monitoring-apis.adoc
+++ b/observability/monitoring/accessing-third-party-monitoring-apis.adoc
@@ -40,9 +40,9 @@ include::modules/monitoring-resources-reference-for-the-cluster-monitoring-opera
 [id="additional-resources_{context}"]
 == Additional resources
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects-uwm_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-remote-write-storage_configuring-the-monitoring-stack[Configuring remote write storage]
 * xref:../../observability/monitoring/managing-metrics.adoc#managing-metrics[Managing metrics]
 * xref:../../observability/monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]

--- a/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -18,10 +18,10 @@ toc::[]
 Parts of {product-title} cluster monitoring are configurable.
 The API is accessible by setting parameters defined in various config maps.
 
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * To configure monitoring components, edit the `ConfigMap` object named `cluster-monitoring-config` in the `openshift-monitoring` namespace.
 These configurations are defined by link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration].
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 * To configure monitoring components that monitor user-defined projects, edit the `ConfigMap` object named `user-workload-monitoring-config` in the `openshift-user-workload-monitoring` namespace.
 These configurations are defined by link:#userworkloadconfiguration[UserWorkloadConfiguration].
@@ -33,12 +33,12 @@ The configuration file is always defined under the `config.yaml` key in the conf
 * Not all configuration parameters for the monitoring stack are exposed.
 Only the parameters and fields listed in this reference are supported for configuration.
 For more information about supported configurations, see 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/getting-started/maintenance-and-support-for-monitoring.adoc#maintenance-and-support-for-monitoring[Maintenance and support for monitoring]
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#maintenance-and-support_configuring-the-monitoring-stack[Maintenance and support for monitoring].
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 * Configuring cluster monitoring is optional.
 * If a configuration does not exist or is empty, default values are used.

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -6,17 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 The {product-title} installation program provides only a low number of configuration options before installation. Configuring most {product-title} framework components, including the cluster monitoring stack, happens after the installation.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 This section explains what configuration is supported,
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 shows how to configure the monitoring stack,
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 shows how to configure the monitoring stack for user-defined projects,
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 and demonstrates several common configuration scenarios.
 
 [IMPORTANT]
@@ -25,11 +25,11 @@ Not all configuration parameters for the monitoring stack are exposed.
 Only the parameters and fields listed in the xref:../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}] are supported for configuration.
 ====
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 == Prerequisites
 
 * The monitoring stack imposes additional resource requirements. Consult the computing resources recommendations in xref:../../scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc#scaling-cluster-monitoring-operator[Scaling the {cmo-full}] and verify that you have sufficient resources.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Maintenance and support for monitoring
 // include::modules/monitoring-maintenance-and-support.adoc[leveloffset=+1]
@@ -44,21 +44,21 @@ Not all configuration options for the monitoring stack are exposed. The only sup
 
 Configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use configurations other than those described in the xref:../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}], your changes will disappear because the {cmo-short} automatically reconciles any differences and resets any unsupported changes back to the originally defined state by default and by design.
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 Installing another Prometheus instance is not supported by the Red Hat Site Reliability Engineers (SRE).
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/monitoring-support-considerations.adoc[leveloffset=+2]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-support-policy-for-monitoring-operators.adoc[leveloffset=+2]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/monitoring-support-version-matrix-for-monitoring-components.adoc[leveloffset=+2]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // Preparing to configure the monitoring stack
 [id="preparing-to-configure-the-monitoring-stack"]
 == Preparing to configure the monitoring stack
@@ -72,9 +72,9 @@ include::modules/monitoring-creating-user-defined-workload-monitoring-configmap.
 .Additional resources
 
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // Granting users permissions for core platform monitoring
 include::modules/monitoring-granting-users-permissions-for-core-platform-monitoring.adoc[leveloffset=+1]
 
@@ -85,7 +85,7 @@ include::modules/monitoring-granting-users-permissions-for-core-platform-monitor
 * xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#resources-reference-for-the-cluster-monitoring-operator_accessing-third-party-monitoring-apis[Resources reference for the {cmo-full}]
 * xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#cmo-services-resources_accessing-third-party-monitoring-apis[CMO services resources]
 
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Configuring the monitoring stack
 include::modules/monitoring-configuring-the-monitoring-stack.adoc[leveloffset=+1]
@@ -93,14 +93,14 @@ include::modules/monitoring-configuring-the-monitoring-stack.adoc[leveloffset=+1
 [role="_additional-resources"]
 .Additional resources
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Configuration reference for the xref:../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#clustermonitoringconfiguration[`cluster-monitoring-config`] config map
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Configuration reference for the xref:../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#userworkloadconfiguration[`user-workload-monitoring-config`] config map
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * See xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Configurable monitoring components
 // The following module should only include monitoring for user-defined projects (UWM tags)
@@ -111,12 +111,12 @@ include::modules/monitoring-using-node-selectors-to-move-monitoring-components.a
 [role="_additional-resources"]
 .Additional resources
 // The nodes topics may apply to OSD/ROSA when that content is ported from OCP.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
 * xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc[Placing pods relative to other pods using affinity and anti-affinity rules]
 * xref:../../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc[Controlling pod placement by using pod topology spread constraints]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#using-pod-topology-spread-constraints-for-monitoring_configuring-the-monitoring-stack[Using pod topology spread constraints for monitoring]
 * link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[Kubernetes documentation about node selectors]
 
@@ -126,14 +126,14 @@ include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
 [role="_additional-resources"]
 .Additional resources
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * See xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 // This xref might be relevant for ROSA/OSD if the Node content is reused:
 * xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]
 // This xref might be relevant for ROSA/OSD if the Node content is reused:
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * See the link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[Kubernetes documentation] for details on the `nodeSelector` constraint
 
 // Assigning tolerations to monitoring components
@@ -142,15 +142,15 @@ include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[
 
 [role="_additional-resources"]
 .Additional resources
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * See xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 // This xref might be relevant for ROSA/OSD if the Node content is reused:
 * See the xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[{product-title} documentation] on taints and tolerations
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * See the link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Kubernetes documentation] on taints and tolerations
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // Setting the body size limit for metrics scraping
 include::modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.adoc[leveloffset=+1]
 
@@ -158,7 +158,7 @@ include::modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.ado
 .Additional resources
 
 * link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config[Prometheus scrape configuration documentation]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Configuring limits and resource requests for monitoring components
 
@@ -185,7 +185,7 @@ include::modules/monitoring-configuring-a-persistent-volume-claim.adoc[leveloffs
 .Additional resources
 * link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims[PersistentVolumeClaims](Kubernetes documentation about how to specify `volumeClaimTemplate`)
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // Resizing a persistent volume
 // The following module should only include monitoring for user-defined projects (UWM tags)
 include::modules/monitoring-resizing-a-persistent-volume.adoc[leveloffset=+2,tags=**;!CPM;UWM]
@@ -194,7 +194,7 @@ include::modules/monitoring-resizing-a-persistent-volume.adoc[leveloffset=+2,tag
 .Additional resources
 * xref:../../scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc#prometheus-database-storage-requirements_recommended-infrastructure-practices[Prometheus database storage requirements]
 * xref:../../storage/expanding-persistent-volumes.adoc#expanding-pvc-filesystem_expanding-persistent-volumes[Expanding persistent volume claims (PVCs) with a file system]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // The retention time and size for Prometheus metrics data
 // This section will be moved in the future PR. Therefore, some of the repetition in the introduction for the following procedure modules does not matter for the time being
@@ -208,17 +208,17 @@ include::modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metric
 
 [role="_additional-resources"]
 .Additional resources
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-the-monitoring-stack[Creating a cluster monitoring config map]
 * xref:../../scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc#prometheus-database-storage-requirements_cluster-monitoring-operator[Prometheus database storage requirements]
 * xref:../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Recommended configurable storage technology]
 * xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
 * xref:../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Configuring remote write storage for Prometheus
 
@@ -238,15 +238,15 @@ include::modules/monitoring-example-remote-write-queue-configuration.adoc[levelo
 
 [role="_additional-resources"]
 .Additional resources
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc#spec-remotewrite-2[Prometheus REST API reference for remote write]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Setting up remote write compatible endpoints] (Prometheus documentation)
 * link:https://prometheus.io/docs/practices/remote_write/#remote-write-tuning[Tuning remote write settings] (Prometheus documentation)
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // This xref might be relevant for ROSA/OSD if this content is reused:
 * xref:../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about_nodes-pods-secrets[Understanding secrets]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Configuring labels for outgoing metrics
 include::modules/monitoring-adding-cluster-id-labels-to-metrics.adoc[leveloffset=+1]
@@ -259,18 +259,18 @@ include::modules/monitoring-creating-cluster-id-labels-for-metrics.adoc[leveloff
 .Additional resources
 
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-remote-write-storage_configuring-the-monitoring-stack[Configuring remote write storage]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../support/gathering-cluster-data.adoc#support-get-cluster-id_gathering-cluster-data[Obtaining your cluster ID]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // Configuring audit logs for Metrics Server
 include::modules/monitoring-configuring-audit-logs-for-metrics-server.adoc[leveloffset=+1]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Configuring metrics collection profiles
 // TP features are excluded from OSD and ROSA. When this feature is GA, it can be included in the OSD/ROSA docs.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-configuring-metrics-collection-profiles.adoc[leveloffset=+1]
 include::modules/monitoring-choosing-a-metrics-collection-profile.adoc[leveloffset=+2]
 
@@ -279,12 +279,12 @@ include::modules/monitoring-choosing-a-metrics-collection-profile.adoc[leveloffs
 
 * See xref:../../observability/monitoring/managing-metrics.adoc#viewing-a-list-of-available-metrics_managing-metrics[Viewing a list of available metrics] for steps to view a list of metrics being collected for a cluster.
 * See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc[Enabling features using feature gates] for steps to enable Technology Preview features.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Controlling the impact of unbound metrics attributes in user-defined projects
 include::modules/monitoring-controlling-the-impact-of-unbound-attributes-in-user-defined-projects.adoc[leveloffset=+1]
 include::modules/monitoring-setting-scrape-and-evaluation-intervals-limits-for-user-defined-projects.adoc[leveloffset=+2]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-creating-scrape-sample-alerts.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -293,7 +293,7 @@ include::modules/monitoring-creating-scrape-sample-alerts.adoc[leveloffset=+2]
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#creating-user-defined-workload-monitoring-configmap_configuring-the-monitoring-stack[Creating a user-defined workload monitoring config map]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 * See xref:../../observability/monitoring/troubleshooting-monitoring-issues.adoc#determining-why-prometheus-is-consuming-disk-space_troubleshooting-monitoring-issues[Determining why Prometheus is consuming a lot of disk space] for steps to query which metrics have the highest number of scrape samples.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 //Configuring external Alertmanager instances
 // The following module should only include monitoring for user-defined projects (UWM tags)
@@ -310,13 +310,13 @@ include::modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.ad
 // The following module should only include monitoring for user-defined projects (UWM tags)
 include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 
 * See xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps.
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Using topology spread constraints for monitoring components
 include::modules/monitoring-using-pod-topology-spread-constraints-for-monitoring.adoc[leveloffset=+1]
@@ -324,10 +324,10 @@ include::modules/monitoring-using-pod-topology-spread-constraints-for-monitoring
 [role="_additional-resources"]
 .Additional resources
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // This xref might be relevant to ROSA/OSD if the Node content is reused:
 * xref:../../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints-about[Controlling pod placement by using pod topology spread constraints]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * link:https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/[Kubernetes Pod Topology Spread Constraints documentation]
 
 // Configuring pod topology spread constraints
@@ -342,29 +342,29 @@ include::modules/monitoring-setting-log-levels-for-monitoring-components.adoc[le
 // The following module should only include monitoring for user-defined projects (UWM tags)
 include::modules/monitoring-setting-query-log-file-for-prometheus.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * See xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
 * See xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects] for steps to enable user-defined monitoring.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Enabling query logging for Thanos Querier
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-enabling-query-logging-for-thanos-querier.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Disabling the local Alertmanager
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * link:https://prometheus.io/docs/alerting/latest/alertmanager/[Prometheus Alertmanager documentation]
 * xref:../../observability/monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
+++ b/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
@@ -9,12 +9,12 @@ toc::[]
 In {product-title}, an administrator can enable alert routing for user-defined projects.
 This process consists of the following steps:
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Enable alert routing for user-defined projects to use the default platform Alertmanager instance or, optionally, a separate Alertmanager instance only for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Enable alert routing for user-defined projects to use a separate Alertmanager instance.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Grant users permission to configure alert routing for user-defined projects.
 
 After you complete these steps, developers and other users can configure custom alerts and alert routing for their user-defined projects.
@@ -23,9 +23,9 @@ After you complete these steps, developers and other users can configure custom 
 include::modules/monitoring-understanding-alert-routing-for-user-defined-projects.adoc[leveloffset=+1]
 
 // Enabling user-defined alerts using the default Alertmanager instance
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc[leveloffset=+1]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Enabling a dedicated Alertmanager instance for use in user-defined projects
 include::modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc[leveloffset=+1]
@@ -36,7 +36,7 @@ include::modules/monitoring-granting-users-permission-to-configure-alert-routing
 [role="_additional-resources"]
 .Additional resources
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user defined projects]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/managing-alerts.adoc#configuring-alert-routing-for-user-defined-projects_managing-alerts[Configuring alert routing for user-defined projects]

--- a/observability/monitoring/managing-metrics.adoc
+++ b/observability/monitoring/managing-metrics.adoc
@@ -26,19 +26,17 @@ include::modules/monitoring-example-service-endpoint-authentication-settings.ado
 [role="_additional-resources"]
 .Additional resources
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * link:https://access.redhat.com/articles/6675491[How to scrape metrics using TLS in a ServiceMonitor configuration in a user-defined project]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../rest_api/monitoring_apis/podmonitor-monitoring-coreos-com-v1.adoc[PodMonitor API]
 * xref:../../rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.adoc[ServiceMonitor API]
-endif::openshift-dedicated,openshift-rosa[]
 
 // Viewing a list of available metrics for a cluster
-ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/monitoring-viewing-a-list-of-available-metrics.adoc[leveloffset=+1]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // include::modules/monitoring-contents-of-the-metrics-ui.adoc[leveloffset=+2]
 

--- a/observability/monitoring/monitoring-overview.adoc
+++ b/observability/monitoring/monitoring-overview.adoc
@@ -10,7 +10,7 @@ toc::[]
 == About {product-title} monitoring
 
 [role="_abstract"]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 {product-title} includes a preconfigured, preinstalled, and self-updating monitoring stack that provides monitoring for core platform components. You also have the option to xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[enable monitoring for user-defined projects].
 
 A cluster administrator can xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack[configure the monitoring stack] with the supported configurations. {product-title} delivers monitoring best practices out of the box.
@@ -21,29 +21,35 @@ In the *Observe* section of {product-title} web console, you can access and mana
 
 After installing {product-title}, cluster administrators can optionally enable monitoring for user-defined projects. By using this feature, cluster administrators, developers, and other users can specify how services and pods are monitored in their own projects.
 As a cluster administrator, you can find answers to common problems such as user metrics unavailability and high consumption of disk space by Prometheus in xref:../../observability/monitoring/troubleshooting-monitoring-issues.adoc#troubleshooting-monitoring-issues[Troubleshooting monitoring issues].
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 In {product-title}, you can monitor your own projects in isolation from Red Hat Site Reliability Engineering (SRE) platform metrics. You can monitor your own projects without the need for an additional monitoring solution.
 
 The {product-title}
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 (ROSA)
-endif::openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 monitoring stack is based on the link:https://prometheus.io/[Prometheus] open source project and its wider ecosystem.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Understanding the monitoring stack
 include::modules/monitoring-understanding-the-monitoring-stack.adoc[leveloffset=+1]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-default-monitoring-components.adoc[leveloffset=+2]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-default-monitoring-targets.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
+ifdef::openshift-rosa-hcp[]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/monitoring/managing-metrics#getting-detailed-information-about-a-target_managing-metrics[Getting detailed information about a metrics target]
+endif::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
 * xref:../../observability/monitoring/managing-metrics.adoc#getting-detailed-information-about-a-target_managing-metrics[Getting detailed information about a metrics target]
+endif::openshift-rosa-hcp[]
 
 include::modules/monitoring-components-for-monitoring-user-defined-projects.adoc[leveloffset=+2]
 include::modules/monitoring-targets-for-user-defined-projects.adoc[leveloffset=+2]
@@ -56,7 +62,7 @@ include::modules/monitoring-monitoring-stack-in-ha-clusters.adoc[leveloffset=+2]
 
 include::modules/monitoring-common-terms.adoc[leveloffset=+1]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
@@ -64,4 +70,4 @@ ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[Granting users permission to monitor user-defined projects]
 * xref:../../security/tls-security-profiles.adoc#tls-security-profiles[Configuring TLS security profiles]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/observability/monitoring/reviewing-monitoring-dashboards.adoc
+++ b/observability/monitoring/reviewing-monitoring-dashboards.adoc
@@ -17,10 +17,10 @@ include::modules/monitoring-reviewing-monitoring-dashboards-admin.adoc[leveloffs
 // Reviewing monitoring dashboards as a developer
 include::modules/monitoring-reviewing-monitoring-dashboards-developer.adoc[leveloffset=+1]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // This additional resource might be valid for ROSA/OSD when the Building applications content is ported.
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
 * xref:../../applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc#monitoring-project-and-application-metrics-using-developer-perspective[Monitoring project and application metrics using the Developer perspective]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/observability/monitoring/troubleshooting-monitoring-issues.adoc
+++ b/observability/monitoring/troubleshooting-monitoring-issues.adoc
@@ -6,15 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Find troubleshooting steps for common issues with core platform and user-defined project monitoring.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Find troubleshooting steps for common issues with user-defined project monitoring.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Investigating why user-defined project metrics are unavailable (OCP)
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -23,27 +23,27 @@ include::modules/monitoring-investigating-why-user-defined-metrics-are-unavailab
 * xref:../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-monitoring-for-user-defined-projects-uwm_preparing-to-configure-the-monitoring-stack-uwm[Enabling monitoring for user-defined projects]
 * xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc#specifying-how-a-service-is-monitored_configuring-metrics-uwm[Specifying how a service is monitored]
 * xref:../../observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc#getting-detailed-information-about-a-target_accessing-metrics-as-an-administrator[Getting detailed information about a metrics target]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Investigating why user-defined project metrics are unavailable (OSD/ROSA)
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/sd-monitoring-troubleshooting-issues.adoc[leveloffset=+1]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Determining why Prometheus is consuming a lot of disk space
 include::modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/accessing-metrics/accessing-monitoring-apis-by-using-the-cli.adoc#accessing-monitoring-apis-by-using-the-cli[Accessing monitoring APIs by using the CLI]
 * xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc#setting-scrape-and-evaluation-intervals-limits-for-user-defined-projects_configuring-performance-and-scalability-uwm[Setting scrape intervals, evaluation intervals, and enforced limits for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#about-accessing-monitoring-web-service-apis_accessing-third-party-monitoring-apis[Accessing monitoring APIs by using the CLI]
 * xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#setting-scrape-and-evaluation-intervals-limits-for-user-defined-projects_configuring-the-monitoring-stack[Setting scrape intervals, evaluation intervals, and enforced limits for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../support/getting-support.adoc#support-submitting-a-case_getting-support[Submitting a support case]
 
 // Resolving the KubePersistentVolumeFillingUp alert firing for Prometheus

--- a/observability/overview/index.adoc
+++ b/observability/overview/index.adoc
@@ -6,22 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 {ObservabilityLongName} provides real-time visibility, monitoring, and analysis of various system metrics, logs, traces, and events to help users quickly diagnose and troubleshoot issues before they impact systems or applications. To help ensure the reliability, performance, and security of your applications and infrastructure, {product-title} offers the following {ObservabilityShortName} components:
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 {ObservabilityLongName} provides real-time visibility, monitoring, and analysis of various system metrics, logs, and events to help users quickly diagnose and troubleshoot issues before they impact systems or applications. To help ensure the reliability, performance, and security of your applications and infrastructure, {product-title} offers the following {ObservabilityShortName} components:
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 * Monitoring
 * {logging-uc}
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Distributed tracing
 * {OTELName}
 * Network Observability
 * {PM-shortname-c}
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 {ObservabilityLongName} connects open-source observability tools and technologies to create a unified {ObservabilityShortName} solution. The components of {ObservabilityLongName} work together to help you collect, store, deliver, analyze, and visualize data.
 
@@ -36,13 +36,13 @@ Monitor the in-cluster health and performance of your applications running on {p
 
 Monitoring stack components are deployed by default in every {product-title} installation and are managed by the {cmo-first}. These components include Prometheus, Alertmanager, Thanos Querier, and others. The {cmo-short} also deploys the Telemeter Client, which sends a subset of data from platform Prometheus instances to Red Hat to facilitate Remote Health Monitoring for clusters.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 For more information, see xref:../../observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc#about-ocp-monitoring[About {product-title} monitoring] and xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring].
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 For more information, see xref:../../observability/monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview] and xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring].
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 [id="cluster-logging-index_{context}"]
 == Logging


### PR DESCRIPTION
Version(s):
`enterprise-4.18+`

Issue:
- **[OSDOCS-12564](https://issues.redhat.com/browse/OSDOCS-12564)**

Link to docs preview:
- **[About Observability](https://89404--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/overview/)** 
- **[Monitoring Overview](https://89404--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/monitoring/monitoring-overview)**

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds all of the Observability book to the ROSA with HCP documentation set.