### PR TITLE
OCPBUGS#52185: HCP BM Label Documentation

### DIFF
--- a/modules/hcp-bm-prereqs.adoc
+++ b/modules/hcp-bm-prereqs.adoc
@@ -15,7 +15,7 @@
 $ oc get managedclusters local-cluster
 ----
 
-* You must add the `topology.kubernetes.io/zone` label to your bare metal hosts on your management cluster. Otherwise, all of the hosted control plane pods are scheduled on a single node, causing single point of failure.
+* You must add the `topology.kubernetes.io/zone` label to your bare metal hosts on your management cluster, as well as using a different value for this label on each host. Otherwise, all of the hosted control plane pods are scheduled on a single node, causing single point of failure.
 
 * To provision {hcp} on bare metal, you can use the Agent platform. The Agent platform uses the central infrastructure management service to add worker nodes to a hosted cluster. For more information, see _Enabling the central infrastructure management service_.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-52185

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.17/hosted_control_planes/hcp-deploy/hcp-deploy-bm.html#hcp-bm-prereqs_hcp-deploy-bm

Current text:
```
You must add the `topology.kubernetes.io/zone` label to your bare metal hosts on your management cluster. Otherwise, all of the hosted control plane pods are scheduled on a single node, causing single point of failure.
```

Proposed updated text:
```
You must add the `topology.kubernetes.io/zone` label to your bare metal hosts on your management cluster, as well as using a different value for this label on each host. Otherwise, all of the hosted control plane pods are scheduled on a single node, causing single point of failure.
```

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
