### PR TITLE
OSDOCS-13464: Documented the 4.18.2 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2995,6 +2995,67 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.2
+[id="ocp-4-18-2_{context}"]
+=== RHBA-2025:1904 - {product-title} {product-version}.2 image release, bug fix, and security update advisory
+
+Issued: 04 March 2025
+
+{product-title} release {product-version}.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:1904[RHBA-2025:1904] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1908[RHSA-2025:1908] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.2 --pullspecs
+----
+
+[id="ocp-4-18-2-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when using the `dry-run` argument with the oc-mirror v2 command, the `cluster-resources` directory was cleared in error. As a result, files that were generated from a previous mirroring operation, such as `idms-oc-mirror.yaml` and `itms-oc-mirror.yaml`, were deleted. With this release, the `cluster-resources` directory is no longer cleared when you add the `dry-run` argument to the oc-mirror v2 command. (link:https://issues.redhat.com/browse/OCPBUGS-51185[*OCPBUGS-51185*])
+
+* Previously, the Operator Controller would not accept live updates to registries with a proxy configuration. Unless the controller pods were restarted, this issue caused OLM v1 to read the wrong image URL. With this release, a fix to the Operator Controller means that it accepts live updates to registries with a proxy configuration and the controller pod no longer needs to be restarted. (link:https://issues.redhat.com/browse/OCPBUGS-51140[*OCPBUGS-51140*])
+
+* Previously, Internet Small Computer System Interface (iSCSI) and Fibre Channel devices that were attached to a multipath device did not resolve correctly when these devices were partitioned. With this relase, a fix ensures that partitioned multipath storage devices can now correctly resolve. (link:https://issues.redhat.com/browse/OCPBUGS-51100[*OCPBUGS-51100*])
+
+* Previously, mirroring of some Operators from catalog resources caused oc-mirror v1 to fail with an error message that indicated an issue with the `ocischema.DeserializedImageIndex` manifest file. With this release, oc-mirror v1 can handle the `ocischema.DeserializedImageIndex` manfiest file so that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-51099[*OCPBUGS-51099*])
+
+* Previously, when you created a cluster with secure proxy enabled and the certificate configuration is set to `configuration.proxy.trustCA`, the cluster installation failed. Additionally, the OpenShift OAuth API server could not use the management cluster proxy to reach cloud APIs. With this release, fixes are in place to prevent these issues. (link:https://issues.redhat.com/browse/OCPBUGS-51050[*OCPBUGS-51050*])
+
+* Previously, when you deleted Dynamic Host Configuration Protocol (DHCP) network on a {ibm-power-server-title} cluster, subresources would still exist. With this release, when you delete a DHCP network, the subresources are also deleted. (link:https://issues.redhat.com/browse/OCPBUGS-50870[*OCPBUGS-50870*])
+
+* Previously, when you deleted Dynamic Host Configuration Protocol (DHCP) network on an {ibm-power-server-title} cluster, subresources could still exist. With this release, when you delete a DHCP network, the subresources deletion now occur before continuing the destroy operation. (link:https://issues.redhat.com/browse/OCPBUGS-50870[*OCPBUGS-50870*])
+
+* Previously, the `vmware-vsphere-csi-driver-operator` Container Storage Interface (CSI) driver entered panic mode when the VMware vCenter address was incorrect or missing. With this release, the CSI driver does not go into panic mode if the VMware vCenter address is incorrect or missing. (link:https://issues.redhat.com/browse/OCPBUGS-50638[*OCPBUGS-50638*])
+
+* Previously, when you used the Agent-based Installer to install a cluster on a host, sometimes the `/dev/sda` device, an Extensible Firmware Interface (EFI) device, failed to mount. With this release, a retry operation is added to the EFI device so it mounts correctly. (link:https://issues.redhat.com/browse/OCPBUGS-50621[*OCPBUGS-50621*])
+
+* Previously, the control plane Operator did not honor the set `_PROXY` environment variables when it checked the API endpoint availability. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-50550[*OCPBUGS-50550*]) 
+
+* Previously, the *Cluster Settings* page would not properly render during a cluster update if the `ClusterVersion` did not receive a `Completed` update.  With this release, the *Cluster Setting* page properly renders even if the `ClusterVersion` has not received a `Completed` update. (link:https://issues.redhat.com/browse/OCPBUGS-49921[*OCPBUGS-49921*])
+
+* Previously, when the `ClusterNetwork` classless inter-domain routing (CIDR) mask value is greater than the `hostPrefix` value and the `networking.ovnKubernetesConfig.ipv4.internalJoinSubnet` section is provided in the `install-config.yaml` file, the installation program failed a validation check and returned a Golang runtime error. With this release, the installation program still fails the validation check and now outputs a descriptive error message that indicates the invalid `hostPrefix` value. (link:https://issues.redhat.com/browse/OCPBUGS-49864[*OCPBUGS-49864*])
+
+* Previously, the router incorrectly assumed that only `SHA1` leaf certificates were rejected by HAProxy. This caused the router to fail as it rejected `SHA1` intermediate certificates. With this release, the router now inspects all non-self-signed certificates and rejects any that use `SHA1`. The router no longer crashes because of the existence of `SHA1` intermediate certificates. Self-signed `SHA1` certificates are no longer rejected. Root CAs can continue to use `SHA1`. (link:https://issues.redhat.com/browse/OCPBUGS-49389[*OCPBUGS-49389*])
+
+* Previously, {gcp-first} did not include a `wait` operation for API calls that destroyed clutser resources. In certain situations, this missing operation caused the installation program to not delete the backend services. With this release, {gcp-short} adds a `wait` operation to an API call so that the installation program can delete backend services. (link:https://issues.redhat.com/browse/OCPBUGS-49320[*OCPBUGS-49320*])
+
+* Previously, on the *Operator Details* page on the web console, `ClusterServiceVersion` (CSV) details did not render. With this release, the CSV details now render on the *Operator Details* page. (link:https://issues.redhat.com/browse/OCPBUGS-48736[*OCPBUGS-48736*])
+
+* Previously, bundle properties occasionally did not get propagated to the annotations on Helm charts that were created during an Operator installation. With this release, properties are now taken from both the CSV of the bundle and the `metadata.yaml` file or the `properties.yaml` file so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-45114[*OCPBUGS-45114*])
+
+* Previously, Local Storage Operator (LSO) ignored existing Small Computer System Interface (SCSI) symlinks during persistent volumes (PV) creation. With this release, the LSO no longer ignores these symlinks because it gathers these symlinks before finding new symlinks when creating a PV. (link:https://issues.redhat.com/browse/OCPBUGS-51056[*OCPBUGS-51056*])
+
+* Previously, a User Datagram Protocol (UDP) packet that was larger than the maximum transmission unit (MTU) value set for the cluster, could not be sent to the endpoint of the packet by using a service. With this release, the pod IP address is used instead of the service IP address regardless of the packet size, so that the UDP packet can be sent to the endpoint. (link:https://issues.redhat.com/browse/OCPBUGS-50512[*OCPBUGS-50512*])
+
+[id="ocp-4-18-2-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
 //Update with relevant advisory information
 [id="ocp-4-18-1-ga_{context}"]
 === RHSA-2024:6122 - {product-title} {product-version}.1 image release, bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13464](https://issues.redhat.com/browse/OSDOCS-13464)

Link to docs preview:
* https://89415--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-2_release-notes

