### PR TITLE
OSDOCS-12563: Images- Classic to HCP breakout-P4

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -474,6 +474,55 @@ Topics:
   - Name: Important changes to OpenShift Jenkins images
     File: important-changes-to-openshift-jenkins-images
 ---
+Name: Images
+Dir: openshift_images
+Distros: openshift-rosa-hcp
+Topics:
+- Name: Overview of images
+  File: index
+# replaced Configuring the Cluster Samples Operator name, cannot configure the operator
+- Name: Overview of the Cluster Samples Operator
+  File: configuring-samples-operator
+  Distros: openshift-rosa-hcp
+- Name: Using the Cluster Samples Operator with an alternate registry
+  File: samples-operator-alt-registry
+  Distros: openshift-rosa-hcp
+- Name: Creating images
+  File: create-images
+- Name: Managing images
+  Dir: managing_images
+  Topics:
+  - Name: Managing images overview
+    File: managing-images-overview
+  - Name: Tagging images
+    File: tagging-images
+  - Name: Image pull policy
+    File: image-pull-policy
+  - Name: Using image pull secrets
+    File: using-image-pull-secrets
+- Name: Managing image streams
+  File: image-streams-manage
+  Distros: openshift-rosa-hcp
+- Name: Using image streams with Kubernetes resources
+  File: using-imagestreams-with-kube-resources
+  Distros: openshift-rosa-hcp
+- Name: Triggering updates on image stream changes
+  File: triggering-updates-on-imagestream-changes
+  Distros: openshift-rosa-hcp
+- Name: Image configuration resources (HCP)
+  File: image-configuration-hcp
+  Distros: openshift-rosa-hcp
+- Name: Using images
+  Dir: using_images
+  Distros: openshift-rosa-hcp
+  Topics:
+  - Name: Using images overview
+    File: using-images-overview
+  - Name: Source-to-image
+    File: using-s21-images
+  - Name: Customizing source-to-image images
+    File: customizing-s2i-images
+---
 Name: Storage
 Dir: storage
 Distros: openshift-rosa-hcp

--- a/modules/images-imagestream-import-images-private-registry.adoc
+++ b/modules/images-imagestream-import-images-private-registry.adoc
@@ -5,7 +5,7 @@
 [id="images-imagestream-import-images-private-registry_{context}"]
 = Importing images and image streams from private registries
 
-An image stream can be configured to import tag and image metadata from private image registries requiring authentication. This procedures applies if you change the registry that the Cluster Samples Operator uses to pull content from to something other than link:https://registry.redhat.io[registry.redhat.io].
+An image stream can be configured to import tag and image metadata from private image registries requiring authentication. This procedure applies if you change the registry that the Cluster Samples Operator uses to pull content from to something other than link:https://registry.redhat.io[registry.redhat.io].
 
 [NOTE]
 ====

--- a/modules/images-using-imagestream-tags.adoc
+++ b/modules/images-using-imagestream-tags.adoc
@@ -6,7 +6,7 @@
 
 An image stream tag is a named pointer to an image in an image stream. It is abbreviated as `istag`. An image stream tag is used to reference or retrieve an image for a given image stream and tag.
 
-Image stream tags can reference any local or externally managed image. It contains a history of images represented as a stack of all images the tag ever pointed to. Whenever a new or existing image is tagged under particular image stream tag, it is placed at the first position in the history stack. The image previously occupying the top position is available at the second position. This allows for easy rollbacks to make tags point to historical images again.
+Image stream tags can reference any local or externally managed image. It contains a history of images represented as a stack of all images the tag ever pointed to. Whenever a new or existing image is tagged under a particular image stream tag, it is placed at the first position in the history stack. The image previously occupying the top position is available at the second position. This allows for easy rollbacks to make tags point to historical images again.
 
 The following image stream tag is from an `ImageStream` object:
 

--- a/modules/samples-operator-overview.adoc
+++ b/modules/samples-operator-overview.adoc
@@ -54,9 +54,9 @@ Certain circumstances result in the Cluster Samples Operator bootstrapping itsel
 * If the Cluster Samples Operator cannot reach link:https://registry.redhat.io[registry.redhat.io] after three minutes on initial startup after a clean installation.
 * If the Cluster Samples Operator detects it is on an IPv6 network.
 // cannot configure the Samples Operator
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * If the xref:../openshift_images/image-configuration.adoc#images-configuration-parameters_image-configuration[image controller configuration parameters] prevent the creation of image streams by using the default image registry, or by using the image registry specified by the xref:../openshift_images/configuring-samples-operator.adoc#samples-operator-configuration_configuring-samples-operator[`samplesRegistry` setting].
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 [NOTE]
 ====
@@ -64,7 +64,7 @@ For {product-title}, the default image registry is
 ifdef::openshift-enterprise[]
 `registry.redhat.io`.
 endif::[]
-ifdef::openshift-rosa,openshift-dedicated,openshift-origin[]
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp,openshift-origin[]
 `registry.access.redhat.com` or `quay.io`.
 endif::[]
 ====

--- a/openshift_images/configuring-samples-operator.adoc
+++ b/openshift_images/configuring-samples-operator.adoc
@@ -1,26 +1,26 @@
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 :_mod-docs-content-type: ASSEMBLY
 [id="configuring-samples-operator"]
 = Configuring the Cluster Samples Operator
 include::_attributes/common-attributes.adoc[]
 :context: configuring-samples-operator
-endif::openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 :_mod-docs-content-type: ASSEMBLY
 [id="configuring-samples-operator"]
 = Overview of the Cluster Samples Operator
 include::_attributes/common-attributes.adoc[]
 :context: configuring-samples-operator
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 toc::[]
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 The Cluster Samples Operator, which operates in the `openshift` namespace, installs and updates the {op-system-base-full}-based {product-title} image streams and {product-title} templates.
-endif::openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 The Cluster Samples Operator, which operates in the `openshift` namespace, installs and updates the {product-title} image streams and {product-title} templates.
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 [IMPORTANT]
 .The Cluster Samples Operator is being deprecated  
@@ -50,24 +50,24 @@ include::modules/samples-operator-overview.adoc[leveloffset=+1]
 
 * If the Cluster Samples Operator is removed during installation, you can xref:../openshift_images/samples-operator-alt-registry.adoc#samples-operator-alt-registry[use the Cluster Samples Operator with an alternate registry] so content can be imported, and then set the Cluster Samples Operator to `Managed` to get the samples.
 // Restricted network not supported ROSA/OSD 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * To ensure the Cluster Samples Operator bootstraps as `Removed` in a restricted network installation with initial network access to defer samples installation until you have decided which samples are desired, follow the instructions for xref:../installing/install_config/installing-customizing.adoc#installing-customizing[customizing nodes] to override the Cluster Samples Operator default configuration and initially come up as `Removed`.
 ** To host samples in your disconnected environment, follow the instructions for xref:../openshift_images/samples-operator-alt-registry.adoc#samples-operator-alt-registry[using the Cluster Samples Operator with an alternate registry].
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 // Restricted network not supported ROSA/OSD 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/installation-images-samples-disconnected-mirroring-assist.adoc[leveloffset=+2]
 
 See xref:../openshift_images/samples-operator-alt-registry.adoc#installation-restricted-network-samples_samples-operator-alt-registry[Using Cluster Samples Operator image streams with alternate or mirrored registries] for a detailed procedure.
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 // cannot patch resource "configs" in API group "samples.operator.openshift.io"
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/samples-operator-configuration.adoc[leveloffset=+1]
 
 include::modules/samples-operator-crd.adoc[leveloffset=+1]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/images-samples-operator-deprecated-image-stream.adoc[leveloffset=+1]
 

--- a/openshift_images/image-configuration-hcp.adoc
+++ b/openshift_images/image-configuration-hcp.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 :context: image-configuration-hcp
 [id="image-configuration-hcp"]
 = Image configuration resources for {hcp-title}

--- a/openshift_images/image-streams-manage.adoc
+++ b/openshift_images/image-streams-manage.adoc
@@ -13,9 +13,9 @@ include::modules/images-imagestream-configure.adoc[leveloffset=+1]
 include::modules/images-using-imagestream-images.adoc[leveloffset=+1]
 include::modules/images-using-imagestream-tags.adoc[leveloffset=+1]
 include::modules/images-using-imagestream-change-triggers.adoc[leveloffset=+1]
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/images-imagestream-mapping.adoc[leveloffset=+1]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 == Working with image streams
 

--- a/openshift_images/index.adoc
+++ b/openshift_images/index.adoc
@@ -14,12 +14,12 @@ An image stream provides a way of storing different versions of the same basic i
 Those different versions are represented by different tags on the same image name.
 
 include::modules/images-about.adoc[leveloffset=+1]
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 You can xref:../openshift_images/create-images.adoc#creating-images[create], xref:../openshift_images/managing_images/managing-images-overview.adoc#managing-images-overview[manage], and xref:../openshift_images/using_images/using-images-overview.adoc#using-images-overview[use] container images.
-endif::openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 You can xref:../openshift_images/create-images.adoc#creating-images[create] and xref:../openshift_images/managing_images/managing-images-overview.adoc#managing-images-overview[manage] container images.
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/images-image-registry-about.adoc[leveloffset=+1]
 
@@ -49,21 +49,21 @@ You can use the Cluster Samples Operator to manage the sample image streams and 
 
 As a cluster administrator, you can use the Cluster Samples Operator to:
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ** xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configure the Operator].
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ** xref:../openshift_images/samples-operator-alt-registry.adoc#samples-operator-alt-registry[Use the Operator with an alternate registry].
 
 [id="about-templates"]
 == About templates
 
 A template is a definition of an object to be replicated.
-You can use xref:../applications/creating_applications/using-templates.adoc#using-templates[templates] to build and deploy configurations.
+You can use link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/building_applications/index[templates] to build and deploy configurations.
 
 [id="how-you-can-use-ruby-on-rails"]
 == How you can use Ruby on Rails
 
-As a developer, you can use xref:../applications/creating_applications/templates-using-ruby-on-rails.adoc#templates-using-ruby-on-rails[Ruby on Rails] to:
+As a developer, you can use link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/building_applications/index#templates-using-ruby-on-rails[Ruby on Rails] to:
 
 ** Write your application:
 *** Set up a database.

--- a/openshift_images/managing_images/using-image-pull-secrets.adoc
+++ b/openshift_images/managing_images/using-image-pull-secrets.adoc
@@ -21,6 +21,6 @@ include::modules/images-allow-pods-to-reference-images-from-secure-registries.ad
 include::modules/images-pulling-from-private-registries.adoc[leveloffset=+2]
 
 // cannot get resource "secrets" in API group "" in the namespace "openshift-config" 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/images-update-global-pull-secret.adoc[leveloffset=+1]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/openshift_images/samples-operator-alt-registry.adoc
+++ b/openshift_images/samples-operator-alt-registry.adoc
@@ -15,11 +15,11 @@ You must have access to the internet to obtain the necessary container images. I
 
 include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 .Additional information
 
 For information on viewing the CRI-O logs to view the image source, see xref:../installing/validation_and_troubleshooting/validating-an-installation.adoc#viewing-the-image-pull-source_validating-an-installation[Viewing the image pull source].
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 [id="samples-preparing-bastion"]
 === Preparing the mirror host


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-12563](https://issues.redhat.com/browse/OSDOCS-12563)

Link to docs preview:
- [Overview of Images](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/)
- [Overview of the Clusters Samples Operator](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/configuring-samples-operator)
- [Using the Cluster Samples Operator with an alternate registry](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/samples-operator-alt-registry)
- [Creating images](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/create-images)
- [Managing images overview](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/managing_images/managing-images-overview)
- [Managing images: Tagging images](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/managing_images/tagging-images)
- [Managing images: Image pull policy](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/managing_images/image-pull-policy)
- [Managing images: Using image pull secrets](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/managing_images/using-image-pull-secrets)
- [Managing image streams](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/image-streams-manage)
- [Using image streams with Kubernetes resources](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/using-imagestreams-with-kube-resources)
- [Triggering updates on image stream changes](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/triggering-updates-on-imagestream-changes)
- [Image configuration resources (Classic)](https://89416--ocpdocs-pr.netlify.app/openshift-rosa/latest/openshift_images/image-configuration) Note: This is not on HCP, just on Classic.
- [Image configuration resources for ROSA with HCP](https://89416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/image-configuration-hcp) Note: This still remains on both Classic and HCP, until we make the final switch.



QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
