### PR TITLE
OSDOCS-13100: adds 4.18.2 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -131,7 +131,12 @@ Red{nbsp}Hat Customer Portal users can enable errata notifications in the accoun
 Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
 ====
 
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections. {microshift-short} uses a priority-based release cadence to provide the most important updates with the least disruption.
+
+[IMPORTANT]
+====
+For any {product-title} release, always review the xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] documentation before proceeding with an update.
+====
 
 [id="microshift-4-18-1-dp_{context}"]
 === RHEA-2024:6124 - {microshift-short} 4.18.1 bug fix and security update advisory
@@ -141,3 +146,22 @@ Issued: 25 February 2025
 {product-title} release 4.18.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:6124[RHEA-2024:6124] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:6122[RHSA-2024:6122] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-18-1-known-issue_{context}"]
+==== Known issue
+
+* A failed greenboot health check flag does not clear when an RPM-install-based {microshift-short} service is updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. (link:https://issues.redhat.com/browse/OCPBUGS-51198[*OCPBUGS-51198*])
+
+[id="microshift-4-18-2-dp_{context}"]
+=== RHBA-2025:1953 - {microshift-short} 4.18.2 bug fix and enhancement advisory
+
+Issued: 4 March 2025
+
+{product-title} release 4.18.2 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:1953[RHBA-2025:1953] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:1904[RHBA-2025:1904] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-18-2-bugs_{context}"]
+==== Bug fix
+
+* Previously, a failed greenboot health check flag did not clear when an RPM-install-based {microshift-short} service was updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. With this release, the primary {microshift-short} greenboot health check clears the condition that causes optional component health checks to continue to fail. (link:https://issues.redhat.com/browse/OCPBUGS-51198[*OCPBUGS-51198*])


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13100](https://issues.redhat.com/browse/OSDOCS-13100)

Link to docs preview:
[microshift-4-18-2-dp_release-notes](https://89421--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-2-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
