### PR TITLE
OSSM-8988 Update mention of 1.24.1 in an example output to 1.24.3

### DIFF
--- a/modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc
+++ b/modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc
@@ -27,7 +27,7 @@ $ oc get istios istio-tenant-a
 [source,terminal]
 ----
 NAME             REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
-istio-tenant-a   1           1       0        istio-tenant-a    Healthy   v1.24.1   30s
+istio-tenant-a   1           1       0        istio-tenant-a    Healthy   v1.24.3   30s
 ----
 +
 [NOTE]

--- a/modules/ossm-migrating-multitenant-workloads.adoc
+++ b/modules/ossm-migrating-multitenant-workloads.adoc
@@ -27,7 +27,7 @@ $ oc get istios istio-tenant-a
 [source,terminal]
 ----
 NAME             REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
-istio-tenant-a   1           1       0        istio-tenant-a    Healthy   v1.24.1   30s
+istio-tenant-a   1           1       0        istio-tenant-a    Healthy   v1.24.3   30s
 ----
 +
 [NOTE]


### PR DESCRIPTION
**OSSM 3.0 GA**

**Merge PR to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

**Cherry pick to**: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0


Version(s):
OSSM 3.0 GA

**Service Mesh has moved to the stand alone format and is no longer cherry-picked back to OCP core.**

Issue:
https://issues.redhat.com/browse/OSSM-8988

Link to docs preview:
https://89424--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/multitenant/ossm-migrating-multitenant-assembly.html#migrating-multitenant-workloads_ossm-migrating-multitenant-assembly
https://89424--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/multitenant/ossm-migrating-multitenant-assembly.html#migrating-multitenant-workloads-with-cert-manager_ossm-migrating-multitenant-assembly

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
