### PR TITLE
imagedigestmirrorset and imagetagmirrorset is cluster wide resource hence need to update OCP DOC 

### DIFF
--- a/modules/oc-mirror-migration-process.adoc
+++ b/modules/oc-mirror-migration-process.adoc
@@ -81,7 +81,7 @@ $ oc get catalogsource -n openshift-marketplace
 +
 [source,terminal]
 ----
-$ oc get imagedigestmirrorset,imagetagmirrorset -n openshift-config
+$ oc get imagedigestmirrorset,imagetagmirrorset
 ----
 +
 For more information, refer to "Mirroring images for a disconnected installation using oc-mirror plugin v2".


### PR DESCRIPTION
imagedigestmirrorset and imagetagmirrorset is cluster wide resource hence no need to give `-n openshift-config` while listing IDMS or ITMS.

Current:
~~~
$ oc get imagedigestmirrorset,imagetagmirrorset -n openshift-config
~~~

Expected:
~~~
$ oc get imagedigestmirrorset,imagetagmirrorset
~~~

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13528

Link to docs preview:
Section "Migrating to oc-mirror plugin v2" step 4. 

https://89449--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/oc-mirror-migration-v1-to-v2.html#oc-mirror-migration-process_oc-mirror-migration-v1-to-v2
