### PR TITLE
OSSM-8939 Add xrefs for Mulitenant Migration Guide

### DIFF
--- a/migrating/multitenant/ossm-migrating-multitenant-assembly.adoc
+++ b/migrating/multitenant/ossm-migrating-multitenant-assembly.adoc
@@ -20,15 +20,11 @@ include::modules/ossm-migrating-multitenant-workloads.adoc[leveloffset=+1]
 
 If you are using gateways, you must migrate them before you complete the migration process for your deployment and workloads.
 
-* Migrate gateways
-//<insert exref to gateway migration content>
-//xrefs across Migration Guides will be handled by OSSM-8852
+* xref:../migrating-gateways/ossm-migrating-gateways-assembly.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
 
 If you are not using gateways, and have verified your mulitenant migration, you can proceed to complete the migration and remove {SMProduct} 2 resources.
 
-* Cleanup {SMProduct} 2
-//<insert exref to done dir>
-//xrefs across Migration Guides will be handled by OSSM-8852
+* xref:../done/ossm-migrating-complete-assembly.adoc[Completing the Migration]
 
 include::modules/ossm-migrating-multitenant-with-cert-manager.adoc[leveloffset=+1]
 include::modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc[leveloffset=+1]
@@ -37,17 +33,10 @@ include::modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc[lev
 
 If you are using gateways, you must migrate them before you can complete the migration process for your deployment and workloads.
 
-* Migrate gateways
-//<insert exref to gateway migration content>
-//xrefs across Migration Guides are handled by OSSM-8852
+* xref:../migrating-gateways/ossm-migrating-gateways-assembly.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
 
 After you have migrated your gateways, you must update the `app.controller.configmapNamespaceSelector` field in your `istio-csr` deployment.
 
 If you are not using gateways, you can complete your migration with cert-manager.
 
-* Complete your migration with cert-manager
-//<insert exreft to complete-cert-manager>
-//xrefs across Migration Guides will be handled by OSSM-8852
-
-
-//Migration likely to resemble https://docs.openshift.com/container-platform/4.17/migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.html#about-migrating-from-3-to-4 when done for OSSM 3.0 GA.
+* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing the Migration]


### PR DESCRIPTION
**OSSM 3.0 GA**

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

**Service Mesh has moved to the stand alone format and is no longer cherry-picked back to OCP core.**

Issue:
https://issues.redhat.com/browse/OSSM-8939

Link to docs preview:
https://89452--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/multitenant/ossm-migrating-multitenant-assembly.html 

QE review:
QE is not required for this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
