### PR TITLE
OSSM-8990 Typo in file name

### DIFF
--- a/migrating/done/ossm-migrating-complete-assembly.adoc
+++ b/migrating/done/ossm-migrating-complete-assembly.adoc
@@ -13,7 +13,7 @@ At this stage, you have completed the migration process. It is safe to remove {S
 Optionally, if you already have Kiali installed, before you delete {SMProduct} {SMv2Version}, you can verify that all data plane namespaces have been migrated by checking the Kiali **Mesh** page. To learn more about the Kiali **Mesh** page, see "Istio infrastructure status (Kiali.io)".
 
 include::modules/ossm-migrating-done-network-policies.adoc[leveloffset=+1]
-include::modules/ossm-migrating-complete-multitant-cert-manager.adoc[leveloffset=+1]
+include::modules/ossm-migrating-complete-multitenant-cert-manager.adoc[leveloffset=+1]
 
 .Next steps
 

--- a/modules/ossm-migrating-complete-multitenant-cert-manager.adoc
+++ b/modules/ossm-migrating-complete-multitenant-cert-manager.adoc
@@ -4,7 +4,7 @@
 // * service-mesh-docs-main/multitenant/ossm-migrating-multitenant-assembly.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="migrating-complete-multitant-cert-manager_{context}""]
+[id="migrating-complete-multitenant-cert-manager_{context}""]
 = Completing a multitenant deployment with cert-manager
 
 .Prerequisites


### PR DESCRIPTION
**OSSM 3.0 GA**

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

Issue:
https://issues.redhat.com/browse/OSSM-8990

Link to docs preview:
https://89465--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/done/ossm-migrating-complete-assembly.html#migrating-complete-multitenant-cert-manager_ossm-migrating-complete-assembly

QE review:
QE is not needed for this review.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
