### PR TITLE
Add release note for `physicalNetworkName` for OVN-Kubernetes secondary networks

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -957,12 +957,11 @@ You must ensure that the configurations of each `NetworkAttachmentDefinition` CR
 You still must restart any workloads that use the network attachment definition for the network changes to take effect for those pods.
 
 [id="ocp-release-notes-networking-ovn-kubernetes-secondary-network-localnet-physical-network-name_{context}"]
-==== OVN-Kubernetes secondary network support for sharing a physical network between localnets
+==== OVN-Kubernetes secondary network support for sharing a physical network between localnet topologies 
 
-When configuring a secondary network that uses the `localnet` topology, you can now specify a physical network name with the `physicalNetworkName` field. By default, this value is set to the name of the localnet. Multiple localnets can share the same physical network.
+When configuring a secondary network that uses the `localnet` topology, you can now specify a physical network name with the `physicalNetworkName` field. By default, this value is set to the name of the localnet. Multiple localnet topologies can share the same physical network.
 
-For more information, see xref:../networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.a
-doc#configuration-ovnk-network-plugin-json-object_configuring-additional-network-ovnk[Configuring a secondary network that uses the localnet topology].
+For more information, see xref:../networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.adoc#configuration-ovnk-network-plugin-json-object_configuring-additional-network-ovnk[OVN-Kubernetes network plugin JSON configuration table].
 
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -956,6 +956,14 @@ You must ensure that the configurations of each `NetworkAttachmentDefinition` CR
 
 You still must restart any workloads that use the network attachment definition for the network changes to take effect for those pods.
 
+[id="ocp-release-notes-networking-ovn-kubernetes-secondary-network-localnet-physical-network-name_{context}"]
+==== OVN-Kubernetes secondary network support for sharing a physical network between localnets
+
+When configuring a secondary network that uses the `localnet` topology, you can now specify a physical network name with the `physicalNetworkName` field. By default, this value is set to the name of the localnet. Multiple localnets can share the same physical network.
+
+For more information, see xref:../networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.a
+doc#configuration-ovnk-network-plugin-json-object_configuring-additional-network-ovnk[Configuring a secondary network that uses the localnet topology].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-12356

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

https://89471--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-networking-ovn-kubernetes-secondary-network-localnet-physical-network-name_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
