### PR TITLE
OCPBUGS:35825 Chronyd examples for nodeDisruptionPolicy are wrong/example of node disruption policy is incorrect/Missing metadata in one of the Node Disruption Policy examples

### DIFF
--- a/modules/machine-config-node-disruption-config.adoc
+++ b/modules/machine-config-node-disruption-config.adoc
@@ -34,9 +34,9 @@ spec:
   nodeDisruptionPolicy: <1>
     files: # <2>
     - actions: # <3>
-      - reload: # <4>
+      - restart: # <4>
           serviceName: chronyd.service # <5>
-        type: Reload
+        type: Restart
       path: /etc/chrony.conf # <6>
     sshkey: # <7>
       actions:
@@ -93,9 +93,9 @@ status:
       files:
 # ...
       - actions:
-        - reload:
+        - restart:
             serviceName: chronyd.service
-          type: Reload
+          type: Restart
         path: /etc/chrony.conf
       sshkey:
         actions:

--- a/modules/machine-config-node-disruption-example.adoc
+++ b/modules/machine-config-node-disruption-example.adoc
@@ -20,6 +20,7 @@ The following example `MachineConfiguration` object shows no user defined polici
 ----
 apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
+metadata:
   name: cluster
 spec:
   logLevel: Normal
@@ -79,7 +80,6 @@ apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
   name: cluster
-  namespace: openshift-machine-config-operator
 # ...
 spec:
   nodeDisruptionPolicy:
@@ -96,7 +96,7 @@ spec:
 # ...
 ----
 
-In the following example, when changes are made to the `/etc/chrony.conf` file, the MCO reloads the `chronyd.service` on the cluster nodes. If files are added to or modified in the `/var/run` directory, the MCO applies the changes with no further action.
+In the following example, when changes are made to the `/etc/chrony.conf` file, the MCO restarts the `chronyd.service` on the cluster nodes. If files are added to or modified in the `/var/run` directory, the MCO applies the changes with no further action.
 
 .Example node disruption policy for a configuration file change
 [source,yaml]
@@ -105,15 +105,14 @@ apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
   name: cluster
-  namespace: openshift-machine-config-operator
 # ...
 spec:
   nodeDisruptionPolicy:
     files:
     - actions:
-      - reload:
+      - restart:
           serviceName: chronyd.service
-        type: Reload
+        type: Restart
         path: /etc/chrony.conf
     - actions:
       - type: None
@@ -129,7 +128,6 @@ apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
   name: cluster
-  namespace: openshift-machine-config-operator
 # ...
 spec:
   nodeDisruptionPolicy:
@@ -155,7 +153,6 @@ apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
   name: cluster
-  namespace: openshift-machine-config-operator
 # ...
 spec:
   nodeDisruptionPolicy:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-35825
https://issues.redhat.com/browse/OCPBUGS-48531
https://issues.redhat.com/browse/OCPBUGS-42022

Previews:
[Example node disruption policies](https://89489--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-node-disruption.html#machine-config-node-disruption-example_machine-configs-configure) -- Changed reload action to restart for crio.service in two code examples.  Removed namespace from output, as it is not present in reality.
[Configuring node restart behaviors upon machine config changes](https://89489--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-node-disruption.html#machine-config-node-disruption-config_machine-configs-configure) -- Changed reload action to restart for crio.service in two code examples. 



QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
