### PR TITLE
OSDOCS12397: Incorrect tolerations example for scheduling pods on the infra nodes

### DIFF
--- a/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
+++ b/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
@@ -133,7 +133,7 @@ tolerations:
     value: reserved <3>
   - effect: NoExecute <4>
     key: node-role.kubernetes.io/infra <5>
-    operator: Exists <6>
+    operator: Equal <6>
     value: reserved <7>
 ----
 <1> Specify the effect that you added to the node.
@@ -141,7 +141,7 @@ tolerations:
 <3> Specify the value of the key-value pair taint that you added to the node.
 <4> Specify the effect that you added to the node.
 <5> Specify the key that you added to the node.
-<6> Specify the `Exists` Operator to require a taint with the key `node-role.kubernetes.io/infra` to be present on the node.
+<6> Specify the `Equal` Operator to require a taint with the key `node-role.kubernetes.io/infra` to be present on the node.
 <7> Specify the value of the key-value pair taint that you added to the node.
 +
 This toleration matches the taint created by the `oc adm taint` command. A pod with this toleration can be scheduled onto the infra node.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-12397

Preview: [Binding infrastructure node workloads using taints and tolerations](https://89490--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html) -- Updated step 2, call out 6. Search for _Specify the Equal Operator to require a taint with the key_

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
