### PR TITLE
OSSM-8997 Remove assembly from Migration Guide file names

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -13,43 +13,43 @@ Dir: migrating
 Distros: openshift-service-mesh
 Topics:
 - Name: Migrating from Service Mesh 2 to Service Mesh 3
-  File: ossm-migrating-from-service-mesh-2-to-3-assembly
+  File: ossm-migrating-from-service-mesh-2-to-3
 - Name: Before migrating
   Dir: checklists
   Topics:
   - Name: Important information to know before migrating
-    File: ossm-migrating-read-me-assembly
+    File: ossm-migrating-read-me
   - Name: Premigration checklists
-    File: ossm-migrating-premigration-checklists-assembly
+    File: ossm-migrating-premigration-checklists
   - Name: Migrating network policies
-    File: ossm-migrating-network-policies-assembly
+    File: ossm-migrating-network-policies
   - Name: Kiali differences for Service Mesh 3
-    File: ossm-migrating-kiali-differences-assembly
+    File: ossm-migrating-kiali-differences
 - Name: Multitenant migration guide
   Dir: multitenant
   Topics:
-  - Name: Migrating a multitenant deployment
-    File: ossm-migrating-multitenant-assembly
+  - Name: Multitenant migration guide
+    File: ossm-migrating-multitenant
 - Name: Cluster-wide migration guide
   Dir: cluster-wide
   Topics:
-  - Name: Migrating a cluster-wide deployment
-    File: ossm-migrating-cluster-wide-assembly
+  - Name: Cluster-wide migration guide
+    File: ossm-migrating-cluster-wide
 - Name: Migrating gateways
   Dir: migrating-gateways
   Topics:
-  - Name: Migrating gateways from Service Mesh 2 to Service Mesh 3
-    File: ossm-migrating-gateways-assembly
+  - Name: Migrating gateways
+    File: ossm-migrating-gateways
 - Name: Completing the migration
   Dir: done
   Topics:
   - Name: Completing the Migration
-    File: ossm-migrating-complete-assembly
+    File: ossm-migrating-complete
 - Name: Reference
   Dir: reference
   Topics:
   - Name: Migrating references
-    File: ossm-migrating-references-assembly
+    File: ossm-migrating-references
 ---
 Name: About
 Dir: about

--- a/about/ossm-about-concepts-assembly.adoc
+++ b/about/ossm-about-concepts-assembly.adoc
@@ -1,14 +1,8 @@
 :_content-type: ASSEMBLY
-[id=ossm-understanding-service-mesh-assembly_{context}]
+[id="ossm-understanding-service-mesh-assembly"]
 = Understanding OpenShift Service Mesh
 include::_attributes/common-attributes.adoc[]
 :context: ossm-about-concepts-assembly
-
-//Conceptual information that is needed for users moving from 2.x to 3, and for new users to understand and orient themselves OSSM 3.x.
-//Customers who are using 3.O TP1 have expressed a need for this content.
-//Did not like calling it "Service Mesh Concepts", though not sold on "Understanding Service Mesh" but like it better than "Service Mesh concepts".
-//TP1 content so likely all info architecture, content, etc will change by GA
-//Kiali attributes are influx
 
 toc::[]
 
@@ -31,7 +25,7 @@ Kali provided by Red Hat is composed of three parts:
 ** {OTELOperator}
 * cert-manager
 * Argo rollouts
-// * Integration of {SMProduct} with 3rd party components that support community Istio integrations --> commented out as none are currently documented in prod docs that are not supported by Red Hat, but support may change for GA so leaving as place holder.
+// * Integration of {SMProduct} with 3rd party components that support community Istio integrations --> commented out as none are currently documented in prod docs that are not supported by Red Hat, but support may change.
 
 include::modules/ossm-about-concepts-resources.adoc[leveloffset=+1]
 

--- a/install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
+++ b/install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="ossm-deploying-multiple-service-meshes-on-single-cluster_{context}"]
+[id="ossm-deploying-multiple-service-meshes-on-single-cluster"]
 = Deploying multiple service meshes on a single cluster
 include::_attributes/common-attributes.adoc[]
 :context: ossm-deploying-multiple-service-meshes-on-single-cluster

--- a/install/ossm-enabling-mtls.adoc
+++ b/install/ossm-enabling-mtls.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id="ossm-enabling-mtls_{context}"]
+[id="ossm-enabling-mtls"]
 = Enabling mutual Transport Layer Security
 include::_attributes/common-attributes.adoc[]
 :context: ossm-enabling-mtls

--- a/install/ossm-installing-openshift-service-mesh.adoc
+++ b/install/ossm-installing-openshift-service-mesh.adoc
@@ -10,7 +10,7 @@ Installing {ocp-short-name} {SMProductShortName} consists of three main tasks: i
 
 [WARNING]
 ====
-Before migrating from {SMProduct} 2, make sure you are not running {SMProduct} 3 and {SMProduct} 2 in the same cluster, because it causes conflicts unless configured correctly. To migrate from {SMProduct} 2, see xref:../migrating/checklists/ossm-migrating-read-me-assembly.adoc#ossm-migrating-read-me-assembly[Migrating from {SMProduct} 2.6].
+Before migrating from {SMProduct} 2, make sure you are not running {SMProduct} 3 and {SMProduct} 2 in the same cluster, because it causes conflicts unless configured correctly. To migrate from {SMProduct} 2, see xref:../migrating/checklists/ossm-migrating-read-me.adoc#ossm-migrating-read-me[Migrating from {SMProduct} 2.6].
 ====
 
 include::modules/ossm-about-deploying-istio-using-service-mesh-operator.adoc[leveloffset=+1]

--- a/install/ossm-running-v2-same-cluster-as-v3-assembly.adoc
+++ b/install/ossm-running-v2-same-cluster-as-v3-assembly.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id="ossm-running-v2-same-cluster-as-v3_{context}"]
+[id="ossm-running-v2-same-cluster-as-v3"]
 = Running {SMProduct} 2.6 in the same cluster as {SMProduct} 3
 include::_attributes/common-attributes.adoc[]
 :context: ossm-running-v2-same-cluster-as-v3-assembly

--- a/migrating/checklists/ossm-migrating-kiali-differences.adoc
+++ b/migrating/checklists/ossm-migrating-kiali-differences.adoc
@@ -3,10 +3,10 @@
 // * migrating/checklists/ossm-kiali-differences-assembly.adoc
 
 :_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-kiali-differences-assembly"]
+[id="ossm-migrating-kiali-differences"]
 = Kiali differences for {SMProductName} 3
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-kiali-differences-assembly
+:context: ossm-migrating-kiali-differences
 
 toc::[]
 

--- a/migrating/checklists/ossm-migrating-network-policies.adoc
+++ b/migrating/checklists/ossm-migrating-network-policies.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-network-policies-assembly"]
+[id="ossm-migrating-network-policies"]
 = Migrating network policies from Service Mesh 2 to Service Mesh 3
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-network-policies-assembly
+:context: ossm-migrating-network-policies
 
 toc::[]
 

--- a/migrating/checklists/ossm-migrating-premigration-checklists.adoc
+++ b/migrating/checklists/ossm-migrating-premigration-checklists.adoc
@@ -1,19 +1,16 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-premigration-checklists-assembly"]
+[id="ossm-migrating-premigration-checklists"]
 = Premigration checklists
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-premigration-checklists-assembly
+:context: ossm-migrating-premigration-checklists
 
 toc::[]
-
-//Kathryn suggested I try to follow this: https://github.com/openshift/openshift-docs/blob/enterprise-4.18/migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc?plain=1
-
 
 .Before you begin
 
 * You have read "Migrating from Service Mesh 2 to Service Mesh 3".
-* You have read and understand the xref:../../migrating/checklists/ossm-migrating-read-me-assembly.adoc#ossm-2-and-3-differences_ossm-migrating-read-me-assembly[differences between OpenShift Service Mesh 2 and OpenShift Service Mesh 3].
-* You have reviewed the xref:../../migrating/reference/ossm-migrating-references-assembly.adoc[Migrating references] material.
+* You have read and understand the xref:../../migrating/checklists/ossm-migrating-read-me.adoc#ossm-2-and-3-differences_ossm-migrating-read-me[differences between OpenShift Service Mesh 2 and OpenShift Service Mesh 3].
+* You have reviewed the xref:../../migrating/reference/ossm-migrating-references.adoc[Migrating references] material.
 * You want to migrate from {SMProduct} 2 to {SMProduct} 3.
 * You are running {SMProduct} {SMv2Version}.
 * You have upgraded your `ServiceMeshControlPlane` resource to the latest version.
@@ -66,7 +63,7 @@ If you do not want your network policies in place during your migration:
 
 If you want your network policies in place during your migration:
 
-* [ ] Manually xref:../../migrating/checklists/ossm-migrating-network-policies-assembly.adoc#ossm-migrating-network-policies-setup-during-migration_ossm-migrating-network-policies-assembly[set up network policies to use during migration].
+* [ ] Manually xref:../../migrating/checklists/ossm-migrating-network-policies.adoc#ossm-migrating-network-policies-setup-during-migration_ossm-migrating-network-policies[set up network policies to use during migration].
 * [ ] Disable network policy management in the {SMProduct} 2 `ServiceMeshControlPlane` resource: `spec.security.manageNetworkPolicy=false`.
 * [ ] Complete the rest of the checklists.
 * [ ] Migrate your deployment and workloads.
@@ -95,13 +92,13 @@ oc get smcp <smcp-name> -n <smcp-namespace> -o jsonpath='{.spec.mode}'
 If you did not set a value for the `.spec.mode` parameter in your `ServiceMeshControlPlane` resource, your deployment is multitenant.
 ====
 
-[id="migrate-based-on-your-deployment-model"]
+[id="migrate-based-on-your-deployment-model_{context}"]
 == Migrate based on your deployment model
 
 If you are not using the cert-manager tool with your deployment, you are ready to migrate your deployment.
 
-* xref:../../migrating/multitenant/ossm-migrating-multitenant-assembly.adoc[Multitenant migration guide]
-* xref:../../migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc[Cluster-wide migration guide]
+* xref:../../migrating/multitenant/ossm-migrating-multitenant.adoc[Multitenant migration guide]
+* xref:../../migrating/cluster-wide/ossm-migrating-cluster-wide.adoc[Cluster-wide migration guide]
 
 If you are unsure, you can check if you are using the cert-manager tool with your deployment.
 
@@ -111,8 +108,8 @@ include::modules/ossm-migrating-premigration-checklists-using-the-cert-manager-t
 
 There are some configurations you must complete first before you can start migrating your deployments.
 
-* xref:../../migrating/multitenant/ossm-migrating-multitenant-assembly.adoc#migrating-multitenant-with-cert-manager_ossm-migrating-multitenant-assembly[Migrating a multitenant deployment with the cert-manager tool]
-* xref:../../migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc#ossm-cluster-wide-migration-methods_ossm-migrating-cluster-wide-assembly[Cluster-wide migration methods]
+* xref:../../migrating/multitenant/ossm-migrating-multitenant.adoc#migrating-multitenant-with-cert-manager_ossm-migrating-multitenant[Migrating a multitenant deployment with the cert-manager tool]
+* xref:../../migrating/cluster-wide/ossm-migrating-cluster-wide.adoc#ossm-cluster-wide-migration-methods_ossm-migrating-cluster-wide[Cluster-wide migration methods]
 
 //Per engineering, uncomment Final check after GA
 //move to module when uncommenting

--- a/migrating/checklists/ossm-migrating-read-me.adoc
+++ b/migrating/checklists/ossm-migrating-read-me.adoc
@@ -1,15 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-read-me-assembly"]
+[id="ossm-migrating-read-me"]
 = Important information to know if you are migrating from OpenShift Service Mesh 2.6
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-read-me-assembly
+:context: ossm-migrating-read-me
 
 toc::[]
 
 If you are moving from {SMProductName} 2.6 to {SMProductName} 3, read the content in this section first as it contains important information and explanations on the differences between the versions. These differences have a direct impact on your installation and configuration of {SMProduct} 3.
-
-//Note to reviewers: this is existing content: https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0.0tp1/html/migrating_from_openshift_service_mesh_2.6/important-information-to-know-before-migrating
-//There were exref updates as this content is moving into a different dir under dir: Migrating
 
 include::modules/ossm-migrating-2-and-3-differences.adoc[leveloffset=+1]
 include::modules/ossm-migrating-read-me-new-operator.adoc[leveloffset=+1]
@@ -51,7 +48,7 @@ include::modules/ossm-migrating-read-me-kubernetes-network-policy-management.ado
 include::modules/ossm-migrating-read-me-tls-configuration-change.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="addition-resource_{context}"]
+[id="additional-resource_{context}"]
 == Additional Resources
 
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/#Observability[Red Hat OpenShift Observability]
@@ -61,5 +58,3 @@ include::modules/ossm-migrating-read-me-tls-configuration-change.adoc[leveloffse
 * link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[Labels and Selectors] (Kubernetes documentation)
 * link:https://istio.io/latest/docs/tasks/security/tls-configuration/workload-min-tls-version/[Istio Workload Minimum TLS Version Configuration] (Istio documentation)
 * link:https://istio.io/latest/docs/reference/config/security/authorization-policy/[Authorization Policies] (Istio documentation)
-
-//Migration likely to resemble https://docs.openshift.com/container-platform/4.17/migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.html#about-migrating-from-3-to-4 when done for OSSM 3.0 GA.

--- a/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
+++ b/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
@@ -3,10 +3,10 @@
 // * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
 
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-cluster-wide-assembly]
+[id="ossm-migrating-cluster-wide"]
 = Cluster-wide migration guide
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-cluster-wide-assembly
+:context: ossm-migrating-cluster-wide
 
 toc::[]
 
@@ -20,11 +20,12 @@ You must complete the premigration checklists before you start migrating your de
 include::modules/ossm-control-plane-configuration-migration-requirements.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources-cluster-wide_{context}"]
 .Additional resources
 
 * xref:../../install/ossm-sidecar-injection-assembly.adoc#ossm-about-sidecar-injection_ossm-sidecar-injection-assembly[About sidecar injection]
 
-* xref:../../migrating/checklists/ossm-migrating-network-policies-assembly.adoc#ossm-migrating-network-policies-setup-during-migration_ossm-migrating-network-policies-assembly[Set up network policies to use during migration]
+* xref:../../migrating/checklists/ossm-migrating-network-policies.adoc#ossm-migrating-network-policies-setup-during-migration_ossm-migrating-network-policies[Set up network policies to use during migration]
 
 * xref:../../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-creating-istiocni-resource[Scoping the mesh with discoverySelectors]
 
@@ -40,11 +41,11 @@ include::modules/ossm-migrating-workloads-using-the-istio-revision-label.adoc[le
 
 If you are using gateways, you must migrate them before you complete the migration process.
 
-* xref:../../migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+* xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc[Migrating gateways]
 
 If you are not using gateways, and have verified your cluster-wide migration, you can proceed to complete the migration and remove {SMProduct} 2 resources.
 
-* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing the Migration]
+* xref:../../migrating/done/ossm-migrating-complete.adoc[Completing the Migration]
 
 //The following tasks are for migrating using the Istio revision label with cert-manager
 include::modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label-with-cert-manager.adoc[leveloffset=+1]
@@ -56,11 +57,11 @@ include::modules/ossm-migrating-workloads-using-the-istio-revision-label-with-ce
 
 If you are using gateways, you must migrate them before you complete the migration process.
 
-* xref:../../migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+* xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc[Migrating gateways]
 
 If you are not using gateways, and have verified your cluster-wide migration, you can proceed to complete the migration and remove {SMProduct} 2 resources.
 
-* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing the Migration]
+* xref:../../migrating/done/ossm-migrating-complete.adoc[Completing the Migration]
 
 // The following tasks are for migrating using the Istio injection label
 
@@ -74,7 +75,7 @@ include::modules/ossm-migrating-workloads-using-the-istio-injection-label.adoc[l
 If you are using gateways, you must migrate them before you complete the migration process.
 
 * Migrating gateways from Service Mesh 2 to Service Mesh 3
-//* xref:../../migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc#ossm-migrating-gateways-assembly[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+//* xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc#ossm-migrating-gateways[Migrating gateways from Service Mesh 2 to Service Mesh 3]
 
 If you are not using gateways, and have verified your cluster-wide migration, create a default revision tag and relabel namespaces.
 
@@ -85,7 +86,7 @@ include::modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespa
 
 You can proceed to complete the migration and remove {SMProduct} 2 resources.
 
-* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing the Migration]
+* xref:../../migrating/done/ossm-migrating-complete.adoc[Completing the Migration]
 
 [IMPORTANT]
 ====
@@ -104,7 +105,7 @@ include::modules/ossm-migrating-workloads-using-the-istio-injection-label-with-c
 If you are using gateways, you must migrate them before you complete the migration process.
 
 * Migrating gateways from Service Mesh 2 to Service Mesh 3
-//* xref:../../migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc#ossm-migrating-gateways-assembly[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+//* xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc#ossm-migrating-gateways[Migrating gateways from Service Mesh 2 to Service Mesh 3]
 
 If you are not using gateways, and have verified your cluster-wide migration, create a default revision tag and relabel namespaces.
 
@@ -124,11 +125,11 @@ include::modules/ossm-migrating-workloads-using-the-simple-migration-method.adoc
 
 If you are using gateways, you must migrate them before you complete the migration process.
 
-* xref:../../migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+* xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc[Migrating gateways]
 
 If you are using gateways, you can complete your migration.
 
-* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing the Migration]
+* xref:../../migrating/done/ossm-migrating-complete.adoc[Completing the Migration]
 
 [id="additional-resources_{context}"]
 == Additional resources

--- a/migrating/done/ossm-migrating-complete.adoc
+++ b/migrating/done/ossm-migrating-complete.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-complete-assembly"]
+[id="ossm-migrating-complete"]
 = Completing the Migration
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-complete-assembly
+:context: ossm-migrating-complete
 
 toc::[]
 
@@ -19,17 +19,13 @@ include::modules/ossm-migrating-complete-multitenant-cert-manager.adoc[leveloffs
 
 * Remove {Smproduct} 2
 
-//content taken from https://github.com/openshift-service-mesh/sail-operator/tree/main/docs/ossm/ossm2-migration#post-migration-checklist which is a new addition to the Premigration Checklist content as of 01/27/2025 even though it is post migration content. However, the engineering staging area, /docs/ossm/ doesn't have a post migration folder, so making note here for reference so whomever else is in this file doesn't have to go digging.
-
-//includes coming.
-
 include::modules/ossm-migrating-complete-remove-2-6-control-plane.adoc[leveloffset=+1]
 include::modules/ossm-migrating-complete-remove-2-6-operator-crds.adoc[leveloffset=+1]
 include::modules/ossm-migrating-complete-remove-maistra-labels.adoc[leveloffset=+1]
 
 
 [role="_additional-resources"]
-[id="addition-resource-complete_{context}"]
+[id="additional-resources-complete_{context}"]
 == Additional Resources
 
 * link:https://kiali.io/docs/features/istio-component-status/#control-plane-namespace[Istio infrastructure status] (Kiali.io documentation)

--- a/migrating/migrating-gateways/ossm-migrating-gateways.adoc
+++ b/migrating/migrating-gateways/ossm-migrating-gateways.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-gateways-assembly]
-= Migrating gateways from Service Mesh 2 to Service Mesh 3
+[id="ossm-migrating-gateways"]
+= Migrating gateways
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-gateways-assembly
+:context: ossm-migrating-gateways
 
 toc::[]
 
@@ -17,20 +17,20 @@ include::modules/ossm-migrating-gateways-canary.adoc[leveloffset=+1]
 
 .Next steps
 
-* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing your migration]
+* xref:../../migrating/done/ossm-migrating-complete.adoc[Completing your migration]
 
 include::modules/ossm-migrating-gateways-in-place.adoc[leveloffset=+1]
 
 .Next steps
 
-* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing your migration]
+* xref:../../migrating/done/ossm-migrating-complete.adoc[Completing your migration]
 
 [role="_additional-resources"]
-[id="addition-resources-gateways_{context}"]
+[id="additional-resources-gateways_{context}"]
 == Additional resources
 
-* xref:../../migrating/multitenant/ossm-migrating-multitenant-assembly.adoc[Multitenant migration guide]
-* xref:../../migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc[Cluster-wide migration guide]
+* xref:../../migrating/multitenant/ossm-migrating-multitenant.adoc[Multitenant migration guide]
+* xref:../../migrating/cluster-wide/ossm-migrating-cluster-wide.adoc[Cluster-wide migration guide]
 
 //there is already a Gateways dir that contains 3.0 concept and procedure content for configuring and using gateways in 3.0.
 //named this dir migrating-gateways for clarity

--- a/migrating/multitenant/ossm-migrating-multitenant.adoc
+++ b/migrating/multitenant/ossm-migrating-multitenant.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-multitenant-assembly]
+[id="ossm-migrating-multitenant"]
 = Multitenant migration guide
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-multitenant-assembly
+:context: ossm-migrating-multitenant
 
 toc::[]
 
@@ -20,11 +20,11 @@ include::modules/ossm-migrating-multitenant-workloads.adoc[leveloffset=+1]
 
 If you are using gateways, you must migrate them before you complete the migration process for your deployment and workloads.
 
-* xref:../migrating-gateways/ossm-migrating-gateways-assembly.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+* xref:../migrating-gateways/ossm-migrating-gateways.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
 
 If you are not using gateways, and have verified your mulitenant migration, you can proceed to complete the migration and remove {SMProduct} 2 resources.
 
-* xref:../done/ossm-migrating-complete-assembly.adoc[Completing the Migration]
+* xref:../done/ossm-migrating-complete.adoc[Completing the Migration]
 
 include::modules/ossm-migrating-multitenant-with-cert-manager.adoc[leveloffset=+1]
 include::modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc[leveloffset=+1]
@@ -33,10 +33,10 @@ include::modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc[lev
 
 If you are using gateways, you must migrate them before you can complete the migration process for your deployment and workloads.
 
-* xref:../migrating-gateways/ossm-migrating-gateways-assembly.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+* xref:../migrating-gateways/ossm-migrating-gateways.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
 
 After you have migrated your gateways, you must update the `app.controller.configmapNamespaceSelector` field in your `istio-csr` deployment.
 
 If you are not using gateways, you can complete your migration with cert-manager.
 
-* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing the Migration]
+* xref:../../migrating/done/ossm-migrating-complete.adoc[Completing the Migration]

--- a/migrating/ossm-migrating-from-service-mesh-2-to-3.adoc
+++ b/migrating/ossm-migrating-from-service-mesh-2-to-3.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="ossm-migrating-from-service-mesh-2-to-3-assembly"]
+[id="ossm-migrating-from-service-mesh-2-to-3"]
 = Migrating from Service Mesh 2 to Service Mesh 3
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-from-service-mesh-2-to-3-assembly
+:context: ossm-migrating-from-service-mesh-2-to-3
 
 toc::[]
 

--- a/migrating/reference/ossm-migrating-references.adoc
+++ b/migrating/reference/ossm-migrating-references.adoc
@@ -1,9 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-references-assembly]
+[id=ossm-migrating-references]
 = Migrating references
 include::_attributes/common-attributes.adoc[]
-:context: ossm-migrating-read-me-assembly
-
+:context: ossm-migrating-references
 toc::[]
 
 Many configuration options in the {SMProduct} 2 `ServiceMeshControlPlane` resource have changed location in the {SMProduct} 3 `Istio` resource. The following tables provide guidance for creating a new `Istio` resource in {SMProduct} 3 based on your existing {SMProduct} 2 `ServiceMeshControlPlane` resource.

--- a/modules/ossm-cluster-wide-migration-methods.adoc
+++ b/modules/ossm-cluster-wide-migration-methods.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 
-// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="ossm-cluster-wide-migration-methods_{context}"]

--- a/modules/ossm-control-plane-configuration-migration-requirements.adoc
+++ b/modules/ossm-control-plane-configuration-migration-requirements.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 
-// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="ossm-about-cluster-wide-migration_{context}"]
@@ -28,7 +28,7 @@ In {SMProduct} 2.6 installations, the `maistra.io/member-of` label is automatica
 [id="ossm-cluster-wide-migration-network-policies_{context}"]
 == Network policies
 
-By default, {SMProduct} 2.6 manages network policies that block traffic to the 3.0 control plane. 
+By default, {SMProduct} 2.6 manages network policies that block traffic to the 3.0 control plane.
 
 For both control planes, during the migration ensure that network policies do not block traffic between the following entities:
 
@@ -64,6 +64,6 @@ In the {SMProduct} 2.6 installation, the member selection configuration in the `
 
 By default, in a 2.6 installation, the `spec.memberSelectors` field in the `ServiceMeshMemberRoll` resource is configured to match the `istio-injection=enabled` label and all of the data plane namespaces in a 2.6 installation have the `istio-injection=enabled` label applied. If you are using the default 2.6 installation settings, you can keep using that label or switch to the `istio.io/rev` label for the 3.0 installation.
 
-If the `spec.memberSelectors` field in the `ServiceMeshMemberRoll` resource is not configured to match the `istio-injection=enabled` label and the 2.6 data plane namespace uses a custom label, you must add the `istio.io/rev` label or the `istio-injection` label during the migration. The custom labels defined in the `spec.memberSelectors` parameter of the `ServiceMeshMemberRoll` resource have no effect on sidecar injection in the {SMProduct} 3 installation and cannot be used. 
+If the `spec.memberSelectors` field in the `ServiceMeshMemberRoll` resource is not configured to match the `istio-injection=enabled` label and the 2.6 data plane namespace uses a custom label, you must add the `istio.io/rev` label or the `istio-injection` label during the migration. The custom labels defined in the `spec.memberSelectors` parameter of the `ServiceMeshMemberRoll` resource have no effect on sidecar injection in the {SMProduct} 3 installation and cannot be used.
 
 If projects in the 2.6 installation were added to the mesh by manually creating the `ServiceMeshMember` resource, you must add the `istio.io/rev` or `istio-injection` label to the project namespaces during the migration.

--- a/modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces.adoc
+++ b/modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces_{context}"]
@@ -110,5 +110,5 @@ ratings-v1-5b67b59fcb-w4whk.bookinfo         Kubernetes     SYNCED (18s)     SYN
 reviews-v1-585fc84dbb-fvm2h.bookinfo         Kubernetes     SYNCED (11s)     SYNCED (11s)     SYNCED (3s)     SYNCED (11s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
 reviews-v2-65cb66b45c-6ggp9.bookinfo         Kubernetes     SYNCED (57s)     SYNCED (57s)     SYNCED (3s)     SYNCED (57s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
 reviews-v2-698b86b848-v92xq.bookinfo         Kubernetes     SYNCED (3s)      SYNCED (3s)      SYNCED (3s)     SYNCED (3s)      IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
-reviews-v3-6cbc49c8c8-v4jck.bookinfo         Kubernetes     SYNCED (11s)     SYNCED (11s)     SYNCED (3s)     SYNCED (11s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3          
+reviews-v3-6cbc49c8c8-v4jck.bookinfo         Kubernetes     SYNCED (11s)     SYNCED (11s)     SYNCED (3s)     SYNCED (11s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
 ----

--- a/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-injection-label.adoc
+++ b/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-injection-label.adoc
@@ -1,14 +1,14 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-migrating-a-cluster-wide-deployment-using-the-istio-injection-label_{context}"]
 = Migrating a cluster-wide deployment by using the istio injection label
 
-You can perform a canary upgrade with the gradual migration of data plane namespaces for a cluster-wide deployment by using the `istio-injection=enabled` label and the `default` revision tag. 
+You can perform a canary upgrade with the gradual migration of data plane namespaces for a cluster-wide deployment by using the `istio-injection=enabled` label and the `default` revision tag.
 
-You must re-label all of the data plane namespaces. However, it is safe to restart any of the workloads at any point during the migration process. 
+You must re-label all of the data plane namespaces. However, it is safe to restart any of the workloads at any point during the migration process.
 
 The `bookinfo` application is used as an example for the `Istio` resource. For more information about configuration differences between the {SMProduct} 2 `ServiceMeshControlPlane` resource and the {SMProduct} 3 `Istio` resource, see "ServiceMeshControlPlane resource to Istio resource fields mapping".
 
@@ -59,7 +59,7 @@ spec:
     type: RevisionBased
   namespace: istio-system # <2>
   version: v1.24.3
-  values:  
+  values:
     meshConfig:
       extensionProviders: # <3>
         - name: prometheus

--- a/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label.adoc
+++ b/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label_{context}"]

--- a/modules/ossm-migrating-a-multitenant-deployment.adoc
+++ b/modules/ossm-migrating-a-multitenant-deployment.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/checklists/ossm-migrating-multitenant-assembly.adoc
+// * service-mesh-docs-main/migrating/checklists/ossm-migrating-multitenant.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="migrating-a-multitenant-deployment_{context}""]

--- a/modules/ossm-migrating-complete-multitenant-cert-manager.adoc
+++ b/modules/ossm-migrating-complete-multitenant-cert-manager.adoc
@@ -1,7 +1,7 @@
 
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/multitenant/ossm-migrating-multitenant-assembly.adoc
+// * service-mesh-docs-main/multitenant/ossm-migrating-multitenant.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="migrating-complete-multitenant-cert-manager_{context}""]

--- a/modules/ossm-migrating-complete-remove-2-6-control-plane.adoc
+++ b/modules/ossm-migrating-complete-remove-2-6-control-plane.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/done/ossm-migrating-complete-assembly
+// * service-mesh-docs-main/migrating/done/ossm-migrating-complete
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-migrating-remove-2-6-control-plane_{context}"]

--- a/modules/ossm-migrating-complete-remove-2-6-operator-crds.adoc
+++ b/modules/ossm-migrating-complete-remove-2-6-operator-crds.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/done/ossm-migrating-complete-assembly
+// * service-mesh-docs-main/migrating/done/ossm-migrating-complete
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-migrating-complete-remove-2-6-operator-crds_{context}"]

--- a/modules/ossm-migrating-complete-remove-maistra-labels.adoc
+++ b/modules/ossm-migrating-complete-remove-maistra-labels.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/done/ossm-migrating-complete-assembly
+// * service-mesh-docs-main/migrating/done/ossm-migrating-complete
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-migrating-complete-remove-maistra-labels_{context}"]

--- a/modules/ossm-migrating-gateways-canary.adoc
+++ b/modules/ossm-migrating-gateways-canary.adoc
@@ -1,7 +1,7 @@
 
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc
+// * service-mesh-docs-main/migrating/migrating-gateways/ossm-migrating-gateways.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-migrating-gateways-canary_{context}"]

--- a/modules/ossm-migrating-gateways-in-place.adoc
+++ b/modules/ossm-migrating-gateways-in-place.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc
+// * service-mesh-docs-main/migrating/migrating-gateways/ossm-migrating-gateways.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-migrating-gateways-in-place_{context}"]

--- a/modules/ossm-migrating-hub-completing-your-migration.adoc
+++ b/modules/ossm-migrating-hub-completing-your-migration.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/ossm-migrating-from-service-mesh-2-to-3-assembly.adoc
+// * service-mesh-docs-main/migrating/ossm-migrating-from-service-mesh-2-to-3.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="ossm-migrating-hub-completing-your-migration_{context}"]

--- a/modules/ossm-migrating-multitenant-with-cert-manager.adoc
+++ b/modules/ossm-migrating-multitenant-with-cert-manager.adoc
@@ -1,7 +1,7 @@
 
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/multitenant/ossm-migrating-multitenant-assembly.adoc
+// * service-mesh-docs-main/multitenant/ossm-migrating-multitenant.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="migrating-multitenant-with-cert-manager_{context}""]

--- a/modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc
+++ b/modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/checklists/ossm-migrating-multitenant-assembly.adoc
+// * service-mesh-docs-main/migrating/checklists/ossm-migrating-multitenant.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="migrating-multitenant-workloads-with-cert-manager_{context}""]

--- a/modules/ossm-migrating-multitenant-workloads.adoc
+++ b/modules/ossm-migrating-multitenant-workloads.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/checklists/ossm-migrating-multitenant-assembly.adoc
+// * service-mesh-docs-main/migrating/checklists/ossm-migrating-multitenant.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="migrating-multitenant-workloads_{context}""]

--- a/modules/ossm-migrating-read-me-new-operator.adoc
+++ b/modules/ossm-migrating-read-me-new-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/about/ossm-migrating-read-me-assembly.adoc
+// * service-mesh-docs-main/about/ossm-migrating-read-me.adoc
 
 //Start of an overall Migrating section.
 //Section is most likely to be reworked/restructured with OSSM 2 to OSSM 3 migration guides for GA. Unknown how many migration guides there are at this time (11/11/2024). It would be beneficial to be able to link from differences to the relevent migration guide so that users A) understand the change, esp significant changes like new operator, installing tracing and Kiali separately, gateways, etc.

--- a/modules/ossm-migrating-workloads-using-the-istio-injection-label.adoc
+++ b/modules/ossm-migrating-workloads-using-the-istio-injection-label.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-migrating-workloads-using-the-istio-injection-label_{context}"]
@@ -46,7 +46,7 @@ $ oc label ns bookinfo istio.io/rev=ossm-3-v1-24-3 maistra.io/ignore-namespace="
 +
 The `oc label` command performs the following actions:
 
-.. Removes the `istio-injection` label: This label prevents the 3.0 control plane from injecting the proxy. The `istio-injection` label takes precedence over the `istio.io/rev` label. You must temporarily remove the `istio-injection=enabled` because you cannot create the default `IstioRevisionTag` tag yet. Leaving the `istio-injection=enabled` label applied would prevent the 3.0 control plane from performing proxy injection. 
+.. Removes the `istio-injection` label: This label prevents the 3.0 control plane from injecting the proxy. The `istio-injection` label takes precedence over the `istio.io/rev` label. You must temporarily remove the `istio-injection=enabled` because you cannot create the default `IstioRevisionTag` tag yet. Leaving the `istio-injection=enabled` label applied would prevent the 3.0 control plane from performing proxy injection.
 
 .. Adds the `istio.io/rev=ossm-3-v1-24-3` label: This label ensures that any newly created or restarted pods in the namespace connect to the {SMProduct} 3.0 proxy.
 

--- a/modules/ossm-migrating-workloads-using-the-istio-revision-label.adoc
+++ b/modules/ossm-migrating-workloads-using-the-istio-revision-label.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/migrating/checklists/ossm-migrating-cluster-wide-assembly.adoc
+// * service-mesh-docs-main/migrating/checklists/ossm-migrating-cluster-wide.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-migrating-workloads-using-the-istio-revision-label_{context}"]
@@ -48,9 +48,9 @@ $ oc label ns bookinfo istio.io/rev=ossm-3-v1-24-3 maistra.io/ignore-namespace="
 +
 Running the command performs the following actions:
 
-.. Removes the `istio-injection` label: This label prevents the 3.0 control plane from injecting the proxy. The `istio-injection` label takes precedence over `istio.io/rev` label. 
+.. Removes the `istio-injection` label: This label prevents the 3.0 control plane from injecting the proxy. The `istio-injection` label takes precedence over `istio.io/rev` label.
 
-.. Adds the `istio.io/rev=ossm-3-v1-24-3` label: This label ensures that any newly created or restarted pods in the namespace connect to the {SMProduct} 3.0 proxy. 
+.. Adds the `istio.io/rev=ossm-3-v1-24-3` label: This label ensures that any newly created or restarted pods in the namespace connect to the {SMProduct} 3.0 proxy.
 
 .. Adds the `maistra.io/ignore-namespace: "true"` label: This label disables sidecar injection for {SMProduct} 2.6 proxies in the namespace. With the label applied, {SMProduct} 2.6 stops injecting proxies in this namespace, and any new proxies are injected by {SMProduct} 3.0. Without this label, the {SMProduct} 2.6 injection webhook tries to inject the pod and the injected sidecar proxy refuses to start since it will have both the {SMProduct} 2.6 and the {SMProduct} 3.0 Container Network Interface(CNI) annotations.
 +

--- a/ossm-release-notes/ossm-release-notes-assembly.adoc
+++ b/ossm-release-notes/ossm-release-notes-assembly.adoc
@@ -27,9 +27,9 @@ include::modules/ossm-release-notes-3-0-deprecated-removed-features.adoc[levelof
 == Additional resources
 
 * xref:../ossm-release-notes/ossm-release-notes-support-tables-assembly.adoc#ossm-release-notes-support-tables-assembly[Service Mesh 3.0 feature support tables]
-* xref:../migrating/ossm-migrating-from-service-mesh-2-to-3-assembly.adoc#ossm-migrating-from-service-mesh-2-to-3[Migrating from {smproductshortname} 2 to {smproductshortname} 3]
-* xref:../migrating/checklists/ossm-migrating-read-me-assembly.adoc#ossm-migrating-read-me-assembly[Important information to know if you are migrating from {SMProduct} 2.6]
-* xref:../migrating/checklists/ossm-migrating-read-me-assembly.adoc#ossm-migrating-read-me-support-for-istioctl_ossm-migrating-read-me-assembly[Support for Istioctl]
+* xref:../migrating/ossm-migrating-from-service-mesh-2-to-3.adoc#ossm-migrating-from-service-mesh-2-to-3[Migrating from {smproductshortname} 2 to {smproductshortname} 3]
+* xref:../migrating/checklists/ossm-migrating-read-me.adoc#ossm-migrating-read-me[Important information to know if you are migrating from {SMProduct} 2.6]
+* xref:../migrating/checklists/ossm-migrating-read-me.adoc#ossm-migrating-read-me-support-for-istioctl_ossm-migrating-read-me[Support for Istioctl]
 * xref:../update/ossm-updating-openshift-service-mesh.adoc#about-revisionbased-strategy_ossm-performing-inplace-update[About RevisionBased strategy]
 * xref:../observability/ossm-observability-service-mesh-assembly.adoc#ossm-observability-service-mesh-assembly[{observabilitylongname} and {smproductshortname}]
 * xref:../observability/kiali/ossm-kiali-assembly.adoc#ossm-kiali-assembly[Using {kialiproduct}]


### PR DESCRIPTION
**OSSM 3.0**

[OSSM-8997](https://issues.redhat.com//browse/OSSM-8997) Remove assembly from Migration Guide file names

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
OSSM 3

Issue:
https://issues.redhat.com/browse/OSSM-8997

Link to docs preview:

* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/about/ossm-about-concepts-assembly.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-deploying-multiple-service-meshes-on-single-cluster.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-enabling-mtls.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-kiali-differences.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-network-policies.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-premigration-checklists.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-read-me.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/cluster-wide/ossm-migrating-cluster-wide.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/done/ossm-migrating-complete.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/migrating-gateways/ossm-migrating-gateways.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/multitenant/ossm-migrating-multitenant.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/ossm-migrating-from-service-mesh-2-to-3.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/reference/ossm-migrating-references.html
* https://89492--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-assembly.html

QE review:
QE is not required for this change. PR is renaming/restructuring files.

Additional information:

* Also removes comments that were left to keep track of things for the migration guides and GA.

* Things were fixed in other files in an effort to troubleshoot continued PR build failures.

* Multi-pronged approach. Updating anchors is a separate Jira that is a sub-task of [OSSM-8997](https://issues.redhat.com//browse/OSSM-8997). This PR is passing and is needed in order for other PRs to pass. Those PRs have changes required for GA, and those PRs are failing for the same reasons addressed in this PR, like https://github.com/openshift/openshift-docs/pull/90156.

* There are other files ending in "assembly" that are addressed in a separate Jira, also a sub-task of [OSSM-8997](https://issues.redhat.com//browse/OSSM-8997). [OSSM-8997](https://issues.redhat.com//browse/OSSM-8997) is specific to the Migration Guides as it is the biggest, and more complicated lift due to the number of xrefs to help users navigate to where they need to go for each part of the migration process, based on their deployment model.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
