### PR TITLE
OCPBUGS#50691: Add link to prevent workload updates section

### DIFF
--- a/updating/updating_a_cluster/control-plane-only-update.adoc
+++ b/updating/updating_a_cluster/control-plane-only-update.adoc
@@ -14,7 +14,7 @@ To do: Remove this comment once 4.13 docs are EOL.
 
 Due to fundamental Kubernetes design, all {product-title} updates between minor versions must be serialized.
 You must update from {product-title} <4.y> to <4.y+1>, and then to <4.y+2>. You cannot update from {product-title} <4.y> to <4.y+2> directly.
-However, administrators who want to update between two even-numbered minor versions can do so incurring only a single reboot of non-control plane hosts. 
+However, administrators who want to update between two even-numbered minor versions can do so incurring only a single reboot of non-control plane hosts.
 
 [IMPORTANT]
 ====
@@ -64,3 +64,4 @@ include::modules/updating-control-plane-only-layered-products.adoc[leveloffset=+
 * xref:../../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators]
 * xref:../../updating/updating_a_cluster/control-plane-only-update.adoc#updating-control-plane-only-update-console_control-plane-only-update[Performing a Control Plane Only update using the web console]
 * xref:../../updating/updating_a_cluster/control-plane-only-update.adoc#updating-control-plane-only-update-cli_control-plane-only-update[Performing a Control Plane Only update using the CLI]
+* xref:../../virt/updating/upgrading-virt.adoc#virt-preventing-workload-updates-during-control-plane-only-update_upgrading-virt[Preventing workload updates during a Control Plane Only update]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-50691
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://89514--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/control-plane-only-update.html#additional-resources_control-plane-only-updates 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- Not required. Only link is being added.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
