### PR TITLE
change disk.enableUUID to TRUE

### DIFF
--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -42,7 +42,7 @@ endif::[]
 ** Minimum 15 GB hard disk space for the file system containing `/var/`.
 ** Minimum 1 GB hard disk space for the file system containing `/usr/local/bin/`.
 ** Minimum 1 GB hard disk space for the file system containing its temporary directory. The temporary system directory is determined according to the rules defined in the tempfile module in the Python standard library.
-* Each system must meet any additional requirements for your system provider. For example, if you installed your cluster on VMware vSphere, your disks must be configured according to its link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html[storage guidelines] and the `disk.enableUUID=true` attribute must be set.
+* Each system must meet any additional requirements for your system provider. For example, if you installed your cluster on VMware vSphere, your disks must be configured according to its link:https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/prerequisites.md[storage guidelines] and the `disk.enableUUID=TRUE` attribute must be set.
 
 * Each system must be able to access the cluster's API endpoints by using DNS-resolvable hostnames. Any network security access control that is in place must allow system access to the cluster's API service endpoints.
 


### PR DESCRIPTION
Changed disk.enableUUID from true to TRUE in rhel-compute-requirements.adoc file

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):  4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-52283](https://issues.redhat.com/browse/OCPBUGS-52283)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://89519--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html
https://89519--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/more-rhel-compute.html
https://89519--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
