### PR TITLE
OSDOCS-13539: Updated the nw-ovn-ipsec-disable.adoc command

### DIFF
--- a/modules/nw-ovn-ipsec-disable.adoc
+++ b/modules/nw-ovn-ipsec-disable.adoc
@@ -10,17 +10,19 @@ As a cluster administrator, you can disable IPsec encryption.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* Log in to the cluster with a user with `cluster-admin` privileges.
+* You installed the {oc-first}.
+* You logged in to the cluster with a user with `cluster-admin` privileges.
 
 .Procedure
 
-. To disable IPsec encryption, enter the following command:
+. Choose one of the following options to disable IPsec encryption:
++
+.. Where the `ipsecConfig.mode` parameter is set to either `External` or `Full` and the `ipsecConfig.full` schema is not added to `networks.operator.openshift.io`, enter the following command:
 +
 [source,terminal]
 ----
-$ oc patch networks.operator.openshift.io cluster --type=merge \
--p '{
+$ oc patch networks.operator.openshift.io cluster --type=merge -p \
+  '{
   "spec":{
     "defaultNetwork":{
       "ovnKubernetesConfig":{
@@ -28,5 +30,14 @@ $ oc patch networks.operator.openshift.io cluster --type=merge \
           "mode":"Disabled"
         }}}}}'
 ----
++
+.. Where the `ipsecConfig.mode` parameter is set to `Full` and the `ipsecConfig.full` configuration is added to `networks.operator.openshift.io`, enter the following command:
++
+[source,terminal]
+----
+$ oc patch networks.operator.openshift.io cluster --type='json' -p \
+      '[{"op": "remove", "path": "/spec/defaultNetwork/ovnKubernetesConfig/ipsecConfig/full"}, 
+      {"op": "replace", "path": "/spec/defaultNetwork/ovnKubernetesConfig/ipsecConfig/mode", "value": "Disabled"}]'
+----
 
-. Optional: You can increase the size of your cluster MTU by `46` bytes because there is no longer any overhead from the IPsec ESP header in IP packets.
+. Optional: You can increase the size of your cluster MTU by `46` bytes because there is no longer any overhead from the IPsec Encapsulating Security Payload (ESP) header in IP packets.

--- a/modules/nw-ovn-ipsec-enable.adoc
+++ b/modules/nw-ovn-ipsec-enable.adoc
@@ -6,7 +6,7 @@
 [id="nw-ovn-ipsec-enable_{context}"]
 = Enabling IPsec encryption
 
-As a cluster administrator, you can enable pod-to-pod IPsec encryption, IPsec encryption between the cluster, and external IPsec endpoints.
+As a cluster administrator you can enable pod-to-pod IPsec encryption between the cluster and external IPsec endpoints.
 
 You can configure IPsec in either of the following modes:
 
@@ -17,6 +17,12 @@ You can configure IPsec in either of the following modes:
 ====
 If you configure IPsec in `Full` mode, you must also complete the "Configuring IPsec encryption for external traffic" procedure.
 ====
+
+If IPsec is enabled in `Full` mode, as a cluster administrator you can configure options for the mode by adding the `full` schema to `networks.operator.openshift.io`. The `full` schema supports the 
+`encapsulation` parameter. You can use this parameter to configure network address translation-traversal (NAT-T) encapsulation for IPsec traffic. The `encapsulation` parameter supports the following values:
+
+* `Auto` is the default value and enables UDP encapsulation when `libreswan` detects network address translation (NAT) packets in traffic within a node.
+* `Always` enables UDP encapsulation for all traffic types available in a node. This option does not rely upon `libreswan` to detect NAT packets in a node.
 
 .Prerequisites
 
@@ -41,6 +47,21 @@ $ oc patch networks.operator.openshift.io cluster --type=merge -p \
 ----
 +
 <1> Specify `External` to encrypt traffic to external hosts or specify `Full` to encrypt pod-to-pod traffic and, optionally, traffic to external hosts. By default, IPsec is disabled.
++
+.Example configuration that has IPsec enabled in `Full` mode and `encapsulation` set to `Always`
+[source,terminal]
+----
+$ oc patch networks.operator.openshift.io cluster --type=merge -p \
+  '{
+  "spec":{
+    "defaultNetwork":{
+      "ovnKubernetesConfig":{
+        "ipsecConfig":{
+          "mode":"Full",
+          "full":{
+            "encapsulation": "Always"
+          }}}}}}'
+----
 
 . Encrypt external traffic with IPsec by completing the "Configuring IPsec encryption for external traffic" procedure.
 

--- a/modules/nwt-gateway-mode.adoc
+++ b/modules/nwt-gateway-mode.adoc
@@ -28,7 +28,7 @@ You can follow the optional step 4 to enable IP forwarding alongside local gatew
 $ oc get network.operator cluster -o yaml > network-config-backup.yaml
 ----
 
-. Set the `routingViaHost` paramemter to `true` for local gateway mode by running the following command:
+. Set the `routingViaHost` parameter to `true` for local gateway mode by running the following command:
 +
 [source,terminal]
 ----

--- a/networking/network_security/configuring-ipsec-ovn.adoc
+++ b/networking/network_security/configuring-ipsec-ovn.adoc
@@ -12,8 +12,7 @@ IPsec is disabled by default. You can enable IPsec either during or after instal
 
 The following support limitations exist for IPsec on a {product-title} cluster:
 
-* You must disable IPsec before updating to {product-title} 4.15. There is a known issue that can cause interruptions in pod-to-pod communication if you update without disabling IPsec. (link:https://issues.redhat.com/browse/OCPBUGS-43323[*OCPBUGS-43323*])
-* On {ibm-cloud-name}, IPsec supports only NAT-T. Encapsulating Security Payload (ESP) is not supported on this platform.
+* On {ibm-cloud-name}, IPsec supports only network address translation-traversal (NAT-T). Encapsulating Security Payload (ESP) is not supported on this platform.
 * If your cluster uses link:https://www.redhat.com/en/topics/containers/what-are-hosted-control-planes[{hcp}] for Red{nbsp}Hat {product-title}, IPsec is not supported for IPsec encryption of either pod-to-pod or traffic to external hosts.
 * Using ESP hardware offloading on any network interface is not supported if one or more of those interfaces is attached to Open vSwitch (OVS). Enabling IPsec for your cluster triggers the use of IPsec with interfaces attached to OVS. By default, {product-title} disables ESP hardware offloading on any interfaces attached to OVS.
 * If you enabled IPsec for network interfaces that are not attached to OVS, a cluster administrator must manually disable ESP hardware offloading on each interface that is not attached to OVS.


### PR DESCRIPTION
Cannot merge until https://github.com/openshift/cluster-network-operator/pull/2573 is merged.

NAT-T encapsulation is 4.19+ only.

Version(s):
4.19+

Issue:
[OSDOCS-13539](https://issues.redhat.com/browse/OSDOCS-13539)

Link to docs preview:
* [Enabling IPsec encryption](https://89520--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn.html#nw-ovn-ipsec-enable_configuring-ipsec-ovn)
* [Disabling IPsec encryption](https://89520--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn.html#nw-ovn-ipsec-disable_configuring-ipsec-ovn)

- [x] SME has approved this change (Periyasamy Palanisamy).
- [x] QE has approved this change (Huiran Wang).


Additional information:
[Slack](https://app.slack.com/client/E030G10V24F/C08DNAFC85T?selected_team_id=E030G10V24F)
