### PR TITLE
Change RHEL version to 8.8 or later

### DIFF
--- a/modules/rhel-images-aws.adoc
+++ b/modules/rhel-images-aws.adoc
@@ -15,14 +15,14 @@ AMI IDs correspond to native boot images for AWS. Because an AMI must exist befo
 
 .Procedure
 
-* Use this command to list {op-system-base} 8.4 Amazon Machine Images (AMI):
+* Use this command to list {op-system-base} 8.8 Amazon Machine Images (AMI):
 +
 --
 [source,terminal]
 ----
 $ aws ec2 describe-images --owners 309956199498 \ <1>
 --query 'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]' \ <2>
---filters "Name=name,Values=RHEL-8.4*" \ <3>
+--filters "Name=name,Values=RHEL-8.8*" \ <3>
 --region us-east-1 \ <4>
 --output table <5>
 ----
@@ -33,14 +33,14 @@ $ aws ec2 describe-images --owners 309956199498 \ <1>
 This account ID is required to display AMI IDs for images that are provided by Red Hat.
 ====
 <2> The `--query` command option sets how the images are sorted with the parameters `'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]'`. In this case, the images are sorted by the creation date, and the table is structured to show the creation date, the name of the image, and the AMI IDs.
-<3> The `--filter` command option sets which version of {op-system-base} is shown. In this example, since the filter is set by `"Name=name,Values=RHEL-8.4*"`, then {op-system-base} 8.4 AMIs are shown.
+<3> The `--filter` command option sets which version of {op-system-base} is shown. In this example, since the filter is set by `"Name=name,Values=RHEL-8.8*"`, then {op-system-base} 8.8 AMIs are shown.
 <4> The `--region` command option sets where the region where an AMI is stored.
 <5> The `--output` command option sets how the results are displayed.
 --
 
 [NOTE]
 ====
-When creating a {op-system-base} compute machine for AWS, ensure that the AMI is {op-system-base} 8.4 or 8.5.
+When creating a {op-system-base} compute machine for AWS, ensure that the AMI is {op-system-base} 8.8 or a later version of RHEL 8.
 ====
 
 .Example output
@@ -49,9 +49,9 @@ When creating a {op-system-base} compute machine for AWS, ensure that the AMI is
 ------------------------------------------------------------------------------------------------------------
 |                                              DescribeImages                                              |
 +---------------------------+-----------------------------------------------------+------------------------+
-|  2021-03-18T14:23:11.000Z |  RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2  |  ami-07eeb4db5f7e5a8fb |
-|  2021-03-18T14:38:28.000Z |  RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2   |  ami-069d22ec49577d4bf |
-|  2021-05-18T19:06:34.000Z |  RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2        |  ami-01fc429821bf1f4b4 |
-|  2021-05-18T20:09:47.000Z |  RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2       |  ami-0b0af3577fe5e3532 |
+|  2021-03-18T14:23:11.000Z |  RHEL-8.8.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2  |  ami-07eeb4db5f7e5a8fb |
+|  2021-03-18T14:38:28.000Z |  RHEL-8.8.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2   |  ami-069d22ec49577d4bf |
+|  2021-05-18T19:06:34.000Z |  RHEL-8.8.0_HVM-20210504-arm64-2-Hourly2-GP2        |  ami-01fc429821bf1f4b4 |
+|  2021-05-18T20:09:47.000Z |  RHEL-8.8.0_HVM-20210504-x86_64-2-Hourly2-GP2       |  ami-0b0af3577fe5e3532 |
 +---------------------------+-----------------------------------------------------+------------------------+
 ----


### PR DESCRIPTION
As per 4.18 release notes, OpenShift Container Platform 4.18 is supported on Red Hat Enterprise Linux (RHEL) 8.8 and a later version of RHEL 8, so changed RHEL version from 8.4 to 8.8 in rhel-images-aws.adoc file.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14,4,15, 4.16, 4.17, 4.18, 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-52281](https://issues.redhat.com/browse/OCPBUGS-52281)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://89521--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html
https://89521--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/more-rhel-compute.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
