### PR TITLE
MCO remove TP note from Updated Boot Images

### DIFF
--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -9,10 +9,7 @@
 
 By default, {product-title} does not manage the boot image. You can configure your cluster to update the boot image whenever you update your cluster by modifying the `MachineConfiguration` object.
 
-Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and as a Technology Preview feature for Amazon Web Services (AWS) clusters. It is not supported for clusters managed by the {cluster-capi-operator}.
-
-:FeatureName: The updating boot image feature for AWS
-include::snippets/technology-preview.adoc[]
+Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) and Amazon Web Services (AWS) clusters. It is not supported for clusters managed by the {cluster-capi-operator}.
 
 .Procedure
 


### PR DESCRIPTION
Neglected to remove a second tech preview note for the MCO Updated Boot Images feature that went GA for AWS clusters in 4.18. See https://issues.redhat.com/browse/OSDOCS-11998

Preview: 
[Configuring updated boot images](https://89534--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-configuring_machine-configs-configure) -- Removed TP note; rewrote second paragraph.  [Current docs](https://docs.openshift.com/container-platform/4.18/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-configuring_machine-configs-configure).

No QE needed