### PR TITLE
[ROX-28351] Patch release notes for 4.5.7

### DIFF
--- a/release_notes/45-release-notes.adoc
+++ b/release_notes/45-release-notes.adoc
@@ -22,6 +22,7 @@ toc::[]
 |`4.5.4` | 16 October 2024
 |`4.5.5` | 22 November 2024
 |`4.5.6` | 11 February 2025
+|`4.5.7` | 10 March 2025
 
 |====
 
@@ -477,5 +478,23 @@ This release also addresses the following security vulnerabilities:
 * link:https://access.redhat.com/security/cve/CVE-2025-21613[CVE-2025-21613]: An argument injection vulnerability was found in the `go-git` package
 * link:https://access.redhat.com/security/cve/CVE-2025-21614[CVE-2025-21614]: Vulnerability allows an attacker to perform denial of service attacks by providing specially crafted responses from a Git server in the `go-git` package
 * link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]: Denial of service vulnerability in the `golang.org/x/net` package
+
+[id="about-release-457_{context}"]
+== About release 4.5.7
+
+*Release date*: 10 March 2025
+
+This release of {product-title-short} includes the following bug fixes:
+
+//ROX-27347
+* Fixed an issue where vulnerability report jobs in {product-title-short} could become deadlocked if a report took too long to complete, preventing new jobs from starting.
+//ROX-13493
+* Fixed the admission controller to perform policy detection and enforcement when a deployment is scaled using the Kubernetes `v1/autoscaling/scale` subresource.
+
+This release also addresses the following security vulnerabilities:
+
+* link:https://access.redhat.com/security/cve/cve-2025-1094[CVE-2025-1094]: PostgreSQL quoting APIs miss neutralizing quoting syntax in text that fails encoding validation.
+* link:https://osv.dev/vulnerability/GHSA-6wxm-mpqj-6jpf[GHSA-6wxm-mpqj-6jpf]: Insecure temporary file usage in `github.com/golang/glog`.
+* link:https://access.redhat.com/security/cve/cve-2025-22868[CVE-2025-22868]: Flaw in Golang in the token parsing component.
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):

4.5

[Issue](https://issues.redhat.com/browse/ROX-28351)

[Link to docs preview
](https://89535--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/45-release-notes.html)

QE review: **ACS has no QE, approved by SME**

- [x] Khushboo - fixed policy enforcement ticket
- [x] Surabhi - fixed vuln reporting ticket
- [x] Tomasz (CVEs)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
