### PR TITLE
OSDOCS#13461: Update z-stream RNs for 4.17.19 

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2879,6 +2879,42 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.19
+[id="ocp-4-17-19_{context}"]
+=== RHSA-2025:1912 - {product-title} {product-version}.19 bug fix, and security update advisory
+
+Issued: 05 March 2025
+
+{product-title} release {product-version}.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1912[RHSA-2025:1912] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1914[RHSA-2025:1914] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.19 --pullspecs
+----
+
+[id="ocp-4-17-19-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when the OpenShift cluster was created with a secure proxy enabled, and the certificate was set in `configuration.proxy.trustCA`, the cluster failed to complete provisioning. With this release, you can create a cluster with secure proxy enabled with the certificate set in `configuration.proxy.trustCA`. Also, the fix prevents an issue that prevented  `oauth` from connecting to Cloud APIs using the management cluster proxy. (link:https://issues.redhat.com/browse/OCPBUGS-51098[*OCPBUGS-51098*])
+
+* Previously, when you deleted a Dynamic Host Configuration Protocol (DHCP) network on an {ibm-power-server-title} cluster, subresources still existed. With this release, when you delete a DHCP network, the subresources deletion occurs before continuing with the delete operation. (link:https://issues.redhat.com/browse/OCPBUGS-50967[*OCPBUGS-50967*])
+
+* Previously, when a worker node tried to join a cluster, the rendezvous node rebooted before the process completed. Because the worker node could not communicate with the rendezvous node, the installation was not successful. With this release, a patch is applied that fixes the racing condition that caused the rendezvous node to reboot prematurely and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-50011[*OCPBUGS-50011*])
+
+* Previously, the DNS-based egress firewall incorrectly disallowed creation of rules containing DNS names in uppercase. With this release, the issue is fixed and the egress firewall is created with uppercase DNS names. (link:https://issues.redhat.com/browse/OCPBUGS-49961[*OCPBUGS-49961*])
+
+* Previously, all host validation status logs referred to the name of the first host registered. When a host validation failed, it was not possible to decide the host with an issue. With this release, the correct host is identified in each log message and the host validation logs correctly how the host that they are linked to. (link:https://issues.redhat.com/browse/OCPBUGS-44058[*OCPBUGS-44058*])
+
+* Previously, when the {vmw-first} vCenter cluster contained an ESXi host that did not have a standard port group defined and the installation program tried to select that host to import the Open Virtual Appliance (OVA), the import failed and the error `Invalid Configuration for device 0` was reported. With this release, the installation program verifies whether a standard port group for an ESXi host is defined and, if not, continues verifying until it locates an ESXi host with a defined standard port group, or reports an error message if it fails to locate one. (link:https://issues.redhat.com/browse/OCPBUGS-37945[*OCPBUGS-37945*])
+
+[id="ocp-4-17-19-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.18
 [id="ocp-4-17-18_{context}"]
 === RHSA-2025:1703 - {product-title} {product-version}.18 bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OCPBUGS-13461](https://issues.redhat.com/browse/OSDOCS-13461)

Link to docs preview:
[4.17.19](https://89536--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-19_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 03/05/25.
