### PR TITLE
OCPBUGS:42836 On-cluster layering uses example uses package not in RHEL

### DIFF
--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -56,13 +56,12 @@ spec:
   machineConfigPool:
     name: <mcp_name> <1>
   buildInputs:
-    containerFile: # <2>
+    containerFile: <2>
     - containerfileArch: noarch <3>
       content: |-
         FROM configs AS final <4>
-        RUN dnf install -y cowsay && \
-         dnf clean all && \
-         ostree container commit
+        RUN rpm-ostree install tree && \
+            ostree container commit
     imageBuilder: # <5>
       imageBuilderType: PodImageBuilder
     baseImagePullSecret: # <6>


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-42836

When documenting OCL for 4.18, I noticed the same issue as referenced in the bug. I [made this same change in 4.18+](https://github.com/openshift/openshift-docs/pull/87730/files#diff-c3d202a77348967cd861dc398f9d95ed70370b9d8d5b80cca7cf08cd4aa98830R106-R110), but neglected to backport the change to 4.16 and 4.17. This PR addresses that. 

PEER REVIEW: No QE needed as the change was already approved by QE in the above linked PR.

Preview:
[Using on-cluster layering to apply a custom layered image](https://89551--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on_mco-coreos-layering) -- Updated YAML example in Step 1. 