### PR TITLE
OSSM-9000: Create a default revision tag and relabel namespace

### DIFF
--- a/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+++ b/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
@@ -26,12 +26,10 @@ include::modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revisi
 
 include::modules/ossm-migrating-workloads-using-the-istio-revision-label.adoc[leveloffset=+2]
 
+include::modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces.adoc[leveloffset=+1]
+
 .Next steps
 
-If you are using gateways, you must migrate them before you complete the migration process.
-
-* xref:../../migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
-
-If you are not using gateways, and have verified your cluster-wide migration, you can proceed to complete the migration and remove {SMProduct} 2 resources.
+You can proceed to complete the migration and remove {SMProduct} 2 resources.
 
 * xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing the Migration]

--- a/modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces.adoc
+++ b/modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces.adoc
@@ -1,0 +1,114 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces_{context}"]
+= Creating the default revision tag and relabeling the namespaces
+
+You can create the default revision tag and relabel the namespaces after you have completed the {SMProduct} 2 to {SMProduct} 3 cluster-wide migration process by using the {istio} injection label.
+
+The `bookinfo` application is used as an example.
+
+.Prerequisites
+
+* You have completed the {SMProduct} 2 to {SMProduct} 3 cluster-wide migration process by using {istio} injection label.
+
+.Procedure
+
+. Create a YAML file called `rev-tag.yaml` that defines the `IstioRevisionTag` resource:
++
+.Example `IstioRevisionTag` resource
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: sailoperator.io/v1
+kind: IstioRevisionTag
+metadata:
+  name: default
+spec:
+  targetRef:
+    kind: IstioRevision
+    name: ossm-3-v1-24-3
+----
+
+. Apply the YAML file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f rev-tag.yaml
+----
+
+. Verify the status of the `IstioRevisionTag` resource by running the following command:
++
+[source,terminal]
+----
+$ oc get istiorevisiontags
+----
++
+.Example output
+[source,terminal]
+----
+NNAME      STATUS                    IN USE   REVISION        AGE
+default    NotReferencedByAnything   False    ossm-3-v1-24-3  18s
+----
+
+. Add the `istio-injection=enabled` label to the `bookinfo` namespace, and remove the `istio.io/rev` label by running the following command:
++
+[source,terminal]
+----
+$ oc label ns bookinfo istio-injection=enabled istio.io/rev-
+----
++
+[NOTE]
+====
+Remove the `maistra.io/ignore-namespace="true"` label only after the 2.6 control plane has been uninstalled.
+====
+
+. Restart the workloads by running the following command:
++
+[source,terminal]
+----
+$ oc rollout restart deployments -n bookinfo
+----
++
+[NOTE]
+====
+Repeat steps 4 and 5 for each namespace you are migrating.
+====
+
+.Verification
+
+. Verify that the `IstioRevisionTag` resource is in use by running the following command:
++
+[source,terminal]
+----
+$ oc get istiorevisiontags
+----
++
+.Example output
+[source,terminal]
+----
+NAME      STATUS    IN USE   REVISION        AGE
+default   Healthy   True     ossm-3-v1-24-3  28s
+----
+
+. Ensure that expected workloads are managed by the new control plane by running the following command:
++
+[source,terminal]
+----
+$ istioctl ps -n bookinfo
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         CLUSTER        CDS              LDS              EDS             RDS              ECDS        ISTIOD                                     VERSION
+details-v1-79dfbd6fff-t5lzm.bookinfo         Kubernetes     SYNCED (57s)     SYNCED (57s)     SYNCED (3s)     SYNCED (57s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
+details-v1-7cb48d8bb-6rjq8.bookinfo          Kubernetes     SYNCED (3s)      SYNCED (3s)      SYNCED (3s)     SYNCED (3s)      IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
+productpage-v1-7d9cdf655d-cqk48.bookinfo     Kubernetes     SYNCED (10s)     SYNCED (10s)     SYNCED (3s)     SYNCED (10s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
+ratings-v1-5b67b59fcb-w4whk.bookinfo         Kubernetes     SYNCED (18s)     SYNCED (18s)     SYNCED (3s)     SYNCED (18s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
+reviews-v1-585fc84dbb-fvm2h.bookinfo         Kubernetes     SYNCED (11s)     SYNCED (11s)     SYNCED (3s)     SYNCED (11s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
+reviews-v2-65cb66b45c-6ggp9.bookinfo         Kubernetes     SYNCED (57s)     SYNCED (57s)     SYNCED (3s)     SYNCED (57s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
+reviews-v2-698b86b848-v92xq.bookinfo         Kubernetes     SYNCED (3s)      SYNCED (3s)      SYNCED (3s)     SYNCED (3s)      IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3
+reviews-v3-6cbc49c8c8-v4jck.bookinfo         Kubernetes     SYNCED (11s)     SYNCED (11s)     SYNCED (3s)     SYNCED (11s)     IGNORED     istiod-ossm-3-v1-24-3-6595bf8695-s8ktn     1.24.3          
+----


### PR DESCRIPTION
Merge to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main
Cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

NOTE: The Service Mesh 3.0 program is a TP release for early adopters to provide feedback. Kathryn is aware of this. There is a lot of content in flight. After several PRs get merged we will go back and add xrefs. Many topics to which we need to link are not merged yet.

Version(s): Tech Preview
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-9000
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://89561--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.html#ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces_ossm-migrating-cluster-wide-assembly
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
