### PR TITLE
OSDOCS-13462: 4.16.37 RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3347,6 +3347,41 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.37
+[id="ocp-4-16-37_{context}"]
+=== RHSA-2025:1907 - {product-title} {product-version}.37 bug fix and security update
+
+Issued: 5 March 2025
+
+{product-title} release {product-version}.37 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1907[RHSA-2025:1907] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1910[RHSA-2025:1910] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.37 --pullspecs
+----
+
+[id="ocp-4-16-37-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, you could not create a cluster with an enabled secure proxy and certificate set in the `configuration.proxy.trustCA` field. Another issue prevented you from reaching cloud APIs through the management cluster proxy. With this release, these issues are resolved. (link:https://issues.redhat.com/browse/OCPBUGS-51296[*OCPBUGS-51296*])
+
+* Previously, there was incorrect logic for bucket name generation. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-51167[*OCPBUGS-51167*])
+
+* Previously, when you deleted Dynamic Host Configuration Protocol (DHCP) network on an {ibm-power-server-title} cluster, subresources could still exist. With this release, when you delete a DHCP network, the subresources deletion now occurs before continuing the destroy operation. (link:https://issues.redhat.com/browse/OCPBUGS-51111[*OCPBUGS-51111*])
+
+* Previously, incorrect addresses were being passed to the Kubernetes EndpointSlice on a cluster, and this issue prevented the installation of the MetalLB Operator on an Agent-based cluster in an IPv6 disconnected environment. With this release, a fix modifies the address evaluation method. Red{nbsp}Hat Marketplace pods can now successfully connect to the cluster API server so that the installation of MetalLB Operator and handling of ingress traffic in IPv6 disconnected environments can occur. (link:https://issues.redhat.com/browse/OCPBUGS-50694[*OCPBUGS-50694*])
+
+* Previously, the `cnf-tests image` used an outdated image version for running tests. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-50611[*OCPBUGS-50611*])
+
+* Previously, an extra name prop was being passed into resource list page extensions used to list related operands on the *CSV details* page. This caused the operand list to be filtered by the CSV name, which would typically cause it to be an empty list. With this update, operands are listed as expected. (link:https://issues.redhat.com/browse/OCPBUGS-46441[*OCPBUGS-46441*])
+
+[id="ocp-4-16-37-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.16.36
 [id="ocp-4-16-36_{context}"]
 === RHSA-2025:1707 - {product-title} {product-version}.36 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-13462](https://issues.redhat.com/browse/OSDOCS-13462)

Link to docs preview:
https://89564--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-37_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (3/5/25)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
