### PR TITLE
fixing some mixed up annotations

### DIFF
--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -121,8 +121,8 @@ endif::edge[]
           instanceType: m6i.large
           kind: AWSMachineProviderConfig
           placement:
-            availabilityZone: <zone> <6>
-            region: <region> <7>
+            availabilityZone: <zone> <5>
+            region: <region> <6>
           securityGroups:
             - filters:
                 - name: tag:Name
@@ -137,16 +137,16 @@ ifndef::edge[]
             filters:
               - name: tag:Name
                 values:
-                  - <infrastructure_id>-private-<zone> <8>
+                  - <infrastructure_id>-private-<zone> <7>
 endif::edge[]
 ifdef::edge[]
-              id: <value_of_PublicSubnetIds> <8>
+              id: <value_of_PublicSubnetIds> <7>
           publicIp: true
 endif::edge[]
           tags:
             - name: kubernetes.io/cluster/<infrastructure_id> 
               value: owned
-            - name: <custom_tag_name> <5>
+            - name: <custom_tag_name> <8>
               value: <custom_tag_value> 
           userDataSecret:
             name: worker-user-data
@@ -188,26 +188,25 @@ $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.ami.id}{"\n"}' \
     get machineset/<infrastructure_id>-<role>-<zone>
 ----
-<5> Optional: Specify custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
+ifndef::edge[]
+<5> Specify the zone name, for example, `us-east-1a`.
+endif::edge[]
+ifdef::edge[]
+<5> Specify the zone name, for example, `us-east-1-nyc-1a`.
+endif::edge[] 
+<6> Specify the region, for example, `us-east-1`.
+ifndef::edge[]
+<7> Specify the infrastructure ID and zone.
+endif::edge[]
+ifdef::edge[]
+<7> The ID of the public subnet that you created in AWS {zone-type}. You created this public subnet ID when you finished the procedure for "Creating a subnet in an AWS zone".
+endif::edge[]
+<8> Optional: Specify custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
 +
 [NOTE]
 ====
 Custom tags can also be specified during installation in the `install-config.yml` file. If the `install-config.yml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yml` file.
 ====
-
-ifndef::edge[]
-<6> Specify the zone, for example, `us-east-1a`.
-endif::edge[]
-ifdef::edge[]
-<6> Specify the zone name, for example, `us-east-1-nyc-1a`.
-endif::edge[]
-<7> Specify the region, for example, `us-east-1`.
-ifndef::edge[]
-<8> Specify the infrastructure ID and zone.
-endif::edge[]
-ifdef::edge[]
-<8> The ID of the public subnet that you created in AWS {zone-type}. You created this public subnet ID when you finished the procedure for "Creating a subnet in an AWS zone".
-endif::edge[]
 ifdef::infra,edge[]
 <9> Specify a taint to prevent user workloads from being scheduled on
 ifdef::infra[`infra`]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
N/A

Link to docs preview:
Sample YAML for a compute machine set custom resource on AWS:
- [edge zones](https://89566--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks.html#machineset-yaml-aws_aws-compute-edge-zone-tasks)
- [infrastructure](https://89566--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-aws_creating-infrastructure-machinesets)
- [standard](https://89566--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machineset-yaml-aws_creating-machineset-aws)

QE review:
N/A

Additional information:
Noticed these were scrambled while working on another bug