### PR TITLE
OCPBUGS-18027: explain use of multiple AWS security groups

### DIFF
--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -59,49 +59,49 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifdef::edge[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
 ifndef::infra,edge[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra,edge[]
         machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
         machine.openshift.io/cluster-api-machine-role: infra <3>
-        machine.openshift.io/cluster-api-machine-type: infra <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
 ifdef::edge[]
         machine.openshift.io/cluster-api-machine-role: edge <3>
-        machine.openshift.io/cluster-api-machine-type: edge <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone> <2>
+        machine.openshift.io/cluster-api-machine-type: edge
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
     spec:
       metadata:
         labels:
 ifndef::infra,edge[]
-          node-role.kubernetes.io/<role>: "" <3>
+          node-role.kubernetes.io/<role>: ""
 endif::infra,edge[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <3>
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
 ifdef::edge[]
           machine.openshift.io/parent-zone-name: <value_of_ParentZoneName>
           machine.openshift.io/zone-group: <value_of_GroupName>
           machine.openshift.io/zone-type: <value_of_ZoneType>
-          node-role.kubernetes.io/edge: "" <3>
+          node-role.kubernetes.io/edge: ""
 endif::edge[]
       providerSpec:
         value:
@@ -117,17 +117,21 @@ endif::edge[]
             name: aws-cloud-credentials
           deviceIndex: 0
           iamInstanceProfile:
-            id: <infrastructure_id>-worker-profile <1>
+            id: <infrastructure_id>-worker-profile
           instanceType: m6i.large
           kind: AWSMachineProviderConfig
           placement:
-            availabilityZone: <zone> <6>
-            region: <region> <7>
+            availabilityZone: <zone> <5>
+            region: <region> <6>
           securityGroups:
             - filters:
                 - name: tag:Name
                   values:
-                    - <infrastructure_id>-worker-sg <1>
+                    - <infrastructure_id>-worker-sg
+            - filters: <7>
+                - name: tag:Name
+                  values:
+                    - <optional_security_group>
           subnet:
 ifndef::edge[]
             filters:
@@ -136,18 +140,18 @@ ifndef::edge[]
                   - <infrastructure_id>-private-<zone> <8>
 endif::edge[]
 ifdef::edge[]
-              id: <value_of_PublicSubnetIds> <8>
+            id: <value_of_PublicSubnetIds> <8>
           publicIp: true
 endif::edge[]
-          tags:
-            - name: kubernetes.io/cluster/<infrastructure_id> <1>
+          tags: <9>
+            - name: kubernetes.io/cluster/<infrastructure_id>
               value: owned
-            - name: <custom_tag_name> <5>
-              value: <custom_tag_value> <5>
+            - name: <custom_tag_name>
+              value: <custom_tag_value>
           userDataSecret:
             name: worker-user-data
 ifdef::infra,edge[]
-      taints: <9>
+      taints: <10>
 ifdef::infra[]
         - key: node-role.kubernetes.io/infra
 endif::infra[]
@@ -184,28 +188,32 @@ $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.ami.id}{"\n"}' \
     get machineset/<infrastructure_id>-<role>-<zone>
 ----
-<5> Optional: Specify custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
-+
-[NOTE]
-====
-Custom tags can also be specified during installation in the `install-config.yml` file. If the `install-config.yml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yml` file.
-====
-
 ifndef::edge[]
-<6> Specify the zone, for example, `us-east-1a`.
+<5> Specify the zone, for example, `us-east-1a`.
 endif::edge[]
 ifdef::edge[]
-<6> Specify the zone name, for example, `us-east-1-nyc-1a`.
+<5> Specify the zone name, for example, `us-east-1-nyc-1a`.
 endif::edge[]
-<7> Specify the region, for example, `us-east-1`.
+<6> Specify the region, for example, `us-east-1`.
+<7> Optional: Specify one or more additional security groups using the format shown.
+When you specify multiple security groups, the rules are merged and applied to the instance as described in link:https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html[{aws-short} documentation about security group rules].
+Refer to {aws-short} documentation for guidance on quotas and other limitations.
 ifndef::edge[]
 <8> Specify the infrastructure ID and zone.
 endif::edge[]
 ifdef::edge[]
 <8> The ID of the public subnet that you created in AWS {zone-type}. You created this public subnet ID when you finished the procedure for "Creating a subnet in an AWS zone".
 endif::edge[]
+<9> Optional: Specify custom tag data for your cluster in addition to the existing `kubernetes.io/cluster/<infrastructure_id>` tag. 
+For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
++
+[NOTE]
+====
+Custom tags can also be specified during installation in the `install-config.yml` file. 
+If the `install-config.yml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yml` file.
+====
 ifdef::infra,edge[]
-<9> Specify a taint to prevent user workloads from being scheduled on
+<10> Specify a taint to prevent user workloads from being scheduled on
 ifdef::infra[`infra`]
 ifdef::edge[`edge`]
 nodes.


### PR DESCRIPTION
Version(s):
4.12-4.15

Issue:
OCPBUGS-18027

Link to docs preview:
Sample YAML for a compute machine set custom resource on AWS:
- [infrastructure](https://89569--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-aws_creating-infrastructure-machinesets)
- [standard](https://89569--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machineset-yaml-aws_creating-machineset-aws)
- [edge zones](https://89569--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/aws-compute-edge-zone-tasks.html#machineset-yaml-aws_aws-compute-edge-zone-tasks)

QE review:
- [ ] QE has approved this change.

Additional information:
Also fixes mixed up callouts