### PR TITLE
OCPBUGS:39347 Consider removing references to old versions

### DIFF
--- a/modules/rhcos-enabling-multipath-day-2.adoc
+++ b/modules/rhcos-enabling-multipath-day-2.adoc
@@ -8,7 +8,7 @@
 
 [IMPORTANT]
 ====
-Enabling multipathing during installation is supported and recommended for nodes provisioned in {product-title} 4.8 or later versions. In setups where any I/O to non-optimized paths results in I/O system errors, you must enable multipathing at installation time. For more information about enabling multipathing during installation time, see "Enabling multipathing post installation" in the _Installing on bare metal_ documentation.
+Enabling multipathing during installation is supported and recommended for nodes provisioned in {product-title}. In setups where any I/O to non-optimized paths results in I/O system errors, you must enable multipathing at installation time. For more information about enabling multipathing during installation time, see "Enabling multipathing post installation" in the _Installing on bare metal_ documentation.
 ====
 
 {op-system-first} supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Postinstallation support is available by activating multipathing via the machine config.
@@ -21,11 +21,11 @@ On {ibm-z-name} and {ibm-linuxone-name}, you can enable multipathing only if you
 
 [IMPORTANT]
 ====
-When a {product-title} {product-version} cluster is installed or configured as a post-installation activity on a single VIOS host with "vSCSI" storage on {ibm-power-name} with multipath configured, the CoreOS nodes with multipath enabled fail to boot. This behavior is expected, as only one path is available to the Node.
+When an {product-title} cluster is installed or configured as a postinstallation activity on a single VIOS host with "vSCSI" storage on {ibm-power-name} with multipath configured, the CoreOS nodes with multipath enabled fail to boot. This behavior is expected, as only one path is available to the node.
 ====
 
 .Prerequisites
-* You have a running {product-title} cluster that uses version 4.7 or later.
+* You have a running {product-title} cluster.
 * You are logged in to the cluster as a user with administrative privileges.
 * You have confirmed that the disk is enabled for multipathing. Multipathing is only supported on hosts that are connected to a SAN via an HBA adapter.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-39347

[Enabling multipathing with kernel arguments on](https://89571--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure.html#rhcos-enabling-multipath-day-2_machine-configs-configure) -- Edited first and third IMPORTANT admonition 1 and 3; first prereq.

No QE. Typo-level edits only