### PR TITLE
OBSDOCS-1742: Fixing doc bugs in FIPS enablement content

### DIFF
--- a/modules/power-monitoring-fips-support.adoc
+++ b/modules/power-monitoring-fips-support.adoc
@@ -6,8 +6,8 @@
 [id="power-monitoring-fips-support_{context}"]
 = About FIPS compliance for {PM-operator}
 
-Starting with version 0.4, {PM-operator} for Red Hat OpenShift is FIPS compliant. When deployed on an {product-title} cluster in FIPS mode, it uses {op-system-base-full} cryptographic libraries validated by National Institute of Standards and Technology (NIST).
+Starting with version 0.4, {PM-operator} for Red{nbsp}Hat OpenShift is FIPS compliant. When deployed on an {product-title} cluster in FIPS mode, it uses {op-system-base-full} cryptographic libraries validated by National Institute of Standards and Technology (NIST).
 
 For details on the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic module validation program]. For the latest NIST status of {op-system-base} cryptographic libraries, see link:https://access.redhat.com/en/compliance[Compliance activities and government standards].
 
-To enable FIPS mode, you must install {PM-operator} for Red{nbsp}Hat OpenShift on an {product-title} cluster. For more information, see "Do you need extra security for your cluster?"
+To enable FIPS mode, you must install {PM-operator} for Red{nbsp}Hat OpenShift on an {product-title} cluster. For more information, see "Do you need extra security for your cluster?".


### PR DESCRIPTION
Change type: Doc update; Fixing doc bugs in FIPS enablement content
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1742

Fix Version: 4.16+

Doc Preview: https://89583--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/power_monitoring/power-monitoring-overview.html#power-monitoring-fips-support_power-monitoring-overview

Changes requested by peer/merge reviewer: @xenolinux on https://github.com/openshift/openshift-docs/pull/88330