### PR TITLE
[SRVCLI-406] GA of kn-event - remove TP notice

### DIFF
--- a/cli_tools/kn-plugins.adoc
+++ b/cli_tools/kn-plugins.adoc
@@ -10,8 +10,9 @@ The Knative (`kn`) CLI supports the use of plugins, which enable you to extend t
 
 Currently, Red Hat supports the `kn-source-kafka` plugin and the `kn-event` plugin.
 
-:FeatureName: The `kn-event` plugin
-include::snippets/technology-preview.adoc[leveloffset=+1]
 // kn event commands
+//Building events by using the kn-event plugin
 include::modules/serverless-build-events-kn.adoc[leveloffset=+1]
+
+//Sending events by using the kn-event plugin
 include::modules/serverless-send-events-kn.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
serverless-docs-1.36

Issue:
https://issues.redhat.com/browse/SRVCLI-406

Link to docs preview:
- https://89602--ocpdocs-pr.netlify.app/openshift-serverless/latest/cli_tools/kn-plugins.html

QE review:
- [x] QE has approved this change.