### PR TITLE
[SRVKE-1693] GA of TLS - remove TP notice

### DIFF
--- a/eventing/serverless-config-tls-encryption-eventing.adoc
+++ b/eventing/serverless-config-tls-encryption-eventing.adoc
@@ -8,8 +8,6 @@ toc::[]
 
 With the transport encryption feature, you can transport data and events over secured and encrypted HTTPS connections by using  _Transport Layer Security_ (TLS).
 
-:FeatureName: {ServerlessProductName} transport encryption for Eventing
-include::snippets/technology-preview.adoc[]
 
 The `transport-encryption` feature flag is an `enum` configuration that defines how Addressables, such as Broker, Channel, and Sink, accept events. It controls whether Addressables must accept events over HTTP or HTTPS based on the selected setting.
 


### PR DESCRIPTION
Version(s):
serverless-docs-1.36

Issue:
https://issues.redhat.com/browse/SRVKE-1694

Link to docs preview:
- https://89614--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/serverless-config-tls-encryption-eventing.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
