### PR TITLE
OCPBUGS:48509 Configuring Linux cgroup docs are referencing to enabled psi which has been disabled with 4.16.7

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -168,11 +168,10 @@ spec:
   kernelArguments:
     systemd_unified_cgroup_hierarchy=1 <1>
     cgroup_no_v1="all" <2>
-    psi=1 <3>
+    psi=0
 ----
 <1> Enables cgroup v2 in systemd.
 <2> Disables cgroup v1.
-<3> Enables the Linux Pressure Stall Information (PSI) feature.
 +
 endif::nodes[]
 .Example output for cgroup v1


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-48509

Preview: 
[Configuring Linux cgroup](https://89615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html) -- Search for `psi=0`.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
