### PR TITLE
OCPBUGS:44488 Fix API version changed in error

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -59,7 +59,7 @@ ifdef::post[]
 .Example `node.config` object
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v2
+apiVersion: config.openshift.io/v1
 kind: Node
 metadata:
   annotations:
@@ -71,7 +71,7 @@ metadata:
   generation: 1
   name: cluster
   ownerReferences:
-  - apiVersion: config.openshift.io/v2
+  - apiVersion: config.openshift.io/v1
     kind: ClusterVersion
     name: version
     uid: 36282574-bf9f-409e-a6cd-3032939293eb
@@ -90,7 +90,7 @@ ifdef::nodes[]
 .Example `node.config` object
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v2
+apiVersion: config.openshift.io/v1
 kind: Node
 metadata:
   annotations:
@@ -102,7 +102,7 @@ metadata:
   generation: 1
   name: cluster
   ownerReferences:
-  - apiVersion: config.openshift.io/v2
+  - apiVersion: config.openshift.io/v1
     kind: ClusterVersion
     name: version
     uid: 36282574-bf9f-409e-a6cd-3032939293eb
@@ -168,11 +168,10 @@ spec:
   kernelArguments:
     systemd_unified_cgroup_hierarchy=1 <1>
     cgroup_no_v1="all" <2>
-    psi=1 <3>
+    psi=0
 ----
 <1> Enables cgroup v2 in systemd.
 <2> Disables cgroup v1.
-<3> Enables the Linux Pressure Stall Information (PSI) feature.
 +
 endif::nodes[]
 .Example output for cgroup v1
@@ -188,9 +187,11 @@ spec:
   kernelArguments:
     systemd.unified_cgroup_hierarchy=0 <1>
     systemd.legacy_systemd_cgroup_controller=1 <2>
+    psi=1 <3>
 ----
 <1> Disables cgroup v2.
 <2> Enables cgroup v1 in systemd.
+<3> Enables the Linux Pressure Stall Information (PSI) feature.
 
 . Check the nodes to see that scheduling on the nodes is disabled. This indicates that the change is being applied:
 +


### PR DESCRIPTION
The API version was changed in error during a copy/paste to update cgroup v1 to cgroup v2.  No QE needed.

[OCPBUGS-44488](https://issues.redhat.com/browse/OCPBUGS-44488)