### PR TITLE
OSSM-9007 Update link to migration content

### DIFF
--- a/install/ossm-installing-openshift-service-mesh.adoc
+++ b/install/ossm-installing-openshift-service-mesh.adoc
@@ -35,3 +35,5 @@ include::modules/ossm-about-accessing-bookinfo-application-using-gateway.adoc[le
 include::modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc[leveloffset=+2]
 include::modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc[leveloffset=+2]
 include::modules/ossm-customizing-istio-configuration.adoc[leveloffset=+1]
+
+//adding comment for force change to see if migration link updates in Pantheon. Currently returning a 404 error.


### PR DESCRIPTION
OSSM 3.0 GA

Merge to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

Cherry-pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

[OSSM-9007](https://issues.redhat.com//browse/OSSM-9007) Update link to migration content


Version(s):
3.0

Issue:
https://issues.redhat.com/browse/OSSM-9007

Link to docs preview:
https://89622--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html

QE review:
QE is not needed for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
