### PR TITLE
OSDOCS-10316#adding DHCP details

### DIFF
--- a/modules/installation-special-config-chrony.adoc
+++ b/modules/installation-special-config-chrony.adoc
@@ -59,12 +59,13 @@ storage:
 <1> On control plane nodes, substitute `master` for `worker` in both of these locations.
 <2> Specify an octal value mode for the `mode` field in the machine config file. After creating the file and applying the changes, the `mode` is converted to a decimal value. You can check the YAML file with the command `oc get mc <mc-name> -o yaml`.
 <3> Specify any valid, reachable time source, such as the one provided by your DHCP server.
+
 +
 [NOTE]
 ====
 For all-machine to all-machine communication, the Network Time Protocol (NTP) on UDP is port `123`. If an external NTP time server is configured, you must open UDP port `123`.
 ====
-ifndef::restricted[Alternately, you can specify any of the following NTP servers: `1.rhel.pool.ntp.org`, `2.rhel.pool.ntp.org`, or `3.rhel.pool.ntp.org`.]
+ifndef::restricted[Alternatively, you can specify any of the following NTP servers: `1.rhel.pool.ntp.org`, `2.rhel.pool.ntp.org`, or `3.rhel.pool.ntp.org`. When you use NTP with your DHCP server, you must set the `sourcedir /run/chrony-dhcp` parameter in the `chrony.conf` file.]
 
 . Use Butane to generate a `MachineConfig` object file, `99-worker-chrony.yaml`, containing the configuration to be delivered to the nodes:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10316

Link to docs preview:
The update is reflected in these pages: 
- [Configuring chrony time service](https://89623--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html) (Customizing nodes)
- [Configuring chrony time service](https://89623--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html) (Installing a user-provisioned bare metal cluster on a disconnected environment)
- [Configuring chrony time service](https://89623--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.html) (Installing a cluster on vSphere in a disconnected environment with user-provisioned infrastructure)
- [Configuring chrony time service](https://89623--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure.html) (Using machine config objects to configure nodes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
As far as I understand, the Vale comment isn't valid here. I haven't added or changed the conditional statements and the file builds correctly. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
