### PR TITLE
OSDOCS-13445-2: adds fixes to Red Hat Device Edge page

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -15,5 +15,6 @@
 :microshift-first: Red Hat build of MicroShift (MicroShift)
 :microshift-short: MicroShift
 :microshift-version: 4.18
+:rhde: Red Hat Device Edge
 :ansible: Red Hat Ansible Automation Platform
-:ansible-version: 2.4
+:ansible-version: 2.5

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -6,7 +6,7 @@
 [id="about-rhde_{context}"]
 = About {product-title}
 
-{product-title} is for organizations that need small-form-factor edge devices and support for bare metal, virtualized, or containerized applications. {product-title} helps address many of the emerging questions around large-scale edge computing at the device edge by incorporating Kubernetes features in a new, smaller, lighter-weight footprint with an edge-optimized Linux operating system built from the world's leading enterprise Linux platform in {op-system}. You can manage {product-title} using {ansible}.
+{product-title} is for organizations that need small-form-factor edge devices and support for bare metal, virtualized, or containerized applications. {product-title} helps address many of the emerging questions around large-scale edge computing at the device edge by incorporating Kubernetes features in a new, smaller, lighter-weight footprint with an edge-optimized Linux operating system built from the world's leading enterprise Linux platform in {op-system-first}. You can manage {product-title} using {ansible}.
 
 .{product-title} components
 image::RHDevice_Edge_Overview_1.png[]
@@ -21,20 +21,20 @@ For a non-technical description of {product-title}, see link:https://www.redhat.
 
 The latest release notes for each product that is part of {product-title} are available at the following links:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}/html/release_notes/index[{microshift-first}]
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{microshift-version}/html/red_hat_build_of_microshift_release_notes/index[{microshift-first}]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.2_release_notes/index[{op-system-ostree-first}] 9.2 release notes contain details about {op-system-ostree}
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.2_release_notes/index[{op-system-ostree-first}] 9.2 release notes contain details about {op-system-ostree}
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.3_release_notes/index[{op-system-ostree-first}] 9.3 release notes contain details about {op-system-ostree}
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.3_release_notes/index[{op-system-ostree-first}] 9.3 release notes contain details about {op-system-ostree}
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.4_release_notes/index[{op-system-ostree-first}] 9.4 release notes contain details about {op-system-ostree}
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.4_release_notes/index[{op-system-ostree-first}] 9.4 release notes contain details about {op-system-ostree}
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{ansible-version}/html/red_hat_ansible_automation_platform_release_notes/index[{ansible} Release Notes]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/release_notes/index[{ansible} Release Notes]
 
 [id="device-edge-compatibility_{context}"]
 == {product-title} product release compatibility matrix
 
-{op-system-first} and {microshift} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift} from 4.14 to 4.16 requires a {op-system} update. Supported configurations of {product-title} use verified releases for each together as listed in the following table:
+{op-system-base} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.14 to 4.16 requires a {op-system-base} update. Supported configurations of {product-title} use verified releases for each together as listed in the following table:
 
 [%header,cols="3",cols="1,1,2"]
 |===
@@ -75,18 +75,15 @@ The latest release notes for each product that is part of {product-title} are av
 
 For more information about the {product-title} products, see the following documentation:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}[Red Hat build of MicroShift]
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{microshift-version}[Red Hat build of MicroShift]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{ansible-version}[Product Documentation for {ansible}]
-
-//* link:https://access.redhat.com/documentation/en-us/edge_management/2023[Product Documentation for Edge management 2023]
-//the RHEL team owns the edge management page; date change was to apply before GA, but no other pages than 2022 exist as of 25Oct2023
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{ansible-version}[Product Documentation for {ansible}]
 
 [id="upgrade-paths-rhde_{context}"]
 == Upgrade paths
 
-For details about {microshift} upgrade paths, see the following documentation:
+For details about {microshift-short} upgrade paths, see the following documentation:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}/html/updating/index[{microshift} updates]
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{microshift-version}/html/updating/microshift-update-options#red-hat-device-edge-updates_microshift-update-options[{rhde} updates]


### PR DESCRIPTION
Version(s):
4

Issue:
[OSDOCS-13445](https://issues.redhat.com/browse/OSDOCS-13445)

Link to docs preview:
[Red Hat Device Edge](https://89624--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

QE review:
- N/A, docs fixes only/attributes, links, etc.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
