### PR TITLE
OCPBUGS:38819 Calculation of Overcommit is wrong

### DIFF
--- a/modules/nodes-cluster-overcommit-resource-requests.adoc
+++ b/modules/nodes-cluster-overcommit-resource-requests.adoc
@@ -24,4 +24,4 @@ to resource limits, which can be set higher than requested resources. The
 difference between request and limit determines the level of overcommit;
 for instance, if a container is given a memory request of 1Gi and a memory limit
 of 2Gi, it is scheduled based on the 1Gi request being available on the node,
-but could use up to 2Gi; so it is 200% overcommitted.
+but could use up to 2Gi; so it is 100% overcommitted.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-38819

Preview:
[Resource requests and overcommit](https://89628--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html) -- Search for _but could use up to 2Gi; so it is 100% overcommitted._

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

