### PR TITLE
OCPBUGS:45742 Incorrect channel setting for installing the Cluster Resource Override Operator using the CLI

### DIFF
--- a/modules/nodes-cluster-resource-override-deploy-cli.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-cli.adoc
@@ -89,7 +89,7 @@ metadata:
   name: clusterresourceoverride
   namespace: clusterresourceoverride-operator
 spec:
-  channel: "{product-version}"
+  channel: "stable"
   name: clusterresourceoverride
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-45742

Previews:
Nodes Working with clusters -> Configuring your cluster to place pods on overcommited nodes -> [Installing the Cluster Resource Override Operator using the CLI](https://89638--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-override-deploy-cli_nodes-cluster-overcommit) -- Changed the `channel` value in the example in step 3a.

Postinstallation configuration -> Node tasks ->  [Installing the Cluster Resource Override Operator using the CLI](https://89638--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks) -- Changed the `channel` value in the example in step 3a.

QE review:
- [x] QE has approved this change in the Jira.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
