### PR TITLE
OSDOCS-4486: add Azure AZ warning in MAPI compute spec

### DIFF
--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -155,7 +155,15 @@ endif::infra[]
 <5> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
 <6> Specify the region to place machines on.
 <7> Optional: Specify custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.
-<8> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+<8> Specify the zone within your region to place machines on. 
+Ensure that your region supports the zone that you specify.
++
+[IMPORTANT]
+====
+If your region supports availability zones, you must specify the zone.
+Specifying the zone avoids volume node affinity failure when a pod requires a persistent volume attachment.
+To do this, you can create a compute machine set for each zone in the same region.
+====
 ifdef::infra[]
 <9> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4486](https://issues.redhat.com//browse/OSDOCS-4486)

Link to docs preview:
Sample YAML for a compute machine set custom resource on Azure

- [standard](https://89658--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-yaml-azure_creating-machineset-azure)
- [infrastructure](https://89658--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-azure_creating-infrastructure-machinesets)

QE review:
- [x] QE has approved this change.

Additional information: