### PR TITLE
Update storage-persistent-storage-fsGroup.adoc

### DIFF
--- a/modules/storage-persistent-storage-fsGroup.adoc
+++ b/modules/storage-persistent-storage-fsGroup.adoc
@@ -31,5 +31,5 @@ securityContext:
 
 [NOTE]
 ====
-The fsGroupChangePolicy field has no effect on ephemeral volume types, such as secret, configMap, and emptydir.
+The fsGroupChangePolicy field has no effect on ephemeral volume types, such as `secret`, `configMap`, and `emptydir`.
 ====

--- a/modules/storage-persistent-storage-fsGroup.adoc
+++ b/modules/storage-persistent-storage-fsGroup.adoc
@@ -31,5 +31,5 @@ securityContext:
 
 [NOTE]
 ====
-The fsGroupChangePolicyfield has no effect on ephemeral volume types, such as secret, configMap, and emptydir.
+The fsGroupChangePolicy field has no effect on ephemeral volume types, such as secret, configMap, and emptydir.
 ====


### PR DESCRIPTION
Added space for the NOTE

FROM  fsGroupChangePolicyfield 

TO  fsGroupChangePolicy field

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OCP 4.15+
Issue:
Added space for the NOTE

Link to docs preview:
https://89662--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#using_fsGroup_understanding-persistent-storage


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
