### PR TITLE
TELCODOCS-2043 - CNF-13766 - unnumbered BGP peering

### DIFF
--- a/modules/nw-metallb-bgppeer-cr.adoc
+++ b/modules/nw-metallb-bgppeer-cr.adoc
@@ -45,6 +45,19 @@ If you use this field, you cannot specify a value in the `spec.peerASN` field.
 |`spec.peerAddress`
 |`string`
 |Specifies the IP address of the peer to contact for establishing the BGP session.
+If you use this field, you cannot specify a value in the `spec.interface` field.
+
+|`spec.interface`
+|`string`
+|Specifies the interface name to use when establishing a session. 
+Use this field to configure unnumbered BGP peering.
+You must establish a point-to-point, layer 2 connection between the two BGP peers.
+You can use unnumbered BGP peering with IPv4, IPv6, or dual-stack, but you must enable IPv6 RAs (Router Advertisements).
+Each interface is limited to one BGP connection.
+If you use this field, you cannot specify a value in the `spec.peerAddress` field.
+The `spec.bgp.routers.neighbors.interface` field is a Technology Preview feature only. 
+For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+
 
 |`spec.sourceAddress`
 |`string`

--- a/modules/nw-metallb-example-bgppeer.adoc
+++ b/modules/nw-metallb-example-bgppeer.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="nw-metallb-example-bgppeer_{context}"]
 = Example BGP peer configurations
+:FeatureName: The `spec.interface` field  
 
 [id="nw-metallb-example-limit-nodes-bgppeer_{context}"]
 == Example: Limit which nodes connect to a BGP peer
@@ -82,3 +83,31 @@ spec:
   peerASN: 64500
   myASN: 64500
 ----
+
+[id="nw-metallb-example-unnumbered-bgp-peering_{context}"]
+== Example: Specify BGP peers for unnumbered BGP peering
+
+include::snippets/technology-preview.adoc[]
+
+To configure unnumbered BGP peering, specify the interface in the `spec.interface` field by using the following example configuration:
+
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: peer-unnumber
+  namespace: metallb-system
+spec:
+  myASN: 64512
+  ASN: 645000
+  interface: net0
+----
+[NOTE]
+====
+To use the `interface` field, you must establish a point-to-point, layer 2 connection between the two BGP peers.
+You can use unnumbered BGP peering with IPv4, IPv6, or dual-stack, but you must enable IPv6 RAs (Router Advertisements).
+Each interface is limited to one BGP connection.
+
+If you use this field, you cannot specify a value in the `spec.bgp.routers.neighbors.address` field.
+====

--- a/modules/nw-metallb-frr-k8s-configuration-crd.adoc
+++ b/modules/nw-metallb-frr-k8s-configuration-crd.adoc
@@ -6,6 +6,8 @@
 [id="nw-metallb-frrconfiguration-crd_{context}"]
 = Configuring the FRRConfiguration CRD
 
+:FeatureName: The `spec.bgp.routers.neighbors.interface` field  
+
 The following section provides reference examples that use the `FRRConfiguration` custom resource (CR).
 
 [id="nw-metallb-frrconfiguration-crd-routers_{context}"]
@@ -208,6 +210,57 @@ spec:
     foo: "bar"
 ----
 
+[id="nw-metallb-frrconfiguration-crd-interface_{context}"]
+== The interface field
+
+include::snippets/technology-preview.adoc[]
+
+You can use the `interface` field to configure unnumbered BGP peering by using the following example configuration:
+
+.Example `FRRConfiguration` CR
+[source,yaml]
+----
+apiVersion: frrk8s.metallb.io/v1beta1
+kind: FRRConfiguration
+metadata:
+  name: test
+  namespace: frr-k8s-system
+spec:
+  bgp:
+    bfdProfiles:
+    - echoMode: false
+      name: simple
+      passiveMode: false
+    routers:
+    - asn: 64512
+      neighbors:
+      - asn: 64512
+        bfdProfile: simple
+        disableMP: false
+        interface: net10 <1>
+        port: 179
+        toAdvertise:
+          allowed:
+            mode: filtered
+            prefixes:
+            - 5.5.5.5/32
+        toReceive:
+          allowed:
+            mode: filtered
+      prefixes:
+      - 5.5.5.5/32
+----
+<1> Activates unnumbered BGP peering.
+
+[NOTE]
+====
+To use the `interface` field, you must establish a point-to-point, layer 2 connection between the two BGP peers.
+You can use unnumbered BGP peering with IPv4, IPv6, or dual-stack, but you must enable IPv6 RAs (Router Advertisements).
+Each interface is limited to one BGP connection.
+
+If you use this field, you cannot specify a value in the `spec.bgp.routers.neighbors.address` field.
+====
+
 The fields for the `FRRConfiguration` custom resource are described in the following table:
 
 .MetalLB FRRConfiguration custom resource
@@ -252,6 +305,17 @@ If you use this field, you cannot specify a value in the `spec.bgp.routers.neigh
 |`spec.bgp.routers.neighbors.address`
 |`string`
 |Specifies the IP address to establish the session with.
+If you use this field, you cannot specify a value in the `spec.bgp.routers.neighbors.interface` field.
+
+|`spec.bgp.routers.neighbors.interface`
+|`string`
+|Specifies the interface name to use when establishing a session. 
+Use this field to configure unnumbered BGP peering.
+There must be a point-to-point, layer 2 connection between the two BGP peers.
+You can use unnumbered BGP peering with IPv4, IPv6, or dual-stack, but you must enable IPv6 RAs (Router Advertisements).
+Each interface is limited to one BGP connection.
+The `spec.bgp.routers.neighbors.interface` field is a Technology Preview feature only.
+For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 
 |`spec.bgp.routers.neighbors.port`
 |`integer`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> [TELCODOCS-2043](https://issues.redhat.com//browse/TELCODOCS-2043) - [CNF-13766](https://issues.redhat.com//browse/CNF-13766) - unnumbered BGP peering

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2043
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- [Configuring MetalLB BGP peers](https://89663--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-bgp-peers.html) 
- [The interface field](https://89663--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-frr-k8s#nw-metallb-frrconfiguration-crd-interface_configure-metallb-frr-k8s)
- [Example: Specify BGP peers for dual-stack networking](https://89663--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-example-unnumbered-bgp-peering_configure-metallb-bgp-peers)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @gkopels 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
