### PR TITLE
OSDOCS-11186: adds TLS config params MicroShift

### DIFF
--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -53,9 +53,21 @@ The following table explains {microshift-short} configuration YAML parameters an
 |Fully qualified domain names (FQDNs), wildcards such as `*.domain.com`, or IP addresses.
 |Subject Alternative Names for API server certificates. SANs indicate all of the domain names and IP addresses that are secured by a certificate.
 
+|`tls`
+|`list`
+|Defines the transport later protocol (TLS) used and the cipher suites allowed. Provides security for the exposed {microshift-short} API server and internal control plane endpoints.
+
+|`tls.cipherSuites`
+|`string`
+|Lists the allowed cipher suites that the API server accepts and serves. Defaults to the cipher suites allowed with the TLS specification set in the `tls.minVersion` parameter.
+
+|`tls.minVersion`
+|`VersionTLS12` or `VersionTLS13`
+|Specifies the minimum version of TLS to serve from the API serve. Default is value is `VersionTLS12`. TLS 1.3 ciphers are preset and not configurable.
+
 |`debugging.logLevel`
 |`Normal`, `Debug`, `Trace`, or `TraceAll`
-|Log verbosity. Default is `Normal`.
+|Log verbosity. Default value is is `Normal`.
 
 |`dns.baseDomain`
 |`valid domain`

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -31,6 +31,10 @@ apiServer:
       names:
         - ""
   subjectAltNames: []
+  tls:
+    cipherSuites:
+            - ""
+    minVersion: VersionTLS12
 debugging:
   logLevel: "Normal"
 dns:


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-11186](https://issues.redhat.com/browse/OSDOCS-11186)

Link to docs preview:
[Configuration parameters table](https://89664--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-config-parameters-table_microshift-configuring)
[Default settings in YAML form](https://89664--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-yaml-default_microshift-configuring)

Reviews:
- [x] QE has approved this change.
- [x] SME review.

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
See https://github.com/openshift/openshift-docs/pull/89670 for concept and procedure.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
