### PR TITLE
OCBUGS:42669 Fix error in Secret Store Vault module

### DIFF
--- a/modules/secrets-store-vault.adoc
+++ b/modules/secrets-store-vault.adoc
@@ -174,7 +174,7 @@ $ TOKEN_REVIEWER_JWT="$(oc exec vault-0 --namespace=vault -- cat /var/run/secret
 +
 [source,terminal]
 ----
-$ KUBERNETES_SERVICE_IP="$(oc get svc kubernetes -o go-template="{{ .spec.clusterIP }}")"
+$ KUBERNETES_SERVICE_IP="$(oc get svc kubernetes --namespace=default -o go-template="{{ .spec.clusterIP }}")"
 ----
 
 ... Update the Kubernetes auth method by running the following command:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-42669

Preview:
[Mounting secrets from HashiCorp Vault](https://89665--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-vault_nodes-pods-secrets-store) -- Updated the command in step 5.b.ii.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
