### PR TITLE
OSDOCS-13582 CLI Manager 0.1.1 release notes

### DIFF
--- a/cli_reference/cli_manager/cli-manager-release-notes.adoc
+++ b/cli_reference/cli_manager/cli-manager-release-notes.adoc
@@ -15,6 +15,20 @@ These release notes track the development of the {cli-manager} for {product-titl
 
 For more information about the {cli-manager}, see xref:../../cli_reference/cli_manager/index.adoc#cli-manager-overview[About the {cli-manager}].
 
+[id="cli-manager-release-notes-0-1-1_{context}"]
+== {cli-manager} 0.1.1 (Technology Preview)
+
+Issued: 12 March 2025
+
+The following advisory is available for the {cli-manager} 0.1.1:
+
+* link:https://access.redhat.com/errata/RHEA-2025:2680[RHEA-2025:2680]
+
+[id="cli-manager-0-1-1-new-features-and-enhancements_{context}"]
+=== New features and enhancements
+
+This release of the CLI Manager updates the Kubernetes version to 1.32.
+
 [id="cli-manager-release-notes-0-1-0_{context}"]
 == {cli-manager} 0.1.0 (Technology Preview)
 


### PR DESCRIPTION
Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13582](https://issues.redhat.com/browse/OSDOCS-13582)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://89666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/cli_manager/cli-manager-release-notes.html#cli-manager-release-notes-0-1-1_cli-manager-release-notes 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: I won't get the advisory link until the release day.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
