### PR TITLE
OCPBUGS:39408 Custom Metrics Autoscaler Cron trigger missing from supported trigger list

### DIFF
--- a/nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 Triggers, also known as scalers, provide the metrics that the Custom Metrics Autoscaler Operator uses to scale your pods.
 
-The custom metrics autoscaler currently supports only the Prometheus, CPU, memory, and Apache Kafka triggers.
+The custom metrics autoscaler currently supports the Prometheus, CPU, memory, Apache Kafka, and cron triggers.
 
 You use a `ScaledObject` or `ScaledJob` custom resource to configure triggers for specific objects, as described in the sections that follow.
 
@@ -27,4 +27,3 @@ include::modules/nodes-cma-autoscaling-custom-trigger-cpu.adoc[leveloffset=+1]
 include::modules/nodes-cma-autoscaling-custom-trigger-memory.adoc[leveloffset=+1]
 include::modules/nodes-cma-autoscaling-custom-trigger-kafka.adoc[leveloffset=+1]
 include::modules/nodes-cma-autoscaling-custom-trigger-cron.adoc[leveloffset=+1]
-


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-39408

[Understanding custom metrics autoscaler triggers](https://89673--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger.html) -- Updated second paragraph.

No QE needed; typo-level change. 