### PR TITLE
[enterprise-4.19] TELCODOCS-1840 siteConfigError created to surface more info on error …

### DIFF
--- a/modules/ztp-troubleshooting-ztp-gitops-installation-crs.adoc
+++ b/modules/ztp-troubleshooting-ztp-gitops-installation-crs.adoc
@@ -36,18 +36,31 @@ $ oc get managedcluster
 +
 [source,terminal]
 ----
-$ oc describe -n openshift-gitops application clusters
+$ oc get applications.argoproj.io -n openshift-gitops clusters -o yaml
 ----
 
-.. Check for the `Status.Conditions` field to view the error logs for the managed cluster. For example, setting an invalid value for `extraManifestPath:` in the `SiteConfig` CR raises the following error:
+.. To identify error logs for the managed cluster, inspect the `status.operationState.syncResult.resources` field. For example, if an invalid value is assigned to the `extraManifestPath` in the `SiteConfig` CR, an error similar to the following is generated:
 +
 [source,text]
 ----
-Status:
-  Conditions:
-    Last Transition Time:  2021-11-26T17:21:39Z
-    Message:               rpc error: code = Unknown desc = `kustomize build /tmp/https___git.com/ran-sites/siteconfigs/ --enable-alpha-plugins` failed exit status 1: 2021/11/26 17:21:40 Error could not create extra-manifest ranSite1.extra-manifest3 stat extra-manifest3: no such file or directory 2021/11/26 17:21:40 Error: could not build the entire SiteConfig defined by /tmp/kust-plugin-config-913473579: stat extra-manifest3: no such file or directory Error: failure in plugin configured via /tmp/kust-plugin-config-913473579; exit status 1: exit status 1
-    Type:  ComparisonError
+syncResult:
+  resources:
+  - group: ran.openshift.io
+    kind: SiteConfig
+    message: The Kubernetes API could not find ran.openshift.io/SiteConfig for
+      requested resource spoke-sno/spoke-sno. Make sure the "SiteConfig" CRD is
+      installed on the destination cluster
+----
+
+.. To see a more detailed `SiteConfig` error, complete the following steps:
+
+... In the Argo CD dashboard, click the *SiteConfig* resource that Argo CD is trying to sync. 
+
+... Check the *DESIRED MANIFEST* tab to find the `siteConfigError` field.
++
+[source,text]
+----
+siteConfigError: >- Error: could not build the entire SiteConfig defined by /tmp/kust-plugin-config-1081291903: stat sno-extra-manifest: no such file or directory
 ----
 
 .. Check the `Status.Sync` field. If there are log errors, the `Status.Sync` field could indicate an `Unknown` error:


### PR DESCRIPTION
[TELCODOCS-1840]: siteConfigError created to surface more info on error
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1840
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://89647--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-sites.html#ztp-troubleshooting-ztp-gitops-installation-crs_ztp-deploying-far-edge-sites
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:“Cherry Picked from https://github.com/openshift/openshift-docs/pull/88028/commits/45006ed55faa43ecd31ef556e0b3a79ea0fc3162  xref: [https://github.com/openshift/openshift-docs/pull/88028]. Already merged to main however forgot to add 4.19 on version to merge to as I had opened before 4.19 created
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
