### PR TITLE
OSSM-9014 Replace sailoperator.io/v1alpha1 with sailoperator.io/v1

### DIFF
--- a/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
@@ -3,13 +3,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-installing-multi-primary-multi-network-mesh_{context}"]
-= Installing a multi-primary multi-network mesh 
+= Installing a multi-primary multi-network mesh
 
-Install {istio} in the multi-primary multi-network topology on two {ocp-product-title} clusters. 
+Install {istio} in the multi-primary multi-network topology on two {ocp-product-title} clusters.
 
 [NOTE]
 ====
-In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster. 
+In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster.
 ====
 
 You can adapt these instructions for a mesh spanning more than two clusters.
@@ -18,7 +18,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 
 * You have installed the {SMProduct} 3 Operator on all of the clusters that comprise the mesh.
 
-* You have completed "Creating certificates for a multi-cluster mesh". 
+* You have completed "Creating certificates for a multi-cluster mesh".
 
 * You have completed "Applying certificates to a multi-cluster topology".
 
@@ -42,7 +42,7 @@ $ export ISTIO_VERSION=1.24.1
 [source,terminal]
 ----
 $ cat <<EOF | oc --context "${CTX_CLUSTER1}" apply -f -
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default

--- a/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label.adoc
+++ b/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label.adoc
@@ -50,7 +50,7 @@ In the following example configuration, the {istio} control plane has access to 
 .Example `Istio` resource
 [source,yaml,subs="attributes,verbatim"]
 ----
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: ossm-3 <1>

--- a/modules/ossm-running-v2-v3-multitenant-deployment-model.adoc
+++ b/modules/ossm-running-v2-v3-multitenant-deployment-model.adoc
@@ -51,7 +51,7 @@ If you are not running {SMProduct} 2.6, you must upgrade to 2.6 before following
 [source, yaml]
 ----
 kind: Istio
-piVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1alpha1
 metadata:
   name: ossm3 # <1>
 spec:


### PR DESCRIPTION
**OSSM 3.0**

[OSSM-9014](https://issues.redhat.com//browse/OSSM-9014) Replace sailoperator.io/v1alpha1 with sailoperator.io/v1

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

Issue:
https://issues.redhat.com/browse/OSSM-9014

Link to docs preview:
https://89706--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html
https://89706--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Note on modules/ossm-running-v2-v3-multitenant-deployment-model.adoc: should remain as sailoperator.io/v1alpha1 as file only applies to TP1 and not GA. Change is fixing typo from "pi" to "api".

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
