### PR TITLE
OCPBUGS-44288-14: Updated the cidr-range-definitions.adoc file

### DIFF
--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -9,25 +9,53 @@ endif::openshift-dedicated,openshift-rosa[]
 
 toc::[]
 
-You must specify non-overlapping ranges for the following CIDR ranges.
+If your cluster uses OVN-Kubernetes, you must specify non-overlapping ranges for Classless Inter-Domain Routing (CIDR) subnet ranges.  
+
+The following subnet types are mandatory for a cluster that uses OVN-Kubernetes:
+
+* Join: Uses a join switch to connect gateway routers to distributed routers. A join switch reduces the number of IP addresses for a distributed router. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the join switch. 
+* Masquerade: Prevents collisions for identical source and destination IP addresses that are sent from a node as hairpin traffic to the same node after a load balancer makes a routing decision.
+* Transit: A transit switch is a type of distributed switch that spans across all nodes in the cluster. A transit switch routes traffic between different zones. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the transit switch. 
 
 [NOTE]
 ====
-Machine CIDR ranges cannot be changed after creating your cluster.
+Starting from {product-title} 4.14.38, you can change the join and transit CIDR ranges for your cluster as a post-installation task.
 ====
 
 ifdef::openshift-rosa,openshift-dedicated[]
 When specifying subnet CIDR ranges, ensure that the subnet CIDR range is within the defined Machine CIDR. You must verify that the subnet CIDR ranges allow for enough IP addresses for all intended workloads, including at least eight IP addresses for possible AWS Load Balancers.
 endif::[]
 
+OVN-Kubernetes, the default network provider in {product-title} 4.14 and later versions, internally uses the following IP address subnet ranges:
+
+* `V4JoinSubnet`: `100.64.0.0/16`
+* `V6JoinSubnet`: `fd98::/64`
+* `V4TransitSwitchSubnet`: `100.88.0.0/16`
+* `V6TransitSwitchSubnet`: `fd97::/64`
+* `defaultV4MasqueradeSubnet`: `169.254.169.0/29`
+* `defaultV6MasqueradeSubnet`: `fd69::/125`
+
 [IMPORTANT]
 ====
-OVN-Kubernetes, the default network provider in {product-title} 4.14 and later versions, uses the following IP address ranges internally: `100.64.0.0/16`, `169.254.169.0/29`, `100.88.0.0/16`, `fd98::/64`, `fd69::/125`, and `fd97::/64`. If your cluster uses OVN-Kubernetes, do not include any of these IP address ranges in any other CIDR definitions in your cluster or infrastructure.
+The previous list includes join, transit, and masquerade IPv4 and IPv6 address subnets. If your cluster uses OVN-Kubernetes, do not include any of these IP address subnet ranges in any other CIDR definitions in your cluster or infrastructure.
 ====
+
+ifndef::openshift-rosa,openshift-dedicated[]
+[role="_additional-resources"]
+.Additional resources
+* For more information about configuring join subnets or transit subnets, see xref:../networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc#configure-ovn-kubernetes-subnets[Configuring OVN-Kubernetes internal IP address subnets].
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="machine-cidr-description"]
 == Machine CIDR
+
 In the Machine classless inter-domain routing (CIDR) field, you must specify the IP address range for machines or cluster nodes.
+
+[NOTE]
+====
+Machine CIDR ranges cannot be changed after creating your cluster.
+====
+
 ifdef::openshift-rosa,openshift-dedicated[]
 This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones.
 endif::openshift-rosa,openshift-dedicated[]
@@ -65,7 +93,6 @@ You can expand the range after cluster installation.
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../networking/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator configuration]
 * xref:../networking/configuring-cluster-network-range.adoc#configuring-cluster-network-range[Configuring the cluster network range]
 endif::openshift-enterprise[]
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OCPBUGS-44288](https://issues.redhat.com/browse/OCPBUGS-44288)

Link to docs preview:
* [CIDR range definitions-CORE](https://89717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/cidr-range-definitions.html)



- [x] SME has approved this change (Arnab Gosh)
- [x] QE has approved this change (Anurag Saxena/Zhanqi)
