### PR TITLE
OSDOCS-13294: adds telemetry parameters MicroShift

### DIFF
--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -260,4 +260,12 @@ container_memory_working_set_bytes{container=`router`,namespace=`openshift-ingre
 |`storage.optionalCsiComponents`
 |`array`
 |Default value is null or an empty array. A null or empty array defaults to deploying `snapshot-controller`. Expected values are `csi-snapshot-controller` or `none`. A value of `none` is mutually exclusive with all other values.
+
+|`telemetry.endpoint`
+|`https://infogw.api.openshift.com`
+|The endpoint where telemetry data is sent. No user or private data is included in the metrics reported. Default value is `https://infogw.api.openshift.com`.
+
+|`telemetry.status`
+|`Enabled`
+|Telemetry status, which can be `Enabled` or `Disabled`. The default value is `Enabled`.
 |===

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -86,6 +86,9 @@ storage:
   driver: "" # <3>
   optionalCsiComponents: # <4>
     - ""
+telemetry:
+    endpoint: https://infogw.api.openshift.com
+    status: Enabled
 ----
 <1> Calculated based on the address of the service network.
 <2> The IP address of the default route.


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13294](https://issues.redhat.com/browse/OSDOCS-13294)

Link to docs preview:
[Default settings](https://89723--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-yaml-default_microshift-configuring)
[Parameters table](https://89723--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-config-parameters-table_microshift-configuring)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Content updates are here, https://github.com/openshift/openshift-docs/pull/89751

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
