### PR TITLE
OSSM-8951: Add additional resources xrefs to cluster-wide migration conceptual topic

### DIFF
--- a/install/ossm-sidecar-injection-assembly.adoc
+++ b/install/ossm-sidecar-injection-assembly.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id="ossm-sidecar-injection_{context}"]
+[id="ossm-sidecar-injection"]
 = Sidecar injection
 include::_attributes/common-attributes.adoc[]
 :context: ossm-sidecar-injection-assembly

--- a/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+++ b/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
@@ -15,6 +15,15 @@ You must complete the premigration checklists before you start migrating your de
 
 include::modules/ossm-control-plane-configuration-migration-requirements.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../install/ossm-sidecar-injection-assembly.adoc#ossm-about-sidecar-injection_ossm-sidecar-injection-assembly[About sidecar injection]
+
+* xref:../../migrating/checklists/ossm-migrating-network-policies-assembly.adoc#ossm-migrating-network-policies-setup-during-migration_ossm-migrating-network-policies-assembly[Set up network policies to use during migration]
+
+* xref:../../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-creating-istiocni-resource[Scoping the mesh with discoverySelectors]
+
 include::modules/ossm-cluster-wide-migration-methods.adoc[leveloffset=+1]
 
 include::modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label.adoc[leveloffset=+1]

--- a/modules/ossm-control-plane-configuration-migration-requirements.adoc
+++ b/modules/ossm-control-plane-configuration-migration-requirements.adoc
@@ -36,14 +36,14 @@ For both control planes, during the migration ensure that network policies do no
 * The data plane namespaces and the control plane
 * The data plane namespaces themselves
 
-In the premigration checklist, you are instructed to disable network policies. However, you can manually re-create them. Manually created network policies must allow traffic for both control planes. When a data plane namespace is migrated to 3.0, the `maistra.io/member-of` label is automatically removed. Do not use this label in network policies. For more information, see "Migration of Network Policies".
+In the premigration checklist, you are instructed to disable network policies. However, you can manually re-create them. Manually created network policies must allow traffic for both control planes. When a data plane namespace is migrated to 3.0, the `maistra.io/member-of` label is automatically removed. Do not use this label in network policies. For more information, see "Set up network policies to use during migration".
 
 [NOTE]
 ====
 In {SMProduct} 2.6 installations, the `maistra.io/member-of` label is automatically created. This label cannot be used because it is automatically removed during the migration process.
 ====
 
-Incorrectly configured network policies can disrupt mesh traffic. When you run the migration, be careful when you create network policies to prevent traffic disruption. For more information, see "Network Policy migration".
+Incorrectly configured network policies can disrupt mesh traffic. When you run the migration, be careful when you create network policies to prevent traffic disruption. For more information, see "Set up network policies to use during migration".
 
 [id="ossm-cluster-wide-migration-sidecar-injection_{context}"]
 == Sidecar injection
@@ -58,7 +58,7 @@ During the migration, you must disable the 2.6 injector. Use the `maistra.io/ign
 [id="ossm-cluster-wide-migration-label-selection_{context}"]
 == Label selection
 
-For {SMProduct} 3.0, you must decide if you want to use the `istio.io/rev` label or the `istio-injection` label to configure sidecar injection. For more information, see "Installing the Sidecar".
+For {SMProduct} 3.0, you must decide if you want to use the `istio.io/rev` label or the `istio-injection` label to configure sidecar injection. For more information, see "About sidecar injection".
 
 In the {SMProduct} 2.6 installation, the member selection configuration in the `ServiceMeshMemberRoll` resource can impact how injection labels are used in the {SMProduct} 3.0 installation.
 


### PR DESCRIPTION
Merge to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main
Cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s): 3.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-8951
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://89727--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
