### PR TITLE
[enterprise-4.14] OCPBUGS:33455 Configuration in CRI-O is deprecated in favor of the configuration in the KubeletConfig

### DIFF
--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -15,16 +15,8 @@ To revert the changes implemented by using a `ContainerRuntimeConfig` CR, you mu
 
 You can modify the following settings by using a `ContainerRuntimeConfig` CR:
 
-* **PIDs limit**: Setting the PIDs limit in the `ContainerRuntimeConfig` is expected to be deprecated. If PIDs limits are required, it is recommended to use the `podPidsLimit` field in the `KubeletConfig` CR instead. The default `podPidsLimit` value is `4096` and the default `pids_limit` value is `0`. If `podPidsLimit` is lower than `pids_limit` then the effective container PIDs limit is defined by the value set in `podPidsLimit`.
-+
-[NOTE]
-====
-The CRI-O flag is applied on the cgroup of the container, while the Kubelet flag is set on the cgroup of the pod. Please adjust the PIDs limit accordingly.
-====
-
 * **Log level**: The `logLevel` parameter sets the CRI-O `log_level` parameter, which is the level of verbosity for log messages. The default is `info` (`log_level = info`). Other options include `fatal`, `panic`, `error`, `warn`, `debug`, and `trace`.
 * **Overlay size**: The `overlaySize` parameter sets the CRI-O Overlay storage driver `size` parameter, which is the maximum size of a container image.
-* **Maximum log size**: Setting the maximum log size in the `ContainerRuntimeConfig` is expected to be deprecated. If a maximum log size is required, it is recommended to use the `containerLogMaxSize` field in the `KubeletConfig` CR instead.
 * **Container runtime**: The `defaultRuntime` parameter sets the container runtime to either `runc` or `crun`. The default is `runc`.
 
 You should have one `ContainerRuntimeConfig` CR for each machine config pool with all the config changes you want for that pool. If you are applying the same content to all the pools, you only need one `ContainerRuntimeConfig` CR for all the pools.

--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -57,8 +57,8 @@ $ oc get kubeletconfig
 
 [source,terminal]
 ----
-NAME                AGE
-set-max-pods        15m
+NAME                      AGE
+set-kubelet-config        15m
 ----
 
 .Example showing a `KubeletConfig` machine config
@@ -74,7 +74,7 @@ $ oc get mc | grep kubelet
 ...
 ----
 
-The following procedure is an example to show how to configure the maximum number of pods per node on the worker nodes.
+The following procedure is an example to show how to configure the maximum number of pods per node, the maximum PIDs per node, and the maximum container log size size on the worker nodes.
 
 .Prerequisites
 
@@ -104,7 +104,7 @@ metadata:
   creationTimestamp: 2019-02-08T14:52:39Z
   generation: 1
   labels:
-    custom-kubelet: set-max-pods <1>
+    custom-kubelet: set-kubelet-config <1>
 ----
 <1> If a label has been added it appears under `labels`.
 
@@ -112,7 +112,7 @@ metadata:
 +
 [source,terminal]
 ----
-$ oc label machineconfigpool worker custom-kubelet=set-max-pods
+$ oc label machineconfigpool worker custom-kubelet=set-kubelet-config
 ----
 
 .Procedure
@@ -154,7 +154,9 @@ Allocatable:
  pods:                        250
 ----
 
-. Set the maximum pods per node on the worker nodes by creating a custom resource file that contains the kubelet configuration:
+. Configure the worker nodes as needed: 
+
+.. Create a YAML file similar to the following that contains the kubelet configuration:
 +
 [IMPORTANT]
 ====
@@ -166,16 +168,23 @@ Kubelet configurations that target a specific machine config pool also affect an
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
-  name: set-max-pods
+  name: set-kubelet-config
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: set-max-pods <1>
-  kubeletConfig:
-    maxPods: 500 <2>
+      custom-kubelet: set-kubelet-config <1>
+  kubeletConfig: <2>
+      podPidsLimit: 8192
+      containerLogMaxSize: 50Mi
+      maxPods: 500
 ----
 <1> Enter the label from the machine config pool.
-<2> Add the kubelet configuration. In this example, use `maxPods` to set the maximum pods per node.
+<2> Add the kubelet configuration. For example: 
++
+--
+* Use `podPidsLimit` to set the maximum number of PIDs in any pod.
+* Use `containerLogMaxSize` to set the maximum size of the container log file before it is rotated.
+* Use `maxPods` to set the maximum pods per node.
 +
 [NOTE]
 ====
@@ -186,22 +195,25 @@ The rate at which the kubelet talks to the API server depends on queries per sec
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
-  name: set-max-pods
+  name: set-kubelet-config
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: set-max-pods
+      custom-kubelet: set-kubelet-config
   kubeletConfig:
     maxPods: <pod_count>
     kubeAPIBurst: <burst_rate>
     kubeAPIQPS: <QPS>
 ----
 ====
+
+--
+
 .. Update the machine config pool for workers with the label:
 +
 [source,terminal]
 ----
-$ oc label machineconfigpool worker custom-kubelet=set-max-pods
+$ oc label machineconfigpool worker custom-kubelet=set-kubelet-config
 ----
 
 .. Create the `KubeletConfig` object:
@@ -211,7 +223,9 @@ $ oc label machineconfigpool worker custom-kubelet=set-max-pods
 $ oc create -f change-maxPods-cr.yaml
 ----
 
-.. Verify that the `KubeletConfig` object is created:
+.Verification
+
+. Verify that the `KubeletConfig` object is created:
 +
 [source,terminal]
 ----
@@ -221,8 +235,8 @@ $ oc get kubeletconfig
 .Example output
 [source,terminal]
 ----
-NAME                AGE
-set-max-pods        15m
+NAME                      AGE
+set-kubelet-config        15m
 ----
 +
 Depending on the number of worker nodes in the cluster, wait for the worker nodes to be rebooted one by one. For a cluster with 3 worker nodes, this could take about 10 to 15 minutes.
@@ -257,7 +271,7 @@ Allocatable:
 +
 [source,terminal]
 ----
-$ oc get kubeletconfigs set-max-pods -o yaml
+$ oc get kubeletconfigs set-kubelet-config -o yaml
 ----
 +
 This should show a status of `True` and `type:Success`, as shown in the following example:
@@ -266,10 +280,12 @@ This should show a status of `True` and `type:Success`, as shown in the followin
 ----
 spec:
   kubeletConfig:
+    containerLogMaxSize: 50Mi
     maxPods: 500
+    podPidsLimit: 8192
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: set-max-pods
+      custom-kubelet: set-kubelet-config
 status:
   conditions:
   - lastTransitionTime: "2021-06-30T17:04:07Z"


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/89570
