### PR TITLE
OSDOCS-13293: adds Telemetry details MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -111,6 +111,8 @@ Topics:
   File: microshift-getting-cluster-id
 - Name: Getting support
   File: microshift-getting-support
+- Name: Remote health monitoring with a connected cluster
+  File: microshift-remote-cluster-monitoring
 ---
 Name: Configuring
 Dir: microshift_configuring

--- a/microshift_support/microshift-remote-cluster-monitoring.adoc
+++ b/microshift_support/microshift-remote-cluster-monitoring.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-remote-cluster-monitoring"]
+= Remote health monitoring with a connected cluster
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-remote-cluster-monitoring
+
+toc::[]
+
+Telemetry and configuration data about your cluster can be collected and reported to Red{nbsp}Hat.
+
+include::modules/microshift-about-remote-health-monitoring.adoc[leveloffset=+1]
+
+include::modules/microshift-info-collected-telemetry.adoc[leveloffset=+1]
+
+include::modules/microshift-opt-out-telemetry.adoc[leveloffset=+1]
+
+[id="additional-resources_microshift-remote-cluster-monitoring_{context}"]
+== Additional resources
+
+* xref:../microshift_configuring/microshift-using-config-yaml.adoc#microshift-config-snippets_microshift-configuring[Using configuration snippets].

--- a/modules/microshift-about-remote-health-monitoring.adoc
+++ b/modules/microshift-about-remote-health-monitoring.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// microshift_support/microshift-remote-cluster-monitoring.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-about-remote-health-monitoring_{context}"]
+= About remote health monitoring with {microshift-short}
+
+Remote health monitoring is conducted in {microshift-short} by the collection of telemetry and configuration data about your cluster that is reported to Red{nbsp}Hat with the Telemeter API. A cluster that reports Telemetry to Red{nbsp}Hat is considered a _connected cluster_.
+
+*Telemetry* is the term that Red{nbsp}Hat uses to describe the information being sent to Red{nbsp}Hat by the {microshift-short} Telemeter API. Lightweight attributes are sent from a connected cluster to Red{nbsp}Hat to monitor the health of clusters.
+
+.Telemetry benefits
+
+Telemetry provides the following benefits:
+
+* *Enhanced identification and resolution of issues*. Events that might seem normal to an end-user can be observed by Red{nbsp}Hat from a broader perspective. Some issues can be more rapidly identified from this point of view and resolved without an end-user needing to open a support case or file a link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Summary&issuetype=1&priority=10200&versions=12385624[Jira issue].
+
+* *Targeted prioritization of new features and functionality*. The data collected provides information about system capabilities and usage characteristics. With this information, Red{nbsp}Hat can focus on developing the new features and functionality that have the greatest impact for our customers.
+
+Telemetry sends a carefully chosen subset of the cluster monitoring metrics to Red{nbsp}Hat. The Telemeter API fetches the metrics values every hour and uploads the data to Red{nbsp}Hat. This stream of data is used by Red{nbsp}Hat to monitor a cluster over time.
+
+This debugging information is available to Red{nbsp}Hat Support and Engineering teams with the same restrictions as accessing data reported through support cases. All _connected cluster_ information is used by Red{nbsp}Hat to help make {microshift-short} better.
+
+[NOTE]
+====
+{microshift-short} does not support Prometheus. To view the Telemetry gathered from your cluster, you must contact Red{nbsp}Hat Support.
+====

--- a/modules/microshift-info-collected-telemetry.adoc
+++ b/modules/microshift-info-collected-telemetry.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * microshift_support/microshift-remote-cluster-monitoring.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-info-collected-by-telemetry_{context}"]
+= Information collected by the {microshift-short} Telemetry API
+
+All metrics combined are generally under 2KB and not expected to consume cluster resources.
+
+The following information is collected by Telemetry:
+
+[id="microshift-telemetry-system-information_{context}"]
+== System information
+
+The system information describes the basic configuration of your {microshift-short} cluster and where it is running, for example:
+
+* Version information, including the {microshift-short} cluster version.
+* The {op-system-base-full} version.
+* The {op-system-base} deployment type.
+
+[id="microshift-telemetry-sizing-information_{context}"]
+== Sizing information
+
+Sizing information details the cluster capacity, for example:
+
+* The CPU cores {microshift-short} can use.
+* Architecture information.
+* The usable bytes of memory.
+
+[id="microshift-telemetry-usage-information_{context}"]
+== Usage information
+
+Usage information outlines what is happening in the cluster, for example:
+
+* The CPU usage in percentage.
+* The memory usage in percentage.
+* The number of Kubernetes objects by resource type (CRDs).
+* The number of running containers, namespaces, and running pods.
+* The number of routes, ingress, services.
+
+[NOTE]
+====
+Telemetry does not collect identifying information such as usernames or passwords. Red{nbsp}Hat does not intend to collect personal information. If Red{nbsp}Hat discovers that personal information has been inadvertently received, Red{nbsp}Hat deletes such information. To the extent that any Telemetry constitutes personal data, refer to the link:https://www.redhat.com/en/about/privacy-policy[Red{nbsp}Hat Privacy Statement] for more information about Red{nbsp}Hat's privacy practices.
+====
+
+[id="microshift-additional-details-rhm-data-use_{context}"]
+== Additional details about how remote health monitoring data is used
+
+Red{nbsp}Hat collects data about your use of the Red{nbsp}Hat product(s) for purposes such as providing support and troubleshooting, improving the offerings and user experience, responding to issues, and for billing purposes if applicable.
+
+.Collection safeguards
+
+Red{nbsp}Hat employs technical and organizational measures designed to protect Telemetry data.
+
+.Sharing
+
+Red{nbsp}Hat might share the data collected through the Telemetry API internally within Red{nbsp}Hat to improve your user experience. Red{nbsp}Hat might share Telemetry data with its business partners in an aggregated form that does not identify customers to help the partners better understand their markets and their customers' use of Red{nbsp}Hat offerings, or to ensure the successful integration of products jointly supported by those partners.
+
+.Third parties
+
+Red{nbsp}Hat might engage certain third parties to assist in the collection, analysis, and storage of Telemetry data.
+
+.User control: Disabling Telemetry data collection
+
+You can disable {microshift-short} Telemetry by following the instructions in the "Opting out of remote health reporting for {microshift-short}" section.

--- a/modules/microshift-opt-out-telemetry.adoc
+++ b/modules/microshift-opt-out-telemetry.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// microshift_support/microshift-remote-cluster-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-opt-out-telemetry_{context}"]
+= Opting out of Telemetry for {microshift-short}
+
+If your cluster is not connected to a network, or you do not want Telemetry gathered, you can easily opt out of Telemetry by disabling the parameter in the {microshift-short} configuration file.
+
+.Prerequisties
+
+* You installed {oc-first}.
+* You have root access to the cluster.
+
+.Procedure
+
+. If you have not done so, make a copy of the provided `config.yaml.default` file in the `/etc/microshift/` directory, renaming it `config.yaml`.
+
+. Keep the new {microshift-short} `config.yaml` in the `/etc/microshift/` directory. Your `config.yaml` file is read every time the {microshift-short} service starts.
++
+[NOTE]
+====
+After you create it, the `config.yaml` file takes precedence over built-in settings.
+====
+
+. Optional: Use a configuration snippet if you are using an existing {microshift-short} YAML. See "Using configuration snippets" in the _Additional resources_ section for more information.
+
+. Set the `telemetry.status` section of the {microshift-short} YAML with the `Disabled` value.
++
+.Example disabled Telemetry configuration
+[source,yaml]
+----
+apiServer:
+# ...
+telemetry:
+    endpoint: https://infogw.api.openshift.com
+    status: Disabled
+# ...
+----
+
+//Should the user also delete the endpoint, or does that not matter?


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13293](https://issues.redhat.com/browse/OSDOCS-13293)

Link to docs preview:
[microshift-remote-cluster-monitoring](https://89751--ocpdocs-pr.netlify.app/microshift/latest/microshift_support/microshift-remote-cluster-monitoring.html)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updates to parameters is here, https://github.com/openshift/openshift-docs/pull/89723

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
