### PR TITLE
TELCODOCS-2222 417 update about NP=1

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1113,7 +1113,7 @@ In this release, if your cluster is installed on a bare metal platform, you can 
 [id="ocp-4-17-support-for-compute-nodes-on-amd-cpus_{context}"]
 ==== Support for compute nodes with AMD EPYC Zen 4 CPUs
 
-From release 4.17.10, you can use PerformanceProfiles to configure compute nodes on machines equipped with AMD EPYC Zen 4 CPUs such as Genoa and Bergamo. Per-pod power management is currently not supported on AMD.
+From release 4.17.10, you can use the `PerformanceProfile` custom resource (CR) to configure compute nodes on machines equipped with AMD EPYC Zen 4 CPUs, such as Genoa and Bergamo. Only single NUMA domain (NPS=1) configurations are supported. Per-pod power management is currently not supported on AMD.
 
 ////
 [id="ocp-4-17-hcp_{context}"]


### PR DESCRIPTION
[TELCODOCS-2222]: Update 4.17 Support for Worker Nodes with AMD EPYC Zen 4 CPUs

Version(s): 4.17

Issue: https://issues.redhat.com/browse/TELCODOCS-2222.

Link to docs preview:https://89756--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-support-for-worker-nodes-on-amd-cpus_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

