### PR TITLE
TELCODOCS-2221-RN: KMM 2.3 release notes.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3511,6 +3511,8 @@ Topics:
   File: psap-node-feature-discovery-operator
 - Name: Kernel Module Management Operator
   File: kmm-kernel-module-management
+- Name: Kernel Module Management Operator release notes
+  File: kmm-release-notes
 ---
 Name: Hardware accelerators
 Dir: hardware_accelerators

--- a/hardware_enablement/kmm-release-notes.adoc
+++ b/hardware_enablement/kmm-release-notes.adoc
@@ -1,0 +1,31 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="kmm-release-notes"]
+= Kernel Module Management Operator release notes
+include::_attributes/common-attributes.adoc[]
+:context: kmm-release-notes
+
+toc::[]
+
+[id="kmm-2-2-RN"]
+== Release notes for Kernel Module Management Operator 2.2
+=== New features
+// TELCODOCS-2022
+* KMM is now using the CRI-O container engine to pull container images in the worker pod instead of using HTTP calls directly from the worker container. For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-example-cr_kernel-module-management-operator[Example Module CR].
+
+// TELCODOCS-2028
+* The Kernel Module Management (KMM) Operator images are now based on `rhel-els-minimal` container images instead of the `rhel-els` images. This change results in a greatly reduced image footprint, while still maintaining FIPS compliance.
+
+// TELCODOCS-1994
+* In this release, the firmware search path has been updated to copy the contents of the specified path into the path specified in worker.setFirmwareClassPath (default: /var/lib/firmware). For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-example-cr_kernel-module-management-operator[Example Module CR].
+
+// TELCODOCS-1977
+* For each node running a kernel matching the regular expression, KMM now checks if you have included a tag or a digest. If you have not specified a tag or digest in the container image, then the validation webhook returns an error and does not apply the module. For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-example-cr_kernel-module-management-operator[Example Module CR].
+
+[id="kmm-2-3-RN"]
+== Release notes for Kernel Module Management Operator 2.3
+=== New features
+// TELCODOCS-2221
+* In this release, KMM uses version 1.23 of the Golang programming language to ensure test continuity for partners.
+
+// TELCODOCS-2197
+* You can now schedule KMM pods by defining taints and tolerations. For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-using-tolerations-for-kernel-module-scheduling_kernel-module-management-operator[Using tolerations for kernel module scheduling].

--- a/hardware_enablement/release-notes/_attributes
+++ b/hardware_enablement/release-notes/_attributes
@@ -1,0 +1,1 @@
+../_attributes/


### PR DESCRIPTION
[D/S and R/N: [MGMT-19352] [TELCODOCS-2197]: Add support for user defined tolerations to modules
[R/N Only:[ [MGMT-19944]] [TELCODOCS-2221]: Bump golang to 1.23

Note to reviewers: Only 2.3 RNs need review.

Version(s): OpenShift-4.18.z+ 

Adding RNs for the following stories:
 Issue:[ https://issues.redhat.com/browse/TELCODOCS-2197](https://issues.redhat.com/browse/TELCODOCS-2197)
 Issue:[ https://issues.redhat.com/browse/TELCODOCS-2221](https://issues.redhat.com/browse/TELCODOCS-2221)

Link to docs preview: https://89788--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-release-notes.html#kmm-2-3-RN

SME:[ @ybettan](https://github.com/ybettan)
 QE:[ @cdvultur](https://github.com/cdvultur)