### PR TITLE
OCPBUGS-49922-fix

### DIFF
--- a/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
+++ b/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
@@ -74,10 +74,10 @@ $ oc get clusterserviceversion -n openshift-nmstate \
 ----
 +
 .Example output
-[source, terminal,subs="attributes+"]
+[source,terminal,subs="attributes+"]
 ----
-Name                                             Phase
-kubernetes-nmstate-operator.4.18.0-202210210157  Succeeded
+Name                                                          Phase
+kubernetes-nmstate-operator.{product-version}.0-202210210157  Succeeded
 ----
 
 . Create an instance of the `nmstate` Operator:
@@ -100,11 +100,11 @@ $ oc get pod -n openshift-nmstate
 ----
 +
 .Example output
-[source, terminal,subs="attributes+"]
+[source,terminal,subs="attributes+"]
 ----
-Name                                      Ready   Status  Restarts  Age
-pod/nmstate-handler-wn55p                 1/1     Running  0        77s
-pod/nmstate-operator-f6bb869b6-v5m92      1/1     Running  0        4m51s
+Name                                      Ready   Status   Restarts  Age
+pod/nmstate-handler-wn55p                 1/1     Running  0         77s
+pod/nmstate-operator-f6bb869b6-v5m92      1/1     Running  0         4m51s
 ...
 ----
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OCPBUGS-49922](https://issues.redhat.com/browse/OCPBUGS-49922)

Link to docs preview:
https://89282--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html#installing-the-kubernetes-nmstate-operator-CLI_k8s-nmstate-operator


- [x] SME has approved this change.
- [x] QE has approved this change.

