### PR TITLE
[enterprise-4.16] OCPBUGS:35825 Chronyd examples for nodeDisruptionPolicy are wrong/example of node disruption policy is incorrect/Missing metadata in one of the Node Disruption Policy examples

### DIFF
--- a/modules/machine-config-node-disruption-config.adoc
+++ b/modules/machine-config-node-disruption-config.adoc
@@ -43,9 +43,9 @@ spec:
   nodeDisruptionPolicy: <1>
     files: # <2>
     - actions: # <3>
-      - reload: # <4>
+      - restart: # <4>
           serviceName: chronyd.service # <5>
-        type: Reload
+        type: Restart
       path: /etc/chrony.conf # <6>
     sshkey: # <7>
       actions:
@@ -102,9 +102,9 @@ status:
       files:
 # ...
       - actions:
-        - reload:
+        - restart:
             serviceName: chronyd.service
-          type: Reload
+          type: Restart
         path: /etc/chrony.conf
       sshkey:
         actions:

--- a/modules/machine-config-node-disruption-example.adoc
+++ b/modules/machine-config-node-disruption-example.adoc
@@ -20,6 +20,7 @@ The following example `MachineConfiguration` object shows no user defined polici
 ----
 apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
+metadata:
   name: cluster
 spec:
   logLevel: Normal
@@ -63,7 +64,6 @@ apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
   name: cluster
-  namespace: openshift-machine-config-operator
 # ...
 spec:
   nodeDisruptionPolicy:
@@ -80,7 +80,7 @@ spec:
 # ...
 ----
 
-In the following example, when changes are made to the `/etc/chrony.conf` file, the MCO reloads the `chronyd.service` on the cluster nodes.
+In the following example, when changes are made to the `/etc/chrony.conf` file, the MCO restarts the `chronyd.service` on the cluster nodes.
 
 .Example node disruption policy for a configuration file change
 [source,yaml]
@@ -89,16 +89,15 @@ apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
   name: cluster
-  namespace: openshift-machine-config-operator
 # ...
 spec:
   nodeDisruptionPolicy:
     files:
     - actions:
-      - reload:
+      - restart:
           serviceName: chronyd.service
-        type: Reload
-      path: /etc/chrony.conf
+        type: Restart
+        path: /etc/chrony.conf
 ----
 
 In the following example, when changes are made to the `auditd.service`	systemd unit, the MCO drains the cluster nodes, reloads the `crio.service`, reloads the systemd manager configuration, and restarts the `crio.service`.
@@ -110,7 +109,6 @@ apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
   name: cluster
-  namespace: openshift-machine-config-operator
 # ...
 spec:
   nodeDisruptionPolicy:
@@ -136,7 +134,6 @@ apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
   name: cluster
-  namespace: openshift-machine-config-operator
 # ...
 spec:
   nodeDisruptionPolicy:


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/89489