### PR TITLE
OSSM-9017 In the migrating gateways there is a errata in a command

### DIFF
--- a/modules/ossm-migrating-gateways-canary.adoc
+++ b/modules/ossm-migrating-gateways-canary.adoc
@@ -35,21 +35,21 @@ kind: Deployment
 metadata:
   name: istio-ingressgateway-canary
   namespace: istio-ingress <1>
-  spec:
-     selector:
-       matchLabels:
-         istio: ingressgateway <2>
-     template:
-       metadata:
-         annotations:
-           inject.istio.io/templates: gateway
-         labels:
-           istio: ingressgateway
-           istio.io/rev: canary <3>
-       spec:
-         containers:
-         - name: istio-proxy
-           image: auto
+spec:
+   selector:
+     matchLabels:
+       istio: ingressgateway <2>
+   template:
+     metadata:
+       annotations:
+         inject.istio.io/templates: gateway
+       labels:
+         istio: ingressgateway
+         istio.io/rev: canary <3>
+     spec:
+       containers:
+       - name: istio-proxy
+         image: auto
 ----
 <1> Your `Deployment` resource must be in in the same namespace as your existing gateway.
 <2> Your `spec.selector.matchlabels.istio` parameter must match your existing gateway service selector.
@@ -63,7 +63,7 @@ metadata:
 +
 [source,terminal]
 ----
-$ oc istioctl ps -n istio-ingress
+$ istioctl ps -n istio-ingress
 ----
 
 .. Test a sample route through the gateway.

--- a/modules/ossm-migrating-gateways-in-place.adoc
+++ b/modules/ossm-migrating-gateways-in-place.adoc
@@ -35,7 +35,7 @@ $ oc -n ${app_namespace} rollout restart deployment ${gateway_name}
 +
 [source,terminal]
 ----
-$ oc istioctl ps -n istio-ingress
+$ istioctl ps -n istio-ingress
 ----
 
 . Test application-specific routes.


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-9017](https://issues.redhat.com//browse/OSSM-9017) In the migrating gateways there is a errata in a command

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

Issue:
https://issues.redhat.com/browse/OSSM-9017

Link to docs preview:
https://89797--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/migrating-gateways/ossm-migrating-gateways-assembly.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
