### PR TITLE
[OCPBUGS-48299] Update installation-special-config-raid-intel-vroc.adoc

### DIFF
--- a/modules/installation-special-config-raid-intel-vroc.adoc
+++ b/modules/installation-special-config-raid-intel-vroc.adoc
@@ -31,7 +31,7 @@ $ mdadm -CR /dev/md/imsm0 -e \
 +
 [source,terminal]
 ----
-$ mdadm -CR /dev/md/dummy -l0 -n2 /dev/imsm0 -z10M --assume-clean
+$ mdadm -CR /dev/md/dummy -l0 -n2 /dev/md/imsm0 -z10M --assume-clean
 ----
 
 .. Create the real RAID1 array by running the following command:


### PR DESCRIPTION

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18 and Below

Issue:

https://issues.redhat.com/browse/OCPBUGS-48299

When trying to follow the procedure as per Red Hat documentation, the below command is failing:   

$ mdadm -CR /dev/md/dummy -l0 -n2 /dev/imsm0 -z10M --assume-clean  mdadm: You haven't given enough devices (real or missing) to create this array

As it seems that the path to the imsm0 device is wrong, and command should be:

$ mdadm -CR /dev/md/dummy -l0 -n2 /dev/md/imsm0 -z10M --assume-clean 

need to correct our relevant documentation. Also, it would be good to verify if there is a need to update the procedure.


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
