### PR TITLE
OSDOCS-13566 RODOO 1.2.1 Release Notes (4.17)

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -14,6 +14,18 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
+[id="run-once-duration-override-operator-release-notes-1-2-1"]
+== {run-once-operator} 1.2.1
+
+Issued: 30 April 2025
+
+The following advisory is available for the {run-once-operator} 1.2.1: (link:https://access.redhat.com/errata/RHBA-2025:4333[RHBA-2025:4333])
+
+[id="run-once-duration-override-operator-1-2-1-bug-fixes"]
+=== Bug fixes
+
+* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
 [id="run-once-duration-override-operator-release-notes-1-2-0"]
 == {run-once-operator} 1.2.0
 


### PR DESCRIPTION
Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13566](https://issues.redhat.com/browse/OSDOCS-13566)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://89799--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#run-once-duration-override-operator-release-notes-1-2-1
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
