### PR TITLE
OSDOCS-13465: Bringing OCP audit logging for network security doc into ROSA

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1109,6 +1109,8 @@ Topics:
       File: default-network-policy
     - Name: Configuring multitenant isolation with network policy
       File: multitenant-network-policy
+  - Name: Audit logging for network security
+    File: logging-network-security
 - Name: OVN-Kubernetes network plugin
   Dir: ovn_kubernetes_network_provider
   Topics:

--- a/networking/network_security/logging-network-security.adoc
+++ b/networking/network_security/logging-network-security.adoc
@@ -39,5 +39,7 @@ include::modules/nw-networkpolicy-audit-disable.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../networking/network_security/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
 * xref:../../networking/network_security/egress_firewall/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-13465

Link to docs preview:
- https://89803--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/logging-network-security.html

QE review:
No QE review needed as no procedure change

