### PR TITLE
OSDOCS-8158: fix older CPMS vSphere FD statements

### DIFF
--- a/modules/cpmso-creating-cr.adoc
+++ b/modules/cpmso-creating-cr.adoc
@@ -65,12 +65,13 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 Before you activate the CR, you must ensure that its configuration is correct for your cluster requirements.
 ====
 <3> Specify the update strategy for the cluster. Valid values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`. For more information about update strategies, see "Updating the control plane configuration".
-<4> Specify your cloud provider platform name. Valid values are `AWS`, `Azure`, `GCP`, `Nutanix`, `VSphere`, and `OpenStack`.
+<4> Specify your cloud provider platform name. Valid values are `AWS`, `Azure`, `GCP`, `Nutanix`, and `OpenStack`.
 <5> Add the `<platform_failure_domains>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample failure domain configuration for your cloud provider.
 +
 [NOTE]
 ====
-VMware vSphere does not support failure domains. For vSphere clusters, replace `<platform_failure_domains>` with an empty `failureDomains:` parameter.
+VMware vSphere does not support failure domains in the control plane machine set.
+For vSphere clusters, do not specify a `failureDomains` stanza in the `machines_v1beta1_machine_openshift_io` section.
 ====
 <6> Specify the infrastructure ID.
 <7> Add the `<platform_provider_spec>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample provider specification for your cloud provider.

--- a/modules/cpmso-yaml-sample-cr.adoc
+++ b/modules/cpmso-yaml-sample-cr.adoc
@@ -62,6 +62,6 @@ Before you activate the Operator, you must ensure that the `ControlPlaneMachineS
 +
 [NOTE]
 ====
-VMware vSphere does not support failure domains.
+{vmw-full} does not support failure domains in the control plane machine set.
 ====
 <8> Specifies the `<platform_provider_spec>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample provider specification for your cloud provider.


### PR DESCRIPTION
Version(s):
4.12-4.14

Issue:
[OSDOCS-8158](https://issues.redhat.com//browse/OSDOCS-8158)

Link to docs preview:
* [Creating a control plane machine set custom resource](https://89808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-getting-started.html#cpmso-creating-cr_cpmso-getting-started)
* [Sample YAML for a control plane machine set custom resource](https://89808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration.html#cpmso-yaml-sample-cr_cpmso-configuration)

QE review:
- [x] QE has approved this change.

Additional information:
"valid values" list will vary per branch but should always exclude `VSphere`.