### PR TITLE
[enterprise-4.15]OSDOCS-13414#Fix docs for non-graceful node shutdown

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1682,8 +1682,6 @@ Topics:
     File: persistent-storage-csi-sc-manage
   - Name: CSI automatic migration
     File: persistent-storage-csi-migration
-  - Name: Detach CSI volumes after non-graceful node shutdown
-    File: persistent-storage-csi-vol-detach-non-graceful-shutdown
   - Name: AliCloud Disk CSI Driver Operator
     File: persistent-storage-csi-alicloud-disk
   - Name: AWS Elastic Block Store CSI Driver Operator

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1721,6 +1721,9 @@ Topics:
 - Name: Dynamic provisioning
   File: dynamic-provisioning
   Distros: openshift-enterprise,openshift-origin
+- Name: Detach volumes after non-graceful node shutdown
+  File: persistent-storage-csi-vol-detach-non-graceful-shutdown
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 ---
 Name: Registry
 Dir: registry

--- a/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
+++ b/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
@@ -32,6 +32,12 @@ If the node is not completely shut down, do not proceed with tainting the node. 
 +
 . Taint the corresponding node object by running the following command:
 +
+[IMPORTANT]
+====
+Tainting a node this way deletes all pods on that node. This also causes any pods that are backed by 
+statefulsets to be evicted, and replacement pods to be created on a different node.
+====
++
 [source,terminal]
 ----
 oc adm taint node <node name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute <1>

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -796,7 +796,7 @@ For more information, see xref:..//storage/persistent_storage/persistent_storage
 
 Starting with {product-title} 4.13, Container Storage Interface (CSI) drivers can automatically detach volumes when a node goes down non-gracefully as a Technology Preview feature. When a non-graceful node shutdown occurs, you can then manually add an out-of-service taint on the node to allow volumes to automatically detach from the node. This feature is now generally available.
 
-For more information, see xref:..//storage/container_storage_interface/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc[Detach CSI volumes after non-graceful node shutdown].
+For more information, see xref:..//storage/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc[Detach CSI volumes after non-graceful node shutdown].
 
 [id="ocp-4-15-storage-gcp-filestore-shared-vpc"]
 ==== Shared VPC is supported for the GCP Filestore CSI Driver Operator as generally available

--- a/storage/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
+++ b/storage/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ephemeral-storage-csi-vol-detach-non-graceful-shutdown"]
-= Detach CSI volumes after non-graceful node shutdown
+= Detach volumes after non-graceful node shutdown
 include::_attributes/common-attributes.adoc[]
 :context: ephemeral-storage-csi-vol-detach-non-graceful-shutdown
 
 toc::[]
 
-This feature allows Container Storage Interface (CSI) drivers to automatically detach volumes when a node goes down non-gracefully.
+This feature allows drivers to automatically detach volumes when a node goes down non-gracefully.
 
 include::modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
 Cherry Picked from 1d3ce349ad26bf2307a61eed460c83987ecf79db xref: https://github.com/openshift/openshift-docs/pull/89067

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
