### PR TITLE
OCPBUGS:37531,42838,42013 RHCOS image layering fixes

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -60,12 +60,16 @@ Hotfixes are provided to you based on link:https://access.redhat.com/solutions/2
 .Example on-cluster Containerfile to apply a Hotfix
 [source,yaml]
 ----
-# Using a 4.17.0 image
 containerfileArch: noarch
 content: |-
   FROM configs AS final
-  #Install hotfix rpm
-  RUN dnf install -y https://example.com/myrepo/haproxy-1.0.16-5.el8.src.rpm && \
+  #Install hotfix package
+  RUN dnf update -y https://example.com/files/systemd-252-46.el9_4.x86_64.rpm \
+                    https://example.com/files/systemd-journal-remote-252-46.el9_4.x86_64.rpm \
+                    https://example.com/files/systemd-libs-252-46.el9_4.x86_64.rpm  \
+                    https://example.com/files/systemd-pam-252-46.el9_4.x86_64.rpm \
+                    https://example.com/files/systemd-udev-252-46.el9_4.x86_64.rpm \
+                    https://example.com/files/systemd-rpm-macros-252-46.el9_4.noarch.rpm && \
       dnf clean all && \
       ostree container commit
 ----
@@ -73,35 +77,32 @@ content: |-
 .Example out-of-cluster Containerfile to apply a Hotfix
 [source,yaml]
 ----
-# Using a 4.17.0 image
 FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
-#Install hotfix rpm
-RUN dnf install -y https://example.com/myrepo/haproxy-1.0.16-5.el8.src.rpm && \
+#Install hotfix package
+RUN dnf update -y https://example.com/files/systemd-252-46.el9_4.x86_64.rpm \
+                  https://example.com/files/systemd-journal-remote-252-46.el9_4.x86_64.rpm \
+                  https://example.com/files/systemd-libs-252-46.el9_4.x86_64.rpm  \
+                  https://example.com/files/systemd-pam-252-46.el9_4.x86_64.rpm \
+                  https://example.com/files/systemd-udev-252-46.el9_4.x86_64.rpm \
+                  https://example.com/files/systemd-rpm-macros-252-46.el9_4.noarch.rpm && \
     dnf clean all && \
     ostree container commit
 ----
+// https://issues.redhat.com/browse/OCPBUGS-42838
 
 * *{op-system-base} packages*. You can download {op-system-base-full} packages from the link:https://access.redhat.com/downloads/content/479/ver=/rhel---9/9.1/x86_64/packages[Red Hat Customer Portal], such as chrony, firewalld, and iputils.
 +
-.Example out-of-cluster Containerfile to apply the libreswan utility
+.Example out-of-cluster Containerfile to apply the rsyslog utility
 [source,yaml,subs="attributes+"]
 ----
-# Get {op-system} base image of target cluster `oc adm release info --image-for rhel-coreos`
-# hadolint ignore=DL3006
+# Using a 4.18.0 image
 FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
-
-# Install our config file
-COPY my-host-to-host.conf /etc/ipsec.d/
-
-# {op-system-base} entitled host is needed here to access {op-system-base} packages
-# Install libreswan as extra {op-system-base} package
-RUN dnf install -y libreswan && \
-    dnf clean all && \
-    systemctl enable ipsec && \
+# Install rsyslog package
+RUN dnf install -y rsyslog && \
     ostree container commit
+# Copy your custom configuration in
+ADD remote.conf /etc/rsyslog.d/remote.conf
 ----
-+
-Because libreswan requires additional {op-system-base} packages, the image must be built on an entitled {op-system-base} host. For RHEL entitlements to work, you must copy the `etc-pki-entitlement` secret into the `openshift-machine-config-operator` namespace. 
 
 * *Third-party packages*. You can download and install RPMs from third-party organizations, such as the following types of packages:
 +
@@ -129,7 +130,6 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
 [source,yaml,subs="attributes+"]
 ----
 # Get {op-system} base image of target cluster `oc adm release info --image-for rhel-coreos`
-# hadolint ignore=DL3006
 FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 
 #Enable EPEL (more info at https://docs.fedoraproject.org/en-US/epel/ ) and install htop
@@ -139,7 +139,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
     ostree container commit
 ----
 +
-This Containerfile installs the {op-system-base} fish program. Because fish requires additional {op-system-base} packages, the image must be built on an entitled {op-system-base} host. For {op-system-base} entitlements to work, you must copy the `etc-pki-entitlement` secret into the `openshift-machine-api` namespace. 
+This Containerfile installs the {op-system-base} fish program. Because fish requires additional {op-system-base} packages, the image must be built on an entitled {op-system-base} host. For {op-system-base} entitlements to work, you must copy the `etc-pki-entitlement` secret into the `openshift-machine-config-operator` namespace. 
 +
 .Example on-cluster Containerfile to apply a third-party package that has {op-system-base} dependencies
 [source,yaml]
@@ -157,7 +157,6 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Pac
 [source,yaml,subs="attributes+"]
 ----
 # Get {op-system} base image of target cluster `oc adm release info --image-for rhel-coreos`
-# hadolint ignore=DL3006
 FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 
 # {op-system-base} entitled host is needed here to access {op-system-base} packages

--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -77,7 +77,17 @@ Note the following limitations when working with the on-cluster layering feature
 
 * You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates". 
 
-* You have a copy of the pull secret in the `openshift-machine-config-operator` namespace that the MCO needs to pull the base operating system image. 
+* You have a copy of the pull secret in the `openshift-machine-config-operator` namespace that the MCO needs to pull the base operating system image.
++
+For example, if you are using the global pull secret, you can run the following command:
++
+[source,terminal]
+----
+$oc create secret docker-registry global-pull-secret-copy \
+  --namespace "openshift-machine-config-operator" \
+  --from-file=.dockerconfigjson=<(oc get secret/pull-secret -n openshift-config -o go-template='{{index .data ".dockerconfigjson" | base64decode}}')
+----
+// https://issues.redhat.com/browse/OCPBUGS-42013
 
 // Not in 4.18; maybe in 4.19
 // If you are using the global pull secret, the MCO automatically creates a copy when you first create a `MachineOSconfig` object.
@@ -121,7 +131,7 @@ spec:
       name: builder-dockercfg-7lzwl
   buildOutputs: <9>
     currentImagePullSecret:
-      name: builder-dockercfg-7lzwl
+      name: builder-dockercfg-mtcl23
 ----
 <1> Specifies the `machineconfiguration.openshift.io/v1` API that is required for `MachineConfig` CRs.
 <2> Specifies a name for the `MachineOSConfig` object. This name is used with other on-cluster layering resources. The examples in this documentation use the name `layered`. 


### PR DESCRIPTION
[OCPBUGS-37531](https://issues.redhat.com/browse/OCPBUGS-37531) - Wrong namespace in  "RHCOS image layering" section when copying the entitled secret
[OCPBUGS-42838](https://issues.redhat.com/browse/OCPBUGS-42838) - A few issues with RHCOS Layering Example Containerfiles section, need new Containerfile examples
[OCPBUGS-42013](https://issues.redhat.com/browse/OCPBUGS-42013) - [enterprise-4.16] Issue in file machine_configuration/mco-coreos-layering.adoc

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
