### PR TITLE
OCPBUGS:42377 Description of --confirm flag is incorrect

### DIFF
--- a/modules/machineconfig-garbage-collect-removing.adoc
+++ b/modules/machineconfig-garbage-collect-removing.adoc
@@ -44,7 +44,7 @@ where:
 
 `--count`:: Optional: Specifies the maximum number of unused rendered machine configs you want to delete, starting with the oldest.
 
-`--confirm`:: Optional: Indicate that pruning should occur, instead of performing a dry-run.
+`--confirm`:: Indicates that pruning should occur, instead of performing a dry-run.
 
 `--pool-name`:: Optional: Specifies the machine config pool from which you want to delete the machine. If not specified, all the pools are evaluated.
 --


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-42377

[Removing unused rendered machine configs](https://89821--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-garbage-collection.html#machineconfig-garbage-collect-removing_machine-configs-garbage-collection) -- Edited call-out in step 2.

No QE needed; typo-level change