### PR TITLE
[enterprise-4.14] OCPBUGS:45742 Incorrect channel setting for installing the Cluster Resource Override Operator using the CLI

### DIFF
--- a/modules/nodes-cluster-resource-override-deploy-cli.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-cli.adoc
@@ -85,7 +85,7 @@ metadata:
   name: clusterresourceoverride
   namespace: clusterresourceoverride-operator
 spec:
-  channel: "4.12"
+  channel: "stable"
   name: clusterresourceoverride
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/89638