### PR TITLE
OSSM-9022 Fix Command in Uninstalling OpenShift Service Mesh

### DIFF
--- a/modules/ossm-uninstalling-service-mesh-operator-control-plane-cli.adoc
+++ b/modules/ossm-uninstalling-service-mesh-operator-control-plane-cli.adoc
@@ -87,25 +87,25 @@ output: subscription.operators.coreos.com "servicemeshoperator3" deleted
 +
 [source,terminal]
 ----
-$ oc get subscription servicemeshoperator3 -n openshift-operators -o yaml | grep currentCSV
+$ oc get clusterserviceversion -n openshift-operators | grep servicemeshoperator3 | awk '{print $1}'
 ----
 +
 .Example output
 [source,terminal]
 ----
-output: currentCSV: servicemeshoperator3.v3.0.0-tp.1
+output: currentCSV: servicemeshoperator3.v3.0.0
 ----
 
 .. Delete the cluster service version (CSV) for the Operator in the target namespace using the `currentCSV` value from the previous step:
 +
 [source,terminal]
 ----
-$ oc delete clusterserviceversion servicemeshoperator3.v3.0.0-tp.1 -n openshift-operators
+$ oc delete clusterserviceversion servicemeshoperator3.v3.0.0 -n openshift-operators
 ----
 +
 .Example output
 +
 [source,terminal]
 ----
-clusterserviceversion.operators.coreos.com "servicemeshoperator3.v3.0.0-tp.1" deleted.
+clusterserviceversion.operators.coreos.com "servicemeshoperator3.v3.0.0" deleted.
 ----


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-9022](https://issues.redhat.com//browse/OSSM-9022) Fix Command in Uninstalling OpenShift Service Mesh

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
GA

Issue:
https://issues.redhat.com/browse/OSSM-9022

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
