### PR TITLE
OSSM-8991: Verify installation for OSSM 3 in doc

### DIFF
--- a/install/ossm-enabling-mtls.adoc
+++ b/install/ossm-enabling-mtls.adoc
@@ -16,8 +16,8 @@ include::modules/ossm-enabling-strict-mtls-namespace.adoc[leveloffset=+1]
 
 include::modules/ossm-enabling-strict-mtls-whole-service-mesh.adoc[leveloffset=+1]
 
-[id="ossm-validating-encrytions-kiali_{context}"]
-== Validating encrytions with Kiali
+[id="ossm-validating-encryptions-kiali_{context}"]
+== Validating encryptions with Kiali
 
 The Kiali console offers several ways to validate whether or not your applications, services, and workloads have mTLS encryption enabled.
 

--- a/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
@@ -3,7 +3,7 @@
 = Accessing the Bookinfo application by using Gateway API
 :context: ossm-accessing-bookinfo-application-using-gateway-API
 
-The {k8s} Gateway API deploys a gateway by creating a `Gateway` resource. In {ocp-product-title} 4.15 and later versions. If you want your cluster to use the Gateway API CRDs, you must enable the CRDs because they are disabled by default.  
+The {k8s} Gateway API deploys a gateway by creating a `Gateway` resource. In {ocp-product-title} 4.15 and later versions. If you want your cluster to use the Gateway API CRDs, you must enable the CRDs because they are disabled by default.
 
 [NOTE]
 ====
@@ -16,7 +16,7 @@ Red{nbsp}Hat provides support for using the {k8s} Gateway API with {SMProductNam
 
 * The {SMProductName} Operator must be installed.
 
-* The {istio} resource must be deployed. 
+* The {istio} resource must be deployed.
 
 .Procedure
 
@@ -31,7 +31,7 @@ $ oc get crd gateways.gateway.networking.k8s.io &> /dev/null ||  { oc kustomize 
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.23/samples/bookinfo/gateway-api/bookinfo-gateway.yaml -n bookinfo
+$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/gateway-api/bookinfo-gateway.yaml -n bookinfo
 ----
 +
 [NOTE]

--- a/modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc
@@ -13,7 +13,7 @@ Gateway injection uses the same mechanisms as {istio} sidecar injection to creat
 
 * The {SMProductName} Operator must be installed.
 
-* The {istio} resource must be deployed. 
+* The {istio} resource must be deployed.
 
 .Procedure
 
@@ -26,14 +26,14 @@ $ oc apply -n bookinfo -f ingress-gateway.yaml
 +
 [NOTE]
 ====
-This example uses a sample `ingress-gateway.yaml` https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/chart/samples/ingress-gateway.yaml[file] that is available in the Istio community repository. 
+This example uses a sample `ingress-gateway.yaml` https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/chart/samples/ingress-gateway.yaml[file] that is available in the Istio community repository.
 ====
 
-. Configure the `bookinfo` application to use the new gateway. Apply the gateway configuration by running the following command: 
+. Configure the `bookinfo` application to use the new gateway. Apply the gateway configuration by running the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.23/samples/bookinfo/networking/bookinfo-gateway.yaml -n bookinfo
+$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/networking/bookinfo-gateway.yaml -n bookinfo
 ----
 +
 [NOTE]
@@ -78,7 +78,7 @@ spec:
 ----
 <1> This example sets the the maximum replicas to `5` and the minimum replicas to `2`. It also creates another replica when utilization reaches 80%.
 
-. Specify the minimum number of pods that must be running on the node. 
+. Specify the minimum number of pods that must be running on the node.
 +
 .Example configuration
 [source,yaml]
@@ -110,5 +110,5 @@ $ HOST=$(oc get route istio-ingressgateway -n bookinfo -o jsonpath='{.spec.host}
 +
 [source,terminal]
 ----
-$ echo productpage URL: http://$HOST/productpage 
+$ echo productpage URL: http://$HOST/productpage
 ----

--- a/modules/ossm-cert-manager-installing-istio-resource.adoc
+++ b/modules/ossm-cert-manager-installing-istio-resource.adoc
@@ -27,7 +27,7 @@ kind: Istio
 metadata:
   name: default
 spec:
-  version: v1.23.0
+  version: v1.24.3
   namespace: istio-system
   values:
     global:

--- a/modules/ossm-cert-manager-istio-csr-revisionbased-strategy.adoc
+++ b/modules/ossm-cert-manager-istio-csr-revisionbased-strategy.adoc
@@ -33,10 +33,10 @@ $ helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
     --set "volumes[0].name=root-ca" \
     --set "volumes[0].secret.secretName=istio-root-ca" \
     --set "app.istio.namespace=istio-system" \
-    --set "app.istio.revisions={default-v1-23-0}"
+    --set "app.istio.revisions={default-v1-24-3}"
 ----
 +
 [NOTE]
 ====
-Revision names use the following format, `<istio-name>-v<major_version>-<minor_version>-<patch_version>`. For example: `default-v1-23-0`.
+Revision names use the following format, `<istio-name>-v<major_version>-<minor_version>-<patch_version>`. For example: `default-v1-24-3`.
 ====

--- a/modules/ossm-cert-manager-update-istio-csr-revisionbased-only.adoc
+++ b/modules/ossm-cert-manager-update-istio-csr-revisionbased-only.adoc
@@ -13,7 +13,7 @@ If you deployed your Istio resource using the revision based update strategy, yo
 
 .Example update for RevisionBased control plane
 
-In this example, the `controlplane` is being updated from `v1.23.0` to `1.23.1.`
+In this example, the `controlplane` is being updated from `v1.24.0` to `1.24.1.`
 
 . Update the `istio-csr` deployment with the new revision by running the following command:
 +
@@ -25,8 +25,8 @@ $ helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
   --set "app.istio.revisions={<old_revision>,<new_revision>}"
 ----
 where:
-`old_revision` :: Specifies the old revision in the `<istio-name>-v<major_version>-<minor_version>-<patch_version>` format. For example: `default-v1-23-0`.
-`new_revision` :: Specfies the new revision in the `<istio-name>-v<major_version>-<minor_version>-<patch_version>` format. For example: `default-v1-23-1`.
+`old_revision` :: Specifies the old revision in the `<istio-name>-v<major_version>-<minor_version>-<patch_version>` format. For example: `default-v1-24-0`.
+`new_revision` :: Specifies the new revision in the `<istio-name>-v<major_version>-<minor_version>-<patch_version>` format. For example: `default-v1-24-1`.
 
 . Update the `istio.spec.version` in the `Istio` object similar to the following example:
 +
@@ -40,7 +40,7 @@ metadata:
 spec:
   version: <new_revision> # <1>
 ----
-<1> Update to the new revision prefixed with the letter _v_, such as `v1.23.1`
+<1> Update to the new revision prefixed with the letter _v_, such as `v1.24.1`
 
 . Remove the old revision from your `istio-csr` deployment by running the following command:
 +
@@ -51,7 +51,7 @@ helm upgrade cert-manager-istio-csr jetstack/cert-manager-istio-csr \
   --namespace cert-manager \
   --wait \
   --reuse-values \
-  --set "app.istio.revisions={default-v1-23-1}"
+  --set "app.istio.revisions={default-v1-24-1}"
 ----
 
 

--- a/modules/ossm-config-otel.adoc
+++ b/modules/ossm-config-otel.adoc
@@ -142,7 +142,7 @@ $ oc label namespace curl istio.io/rev=default-v1-23-0
 +
 [source, terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.23/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
+$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
 ----
 
 . Generate traffic to the `productpage` pod to generate traces:

--- a/modules/ossm-deploy-application-workloads-in-each-mesh.adoc
+++ b/modules/ossm-deploy-application-workloads-in-each-mesh.adoc
@@ -42,8 +42,8 @@ $ oc get istiorevisions
 [source,terminal]
 ----
 $ oc apply -n app-ns-1 \
-   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/sleep/sleep.yaml \
-   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/httpbin/httpbin.yaml
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/sleep/sleep.yaml \
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/httpbin/httpbin.yaml
 ----
 
 . Wait for the `httpbin` and `sleep` pods to run with sidecars injected by running the following command:
@@ -61,7 +61,7 @@ httpbin-7f56dc944b-kpw2x   2/2     Running   0          2m26s
 sleep-5577c64d7c-b5wd2     2/2     Running   0          91m
 ----
 
-. Create a second applicatiom namespace called `app-ns-2` by running the following command:
+. Create a second application namespace called `app-ns-2` by running the following command:
 +
 [source,terminal]
 ----
@@ -82,22 +82,22 @@ $ oc create namespace app-ns-3
 $ oc label namespace app-ns-2 app-ns-3 istio-discovery=mesh-2 istio.io/rev=mesh-2
 ----
 
-. Deploy the `sleep` and `httbin` applications to the `app-ns-2` namespace by running the following command:
+. Deploy the `sleep` and `httpbin` applications to the `app-ns-2` namespace by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -n app-ns-2 \
-   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/sleep/sleep.yaml \
-   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/httpbin/httpbin.yaml
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/sleep/sleep.yaml \
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/httpbin/httpbin.yaml
 ----
 
-. Deploy the `sleep` and `httbin` applications to the `app-ns-3` namespace by running the following command:
+. Deploy the `sleep` and `httpbin` applications to the `app-ns-3` namespace by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -n app-ns-3 \
-   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/sleep/sleep.yaml \
-   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.23/samples/httpbin/httpbin.yaml
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/sleep/sleep.yaml \
+   -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/httpbin/httpbin.yaml
 ----
 
 . Optional: Use the following command to wait for a deployment to be available:

--- a/modules/ossm-deploying-bookinfo-application.adoc
+++ b/modules/ossm-deploying-bookinfo-application.adoc
@@ -21,7 +21,7 @@
 
 . Enter `bookinfo` in the *Project name* field.
 +
-The *Display name* and *Description* fields provide supplementary information and are not required. 
+The *Display name* and *Description* fields provide supplementary information and are not required.
 
 . Click *Create*.
 
@@ -29,7 +29,7 @@ The *Display name* and *Description* fields provide supplementary information an
 +
 [source,terminal]
 ----
-$ oc label namespace bookinfo istio-discovery=enabled istio-injection=enabled 
+$ oc label namespace bookinfo istio-discovery=enabled istio-injection=enabled
 ----
 +
 [NOTE]
@@ -41,7 +41,7 @@ In this example, the name of the Istio resource is `default`. If the Istio resou
 +
 [source,terminal]
 ----
-oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.23/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
+oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
 ----
 
 .Verification
@@ -88,5 +88,5 @@ When the `Ready` columns displays `2/2`, the proxy sidecar was successfully inje
 +
 [source,terminal]
 ----
-$ oc exec "$(oc get pod -l app=ratings -n bookinfo -o jsonpath='{.items[0].metadata.name}')" -c ratings -n bookinfo -- curl -sS productpage:9080/productpage | grep -o "<title>.*</title>" 
+$ oc exec "$(oc get pod -l app=ratings -n bookinfo -o jsonpath='{.items[0].metadata.name}')" -c ratings -n bookinfo -- curl -sS productpage:9080/productpage | grep -o "<title>.*</title>"
 ----

--- a/modules/ossm-enabling-sidecar-injection.adoc
+++ b/modules/ossm-enabling-sidecar-injection.adoc
@@ -94,7 +94,7 @@ productpage-v1-54f48db985-gd5q9   2/2     Running   0          55s
 ratings-v1-5d645c985f-xsw7p       2/2     Running   0          55s
 reviews-v1-bd5f54b8c-zns4v        2/2     Running   0          55s
 reviews-v2-5d7b9dbf97-wbpjr       2/2     Running   0          55s
-reviews-v3-5fccc48c8c-bjktn       2/2     Running   0          55sz
+reviews-v3-5fccc48c8c-bjktn       2/2     Running   0          55s
 ----
 
 [id="ossm-enabling-sidecar-injection-exclude-workload-from-mesh_{context}"]
@@ -230,7 +230,7 @@ spec:
 +
 [NOTE]
 ====
-Adding the label to the `Deployment`'s top-level `labels` section does not impact sidecar injection.
+Adding the label to the top-level `labels` section of the `Deployment` resource does not impact sidecar injection.
 ====
 +
 Updating the deployment triggers a rollout, creating a new ReplicaSet with the updated pod(s).

--- a/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
@@ -32,7 +32,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 +
 [source,terminal]
 ----
-$ export ISTIO_VERSION=1.24.1
+$ export ISTIO_VERSION=1.24.3
 ----
 
 . Install {istio} on the East cluster:

--- a/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
+++ b/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
@@ -3,9 +3,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-installing-primary-remote-multi-network-mesh_{context}"]
-= Installing a primary-remote multi-network mesh 
+= Installing a primary-remote multi-network mesh
 
-Install {istio} in a primary-remote multi-network topology on two {ocp-product-title} clusters. 
+Install {istio} in a primary-remote multi-network topology on two {ocp-product-title} clusters.
 
 [NOTE]
 ====
@@ -18,7 +18,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 
 * You have installed the {SMProduct} 3 Operator on all of the clusters that comprise the mesh.
 
-* You have completed "Creating certificates for a multi-cluster mesh". 
+* You have completed "Creating certificates for a multi-cluster mesh".
 
 * You have completed "Applying certificates to a multi-cluster topology".
 
@@ -32,7 +32,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 +
 [source,terminal]
 ----
-$ export ISTIO_VERSION=1.24.1 
+$ export ISTIO_VERSION=1.24.3
 ----
 
 . Install {istio} on the East cluster:
@@ -63,7 +63,7 @@ spec:
         clusterName: cluster1
       network: network1
       externalIstiod: true <1>
-EOF      
+EOF
 ----
 <1> This enables the control plane installed on the East cluster to serve as an external control plane for other remote clusters.
 
@@ -120,11 +120,11 @@ spec:
   namespace: istio-system
   profile: remote
   values:
-    istiodRemote: 
+    istiodRemote:
       injectionPath: /inject/cluster/cluster2/net/network2
     global:
       remotePilotAddress: ${DISCOVERY_ADDRESS}
-EOF      
+EOF
 ----
 
 .. Annotate the `istio-system` namespace in the West cluster so that it is managed by the control plane in the East cluster by running the following command:


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-8991](https://issues.redhat.com//browse/OSSM-8991) Verify installation for OSSM 3 in doc

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

Issue:
https://issues.redhat.com/browse/OSSM-8991

Link to docs preview:
https://89837--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-cert-manager-assembly.html
https://89837--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-deploying-multiple-service-meshes-on-single-cluster.html
https://89837--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-enabling-mtls.html
https://89837--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html
https://89837--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html
https://89837--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/traces/ossm-distr-tracing-assembly.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
