### PR TITLE
OSSM-8959: Cluster-wide migration using simple migration method

### DIFF
--- a/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+++ b/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
@@ -35,7 +35,8 @@ include::modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revisi
 
 include::modules/ossm-migrating-workloads-using-the-istio-revision-label.adoc[leveloffset=+2]
 
-.Next steps
+[id="next-steps-istio-revision_{context}"]
+== Next steps
 
 If you are using gateways, you must migrate them before you complete the migration process.
 
@@ -50,7 +51,8 @@ include::modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revisi
 
 include::modules/ossm-migrating-workloads-using-the-istio-revision-label-with-cert-manager.adoc[leveloffset=+2]
 
-.Next steps
+[id="next-steps-istio-revision-with-cert-manager_{context}"]
+== Next steps
 
 If you are using gateways, you must migrate them before you complete the migration process.
 
@@ -66,7 +68,8 @@ include::modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-inject
 
 include::modules/ossm-migrating-workloads-using-the-istio-injection-label.adoc[leveloffset=+2]
 
-.Next steps
+[id="next-steps-istio-injection_{context}"]
+== Next steps
 
 If you are using gateways, you must migrate them before you complete the migration process.
 
@@ -77,7 +80,8 @@ If you are not using gateways, and have verified your cluster-wide migration, cr
 
 include::modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces.adoc[leveloffset=+2]
 
-.Next steps
+[id="next-steps-istio-injection-relabel_{context}"]
+== Next steps
 
 You can proceed to complete the migration and remove {SMProduct} 2 resources.
 
@@ -94,7 +98,8 @@ include::modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-inject
 
 include::modules/ossm-migrating-workloads-using-the-istio-injection-label-with-cert-manager.adoc[leveloffset=+2]
 
-.Next steps
+[id="next-steps-istio-injection-with-cert-manager_{context}"]
+== Next steps
 
 If you are using gateways, you must migrate them before you complete the migration process.
 
@@ -110,7 +115,22 @@ Before creating a default revision tag and relabelling the namespaces, you must 
 
 include::modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces-with-cert-manager.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
+//Te following tasks are for migration using the simple migration method
+include::modules/ossm-migrating-a-cluster-wide-deployment-using-the-simple-migration-method.adoc[leveloffset=+1]
+include::modules/ossm-migrating-workloads-using-the-simple-migration-method.adoc[leveloffset=+2]
+
+[id="next-steps-simple-migration_{context}"]
+== Next steps
+
+If you are using gateways, you must migrate them before you complete the migration process.
+
+* xref:../../migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+
+If you are using gateways, you can complete your migration.
+
+* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing the Migration]
+
+[id="additional-resources_{context}"]
+== Additional resources
 
 * xref:../../install/ossm-sidecar-injection-assembly.adoc#ossm-identifying-revision-name_ossm-sidecar-injection-assembly[Identifying the revision name]

--- a/modules/ossm-migrating-a-cluster-wide-deployment-using-the-simple-migration-method.adoc
+++ b/modules/ossm-migrating-a-cluster-wide-deployment-using-the-simple-migration-method.adoc
@@ -1,0 +1,111 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-a-cluster-wide-deployment-using-the-simple-migration-method_{context}"]
+= Migrating a cluster-wide deployment by using the simple migration method 
+
+You can perform a canary upgrade with the gradual migration of data plane namespaces for a cluster-wide deployment by using the simple migration method. In an {SMProduct} {SMv2Version} installation, if the `istio-injection=enabled` label is already applied to the data plane namespaces, the simple migration method is the easiest way to migrate from the {SMProduct} 2 installation to the {SMProduct} 3 installation. 
+
+The simple migration method should not be used in production environments. 
+
+[NOTE]
+====
+Using the simple migration method to migrate from {SMProduct} 2 to {SMProduct} 3 might result in traffic disruption to the services running on a mesh. There are two methods to perform the cluster-wide migration without disrupting traffic. See "Migrating a cluster-wide deployment by using the istio injection label" or "Migrating a cluster-wide deployment by using the Istio revision label" for more information.
+====
+
+The `bookinfo` application is used as an example for the `Istio` resource. For more information about configuration differences between the {SMProduct} 2 `ServiceMeshControlPlane` resource and the {SMProduct} 3 `Istio` resource, see "ServiceMeshControlPlane resource to Istio resource fields mapping."
+
+.Prerequisites
+
+* You have deployed {ocp-product-title} 4.14 or later.
+* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
+* You have completed the premigration checklists.
+* You have the {SMProduct} {SMv2Version} Operator installed.
+* You have the {SMProduct} 3 Operator installed.
+* You have created an `IstioCNI` resource.
+* You have installed the `istioctl` tool.
+* You are running a cluster-wide Service Mesh control plane resource.
+* You have installed the `bookinfo` application.
+
+.Procedure
+
+. Identify the namespaces that contain a 2.6 control plane by running the following command:
++
+[source,terminal]
+----
+$ oc get smcp -A
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE      NAME                   READY   STATUS            PROFILES      VERSION   AGE
+istio-system   install-istio-system   6/6     ComponentsReady   ["default"]   2.6.6     115m
+----
+
+. Create a YAML file named `ossm-3.yaml`. This procedure creates the {istio} resource for the 3.0 installation in the same namespace as the `ServiceMeshControlPlane` resource for the 2.6 installation.
++
+[NOTE]
+====
+In the following example configuration, the {istio} control plane has access to all namespaces on the cluster. If you want to limit the namespaces the control plane has access to, you must define discovery selectors. You must match all the data plane namespaces that you plan to migrate from version 2.6.
+====
++
+.Example `Istio` resource
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: default # <1>
+spec:
+  updateStrategy:
+    type: InPlace
+  namespace: istio-system # <2>
+  version: v1.24.3
+  values:  
+    meshConfig:
+      extensionProviders: # <3>
+        - name: prometheus
+          prometheus: {}
+        - name: otel
+          opentelemetry:
+            port: 4317
+            service: otel-collector.opentelemetrycollector-3.svc.cluster.local
+----
+<1> The `name`, `updateStrategy` and `version` fields specify how the `IstioRevision` resource name is created. For more information, see "Identifying the revision name."
+<2> The 3.0 and 2.6 control planes must run in the same namespace.
+<3> If you are migrating metrics and tracing, update the `extensionProviders` fields according to your tracing and metrics configurations.
++
+[NOTE]
+====
+If the {istio} resource is named `default`, and the installation uses the `InPlace` update strategy, you can use the `istio-injection=enabled` label without creating the `IstioRevisionTag` tag. If you use a different name for the {istio} resource or you use the `RevisionBased` update strategy, you must configure the default `IstioRevisionTag` tag. For more information, see "Creating the default revision tag and relabeling the namespaces."
+====
+
+. Apply the YAML file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f ossm-3.yaml
+----
++
+[NOTE]
+====
+After you apply the YAML file, any time the workloads are restarted, both the {SMProduct} 2.6 and the {SMProduct} 3.0 control planes will try to inject side cars to all pods in namespaces that have the `istio-injection=enabled` label applied and to all pods that have the `sidecar.istio.io/inject="true"` label applied. This causes a traffic disruption. To prevent traffic disruption, restart the workloads only after the `maistra.io/ignore-namespace: "true"` label is added.
+====
+
+.Verification
+
+. Verify that the new `istiod` resource uses the existing root certificate by running the following command:
++
+[source,terminal]
+----
+$ oc logs deployments/istiod -n istio-system | grep 'Load signing key and cert from existing secret'
+----
++
+.Example output
+[source,terminal]
+----
+2024-12-18T08:13:53.788959Z	info	pkica	Load signing key and cert from existing secret istio-system/istio-ca-secret
+----

--- a/modules/ossm-migrating-workloads-using-the-simple-migration-method.adoc
+++ b/modules/ossm-migrating-workloads-using-the-simple-migration-method.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-migrating-workloads-using-the-simple-migration-method_{context}"]
+= Migrating workloads by using the simple migration method
+
+After migrating a cluster-wide deployment, you can migrate your workloads from the {SMProduct} 2.6 control plane to the {SMproduct} 3.0 control plane.
+
+[NOTE]
+====
+You can migrate workloads and gateways separately, and in any order. For more information, see "Migrating gateways."
+====
+
+.Procedure
+
+. Add the `maistra.io/ignore-namespace: "true"` label to the data plane namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label ns bookinfo maistra.io/ignore-namespace="true"
+----
++
+The `maistra.io/ignore-namespace: "true"` label disables sidecar injection for {SMProduct} 2.6 proxies in the namespace. With the label applied, {SMProduct} 2.6 stops injecting proxies in this namespace, and any new proxies are injected by {SMProduct} 3.0. Without this label, the {SMProduct} 2.6 injection webhook tries to inject the pod and the injected sidecar proxy refuses to start since it has both the {SMProduct} 2.6 and the {SMProduct} 3.0 Container Network Interface(CNI) annotations.
++
+[NOTE]
+====
+After you apply the `maistra.io/ignore-namespace` label, any new pod that gets created or restarted in the namespace connects to the {SMProduct} 3.0 proxy. Workloads can still communicate with each other regardless of which control plane they are connected to.
+====
+
+. Restart the workloads by using one of the following options:
++
+.. To restart all the workloads at the same time so that the new pods are injected with the {SMProduct} 3.0 proxy, run the following command:
++
+.Example command for `bookinfo` application
+[source,terminal]
+----
+$ oc rollout restart deployments -n bookinfo
+----
+
+.. To restart each workload individually, run the following command for each workload:
++
+.Example command for `bookinfo` application
+[source,terminal]
+----
+$ oc rollout restart deployments productpage-v1 -n bookinfo
+----
+
+. Wait for the `productpage` application to restart by running the following command:
++
+[source,terminal]
+----
+$ oc rollout status deployment productpage-v1 -n bookinfo
+----
+
+.Verification
+
+. Verify that the the new control plane manages the expected workloads by running the following command:
++
+[source,terminal]
+----
+$ istioctl ps -n bookinfo
+----
++
+.Example output:
+[source,terminal]
+----
+NAME                                          CLUSTER        CDS             LDS             EDS             RDS             ECDS         ISTIOD                                           VERSION
+details-v1-7f46897b-d497c.bookinfo            Kubernetes     SYNCED          SYNCED          SYNCED          SYNCED          NOT SENT     istiod-install-istio-system-866b57d668-6lpcr     1.20.8
+productpage-v1-74bfbd4d65-vsxqm.bookinfo      Kubernetes     SYNCED (4s)     SYNCED (4s)     SYNCED (3s)     SYNCED (4s)     IGNORED      istiod-797bb4d78f-xpchx           1.24.3
+ratings-v1-559b64556-c5ppg.bookinfo           Kubernetes     SYNCED          SYNCED          SYNCED          SYNCED          NOT SENT     istiod-install-istio-system-866b57d668-6lpcr     1.20.8
+reviews-v1-847fb7c54d-qxt5d.bookinfo          Kubernetes     SYNCED          SYNCED          SYNCED          SYNCED          NOT SENT     istiod-install-istio-system-866b57d668-6lpcr     1.20.8
+reviews-v2-5c7ff5b77b-8jbhd.bookinfo          Kubernetes     SYNCED          SYNCED          SYNCED          SYNCED          NOT SENT     istiod-install-istio-system-866b57d668-6lpcr     1.20.8
+reviews-v3-5c5d764c9b-rrx8w.bookinfo          Kubernetes     SYNCED          SYNCED          SYNCED          SYNCED          NOT SENT     istiod-install-istio-system-866b57d668-6lpcr     1.20.8
+----
++
+The output shows that the `productpage-v1` deployment is the only deployment that has been restarted and was injected with the 3.0 proxy. Even if there are different versions of the proxies, communication between the services still works.
+
+. If the 2.6 installation contains additional namespaces, migrate the next namespace now.
++
+[NOTE]
+====
+Remove the `maistra.io/ignore-namespace="true"` label only after the 2.6 control plane has been uninstalled.
+====


### PR DESCRIPTION
Merge to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main
Cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s): Technology Preview

NOTE: The Service Mesh 3.0 program is a TP release for early adopters to provide feedback. Kathryn is aware of this. There is a lot of content in flight. After several PRs get merged we will go back and add xrefs. Many topics to which we need to link are not merged yet.

Issue: https://issues.redhat.com/browse/OSSM-8959
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://89842--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.html#ossm-migrating-a-cluster-wide-deployment-using-the-simple-migration-method_ossm-migrating-cluster-wide-assembly

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
