### PR TITLE
OBSDOCS-1755: Need to remove additional nodeSelector and tolerations from Lokistack CR

### DIFF
--- a/modules/log6x-loki-pod-placement.adoc
+++ b/modules/log6x-loki-pod-placement.adoc
@@ -81,15 +81,6 @@ spec:
       - effect: NoExecute
         key: node-role.kubernetes.io/infra
         value: reserved
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        value: reserved
-      - effect: NoExecute
-        key: node-role.kubernetes.io/infra
-        value: reserved
     indexGateway:
       nodeSelector:
         node-role.kubernetes.io/infra: ""


### PR DESCRIPTION
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> 

RHOCP 4.14, RHOCP 4.15, RHOCP 4.16, RHOCP 4.17, RHOCP 4.18, RHOCP 4.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1755

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://89859--ocpdocs-pr.netlify.app/
https://89859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-loki-6.1.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

- Need to remove additional nodeSelector and tolerations from Lokistack CR
- Here is the documentation link: https://docs.openshift.com/container-platform/4.14/observability/logging/logging-6.0/log6x-loki.html#logging-loki-pod-placement_logging-6x:~:text=Example%20LokiStack%20CR%20with%20node%20selectors%20and%20tolerations
- nodeSelector and tolerations are mentioned twice under the distributor field of Lokistack CR. 
~~~
    distributor:
      nodeSelector:
        node-role.kubernetes.io/infra: ""
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/infra
        value: reserved
      - effect: NoExecute
        key: node-role.kubernetes.io/infra
        value: reserved
      nodeSelector:
        node-role.kubernetes.io/infra: ""
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/infra
        value: reserved
      - effect: NoExecute
        key: node-role.kubernetes.io/infra
        value: reserved 
~~~

- values for both nodeSelector and tolerations are the same.
- Keeping it twice is not required and it is an unnecessary configuration.
- Hence need to remove additional nodeSelector and tolerations from the documentation.

- Here is the updated look:
~~~
    distributor:
      nodeSelector:
        node-role.kubernetes.io/infra: ""
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/infra
        value: reserved
      - effect: NoExecute
        key: node-role.kubernetes.io/infra
        value: reserved 
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->