### PR TITLE
OSSM-9025: Update YAML example in multitenant migration with cert-manager

### DIFF
--- a/modules/ossm-migrating-multitenant-with-cert-manager.adoc
+++ b/modules/ossm-migrating-multitenant-with-cert-manager.adoc
@@ -89,11 +89,11 @@ spec:
           opentelemetry:
            port: 4317
           service: otel-collector.opentelemetrycollector-3.svc.cluster.local
-  global:
-    caAddress: cert-manager-istio-csr.istio-system.svc:443
-    pilot:
-      env:
-        ENABLE_CA_SERVER: "false"
+    global:
+      caAddress: cert-manager-istio-csr.istio-system.svc:443
+      pilot:
+        env:
+          ENABLE_CA_SERVER: "false"
 ----
 +
 <1> The `spec.namespace` field in your `Istio` resource must be the _same_ namespace as your `ServiceMeshControlPlane` resource. If you set the `spec.namespace` field in your `Istio` resource to a different namespace than your `ServiceMeshControlPlane` resource, the migration will not work properly.


### PR DESCRIPTION
Merge to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main
Cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s): Technology Preview

Issue: https://issues.redhat.com/browse/OSSM-9025
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[Migrating a multitenant deployment with cert-manager](https://89874--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/multitenant/ossm-migrating-multitenant-assembly#migrating-multitenant-with-cert-manager_ossm-migrating-multitenant-assembly) -- Step 3.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
