### PR TITLE
osdocs-13599 added admonition for Egress IPs on HCP clusters

### DIFF
--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -11,6 +11,11 @@ As a cluster administrator, you can configure the OVN-Kubernetes Container Netwo
 
 [IMPORTANT]
 ====
+Configuring egress IPs is not supported for {hcp-title} clusters at this time. 
+====
+
+[IMPORTANT]
+====
 In an installer-provisioned infrastructure cluster, do not assign egress IP addresses to the infrastructure node that already hosts the ingress VIP. For more information, see the Red{nbsp}Hat Knowledgebase solution link:https://access.redhat.com/solutions/7069883[POD from the egress IP enabled namespace cannot access OCP route in an IPI cluster when the egress IP is assigned to the infra node that already hosts the ingress VIP].
 ====
 


### PR DESCRIPTION
Added  temporary admonition about Egress IPs not being supported in HCP clusters.


Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13599

Link to docs preview:
https://89879--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html

QE review:
QE not required

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
