### PR TITLE
OSDOCS-10635: Docs for Cluster API Provider OpenStack pre-4.18

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2463,6 +2463,8 @@ Topics:
       File: cluster-api-config-options-aws
     - Name: Cluster API configuration options for Google Cloud Platform
       File: cluster-api-config-options-gcp
+    - Name: Cluster API configuration options for Red Hat OpenStack Platform
+      File: cluster-api-config-options-rhosp
     - Name: Cluster API configuration options for VMware vSphere
       File: cluster-api-config-options-vsphere
 #  - Name: Cluster API resiliency and recovery

--- a/machine_management/cluster_api_machine_management/cluster-api-about.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-about.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: Managing machines with the Cluster API
 include::snippets/technology-preview.adoc[]
 
-The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for {aws-first}, {gcp-first}, and {vmw-first}.
+The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for {aws-first}, {gcp-first}, {rh-openstack-first}, and {vmw-first}.
 
 //Cluster API overview
 include::modules/capi-overview.adoc[leveloffset=+1]

--- a/machine_management/cluster_api_machine_management/cluster-api-configuration.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-configuration.adoc
@@ -24,4 +24,6 @@ For provider-specific configuration options for your cluster, see the following 
 
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#cluster-api-config-options-gcp[Cluster API configuration options for {gcp-full}]
 
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc#cluster-api-config-options-rhosp[Cluster API configuration options for {rh-openstack}]
+
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#cluster-api-config-options-vsphere[Cluster API configuration options for {vmw-full}]

--- a/machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc
@@ -33,6 +33,7 @@ include::modules/capi-creating-infrastructure-resource.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-infrastructure-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API infrastructure resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-infrastructure-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API infrastructure resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc#capi-yaml-infrastructure-rhosp_cluster-api-config-options-rhosp[Sample YAML for a Cluster API infrastructure resource on {rh-openstack}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-infrastructure-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API infrastructure resource on {vmw-full}]
 
 //Creating a Cluster API machine template
@@ -41,6 +42,7 @@ include::modules/capi-creating-machine-template.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-machine-template-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API machine template resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-machine-template-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API machine template resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc#capi-yaml-machine-template-rhosp_cluster-api-config-options-rhosp[Sample YAML for a Cluster API machine template resource on {rh-openstack}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-template-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API machine template resource on {vmw-full}]
 
 //Creating a Cluster API compute machine set
@@ -49,4 +51,5 @@ include::modules/capi-creating-machine-set.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-machine-set-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API compute machine set resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-machine-set-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API compute machine set resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc#capi-yaml-machine-set-rhosp_cluster-api-config-options-rhosp[Sample YAML for a Cluster API compute machine set resource on {rh-openstack}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-set-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API compute machine set resource on {vmw-full}]

--- a/machine_management/cluster_api_machine_management/cluster-api-managing-machines.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-managing-machines.adoc
@@ -15,6 +15,7 @@ include::modules/capi-modifying-machine-template.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-machine-template-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API machine template resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-machine-template-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API machine template resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc#capi-yaml-machine-template-rhosp_cluster-api-config-options-rhosp[Sample YAML for a Cluster API machine template resource on {rh-openstack}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-template-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API machine template resource on {vmw-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster-api-managing-machines.adoc#machineset-modifying_cluster-api-managing-machines[Modifying a compute machine set by using the CLI]
 
@@ -25,4 +26,5 @@ include::modules/machineset-modifying.adoc[leveloffset=+1,tag=!MAPI]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-machine-set-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API compute machine set resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-machine-set-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API compute machine set resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc#capi-yaml-machine-set-rhosp_cluster-api-config-options-rhosp[Sample YAML for a Cluster API compute machine set resource on {rh-openstack}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-set-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API compute machine set resource on {vmw-full}]

--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc
@@ -1,0 +1,33 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cluster-api-config-options-rhosp"]
+= Cluster API configuration options for Red{nbsp}Hat OpenStack Platform
+include::_attributes/common-attributes.adoc[]
+:context: cluster-api-config-options-rhosp
+
+toc::[]
+
+:FeatureName: Managing machines with the Cluster API
+include::snippets/technology-preview.adoc[]
+
+You can change the configuration of your {rh-openstack-first} Cluster API machines by updating values in the Cluster API custom resource manifests.
+
+[id="cluster-api-sample-yaml-rhosp_{context}"]
+== Sample YAML for configuring {rh-openstack} clusters
+
+The following example YAML files show configurations for a {rh-openstack} cluster.
+
+//Sample YAML for a CAPI RHOSP infrastructure resource
+include::modules/capi-yaml-infrastructure-rhosp.adoc[leveloffset=+2]
+
+//Sample YAML for CAPI RHOSP machine template resource
+include::modules/capi-yaml-machine-template-rhosp.adoc[leveloffset=+2]
+
+//Sample YAML for a CAPI RHOSP compute machine set resource
+include::modules/capi-yaml-machine-set-rhosp.adoc[leveloffset=+2]
+
+// [id="cluster-api-supported-features-rhosp_{context}"]
+// == Enabling {rh-openstack} features with the Cluster API
+
+// You can enable the following features by updating values in the Cluster API custom resource manifests.
+
+//Not sure what, if anything, we can add here at this time.

--- a/modules/capi-arch-resources.adoc
+++ b/modules/capi-arch-resources.adoc
@@ -10,7 +10,7 @@ The Cluster API consists of the following primary resources. For the Technology 
 
 Cluster:: A fundamental unit that represents a cluster that is managed by the Cluster API.
 
-Infrastructure:: A provider-specific resource that defines properties that are shared by all the compute machine sets in the cluster, such as the region and subnets.
+Infrastructure cluster:: A provider-specific resource that defines properties that are shared by all the compute machine sets in the cluster, such as the region and subnets.
 
 Machine template:: A provider-specific template that defines the properties of the machines that a compute machine set creates.
 

--- a/modules/capi-creating-cluster-resource.adoc
+++ b/modules/capi-creating-cluster-resource.adoc
@@ -43,9 +43,22 @@ spec:
 <2> Specify the infrastructure kind for the cluster.
 The following values are valid:
 +
-* `AWSCluster`: The cluster is running on {aws-first}.
-* `GCPCluster`: The cluster is running on {gcp-first}.
-* `VSphereCluster`: The cluster is running on {vmw-first}.
+|====
+|Cluster cloud provider |Value
+
+|{aws-first}
+|`AWSCluster`
+
+|{gcp-first}
+|`GCPCluster`
+
+|{rh-openstack-first}
+|`OpenStackCluster`
+
+|{vmw-first}
+|`VSphereCluster`
+
+|====
 --
 
 . Create the cluster CR by running the following command:

--- a/modules/capi-creating-infrastructure-resource.adoc
+++ b/modules/capi-creating-infrastructure-resource.adoc
@@ -40,13 +40,27 @@ spec: # <4>
 For more information, see the sample Cluster API infrastructure resource YAML for your provider.
 The following values are valid:
 * `infrastructure.cluster.x-k8s.io/v1beta2`: The version that {aws-first} clusters use.
-* `infrastructure.cluster.x-k8s.io/v1beta1`: The version that {gcp-first} and {vmw-first} clusters use.
+* `infrastructure.cluster.x-k8s.io/v1beta1`: The version that {gcp-first}, {rh-openstack-first} and {vmw-first} clusters use.
 <2> Specify the infrastructure kind for the cluster.
 This value must match the value for your platform.
 The following values are valid:
-* `AWSCluster`: The cluster is running on {aws-short}.
-* `GCPCluster`: The cluster is running on {gcp-short}.
-* `VSphereCluster`: The cluster is running on {vmw-short}.
++
+|====
+|Cluster cloud provider |Value
+
+|{aws-first}
+|`AWSCluster`
+
+|{gcp-first}
+|`GCPCluster`
+
+|{rh-openstack-first}
+|`OpenStackCluster`
+
+|{vmw-first}
+|`VSphereCluster`
+
+|====
 <3> Specify the name of the cluster.
 <4> Specify the details for your environment.
 These parameters are provider specific.

--- a/modules/capi-creating-machine-template.adoc
+++ b/modules/capi-creating-machine-template.adoc
@@ -36,10 +36,25 @@ spec:
   template:
     spec: # <3>
 ----
-<1> Specify the machine template kind. This value must match the value for your platform. The following values are valid:
-* `AWSMachineTemplate`: The cluster is running on {aws-first}.
-* `GCPMachineTemplate`: The cluster is running on {gcp-first}.
-* `VSphereMachineTemplate`: The cluster is running on {vmw-first}.
+<1> Specify the machine template kind. This value must match the value for your platform.
+The following values are valid:
++
+|====
+|Cluster cloud provider |Value
+
+|{aws-first}
+|`MachineTemplate`
+
+|{gcp-first}
+|`MachineTemplate`
+
+|{rh-openstack-first}
+|`OpenStackMachineTemplate`
+
+|{vmw-first}
+|`VSphereMachineTemplate`
+
+|====
 <2> Specify a name for the machine template.
 <3> Specify the details for your environment. These parameters are provider specific. For more information, see the sample Cluster API machine template YAML for your provider.
 --

--- a/modules/capi-limitations.adoc
+++ b/modules/capi-limitations.adoc
@@ -15,7 +15,7 @@ Using the Cluster API to manage machines is a Technology Preview feature and has
 Enabling this feature set cannot be undone and prevents minor version updates.
 ====
 
-* Only {aws-first}, {gcp-first}, and {vmw-first} clusters can use the Cluster API.
+* Only {aws-first}, {gcp-first}, {rh-openstack-first}, and {vmw-first} clusters can use the Cluster API.
 
 * You must manually create the primary resources that the Cluster API requires.
 For more information, see "Getting started with the Cluster API".

--- a/modules/capi-modifying-machine-template.adoc
+++ b/modules/capi-modifying-machine-template.adoc
@@ -26,9 +26,23 @@ You can update the machine template resource for your cluster by modifying the Y
 $ oc get <machine_template_kind> <1>
 ----
 <1> Specify the value that corresponds to your platform. The following values are valid:
-* `AWSMachineTemplate`: The cluster is running on {aws-first}.
-* `GCPMachineTemplate`: The cluster is running on {gcp-first}.
-* `VSphereMachineTemplate`: The cluster is running on {vmw-first}.
++
+|====
+|Cluster cloud provider |Value
+
+|{aws-first}
+|`MachineTemplate`
+
+|{gcp-first}
+|`MachineTemplate`
+
+|{rh-openstack-first}
+|`OpenStackMachineTemplate`
+
+|{vmw-first}
+|`VSphereMachineTemplate`
+
+|====
 --
 +
 .Example output

--- a/modules/capi-yaml-cluster.adoc
+++ b/modules/capi-yaml-cluster.adoc
@@ -29,10 +29,21 @@ spec:
 <1> Specify the name of the cluster.
 <2> Specify the IP address of the control plane endpoint and the port used to access it.
 <3> Specify the infrastructure kind for the cluster.
-Valid values are:
+The following values are valid:
 +
---
-* `AWSCluster`: The cluster is running on {aws-full}.
-* `GCPCluster`: The cluster is running on {gcp-full}.
-* `VSphereCluster`: The cluster is running on {vmw-full}.
---
+|====
+|Cluster cloud provider |Value
+
+|{aws-full}
+|`AWSCluster`
+
+|{gcp-short}
+|`GCPCluster`
+
+|{rh-openstack}
+|`OpenStackCluster`
+
+|{vmw-full}
+|`VSphereCluster`
+
+|====

--- a/modules/capi-yaml-infrastructure-rhosp.adoc
+++ b/modules/capi-yaml-infrastructure-rhosp.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="capi-yaml-infrastructure-rhosp_{context}"]
+= Sample YAML for a Cluster API infrastructure cluster resource on {rh-openstack}
+
+The infrastructure cluster resource is provider-specific and defines properties that are shared by all the compute machine sets in the cluster, such as the region and subnets.
+The compute machine set references this resource when creating machines.
+
+[IMPORTANT]
+====
+Only the parameters in the following example are validated to be compatible with {product-title}.
+Other parameters, such as those documented in the upstream link:https://cluster-api-openstack.sigs.k8s.io/clusteropenstack/configuration#optional-configuration[{cap-openstack-first}] book, might cause undesired behavior.
+====
+
+[source,yaml]
+----
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackCluster # <1>
+metadata:
+  name: <cluster_name> # <2>
+  namespace: openshift-cluster-api
+  labels:
+    cluster.x-k8s.io/cluster-name: <cluster_name>
+spec:
+  controlPlaneEndpoint: <control_plane_endpoint_address> # <3>
+  disableAPIServerFloatingIP: true
+  tags:
+    - openshiftClusterID=<cluster_name>
+  network:
+    id: <api_service_network_id> # <4>
+  externalNetwork:
+    id: <floating_network_id> # <5>
+  identityRef:
+    cloudName: openstack
+    name: openstack-cloud-credentials
+----
+<1> Specify the infrastructure kind for the cluster.
+This value must match the value for your platform.
+<2> Specify the cluster ID as the name of the cluster.
+<3> Specify the IP address of the control plane endpoint and the port used to access it.
+<4> Specify the UUID of the default network to use for machines that do not specify ports.
++
+[NOTE]
+====
+This feature might be removed in a future release.
+To prevent issues due to the removal of this feature, specify at least one port in the machine specification instead of relying solely on this feature.
+====
+
+<5> Specify the UUID of an external network.
+You can specify the network used to assign external floating IP addresses or the network used for egress for this field.
++
+[NOTE]
+====
+The infrastructure cluster resource requires this field but does not currently use this value.
+This requirement is planned to be removed in a future release.
+====

--- a/modules/capi-yaml-machine-set-rhosp.adoc
+++ b/modules/capi-yaml-machine-set-rhosp.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="capi-yaml-machine-set-rhosp_{context}"]
+= Sample YAML for a Cluster API compute machine set resource on {rh-openstack}
+
+The compute machine set resource defines additional properties of the machines that it creates.
+The compute machine set also references the infrastructure resource and machine template when creating machines.
+
+[source,yaml]
+----
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineSet
+metadata:
+  name: <machine_set_name> # <1>
+  namespace: openshift-cluster-api
+spec:
+  clusterName: <cluster_name> # <2>
+  replicas: 1
+  selector:
+    matchLabels:
+      test: example
+      cluster.x-k8s.io/cluster-name: <cluster_name>
+      cluster.x-k8s.io/set-name: <machine_set_name>
+  template:
+    metadata:
+      labels:
+        test: example
+        cluster.x-k8s.io/cluster-name: <cluster_name>
+        cluster.x-k8s.io/set-name: <machine_set_name>
+        node-role.kubernetes.io/<role>: ""
+    spec:
+      bootstrap:
+         dataSecretName: worker-user-data # <3>
+      clusterName: <cluster_name>
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: OpenStackMachineTemplate # <4>
+        name: <template_name> # <5>
+      failureDomain: <nova_availability_zone> # <6>
+----
+<1> Specify a name for the compute machine set.
+<2> Specify the cluster ID as the name of the cluster.
+<3> For the Cluster API Technology Preview, the Operator can use the worker user data secret from the `openshift-machine-api` namespace.
+<4> Specify the machine template kind.
+This value must match the value for your platform.
+<5> Specify the machine template name.
+<6> Optional: Specify the name of the Nova availability zone for the machine set to create machines in.
+If you do not specify a value, machines are not restricted to a specific availability zone.

--- a/modules/capi-yaml-machine-template-rhosp.adoc
+++ b/modules/capi-yaml-machine-template-rhosp.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="capi-yaml-machine-template-rhosp_{context}"]
+= Sample YAML for a Cluster API machine template resource on {rh-openstack}
+
+The machine template resource is provider-specific and defines the basic properties of the machines that a compute machine set creates.
+The compute machine set references this template when creating machines.
+
+[source,yaml]
+----
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate # <1>
+metadata:
+  name: <template_name> # <2>
+  namespace: openshift-cluster-api
+spec:
+  template:
+    spec: # <3>
+      flavor: <openstack_node_machine_flavor> # <4>
+      image:
+        filter:
+          name: <openstack_image> # <5>
+----
+<1> Specify the machine template kind.
+This value must match the value for your platform.
+<2> Specify a name for the machine template.
+<3> Specify the details for your environment.
+The values here are examples.
+<4> Specify the {rh-openstack} flavor to use.
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/configuring_the_compute_service_for_instance_creation/assembly_creating-flavors-for-launching-instances_instance-flavors[Creating flavors for launching instances].
+<5> Specify the image to use.

--- a/modules/cluster-capi-operator.adoc
+++ b/modules/cluster-capi-operator.adoc
@@ -7,7 +7,7 @@
 
 [NOTE]
 ====
-This Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for {aws-first}, {gcp-first}, and {vmw-first} clusters.
+This Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for {aws-first}, {gcp-first}, and {rh-openstack-first}, {vmw-first} clusters.
 ====
 
 [discrete]
@@ -26,29 +26,31 @@ link:https://github.com/openshift/cluster-capi-operator[cluster-capi-operator]
 * `awsmachines.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `awsmachine`
-** Validation: No
 
 *  `gcpmachines.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `gcpmachine`
-** Validation: No
+
+*  `openstackmachines.infrastructure.cluster.x-k8s.io`
+** Scope: Namespaced
+** CR: `openstackmachine`
 
 *  `vspheremachines.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `vspheremachine`
-** Validation: No
 
 * `awsmachinetemplates.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `awsmachinetemplate`
-** Validation: No
 
 *  `gcpmachinetemplates.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `gcpmachinetemplate`
-** Validation: No
+
+*  `openstackmachinetemplates.infrastructure.cluster.x-k8s.io`
+** Scope: Namespaced
+** CR: `openstackmachinetemplate`
 
 *  `vspheremachinetemplates.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `vspheremachinetemplate`
-** Validation: No


### PR DESCRIPTION
Version(s):
4.15-4.17

Issue:
[OSDOCS-10635](https://issues.redhat.com//browse/OSDOCS-10635)

Link to docs preview:
- [About the Cluster API](https://89880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-about.html)
- [Getting started with the Cluster API](https://89880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-getting-started)
- [Modifying a Cluster API machine template](https://89880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-managing-machines.html#capi-modifying-machine-template_cluster-api-managing-machines)
- [Sample YAML for a Cluster API cluster resource](https://89880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-configuration.html#capi-yaml-cluster_cluster-api-configuration)
- [Cluster API configuration options for Red Hat OpenStack Platform](https://89880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp)
- [Cluster CAPI Operator](https://89880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-capi-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information:
* Splits pre-4.18 work out of #79330
* 4.18+ version: #89881 