### PR TITLE
OSSM-9027 Add xrefs to Gateway migration guide

### DIFF
--- a/migrating/done/ossm-migrating-complete-assembly.adoc
+++ b/migrating/done/ossm-migrating-complete-assembly.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id=ossm-migrating-complete-assembly.adoc]
+[id="ossm-migrating-complete-assembly"]
 = Completing the Migration
 include::_attributes/common-attributes.adoc[]
 :context: ossm-migrating-complete-assembly

--- a/migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc
+++ b/migrating/migrating-gateways/ossm-migrating-gateways-assembly.adoc
@@ -17,23 +17,20 @@ include::modules/ossm-migrating-gateways-canary.adoc[leveloffset=+1]
 
 .Next steps
 
-* xref:../done/ossm-migrating-complete-assembly.adoc[Completing your migration]
+* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing your migration]
 
 include::modules/ossm-migrating-gateways-in-place.adoc[leveloffset=+1]
 
 .Next steps
 
-* xref:../done/ossm-migrating-complete-assembly.adoc[Completing your migration]
+* xref:../../migrating/done/ossm-migrating-complete-assembly.adoc[Completing your migration]
 
 [role="_additional-resources"]
 [id="addition-resources-gateways_{context}"]
-== Additional Resources
+== Additional resources
 
-* xref:../multitenant/ossm-migrating-multitenant-assembly.adoc[Multitenant migration guide]
-//* Cluster-wide migration guide
-
-//exrefs are being handled by OSSM-8852 for all migration guide content
-
+* xref:../../migrating/multitenant/ossm-migrating-multitenant-assembly.adoc[Multitenant migration guide]
+* xref:../../migrating/cluster-wide/ossm-migrating-cluster-wide-assembly.adoc[Cluster-wide migration guide]
 
 //there is already a Gateways dir that contains 3.0 concept and procedure content for configuring and using gateways in 3.0.
 //named this dir migrating-gateways for clarity


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-9027](https://issues.redhat.com//browse/OSSM-9027) Add xrefs to Gateway migration guide

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

Issue:
https://issues.redhat.com/browse/OSSM-9027

Link to docs preview:
https://89882--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/migrating-gateways/ossm-migrating-gateways-assembly.html#addition-resources-gateways_ossm-migrating-gateways-assembly

QE review:
QE is not required for this PR.

Additional information:
There is a known issue with the use of anchors in xrefs in 3.0 content. A Jira has been created for it to be addressed and fixed post GA.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
