### PR TITLE
ROX-22488: Update recommended resource requirements for ACS 2

### DIFF
--- a/modules/recommended-requirements-central-services.adoc
+++ b/modules/recommended-requirements-central-services.adoc
@@ -13,6 +13,7 @@ If you are using {rh-rhacscs-first}, you do not need to review the requirements 
 Central services contain the following components:
 
 * Central
+* Central DB
 * Scanner
 +
 [NOTE]
@@ -24,7 +25,7 @@ For default resource requirements for the scanner, see the default resource requ
 == Central
 
 [discrete]
-== Memory and CPU requirements
+=== Memory and CPU requirements
 
 The following table lists the minimum memory and CPU values required to run Central for one secured cluster. The table includes the number of concurrent web portal users.
 
@@ -38,8 +39,8 @@ The following table lists the minimum memory and CPU values required to run Cent
 
 | < 25,000
 | < 5 users
-| 6 cores
-| 12 GiB
+| 2 cores
+| 8 GiB
 
 | < 50,000
 | 1 user
@@ -52,11 +53,43 @@ The following table lists the minimum memory and CPU values required to run Cent
 | 16 GiB
 |===
 
+[id="recommended-requirements-central-db-services-central_{context}"]
+== Central DB
+
+[discrete]
+=== Memory and CPU requirements
+
+The following table lists the minimum memory and CPU values required to run Central DB for one secured cluster. The table includes the number of concurrent web portal users.
+
+|===
+| Deployments | Concurrent web portal users | CPU | Memory
+
+| < 25,000
+| 1 user
+| 12 cores
+| 32 GiB
+
+| < 25,000
+| < 5 users
+| 24 cores
+| 32 GiB
+
+| < 50,000
+| 1 user
+| 16 cores
+| 32 GiB
+
+| < 50,000
+| < 5 users
+| 32 cores
+| 32 GiB
+|===
+
 [id="recommended-requirements-central-services-scanner_{context}"]
 == Scanner
 
 [discrete]
-== StackRox Scanner Memory and CPU requirements
+=== StackRox Scanner Memory and CPU requirements
 
 The following table lists the minimum memory and CPU values required for the StackRox Scanner deployment in the Central cluster. The table includes the number of unique images deployed in all secured clusters.
 

--- a/modules/recommended-requirements-secured-cluster-services.adoc
+++ b/modules/recommended-requirements-secured-cluster-services.adoc
@@ -22,23 +22,22 @@ Collector component is not included on this page. Required resource requirements
 
 Sensor monitors your Kubernetes and OpenShift Container Platform clusters. These services currently deploy in a single deployment, which handles interactions with the Kubernetes API and coordinates with Collector.
 
+
 [discrete]
 == Memory and CPU requirements
 
 The following table lists the minimum memory and CPU values required to run Sensor on a secured cluster.
 
 |===
-| Deployments | Pods per deployment | CPU | Memory
+| Deployments | CPU | Memory
 
 | < 25,000
-| 3
 | 2 cores
-| 8 GiB
+| 10 GiB
 
 | < 50,000
-| 3
 | 2 cores
-| 16 GiB
+| 20 GiB
 |===
 
 [id="recommended-requirements-secured-cluster-services-admission-controller_{context}"]
@@ -52,15 +51,13 @@ The admission controller prevents users from creating workloads that violate pol
 The following table lists the minimum memory and CPU values required to run the admission controller on a secured cluster.
 
 |===
-| Deployments | Pods per deployment | CPU | Memory
+| Deployments | CPU | Memory
 
 | < 25,000
-| 3
 | 0.5 cores
-| 600 MiB
+| 300 MiB
 
 | < 50,000
-| 3
 | 0.5 cores
-| 1200 MiB
+| 600 MiB
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.5,4.6,4.7

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

This PR is a duplicate of another PR that was reverted due to having multiple commits https://github.com/openshift/openshift-docs/pull/88047

Updates the recommended resource requirements for Sensor and Admission control based on performance testing. Also updates the recommended resource requirements for Central and Central DB based on K6 load testing.

More information about the performance testing can be found here. https://docs.google.com/document/d/18hDIMpVmUbmfq7V1vYgHpnQDS_HtpaJ6-gsPt8Kx8Yo/edit?tab=t.0

More information about the K6 load testing can be found here.
https://docs.google.com/document/d/1YbIHVLnwLGvQFc35wKPMHwBbhbZFI-SKG9rmkXqisJM/edit?tab=t.0#heading=h.kdzxu1msgans

### Added

A section on recommended resource requirements for Central DB is added.

### Lowered recommendations

For Central the recommended number of cores is decreased from 6 cores to 2 cores and the recommended requirement for memory is decreased from 12 GiB to 8 GiB.

For Admission controller the memory requirement is reduces from 600 MiB to 300 MiB for 25,000 deployments and from 1,200 MiB to 600 MiB for 50,000 deployments.

### Increased recommendations

For Sensor the recommended requirement for memory is increased from 8 GiB to 10 GiB for 25,000 deployments and from 16 GiB to 20 GiB for 50,000 deployments.

### Differences from default requirements

There is another document with the default CPU and memory requests and limits for ACS components. That document can be found here  https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.6/html/installing/acs-default-requirements#default-requirements-secured-cluster-services-collector_acs-default-requirements 


The following is a comparison of the changes here and the default limits in that document

#### Central

For Central this document recommends 2 cores for 25,000 deployments and 6 cores for 50,000 deployments, while the default limit is 8 cores. This would make sense if we expect users to have more than 50,000 deployments. Perhaps we should have an entry for more than 50,000 deployments. Alternatively we could decrease the default CPU limit for Central.

The memory limit recommended here is twice as high as the default memory limit for Central.

#### Central DB

The CPU and memory recommendations here are much higher than the default limits for Central DB. This would make sense if we were expecting customers to have fewer than 25,000 deployments, but that contradicts the analysis for Central.

#### Sensor

There is no change to the recommended CPU requirements for Sensor.

The default limit for memory is 8 GIB for Sensor. The recommendation here is for 10 GiB for 25,000 deployments and 20 GiB for 50,000 deployments. This default and recommendation here are not out of line, if we are expecting customers to have 25,000 deployments.

#### Admission controller

There is no change to the recommended CPU requirements for Sensor.

The default limit for memory for Admission controller is 500 MiB, which is close to the recommended requirement of 600 MiB for 50,000 deployments.