### PR TITLE
OSSM-9008 Add link from 2.x to 3.x

### DIFF
--- a/modules/ossm-servicemesh-overview.adoc
+++ b/modules/ossm-servicemesh-overview.adoc
@@ -11,3 +11,8 @@ Module included in the following assemblies:
 Microservice architectures split the work of enterprise applications into modular services, which can make scaling and maintenance easier. However, as an enterprise application built on a microservice architecture grows in size and complexity, it becomes difficult to understand and manage. {SMProductShortName} can address those architecture problems by capturing or intercepting traffic between services and can modify, redirect, or create new requests to other services.
 
 {SMProductShortName}, which is based on the open source link:https://istio.io/[Istio project], provides an easy way to create a network of deployed services that provides discovery, load balancing, service-to-service authentication, failure recovery, metrics, and monitoring. A service mesh also provides more complex operational functionality, including A/B testing, canary releases, access control, and end-to-end authentication.
+
+[NOTE]
+====
+{SMProductName} 3 is generally available. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/[{SMProductName} 3.0].
+====


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-9008](https://issues.redhat.com//browse/OSSM-9008) Add link from 2.x to 3.x

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OCP 4.14+

**Service Mesh 2.x is not stand alone, so this needs to be cherry-picked back to OCP core.**

Issue:
https://issues.redhat.com/browse/OSSM-9008

Link to docs preview:
https://89899--ocpdocs-pr.netlify.app/openshift-rosa/latest/service_mesh/v2x/ossm-about.html#ossm-servicemesh-overview_ossm-about

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
