### PR TITLE
OSSM-9029 Wrong indent on Istio resource in multitenant with cert manager migration

### DIFF
--- a/modules/ossm-migrating-multitenant-with-cert-manager.adoc
+++ b/modules/ossm-migrating-multitenant-with-cert-manager.adoc
@@ -88,12 +88,12 @@ spec:
         - name: otel
           opentelemetry:
            port: 4317
-          service: otel-collector.opentelemetrycollector-3.svc.cluster.local
+           service: otel-collector.opentelemetrycollector-3.svc.cluster.local
     global:
       caAddress: cert-manager-istio-csr.istio-system.svc:443
-      pilot:
-        env:
-          ENABLE_CA_SERVER: "false"
+    pilot:
+      env:
+        ENABLE_CA_SERVER: "false"
 ----
 +
 <1> The `spec.namespace` field in your `Istio` resource must be the _same_ namespace as your `ServiceMeshControlPlane` resource. If you set the `spec.namespace` field in your `Istio` resource to a different namespace than your `ServiceMeshControlPlane` resource, the migration will not work properly.


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-9029](https://issues.redhat.com//browse/OSSM-9029) Wrong indent on Istio resource in multitenant with cert manager migration

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
GA

Issue:
https://issues.redhat.com/browse/OSSM-9029

Link to docs preview:
https://89902--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/multitenant/ossm-migrating-multitenant-assembly.html#migrating-multitenant-with-cert-manager_ossm-migrating-multitenant-assembly

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
