### PR TITLE
OSSM-9028 update some command in observability doc

### DIFF
--- a/modules/ossm-config-openshift-monitoring-kiali.adoc
+++ b/modules/ossm-config-openshift-monitoring-kiali.adoc
@@ -6,12 +6,6 @@
 [id="ossm-config-openshift-monitoring-kiali_{context}"]
 = Configuring OpenShift Monitoring with Kiali
 
-// TP 1 content. Banner handled separately by different PR handled by Tim O'Keefe. Per Tim, banner should appear across all 3.0 content, nothing needs to be added to this file.
-// Possible file name may change
-// Possible assembly file may change
-// Assemblies, topic map info needs to be worked out still for 3.0.
-// Possible content will change.
-
 The following steps show how to integrate the {KialiProduct} with user-workload monitoring.
 
 .Prerequisites
@@ -22,7 +16,7 @@ The following steps show how to integrate the {KialiProduct} with user-workload 
 
 * OpenShift Monitoring has been configured with {SMProductShortName}. See "Configuring OpenShift Monitoring with Service Mesh".
 
-* {KialiProduct} 1.89 is installed.
+* {KialiProduct} 2.4 is installed.
 
 .Procedure
 
@@ -74,3 +68,5 @@ $ echo "https://$(oc get routes -n istio-system kiali -o jsonpath='{.spec.host}'
 ----
 
 . Follow the URL to open Kiali in your web browser.
+
+. Navigate to the **Traffic Graph** tab to check the traffic in the Kiali UI.

--- a/modules/ossm-config-otel.adoc
+++ b/modules/ossm-config-otel.adoc
@@ -127,15 +127,15 @@ $ oc get istiorevisions.sailoperator.io
 .Example output
 [source,terminal]
 ----
-NAME              TYPE    READY   STATUS    IN USE   VERSION   AGE
-default-v1-23-0   Local   True    Healthy   True     v1.23.0   3m33s
+NAME      TYPE    READY   STATUS    IN USE   VERSION   AGE
+default   Local   True    Healthy   True     v1.24.3   3m33s
 ----
 
 ... Label the namespace with the revision name to enable sidecar injection by running the following command:
 +
 [source,terminal]
 ----
-$ oc label namespace curl istio.io/rev=default-v1-23-0
+$ oc label namespace curl istio.io/rev=default
 ----
 
 . Deploy the `bookinfo` application in the `bookinfo` namespace by running the following command:


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-9028](https://issues.redhat.com//browse/OSSM-9028) update some command in observability doc

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

Issue:
https://issues.redhat.com/browse/OSSM-9028

Link to docs preview:
https://89910--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/kiali/ossm-kiali-assembly#ossm-config-openshift-monitoring-kiali_ossm-kiali-assembly

https://89910--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/traces/ossm-distr-tracing-assembly.html#ossm-config-otel_ossm-traces-assembly

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
