### PR TITLE
OCPBUGS-43869 Is image layering only allowed on ‘worker’ nodes?

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -12,7 +12,7 @@ toc::[]
 [id="coreos-layering-about_{context}"]
 == About {op-system} image layering
 
-Image layering allows you to customize the underlying node operating system on any of your cluster worker nodes. This helps keep everything up-to-date, including the node operating system and any added customizations such as specialized software.
+Image layering allows you to customize the underlying node operating system on any of your cluster nodes. This helps keep everything up-to-date, including the node operating system and any added customizations such as specialized software.
 
 You create a custom layered image by using a Containerfile and applying it to nodes by using a custom object. At any time, you can remove the custom layered image by deleting that custom object.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-43869
I suggest we remove the word "worker" from that sentence, as it's supported for any type of node.

Preview: [About RHCOS image layering](https://89913--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html) -- Changed "any of your cluster worker nodes" to "any of your cluster nodes". Because of the flawed preview, please search for "Image layering allows you to customize the underlying node operating system on any of your cluster nodes."

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

