### PR TITLE
remove ssh key param from Azure CAPI machine template

### DIFF
--- a/modules/capi-yaml-machine-template-azure.adoc
+++ b/modules/capi-yaml-machine-template-azure.adoc
@@ -32,7 +32,6 @@ spec:
         managedDisk:
           storageAccountType: Premium_LRS
         osType: Linux
-      sshPublicKey: <ssh_key_value>
       userAssignedIdentities:
         - providerID: 'azure:///subscriptions/<subscription_id>/resourcegroups/<cluster_name>-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<cluster_name>-identity'
       vmSize: Standard_D4s_v3


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[Slack report](https://redhat-internal.slack.com/archives/CBZHF4DHC/p1741356650357729?thread_ts=1741355248.343129&cid=CBZHF4DHC)

Link to docs preview:
[Sample YAML for a Cluster API machine template resource on Microsoft Azure](https://89925--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-azure#capi-yaml-machine-template-azure_cluster-api-config-options-azure)

QE review:
- [ ] QE has approved this change.

Additional information: