### PR TITLE
Note for oc-mirror v1 deprecation

### DIFF
--- a/disconnected/mirroring/installing-mirroring-disconnected.adoc
+++ b/disconnected/mirroring/installing-mirroring-disconnected.adoc
@@ -10,6 +10,11 @@ Running your cluster in a restricted network without direct internet connectivit
 
 You can use the oc-mirror OpenShift CLI (`oc`) plugin to mirror images to a mirror registry in your fully or partially disconnected environments. You must run oc-mirror from a system with internet connectivity in order to download the required images from the official Red Hat registries.
 
+[IMPORTANT]
+====
+The oc-mirror plugin v1 is now deprecated. Transition to the xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#installation-oc-mirror-v2-about_about-installing-oc-mirror-v2[oc-mirror plugin v2] for continued support and improvements.
+====
+
 // About the oc-mirror plugin
 include::modules/oc-mirror-about.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Note for oc-mirror v1 deprecation in OCP 4.18 and 4.19
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18, 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-52571](https://issues.redhat.com/browse/OCPBUGS-52571)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://89930--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-disconnected.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
