### PR TITLE
[SRVKS-1306] Configuring long running requests

### DIFF
--- a/knative-serving/config-applications/configuring-revision-timeouts.adoc
+++ b/knative-serving/config-applications/configuring-revision-timeouts.adoc
@@ -8,5 +8,17 @@ toc::[]
 
 You can configure timeout durations for revisions globally or individually to control the time spent on requests.
 
+//Configuring revision timeout
 include::modules/configuring-revision-timeout.adoc[leveloffset=+1]
+
+//Configuring maximum revision timeout
 include::modules/configuring-maximum-revision-timeout.adoc[leveloffset=+1]
+
+//Long-running requests
+include::modules/serverless-long-running-requests.adoc[leveloffset=+1]
+
+//Configuring the default route timeouts globally (+2)
+include::modules/configuring-default-route-timeouts-globally.adoc[leveloffset=+2]
+
+//Configuring the default route timeouts per revision (+2)
+include::modules/configuring-default-route-timeouts.adoc[leveloffset=+2]

--- a/modules/configuring-default-route-timeouts-globally.adoc
+++ b/modules/configuring-default-route-timeouts-globally.adoc
@@ -1,0 +1,111 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/configuring-revision-timeouts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-default-route-timeouts-globally_{context}"]
+= Configuring the default route timeouts globally
+
+By configuring the route timeouts globally, you can ensure consistent timeout settings across all services, simplifying management for workloads that have similar timeout needs and reducing the need for individual adjustments.
+
+You can configure the route timeouts globally by updating the `ROUTE_HAPROXY_TIMEOUT` environment value in your `serverless-operator` subscription and updating the `max-revision-timeout-seconds` field in your `KnativeServing` custom resource (CR). This applies the timeout changes across all Knative services, and you can deploy services with specific timeouts up to the maximum value set.
+
+.Procedure
+
+. Set the value of `ROUTE_HAPROXY_TIMEOUT` in your subscription to your required timeout in seconds by running the following command:
++
+.Setting the `ROUTE_HAPROXY_TIMEOUT` value to 900 seconds
+[source,terminal]
+----
+$ oc patch subscription.operators.coreos.com serverless-operator -n openshift-serverless --type='merge' -p '{"spec": {"config": {"env": [{"name": "ROUTE_HAPROXY_TIMEOUT", "value": "900"}]}}}'
+----
++
+The `ROUTE_HAPROXY_TIMEOUT`  environment variable is managed by the Serverless Operator and by default is set to `600`. Set the value of `ROUTE_HAPROXY_TIMEOUT` in your subscription to your required timeout in seconds by running the following command. Note that this causes pods to be redeployed in the `openshift-serverless` namespace.
++
+[NOTE]
+====
+If you created your routes manually and disabled auto-generation with the `serving.knative.openshift.io/disableRoute` annotation, you can configure the timeouts directly in the route definitions.
+====
+
+. Set the maximum revision timeout in your `KnativeServing` CR:
++
+.`KnativeServing` CR with `max-revision-timeout-seconds` set to 900 seconds
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    defaults:
+      max-revision-timeout-seconds: "900"
+#...
+----
++
+The Serverless Operator automatically adjusts the `terminationGracePeriod` value of the activator to the set maximum revision timeout value to avoid request termination in cases where activator pods are being terminated themselves.
++
+. Optional: Verify that the timeout has been set by running the following command: 
++
+[source,terminal]
+----
+$ oc get deployment activator -n knative-serving -o jsonpath="{.spec.template.spec.terminationGracePeriodSeconds}"
+----
+
+. If necessary for your cloud provider, adjust the load balancer timeout by running the following command:
++
+.Load balancer timeout adjustment for AWS Classic LB 
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/default --type=merge --patch=' \
+  {"spec":{"endpointPublishingStrategy":  \
+  {"type":"LoadBalancerService", "loadBalancer":  \
+  {"scope":"External", "providerParameters":{"type":"AWS", "aws":  \
+  {"type":"Classic", "classicLoadBalancer":  \
+  {"connectionIdleTimeout":"20m"}}}}}}}'
+----
+
+. Deploy a Knative service with the desired timeouts less or equal to the `max-revision-timeout-seconds` variable:
++
+.A Service definition with timeouts set to 800 seconds
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: example-service-name
+spec:
+  template:
+    spec:
+      timeoutSeconds: 800
+      responseStartTimeoutSeconds: 800
+----
++
+[IMPORTANT]
+====
+When using {SMProductShortName}, if the activator pod is stopped while a long-running request is in-flight, the request is interrupted.
+To avoid request interruptions, you must adjust the value of the `terminationDrainDuration` field in the `ServiceMeshControlPlane` CR: 
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+#...
+spec: 
+  techPreview:
+      meshConfig:
+        defaultConfig:
+          terminationDrainDuration: 1000s <1>
+#... 
+----
+<1> Ensure that the value exceeds the request duration to avoid the Istio proxy shutdown, which would interrupt the request.
+====
+
+.Verification
+
+* If you are using Kourier, you can verify the current value of the timeout at the {ocp-product-title} route by running the following command:
++
+[source,terminal]
+----
+$ oc get route <route_name> -n knative-serving-ingress ess -o jsonpath="{.metadata.annotations.haproxy\.router\.openshift\.io/timeout}"
+800s
+----

--- a/modules/configuring-default-route-timeouts.adoc
+++ b/modules/configuring-default-route-timeouts.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/configuring-revision-timeouts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-default-route-timeouts_{context}"]
+= Configuring the default route timeouts per revision
+
+By configuring the route timeouts per revision, you can fine-tune timeouts for workloads with unique requirements, such as AI or data processing applications, without impacting the global timeout settings for other services.
+You can configure the timeouts of a specific revision by updating your `KnativeServing` custom resource (CR), the Service definition, and using the `serving.knative.openshift.io/setRouteTimeout` annotation to adjust the {ocp-product-title} route timeout.
+
+.Procedure
+
+. Set the `max-revision-timeout` annotation in your `KnativeServing` CR as you require:
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    defaults:
+      max-revision-timeout-seconds: "900"
+----
+
+. Optional: Verify the termination grace period of an activator by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment activator -n knative-serving -o jsonpath="{.spec.template.spec.terminationGracePeriodSeconds}"
+
+900
+----
+
+. If necessary for your cloud provider, adjust the load balancer timeout by running the following command:
++
+.Load balancer timeout adjustment for AWS Classic LB 
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/default \
+  --type=merge --patch='{"spec":{"endpointPublishingStrategy":  \
+  {"type":"LoadBalancerService", "loadBalancer":  \
+  {"scope":"External", "providerParameters":{"type":"AWS", "aws":  \
+  {"type":"Classic", "classicLoadBalancer":  \
+  {"connectionIdleTimeout":"20m"}}}}}}}'
+----
+
+. Set the timeout for your specific service:
++
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1f
+kind: Service
+metadata:
+  name: <your_service_name>
+  annotations:
+    serving.knative.openshift.io/setRouteTimeout: "800" <1>
+spec:
+  template:
+    metadata:
+      annotations:
+#...
+    spec:
+      timeoutSeconds: 800 <2>
+      responseStartTimeoutSeconds: 800 <3>
+----
+<1> This annotation sets the timeout for the {ocp-product-title} route. You can fine-tune this for each service instead of setting a global maximum.
+<2> This ensures that the request does not exceed the specific value.
+<3> This ensures that the response start timeout does not trigger before the max threshold is reached. The default value is `300`.
+
++
+[IMPORTANT]
+====
+When using {SMProductShortName}, if the activator pod is stopped while a long-running request is in-flight, the request is interrupted.
+To avoid request interruptions, you must adjust the value of the `terminationDrainDuration` field in the `ServiceMeshControlPlane` CR: 
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+#...
+spec: 
+  techPreview:
+      meshConfig:
+        defaultConfig:
+          terminationDrainDuration: 1000s <1>
+#... 
+----
+<1> Ensure that the value exceeds the request duration to avoid the Istio proxy shutdown, which would interrupt the request.
+====
+
+.Verification
+
+* If you are using Kourier, you can verify the current value of the timeout at the {ocp-product-title} route by running the following command:
++
+[source,terminal]
+----
+$ oc get route <route-name> -n knative-serving-ingress ess -o jsonpath="{.metadata.annotations.haproxy\.router\.openshift\.io/timeout}"
+800s
+----

--- a/modules/serverless-long-running-requests.adoc
+++ b/modules/serverless-long-running-requests.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/configuring-revision-timeouts.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-long-running-requests_{context}"]
+= Long running requests
+
+To ensure that requests exceeding the default 600 second timeout set by Knative are not prematurely terminated, you need to adjust the timeouts in the following components:
+
+* {ocp-product-title} route
+* {ServerlessProductName} Serving
+* Load balancer, depending on the cloud provider
+
+You can configure the timeouts globally or per revision. You can configure the timeouts globally if you have requests across all Knative services that need extended durations, or per revision for specific workloads that require different timeout values, such as AI deployments.


### PR DESCRIPTION
Version(s):
serverless-docs-1.36+

Issue:
https://issues.redhat.com/browse/SRVKS-1306

Link to docs preview:
- https://89935--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-applications/configuring-revision-timeouts.html#serverless-long-running-requests_configuring-revision-timeouts

QE review:
- [x] QE has approved this change.

Additional information:
_Merge BEFORE [SRVKS-1289](https://github.com/openshift/openshift-docs/pull/88871)._