### PR TITLE
OBSDOCS-1758 add namespace to expose service command

### DIFF
--- a/modules/monitoring-validating-a-monitoringstack-for-cluster-observability-operator.adoc
+++ b/modules/monitoring-validating-a-monitoringstack-for-cluster-observability-operator.adoc
@@ -22,7 +22,7 @@ To validate that the monitoring stack is working correctly, access the example s
 +
 [source,terminal]
 ----
-$ oc expose svc prometheus-coo-example-app
+$ oc expose svc prometheus-coo-example-app -n ns1-coo
 ----
 . Access the route from your browser, or command line, to generate metrics.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-1758](https://issues.redhat.com//browse/OBSDOCS-1758)

Link to docs preview:

https://89938--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service.html
