### PR TITLE
OSSM-9033 Fix indent in Istio resource in Multitenant migration doc

### DIFF
--- a/modules/ossm-migrating-a-multitenant-deployment.adoc
+++ b/modules/ossm-migrating-a-multitenant-deployment.adoc
@@ -34,25 +34,25 @@ apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: istio-tenant-a
-  spec:
-    namespace: istio-system-tenant-a <1>
-    version: v1.24.3
-    values:
-      meshConfig:
-        discoverySelectors: <2>
-          - matchLabels:
-              tenant: tenant-a
-    extensionProviders:  <3>
-      - name: prometheus
-        prometheus: {}
-      - name: otel
-        opentelemetry:
-          port: 4317
-          service: otel-collector.opentelemetrycollector-3.svc.cluster.local
+spec:
+  namespace: istio-system-tenant-a <1>
+  version: v1.24.3
+  values:
+    meshConfig:
+      discoverySelectors: <2>
+        - matchLabels:
+            tenant: tenant-a
+      extensionProviders:  <3>
+        - name: prometheus
+          prometheus: {}
+        - name: otel
+          opentelemetry:
+            port: 4317
+            service: otel-collector.opentelemetrycollector-3.svc.cluster.local
 ----
 +
 <1> The `spec.namespace` field in your `Istio` resource must be the same namespace as your `ServiceMeshControlPlane` resource. If you set the `spec.namespace` field in your `Istio` resource to a different namespace than your `ServiceMeshControlPlane` resource, the migration does not complete successfully.
-<2> By default, control planes watch the entire cluster. When managing multiple control planes on a single cluster, you must narrow the scope of each control plane by setting `discoverySelectors` fields. In this example, the label `tenant` is used, but you can use any label or combination of labels.
+<2> By default, control planes watch the entire cluster. When managing multiple control planes on a single cluster, you must narrow the scope of each control plane by setting `discoverySelectors` fields. In this example, the label `tenant-a` is used, but you can use any label or combination of labels.
 <3> Optional: If you are migrating metrics and tracing, update the `extensionProviders` fields according to your tracing and metrics configurations.
 
 . Add your `tenant` label to each one of your dataplane namespaces by running the following command for each dataplane namespace:

--- a/modules/ossm-migrating-multitenant-with-cert-manager.adoc
+++ b/modules/ossm-migrating-multitenant-with-cert-manager.adoc
@@ -79,9 +79,9 @@ spec:
   version: v1.24.3
   values:
     meshConfig:
-      discoverySelectors:
+      discoverySelectors: <2>
         - matchLabels:
-            tenant: tenant-a <2>
+            tenant: tenant-a
       extensionProviders:  <3>
         - name: prometheus
           prometheus: {}
@@ -97,7 +97,7 @@ spec:
 ----
 +
 <1> The `spec.namespace` field in your `Istio` resource must be the _same_ namespace as your `ServiceMeshControlPlane` resource. If you set the `spec.namespace` field in your `Istio` resource to a different namespace than your `ServiceMeshControlPlane` resource, the migration will not work properly.
-<2> By default, control planes watch the entire cluster. When managing multiple control planes on a single cluster, you must narrow the scope of each control plane by setting `discoverySelectors` fields. In this example, the label `tenant` is used, but you can use any label or combination of labels.
+<2> By default, control planes watch the entire cluster. When managing multiple control planes on a single cluster, you must narrow the scope of each control plane by setting `discoverySelectors` fields. In this example, the label `tenant-a` is used, but you can use any label or combination of labels.
 <3> Optional: If you are migrating metrics and tracing, update the `extensionProviders` fields according to your tracing and metrics configurations.
 
 . Add your `tenant` label to each one of your dataplane namespaces by running the following command for each dataplane namespace:


### PR DESCRIPTION
**OSSM 3.0 GA**

[OSSM-9033](https://issues.redhat.com//browse/OSSM-9033) Fix indent in Istio resource in Multitenant migration doc

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
GA

Issue:
https://issues.redhat.com/browse/OSSM-9033

Link to docs preview:
https://89942--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/multitenant/ossm-migrating-multitenant-assembly.html#migrating-a-multitenant-deployment_ossm-migrating-multitenant-assembly
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
