### PR TITLE
OBSDOCS-1703: Remove Support exception for the Logging UI Plugin

### DIFF
--- a/observability/logging/logging-6.0/log60-cluster-logging-support.adoc
+++ b/observability/logging/logging-6.0/log60-cluster-logging-support.adoc
@@ -31,11 +31,6 @@ include::snippets/log6x-api-support-states-snip.adoc[]
 include::modules/cluster-logging-maintenance-support-list-6x.adoc[leveloffset=+1]
 include::modules/unmanaged-operators.adoc[leveloffset=+1]
 
-[id="support-exception-for-coo-logging-ui-plugin_{context}"]
-== Support exception for the Logging UI Plugin
-
-Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its Logging UI Plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
-
 [id="cluster-logging-support-must-gather_{context}"]
 == Collecting {logging} data for Red Hat Support
 

--- a/observability/logging/logging-6.1/log61-cluster-logging-support.adoc
+++ b/observability/logging/logging-6.1/log61-cluster-logging-support.adoc
@@ -31,11 +31,6 @@ include::snippets/log6x-api-support-states-snip.adoc[]
 include::modules/cluster-logging-maintenance-support-list-6x.adoc[leveloffset=+1]
 include::modules/unmanaged-operators.adoc[leveloffset=+1]
 
-[id="support-exception-for-coo-logging-ui-plugin_{context}"]
-== Support exception for the Logging UI Plugin
-
-Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its Logging UI Plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
-
 [id="cluster-logging-support-must-gather_{context}"]
 == Collecting {logging} data for Red Hat Support
 

--- a/observability/logging/logging-6.2/log62-cluster-logging-support.adoc
+++ b/observability/logging/logging-6.2/log62-cluster-logging-support.adoc
@@ -31,11 +31,6 @@ include::snippets/log6x-api-support-states-snip.adoc[]
 include::modules/cluster-logging-maintenance-support-list-6x.adoc[leveloffset=+1]
 include::modules/unmanaged-operators.adoc[leveloffset=+1]
 
-[id="support-exception-for-coo-logging-ui-plugin_{context}"]
-== Support exception for the Logging UI Plugin
-
-Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its Logging UI Plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
-
 [id="cluster-logging-support-must-gather_{context}"]
 == Collecting {logging} data for Red Hat Support
 


### PR DESCRIPTION
Version(s): Cherry-pick to logging-docs-6.2-4.18, logging-docs-6.2-4.17, logging-docs-6.2-4.16 release branches. 

Issue: https://issues.redhat.com/browse/OBSDOCS-1703

Link to docs preview:
https://89946--ocpdocs-pr.netlify.app/
https://89946--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log61-cluster-logging-support.html
https://89946--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log62-cluster-logging-support.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
