### PR TITLE
Update cluster-logging-kibana-scaling.adoc

### DIFF
--- a/modules/cluster-logging-kibana-scaling.adoc
+++ b/modules/cluster-logging-kibana-scaling.adoc
@@ -14,7 +14,7 @@ You can scale the pod that hosts the log visualizer for redundancy.
 +
 [source,terminal]
 ----
-$ oc edit ClusterLogging instance
+$ oc -n openshift-logging edit ClusterLogging instance
 ----
 +
 [source,yaml]
@@ -23,13 +23,13 @@ apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:
   name: "instance"
-
+  namespace: openshift-logging
 ....
 
 spec:
-    visualization:
-      type: "kibana"
-      kibana:
-        replicas: 1 <1>
+  visualization:
+    type: "kibana"
+    kibana:
+      replicas: 1 <1>
 ----
 <1> Specify the number of Kibana nodes.


### PR DESCRIPTION
- Incorrect configuration under scaling redundancy for the log visualizer nodes documentation

- Here is the documentation link: https://docs.openshift.com/container-platform/4.16/observability/logging/log_visualization/logging-kibana.html#cluster-logging-kibana-scaling_logging-kibana

=======================================
- namespace name is missing from the command.
- same command is mentioned twice in the second block. Which is not required and hence needs to be removed.
- "namespace: openshift-logging" field is missing under `metadata` section.
- 2 extra spaces under `spec.visulization`, it will not cause any effect. But it needs to be with correct indentation. 

=======================================

=======================================
Reason:

1. Suppose the user is not a part of openshift-logging project, and he tries to run this command then this command will not work.
2. If the credentials are shared, and two people are using the same cluster at the same time, then, the second person could change to work in a different namespace. 

=======================================

Updated documentation will look like the following:

1. Edit the ClusterLogging custom resource (CR) in the openshift-logging project:

~~~
$ oc -n openshift-logging edit ClusterLogging instance 
~~~
~~~
apiVersion: "logging.openshift.io/v1"
kind: "ClusterLogging"
metadata:
  name: "instance"
  namespace: openshift-logging
....

spec:
  visualization:
    type: "kibana"
    kibana:
      replicas: 1 
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP-4.18, RHOCP-4.17, RHOCP-4.16, RHOCP-4.15, RHOCP-4.14, RHOCP-4.13, RHOCP-4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1756

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://89957--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/log_visualization/logging-kibana.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
