### PR TITLE
Removing 'custom resources?' from Vale accept list

### DIFF
--- a/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
@@ -13,7 +13,6 @@
 [Uu]npause
 Assisted Installer
 Control Plane Machine Set Operator
-custom resources?
 GHz
 gpsd
 gpspipe


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): NA
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [Vale issue 911](https://github.com/redhat-documentation/vale-at-red-hat/issues/911)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: NA
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
