### PR TITLE
OCPBUGS:44488 Fix API version changed in error redux

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -158,7 +158,7 @@ ifdef::nodes[]
 .Example output for cgroup v2
 [source,terminal]
 ----
-apiVersion: machineconfiguration.openshift.io/v2
+apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
@@ -177,7 +177,7 @@ endif::nodes[]
 .Example output for cgroup v1
 [source,terminal]
 ----
-apiVersion: machineconfiguration.openshift.io/v2
+apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:


### PR DESCRIPTION
The API version was changed in error during a copy/paste to update cgroup v1 to cgroup v2. I missed a couple in https://github.com/openshift/openshift-docs/pull/89619. No QE needed.