### PR TITLE
Legacy service accounts: Update log6x-collection-setup.adoc

### DIFF
--- a/modules/log6x-collection-setup.adoc
+++ b/modules/log6x-collection-setup.adoc
@@ -18,6 +18,10 @@ To use the existing legacy service account `logcollector`, create the following 
 [source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user collect-application-logs system:serviceaccount:openshift-logging:logcollector
+----
+
+[source,terminal]
+----
 $ oc adm policy add-cluster-role-to-user collect-infrastructure-logs system:serviceaccount:openshift-logging:logcollector
 ----
 


### PR DESCRIPTION
- More than one command is mentioned in the single code block
- Here is the documentation link  [1]: 
[1] https://docs.openshift.com/container-platform/4.18/observability/logging/logging-6.0/log6x-clf.html#legacy-service-accounts
- As per the standard rule, using more than one command per code block is not recommended.
- Please check Standard rule  [2] for reference: 
[2] https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#single-command-per-code-block

- When commands are bunched together, the copy to clipboard functionality might not break the lines up correctly. Using a single command per code block makes it copy-and-paste friendly.
- Hence we need to mention 2 separate code blocks for above 2 commands.

- Here is the updated look of the documentation: 
~~~
$ oc adm policy add-cluster-role-to-user collect-application-logs system:serviceaccount:openshift-logging:logcollector  
~~~
~~~
$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs system:serviceaccount:openshift-logging:logcollector
~~~
=====================

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.14, RHOCP 4.15, RHOCP 4.16, RHOCP 4.17, RHOCP 4.18, RHOCP 4.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1759

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://89961--ocpdocs-pr.netlify.app/
https://89961--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-clf-6.1.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
