### PR TITLE
OSDOCS-13292: adds telemetry release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -60,8 +60,9 @@ With this release, configurable transport layer security (TLS) protocols on inte
 [id="microshift-4-19-support_{context}"]
 === Support
 
-//[id="microshift-4-19-example-support-feature_{context}"]
-//==== Example Support feature here
+[id="microshift-4-19-telemetry_{context}"]
+==== Telemetry now available
+With this release, {microshift-short} adds the Telemeter API. Lightweight attributes can be sent from a connected cluster to Red{nbsp}Hat to monitor the health of the cluster. To opt-out of Telemetry, see xref:../microshift_support/microshift-remote-cluster-monitoring.adoc#microshift-remote-cluster-monitoring[Remote health monitoring with a connected cluster].
 
 //[id="microshift-4-19-doc-enhancements_{context}"]
 //=== Documentation enhancements


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13292](https://issues.redhat.com/browse/OSDOCS-13292)

Link to docs preview:
[microshift-4-19-support_release-notes](https://89962--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-support_release-notes)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Main PR is here, https://github.com/openshift/openshift-docs/pull/89751

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
