### PR TITLE
OSDOCS-11185: adds TLS release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -47,6 +47,10 @@ Updates for both single-version minor releases and patch releases are supported.
 //==== Control ingress for your use case with additional parameters
 //add phase 2 ingress control parameters announcement here
 
+[id="microshift-4-19-tls-config_{context}"]
+==== {microshift-short} control plane enhanced with TLS
+With this release, configurable transport layer security (TLS) protocols on internal control plane components are enabled to help prevent known insecure protocols, ciphers, or algorithms from accessing the applications you run on {microshift-short}. You use either the TLS 1.2 or TLS 1.3 with {microshift-short}. For more information, see xref:../microshift_configuring/microshift_auth_security/microshift-tls-config.adoc#microshift-tls-config[Configuring TLS security profiles].
+
 [id="microshift-4-19-running-apps_{context}"]
 === Running applications
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-11185](https://issues.redhat.com/browse/OSDOCS-11185)

Link to docs preview:
[microshift-4-19-configuring_release-notes](https://89974--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-configuring_release-notes)
NOTE: decommissioning of docs.openshift.com has broken preview formatting

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Main PR is here, https://github.com/openshift/openshift-docs/pull/89670

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
