### PR TITLE
CNV#45693- Fix kubevirt_vmi_vcpu_wait_seconds_total docs to be IO specific

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -21,7 +21,8 @@ ifndef::openshift-rosa,openshift-dedicated[]
 The following query can identify virtual machines that are waiting for Input/Output (I/O):
 
 `kubevirt_vmi_vcpu_wait_seconds_total`::
-Returns the wait time (in seconds) for a virtual machine's vCPU. Type: Counter.
+Returns the wait time (in seconds) on I/O for vCPUs of a virtual machine. Type: Counter. 
+
 
 A value above '0' means that the vCPU wants to run, but the host scheduler cannot run it yet. This inability to run indicates that there is an issue with I/O.
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/CNV-45693

Link to docs preview:
https://89980--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Comments:
Have revised the changes after the peer review is done once. 

