### PR TITLE
OSSM-9018 Add a note to Disable the old gateway in the documentation

### DIFF
--- a/modules/ossm-migrating-from-smcp-defined-gateways-to-gateway-injection.adoc
+++ b/modules/ossm-migrating-from-smcp-defined-gateways-to-gateway-injection.adoc
@@ -18,11 +18,11 @@ This procedure explains how to migrate with zero downtime from gateways defined 
 
 .Procedure
 
-. Create a new ingress gateway that is configured to use gateway injection. 
+. Create a new ingress gateway that is configured to use gateway injection.
 +
 [NOTE]
 ====
-This procedure migrates away from the default ingress gateway deployment defined in the `ServiceMeshControlPlane` resource to gateway injection. The procedure may be modified to migrate from additional ingress gateways configured in the SMCP.    
+This procedure migrates away from the default ingress gateway deployment defined in the `ServiceMeshControlPlane` resource to gateway injection. The procedure may be modified to migrate from additional ingress gateways configured in the SMCP.
 ====
 +
 .Example ingress gateway resource with gateway injection
@@ -31,13 +31,13 @@ This procedure migrates away from the default ingress gateway deployment defined
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-ingressgateway-canary 
+  name: istio-ingressgateway-canary
   namespace: istio-system <1>
 spec:
   selector:
     matchLabels:
       app: istio-ingressgateway
-      istio: ingressgateway 
+      istio: ingressgateway
   template:
     metadata:
       annotations:
@@ -94,16 +94,16 @@ spec:
     - {}
   policyTypes:
     - Ingress
----- 
-<1> The gateway injection deployment and all supporting resources should be deployed in the same namespace as the SMCP-defined gateway. 
+----
+<1> The gateway injection deployment and all supporting resources should be deployed in the same namespace as the SMCP-defined gateway.
 <2> Ensure that the labels specified in the pod template include all of the label selectors specified in the `Service` object associated with the existing SMCP-defined gateway.
 <3> Grant access to the new gateway from outside the cluster. This access is required whenever the `spec.security.manageNetworkPolicy` of the `ServiceMeshControlPlane` resource is set to `true`, which is the default setting.
 
-. Verify that the new gateway deployment is successfully handling requests. 
+. Verify that the new gateway deployment is successfully handling requests.
 +
 If access logging was configured in the `ServiceMeshControlPlane` resource, view the access logs of the new gateway deployment to confirm the behavior.
 
-. Scale down the old deployment and scale up the new deployment. 
+. Scale down the old deployment and scale up the new deployment.
 +
 Gradually shift traffic from the old gateway deployment to the new gateway deployment by performing the following steps:
 
@@ -120,7 +120,7 @@ $ oc scale -n istio-system deployment/<new_gateway_deployment> --replicas <new_n
 $ oc scale -n istio-system deployment/<old_gateway_deployment> --replicas <new_number_of_replicas>
 ----
 
-.. Repeat running the previous two commands. Each time, increase the number of replicas for the new gateway deployment and decrease the number of replicas for the old gateway deployment. Continue repeating until the new gateway deployment handles all traffic to the gateway `Service` object. 
+.. Repeat running the previous two commands. Each time, increase the number of replicas for the new gateway deployment and decrease the number of replicas for the old gateway deployment. Continue repeating until the new gateway deployment handles all traffic to the gateway `Service` object.
 
 . Remove the `app.kubernetes.io/managed-by` label from the gateway `Service` object by running the following command:
 +
@@ -129,7 +129,7 @@ $ oc scale -n istio-system deployment/<old_gateway_deployment> --replicas <new_n
 $ oc label service -n istio-system istio-ingressgateway app.kubernetes.io/managed-by-
 ----
 +
-Removing the label prevents the service from being deleted when the gateway is disabled in the `ServiceMeshControlPlane` resource. 
+Removing the label prevents the service from being deleted when the gateway is disabled in the `ServiceMeshControlPlane` resource.
 
 . Remove the `ownerReferences` object from the gateway `Service` object by running the following command:
 +
@@ -149,5 +149,6 @@ $ oc patch smcp -n istio-system <smcp_name> --type='json' -p='[{"op": "replace",
 +
 [NOTE]
 ====
-When the old ingress gateway `Service` object is disabled it is not deleted. You may save this `Service` object to a file and manage it alongside the new gateway injection resources.
+* When the old ingress gateway `Service` object is disabled it is not deleted. You may save this `Service` object to a file and manage it alongside the new gateway injection resources.
+* The `/spec/gateways/ingress/enabled` path is available if you explicitly set it for the `ServiceMeshControlPlane` resource. If you are using the default value, you must patch the `/spec/gateways/enabled` path for both ingress and egress gateways.
 ====


### PR DESCRIPTION
[OSSM-9018](https://issues.redhat.com//browse/OSSM-9018) Add a note to Disable the old gateway in the documentation


Version(s):
OCP 4.14+

**Service Mesh 2.x is not stand alone, so it needs to be cherry-picked back to OCP core.**

Issue:
https://issues.redhat.com/browse/OSSM-9018

Link to docs preview:
https://89986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-gateway-migration.html#additional-resources_gateway-migration

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
