### PR TITLE
OCPBUGS#30895: Fix missing `&&` in example Containerfile

### DIFF
--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -32,7 +32,7 @@ For example, the following Containerfile creates a custom layered image from an 
 # Using a 4.12.0 image
 FROM quay.io/openshift-release/ocp-release@sha256... <1>
 #Install hotfix rpm
-RUN rpm-ostree cliwrap install-to-root / \ <2>
+RUN rpm-ostree cliwrap install-to-root / && \ <2>
     rpm-ostree override replace http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-{,core-,modules-,modules-extra-}4.18.0-483.el8.x86_64.rpm && \ <3>
     rpm-ostree cleanup -m && \
     ostree container commit


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OCPBUGS-30895](https://issues.redhat.com/browse/OCPBUGS-30895)

Link to docs preview:
[Applying a RHCOS custom layered image](https://89997--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html#coreos-layering-configuring_coreos-layering)

QE review:
- [x] QE has approved this change.

Additional information:

N/A