### PR TITLE
OCPBUGS-46490: Using sysctls in containers has an error

### DIFF
--- a/nodes/containers/nodes-containers-sysctls.adoc
+++ b/nodes/containers/nodes-containers-sysctls.adoc
@@ -17,7 +17,7 @@ Moreover, only those sysctls considered _safe_ are whitelisted by default; you
 can manually enable other _unsafe_ sysctls on the node to be available to the
 user.
 
-If you are setting the sysctl and it is not node-level, you can find information on this procedure in the section xref:../../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator].
+If you are setting the sysctl and it is node-level, you can find information on this procedure in the section xref:../../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator].
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-46490
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://89999--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-sysctls.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Error in documentation found by Mitchell Rollinson, Software Maint. Engr.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
