### PR TITLE
Update log6x-loki-zone-fail-recovery.adoc

### DIFF
--- a/modules/log6x-loki-zone-fail-recovery.adoc
+++ b/modules/log6x-loki-zone-fail-recovery.adoc
@@ -61,14 +61,14 @@ wal-logging-loki-ruler-1
 +
 [source,terminal]
 ----
-$ oc delete pvc <pvc_name>  -n openshift-logging
+$ oc delete pvc <pvc_name> -n openshift-logging
 ----
 +
 . Delete the pod(s) by running the following command:
 +
 [source,terminal]
 ----
-$ oc delete pod <pod_name>  -n openshift-logging
+$ oc delete pod <pod_name> -n openshift-logging
 ----
 +
 Once these objects have been successfully deleted, they should automatically be rescheduled in an available zone.


### PR DESCRIPTION
Removed extra space in between <pvc_name> and -n, which might not cause an issue in execution but is an inconsistency in formatting. This should be corrected to ensure proper syntax.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->RHOCP 4.14 to 4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/OBSDOCS-1760

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. ---> 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
