### PR TITLE
OCPBUGS-45422: Remove link to computingforgeeks.com

### DIFF
--- a/hardware_accelerators/nvidia-gpu-architecture.adoc
+++ b/hardware_accelerators/nvidia-gpu-architecture.adoc
@@ -39,10 +39,8 @@ include::modules/nvidia-gpu-vsphere.adoc[leveloffset=+2]
 .Additional resources
 * link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/openshift/nvaie-with-ocp.html#openshift-container-platform-on-vmware-vsphere-with-nvidia-vgpus[OpenShift Container Platform on VMware vSphere with NVIDIA vGPUs]
 
+// OCPBUGS-45422 Removed link.
 include::modules/nvidia-gpu-kvm.adoc[leveloffset=+2]
-[role="_additional-resources"]
-.Additional resources
-* link:https://computingforgeeks.com/how-to-deploy-openshift-container-platform-on-kvm/[How To Deploy OpenShift Container Platform 4.13 on KVM]
 
 include::modules/nvidia-gpu-csps.adoc[leveloffset=+2]
 [role="_additional-resources"]


### PR DESCRIPTION
[OpenShift Bugs][OCPBUGS-45422] A page from computingforgeeks.com is linked in the OCP product documentation

Removed the link. I did not add peer review label because no text was changed.

Version(s): OpenShift-4.17+

Issue: https://issues.redhat.com/browse/OCPBUGS-45422

Link to docs preview: https://90007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_accelerators/nvidia-gpu-architecture.html#nvidia-gpu-kvm_nvidia-gpu-architecture

QE: @wabouhamad 