### PR TITLE
v6.0 Forwarding to Red Hat Managed Elasticsearch is broken

### DIFF
--- a/observability/logging/logging-6.0/log6x-upgrading-to-6.adoc
+++ b/observability/logging/logging-6.0/log6x-upgrading-to-6.adoc
@@ -250,13 +250,48 @@ metadata:
   name: instance
   namespace: openshift-logging
 spec:
+  serviceAccount:
+    name: <service_account_name>
+  managementState: Managed
   outputs:
-  - name: default-elasticsearch
+  - name: audit-elasticsearch
     type: elasticsearch
     elasticsearch:
       url: https://elasticsearch:9200
       version: 6
-      index: <log_type>-write-{+yyyy.MM.dd}
+      index: audit-write
+    tls:
+      ca:
+        key: ca-bundle.crt
+        secretName: collector
+      certificate:
+        key: tls.crt
+        secretName: collector
+      key:
+        key: tls.key
+        secretName: collector
+  - name: app-elasticsearch
+    type: elasticsearch
+    elasticsearch:
+      url: https://elasticsearch:9200
+      version: 6
+      index: app-write
+    tls:
+      ca:
+        key: ca-bundle.crt
+        secretName: collector
+      certificate:
+        key: tls.crt
+        secretName: collector
+      key:
+        key: tls.key
+        secretName: collector
+  - name: infra-elasticsearch
+    type: elasticsearch
+    elasticsearch:
+      url: https://elasticsearch:9200
+      version: 6
+      index: infra-write
     tls:
       ca:
         key: ca-bundle.crt
@@ -268,17 +303,22 @@ spec:
         key: tls.key
         secretName: collector
   pipelines:
-  - outputRefs:
-    - default-elasticsearch
-  - inputRefs:
+  - name: app
+    inputRefs:
     - application
+    outputRefs:
+    - app-elasticsearch
+  - name: audit
+    inputRefs:
+    - audit
+    outputRefs:
+    - audit-elasticsearch
+  - name: infra
+    inputRefs:
     - infrastructure
+    outputRefs:
+    - infra-elasticsearch
 ----
-
-[NOTE]
-====
-In this example, application logs are written to the `application-write` alias/index instead of `app-write`.
-====
 
 == Red Hat Managed LokiStack
 


### PR DESCRIPTION
- v6.0 Forwarding to Red Hat Managed Elasticsearch is broken
- Here is the documentation link: https://docs.openshift.com/container-platform/4.16/observability/logging/logging-6.0/log6x-upgrading-to-6.html#red-hat-managed-elasticsearch

- Here entire example for `v6.0 Forwarding to Red Hat Managed Elasticsearch` is wrongly mentioned.
- For correct format kindly refer to KCS: https://access.redhat.com/solutions/7105074

- We need to correct this configuration in the documentation as well.
- Here is the updated `ClusterLogForwarder` configuration:

~~~
apiVersion: observability.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  name: collector
  namespace: openshift-logging
spec:
  serviceAccount:
    name: <service_account_name>
  managementState: Managed
  outputs:
  - name: audit-elasticsearch
    type: elasticsearch
    elasticsearch:
      url: https://elasticsearch:9200
      version: 6
      index: audit-write
    tls:
      ca:
        key: ca-bundle.crt
        secretName: collector
      certificate:
        key: tls.crt
        secretName: collector
      key:
        key: tls.key
        secretName: collector
  - name: app-elasticsearch
    type: elasticsearch
    elasticsearch:
      url: https://elasticsearch:9200
      version: 6
      index: app-write
    tls:
      ca:
        key: ca-bundle.crt
        secretName: collector
      certificate:
        key: tls.crt
        secretName: collector
      key:
        key: tls.key
        secretName: collector
  - name: infra-elasticsearch
    type: elasticsearch
    elasticsearch:
      url: https://elasticsearch:9200
      version: 6
      index: infra-write
    tls:
      ca:
        key: ca-bundle.crt
        secretName: collector
      certificate:
        key: tls.crt
        secretName: collector
      key:
        key: tls.key
        secretName: collector
  pipelines:
  - name: app
    inputRefs:
    - application
    outputRefs:
    - app-elasticsearch
  - name: audit
    inputRefs:
    - audit
    outputRefs:
    - audit-elasticsearch
  - name: infra
    inputRefs:
    - infrastructure
    outputRefs:
    - infra-elasticsearch
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.14, RHOCP 4.15, RHOCP 4.16, RHOCP 4.17, RHOCP 4.18, RHOCP 4.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1645

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
