### PR TITLE
OSDOCS-11626: Remove rendered :!rosa-with-hcp:

### DIFF
--- a/modules/rosa-sdpolicy-networking.adoc
+++ b/modules/rosa-sdpolicy-networking.adoc
@@ -100,6 +100,7 @@ For {product-title} clusters that have a private cloud network configuration, a 
 Network verification checks run automatically when you deploy a {product-title} cluster into an existing Virtual Private Cloud (VPC) or create an additional machine pool with a subnet that is new to your cluster. The checks validate your network configuration and highlight errors, enabling you to resolve configuration issues prior to deployment.
 
 You can also run the network verification checks manually to validate the configuration for an existing cluster.
+
 ifeval::["{context}" == "rosa-hcp-service-definition"]
 :!rosa-with-hcp:
 endif::[]


### PR DESCRIPTION
[OSDOCS-11626](https://issues.redhat.com//browse/OSDOCS-11626): Remove rendered :!rosa-with-hcp:

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-11626

Link to docs preview:
https://90009--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-network-verification_rosa-hcp-service-definition

QE review:
- Typo, QE not needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
