### PR TITLE
TELCODOCS-2214 - Removing out of date Hub cluster software versions

### DIFF
--- a/modules/ztp-gitops-ztp-max-spoke-clusters.adoc
+++ b/modules/ztp-gitops-ztp-max-spoke-clusters.adoc
@@ -52,15 +52,6 @@ The following guidelines are based on internal lab benchmark testing only and do
 |Requirement
 |Description
 
-|{product-title}
-|version 4.13
-
-|{rh-rhacm}
-|version 2.7
-
-|{cgu-operator-first}
-|version 4.13
-
 |Server hardware
 |3 x Dell PowerEdge R650 rack servers
 


### PR DESCRIPTION
Removing out of date software versions for the hub cluster. The hardware specs table does not need to include the software versions which are defined elsewhere anyway.

Version(s):
enterprise-4.13+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2214

Link to docs preview:

https://90065--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-preparing-the-hub-cluster.html#ztp-gitops-ztp-max-spoke-clusters_ztp-preparing-the-hub-cluster

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

