### PR TITLE
OCPBUGS-51282 - Remove out of date MCE table

### DIFF
--- a/snippets/ztp-patch-argocd-hub-cluster.adoc
+++ b/snippets/ztp-patch-argocd-hub-cluster.adoc
@@ -5,34 +5,15 @@ Customize the patch file that you previously extracted into the `out/argocd/depl
 .. Select the `multicluster-operators-subscription` image that matches your {rh-rhacm} version.
 +
 --
-.`multicluster-operators-subscription` image versions
-[cols="1,1,1,1,3", options="header"]
-|====
-|{product-title} version
-|{rh-rhacm} version
-|MCE version
-|MCE RHEL version
-|MCE image
-
-|4.14, 4.15, 4.16
-|2.8, 2.9
-|2.8, 2.9
-|RHEL 8
-|`registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v2.8`
-
-`registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v2.9`
-
-|4.14, 4.15, 4.16
-|2.10
-|2.10
-|RHEL 9
-|`registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.10`
-|====
+* For {rh-rhacm} 2.8 and 2.9, use the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v<rhacm_version>` image.
+* For {rh-rhacm} 2.10 and later, use the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v<rhacm_version>` image.
 
 [IMPORTANT]
 ====
-The version of the `multicluster-operators-subscription` image should match the {rh-rhacm} version.
-Beginning with the MCE 2.10 release, RHEL 9 is the base image for `multicluster-operators-subscription` images.
+The version of the `multicluster-operators-subscription` image must match the {rh-rhacm} version.
+Beginning with the MCE 2.10 release, {op-system-base} 9 is the base image for `multicluster-operators-subscription` images.
+
+Click `[Expand for Operator list]` in the "Platform Aligned Operators" table in link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] to view the complete supported Operators matrix for {product-title}.
 ====
 --
 


### PR DESCRIPTION
MCE version table is confusing and out of date. Link to the canonical generated support docs table instead. 

Version(s):
enterprise-4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-51282

Link to docs preview:
https://90069--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-preparing-the-hub-cluster#ztp-configuring-hub-cluster-with-argocd_ztp-preparing-the-hub-cluster

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
