### PR TITLE
OCPBUGS-50586:removes flexibility statement

### DIFF
--- a/modules/nw-udn-benefits.adoc
+++ b/modules/nw-udn-benefits.adoc
@@ -13,7 +13,7 @@ User-defined networks provide the following benefits:
 
 . Network flexibility
 +
-* **Layer 2 and layer 3 support**: Cluster administrators can configure primary networks as layer 2 or layer 3 network types. This provides the flexibility of a secondary network to the primary network.
+* **Layer 2 and layer 3 support**: Cluster administrators can configure primary networks as layer 2 or layer 3 network types.
 
 . Simplified network management
 +
@@ -31,6 +31,6 @@ User-defined networks provide the following benefits:
 
 Developers and administrators can create a user-defined network that is namespace scoped using the custom resource. An overview of the process is as follows:
 
-. An administrator creates a namespace for a user-defined network with the `k8s.ovn.org/primary-user-defined-network` label. 
+. An administrator creates a namespace for a user-defined network with the `k8s.ovn.org/primary-user-defined-network` label.
 . The `UserDefinedNetwork` CR is created by either the cluster administrator or the user.
 . The user creates pods in the namespace.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-50586
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://90076--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html#:~:text=cross%2Dtenant%20traffic.-,Network%20flexibility,-Layer%202%20and
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
