### PR TITLE
Incorrect command provided for adding SCC to a serviceaccount while deploying KMM in custom namespace.

### DIFF
--- a/modules/kmm-security.adoc
+++ b/modules/kmm-security.adoc
@@ -36,7 +36,7 @@ To allow any `ServiceAccount` to use the `privileged` SCC and run worker or devi
 
 [source,terminal]
 ----
-$ oc adm policy add-scc-to-user privileged -z "${serviceAccountName}" [ -n "${namespace}" ]
+$ oc adm policy add-scc-to-user privileged -z serviceAccountName -n namespace
 ----
 
 [id="pod-security-standards_{context}"]


### PR DESCRIPTION
In below documentation:
https://docs.openshift.com/container-platform/4.18/hardware_enablement/kmm-kernel-module-management.html the command provided for adding SCC to a serviceaccount while deploying KMM in custom namespace is incorrect.

$ oc adm policy add-scc-to-user privileged -z "${serviceAccountName}" [ -n "${namespace}" ]

Above command is giving an error because of incorrect brackets, ideally it should be:

Right Command:
"$ oc adm policy add-scc-to-user privileged -z serviceAccountName -n namespace" We can add note below the right command: Replace the 'namespace' argument with the 'operator namespace'.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OCP 4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-52586 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
