### PR TITLE
OLM v1 should be in GA instead of TP in OCP 4.18

### DIFF
--- a/operators/olm_v1/index.adoc
+++ b/operators/olm_v1/index.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="olmv1-about"]
-= About Operator Lifecycle Manager v1 (Technology Preview)
+= About Operator Lifecycle Manager v1 (General Availability) 
+Copy link)
 include::_attributes/common-attributes.adoc[]
 :context: olmv1-about
 


### PR DESCRIPTION
 In the following documentation:

https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/operators/index#olmv1-about

https://docs.openshift.com/container-platform/4.18/operators/olm_v1/index.html

It shows that OLM v1 is in TP phase, however, according to the release note, OLM v1 is GA in OCP 4.18:

https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/release_notes/index#ocp-release-notes-extensions-olmv1-ga_release-notes

https://docs.openshift.com/container-platform/4.18/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-extensions_release-notes

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OCP 4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-52264 
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
