### PR TITLE
 Red Hat Managed Lokistack example misses to set the "serviceAccount" field

### DIFF
--- a/observability/logging/logging-6.0/log6x-upgrading-to-6.adoc
+++ b/observability/logging/logging-6.0/log6x-upgrading-to-6.adoc
@@ -307,6 +307,8 @@ metadata:
   name: instance
   namespace: openshift-logging
 spec:
+  serviceAccount:
+    name: <service_account_name>
   outputs:
   - name: default-lokistack
     type: lokiStack


### PR DESCRIPTION
-  Red Hat Managed Lokistack example misses to set the "serviceAccount" field
- Here is the documentation link: https://docs.openshift.com/container-platform/4.18/observability/logging/logging-6.0/log6x-upgrading-to-6.html#red-hat-managed-lokistack:~:text=v6.0%20Forwarding%20to%20Red%20Hat%20Managed%20LokiStack

- Current example misses the field ".spec.serviceAccount: <serviceAccountName>".
-  A valid example should be like: 
~~~
apiVersion: observability.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  name: instance
  namespace: openshift-logging
spec:
  serviceAccount:
    name: <service_account_name>
  outputs:
  - name: default-lokistack
    type: lokiStack
    lokiStack:
      target:
        name: lokistack-dev
        namespace: openshift-logging
      authentication:
        token:
          from: serviceAccount
    tls:
      ca:
        key: service-ca.crt
        configMapName: openshift-service-ca.crt
  pipelines:
  - outputRefs:
    - default-lokistack
  - inputRefs:
    - application
    - infrastructure
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.14, RHOCP 4.15, RHOCP 4.16, RHOCP 4.17, RHOCP 4.18, RHOCP 4.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1762

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
