### PR TITLE
OBSDOCS-1763: Unpublish Configuring the logging collector chapter

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3016,8 +3016,8 @@ Topics:
       File: log6x-about-6.2
     - Name: Configuring log forwarding
       File: log6x-clf-6.2
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.2
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.2
     - Name: Configuring LokiStack storage
       File: log6x-loki-6.2
     - Name: Configuring LokiStack for OTLP
@@ -3035,8 +3035,8 @@ Topics:
       File: log6x-about-6.1
     - Name: Configuring log forwarding
       File: log6x-clf-6.1
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.1
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.1
     - Name: Configuring LokiStack storage
       File: log6x-loki-6.1
     - Name: Configuring LokiStack for OTLP


### PR DESCRIPTION
Version(s): Only needs to be merged to logging-docs-6.2 where it is currently pointing 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1763

Link to docs preview: https://90100--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log62-cluster-logging-support (note, Configuring the logging collector is not visible as required)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: QE approval is not required because this just removes some content from the docs.

Additional information:
There will be a separate PR for other OCP versions as cherry-picking will not be possible due to the difference in cadence of releases. Related PRs for other releases:

- https://github.com/openshift/openshift-docs/pull/90101
- https://github.com/openshift/openshift-docs/pull/90104