### PR TITLE
OBSDOCS-1763: Unpublish Configuring the logging collector chapter 4.17

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3001,8 +3001,8 @@ Topics:
       File: 6x-cluster-logging-deploying-6.2
     - Name: Configuring log forwarding
       File: log6x-clf-6.2
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.2
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.2
     - Name: Configuring LokiStack storage
       File: log6x-loki-6.2
     - Name: Configuring LokiStack for OTLP
@@ -3022,8 +3022,8 @@ Topics:
       File: 6x-cluster-logging-deploying-6.1
     - Name: Configuring log forwarding
       File: log6x-clf-6.1
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.1
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.1
     - Name: Configuring LokiStack storage
       File: log6x-loki-6.1
     - Name: Configuring LokiStack for OTLP
@@ -3045,8 +3045,8 @@ Topics:
       File: log6x-upgrading-to-6
     - Name: Configuring log forwarding
       File: log6x-clf
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.0
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.0
     - Name: Configuring LokiStack storage
       File: log6x-loki
     - Name: Visualization for logging
@@ -3060,8 +3060,8 @@ Topics:
       File: logging-5-8-release-notes
     - Name: Installing Logging
       File: cluster-logging-deploying
-    - Name: Configuring the logging collector
-      File: cluster-logging-collector
+#    - Name: Configuring the logging collector
+#      File: cluster-logging-collector
 #  - Name: Support
 #    File: cluster-logging-support
 #  - Name: Troubleshooting logging


### PR DESCRIPTION
Version(s): Only needs to be merged to logging-docs-6.2-4.17 where it is currently pointing

Issue: https://issues.redhat.com/browse/OBSDOCS-1763

Link to docs preview: https://90101--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log62-cluster-logging-support (note, Configuring the logging collector is not visible as required)

QE review: QE approval is not required because this just removes some content from the docs.

Additional information:
There will be a separate PR for other OCP versions as cherry-picking will not be possible due to the difference in cadence of releases. Related PRs for other releases:

- https://github.com/openshift/openshift-docs/pull/90100
- https://github.com/openshift/openshift-docs/pull/90104
