### PR TITLE
OBSDOCS-1763: Unpublish Configuring the logging collector chapter 4.16

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2806,8 +2806,8 @@ Topics:
       File: log6x-upgrading-to-6
     - Name: Configuring log forwarding
       File: log6x-clf
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.0
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.0
     - Name: Configuring LokiStack storage
       File: log6x-loki
     - Name: Visualization for logging
@@ -2834,8 +2834,8 @@ Topics:
       File: log6x-about-6.1
     - Name: Configuring log forwarding
       File: log6x-clf-6.1
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.1
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.1
     - Name: Configuring LokiStack storage
       File: log6x-loki-6.1
     - Name: Configuring LokiStack for OTLP
@@ -2855,8 +2855,8 @@ Topics:
       File: log6x-about-6.2
     - Name: Configuring log forwarding
       File: log6x-clf-6.2
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.2
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.2
     - Name: Configuring LokiStack storage
       File: log6x-loki-6.2
     - Name: Configuring LokiStack for OTLP


### PR DESCRIPTION
Version(s): Only needs to be merged to logging-docs-6.2-4.16 where it is currently pointing

Issue: https://issues.redhat.com/browse/OBSDOCS-1763

Link to docs preview: https://90104--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log62-cluster-logging-support (Note Configuring the logging collector is not visible as required in 6.x releases. The chapter is visible outside the 6.x headings which is expected as it pertains to  older releases).

QE review: QE approval is not required because this just removes some content from the docs.

Additional information:
There will be a separate PR for other OCP versions as cherry-picking will not be possible due to the difference in cadence of releases. Related PRs for other releases:

- https://github.com/openshift/openshift-docs/pull/90100
- https://github.com/openshift/openshift-docs/pull/90101