### PR TITLE
Three different command mentioned in single block under "Uninstalling the Local Storage Operator

### DIFF
--- a/modules/persistent-storage-local-uninstall-operator.adoc
+++ b/modules/persistent-storage-local-uninstall-operator.adoc
@@ -25,7 +25,15 @@ there might be indeterminate behavior if the Operator is uninstalled and reinsta
 [source,terminal]
 ----
 $ oc delete localvolume --all --all-namespaces
+----
++
+[source,terminal]
+----
 $ oc delete localvolumeset --all --all-namespaces
+----
++
+[source,terminal]
+----
 $ oc delete localvolumediscovery --all --all-namespaces
 ----
 


### PR DESCRIPTION
- Three different commands mentioned ina  single block under "Uninstalling the Local Storage Operator
- Here is the documentation link: https://docs.openshift.com/container-platform/4.18/storage/persistent_storage/persistent_storage_local/persistent-storage-local.html#local-storage-uninstall_persistent-storage-local

- As per the standard rule, using more than one command per code block is not recommended. Please check Standard rule  [2] for reference:
 [2] https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#single-command-per-code-block

- When commands are bunched together, the copy to clipboard functionality might not break the lines up correctly. Using a single command per code block makes it copy-and-paste friendly.

- Hence we need to mention 3 separate code blocks for above 3 commands.
- Here is the updated look of the documentation: 
~~~
$ oc delete localvolume --all --all-namespaces 
~~~
~~~
$ oc delete localvolumeset --all --all-namespaces  
~~~
~~~
$ oc delete localvolumediscovery --all --all-namespaces  
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.12, RHOCP 4.13, RHOCP 4.14, RHOCP 4.15, RHOCP 4.16, RHOCP 4.17, RHOCP 4.18, RHOCP 4.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1764

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://90121--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-local.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
