### PR TITLE
RHDEVDOCS 6391 remove the Viewing Pipeline Logs section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -81,8 +81,6 @@ Distros: openshift-pipelines
 Topics:
 - Name: Using Tekton Results for OpenShift Pipelines observability
   File: using-tekton-results-for-openshift-pipelines-observability
-- Name: Viewing pipeline logs using the OpenShift Logging Operator
-  File: viewing-pipeline-logs-using-the-openshift-logging-operator
 ---
 Name: Pipelines as Code
 Dir: pac


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
pipelines-docs-1.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6391

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

n/a as the PR *removes* a section. The link to the secrion being removed, in the existing doc: https://docs.openshift.com/pipelines/1.17/records/viewing-pipeline-logs-using-the-openshift-logging-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
