### PR TITLE
OSDOCS#13598-new: Update the z-stream RN for 4.15.47

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2779,6 +2779,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.47
+[id="ocp-4-15-47_{context}"]
+=== RHSA-2025:2454 - {product-title} 4.15.47 bug fix and security update
+
+Issued: 12 March 2025
+
+{product-title} release 4.15.47, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:2454[RHSA-2025:2454] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2025:2456[RHSA-2025:2456] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.47 --pullspecs
+----
+
+[id="ocp-4-15-47-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, an extra `name` prop was passed into the resource list page extensions used to list related operands on the *CSV details* page. This caused the operand list to be filtered by the `CSV` name, which often caused it to be an empty list. With this update, the operands are listed as expected. (link:https://issues.redhat.com/browse/OCPBUGS-51332[*OCPBUGS-51332*])
+
+* Previously, incorrect addresses were passed to the Kubernetes EndpointSlice on a cluster. This issue prevented the installation of the MetalLB Operator on an Agent-based cluster in an IPv6 disconnected environment. With this release, a fix modifies the address evaluation method. Red{nbsp}Hat Marketplace pods can successfully connect to the cluster API server. As a result, the installation of the MetalLB Operator and the handling of ingress traffic in IPv6 disconnected environments can occur. (link:https://issues.redhat.com/browse/OCPBUGS-51253[*OCPBUGS-51253*])
+
+* Previously,`konnectivity-https-proxy` did not have the additional trust bundles that were applied in the `configuration.proxy.trustCA` certificate. This caused hosted clusters to fail the provisioning process. With this release, the specified certificates are added to `Konnectivity` and propagate the proxy environment variables, allowing hosted clusters with secure proxies and custom certificates to successfully complete their provisioning. (link:https://issues.redhat.com/browse/OCPBUGS-52172[*OCPBUGS-52172*])
+
+* Previously, in the Red{nbsp}Hat {product-title} web console *Notifications* section, silenced alerts were visible in the notification drawer because the alerts did not include external labels. With this release, the alerts include external labels so that silenced alerts are not visible on the notification drawer. (link:https://issues.redhat.com/browse/OCPBUGS-49849[*OCPBUGS-49849*])
+
+[id="ocp-4-15-47-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.15.46
 [id="ocp-4-15-46_{context}"]
 === RHSA-2025:1711 - {product-title} 4.15.46 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-13598](https://issues.redhat.com//browse/OSDOCS-13598)

Link to docs preview:
[4.15.47](https://90128--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-47_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream relnotes

Additional information:
The errata URLs will return 404 until the go-live date of 03/12/25.


