### PR TITLE
[OCPBUGS-52991] : Correcting the typo for the path in section "3.2.6. Updating mirror registry for Red Hat OpenShift from a remote host"

### DIFF
--- a/modules/mirror-registry-remote-host-update.adoc
+++ b/modules/mirror-registry-remote-host-update.adoc
@@ -16,7 +16,7 @@ When upgrading from version 1 to version 2, be aware of the following constraint
 ** You must not use the _mirror registry for Red{nbsp}Hat OpenShift_ user interface (UP).
 ** Do not access the `sqlite-storage` Podman volume during the upgrade.
 ** There is intermittent downtime of your mirror registry because it is restarted during the upgrade process.
-** PostgreSQL data is backed up under the `/$HOME/quay-instal/quay-postgres-backup/` directory for recovery.
+** PostgreSQL data is backed up under the `/$HOME/quay-install/quay-postgres-backup/` directory for recovery.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Correcting the typo for the path, 
/$HOME/quay-instal/quay-postgres-backup/

It should be
/$HOME/quay-install/quay-postgres-backup/

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+ 

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[OCPBUGS-52991](https://issues.redhat.com/browse/OCPBUGS-52991)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://90129--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-creating-registry.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
