### PR TITLE
OSDOCS-13634: Updated 4.18 RN table for br-ex

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2563,9 +2563,9 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-|Customized `br-ex` bridge needed by OVN-Kuberenetes to use NMState
-|Technology Preview
-|Technology Preview
+|Customized `br-ex` bridge needed by OVN-Kubernetes to use NMState
+|General Availability
+|General Availability
 |General Availability
 
 | Live migration to OVN-Kubernetes from OpenShift SDN


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13634](https://issues.redhat.com/browse/OSDOCS-13634)

Link to docs preview:
* [Release notes](https://90132--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-technology-preview-tables_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.

