### PR TITLE
OSDOCS-13634-17: Removed TP notice for customized br-ex bridge

### DIFF
--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -21,16 +21,10 @@ endif::[]
 
 ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `MachineConfig` object that includes an NMState configuration file. The NMState configuration file creates a customized `br-ex` bridge network configuration on each node in your cluster.
-
-:FeatureName: Creating a `MachineConfig` object that includes a customized `br-ex` bridge
-include::snippets/technology-preview.adoc[]
 endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 
 ifdef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `NodeNetworkConfigurationPolicy` custom resource (CR) that includes an NMState configuration file. The NMState configuration file creates a customized `br-ex` bridge network configuration on each node in your cluster.
-
-:FeatureName: Creating a `NodeNetworkConfigurationPolicy` CR that includes a customized `br-ex` bridge
-include::snippets/technology-preview.adoc[]
 
 This feature supports the following tasks:
 
@@ -46,7 +40,6 @@ Consider the following use cases for creating a manifest object that includes a 
 * You want to make advanced configurations to the bridge that are not possible with the `configure-ovs.sh` shell script. Using the script for these configurations might result in the bridge failing to connect multiple network interfaces and facilitating data forwarding between the interfaces.
 
 ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
-
 [NOTE]
 ====
 If you require an environment with a single network interface controller (NIC) and default network settings, use the `configure-ovs.sh` shell script.

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2235,15 +2235,15 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |General Availability
 
-|Configure the `br-ex` bridge needed by OVN-Kuberenetes using NMState
+|Configure the `br-ex` bridge needed for OVN-Kubernetes to use NMState
 |Not Available
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
 
-| Overlapping IP configuration for multi-tenant networks with Whereabouts
-| Not Available
-| General Availability
-| General Availability
+|Overlapping IP configuration for multi-tenant networks with Whereabouts
+|Not Available
+|General Availability
+|General Availability
 
 |User defined network segmentation
 |Not Available


### PR DESCRIPTION
CM sent: [link](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-6906048495467550628)

Version(s):
4.17

Issue:
[OSDOCS-13634](https://issues.redhat.com/browse/OSDOCS-13634)

Link to docs preview:
* [customized br-ex bridge](https://90133--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal)
* [Release notes](https://90133--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-technology-preview-tables_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.
