### PR TITLE
OSDOCS-13634-16: Removed TP notice for customized br-ex bridge

### DIFF
--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -22,16 +22,10 @@ endif::[]
 
 ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `MachineConfig` object that includes an NMState configuration file. The NMState configuration file creates a customized `br-ex` bridge network configuration on each node in your cluster.
-
-:FeatureName: Creating a `MachineConfig` object that includes a customized `br-ex` bridge
-include::snippets/technology-preview.adoc[]
 endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 
 ifdef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `NodeNetworkConfigurationPolicy` custom resource (CR) that includes an NMState configuration file. The NMState configuration file creates a customized `br-ex` bridge network configuration on each node in your cluster.
-
-:FeatureName: Creating a `NodeNetworkConfigurationPolicy` CR that includes a customized `br-ex` bridge
-include::snippets/technology-preview.adoc[]
 
 This feature supports the following tasks:
 

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -2690,10 +2690,10 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
-|Configure the `br-ex` bridge needed by OVN-Kuberenetes using NMState
+|Configure the `br-ex` bridge needed by OVN-Kubernetes to use NMState
 |Not Available
 |Not Available
-|Technology Preview
+|General Availability
 
 |Creating a route with externally managed certificate
 |Not Available


### PR DESCRIPTION
CM sent: [link](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-6906048495467550628)

Version(s):
4.16

Issue:
[OSDOCS-13634](https://issues.redhat.com/browse/OSDOCS-13634)

Link to docs preview:
* [customized br-ex bridge](https://90134--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal)
* [Release notes](https://90134--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes#ocp-4-16-technology-preview-tables_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.
