### PR TITLE
OBSDOCS-1729: Create RNs for OpenShift Logging 6.2 4.17

### DIFF
--- a/modules/log6x-6-2-0-rn.adoc
+++ b/modules/log6x-6-2-0-rn.adoc
@@ -6,29 +6,23 @@
 [id="logging-release-notes-6-2-0_{context}"]
 = Logging 6.2.0 Release Notes
 
-////
-TOFIX
-This release includes link:https://access.redhat.com/errata/RHBA-2024:9038[{logging-uc} {for} Bug Fix Release 6.2.0].
-////
+This release includes link:https://access.redhat.com/errata/RHBA-2025:2398[{logging-uc} {for} Bug Fix Release 6.2.0].
 
 [id="openshift-logging-release-notes-6-2-0-enhancements_{context}"]
 == New Features and Enhancements
 
-////
-TOFIX:
+
 === Log Collection
 
-* This enhancement adds the source `iostream` to the attributes sent from collected container logs. The value is set to either `stdout` or `stderr` based on how the collector received it. (link:https://issues.redhat.com/browse/LOG-5292[LOG-5292])
-
-* With this update, the default memory limit for the collector increases from 1024 Mi to 2048 Mi. Users should adjust resource limits based on their cluster’s specific needs and specifications. (link:https://issues.redhat.com/browse/LOG-6072[LOG-6072])
-
-* With this update, users can now set the syslog output delivery mode of the `ClusterLogForwarder` CR to either `AtLeastOnce` or `AtMostOnce.` (link:https://issues.redhat.com/browse/LOG-6355[LOG-6355])
+* With this update, HTTP outputs include a `proxy` field that you can use to send log data through an HTTP proxy. (link:https://issues.redhat.com/browse/LOG-6069[LOG-6069])
 
 === Log Storage
 
-* With this update, the new `1x.pico` LokiStack size supports clusters with fewer workloads and lower log volumes (up to 50GB/day). (link:https://issues.redhat.com/browse/LOG-5939[LOG-5939])
+* With this update, time-based stream sharding in Loki is now enabled by the {loki-op}. This solves the issue of ingesting log entries older than the sliding time-window used by Loki. (link:https://issues.redhat.com/browse/LOG-6757[LOG-6757])
 
-////
+* With this update, you can configure a custom certificate authority (CA) certificate with {loki-op} when using Swift as an object store. (link:https://issues.redhat.com/browse/LOG-4818[LOG-4818])
+
+* With this update, you can configure workload identity federation on {gcp-first} by using the Cluster Credential Operator in OpenShift 4.17 and later releases with the {loki-op}. (link:https://issues.redhat.com/browse/LOG-6158[LOG-6158])
 
 [id="logging-release-notes-6-2-0-technology-preview-features_{context}"]
 == Technology Preview
@@ -36,22 +30,36 @@ TOFIX:
 :FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
 include::snippets/technology-preview.adoc[]
 
-////
-* With this update, a `dataModel` field has been added to the `lokiStack` output specification. Set the `dataModel` to `Otel` to configure log forwarding using the OpenTelemetry data format. The default is set to `Viaq`. For information about data mapping see link:https://opentelemetry.io/docs/specs/otlp/[OTLP Specification].
+* With this update, OpenTelemetry support offered by OpenShift {logging-uc} continues to improve, specifically in the area of enabling migrations from the ViaQ data model to `OpenTelemetry` when forwarding to `LokiStack`. (link:https://issues.redhat.com/browse/LOG-6146[LOG-6146])
 
-////
+* With this update, the `structuredMetadata` field has been removed from {loki-op} in the `otlp` configuration because structured metadata is now the default type. Additionally, the update introduces a `drop` field that administrators can use to drop `OpenTelemetry` attributes when receiving data through `OpenTelemetry` protocol (OTLP). (link:https://issues.redhat.com/browse/LOG-6507[LOG-6507])
 
 [id="logging-release-notes-6-2-0-bug-fixes_{context}"]
 == Bug Fixes
-////
-TOFIX:
-None.
-////
+
+* Before this update, the timestamp shown in the console logs did not match the `@timestamp` field in the message. With this update the timestamp is correctly shown in the console. (link:https://issues.redhat.com/browse/LOG-6222[LOG-6222])
+
+* The introduction of `ClusterLogForwarder` 6.x modified the `ClusterLogForwarder` API to allow for a consistent templating mechanism. However, this was not applied to the `syslog` output spec API for the `facility` and `severity` fields. This update adds the required validation to the `ClusterLogForwarder` API for the `facility` and `severity` fields. (https://issues.redhat.com/browse/LOG-6661[LOG-6661])
+
+* Before this update, an error in the {loki-op} generating the Loki configuration caused the amount of workers to delete to be zero when `1x.pico` was set as the `LokiStack` size. With this update, the number of workers to delete is set to 10. (https://issues.redhat.com/browse/LOG-6781[LOG-6781])
+
+[id="logging-release-notes-6-2-0-known-issues_{context}"]
+== Known Issues
+
+* The previous data model encoded all information in JSON. The console still uses the query of the previous data model to decode both old and new entries. The logs that are stored by using the new `OpenTelemetry` data model for the `LokiStack` output display the following error in the logging console:
++
+----
+__error__ JSONParserErr 
+__error_details__ Value looks like object, but can't find closing '}' symbol
+----
++
+You can ignore the error as it is only a result of the query and not a data-related error. (https://issues.redhat.com/browse/LOG-6808[LOG-6808])
+
+* Currently, the API documentation incorrectly mentions `OpenTelemetry` protocol (OTLP) attributes as `included` instead of `excluded` in the descriptions of the `drop` field. (https://issues.redhat.com/browse/LOG-6839[LOG-6839]).
+
 
 [id="logging-release-notes-6-2-0-CVEs_{context}"]
 == CVEs
-////
-TOFIX:
-* link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
-* link:https://access.redhat.com/security/cve/CVE-2024-6232[CVE-2024-6232]
-////
+
+* link:https://access.redhat.com/security/cve/CVE-2020-11023[CVE-2020-11023]
+* link:https://access.redhat.com/security/cve/CVE-2024-12797[CVE-2024-12797]


### PR DESCRIPTION
Version(s): to be merged only in logging-docs-6.2-4.17

Additional information:
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/89417