### PR TITLE
OCPBUGS52831: The steps to disable the chrony time service will cause chronyd.service to be Failed status.

### DIFF
--- a/modules/cnf-disable-chronyd.adoc
+++ b/modules/cnf-disable-chronyd.adoc
@@ -53,6 +53,14 @@ spec:
             WantedBy=multi-user.target
           enabled: false
           name: "chronyd.service"
+        - name: "kubelet-dependencies.target"
+          contents: |
+            [Unit]
+            Description=Dependencies necessary to run kubelet
+            Documentation=https://github.com/openshift/machine-config-operator/
+            Requires=basic.target network-online.target
+            Wants=NetworkManager-wait-online.service crio-wipe.service
+            Wants=rpc-statd.service
 ----
 <1> Node role where you want to disable `chronyd`, for example, `master`.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-52831

Preview:
[Disabling the chrony time service](https://90141--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure.html) -- Added the _name: "kubelet-dependencies.target"_. Because of flawed preview, please search on that string.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
