### PR TITLE
OCPBUGS-53001: Fixing partition size notation

### DIFF
--- a/modules/ibi-installer-installation-config.adoc
+++ b/modules/ibi-installer-installation-config.adoc
@@ -33,7 +33,7 @@ If the seed image requires a separate private registry authentication, add the a
 |====
 |Specification|Type|Description
 |`shutdown`|`boolean`|Specifies if the host shuts down after the installation process completes. The default value is `false`.
-|`extraPartitionStart`|`string`|Specifies the start of the extra partition used for `/var/lib/containers`. The default value is `-40Gb`, which means that the partition will be exactly 40Gb in size and uses the space 40Gb from the end of the disk. If you specify a positive value, the partition will start at that position of the disk and extend to the end of the disk.
+|`extraPartitionStart`|`string`|Specifies the start of the extra partition used for `/var/lib/containers`. The default value is `-40G`, which means that the partition will be exactly 40GiB in size and uses the space 40GiB from the end of the disk. If you specify a positive value, the partition will start at that position of the disk and extend to the end of the disk.
 |`extraPartitionLabel`|`string`|The label of the extra partition you use for `/var/lib/containers`. The default partition label is `var-lib-containers`.
 
 [NOTE]


### PR DESCRIPTION
OCPBUGS-53001: Fixing partition size notation... it should be the wonderfully named "gibibyte" with the notation GiB in regular text. 

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-53001

Link to docs preview:


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
