### PR TITLE
OSDOCS-13299: adds RHEL 9.6 to MicroShift relnotes

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -16,8 +16,7 @@ Version {product-version} of {microshift-short} includes new features and enhanc
 
 You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
 
-//TODO confirm RHEL version compatibility
-//{microshift-short} {product-version} is supported on {op-system-base-full} 9.6.
+{microshift-short} {product-version} is supported on {op-system-base-full} 9.6.
 
 For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
 
@@ -27,7 +26,7 @@ For lifecycle information, see the link:https://access.redhat.com/product-life-c
 This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s
-//[id="microshift-4-18-rhel_{context}"]
+//[id="microshift-4-19-rhel_{context}"]
 //=== {op-system-base-full}
 //Image mode for RHEL here if GA; otherwise leave in TP
 
@@ -84,11 +83,11 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //=== {op-system-base-full} image mode Technology Preview feature
 //* You can install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
 
-See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
+//See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
 
-[id="microshift-4-19-deprecated-and-removed-features_{context}"]
-== Deprecated and removed features
-With this release, the CSI snapshot webhook feature available in previous releases is removed. The webhook is replaced by CEL validation rules for snapshot objects.
+//[id="microshift-4-19-deprecated-and-removed-features_{context}"]
+//== Deprecated and removed features
+//add deprecated and removed user-facing or deployment-impacting features here
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
 [id="microshift-4-19-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13299](https://issues.redhat.com/browse/OSDOCS-13299)

Link to docs preview:
[About this release](https://90145--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html)
NOTE: decommissioning of docs.openshift.com has broken preview formatting

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
