### PR TITLE
OSSM-9037 Show oc label command in Performing RevisionBased update procedure

### DIFF
--- a/modules/ossm-performing-revisionbased-update.adoc
+++ b/modules/ossm-performing-revisionbased-update.adoc
@@ -34,7 +34,12 @@ The {SMProductShortName} Operator deploys a new version of the control plane alo
 $ oc get istiorevisions
 ----
 
-. Move the workloads to the new control plane by updating the `istio.io/rev` label on the application namespace or the pods to the revision name of the new control plane.
+. Move the workloads to the new control plane by updating the `istio.io/rev` label on the application namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace <namespace_name> istio.io/rev=<new_revision_name> --overwrite
+----
 
 . Restart the application workloads so that the new version of the sidecar gets injected.
 +


### PR DESCRIPTION
**OSSM 3.0**

[OSSM-9037](https://issues.redhat.com//browse/OSSM-9037) Show oc label command in Performing RevisionBased update procedure

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
OSSM 3.0

Issue:
https://issues.redhat.com/browse/OSSM-9037

Link to docs preview:
https://90146--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/update/ossm-updating-openshift-service-mesh.html#performing-revisionbased-update_ossm-attach-workloads-to-control-plane-revisionbased

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
