### PR TITLE
OSSM-8594 Consistent external link referencing in Additional resources

### DIFF
--- a/install/ossm-sidecar-injection-assembly.adoc
+++ b/install/ossm-sidecar-injection-assembly.adoc
@@ -16,7 +16,7 @@ include::modules/ossm-enabling-sidecar-injection.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources-sidecar-injection"]
 == Additional resources
-* link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[About admission controllers]
-* link:https://istio.io/latest/docs/ops/common-problems/injection/[Istio sidecar injection problems]
+* link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[About admission controllers] (Kubernetes documentation)
+* link:https://istio.io/latest/docs/ops/common-problems/injection/[Istio sidecar injection problems] (Istio documentation)
 * xref:../install/ossm-installing-openshift-service-mesh.adoc#deploying-book-info_ossm-about-bookinfo-application[Bookinfo application]
 * xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-creating-istiocni-resource[Scoping service mesh with discovery selectors]

--- a/migrating/done/ossm-migrating-complete-assembly.adoc
+++ b/migrating/done/ossm-migrating-complete-assembly.adoc
@@ -32,4 +32,4 @@ include::modules/ossm-migrating-complete-remove-maistra-labels.adoc[leveloffset=
 [id="addition-resource-complete_{context}"]
 == Additional Resources
 
-* link:https://kiali.io/docs/features/istio-component-status/#control-plane-namespace[Istio infrastructure status (Kiali.io)]
+* link:https://kiali.io/docs/features/istio-component-status/#control-plane-namespace[Istio infrastructure status] (Kiali.io documentation)

--- a/modules/ossm-about-configuring-a-gateway-to-accept-ingress-traffic.adoc
+++ b/modules/ossm-about-configuring-a-gateway-to-accept-ingress-traffic.adoc
@@ -61,6 +61,7 @@ spec:
 ----
 
 [role="_additional-resources"]
+[id="ossm-about-configuring-gateways-additional-resources_{context}"]
 .Additional resources
 
 * xref:../gateways/ossm-about-gateways.adoc#ossm-about-gateway-injection_ossm-about-gateways[About gateway injection]

--- a/modules/ossm-about-discoveryselectors.adoc
+++ b/modules/ossm-about-discoveryselectors.adoc
@@ -25,6 +25,7 @@ Discovery selectors are not a security boundary. Istiod continues to have access
 ====
 
 [role="_additional-resources"]
+[id="ossm-about-discoveryselectors-additional-resources_{context}"]
 .Additional resources
-* link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors[Label selectors]
-* link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements[Resources that support set-based requirements]
+* link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors[Label selectors] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements[Resources that support set-based requirements] (Kubernetes documentation)

--- a/modules/ossm-customizing-istio-configuration.adoc
+++ b/modules/ossm-customizing-istio-configuration.adoc
@@ -24,5 +24,6 @@ For a list of available configuration for the `values` field, refer to link:http
 * link:https://artifacthub.io/packages/helm/istio-official/ztunnel?modal=values[ZTunnel parameters]
 
 [role="_additional-resources"]
+[id="ossm-customizing-istio-additional-resources_{context}"]
 .Additional resources
 * link:https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md[Service Mesh 3.0 Operator community documentation]

--- a/modules/ossm-exposing-a-gateway-to-traffic-outside-the-cluster-using-openshift-routes.adoc
+++ b/modules/ossm-exposing-a-gateway-to-traffic-outside-the-cluster-using-openshift-routes.adoc
@@ -74,6 +74,7 @@ $ curl -s -I -H Host:httpbin.example.com http://$INGRESS_HOST/headers
 . Verify that the response has the `HTTP/1.1 200 OK` status, which indicates that the request was successful.
 
 [role="_additional-resources"]
+[id="ossm-exposing-gateway-outside-cluster-additional-resources_{context}"]
 .Additional resources
 
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/networking/configuring-routes#nw-creating-a-route_route-configuration[Creating an HTTP-based Route]

--- a/modules/ossm-exposing-service-using-istio-gateway-and-virtualservice.adoc
+++ b/modules/ossm-exposing-service-using-istio-gateway-and-virtualservice.adoc
@@ -225,9 +225,9 @@ $ curl -s -I -H Host:httpbin.example.com http://$INGRESS_HOST/headers
 
 . Verify that the response has the `HTTP/1.1 200 OK` status, which indicates that the request was successful.
 
-.Additional resources
 [role="_additional-resources"]
+[id="ossm-exposing-service-additional-resources_{context}"]
+.Additional resources
 
-https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway[Istio Gateway resource API reference]
-
-https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService[VirtualService API reference]
+* https://istio.io/latest/docs/reference/config/networking/gateway/#Gateway[Istio Gateway resource API reference] (Istio documentation)
+* https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService[VirtualService API reference] (Istio documentation)

--- a/observability/kiali/ossm-kiali-assembly.adoc
+++ b/observability/kiali/ossm-kiali-assembly.adoc
@@ -19,6 +19,7 @@ include::modules/ossm-integrating-kiali-otel.adoc[leveloffset=+1]
 include::modules/ossm-config-otel-kiali.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+[id="ossm-kiali-additional-resource_{context}"]
 .Additional resources
 
 * xref:../metrics/ossm-metrics-assembly.adoc#ossm-config-openshift-monitoring-only_ossm-metrics-assembly[Configuring OpenShift Monitoring with Service Mesh]


### PR DESCRIPTION
**OSSM 3.0**

[OSSM-8594](https://issues.redhat.com//browse/OSSM-8594) Consistent external link referencing in Additional resources

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
OSSM 3.0

Issue:
https://issues.redhat.com/browse/OSSM-8594

Link to docs preview:

* https://90149--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-sidecar-injection-assembly.html#additional-resources-sidecar-injection

* https://90149--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/gateways/ossm-getting-traffic-into-a-mesh.html#ossm-exposing-service-using-istio-gateway-and-virtualservice_ossm-about-configuring-a-gateway-to-accept-ingress-traffic

* https://90149--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#ossm-about-discoveryselectors_ossm-scoping-service-mesh-with-discoveryselectors

* https://90149--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/done/ossm-migrating-complete-assembly.html#addition-resource-complete_ossm-migrating-complete-assembly

* https://90149--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/kiali/ossm-kiali-assembly.html#ossm-config-otel-kiali_ossm-kiali-assembly

* https://90149--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh#ossm-customizing-istio_ossm-accessing-bookinfo-application-using-gateway-API

QE review:
QE review is not required for this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
