### PR TITLE
TELCODOCS-2227 Improve documentation adding how NumeResourceOperator can be applied to more than 1 pool

### DIFF
--- a/modules/cnf-creating-nrop-cr.adoc
+++ b/modules/cnf-creating-nrop-cr.adoc
@@ -42,6 +42,29 @@ spec:
 $ oc create -f nrop.yaml
 ----
 
+. Optional: To enable NUMA-aware scheduling for multiple machine config pools (MCPs), define a separate `NodeGroup` for each pool. For example, define three `NodeGroups` for `worker-cnf`, `worker-ht`, and `worker-other`, in the `NUMAResourcesOperator` CR as shown in the following example:
++
+.Example YAML definition for a `NUMAResourcesOperator` CR with multiple `NodeGroups`
+[source,yaml]
+----
+apiVersion: nodetopology.openshift.io/v1
+kind: NUMAResourcesOperator
+metadata:
+  name: numaresourcesoperator
+spec:
+  logLevel: Normal
+  nodeGroups:
+    - machineConfigPoolSelector:
+        matchLabels:
+          machineconfiguration.openshift.io/role: worker-ht
+    - machineConfigPoolSelector:
+        matchLabels:
+          machineconfiguration.openshift.io/role: worker-cnf
+    - machineConfigPoolSelector:
+        matchLabels:
+          machineconfiguration.openshift.io/role: worker-other
+----
+
 .Verification
 
 . Verify that the NUMA Resources Operator deployed successfully by running the following command:


### PR DESCRIPTION
[TELCODOCS-2227]: Improve documentation adding how NumeResourceOperator can be applied to more than 1 pool

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19, 4.18, 4.17, 4.16, 4.15, 4.14, 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2227
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://90150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-creating-nrop-cr_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
