### PR TITLE
OSSM-9052 cluster-wide fixes

### DIFF
--- a/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
+++ b/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
@@ -74,8 +74,7 @@ include::modules/ossm-migrating-workloads-using-the-istio-injection-label.adoc[l
 
 If you are using gateways, you must migrate them before you complete the migration process.
 
-* Migrating gateways from Service Mesh 2 to Service Mesh 3
-//* xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc#ossm-migrating-gateways[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+* xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc#ossm-migrating-gateways[Migrating gateways]
 
 If you are not using gateways, and have verified your cluster-wide migration, create a default revision tag and relabel namespaces.
 
@@ -104,8 +103,7 @@ include::modules/ossm-migrating-workloads-using-the-istio-injection-label-with-c
 
 If you are using gateways, you must migrate them before you complete the migration process.
 
-* Migrating gateways from Service Mesh 2 to Service Mesh 3
-//* xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc#ossm-migrating-gateways[Migrating gateways from Service Mesh 2 to Service Mesh 3]
+* xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc#ossm-migrating-gateways[Migrating gateways]
 
 If you are not using gateways, and have verified your cluster-wide migration, create a default revision tag and relabel namespaces.
 
@@ -127,10 +125,11 @@ If you are using gateways, you must migrate them before you complete the migrati
 
 * xref:../../migrating/migrating-gateways/ossm-migrating-gateways.adoc[Migrating gateways]
 
-If you are using gateways, you can complete your migration.
+If you are not using gateways, you can complete your migration.
 
 * xref:../../migrating/done/ossm-migrating-complete.adoc[Completing the Migration]
 
+[role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
 


### PR DESCRIPTION
**OSSM 3.0**

[OSSM-9052](https://issues.redhat.com//browse/OSSM-9052) cluster-wide fixes

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
3.0

Issue:
https://issues.redhat.com/browse/OSSM-9052

Link to docs preview:

* https://90156--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/cluster-wide/ossm-migrating-cluster-wide.html#next-steps-istio-injection-with-cert-manager_ossm-migrating-cluster-wide
* https://90156--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/cluster-wide/ossm-migrating-cluster-wide.html#additional-resources_ossm-migrating-cluster-wide

QE review:
QE is not required for this change.

Additional information:
Larger renaming/restructuring work is being done in https://github.com/openshift/openshift-docs/pull/89492. This PR, 90156 has changes necessary for OSSM 3.0 GA. GA was 03/11/2025.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
