### PR TITLE
OSDOCS#13590: Update the z-stream RN for 4.12.74

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5102,3 +5102,23 @@ $ oc adm release info 4.12.73 --pullspecs
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
+// 4.12.74
+[id="ocp-4-12-74_{context}"]
+=== RHSA-2025:2441 - {product-title} 4.12.74 bug fix and security update
+
+Issued: 13 March 2025
+
+{product-title} release 4.12.74 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:2441[RHSA-2025:2441] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:2443[RHSA-2025:2443] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.74 --pullspecs
+----
+
+[id="ocp-4-12-74-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-13590](https://issues.redhat.com//browse/OSDOCS-13590)

Link to docs preview:
[4.12.74](https://90175--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-74_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream relnotes.

Additional information:
The errata URLs will return 404 until the go-live date of 03/13/25.
