### PR TITLE
OSDOCS#12846: custom manifest clarification

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -40,6 +40,11 @@ include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+2]
 
 As an optional task, you can create additional manifests to further configure your cluster beyond the configurations available in the `install-config.yaml` and `agent-config.yaml` files.
 
+[IMPORTANT]
+====
+Customizations to the cluster made by additional manifests are not validated, are not guaranteed to work, and might result in a nonfunctional cluster.
+====
+
 // Creating a directory to contain additional manifests
 include::modules/installing-ocp-agent-manifest-folder.adoc[leveloffset=+3]
 

--- a/modules/installation-bare-metal-agent-installer-config-yaml.adoc
+++ b/modules/installation-bare-metal-agent-installer-config-yaml.adoc
@@ -16,9 +16,11 @@ baseDomain: example.com <1>
 compute: <2>
 - name: worker
   replicas: 0 <3>
+  architecture: amd64
 controlPlane: <2>
   name: master
   replicas: 1 <4>
+  architecture: amd64
 metadata:
   name: sno-cluster <5>
 networking:


### PR DESCRIPTION
[OSDOCS-12846](https://issues.redhat.com/browse/OSDOCS-12846) and [OCPBUGS-51146](https://issues.redhat.com/browse/OCPBUGS-51146)

Version(s): 4.15+

This PR adds to the Agent docs 1. A clarification that custom manifests aren't validated and can break your cluster and 2. architecture values in an example `install-config.yaml` file.

QE review:
- [x] QE has approved this change.

Previews:

- [Creating additional manifest files](https://90180--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-opt-manifests_installing-with-agent-based-installer)
- [Sample install-config.yaml file for bare metal](https://90180--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#installation-bare-metal-agent-installer-config-yaml_preparing-to-install-with-agent-based-installer)
