### PR TITLE
OCPBUGS-51127: Scrubbing lingering unsupported enable filter option

### DIFF
--- a/modules/network-observability-netobserv-cli-reference.adoc
+++ b/modules/network-observability-netobserv-cli-reference.adoc
@@ -95,7 +95,7 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 .Example running flows capture on TCP protocol and port 49051 with PacketDrop and RTT features enabled:
 [source,terminal]
 ----
-$ oc netobserv flows --enable_pkt_drop  --enable_rtt --enable_filter --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051
+$ oc netobserv flows --enable_pkt_drop  --enable_rtt --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051
 ----
 [id="cli-reference-packet-capture-options_{context}"]
 == Packets capture options
@@ -190,5 +190,5 @@ $ oc netobserv metrics [<option>]
 .Example running metrics capture for TCP drops
 [source,terminal]
 ----
-$ oc netobserv metrics --enable_pkt_drop --enable_filter --protocol=TCP 
+$ oc netobserv metrics --enable_pkt_drop --protocol=TCP 
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-51127
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://90181--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-reference.html
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
There was a lingering instance of this unsupported option in a couple of examples after the initial scrub. Removing those instances with this PR. 
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
