### PR TITLE
OBSDOCS-1767: Fix logging docs build in OCP 4.17

### DIFF
--- a/observability/logging/cluster-logging-support.adoc
+++ b/observability/logging/cluster-logging-support.adoc
@@ -1,0 +1,78 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cluster-logging-support"]
+include::_attributes/common-attributes.adoc[]
+= Support
+:context: cluster-logging-support
+
+toc::[]
+
+include::snippets/logging-supported-config-snip.adoc[]
+include::snippets/logging-compatibility-snip.adoc[]
+include::snippets/log6x-loki-statement-snip.adoc[]
+
+{logging-uc} {for} is an opinionated collector and normalizer of application, infrastructure, and audit logs. You can use it to forward logs to various supported systems.
+
+{logging-uc} is not:
+
+* A high scale log collection system
+* Security Information and Event Monitoring (SIEM) compliant
+* A "bring your own" (BYO) log collector configuration
+* Historical or long term log retention or storage
+* A guaranteed log sink
+* Secure storage - audit logs are not stored by default
+
+[id="cluster-logging-support-CRDs_{context}"]
+== Supported API custom resource definitions
+
+The following table describes the supported {logging-uc} APIs.
+
+.Loki API support states
+[cols="3",options="header"]
+|===
+|CustomResourceDefinition (CRD)
+|ApiVersion
+|Support state
+
+|LokiStack
+|lokistack.loki.grafana.com/v1
+|Supported from 5.5
+
+|RulerConfig
+|rulerconfig.loki.grafana/v1
+|Supported from 5.7
+
+|AlertingRule
+|alertingrule.loki.grafana/v1
+|Supported from 5.7
+
+|RecordingRule
+|recordingrule.loki.grafana/v1
+|Supported from 5.7
+
+|LogFileMetricExporter
+|LogFileMetricExporter.logging.openshift.io/v1alpha1
+|Supported from 5.8
+
+|ClusterLogForwarder
+|clusterlogforwarder.logging.openshift.io/v1
+|Supported from 4.5.
+|===
+
+include::modules/cluster-logging-maintenance-support-list.adoc[leveloffset=+1]
+include::modules/unmanaged-operators.adoc[leveloffset=+1]
+
+[id="support-exception-for-coo-logging-ui-plugin_{context}"]
+== Support exception for the Logging UI Plugin
+
+Until the General Availability (GA) of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its Logging UI Plugin on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
+
+[id="cluster-logging-support-must-gather_{context}"]
+== Collecting logging data for Red Hat Support
+
+When opening a support case, it is helpful to provide debugging information about your cluster to Red{nbsp}Hat Support.
+
+You can use the xref:../../support/gathering-cluster-data.adoc#gathering-cluster-data[must-gather tool] to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
+For prompt support, supply diagnostic information for both {product-title} and {logging}.
+
+include::modules/cluster-logging-must-gather-about.adoc[leveloffset=+2]
+include::modules/cluster-logging-must-gather-collecting.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): needs to be merged to logging-docs-6.2-4.17 where the PR is currently pointing to
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1767
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: QE review not required.

Additional information:
This PR is to fix validation errors in https://github.com/openshift/openshift-docs/pull/90136
Please note that this is not new content. This PR simply copies an existing file: https://github.com/openshift/openshift-docs/blob/4acdbc7beb85c37078c91905be646795111e9728/observability/logging/logging_release_notes/cluster-logging-support.adoc?plain=1 to another directory without making any content changes.