### PR TITLE
OSSM-8856 [DOC] Add warning to installation instructions about conflicts with existing OSSM 3 installations

### DIFF
--- a/install/ossm-installing-openshift-service-mesh.adoc
+++ b/install/ossm-installing-openshift-service-mesh.adoc
@@ -10,12 +10,17 @@ Installing {ocp-short-name} {SMProductShortName} consists of three main tasks: i
 
 [WARNING]
 ====
-Before migrating from {SMProduct} 2, make sure you are not running {SMProduct} 3 and {SMProduct} 2 in the same cluster, because it causes conflicts unless configured correctly. To migrate from {SMProduct} 2, see xref:../migrating/checklists/ossm-migrating-read-me.adoc#ossm-migrating-read-me[Migrating from {SMProduct} 2.6].
+Before installing {SMProduct} 3, make sure you are not running {SMProduct} 3 and {SMProduct} 2 in the same cluster, because it causes conflicts unless configured correctly. To migrate from {SMProduct} 2, see xref:../migrating/checklists/ossm-migrating-read-me.adoc#ossm-migrating-read-me[Migrating from {SMProduct} 2.6].
 ====
 
 include::modules/ossm-about-deploying-istio-using-service-mesh-operator.adoc[leveloffset=+1]
 include::modules/ossm-about-deployment-and-update-strategies.adoc[leveloffset=+2]
 include::modules/ossm-installing-operator.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc#ossm-deploying-multiple-service-meshes-on-single-cluster[Deploying multiple service meshes on a single cluster]
+
 include::modules/ossm-about-service-mesh-custom-resource-definitions.adoc[leveloffset=+2]
 include::modules/ossm-about-istio-deployment.adoc[leveloffset=+1]
 include::modules/ossm-creating-istio-project-using-console.adoc[leveloffset=+2]

--- a/modules/ossm-installing-operator.adoc
+++ b/modules/ossm-installing-operator.adoc
@@ -4,13 +4,17 @@
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-installing-operator_{context}"]
 = Installing the {SMProductShortName} Operator
-:context: ossm-installing-operator
+
+[WARNING]
+====
+For clusters without {SMProduct} instances, install the {SMProductShortName} Operator. {SMProduct} operates cluster-wide and needs a scope configuration to prevent conflicts between {istio} control planes. For clusters with {SMProduct} 3 or later, see "Deploying multiple service meshes on a single cluster".
+====
 
 .Prerequisites
 
-You have deployed a cluster on {ocp-product-title} 4.14 or later.
+* You have deployed a cluster on {ocp-product-title} 4.14 or later.
 
-You are logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
+* You are logged in to the {ocp-product-title} web console as a user with the cluster-admin role.
 
 .Procedure
 


### PR DESCRIPTION
Change type: Doc update; Add warning to installation instructions about conflicts with existing OSSM 3 installations

Doc JIRA: https://issues.redhat.com/browse/OSSM-8856

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://90200--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html

SME Review/QE Review: @FilipB @unsortedhashsets 
Peer Review: @xenolinux 