### PR TITLE
OBSDOCS-1646: Document enabling Full In-Cluster OpenTelemetry Support…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3020,6 +3020,8 @@ Topics:
       File: log6x-clf-6.2
     - Name: Configuring LokiStack storage
       File: log6x-loki-6.2
+    - Name: Configuring LokiStack for OTLP
+      File: log6x-configuring-lokistack-otlp-6.2
     - Name: Visualization for logging
       File: log6x-visual-6.2
   - Name: Logging 6.1


### PR DESCRIPTION
Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1646
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://90203--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-configuring-lokistack-otlp-6.2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Additional information:
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/88721

Note that because the original branch from which this was cherry-picked was a release branch and the branch to which the content is being cherry-picked is a live branch. Therefore the number of files changed don't correspond. 