### PR TITLE
OSDOCS-8326: Removed value cannot be changed DAY 2 from SDN table

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -16,7 +16,6 @@
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * networking/cluster-network-operator.adoc
 // * networking/network_security/logging-network-security.adoc
-// * post_installation_configuration/network-configuration.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -25,13 +24,6 @@
 // Installation assemblies need different details than the CNO operator does
 ifeval::["{context}" == "cluster-network-operator"]
 :operator:
-endif::[]
-
-ifeval::["{context}" == "post-install-network-configuration"]
-:post-install-network-configuration:
-endif::[]
-ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
-:ibm-cloud:
 endif::[]
 
 :_mod-docs-content-type: CONCEPT
@@ -48,13 +40,13 @@ The CNO configuration inherits the following fields during cluster installation 
 `defaultNetwork.type`:: Cluster network plugin. `OVNKubernetes` is the only supported plugin during installation.
 
 // For the post installation assembly, no further content is provided.
-ifdef::post-install-network-configuration,operator[]
+ifdef::operator[]
 [NOTE]
 ====
 After cluster installation, you can only modify the `clusterNetwork` IP address range. The default network type can only be changed from OpenShift SDN to OVN-Kubernetes through migration.
 ====
 endif::[]
-ifndef::post-install-network-configuration[]
+
 You can specify the cluster network plugin configuration for your cluster by setting the fields for the `defaultNetwork` object in the CNO object named `cluster`.
 
 [id="nw-operator-cr-cno-object_{context}"]
@@ -146,7 +138,6 @@ The values for the `defaultNetwork` object are defined in the following table:
 
 |====
 
-ifdef::operator,post-installation-network-configuration[]
 [discrete]
 [id="nw-operator-configuration-parameters-for-openshift-sdn_{context}"]
 ==== Configuration for the OpenShift SDN network plugin
@@ -178,9 +169,9 @@ The maximum transmission unit (MTU) for the VXLAN overlay network. This is detec
 
 If the auto-detected value is not what you expect it to be, confirm that the MTU on the primary network interface on your nodes is correct. You cannot use this option to change the MTU value of the primary network interface on the nodes.
 
-If your cluster requires different MTU values for different nodes, you must set this value to `50` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1450`.
+If your cluster requires different MTU values for different nodes, you must set this value to `50` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1450`. 
 
-This value cannot be changed after cluster installation.
+You can set the value during cluster installation or as a post-installation task. For more information, see "Changing the MTU for the cluster network" in the {product-title} Networking document. 
 endif::operator[]
 ifdef::operator[]
 The maximum transmission unit (MTU) for the VXLAN overlay network. This value is normally configured automatically.
@@ -202,6 +193,7 @@ endif::operator[]
 
 |====
 
+ifdef::operator[]
 .Example OpenShift SDN configuration
 [source,yaml]
 ----
@@ -212,7 +204,7 @@ defaultNetwork:
     mtu: 1450
     vxlanPort: 4789
 ----
-endif::[]
+endif::operator[]
 
 [discrete]
 [id="nw-operator-configuration-parameters-for-ovn-sdn_{context}"]
@@ -360,6 +352,7 @@ One of the following additional audit log targets:
 // end::policy-audit[]
 
 [id="gatewayConfig-object_{context}"]
+
 .`gatewayConfig` object
 [cols=".^2,.^2,.^6a",options="header"]
 |====
@@ -514,15 +507,8 @@ spec:
       clusterNetworkMTU: 8900
 ----
 endif::operator[]
-endif::post-install-network-configuration[]
 
 ifeval::["{context}" == "cluster-network-operator"]
 :!operator:
 endif::[]
 
-ifeval::["{context}" == "post-install-network-configuration"]
-:!post-install-network-configuration:
-endif::[]
-ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
-:!ibm-cloud:
-endif::[]


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[OSDOCS-8326](https://issues.redhat.com/browse/OSDOCS-8326)

Link to docs preview:
* [Configuration for the OpenShift SDN network plugin in vSphere doc: **core change** for post-installation reference](https://90204--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.html#nw-operator-cr_installing-vsphere-installer-provisioned-network-customizations)
* [Cluster Network Operator - ifeval for Operator](https://90204--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/cluster-network-operator.html#nw-operator-cr_cluster-network-operator)
* [Installing a cluster on IBM Cloud with network customizations - ifeval for ibm-cloud](https://90204--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.html#nw-operator-cr_installing-ibm-cloud-network-customizations)
* [Installing a cluster on AWS with network customizations - no dedicated ifdefs](https://90204--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-network-customizations.html#nw-operator-cr_installing-aws-network-customizations)

- [x] SME has approved this change (Jaime Caamano).
- [x] QE has approved this change (Zhanqi Zhao).

Additional resources:

* [Published doc for Installing a cluster on AWS with network customizations](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html-single/installing_on_aws/index#nw-operator-cr-cno-object_installing-aws-network-customizations)
* [Published doc for Cluster Network Operator](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/networking/networking-operators#nw-cno-logs_cluster-network-operator)
* [Published doc for Installing a cluster on IBM Cloud with network customizations](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html-single/installing_on_ibm_cloud/index#modifying-nwoperator-config-startup_installing-ibm-cloud-network-customizations)

