### PR TITLE
OCPBUGS-48847-move: Moved infinband file to nmstate doc

### DIFF
--- a/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
@@ -17,9 +17,6 @@ include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leve
 // Creating a manifest object that includes a customized `br-ex` bridge
 include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
 
-// Creating an InfiniBand interface on nodes
-include::modules/virt-creating-infiniband-interface-on-nodes.adoc[leveloffset=+1]
-
 // Services for a user-managed load balancer
 include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
 

--- a/modules/virt-creating-infiniband-interface-on-nodes.adoc
+++ b/modules/virt-creating-infiniband-interface-on-nodes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
+// * networking/k8s_nmstate/k8s-observing-node-network-state.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-creating-infiniband-interface-on-nodes_{context}"]

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -32,6 +32,9 @@ include::modules/node-network-configuration-policy-file.adoc[leveloffset=+1]
 
 * xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-removing-interface-from-nodes_{context}[Removing an interface from nodes]
 
+// Creating an InfiniBand interface on nodes
+include::modules/virt-creating-infiniband-interface-on-nodes.adoc[leveloffset=+1]
+
 // Managing policy from the web console
 include::modules/virt-node-network-config-console.adoc[leveloffset=+1]
 
@@ -41,13 +44,13 @@ include::modules/virt-monitor-node-network-config-console.adoc[leveloffset=+2]
 // Creating a policy
 include::modules/virt-create-node-network-config-console.adoc[leveloffset=+2]
 
-=== Updating the policy
+== Updating the policy
 
 // Updating the policy by using form
-include::modules/virt-update-node-network-config-form.adoc[leveloffset=+3]
+include::modules/virt-update-node-network-config-form.adoc[leveloffset=+2]
 
 // Updating the policy by using YAML
-include::modules/virt-update-node-network-config-yaml.adoc[leveloffset=+3]
+include::modules/virt-update-node-network-config-yaml.adoc[leveloffset=+2]
 
 // Deleting the policy
 include::modules/virt-delete-node-network-config.adoc[leveloffset=+2]


### PR DESCRIPTION
Moved the Creating an IP over InfiniBand interface on nodes file from Postinstallation configuration to Kubernetes NMState guide.

Version(s):
4.15+

Issue:
[OCPBUGS-48847](https://issues.redhat.com/browse/OCPBUGS-48847)

Link to docs preview:
* [Creating an IP over InfiniBand interface on nodes](https://90225--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-creating-infiniband-interface-on-nodes_k8s-nmstate-updating-node-network-config)

- [x] SME has approved this change.
- [x] QE has approved this change.