### PR TITLE
OSDOCS-13300: adds RHEL updates to MicroShift

### DIFF
--- a/microshift_updating/microshift-update-options.adoc
+++ b/microshift_updating/microshift-update-options.adoc
@@ -48,9 +48,9 @@ To begin a {microshift-short} update by embedding in a {op-system-ostree} image,
 
 * xref:../microshift_updating/microshift-update-rpms-ostree.adoc#microshift-update-rpms-ostree[Applying updates on an OSTree system]
 
-To understand more about Greenboot, see the following documentation:
+To understand more about greenboot, see the following documentation:
 
-* xref:../microshift_install_get_ready/microshift-greenboot.adoc#microshift-greenboot[The Greenboot health check]
+* xref:../microshift_install_get_ready/microshift-greenboot.adoc#microshift-greenboot[The greenboot health check]
 * xref:../microshift_running_apps/microshift-greenboot-workload-scripts.adoc#microshift-greenboot-workload-scripts[Greenboot workload health check scripts]
 
 [id="microshift-update-options-manual-rpm-updates_{context}"]
@@ -72,7 +72,7 @@ You can update {op-system-ostree} or {op-system-base} without updating {microshi
 //additional resources for updating RHEL alone
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[Managing RHEL for Edge images]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
 
 [id="microshift-update-options-simultaneous-microshift-rhel-updates_{context}"]
 == Simultaneous {microshift-short} and operating system updates
@@ -87,8 +87,8 @@ You can update {op-system-ostree} or {op-system-base} and update {microshift-sho
 [role="_additional-resources"]
 .Additional resources
 * link:https://access.redhat.com/articles/rhel-eus#c5[How to Access EUS]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/index[Composing a customized RHEL system image]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/index[Composing a customized RHEL system image]
 * xref:../microshift_updating/microshift-update-rpms-ostree.adoc#microshift-update-rpms-ostree[Applying updates on an OSTree system]
 * xref:../microshift_updating/microshift-update-rpms-manually.adoc#microshift-update-rpms-manually[Applying updates manually with RPMs]
-* xref:../microshift_install_get_ready/microshift-greenboot.adoc#microshift-greenboot[The Greenboot system health check]
+* xref:../microshift_install_get_ready/microshift-greenboot.adoc#microshift-greenboot[The greenboot system health check]
 * xref:../microshift_running_apps/microshift-greenboot-workload-scripts.adoc#microshift-greenboot-workload-scripts[Greenboot workload scripts]

--- a/modules/microshift-get-rpm-release-info.adoc
+++ b/modules/microshift-get-rpm-release-info.adoc
@@ -42,8 +42,7 @@ microshift-release-info-0:4.17.9-202408220842.p0.gefa92a2.assembly.4.17.9.el9.no
 . Download the RPM package you want by running the following command:
 +
 --
-[subs="+quotes"]
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ sudo dnf download microshift-release-info-_<release_version>_ # <1>
 ----
@@ -52,8 +51,7 @@ $ sudo dnf download microshift-release-info-_<release_version>_ # <1>
 +
 --
 .Example output
-[subs="+quotes"]
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 microshift-release-info-4.17.1.-202311101230.p0.g7dc6a00.assembly.4.17.1.el9.noarch.rpm # <1>
 ----
@@ -62,8 +60,7 @@ microshift-release-info-4.17.1.-202311101230.p0.g7dc6a00.assembly.4.17.1.el9.noa
 
 . Unpack the RPM package without installing it by running the following command:
 +
-[subs="+quotes"]
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ rpm2cpio _<microshift_release_info>_ | cpio -idmv # <1>
 ----

--- a/modules/microshift-updates-rhde-config-rhel-repos.adoc
+++ b/modules/microshift-updates-rhde-config-rhel-repos.adoc
@@ -18,39 +18,40 @@ When using RPM updates, avoid creating an unsupported configuration or breaking 
 
 . Avoid unintended updates by locking your operating system version by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo subscription-manager release --set=<x.y> # <1>
+$ sudo subscription-manager release --set=_<x.y>_ # <1>
 ----
-<1> Replace _<x.y>_ with the major and minor version of your compatible {op-system-base} system. For example, _9.4_.
+<1> Replace _<x.y>_ with the major and minor version of your compatible {op-system-base} system. For example, _9.6_.
 
+//this is the same command as above; is this correct?
 . Update both {microshift-short} and {op-system-base} versions by running the following command:
 +
 [source,terminal]
 ----
-$ sudo subscription-manager release --set=<9.4> command. # <1>
+$ sudo subscription-manager release --set={ocp-version} # <1>
 ----
-<1> Replace _<9.4>_ with the major and minor version of your compatible {op-system-base} system.
+<1> You can replace _{ocp-version}_ with the major and minor version of your compatible {op-system-base} system if it is not the same version given in this example.
 
 . If you are using an EUS {microshift-short} release, disable the {op-system-base} standard-support-scope repositories by running the following command:
 +
 [source,terminal]
 ----
 $ sudo subscription-manager repos \
-    --disable=rhel-<9>-for-x86_64-appstream-rpms \ # <1>
-    --disable=rhel-<9>-for-x86_64-baseos-rpms
+    --disable=rhel-{op-system-version-major}-for-$(uname -m)-appstream-rpms \ # <1>
+    --disable=rhel-{op-system-version-major}-for-$(uname -m)-baseos-rpms
 ----
-<1> Replace _<9>_ with the major version of your compatible {op-system-base} system.
+<1> You can replace _{op-system-version-major}_ with the major version of your compatible {op-system-base} system if it is not same version given in this example.
 
 . After you disable the standard-support repositories, enable the {op-system-base} EUS repos by running the following command:
 +
 [source,terminal]
 ----
 $ sudo subscription-manager repos \
-    --enable rhel-<9>-for-x86_64-appstream-eus-rpms \  # <1>
-    --enable rhel-<9>-for-x86_64-baseos-eus-rpms`
+    --enable rhel-{op-system-version-major}-for-$(uname -m)-appstream-eus-rpms \  # <1>
+    --enable rhel-{op-system-version-major}-for-$(uname -m)-baseos-eus-rpms
 ----
-<1> Replace _<9>_ with the major version of your compatible {op-system-base} system.
+<1> You can replace _{op-system-version-major}_ with the major version of your compatible {op-system-base} system if it is not same version given in this example.
 
 .Verification
 

--- a/modules/microshift-updating-rpms-ostree.adoc
+++ b/modules/microshift-updating-rpms-ostree.adoc
@@ -54,11 +54,11 @@ $ sudo composer-cli sources add {rpm-repo-version}.toml
 
 . Build a new image of {op-system-ostree} that contains the new version of {microshift-short}. To determine the steps required, use the following documentation:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/managing-rhel-for-edge-images_composing-installing-managing-rhel-for-edge-images#proc_building-a-commit-update_managing-rhel-for-edge-images[Building a RHEL for Edge commit update]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/managing-rhel-for-edge-images_composing-installing-managing-rhel-for-edge-images#proc_building-a-commit-update_managing-rhel-for-edge-images[Building a commit update]
 
 . Update the host to use the new image of {op-system-ostree}. To determine the steps required, use the following documentation:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/managing-rhel-for-edge-images_composing-installing-managing-rhel-for-edge-images#how-are-rhel-for-edge-image-updates-deployed_managing-rhel-for-edge-images[Deploying RHEL for Edge image updates]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/managing-rhel-for-edge-images_composing-installing-managing-rhel-for-edge-images#how-are-rhel-for-edge-image-updates-deployed_managing-rhel-for-edge-images[How RHEL for Edge image updates are deployed]
 
 . Reboot the host to apply updates by running the following command:
 +

--- a/modules/microshift-updating-rpms-z.adoc
+++ b/modules/microshift-updating-rpms-z.adoc
@@ -8,7 +8,10 @@
 
 Updating {microshift-short} on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to upgrade from 4.19.1 to 4.19.2.
 
+include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
+
 .Prerequisites
+
 * The system requirements for installing {microshift-short} have been met.
 * You have root user access to the host.
 * The version of {microshift-short} you have is compatible to upgrade to the version you are preparing to use.
@@ -21,13 +24,15 @@ You cannot downgrade {microshift-short} with this process. Downgrades are not su
 ====
 
 .Procedure
-* Update the {microshift-short} RPMs by running the following command:
+
+. Update the {microshift-short} RPMs by running the following command:
 +
 [source,terminal]
 ----
 $ sudo dnf update microshift
 ----
-* Restart {microshift-short} by running the following command:
+
+. Restart {microshift-short} by running the following command:
 +
 [source,terminal]
 ----
@@ -36,5 +41,5 @@ $ sudo systemctl restart microshift
 
 [NOTE]
 ====
-The system health check runs on this update type, but does not perform any actions. If the update fails, an error message appears with the instruction to check the logs.
+The greenboot system health check runs on this update type, but does not perform any actions. If the update fails, an error message appears with the instruction to check the logs.
 ====


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13300](https://issues.redhat.com/browse/OSDOCS-13300)

Link to docs preview:
[Update options](https://90229--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options.html)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
