### PR TITLE
OSDOCS-13516-v415 switched steps 7 and 8 under Restart the Cluster

### DIFF
--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -105,6 +105,13 @@ $ oc describe csr <csr_name> <1>
 $ oc adm certificate approve <csr_name>
 ----
 
+. After the control plane and compute nodes are ready, mark all the nodes in the cluster as schedulable by running the following command:
++
+[source,terminal]
+----
+$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do echo ${node} ; oc adm uncordon ${node} ; done
+----
+
 . Verify that the cluster started properly.
 
 .. Check that there are no degraded cluster Operators.
@@ -152,10 +159,4 @@ ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.28.5
 +
 If the cluster did not start properly, you might need to restore your cluster using an etcd backup.
 
-. After the control plane and worker nodes are ready, mark all the nodes in the cluster as schedulable.
-Run the following command:
-+
-[source,terminal]
-----
-for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do echo ${node} ; oc adm uncordon ${node} ; done
-----
+


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-13516

Link to docs preview:
https://90230--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-restart.html

QE review:
- [x] QE has approved this change.



