### PR TITLE
OSDOCS#13517: Note 4-, 5-node HA clusters in etcd quorum restore docs

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -18,7 +18,7 @@
 
 You can use a saved etcd backup to restore a previous cluster state or restore a cluster that has lost the majority of control plane hosts.
 
-For high availability (HA) clusters, a three-node HA cluster requires you to shutdown etcd on two hosts to avoid a cluster split. Quorum requires a simple majority of nodes. The minimum number of nodes required for quorum on a three-node HA cluster is two. If you start a new cluster from backup on your recovery host, the other etcd members might still be able to form quorum and continue service.
+For high availability (HA) clusters, a three-node HA cluster requires you to shut down etcd on two hosts to avoid a cluster split. On four-node and five-node HA clusters, you must shut down three hosts. Quorum requires a simple majority of nodes. The minimum number of nodes required for quorum on a three-node HA cluster is two. On four-node and five-node HA clusters, the minimum number of nodes required for quorum is three. If you start a new cluster from backup on your recovery host, the other etcd members might still be able to form quorum and continue service.
 
 [NOTE]
 ====

--- a/modules/dr-restoring-etcd-quorum-ha.adoc
+++ b/modules/dr-restoring-etcd-quorum-ha.adoc
@@ -8,6 +8,8 @@
 
 You can use the `quorum-restore.sh` script to instantly bring back a new single-member etcd cluster based on its local data directory and mark all other members as invalid by retiring the previous cluster identifier. No prior backup is required to restore the control plane from.
 
+For high availability (HA) clusters, a three-node HA cluster requires you to shut down etcd on two hosts to avoid a cluster split. On four-node and five-node HA clusters, you must shut down three hosts. Quorum requires a simple majority of nodes. The minimum number of nodes required for quorum on a three-node HA cluster is two. On four-node and five-node HA clusters, the minimum number of nodes required for quorum is three. If you start a new cluster from backup on your recovery host, the other etcd members might still be able to form quorum and continue service.
+
 [WARNING]
 ====
 You might experience data loss if the host that runs the restoration does not have all data replicated to it.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-13517](https://issues.redhat.com/browse/OSDOCS-13517)

Link to docs preview:
[Restoring etcd quorum for high availability clusters](https://90231--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/quorum-restoration.html#dr-restoring-etcd-quorum-ha_dr-quorum-restoration)
[Restoring to a previous cluster state](https://90231--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state)


QE review:
- [x] QE has approved this change.

Additional information:

N/A
