### PR TITLE
[OSDOCS-13654]: Update links to ACM in HCP content

### DIFF
--- a/architecture/mce-overview-ocp.adoc
+++ b/architecture/mce-overview-ocp.adoc
@@ -22,7 +22,7 @@ When you enable multicluster engine on {product-title}, you gain the following c
 * Infrastructure Operator, which manages the deployment of the Assisted Service to orchestrate on-premise bare metal and vSphere installations of {product-title}, such as {sno} on bare metal. The Infrastructure Operator includes xref:../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-challenges-of-far-edge-deployments_ztp-deploying-far-edge-clusters-at-scale[{ztp-first}], which fully automates cluster creation on bare metal and vSphere provisioning with GitOps workflows to manage deployments and configuration changes.
 * Open cluster management, which provides resources to manage Kubernetes clusters.
 
-The multicluster engine is included with your {product-title} support subscription and is delivered separately from the core payload. To start to use multicluster engine, you deploy the {product-title} cluster and then install the operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator].
+The multicluster engine is included with your {product-title} support subscription and is delivered separately from the core payload. To start to use multicluster engine, you deploy the {product-title} cluster and then install the operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator].
 
 [id="mce-on-rhacm"]
 == Cluster management with Red Hat Advanced Cluster Management
@@ -32,4 +32,4 @@ If you need cluster management capabilities beyond what {product-title} with mul
 [id="mce-additional-resources-ocp"]
 == Additional resources
 
-For the complete documentation for multicluster engine, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview[Cluster lifecycle with multicluster engine documentation], which is part of the product documentation for Red Hat Advanced Cluster Management.
+For the complete documentation for multicluster engine, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview[Cluster lifecycle with multicluster engine documentation], which is part of the product documentation for Red Hat Advanced Cluster Management.

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
@@ -16,11 +16,11 @@ include::modules/hcp-aws-prereqs.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
 
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
 
@@ -68,7 +68,7 @@ include::modules/hcp-create-np-arm64-aws.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#configure-hosted-disconnected-digest-image[Extracting the {product-title} release image digest]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#configure-hosted-disconnected-digest-image[Extracting the {product-title} release image digest]
 
 include::modules/hcp-create-private-hc-aws.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
@@ -26,8 +26,8 @@ include::modules/hcp-bm-prereqs.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
 
 include::modules/hcp-bm-firewall-port-svc-reqs.adoc[leveloffset=+2]
 
@@ -43,7 +43,7 @@ include::modules/hcp-bm-infra-reqs.adoc[leveloffset=+2]
 * xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc[Persistent storage using {lvms}]
 * xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
 
 include::modules/hcp-bm-dns.adoc[leveloffset=+1]
 include::modules/hcp-bm-hc.adoc[leveloffset=+1]
@@ -60,9 +60,9 @@ include::modules/hcp-bm-hc-console.adoc[leveloffset=+2]
 include::modules/hcp-bm-hc-mirror.adoc[leveloffset=+2]
 
 .Next steps
-* To create credentials that you can reuse when you create a hosted cluster with the console, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment].
+* To create credentials that you can reuse when you create a hosted cluster with the console, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment].
 * To access a hosted cluster, see xref:../../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-access_hcp-manage-bm[Accessing the hosted cluster].
-* To add hosts to the host inventory by using the Discovery Image, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#add-host-host-inventory[Adding hosts to the host inventory by using the Discovery Image].
-* To extract the {product-title} release image digest, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#configure-hosted-disconnected-digest-image[Extracting the {product-title} release image digest].
+* To add hosts to the host inventory by using the Discovery Image, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#add-host-host-inventory[Adding hosts to the host inventory by using the Discovery Image].
+* To extract the {product-title} release image digest, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#configure-hosted-disconnected-digest-image[Extracting the {product-title} release image digest].
 
 include::modules/hcp-bm-verify.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
@@ -26,8 +26,8 @@ include::modules/hcp-ibm-power-prereqs.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the {hcp} command-line interface]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
@@ -28,8 +28,8 @@ include::modules/hcp-ibm-z-prereqs.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the {hcp} command-line interface]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
@@ -30,9 +30,9 @@ include::modules/hcp-non-bm-prereqs.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
 
 include::modules/hcp-non-bm-firewall-port-svc-reqs.adoc[leveloffset=+2]
 include::modules/hcp-non-bm-infra-reqs.adoc[leveloffset=+2]
@@ -50,7 +50,7 @@ include::modules/hcp-non-bm-infra-reqs.adoc[leveloffset=+2]
 
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
 
 include::modules/hcp-non-bm-dns.adoc[leveloffset=+1]
 include::modules/hcp-non-bm-hc.adoc[leveloffset=+1]
@@ -70,12 +70,12 @@ include::modules/hcp-bm-hc-mirror.adoc[leveloffset=+2]
 
 .Next steps
 
-* To create credentials that you can reuse when you create a hosted cluster with the console, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment].
+* To create credentials that you can reuse when you create a hosted cluster with the console, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment].
 
 * To access a hosted cluster, see xref:../../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-access_hcp-manage-bm[Accessing the hosted cluster].
 
-* To add hosts to the host inventory by using the Discovery Image, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#add-host-host-inventory[Adding hosts to the host inventory by using the Discovery Image].
+* To add hosts to the host inventory by using the Discovery Image, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#add-host-host-inventory[Adding hosts to the host inventory by using the Discovery Image].
 
-* To extract the {product-title} release image digest, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#configure-hosted-disconnected-digest-image[Extracting the {product-title} release image digest].
+* To extract the {product-title} release image digest, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#configure-hosted-disconnected-digest-image[Extracting the {product-title} release image digest].
 
 include::modules/hcp-non-bm-verify.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
@@ -21,7 +21,7 @@ You can use the hosted control plane command line interface, `hcp`, to create an
 .Additional resources
 * xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
 
 include::modules/hcp-virt-reqs.adoc[leveloffset=+1]
 
@@ -39,7 +39,7 @@ include::modules/hcp-virt-prereqs.adoc[leveloffset=+2]
 * xref:../../post_installation_configuration/post-install-storage-configuration.adoc#post-install-storage-configuration[Postinstallation storage configuration]
 * link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure]
 * xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc#hcp-metallb_hcp-deploy-virt[Configuring MetalLB]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
 
 include::modules/hcp-virt-firewall-port.adoc[leveloffset=+2]
 
@@ -57,7 +57,7 @@ include::modules/hcp-virt-create-hc-console.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* To create credentials that you can reuse when you create a hosted cluster with the console, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment].
+* To create credentials that you can reuse when you create a hosted cluster with the console, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment].
 
 * To access the hosted cluster, see xref:../../hosted_control_planes/hcp-manage/hcp-manage-virt.adoc#hcp-virt-access_hcp-manage-virt[Accessing the hosted cluster].
 

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-When you provision {hcp} on bare metal, you use the Agent platform. The Agent platform and {mce} work together to enable disconnected deployments. The Agent platform uses the central infrastructure management service to add worker nodes to a hosted cluster. For an introduction to the central infrastructure management service, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service].
+When you provision {hcp} on bare metal, you use the Agent platform. The Agent platform and {mce} work together to enable disconnected deployments. The Agent platform uses the central infrastructure management service to add worker nodes to a hosted cluster. For an introduction to the central infrastructure management service, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service].
 
 include::modules/hcp-dc-bm-arch.adoc[leveloffset=+1]
 include::modules/hcp-dc-bm-reqs.adoc[leveloffset=+1]
@@ -34,8 +34,8 @@ include::modules/hcp-dc-apply-objects.adoc[leveloffset=+1]
 
 The {mce} plays a crucial role in deploying clusters across providers. If you do not have {mce-short} installed, review the following documentation to understand the prerequisites and steps to install it:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with multicluster engine operator]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with multicluster engine operator]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
 
 include::modules/hcp-agentserviceconfig.adoc[leveloffset=+2]
 

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
@@ -32,8 +32,8 @@ include::modules/hcp-dc-apply-objects.adoc[leveloffset=+1]
 
 The {mce} plays a crucial role in deploying clusters across providers. If you do not have {mce-short} installed, review the following documentation to understand the prerequisites and steps to install it:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with multicluster engine operator]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with multicluster engine operator]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
 
 [id="hcp-dc-tls-virt"]
 == Configuring TLS certificates for a disconnected installation of {hcp}

--- a/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
@@ -18,6 +18,6 @@ include::modules/hcp-support-matrix.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/articles/7086906[The {mce} 2.7 support matrix]
+* link:https://access.redhat.com/articles/7099674[The {mce} 2.8 support matrix]
 * link:https://access.redhat.com/labs/ocpouic/?operator=multicluster-engine&&upgrade_path=4.14%20to%204.16[Red{nbsp}Hat {product-title} Operator Update Information Checker]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc#hcp-shared-infra_hcp-sizing-guidance[Shared infrastructure between hosted and standalone control planes]

--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -20,7 +20,7 @@ include::modules/hcp-must-gather-dc.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#install-on-disconnected-networks[Install on disconnected networks]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#install-on-disconnected-networks[Install on disconnected networks]
 
 [id="hcp-ts-ocp-virt"]
 == Troubleshooting hosted clusters on {VirtProductName}
@@ -33,7 +33,7 @@ include::modules/hcp-ts-no-nodes-reg.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#identifying-vm-console-logs[Identifying the problem: Access the VM console logs]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#identifying-vm-console-logs[Identifying the problem: Access the VM console logs]
 
 include::modules/hcp-ts-nodes-stuck.adoc[leveloffset=+2]
 include::modules/hcp-ts-ingress-not-online.adoc[leveloffset=+2]
@@ -46,7 +46,7 @@ include::modules/hcp-ts-non-bm.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management]
 
 [id="hcp-ts-bm"]
 == Troubleshooting hosted clusters on bare metal
@@ -58,7 +58,7 @@ include::modules/hcp-ts-bm-nodes-not-added.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/clusters/index#on-prem-creating-your-cluster-with-the-cli-pull-secret[Add the pull secret to the namespace]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html-single/clusters/index#on-prem-creating-your-cluster-with-the-cli-pull-secret[Add the pull secret to the namespace]
 
 include::modules/hosted-restart-hcp-components.adoc[leveloffset=+1]
 include::modules/hosted-control-planes-pause-reconciliation.adoc[leveloffset=+1]
@@ -67,4 +67,4 @@ include::modules/scale-down-data-plane.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#trouble-hosted-cluster-backplane[Must-gather for a hosted cluster]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#trouble-hosted-cluster-backplane[Must-gather for a hosted cluster]

--- a/modules/hcp-dc-image-mirror.adoc
+++ b/modules/hcp-dc-image-mirror.adoc
@@ -122,4 +122,4 @@ For more information, see "Mirroring an image set in a fully disconnected enviro
 $ oc mirror -c imagesetconfig.yaml --from file://<file_path> docker://<mirror_registry_url> --v2
 ----
 
-. Mirror the latest {mce-short} images by following the steps in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#install-on-disconnected-networks[Install on disconnected networks].
+. Mirror the latest {mce-short} images by following the steps in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#install-on-disconnected-networks[Install on disconnected networks].

--- a/modules/hcp-dr-oadp-restore.adoc
+++ b/modules/hcp-dr-oadp-restore.adoc
@@ -18,8 +18,8 @@ After you back up your hosted cluster, you must destroy it to initiate the resto
 
 .Prerequisites
 
-* You completed the steps in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#remove-a-cluster-by-using-the-console[Removing a cluster by using the console] to delete your hosted cluster.
-* You completed the steps in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#removing-a-cluster-from-management-in-special-cases[Removing remaining resources after removing a cluster].
+* You completed the steps in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#remove-a-cluster-by-using-the-console[Removing a cluster by using the console] to delete your hosted cluster.
+* You completed the steps in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#removing-a-cluster-from-management-in-special-cases[Removing remaining resources after removing a cluster].
 
 To monitor and observe the backup process, see "Observing the backup and restore process".
 

--- a/modules/hcp-non-bm-prereqs.adoc
+++ b/modules/hcp-non-bm-prereqs.adoc
@@ -10,14 +10,14 @@ Before you deploy {hcp} on non-bare-metal agent machines, ensure you meet the fo
 
 * You must have {mce} 2.5 or later installed on an {product-title} cluster. You can install the {mce-short} as an Operator from the {product-title} OperatorHub.
 
-* You must have at least one managed {product-title} cluster for the {mce-short}. The `local-cluster` management cluster is automatically imported. For more information about the `local-cluster`, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration] in the {rh-rhacm-title} documentation. You can check the status of your management cluster by running the following command:
+* You must have at least one managed {product-title} cluster for the {mce-short}. The `local-cluster` management cluster is automatically imported. For more information about the `local-cluster`, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration] in the {rh-rhacm-title} documentation. You can check the status of your management cluster by running the following command:
 +
 [source,terminal]
 ----
 $ oc get managedclusters local-cluster
 ----
 
-* You have enabled central infrastructure management. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service] in the {rh-rhacm-title} documentation.
+* You have enabled central infrastructure management. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service] in the {rh-rhacm-title} documentation.
 
 * You have installed the `hcp` command-line interface.
 

--- a/modules/hosted-control-planes-concepts-personas.adoc
+++ b/modules/hosted-control-planes-concepts-personas.adoc
@@ -21,7 +21,7 @@ hosted control plane:: An {product-title} control plane that runs on the managem
 
 hosting cluster:: See _management cluster_.
 
-managed cluster:: A cluster that the hub cluster manages. This term is specific to the cluster lifecycle that the {mce} manages in Red Hat Advanced Cluster Management. A managed cluster is not the same thing as a _management cluster_. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/about/welcome-to-red-hat-advanced-cluster-management-for-kubernetes#managed-cluster[Managed cluster].
+managed cluster:: A cluster that the hub cluster manages. This term is specific to the cluster lifecycle that the {mce} manages in Red Hat Advanced Cluster Management. A managed cluster is not the same thing as a _management cluster_. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/about/welcome-to-red-hat-advanced-cluster-management-for-kubernetes#managed-cluster[Managed cluster].
 
 management cluster:: An {product-title} cluster where the HyperShift Operator is deployed and where the control planes for hosted clusters are hosted. The management cluster is synonymous with the _hosting cluster_.
 

--- a/modules/hosted-control-planes-overview.adoc
+++ b/modules/hosted-control-planes-overview.adoc
@@ -8,7 +8,7 @@
 [id="hosted-control-planes-overview_{context}"]
 = Introduction to {hcp}
 
-{hcp-capital} is available by using a link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#cluster_mce_overview[supported version of {mce}] on the following platforms:
+{hcp-capital} is available by using a link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#cluster_mce_overview[supported version of {mce}] on the following platforms:
 
 * Bare metal by using the Agent provider
 * Non-bare-metal Agent machines, as a Technology Preview feature


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13654
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- MCE overview: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/mce-overview-ocp
- Deploying HCP on AWS: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-aws (see Additional resources section)
- Deploying HCP on bare metal: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-bm (see Additional resources)
- Deploying HCP on IBM Power: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power (see Additional resources)
- Deploying HCP on IBM Z: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz (see Additional resources)
- Deploying HCP on non-bare-metal agent machines: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm (see Additional resources)
- Deploying HCP on OpenShift Virtualization: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-virt (see Additional resources)
- Deploying HCP on bare metal in a disconnected environment: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm
- Deploying HCP on OpenShift Virtualization in a disconnected environment: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt
- Troubleshooting HCP: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting (see Additional resources)
- Configuring image mirroring: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt#hcp-dc-image-mirror_hcp-deploy-dc-virt (see links at the end of the procedure)
- Restoring a hosted cluster by using OADP: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp#hcp-dr-oadp-restore_hcp-disaster-recovery-oadp
- Preparing to deploy on non-bare-metal: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm#hcp-non-bm-prepare_hcp-deploy-non-bm
- Glossary: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/#hosted-control-planes-concepts_hcp-overview
- Intro to HCP: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/#hosted-control-planes-overview_hcp-overview
- Support matrix: https://90236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/#hosted-control-planes-overview_hcp-overview (see link to the MCE 2.8 support matrix)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR updates links to the RHACM docs from version 4.12 to 4.13. The version 4.13 docs are set to go live on March 20.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
