### PR TITLE
OSDOCS-13649: Documented the 4.13.56 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4486,3 +4486,24 @@ $ oc adm release info 4.13.55 --pullspecs
 [id="ocp-4-13-55-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.13.56
+[id="ocp-4-13-56_{context}"]
+=== RHSA-2025:2701 - {product-title} 4.13.56 bug fix and security updates
+
+Issued: 20 March 2025
+
+{product-title} release 4.13.56, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RRHSA-2025:2701[RHSA-2025:2701] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:2703[RHSA-2025:2703] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.56 --pullspecs
+----
+
+[id="ocp-4-13-56-updating_{context}"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-13649](https://issues.redhat.com/browse/OSDOCS-13649)

Link to docs preview:

https://90237--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-56_release-notes

