### PR TITLE
OSDOCS-13648: Documented the 4.14.49 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3399,6 +3399,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+// 4.14.49
+[id="ocp-4-14-49_{context}"]
+=== RHSA-2025:2710 - {product-title} 4.14.49 bug fix and security update
+
+Issued: 19 March 2025
+
+{product-title} release 4.14.49, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:2710[RHSA-2025:2710] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:2712[RHSA-2025:2712] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.49 --pullspecs
+----
+
+[id="ocp-4-14-49-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, after a compute node was removed from the cluster, provisioning of a `PersistentVolume` (PV) resource failed with a message that stated: `The object <virtual machine ID> has already been deleted or has not been completely created`. With this release, a fix ensures that when a compute node is removed, this removal does not impact provisioning of a PV resource. (link:https://issues.redhat.com/browse/OCPBUGS-51045[*OCPBUGS-51045*])
+
+* Previously, requests to the `deploymentconfig/scale` subresource would fail when there was an admission webhook matching the request. With this release, the issue is resolved and requests to the `deploymentconfig/scale` subresource succeed. (link:https://issues.redhat.com/browse/OCPBUGS-50477[*OCPBUGS-50477*]) 
+
+* Previously, when you used the *Form View* to edit `Deployment` or `DeploymentConfig` API objects on the {product-title} web console, duplicate `ImagePullSecrets` parameters existed in the YAML configuration for either object. With this release, a fix ensures that duplicate `ImagePullSecrets` parameters do not get automatically added for either object. (link:https://issues.redhat.com/browse/OCPBUGS-49753[*OCPBUGS-49753*])
+
+[id="ocp-4-14-49-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.48
 [id="ocp-4-14-48_{context}"]
 === RHSA-2025:1451 - {product-title} 4.14.48 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-13648](https://issues.redhat.com/browse/OSDOCS-13648)

Link to docs preview:
* [4.14.49 RN DOC](https://90240--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-49_release-notes)

