### PR TITLE
Fix Typo

### DIFF
--- a/rest_api/workloads_apis/build-build-openshift-io-v1.adoc
+++ b/rest_api/workloads_apis/build-build-openshift-io-v1.adoc
@@ -1984,7 +1984,7 @@ Required::
 
 | `stages`
 | `array`
-| stages contains details about each stage that occurs during the build including start time, duration (in milliseconds), and the steps that occured within each stage.
+| stages contains details about each stage that occurs during the build including start time, duration (in milliseconds), and the steps that occurred within each stage.
 
 | `stages[]`
 | `object`
@@ -2103,7 +2103,7 @@ Please note that this field may not always be set even if the push completes suc
 Description::
 +
 --
-stages contains details about each stage that occurs during the build including start time, duration (in milliseconds), and the steps that occured within each stage.
+stages contains details about each stage that occurs during the build including start time, duration (in milliseconds), and the steps that occurred within each stage.
 --
 
 Type::


### PR DESCRIPTION
Correct misspelling of 'occured' to 'occurred' in rest_api/workloads_apis/build-build-openshift-io-v1.adoc