### PR TITLE
OCPBUGS-52570 deleted the word search under the important admonition

### DIFF
--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -149,8 +149,7 @@ You can specify DNS options under the `dns-resolver.config` section of your NNCP
 desiredState:
     dns-resolver:
       config:
-        search:
-         options:
+        options:
          - timeout:2
          - attempts:3
 # ...


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-52570

Link to docs preview:
https://90245--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html


QE review:
- [x] QE has approved this change.



