### PR TITLE
OSDOCS#13609: Oracle dedicated region clarification

### DIFF
--- a/installing/installing_oci/installing-oci-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-oci-agent-based-installer.adoc
@@ -10,6 +10,11 @@ In {product-title} {product-version}, you can use the Agent-based Installer to i
 
 Installing a cluster on {oci} is supported for virtual machines (VMs) and bare-metal machines.
 
+[NOTE]
+====
+You can deploy {product-title} on a link:https://www.oracle.com/uk/cloud/cloud-at-customer/dedicated-region/[Dedicated Region] (Oracle documentation) the same as any region from {oci-first-no-rt}.
+====
+
 // The Agent-based Installer and OCI overview
 include::modules/installing-oci-about-agent-based-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_oci/installing-oci-assisted-installer.adoc
+++ b/installing/installing_oci/installing-oci-assisted-installer.adoc
@@ -10,6 +10,11 @@ You can use the {ai-full} to install a cluster on {oci-first}. This method is re
 
 If you want to set up the cluster manually or using other automation tools, or if you are working in a disconnected environment, you can use the Red Hat Agent-based Installer for the installation. For details, see xref:../../installing/installing_oci/installing-oci-agent-based-installer.adoc#installing-oci-agent-based-installer[Installing a cluster on {oci-first-no-rt} by using the Agent-based Installer].
 
+[NOTE]
+====
+You can deploy {product-title} on a link:https://www.oracle.com/uk/cloud/cloud-at-customer/dedicated-region/[Dedicated Region] (Oracle documentation) the same as any region from {oci-first-no-rt}.
+====
+
 // The Assisted Installer and OCI overview
 include::modules/installing-oci-about-assisted-installer.adoc[leveloffset=+1]
 
@@ -27,12 +32,12 @@ include::modules/creating-oci-resources-services.adoc[leveloffset=+1]
 [id="using-assisted-installer-oci-agent-iso_{context}"]
 == Using the {ai-full} to generate an {oci}-compatible discovery ISO image
 
-Create the cluster configuration and generate the discovery ISO image in the {ai-full} web console. 
+Create the cluster configuration and generate the discovery ISO image in the {ai-full} web console.
 
 .Prerequisites
 
-* You created a child compartment and an object storage bucket on {oci}. For details, see _Preparing the {oci} environment_. 
-* You reviewed details about the {product-title} installation and update processes. 
+* You created a child compartment and an object storage bucket on {oci}. For details, see _Preparing the {oci} environment_.
+* You reviewed details about the {product-title} installation and update processes.
 
 include::modules/using-assisted-installer-oci-create-cluster.adoc[leveloffset=+2]
 


### PR DESCRIPTION
[OSDOCS-13609](https://issues.redhat.com/browse/OSDOCS-13609)

Version(s): 4.16+

This PR adds a clarification to the Oracle docs about installing OCP on a dedicated region.

QE review:
- [x] QE has approved this change.

Previews:

- [Installing a cluster on Oracle Cloud Infrastructure by using the Assisted Installer](https://90252--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-assisted-installer)
- [Installing a cluster on Oracle Cloud Infrastructure by using the Agent-based Installer](https://90252--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer)