### PR TITLE
Update ocp-4-18-release-notes.adoc

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. From the {hybrid-console}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.8 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported on {op-system-first}. To understand {op-system-base} versions used by {op-system}, see link:https://access.redhat.com/articles/6907891[{op-system-base} Versions Utilized by {op-system-first} and {product-title}] (Knowledgebase article).
+{product-title} {product-version} is supported on {op-system-base-full} 8.8 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported on {op-system-first} {product-version}. To understand {op-system-base} versions used by {op-system}, see link:https://access.redhat.com/articles/6907891[{op-system-base} Versions Utilized by {op-system-first} and {product-title}] (Knowledgebase article).
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines. {op-system-base} machines are deprecated in {product-title} 4.16 and will be removed in a future release.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
Need to add product version as mentioned here in https://issues.redhat.com/browse/OCPBUGS-51316

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-51316
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
 It does not mention anything about the version of RHCOS which looks ambiguous. Ideally, it should be Red Hat Enterprise Linux CoreOS (RHCOS) 4.18 and the statement should be :  

"OpenShift Container Platform 4.18 is also supported on Red Hat Enterprise Linux CoreOS (RHCOS) 4.18.   
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
