### PR TITLE
TELCODOCS-2105/TELCODOCS-21106: RN for for EgressSerivce and MetalLB VRF TP to GA features

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -447,6 +447,18 @@ We will have details here when {product-title} {product-version} is released.
 ==== Support for managing the Gateway API custom resource definition (CRD) lifecycle
 We will have details here when {product-title} {product-version} is released.
 
+[id="ocp-4-19-egress-service-cr_{context}"]
+==== Egress service resource is generally available
+The `EgressService` custom resource (CR) was introduced as a Technology Preview in {product-title} 4.14. With this update, configuring the `EgressService` CR to manage egress traffic for pods behind a load balancer service is generally available. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc#configuring-egress-traffic-loadbalancer-services[Configuring an egress service].
+
+[id="ocp-4-19-vrf-spec-bgppeer_{context}"]
+==== VRF specification in MetalLB's BGPPeer resource is generally available
+Configuring a Virtual Routing and Forwarding (VRF) instance in a `BGPPeer` custom resource was introduced as a Technology Preview in {product-title} 4.14. With this update, this feature is generally available. For more information, see xref:../networking/metallb/metallb-configure-bgp-peers.adoc#nw-metallb-bgp-peer-vrf_configure-metallb-bgp-peers[Exposing a service through a network VRF]
+
+[id="ocp-4-19-vrf-spec-nncp_{context}"]
+==== VRF specification in NMState's NodeNetworkConfigurationPolicy resource is generally available
+Associating a Virtual Routing and Forwarding (VRF) instance with a network interface by using a `NodeNetworkConfigurationPolicy` resource was introduced as a Technology Preview in {product-title} 4.14. With this update, this feature is generally available. For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-host-vrf_k8s_nmstate-updating-node-network-config[Example: Network interface with a VRF instance node network configuration policy].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 
@@ -1171,7 +1183,7 @@ In the following tables, features are marked with the following statuses:
 |{ols-official} in the {product-title} web console
 |Technology Preview
 |Technology Preview
-|Technology Peview
+|Technology Preview
 |====
 
 [discrete]
@@ -1231,17 +1243,17 @@ In the following tables, features are marked with the following statuses:
 |Egress service custom resource
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |VRF specification in `BGPPeer` custom resource
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |VRF specification in `NodeNetworkConfigurationPolicy` custom resource
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Host network settings for SR-IOV VFs
 |General Availability


### PR DESCRIPTION
[TELCODOCS-2105](https://issues.redhat.com//browse/TELCODOCS-2105) / TELCODOCS-21106: RN for for EgressSerivce and MetalLB VRF TP to GA features 

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/TELCODOCS-2105
https://issues.redhat.com/browse/TELCODOCS-2106

Link to docs preview:
- https://file.corp.redhat.com/rohennes/TELCODOCS-2105-RN/release_notes/ocp-4-19-release-notes.html#ocp-4-19-egress-service-cr_release-notes
- https://file.corp.redhat.com/rohennes/TELCODOCS-2105-RN/release_notes/ocp-4-19-release-notes.html#ocp-4-19-vrf-spec-bgppeer_release-notes
- https://file.corp.redhat.com/rohennes/TELCODOCS-2105-RN/release_notes/ocp-4-19-release-notes.html#ocp-4-19-vrf-spec-nncp_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
