### PR TITLE
TELCODOCS-2125 NIST 800-53 RAN hardening for high security issues 2

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3400,6 +3400,8 @@ Topics:
   File: ztp-sno-additional-worker-node
 - Name: Pre-caching images for single-node OpenShift deployments
   File: ztp-precaching-tool
+- Name: Security hardening
+  File: ztp-security-hardening
 - Name: Image-based upgrade for single-node OpenShift clusters
   Dir: image_based_upgrade
   Distros: openshift-origin,openshift-enterprise

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ztp-security-hardening"]
-= RAN hardening for high security issues (Technology preview)
+= Security hardening for edge deployments (Technology preview)
 include::_attributes/common-attributes.adoc[]
 :context: security-hardening
 
@@ -11,7 +11,7 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 
 Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
 
-The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, on {product-title}, identified security compliance issues. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening high-severity issues being addressed.
+The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, on {product-title}, identified areas for security hardening and validated adherence to best practices. Enhancements in {product-version}, primarily implemented using ZTP manifests, are proactively implementing these critical security controls. The following sections detail the high-severity security hardening measures being implemented.
 
 include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
 

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ztp-security-hardening"]
+= Security hardening
+include::_attributes/common-attributes.adoc[]
+:context: security-hardening
+
+toc::[]
+
+Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
+
+The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes Benchmarks, on {product-title}, identified security impacts. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening process for edge deployments.
+
+include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
+
+
+[role="_additional-resources"]
+.Additional resources
+

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
 
-The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes benchmarks, on {product-title}, identified security compliance issues. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening high-severity issues being addressed.
+The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, on {product-title}, identified security compliance issues. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening high-severity issues being addressed.
 
 include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
 

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -1,10 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ztp-security-hardening"]
-= Security hardening
+= RAN hardening for high security issues (Technology preview)
 include::_attributes/common-attributes.adoc[]
 :context: security-hardening
 
 toc::[]
+
+:FeatureName: RAN hardening for high security issues
+include::snippets/technology-preview.adoc[leveloffset=+2]
 
 Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
 

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
 
-The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes Benchmarks, on {product-title}, identified security impacts. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening process issues being addressed.
+The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes benchmarks, on {product-title}, identified security compliance issues. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening high-severity issues being addressed.
 
 include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
 
@@ -16,3 +16,7 @@ include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* link:https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final[NIST SP 800-53]
+* link:https://www.cisecurity.org/benchmark/kubernetes/[CIS Kubernetes benchmarks]
+* xref:../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#compliance-operator-understanding[Understanding the Compliance Operator]
+* xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu[Configuring host firmware for low latency and high performance]     

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
 
-The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes Benchmarks, on {product-title}, identified security impacts. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening process for edge deployments.
+The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes Benchmarks, on {product-title}, identified security impacts. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening process issues being addressed.
 
 include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
 

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -9,8 +9,6 @@ toc::[]
 :FeatureName: RAN hardening for high security issues
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-TEST
-
 Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
 
 The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, on {product-title}, identified security compliance issues. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening high-severity issues being addressed.

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -9,6 +9,8 @@ toc::[]
 :FeatureName: RAN hardening for high security issues
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
+TEST
+
 Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
 
 The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, on {product-title}, identified security compliance issues. Enhancements in {product-version}, primarily implemented using ZTP manifests, are addressing the high-severity issues. The following sections describe the security hardening high-severity issues being addressed.

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -11,7 +11,7 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 
 Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
 
-The Compliance Operator running a custom telecommunications security profile, based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, on {product-title}, identified areas for security hardening and validated adherence to best practices. Enhancements in {product-version}, primarily implemented using ZTP manifests, are proactively implementing these critical security controls. The following sections detail the high-severity security hardening measures being implemented.
+The Compliance Operator on {product-title}, running a custom telecommunications security profile based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, identified areas for security hardening and validated adherence to best practices. Using ZTP manifests, enhancements in {product-version} provide these critical security controls. The following sections detail the high-severity security hardening measures being implemented.
 
 include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
 

--- a/modules/ztp-du-host-firmware-requirements.adoc
+++ b/modules/ztp-du-host-firmware-requirements.adoc
@@ -60,6 +60,15 @@ The exact firmware configuration depends on your specific hardware and network r
 
 |Processor C6
 |Disabled
+
+|USB Boot
+|Disabled
+
+|Wireless LAN
+|Disabled
+
+|Bluetooth
+|Disabled
 |====
 
 [NOTE]

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -6,23 +6,23 @@
 [id="ztp-addressed-security-issues_{context}"]
 = Security hardening measures implemented
 
-== Security control 1: Disabling USB boot, wireless and bluetooth access  
+== Disabling USB boot, wireless and bluetooth access  
 
 To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, USB boot, wireless, and Bluetooth are disabled in the BIOS settings. These setting are not controlled through ZTP configuration. For example, disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Configuring host firmware for low latency and high performance".
 
-== Security control 2: Preventing unauthorized Reboots
+== Preventing unauthorized Reboots
  
 Disabling `CtrlAltDelBurstAction` and `Ctrl+Alt+Del` prevents unauthorized reboots.
 
-== Security control 3: Restricting direct SSH access
+== Restricting direct SSH access
   
 Direct SSH access to {product-title} is limited by disabling `root` login.
 
-== Security control 4: Adhering to the principle of least privilege with RBAC
+== Adhering to the principle of least privilege with RBAC
   
 Enforce strict authentication policies by disabling logins for accounts without passwords, ensuring compliance with security best practices and reducing unauthorized access risks.
 
-== Security control 5: Ensure that the RBAC setup follows the principle of least privilege
+== Ensure that the RBAC setup follows the principle of least privilege
 
 To minimize the risk of unauthorized access, the RBAC setup follows the principle of least privilege, as described in "Using RBAC to define and apply permissions", granting users the minimum required permissions. 
 

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -26,7 +26,7 @@ Enforce strict authentication policies by disabling logins for accounts without 
 
 To minimize the risk of unauthorized access, the RBAC setup follows the principle of least privilege, as described in "Using RBAC to define and apply permissions", granting users the minimum required permissions. 
 
-{product-title} provides the tools for creating minimal permissions.However, you need to assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
+{product-title} provides the tools for creating minimal permissions. However, you need to assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
 
 For example, consider creating a role that:
 

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -4,41 +4,36 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="ztp-addressed-security-issues_{context}"]
-= Security issues addressed
+= Security hardening measures implemented
 
-== Issue 1: Disable USB boot, wireless and bluetooth access  
+== Security control 1: Disabling USB boot, wireless and bluetooth access  
 
-To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, disable USB boot, wireless and bluetooth in the BIOS settings. These setting are not controlled through ZTP configuration. For example disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Chapter 6. Configuring host firmware for low latency and high performance".
+To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, USB boot, wireless, and Bluetooth are disabled in the BIOS settings. These setting are not controlled through ZTP configuration. For example, disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Configuring host firmware for low latency and high performance".
 
-== Issue 2: Disable Ctrl+Alt+Del reboots
+== Security control 2: Preventing unauthorized Reboots
  
-Disabling CtrlAltDelBurstAction and Ctrl+Alt+Del prevents unauthorized reboots.
+Disabling `CtrlAltDelBurstAction` and `Ctrl+Alt+Del` prevents unauthorized reboots.
 
-== Issue 3:  Restrict SSH access
+== Security control 3: Restricting direct SSH access
   
-Limit direct SSH access to {product-title} by disabling root login. 
+Direct SSH access to {product-title} is limited by disabling `root` login.
 
-== Issue 4:   Prevent login to accounts with empty passwords
+== Security control 4: Adhering to the principle of least privilege with RBAC
   
 Enforce strict authentication policies by disabling logins for accounts without passwords, ensuring compliance with security best practices and reducing unauthorized access risks.
 
-== Ensure that the RBAC setup follows the principle of least privilege
+== Security control 5: Ensure that the RBAC setup follows the principle of least privilege
 
-To minimize the risk of unauthorized access, ensure that the RBAC setup as described in "Chapter 8. Using RBAC to define and apply permissions" follows the principle of least privilege, granting users the minimum required permissions. 
+To minimize the risk of unauthorized access, the RBAC setup follows the principle of least privilege, as described in "Using RBAC to define and apply permissions", granting users the minimum required permissions. 
 
-[NOTE]
-====
-{product-title} provides the tools for creating minimal permissions, you need to assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
-====
+{product-title} provides the tools for creating minimal permissions.However, you need to assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
 
-For example you might consider creating:
+For example, consider creating a role that:
 
-* A role with minimal permissions to control user access, such as granting users the ability to view resources without modifying them.
-* A role that allows developers to manage only deployments and services within a specific namespace, without granting access to sensitive resources 
-* A role for users who need to view configuration resources, such as `ConfigMaps` and `Secrets`, but not change them.
+* Provides permissions to control user access, such as granting users the ability to view resources without modifying them.
+* Enables developers to manage only deployments and services within a specific namespace, without granting access to sensitive resources. 
+* Allows users to view configuration resources, such as `ConfigMaps` and `Secrets`, but not change them.
 
-[NOTE]
-====
 Regularly review and update permissions to ensure that users have only the permissions necessary to perform their tasks.
-====
+
 

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-security-hardening.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ztp-addressed-security-issues_{context}"]
+= Security issues addressed
+
+
+=== Issue 1: Disable USB Boot   
+
+To prevent unauthorized modifications to the operating system and reduces the risk of physical attack vectors, disable USB boot in the BIOS settings. This prevents attackers from booting from a USB drive and gaining unauthorized access to the system. 
+
+=== Issue 2: Disable Ctrl+Alt+Del reboots
+ 
+Disabling CtrlAltDelBurstAction and Ctrl+Alt+Del prevents unauthorized reboots.
+
+=== Issue 3:  Restrict SSH access
+  
+Limit direct SSH access to {product-title} by disabling root login. 
+
+=== Issue 4:  Restrict SSH access
+  
+Enforce strict authentication policies by disabling logins for accounts without passwords, ensuring compliance with security best practices and reducing unauthorized access risks.. 

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -6,9 +6,9 @@
 [id="ztp-addressed-security-issues_{context}"]
 = Security issues addressed
 
-== Issue 1: Disable USB Boot   
+== Issue 1: Disable USB boot, wireless and bluetooth access  
 
-To prevent unauthorized modifications to the operating system and reduces the risk of physical attack vectors, disable USB boot in the BIOS settings. This prevents attackers from booting from a USB drive and gaining unauthorized access to the system. 
+To prevent unauthorized modifications to the operating system and reduces the risk of physical attack vectors, disable USB boot, wireless and bluetooth in the BIOS settings. These setting are not controlled through ZTP configuration. For example disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recoomended firmware configuration is described in "Chapter 6. Configuring host firmware for low latency nad high performance".
 
 == Issue 2: Disable Ctrl+Alt+Del reboots
  
@@ -25,7 +25,7 @@ Enforce strict authentication policies by disabling logins for accounts without 
 == Ensure that the RBAC setup follows the principle of least privilege
 
 To minimize the risk of unauthorized access, ensure that the RBAC setup as described in "Chapter 8. Using RBAC to define and apply permissions" follows the principle of least privilege, granting users the minimum required permissions. 
-+
+
 [NOTE]
 ====
 {product-title} provides the tools for creating minimal permissions, you need to assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
@@ -39,6 +39,6 @@ For example you might consider creating:
 
 [NOTE]
 ====
-Regularly reviewing and updating permissions to ensure that users have only the permissions necessary to perform their tasks.
+Regularly review and update permissions to ensure that users have only the permissions necessary to perform their tasks.
 ====
 

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -8,7 +8,7 @@
 
 == Issue 1: Disable USB boot, wireless and bluetooth access  
 
-To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, disable USB boot, wireless and bluetooth in the BIOS settings. These setting are not controlled through ZTP configuration. For example disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Chapter 6. Configuring host firmware for low latency nad high performance".
+To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, disable USB boot, wireless and bluetooth in the BIOS settings. These setting are not controlled through ZTP configuration. For example disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Chapter 6. Configuring host firmware for low latency and high performance".
 
 == Issue 2: Disable Ctrl+Alt+Del reboots
  

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -6,19 +6,18 @@
 [id="ztp-addressed-security-issues_{context}"]
 = Security issues addressed
 
-
-=== Issue 1: Disable USB Boot   
+== Issue 1: Disable USB Boot   
 
 To prevent unauthorized modifications to the operating system and reduces the risk of physical attack vectors, disable USB boot in the BIOS settings. This prevents attackers from booting from a USB drive and gaining unauthorized access to the system. 
 
-=== Issue 2: Disable Ctrl+Alt+Del reboots
+== Issue 2: Disable Ctrl+Alt+Del reboots
  
 Disabling CtrlAltDelBurstAction and Ctrl+Alt+Del prevents unauthorized reboots.
 
-=== Issue 3:  Restrict SSH access
+== Issue 3:  Restrict SSH access
   
 Limit direct SSH access to {product-title} by disabling root login. 
 
-=== Issue 4:  Restrict SSH access
+== Issue 4:  Restrict SSH access
   
 Enforce strict authentication policies by disabling logins for accounts without passwords, ensuring compliance with security best practices and reducing unauthorized access risks.. 

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -8,7 +8,7 @@
 
 == Issue 1: Disable USB boot, wireless and bluetooth access  
 
-To prevent unauthorized modifications to the operating system and reduces the risk of physical attack vectors, disable USB boot, wireless and bluetooth in the BIOS settings. These setting are not controlled through ZTP configuration. For example disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recoomended firmware configuration is described in "Chapter 6. Configuring host firmware for low latency nad high performance".
+To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, disable USB boot, wireless and bluetooth in the BIOS settings. These setting are not controlled through ZTP configuration. For example disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Chapter 6. Configuring host firmware for low latency nad high performance".
 
 == Issue 2: Disable Ctrl+Alt+Del reboots
  

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -18,6 +18,27 @@ Disabling CtrlAltDelBurstAction and Ctrl+Alt+Del prevents unauthorized reboots.
   
 Limit direct SSH access to {product-title} by disabling root login. 
 
-== Issue 4:  Restrict SSH access
+== Issue 4:   Prevent login to accounts with empty passwords
   
-Enforce strict authentication policies by disabling logins for accounts without passwords, ensuring compliance with security best practices and reducing unauthorized access risks.. 
+Enforce strict authentication policies by disabling logins for accounts without passwords, ensuring compliance with security best practices and reducing unauthorized access risks.
+
+== Ensure that the RBAC setup follows the principle of least privilege
+
+To minimize the risk of unauthorized access, ensure that the RBAC setup as described in "Chapter 8. Using RBAC to define and apply permissions" follows the principle of least privilege, granting users the minimum required permissions. 
++
+[NOTE]
+====
+{product-title} provides the tools for creating minimal permissions, you need to assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
+====
+
+For example you might consider creating:
+
+* A role with minimal permissions to control user access, such as granting users the ability to view resources without modifying them.
+* A role that allows developers to manage only deployments and services within a specific namespace, without granting access to sensitive resources 
+* A role for users who need to view configuration resources, such as `ConfigMaps` and `Secrets`, but not change them.
+
+[NOTE]
+====
+Regularly reviewing and updating permissions to ensure that users have only the permissions necessary to perform their tasks.
+====
+

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -8,25 +8,25 @@
 
 == Disabling USB boot, wireless and bluetooth access  
 
-To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, USB boot, wireless, and Bluetooth are disabled in the BIOS settings. These setting are not controlled through ZTP configuration. For example, disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Configuring host firmware for low latency and high performance".
+To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, USB boot, wireless, and Bluetooth are disabled in the BIOS settings. These settings are not controlled by using ZTP configuration. Disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Configuring host firmware for low latency and high performance".
 
-== Preventing unauthorized Reboots
+== Preventing unauthorized reboots
  
-Disabling `CtrlAltDelBurstAction` and `Ctrl+Alt+Del` prevents unauthorized reboots.
+Disabling `CtrlAltDelBurstAction` and `Ctrl+Alt+Del` actions prevents unauthorized reboots.
 
 == Restricting direct SSH access
   
-Direct SSH access to {product-title} is limited by disabling `root` login.
+Direct SSH access to {product-title} is limited by disabling the `root` login.
 
-== Adhering to the principle of least privilege with RBAC
+== Disabling passwordless logins
   
-Enforce strict authentication policies by disabling logins for accounts without passwords, ensuring compliance with security best practices and reducing unauthorized access risks.
+This feature enforces strict authentication policies by disabling logins for accounts without passwords to ensure compliance with security best practices and reduce unauthorized access risks.
 
 == Ensure that the RBAC setup follows the principle of least privilege
 
 To minimize the risk of unauthorized access, the RBAC setup follows the principle of least privilege, as described in "Using RBAC to define and apply permissions", granting users the minimum required permissions. 
 
-{product-title} provides the tools for creating minimal permissions. However, you need to assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
+{product-title} provides the tools for creating minimal permissions. However, you must assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
 
 For example, consider creating a role that:
 


### PR DESCRIPTION
[TELCODOCS-2125]: NIST 800-53 RAN hardening for high security issues

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19 & main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2125
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

* https://90286--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-security-hardening.html
* https://90286--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
