### PR TITLE
OSDOCS-13624: enable region: Malaysia ap-southeast-5

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -32,43 +32,170 @@ For GovCloud (US) regions, you must submit an link:https://console.redhat.com/op
 GovCloud (US) regions are only supported on ROSA Classic clusters.
 ====
 
-.AWS Regions
-[%collapsible]
-====
-* us-east-1 (N. Virginia)
-* us-east-2 (Ohio)
+.AWS regions
+[cols="4",options="header"]
+|===
+|Region
+|Location
+|Minimum ROSA version required
+|AWS opt-in required
+
+|us-east-1
+|N. Virginia
+|4.14
+|No
+
+|us-east-2
+|Ohio
+|4.14
+|No
+
 ifndef::rosa-with-hcp[]
-* us-west-1 (N. California)
+|us-west-1
+|N. California
+|4.14
+|No
 endif::rosa-with-hcp[]
-* us-west-2 (Oregon)
-* af-south-1 (Cape Town, AWS opt-in required)
-* ap-east-1 (Hong Kong, AWS opt-in required)
-* ap-south-2 (Hyderabad, AWS opt-in required)
-* ap-southeast-3 (Jakarta, AWS opt-in required)
-* ap-southeast-4 (Melbourne, AWS opt-in required)
-* ap-south-1 (Mumbai)
-* ap-northeast-3 (Osaka)
-* ap-northeast-2 (Seoul)
-* ap-southeast-1 (Singapore)
-* ap-southeast-2 (Sydney)
-* ap-northeast-1 (Tokyo)
-* ca-central-1 (Central Canada)
-* eu-central-1 (Frankfurt)
-* eu-north-1 (Stockholm)
-* eu-west-1 (Ireland)
-* eu-west-2 (London)
-* eu-south-1 (Milan, AWS opt-in required)
-* eu-west-3 (Paris)
-* eu-south-2 (Spain)
-* eu-central-2 (Zurich, AWS opt-in required)
-* me-south-1 (Bahrain, AWS opt-in required)
-* me-central-1 (UAE, AWS opt-in required)
-* sa-east-1 (São Paulo)
+
+|us-west-2
+|Oregon
+|4.14
+|No
+
+|af-south-1
+|Cape Town
+|4.14
+|Yes
+
+|ap-east-1
+|Hong Kong
+|4.14
+|Yes
+
+|ap-south-2
+|Hyderabad
+|4.14
+|Yes
+
+|ap-southeast-3
+|Jakarta
+|4.14
+|Yes
+
+|ap-southeast-4
+|Melbourne
+|4.14
+|Yes
+
+ifdef::rosa-with-hcp[]
+|ap-southeast-5
+|Malaysia
+|4.15.45; 4.16.34; 4.17.15
+|Yes
+endif::rosa-with-hcp[]
+
+|ap-south-1
+|Mumbai
+|4.14
+|No
+
+|ap-northeast-3
+|Osaka
+|4.14
+|No
+
+|ap-northeast-2
+|Seoul
+|4.14
+|No
+
+|ap-southeast-1
+|Singapore
+|4.14
+|No
+
+|ap-southeast-2
+|Sydney
+|4.14
+|No
+
+|ap-northeast-1
+|Tokyo
+|4.14
+|No
+
+|ca-central-1
+|Central Canada
+|4.14
+|No
+
+|eu-central-1
+|Frankfurt
+|4.14
+|No
+
+|eu-north-1
+|Stockholm
+|4.14
+|No
+
+|eu-west-1
+|Ireland
+|4.14
+|No
+
+|eu-west-2
+|London
+|4.14
+|No
+
+|eu-south-1
+|Milan
+|4.14
+|Yes
+
+|eu-west-3
+|Paris
+|4.14
+|No
+
+|eu-south-2
+|Spain
+|4.14
+|Yes
+
+|eu-central-2
+|Zurich
+|4.14
+|Yes
+
+|me-south-1
+|Bahrain
+|4.14
+|Yes
+
+|me-central-1
+|UAE
+|4.14
+|Yes
+
+|sa-east-1
+|São Paulo
+|4.14
+|No
+
 ifndef::rosa-with-hcp[]
-* us-gov-east-1 (AWS GovCloud - US-East)
-* us-gov-west-1 (AWS GovCloud - US-West)
+|us-gov-east-1
+|AWS GovCloud - US-East
+|4.14
+|No
+
+|us-gov-west-1
+|AWS GovCloud - US-West
+|4.14
+|No
 endif::rosa-with-hcp[]
-====
+|===
 
 Multiple availability zone clusters can only be deployed in regions with at least 3 availability zones. For more information, see the link:https://aws.amazon.com/about-aws/global-infrastructure/regions_az/[Regions and Availability Zones] section in the AWS documentation.
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -23,6 +23,14 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
+* **{hcp-title} region added.** {hcp-title-first} is now available in the following region:
++
+** Malaysia (`ap-southeast-5`)
++
+For more information on region availabilities, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones].
+endif::openshift-rosa-hcp[]
+
+ifdef::openshift-rosa-hcp[]
 * **Cluster autoscaling is now available for {product-title}.** You can configure cluster autoscaling for {product-title}. For more information, see xref:../rosa_cluster_admin/rosa-cluster-autoscaling.adoc#rosa-cluster-autoscaling[Cluster autoscaling].
 endif::openshift-rosa-hcp[]
 


### PR DESCRIPTION
[OSDOCS-13624](https://issues.redhat.com//browse/OSDOCS-13624): enable region: Malaysia ap-southeast-5

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13624

Link to docs preview:
ROSA Classic: https://90307--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition#rosa-sdpolicy-regions-az_rosa-service-definition
ROSA HCP: https://90307--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition 
What's New ROSA Classic: https://90307--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes
What's New ROSA HCP: https://90307--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
