### PR TITLE
[enterprise-4.16] TELCODOCS-2227 Improve documentation adding how NumeResourceOperator can be applied to more than 1 pool

### DIFF
--- a/modules/cnf-creating-nrop-cr.adoc
+++ b/modules/cnf-creating-nrop-cr.adoc
@@ -47,6 +47,29 @@ $ oc create -f nrop.yaml
 Creating the `NUMAResourcesOperator` triggers a reboot on the corresponding machine config pool and therefore the affected node.
 ====
 
+. Optional: To enable NUMA-aware scheduling for multiple machine config pools (MCPs), define a separate `NodeGroup` for each pool. For example, define three `NodeGroups` for `worker-cnf`, `worker-ht`, and `worker-other`, in the `NUMAResourcesOperator` CR as shown in the following example:
++
+.Example YAML definition for a `NUMAResourcesOperator` CR with multiple `NodeGroups` 
+[source,yaml]
+----
+apiVersion: nodetopology.openshift.io/v1
+kind: NUMAResourcesOperator
+metadata:
+  name: numaresourcesoperator
+spec:
+  logLevel: Normal
+  nodeGroups:
+    - machineConfigPoolSelector:
+        matchLabels:
+          machineconfiguration.openshift.io/role: worker-ht
+    - machineConfigPoolSelector:
+        matchLabels:
+          machineconfiguration.openshift.io/role: worker-cnf
+    - machineConfigPoolSelector:
+        matchLabels:
+          machineconfiguration.openshift.io/role: worker-other
+----
+
 .Verification
 
 . Verify that the NUMA Resources Operator deployed successfully by running the following command:


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/90150