### PR TITLE
[OCPBUGS-53162]: Long command-line prompts not visible

### DIFF
--- a/modules/advanced-node-tuning-hosted-cluster.adoc
+++ b/modules/advanced-node-tuning-hosted-cluster.adoc
@@ -114,7 +114,8 @@ After the nodes are available, the containerized TuneD daemon calculates the req
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="<hosted_cluster_kubeconfig>" get tuned.tuned.openshift.io -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="<hosted_cluster_kubeconfig>" get tuned.tuned.openshift.io \
+  -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output
@@ -130,7 +131,8 @@ rendered             123m
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="<hosted_cluster_kubeconfig>" get profile.tuned.openshift.io -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="<hosted_cluster_kubeconfig>" get profile.tuned.openshift.io \
+  -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output
@@ -149,7 +151,8 @@ Both of the worker nodes in the new `NodePool` have the `openshift-node-hugepage
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="<hosted_cluster_kubeconfig>" debug node/nodepool-1-worker-1 -- chroot /host cat /proc/cmdline
+$ oc --kubeconfig="<hosted_cluster_kubeconfig>" \
+  debug node/nodepool-1-worker-1 -- chroot /host cat /proc/cmdline
 ----
 +
 .Example output

--- a/modules/backup-etcd-hosted-cluster.adoc
+++ b/modules/backup-etcd-hosted-cluster.adoc
@@ -19,28 +19,38 @@ This procedure requires API downtime.
 +
 [source,terminal]
 ----
-$ oc patch -n clusters hostedclusters/<hosted_cluster_name> -p '{"spec":{"pausedUntil":"true"}}' --type=merge
+$ oc patch -n clusters hostedclusters/<hosted_cluster_name> \
+  -p '{"spec":{"pausedUntil":"true"}}' --type=merge
 ----
 
 . Stop all etcd-writer deployments by entering the following command:
 +
 [source,terminal]
 ----
-$ oc scale deployment -n <hosted_cluster_namespace> --replicas=0 kube-apiserver openshift-apiserver openshift-oauth-apiserver
+$ oc scale deployment -n <hosted_cluster_namespace> --replicas=0 \
+  kube-apiserver openshift-apiserver openshift-oauth-apiserver
 ----
 
 . To take an etcd snapshot, use the `exec` command in each etcd container by entering the following command:
 +
 [source,terminal]
 ----
-$ oc exec -it <etcd_pod_name> -n <hosted_cluster_namespace> -- env ETCDCTL_API=3 /usr/bin/etcdctl --cacert /etc/etcd/tls/etcd-ca/ca.crt --cert /etc/etcd/tls/client/etcd-client.crt --key /etc/etcd/tls/client/etcd-client.key --endpoints=localhost:2379 snapshot save /var/lib/data/snapshot.db
+$ oc exec -it <etcd_pod_name> -n <hosted_cluster_namespace> -- \
+  env ETCDCTL_API=3 /usr/bin/etcdctl \
+  --cacert /etc/etcd/tls/etcd-ca/ca.crt \
+  --cert /etc/etcd/tls/client/etcd-client.crt \
+  --key /etc/etcd/tls/client/etcd-client.key \
+  --endpoints=localhost:2379 \
+  snapshot save /var/lib/data/snapshot.db
 ----
 
 . To check the snapshot status, use the `exec` command in each etcd container by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec -it <etcd_pod_name> -n <hosted_cluster_namespace> -- env ETCDCTL_API=3 /usr/bin/etcdctl -w table snapshot status /var/lib/data/snapshot.db
+$ oc exec -it <etcd_pod_name> -n <hosted_cluster_namespace> -- \
+  env ETCDCTL_API=3 /usr/bin/etcdctl -w table snapshot status \
+  /var/lib/data/snapshot.db
 ----
 
 . Copy the snapshot data to a location where you can retrieve it later, such as an S3 bucket. See the following example.
@@ -78,7 +88,8 @@ oc exec -it etcd-0 -n ${HOSTED_CLUSTER_NAMESPACE} -- curl -X PUT -T "/var/lib/da
 +
 [source,terminal]
 ----
-$ oc get hostedcluster <hosted_cluster_name> -o=jsonpath='{.spec.secretEncryption.aescbc}'
+$ oc get hostedcluster <hosted_cluster_name> \
+  -o=jsonpath='{.spec.secretEncryption.aescbc}'
 {"activeKey":{"name":"<hosted_cluster_name>-etcd-encryption-key"}}
 ----
 
@@ -86,7 +97,8 @@ $ oc get hostedcluster <hosted_cluster_name> -o=jsonpath='{.spec.secretEncryptio
 +
 [source,terminal]
 ----
-$ oc get secret <hosted_cluster_name>-etcd-encryption-key -o=jsonpath='{.data.key}'
+$ oc get secret <hosted_cluster_name>-etcd-encryption-key \
+  -o=jsonpath='{.data.key}'
 ----
 +
 You can decrypt this key when restoring a snapshot on a new cluster.
@@ -95,14 +107,16 @@ You can decrypt this key when restoring a snapshot on a new cluster.
 +
 [source,terminal]
 ----
-$ oc scale deployment -n <control_plane_namespace> --replicas=3 kube-apiserver openshift-apiserver openshift-oauth-apiserver
+$ oc scale deployment -n <control_plane_namespace> --replicas=3 \
+  kube-apiserver openshift-apiserver openshift-oauth-apiserver
 ----
 
 . Resume the reconciliation of the hosted cluster by entering the following command:
 +
 [source,terminal]
 ----
-$ oc patch -n <hosted_cluster_namespace> -p '[\{"op": "remove", "path": "/spec/pausedUntil"}]' --type=json
+$ oc patch -n <hosted_cluster_namespace> \
+  -p '[\{"op": "remove", "path": "/spec/pausedUntil"}]' --type=json
 ----
 
 .Next steps

--- a/modules/destroy-hc-ibm-z-cli.adoc
+++ b/modules/destroy-hc-ibm-z-cli.adoc
@@ -14,7 +14,8 @@ To destroy a hosted cluster and its managed cluster on `x86` bare metal with {ib
 +
 [source,terminal]
 ----
-$ oc -n <hosted_cluster_namespace> scale nodepool <nodepool_name> --replicas 0
+$ oc -n <hosted_cluster_namespace> scale nodepool <nodepool_name> \
+  --replicas 0
 ----
 +
 After the `NodePool` object is scaled to `0`, the compute nodes are detached from the hosted cluster. In {product-title} version 4.17, this function is applicable only for {ibm-z-title} with KVM. For z/VM and LPAR, you must delete the compute nodes manually.
@@ -26,7 +27,8 @@ If you want to re-attach compute nodes to the cluster, you can scale up the `Nod
 If the compute nodes are not detached from the hosted cluster or are stuck in the `Notready` state, delete the compute nodes manually by running the following command:
 [source,terminal]
 ----
-$ oc --kubeconfig <hosted_cluster_name>.kubeconfig delete node <compute_node_name>
+$ oc --kubeconfig <hosted_cluster_name>.kubeconfig delete \
+  node <compute_node_name>
 ----
 ====
 
@@ -55,5 +57,6 @@ You can delete the virtual machines that you created as agents after you delete 
 +
 [source,terminal]
 ----
-$ hcp destroy cluster agent --name <hosted_cluster_name> --namespace <hosted_cluster_namespace>
+$ hcp destroy cluster agent --name <hosted_cluster_name> \
+  --namespace <hosted_cluster_namespace>
 ----

--- a/modules/dr-hosted-cluster-within-aws-region-backup.adoc
+++ b/modules/dr-hosted-cluster-within-aws-region-backup.adoc
@@ -14,7 +14,8 @@ To recover your hosted cluster in your target management cluster, you first need
 +
 [source,terminal]
 ----
-$ oc create configmap mgmt-parent-cluster -n default --from-literal=from=${MGMT_CLUSTER_NAME}
+$ oc create configmap mgmt-parent-cluster -n default \
+  --from-literal=from=${MGMT_CLUSTER_NAME}
 ----
 
 . Shut down the reconciliation in the hosted cluster and in the node pools by entering these commands:
@@ -22,16 +23,21 @@ $ oc create configmap mgmt-parent-cluster -n default --from-literal=from=${MGMT_
 [source,terminal]
 ----
 $ PAUSED_UNTIL="true"
-$ oc patch -n ${HC_CLUSTER_NS} hostedclusters/${HC_CLUSTER_NAME} -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
-$ oc scale deployment -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --replicas=0 kube-apiserver openshift-apiserver openshift-oauth-apiserver control-plane-operator
+$ oc patch -n ${HC_CLUSTER_NS} hostedclusters/${HC_CLUSTER_NAME} \
+  -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
+$ oc scale deployment -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --replicas=0 \
+  kube-apiserver openshift-apiserver openshift-oauth-apiserver control-plane-operator
 ----
 +
 [source,terminal]
 ----
 $ PAUSED_UNTIL="true"
-$ oc patch -n ${HC_CLUSTER_NS} hostedclusters/${HC_CLUSTER_NAME} -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
-$ oc patch -n ${HC_CLUSTER_NS} nodepools/${NODEPOOLS} -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
-$ oc scale deployment -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --replicas=0 kube-apiserver openshift-apiserver openshift-oauth-apiserver control-plane-operator
+$ oc patch -n ${HC_CLUSTER_NS} hostedclusters/${HC_CLUSTER_NAME} \
+  -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
+$ oc patch -n ${HC_CLUSTER_NS} nodepools/${NODEPOOLS} \
+  -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
+$ oc scale deployment -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} --replicas=0 \
+  kube-apiserver openshift-apiserver openshift-oauth-apiserver control-plane-operator
 ----
 
 . Back up etcd and upload the data to an S3 bucket by running this bash script:
@@ -89,7 +95,8 @@ For more information about backing up etcd, see "Backing up and restoring etcd o
 +
 [source,terminal]
 ----
-$ mkdir -p ${BACKUP_DIR}/namespaces/${HC_CLUSTER_NS} ${BACKUP_DIR}/namespaces/${HC_CLUSTER_NS}-${HC_CLUSTER_NAME}
+$ mkdir -p ${BACKUP_DIR}/namespaces/${HC_CLUSTER_NS} \
+  ${BACKUP_DIR}/namespaces/${HC_CLUSTER_NS}-${HC_CLUSTER_NAME}
 $ chmod 700 ${BACKUP_DIR}/namespaces/
 
 # HostedCluster

--- a/modules/hcp-access-hc-aws-hcpcli.adoc
+++ b/modules/hcp-access-hc-aws-hcpcli.adoc
@@ -14,7 +14,8 @@ You can access the hosted cluster by using the `hcp` command-line interface (CLI
 +
 [source,terminal]
 ----
-$ hcp create kubeconfig --namespace <hosted_cluster_namespace> --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
+$ hcp create kubeconfig --namespace <hosted_cluster_namespace> \
+  --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
 ----
 
 . After you save the `kubeconfig` file, you can access the hosted cluster by entering the following command:

--- a/modules/hcp-access-priv-mgmt-aws.adoc
+++ b/modules/hcp-access-priv-mgmt-aws.adoc
@@ -14,7 +14,10 @@ You can access your private management cluster by using the command-line interfa
 +
 [source,terminal]
 ----
-$ aws ec2 describe-instances --filter="Name=tag:kubernetes.io/cluster/<infra_id>,Values=owned" | jq '.Reservations[] | .Instances[] | select(.PublicDnsName=="") | .PrivateIpAddress'
+$ aws ec2 describe-instances \
+  --filter="Name=tag:kubernetes.io/cluster/<infra_id>,Values=owned" \
+  | jq '.Reservations[] | .Instances[] | select(.PublicDnsName=="") \
+  | .PrivateIpAddress'
 ----
 
 . Create a `kubeconfig` file for the hosted cluster that you can copy to a node by entering the following command:
@@ -28,7 +31,8 @@ $ hcp create kubeconfig > <hosted_cluster_kubeconfig>
 +
 [source,terminal]
 ----
-$ ssh -o ProxyCommand="ssh ec2-user@<bastion_ip> -W %h:%p" core@<node_ip>
+$ ssh -o ProxyCommand="ssh ec2-user@<bastion_ip> \
+  -W %h:%p" core@<node_ip>
 ----
 
 . From the SSH shell, copy the `kubeconfig` file contents to a file on the node by entering the following command:

--- a/modules/hcp-access-pub-hc-aws-cli.adoc
+++ b/modules/hcp-access-pub-hc-aws-cli.adoc
@@ -14,7 +14,8 @@ You can access the hosted cluster by using the `hcp` command-line interface (CLI
 +
 [source,terminal]
 ----
-$ hcp create kubeconfig --namespace <hosted_cluster_namespace> --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
+$ hcp create kubeconfig --namespace <hosted_cluster_namespace> \
+  --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
 ----
 
 . After you save the `kubeconfig` file, access the hosted cluster by entering the following command:

--- a/modules/hcp-aws-create-dns-hosted-zone.adoc
+++ b/modules/hcp-aws-create-dns-hosted-zone.adoc
@@ -39,7 +39,9 @@ $ dig +short test.user-dest-public.aws.kerberos.com
 +
 [source,terminal]
 ----
-$ hcp create cluster aws --name=<hosted_cluster_name> --endpoint-access=PublicAndPrivate --external-dns-domain=<public_hosted_zone> ... <1>
+$ hcp create cluster aws --name=<hosted_cluster_name> \
+  --endpoint-access=PublicAndPrivate \
+  --external-dns-domain=<public_hosted_zone> ... <1>
 ----
 +
 <1> Replace `<public_hosted_zone>` with the public hosted zone that you created.

--- a/modules/hcp-aws-create-public-zone.adoc
+++ b/modules/hcp-aws-create-public-zone.adoc
@@ -14,7 +14,9 @@ To access applications in your hosted clusters, you must configure the routable 
 +
 [source,terminal]
 ----
-$ aws route53 create-hosted-zone --name <basedomain> --caller-reference $(whoami)-$(date --rfc-3339=date) <1>
+$ aws route53 create-hosted-zone \
+  --name <basedomain> \// <1>
+  --caller-reference $(whoami)-$(date --rfc-3339=date)
 ----
 +
 <1> Replace `<basedomain>` with your base domain, for example, `www.example.com`.

--- a/modules/hcp-aws-create-role-sts-creds.adoc
+++ b/modules/hcp-aws-create-role-sts-creds.adoc
@@ -49,9 +49,9 @@ Use this output as the value for `<arn>` in the next step.
 [source,terminal]
 ----
 $ aws iam create-role \
---role-name <name> \// <1>
---assume-role-policy-document file://<file_name>.json \// <2>
---query "Role.Arn"
+  --role-name <name> \// <1>
+  --assume-role-policy-document file://<file_name>.json \// <2>
+  --query "Role.Arn"
 ----
 <1> Replace `<name>` with the role name, for example, `hcp-cli-role`.
 <2> Replace `<file_name>` with the name of the JSON file you created in the previous step.
@@ -221,11 +221,11 @@ $ aws sts get-session-token --output json > sts-creds.json
 [source,json]
 ----
 {
-              "Credentials": {
-                  "AccessKeyId": "ASIA1443CE0GN2ATHWJU",
-                  "SecretAccessKey": "XFLN7cZ5AP0d66KhyI4gd8Mu0UCQEDN9cfelW1”,
-                  "SessionToken": "IQoJb3JpZ2luX2VjEEAaCXVzLWVhc3QtMiJHMEUCIDyipkM7oPKBHiGeI0pMnXst1gDLfs/TvfskXseKCbshAiEAnl1l/Html7Iq9AEIqf////KQburfkq4A3TuppHMr/9j1TgCj1z83SO261bHqlJUazKoy7vBFR/a6LHt55iMBqtKPEsIWjBgj/jSdRJI3j4Gyk1//luKDytcfF/tb9YrxDTPLrACS1lqAxSIFZ82I/jDhbDs=",
-                  "Expiration": "2025-05-16T04:19:32+00:00"
-              }
-          }
+    "Credentials": {
+        "AccessKeyId": "ASIA1443CE0GN2ATHWJU",
+        "SecretAccessKey": "XFLN7cZ5AP0d66KhyI4gd8Mu0UCQEDN9cfelW1”,
+        "SessionToken": "IQoJb3JpZ2luX2VjEEAaCXVzLWVhc3QtMiJHMEUCIDyipkM7oPKBHiGeI0pMnXst1gDLfs/TvfskXseKCbshAiEAnl1l/Html7Iq9AEIqf////KQburfkq4A3TuppHMr/9j1TgCj1z83SO261bHqlJUazKoy7vBFR/a6LHt55iMBqtKPEsIWjBgj/jSdRJI3j4Gyk1//luKDytcfF/tb9YrxDTPLrACS1lqAxSIFZ82I/jDhbDs=",
+        "Expiration": "2025-05-16T04:19:32+00:00"
+    }
+}
 ----

--- a/modules/hcp-aws-create-secret-s3.adoc
+++ b/modules/hcp-aws-create-secret-s3.adoc
@@ -48,7 +48,8 @@ $ echo '{
 +
 [source,terminal]
 ----
-$ aws s3api put-bucket-policy --bucket <bucket_name> --policy file://policy.json <1>
+$ aws s3api put-bucket-policy --bucket <bucket_name> \// <1>
+  --policy file://policy.json
 ----
 +
 <1> Replace `<bucket_name>` with the name of the S3 bucket you are creating.
@@ -83,7 +84,11 @@ If you are using a Mac computer, you must export the bucket name in order for th
 +
 [source,terminal]
 ----
-$ oc create secret generic <secret_name> --from-file=credentials=<path>/.aws/credentials --from-literal=bucket=<s3_bucket> --from-literal=region=<region> -n local-cluster
+$ oc create secret generic <secret_name> \
+  --from-file=credentials=<path>/.aws/credentials \
+  --from-literal=bucket=<s3_bucket> \
+  --from-literal=region=<region> \
+  -n local-cluster
 ----
 +
 [NOTE]
@@ -91,6 +96,7 @@ $ oc create secret generic <secret_name> --from-file=credentials=<path>/.aws/cre
 Disaster recovery backup for the secret is not automatically enabled. To add the label that enables the `hypershift-operator-oidc-provider-s3-credentials` secret to be backed up for disaster recovery, run the following command:
 [source,terminal]
 ----
-$ oc label secret hypershift-operator-oidc-provider-s3-credentials -n local-cluster cluster.open-cluster-management.io/backup=true
+$ oc label secret hypershift-operator-oidc-provider-s3-credentials \
+  -n local-cluster cluster.open-cluster-management.io/backup=true
 ----
 ====

--- a/modules/hcp-aws-enable-private-link.adoc
+++ b/modules/hcp-aws-enable-private-link.adoc
@@ -36,7 +36,10 @@ To create an {aws-short} secret, run the following command:
 
 [source,terminal]
 ----
-$ oc create secret generic <secret_name> --from-literal=aws-access-key-id=<aws_access_key_id> --from-literal=aws-secret-access-key=<aws_secret_access_key> --from-literal=region=<region> -n local-cluster
+$ oc create secret generic <secret_name> \
+  --from-literal=aws-access-key-id=<aws_access_key_id> \
+  --from-literal=aws-secret-access-key=<aws_secret_access_key> \
+  --from-literal=region=<region> -n local-cluster
 ----
 
 [NOTE]
@@ -44,6 +47,8 @@ $ oc create secret generic <secret_name> --from-literal=aws-access-key-id=<aws_a
 Disaster recovery backup for the secret is not automatically enabled. Run the following command to add the label that enables the `hypershift-operator-private-link-credentials` secret to be backed up for disaster recovery:
 [source,terminal]
 ----
-$ oc label secret hypershift-operator-private-link-credentials -n local-cluster cluster.open-cluster-management.io/backup=""
+$ oc label secret hypershift-operator-private-link-credentials \
+  -n local-cluster \
+  cluster.open-cluster-management.io/backup=""
 ----
 ====

--- a/modules/hcp-aws-set-up-ext-dns.adoc
+++ b/modules/hcp-aws-set-up-ext-dns.adoc
@@ -43,7 +43,10 @@ You can provision {hcp} with external DNS or service-level DNS.
 +
 [source,terminal]
 ----
-$ oc create secret generic <secret_name> --from-literal=provider=aws --from-literal=domain-filter=<domain_name> --from-file=credentials=<path_to_aws_credentials_file> -n local-cluster
+$ oc create secret generic <secret_name> \
+  --from-literal=provider=aws \
+  --from-literal=domain-filter=<domain_name> \
+  --from-file=credentials=<path_to_aws_credentials_file> -n local-cluster
 ----
 +
 [NOTE]
@@ -51,6 +54,8 @@ $ oc create secret generic <secret_name> --from-literal=provider=aws --from-lite
 Disaster recovery backup for the secret is not automatically enabled. To back up the secret for disaster recovery, add the `hypershift-operator-external-dns-credentials` by entering the following command:
 [source,terminal]
 ----
-$ oc label secret hypershift-operator-external-dns-credentials -n local-cluster cluster.open-cluster-management.io/backup=""
+$ oc label secret hypershift-operator-external-dns-credentials \
+  -n local-cluster \
+  cluster.open-cluster-management.io/backup=""
 ----
 ====

--- a/modules/hcp-bm-access.adoc
+++ b/modules/hcp-bm-access.adoc
@@ -35,7 +35,8 @@ The `kubeadmin` password secret is also Base64-encoded. You can decode it and us
 +
 [source,terminal]
 ----
-$ hcp create kubeconfig --namespace <hosted_cluster_namespace> --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
+$ hcp create kubeconfig --namespace <hosted_cluster_namespace> \
+  --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
 ----
 
 . After you save the `kubeconfig` file, you can access the hosted cluster by entering the following example command:

--- a/modules/hcp-bm-autoscale-disable.adoc
+++ b/modules/hcp-bm-autoscale-disable.adoc
@@ -15,7 +15,9 @@ To disable node auto-scaling, complete the following procedure.
 +
 [source,terminal]
 ----
-$ oc -n <hosted_cluster_namespace> patch nodepool <hosted_cluster_name> --type=json -p '[\{"op":"remove", "path": "/spec/autoScaling"}, \{"op": "add", "path": "/spec/replicas", "value": <specify_value_to_scale_replicas>]'
+$ oc -n <hosted_cluster_namespace> patch nodepool <hosted_cluster_name> \
+  --type=json \
+  -p '[\{"op":"remove", "path": "/spec/autoScaling"}, \{"op": "add", "path": "/spec/replicas", "value": <specify_value_to_scale_replicas>]'
 ----
 +
 The command removes `"spec.autoScaling"` from the YAML file, adds `"spec.replicas"`, and sets `"spec.replicas"` to the integer value that you specify.

--- a/modules/hcp-bm-autoscale.adoc
+++ b/modules/hcp-bm-autoscale.adoc
@@ -15,7 +15,9 @@ When you need more capacity in your hosted cluster and spare agents are availabl
 +
 [source,terminal]
 ----
-$ oc -n <hosted_cluster_namespace> patch nodepool <hosted_cluster_name> --type=json -p '[{"op": "remove", "path": "/spec/replicas"},{"op":"add", "path": "/spec/autoScaling", "value": { "max": 5, "min": 2 }}]'
+$ oc -n <hosted_cluster_namespace> patch nodepool <hosted_cluster_name> \
+  --type=json \
+  -p '[{"op": "remove", "path": "/spec/replicas"},{"op":"add", "path": "/spec/autoScaling", "value": { "max": 5, "min": 2 }}]'
 ----
 +
 [NOTE]
@@ -71,7 +73,9 @@ $ oc apply -f workload-config.yaml
 +
 [source,terminal]
 ----
-$ oc extract -n <hosted_cluster_namespace> secret/<hosted_cluster_name>-admin-kubeconfig --to=./hostedcluster-secrets --confirm
+$ oc extract -n <hosted_cluster_namespace> \
+  secret/<hosted_cluster_name>-admin-kubeconfig \
+  --to=./hostedcluster-secrets --confirm
 ----
 +
 .Example output
@@ -90,7 +94,8 @@ $ oc --kubeconfig ./hostedcluster-secrets get nodes
 +
 [source,terminal]
 ----
-$ oc --kubeconfig ./hostedcluster-secrets -n <namespace> delete deployment <deployment_name>
+$ oc --kubeconfig ./hostedcluster-secrets -n <namespace> \
+  delete deployment <deployment_name>
 ----
 
 . Wait for several minutes to pass without requiring the additional capacity. On the Agent platform, the agent is decommissioned and can be reused. You can confirm that the node was removed by entering the following command:

--- a/modules/hcp-bm-scale-np.adoc
+++ b/modules/hcp-bm-scale-np.adoc
@@ -51,7 +51,8 @@ da503cf1-a347-44f2-875c-4960ddb04091   hypercluster1   true       auto-assign
 +
 [source,terminal]
 ----
-$ oc -n <hosted_control_plane_namespace> get agent -o jsonpath='{range .items[*]}BMH: {@.metadata.labels.agent-install\.openshift\.io/bmh} Agent: {@.metadata.name} State: {@.status.debugInfo.state}{"\n"}{end}'
+$ oc -n <hosted_control_plane_namespace> get agent \
+  -o jsonpath='{range .items[*]}BMH: {@.metadata.labels.agent-install\.openshift\.io/bmh} Agent: {@.metadata.name} State: {@.status.debugInfo.state}{"\n"}{end}'
 ----
 +
 .Example output
@@ -66,7 +67,9 @@ BMH: ocp-worker-1 Agent: da503cf1-a347-44f2-875c-4960ddb04091 State: insufficien
 +
 [source,terminal]
 ----
-$ oc extract -n <hosted_cluster_namespace> secret/<hosted_cluster_name>-admin-kubeconfig --to=- > kubeconfig-<hosted_cluster_name>
+$ oc extract -n <hosted_cluster_namespace> \
+  secret/<hosted_cluster_name>-admin-kubeconfig --to=- \
+  > kubeconfig-<hosted_cluster_name>
 ----
 
 . After the agents reach the `added-to-existing-cluster` state, verify that you can see the {product-title} nodes in the hosted cluster by entering the following command:

--- a/modules/hcp-bm-verify.adoc
+++ b/modules/hcp-bm-verify.adoc
@@ -14,7 +14,8 @@ After the deployment process is complete, you can verify that the hosted cluster
 +
 [source,terminal]
 ----
-$ oc extract -n <hosted-control-plane-namespace> secret/admin-kubeconfig --to=- > kubeconfig-<hosted-cluster-name>
+$ oc extract -n <hosted-control-plane-namespace> secret/admin-kubeconfig \
+  --to=- > kubeconfig-<hosted-cluster-name>
 ----
 
 . Use the kubeconfig to view the cluster Operators of the hosted cluster. Enter the following command:

--- a/modules/hcp-cco-verify-aws-sts.adoc
+++ b/modules/hcp-cco-verify-aws-sts.adoc
@@ -19,7 +19,9 @@ You can verify that the Cloud Credential Operator (CCO) is running correctly in 
 +
 [source,terminal]
 ----
-$ oc get cloudcredentials <hosted_cluster_name> -n <hosted_cluster_namespace> -o=jsonpath={.spec.credentialsMode}
+$ oc get cloudcredentials <hosted_cluster_name> \
+  -n <hosted_cluster_namespace> \
+  -o=jsonpath={.spec.credentialsMode}
 ----
 +
 .Expected output
@@ -32,7 +34,8 @@ Manual
 +
 [source,terminal]
 ----
-$ oc get authentication cluster --kubeconfig <hosted_cluster_name>.kubeconfig -o jsonpath --template '{.spec.serviceAccountIssuer }'
+$ oc get authentication cluster --kubeconfig <hosted_cluster_name>.kubeconfig \
+  -o jsonpath --template '{.spec.serviceAccountIssuer }'
 ----
 +
 .Example output

--- a/modules/hcp-dc-addon.adoc
+++ b/modules/hcp-dc-addon.adoc
@@ -16,7 +16,8 @@ By default, no node placement preference is specified for the `hypershift-addon`
 +
 [source,terminal]
 ----
-$ oc edit addondeploymentconfig hypershift-addon-deploy-config -n multicluster-engine
+$ oc edit addondeploymentconfig hypershift-addon-deploy-config \
+  -n multicluster-engine
 ----
 
 . Add the `nodePlacement` field to the specification, as shown in the following example:

--- a/modules/hcp-dc-hypervisor.adoc
+++ b/modules/hcp-dc-hypervisor.adoc
@@ -14,7 +14,8 @@ The following information applies to virtual machine environments only.
 +
 [source,terminal]
 ----
-$ sudo dnf install dnsmasq radvd vim golang podman bind-utils net-tools httpd-tools tree htop strace tmux -y
+$ sudo dnf install dnsmasq radvd vim golang podman bind-utils \
+  net-tools httpd-tools tree htop strace tmux -y
 ----
 
 . Enable and start the Podman service by entering the following command:
@@ -89,7 +90,9 @@ if ! [[ `grep -q "$IP" /etc/resolv.conf` ]]; then
 export TMP_FILE=$(mktemp /etc/forcedns_resolv.conf.XXXXXX)
 cp $BASE_RESOLV_CONF $TMP_FILE
 chmod --reference=$BASE_RESOLV_CONF $TMP_FILE
-sed -i -e "s/dns.base.domain.name//" -e "s/search /& dns.base.domain.name /" -e "0,/nameserver/s/nameserver/& $IP\n&/" $TMP_FILE <2>
+sed -i -e "s/dns.base.domain.name//" \
+       -e "s/search /& dns.base.domain.name /" \
+       -e "0,/nameserver/s/nameserver/& $IP\n&/" $TMP_FILE <2>
 mv $TMP_FILE /etc/resolv.conf
 fi
 echo "ok"
@@ -147,7 +150,8 @@ If you are working in a production environment, you must establish proper rules 
 +
 [source,terminal]
 ----
-$ sed -i s/^SELINUX=.*$/SELINUX=permissive/ /etc/selinux/config; setenforce 0
+$ sed -i s/^SELINUX=.*$/SELINUX=permissive/ /etc/selinux/config; \
+  setenforce 0
 ----
 
 * For `firewalld`, enter the following command:

--- a/modules/hcp-dc-image-mirror.adoc
+++ b/modules/hcp-dc-image-mirror.adoc
@@ -73,7 +73,8 @@ mirror:
 +
 [source,terminal]
 ----
-$ oc-mirror --v2 --config imagesetconfig.yaml  --workspace file://mirror-file docker://<registry>
+$ oc-mirror --v2 --config imagesetconfig.yaml \
+  --workspace file://mirror-file docker://<registry>
 ----
 +
 After the mirroring process is finished, you have a new folder named `mirror-file`, which contains the `ImageDigestMirrorSet` (IDMS), `ImageTagMirrorSet` (ITMS), and the catalog sources to apply on the hosted cluster.
@@ -99,7 +100,8 @@ mirror:
 +
 [source,terminal]
 ----
-$ oc mirror -c imagesetconfig.yaml --workspace file://<file_path> docker://<mirror_registry_url> --v2
+$ oc mirror -c imagesetconfig.yaml \
+  --workspace file://<file_path> docker://<mirror_registry_url> --v2
 ----
 +
 For more information, see "Mirroring an image set in a partially disconnected environment".
@@ -119,7 +121,8 @@ For more information, see "Mirroring an image set in a fully disconnected enviro
 +
 [source,terminal]
 ----
-$ oc mirror -c imagesetconfig.yaml --from file://<file_path> docker://<mirror_registry_url> --v2
+$ oc mirror -c imagesetconfig.yaml \
+  --from file://<file_path> docker://<mirror_registry_url> --v2
 ----
 
 . Mirror the latest {mce-short} images by following the steps in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#install-on-disconnected-networks[Install on disconnected networks].

--- a/modules/hcp-dc-mgmt-cluster.adoc
+++ b/modules/hcp-dc-mgmt-cluster.adoc
@@ -14,7 +14,8 @@ To set up an {product-title} management cluster, you can use dev-scripts, or if 
 +
 [source,terminal]
 ----
-$ kcli create network -c 192.168.126.0/24 -P dhcp=false -P dns=false -d 2620:52:0:1306::0/64 --domain dns.base.domain.name --nodhcp dual
+$ kcli create network -c 192.168.126.0/24 -P dhcp=false -P dns=false \
+  -d 2620:52:0:1306::0/64 --domain dns.base.domain.name --nodhcp dual
 ----
 +
 where:

--- a/modules/hcp-dc-scale-np.adoc
+++ b/modules/hcp-dc-scale-np.adoc
@@ -14,7 +14,8 @@ After you create the bare metal hosts, their statuses change from `Registering` 
 +
 [source,terminal]
 ----
-$ oc -n <hosted_cluster_namespace> scale nodepool <hosted_cluster_name> --replicas 3
+$ oc -n <hosted_cluster_namespace> scale nodepool <hosted_cluster_name> \
+  --replicas 3
 ----
 +
 where:

--- a/modules/hcp-dc-verify.adoc
+++ b/modules/hcp-dc-verify.adoc
@@ -14,7 +14,8 @@ The hosted control plane feature is enabled by default.
 +
 [source,terminal]
 ----
-$ oc patch mce <multiclusterengine> --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": true}]}}}'
+$ oc patch mce <multiclusterengine> --type=merge -p \
+  '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": true}]}}}'
 ----
 +
 When you enable the feature, the `hypershift-addon` managed cluster add-on is installed in the `local-cluster` managed cluster, and the add-on agent installs the HyperShift Operator on the {mce-short} hub cluster.
@@ -36,12 +37,14 @@ hypershift-addon   True        False
 +
 [source,terminal]
 ----
-$ oc wait --for=condition=Degraded=True managedclusteraddons/hypershift-addon -n local-cluster --timeout=5m
+$ oc wait --for=condition=Degraded=True managedclusteraddons/hypershift-addon \
+  -n local-cluster --timeout=5m
 ----
 +
 [source,terminal]
 ----
-$ oc wait --for=condition=Available=True managedclusteraddons/hypershift-addon -n local-cluster --timeout=5m
+$ oc wait --for=condition=Available=True managedclusteraddons/hypershift-addon \
+  -n local-cluster --timeout=5m
 ----
 +
 When the process is complete, the `hypershift-addon` managed cluster add-on and the HyperShift Operator are installed, and the `local-cluster` managed cluster is available to host and manage hosted clusters.

--- a/modules/hcp-dc-web-server.adoc
+++ b/modules/hcp-dc-web-server.adoc
@@ -16,7 +16,8 @@ To configure the web server, complete the following steps:
 +
 [source,terminal]
 ----
-$ oc adm -a ${LOCAL_SECRET_JSON} release extract --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}"
+$ oc adm -a ${LOCAL_SECRET_JSON} release extract --command=openshift-install \
+  "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}"
 ----
 
 . Run the following script. The script creates a folder in the `/opt/srv` directory. The folder contains the {op-system} images to provision the worker nodes.

--- a/modules/hcp-disable-feature.adoc
+++ b/modules/hcp-disable-feature.adoc
@@ -17,7 +17,8 @@ To disable the {hcp} feature, complete the following steps.
 +
 [source,terminal]
 ----
-$ oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": false}]}}}' <1>
+$ oc patch mce multiclusterengine --type=merge -p \// <1>
+  '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": false}]}}}'
 ----
 +
 <1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.

--- a/modules/hcp-disable-metrics.adoc
+++ b/modules/hcp-disable-metrics.adoc
@@ -23,7 +23,8 @@ $ oc login
 +
 [source,terminal]
 ----
-$ oc edit addondeploymentconfig hypershift-addon-deploy-config -n multicluster-engine
+$ oc edit addondeploymentconfig hypershift-addon-deploy-config \
+  -n multicluster-engine
 ----
 
 . Add the `disableMetrics=true` customized variable to the specification, as shown in the following example:

--- a/modules/hcp-dr-oadp-backup-cp-workload.adoc
+++ b/modules/hcp-dr-oadp-backup-cp-workload.adoc
@@ -155,7 +155,8 @@ $ oc apply -f backup-control-plane.yaml
 +
 [source,terminal]
 ----
-$ oc get backups.velero.io <backup_resource_name> -n openshift-adp -o jsonpath='{.status.phase}'
+$ oc get backups.velero.io <backup_resource_name> -n openshift-adp \
+  -o jsonpath='{.status.phase}'
 ----
 
 .Next steps

--- a/modules/hcp-dr-oadp-restore.adoc
+++ b/modules/hcp-dr-oadp-restore.adoc
@@ -81,7 +81,8 @@ $ oc apply -f restore-hosted-cluster.yaml
 +
 [source,terminal]
 ----
-$ oc get hostedcluster <hosted_cluster_name> -n <hosted_cluster_namespace> -o jsonpath='{.status.phase}'
+$ oc get hostedcluster <hosted_cluster_name> -n <hosted_cluster_namespace> \
+  -o jsonpath='{.status.phase}'
 ----
 
 . After the restore process is complete, start the reconciliation of the `HostedCluster` and `NodePool` resources that you paused during backing up of the control plane workload:
@@ -92,7 +93,8 @@ $ oc get hostedcluster <hosted_cluster_name> -n <hosted_cluster_namespace> -o js
 ----
 $ oc --kubeconfig <management_cluster_kubeconfig_file> \
   patch hostedcluster -n <hosted_cluster_namespace> <hosted_cluster_name> \
-  --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "false"}]'
+  --type json \
+  -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "false"}]'
 ----
 
 .. Start the reconciliation of the `NodePool` resource by running the following command:
@@ -101,7 +103,8 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
 ----
 $ oc --kubeconfig <management_cluster_kubeconfig_file> \
   patch nodepool -n <hosted_cluster_namespace> <node_pool_name> \
-  --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "false"}]'
+  --type json \
+  -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "false"}]'
 ----
 
 . Start the reconciliation of the Agent provider resources that you paused during backing up of the control plane workload:

--- a/modules/hcp-enable-manual.adoc
+++ b/modules/hcp-enable-manual.adoc
@@ -13,7 +13,8 @@ If you need to manually enable {hcp}, complete the following steps.
 +
 [source,terminal]
 ----
-$ oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": true}]}}}' <1>
+$ oc patch mce multiclusterengine --type=merge -p \
+  '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": true}]}}}' <1>
 ----
 <1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
 

--- a/modules/hcp-hc-objects.adoc
+++ b/modules/hcp-hc-objects.adoc
@@ -196,7 +196,9 @@ status:
 +
 [source,terminal]
 ----
-$ oc adm release info registry.<dns.base.domain.name>:5000/openshift-release-dev/ocp-release:<4.x.y>-x86_64 | grep hypershift
+$ oc adm release info \
+  registry.<dns.base.domain.name>:5000/openshift-release-dev/ocp-release:<4.x.y>-x86_64 \
+  | grep hypershift
 ----
 +
 where `<dns.base.domain.name>` is the DNS base domain name and `<4.x.y>` is the supported {product-title} version you want to use.

--- a/modules/hcp-ibm-power-infraenv.adoc
+++ b/modules/hcp-ibm-power-infraenv.adoc
@@ -45,5 +45,6 @@ $ oc apply -f infraenv-config.yaml
 +
 [source,terminal]
 ----
-$ oc -n <hosted_control_plane_namespace> get InfraEnv <hosted_cluster_name> -o json
+$ oc -n <hosted_control_plane_namespace> get InfraEnv <hosted_cluster_name> \
+  -o json
 ----

--- a/modules/hcp-ibm-power-scale-np.adoc
+++ b/modules/hcp-ibm-power-scale-np.adoc
@@ -30,7 +30,8 @@ The Cluster API agent provider randomly picks two agents that are then assigned 
 +
 [source,terminal]
 ----
-$ oc -n <hosted_control_plane_namespace> get agent -o jsonpath='{range .items[*]}BMH: {@.metadata.labels.agent-install\.openshift\.io/bmh} Agent: {@.metadata.name} State: {@.status.debugInfo.state}{"\n"}{end}'
+$ oc -n <hosted_control_plane_namespace> get agent \
+  -o jsonpath='{range .items[*]}BMH: {@.metadata.labels.agent-install\.openshift\.io/bmh} Agent: {@.metadata.name} State: {@.status.debugInfo.state}{"\n"}{end}'
 ----
 +
 .Example output
@@ -60,7 +61,8 @@ da503cf1-a347-44f2-875c-4960ddb04091   hosted-forwarder   true           auto-as
 +
 [source,terminal]
 ----
-$ hcp create kubeconfig --namespace <hosted_cluster_namespace> --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
+$ hcp create kubeconfig --namespace <hosted_cluster_namespace> \
+  --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
 ----
 
 . After the agents reach the `added-to-existing-cluster` state, verify that you can see the {product-title} nodes by entering the following command:

--- a/modules/hcp-ibm-z-adding-credentials-registry.adoc
+++ b/modules/hcp-ibm-z-adding-credentials-registry.adoc
@@ -41,7 +41,9 @@ spec:
 +
 [source,terminal]
 ----
-$ oc get secret/pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > authfile
+$ oc get secret/pull-secret -n openshift-config -o json \
+  | jq -r '.data.".dockerconfigjson"' \
+  | base64 -d > authfile
 ----
 .. Edit the fetched secret JSON file to include a section with the credentials of the certificate authority:
 +
@@ -61,5 +63,6 @@ $ oc get secret/pull-secret -n openshift-config -o json | jq -r '.data.".dockerc
 +
 [source,terminal]
 ----
-$ oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=authfile
+$ oc set data secret/pull-secret -n openshift-config \
+  --from-file=.dockerconfigjson=authfile
 ----

--- a/modules/hcp-ibm-z-scale-np.adoc
+++ b/modules/hcp-ibm-z-scale-np.adoc
@@ -66,7 +66,9 @@ da503cf1-a347-44f2-875c-4960ddb04091   hosted-forwarder   true          auto-ass
 +
 [source,terminal]
 ----
-$ hcp create kubeconfig --namespace <clusters_namespace> --name <hosted_cluster_namespace> > <hosted_cluster_name>.kubeconfig
+$ hcp create kubeconfig \
+  --namespace <clusters_namespace> \
+  --name <hosted_cluster_namespace> > <hosted_cluster_name>.kubeconfig
 ----
 
 . After the agents reach the `added-to-existing-cluster` state, verify that you can see the {product-title} nodes by entering the following command:

--- a/modules/hcp-import-disable.adoc
+++ b/modules/hcp-import-disable.adoc
@@ -25,7 +25,8 @@ To disable the automatic import of hosted clusters, complete the following steps
 +
 [source,terminal]
 ----
-$ oc edit addondeploymentconfig hypershift-addon-deploy-config -n multicluster-engine
+$ oc edit addondeploymentconfig hypershift-addon-deploy-config \
+  -n multicluster-engine
 ----
 
 . In the `spec.customizedVariables` section, add the `autoImportDisabled` variable with value of `"true"`, as shown in the following example:

--- a/modules/hcp-migrate-aws-multiarch-nodepools.adoc
+++ b/modules/hcp-migrate-aws-multiarch-nodepools.adoc
@@ -15,10 +15,10 @@ After transitioning your hosted cluster from single-architecture to multi-archit
 [source,terminal]
 ----
 $ hcp create nodepool aws \
---cluster-name <hosted_cluster_name> \// <1>
---name <nodepool_name> \// <2>
---node-count=<node_count> \// <3>
---arch arm64
+  --cluster-name <hosted_cluster_name> \// <1>
+  --name <nodepool_name> \// <2>
+  --node-count=<node_count> \// <3>
+  --arch arm64
 ----
 <1> Replace `<hosted_cluster_name>` with your hosted cluster name.
 <2> Replace `<nodepool_name>` with your node pool name.
@@ -29,10 +29,10 @@ $ hcp create nodepool aws \
 [source,terminal]
 ----
 $ hcp create nodepool aws \
---cluster-name <hosted_cluster_name> \// <1>
---name <nodepool_name> \// <2>
---node-count=<node_count> \// <3>
---arch amd64
+  --cluster-name <hosted_cluster_name> \// <1>
+  --name <nodepool_name> \// <2>
+  --node-count=<node_count> \// <3>
+  --arch amd64
 ----
 <1> Replace `<hosted_cluster_name>` with your hosted cluster name.
 <2> Replace `<nodepool_name>` with your node pool name.

--- a/modules/hcp-migrate-aws-single-to-multiarch.adoc
+++ b/modules/hcp-migrate-aws-single-to-multiarch.adoc
@@ -28,7 +28,8 @@ A single-architecture hosted cluster can manage node pools of only one particula
 +
 [source,terminal]
 ----
-$ oc get hostedcluster/<hosted_cluster_name> -o jsonpath='{.spec.release.image}' <1>
+$ oc get hostedcluster/<hosted_cluster_name> \// <1>
+  -o jsonpath='{.spec.release.image}'
 ----
 +
 <1> Replace `<hosted_cluster_name>` with your hosted cluster name.
@@ -46,14 +47,17 @@ quay.io/openshift-release-dev/ocp-release:<4.y.z>-x86_64 <1>
 +
 [source,terminal]
 ----
-$ OCP_VERSION=$(oc image info quay.io/openshift-release-dev/ocp-release@sha256:ac78ebf77f95ab8ff52847ecd22592b545415e1ff6c7ff7f66bf81f158ae4f5e -o jsonpath='{.config.config.Labels["io.openshift.release"]}')
+$ OCP_VERSION=$(oc image info quay.io/openshift-release-dev/ocp-release@sha256:ac78ebf77f95ab8ff52847ecd22592b545415e1ff6c7ff7f66bf81f158ae4f5e \
+  -o jsonpath='{.config.config.Labels["io.openshift.release"]}')
 ----
 
 .. Set the `MULTI_ARCH_TAG` environment variable for the multi-architecture tag version of your release image by running the following command:
 +
 [source,terminal]
 ----
-$ MULTI_ARCH_TAG=$(skopeo inspect docker://quay.io/openshift-release-dev/ocp-release@sha256:ac78ebf77f95ab8ff52847ecd22592b545415e1ff6c7ff7f66bf81f158ae4f5e | jq -r '.RepoTags' | sed 's/"//g' | sed 's/,//g' | grep -w "$OCP_VERSION-multi$" | xargs)
+$ MULTI_ARCH_TAG=$(skopeo inspect docker://quay.io/openshift-release-dev/ocp-release@sha256:ac78ebf77f95ab8ff52847ecd22592b545415e1ff6c7ff7f66bf81f158ae4f5e \
+  | jq -r '.RepoTags' | sed 's/"//g' | sed 's/,//g' \
+  | grep -w "$OCP_VERSION-multi$" | xargs)
 ----
 
 .. Set the `IMAGE` environment variable for the multi-architecture release image name by running the following command:
@@ -86,7 +90,9 @@ linux/arm64   sha256:7b046404572ac96202d82b6cb029b421dddd40e88c73bbf35f602ffc130
 +
 [source,terminal]
 ----
-$ oc patch -n clusters hostedclusters/<hosted_cluster_name> -p '{"spec":{"release":{"image":"quay.io/openshift-release-dev/ocp-release:<4.x.y>-multi"}}}' --type=merge <1>
+$ oc patch -n clusters hostedclusters/<hosted_cluster_name> -p \
+  '{"spec":{"release":{"image":"quay.io/openshift-release-dev/ocp-release:<4.x.y>-multi"}}}' \// <1>
+  --type=merge
 ----
 <1> Replace `<4.y.z>` with the supported {product-title} version that you use.
 
@@ -94,7 +100,8 @@ $ oc patch -n clusters hostedclusters/<hosted_cluster_name> -p '{"spec":{"releas
 +
 [source,terminal]
 ----
-$ oc get hostedcluster/<hosted_cluster_name> -o jsonpath='{.spec.release.image}'
+$ oc get hostedcluster/<hosted_cluster_name> \
+  -o jsonpath='{.spec.release.image}'
 ----
 
 . Check that the status of the `HostedControlPlane` resource is `Progressing` by running the following command:
@@ -121,7 +128,8 @@ $ oc get hostedcontrolplane -n <hosted_control_plane_namespace> -oyaml
 +
 [source,terminal]
 ----
-$ oc get hostedcluster <hosted_cluster_name> -n <hosted_cluster_namespace> -oyaml
+$ oc get hostedcluster <hosted_cluster_name> \
+  -n <hosted_cluster_namespace> -oyaml
 ----
 
 .Verification

--- a/modules/hcp-monitor-cp.adoc
+++ b/modules/hcp-monitor-cp.adoc
@@ -26,5 +26,11 @@ $ export KUBECONFIG=/root/.kcli/clusters/hub-ipv4/auth/kubeconfig
 +
 [source,terminal]
 ----
-$ watch "oc get pod -n hypershift;echo;echo;oc get pod -n clusters-hosted-ipv4;echo;echo;oc get bmh -A;echo;echo;oc get agent -A;echo;echo;oc get infraenv -A;echo;echo;oc get hostedcluster -A;echo;echo;oc get nodepool -A;echo;echo;"
+$ watch "oc get pod -n hypershift;echo;echo;\
+  oc get pod -n clusters-hosted-ipv4;echo;echo;\
+  oc get bmh -A;echo;echo;\
+  oc get agent -A;echo;echo;\
+  oc get infraenv -A;echo;echo;\
+  oc get hostedcluster -A;echo;echo;\
+  oc get nodepool -A;echo;echo;"
 ----

--- a/modules/hcp-monitor-dp.adoc
+++ b/modules/hcp-monitor-dp.adoc
@@ -17,7 +17,8 @@ While the deployment proceeds, you can monitor the data plane by gathering infor
 * Enter the following commands:
 +
 ----
-$ oc get secret -n clusters-hosted-ipv4 admin-kubeconfig -o jsonpath='{.data.kubeconfig}' |base64 -d > /root/hc_admin_kubeconfig.yaml
+$ oc get secret -n clusters-hosted-ipv4 admin-kubeconfig \
+  -o jsonpath='{.data.kubeconfig}' | base64 -d > /root/hc_admin_kubeconfig.yaml
 ----
 +
 ----

--- a/modules/hcp-non-bm-verify.adoc
+++ b/modules/hcp-non-bm-verify.adoc
@@ -14,7 +14,9 @@ After the deployment process is complete, you can verify that the hosted cluster
 +
 [source,terminal]
 ----
-$ oc extract -n <hosted_cluster_namespace> secret/<hosted_cluster_name>-admin-kubeconfig --to=- > kubeconfig-<hosted_cluster_name>
+$ oc extract -n <hosted_cluster_namespace> \
+  secret/<hosted_cluster_name>-admin-kubeconfig --to=- \
+  > kubeconfig-<hosted_cluster_name>
 ----
 
 . Use the `kubeconfig` file to view the cluster Operators of the hosted cluster. Enter the following command:

--- a/modules/hcp-override.adoc
+++ b/modules/hcp-override.adoc
@@ -38,7 +38,8 @@ data:
 +
 [source,terminal]
 ----
-$ oc delete deployment hypershift-addon-agent -n open-cluster-management-agent-addon
+$ oc delete deployment hypershift-addon-agent \
+  -n open-cluster-management-agent-addon
 ----
 
 .Verification

--- a/modules/hcp-ts-load-balancer-svcs.adoc
+++ b/modules/hcp-ts-load-balancer-svcs.adoc
@@ -16,5 +16,6 @@ If a hosted control plane is not coming fully online because the load balancer s
 +
 [source,terminal]
 ----
-$ oc get pods -n <hosted_control_plane_namespace> -l app=cloud-controller-manager
+$ oc get pods -n <hosted_control_plane_namespace> \
+  -l app=cloud-controller-manager
 ----

--- a/modules/hcp-ts-pvcs-not-avail.adoc
+++ b/modules/hcp-ts-pvcs-not-avail.adoc
@@ -16,7 +16,8 @@ If a hosted control plane is not coming fully online because the persistent volu
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-cluster-csi-drivers -o wide -l app=kubevirt-csi-driver
+$ oc get pods -n openshift-cluster-csi-drivers -o wide \
+  -l app=kubevirt-csi-driver
 ----
 
 * If a PVC cannot bind to a persistent volume (PV), view the logs of the kubevirt-csi-controller component within the hosted control plane namespace. To identify the kubevirt-csi-controller pod within the hosted control plane namespace, enter the following command:

--- a/modules/hcp-ts-rhcos.adoc
+++ b/modules/hcp-ts-rhcos.adoc
@@ -16,7 +16,8 @@ To resolve this issue, manually mirror the {op-system} image to the internal reg
 +
 [source,terminal]
 ----
-$ oc get imagecontentsourcepolicy -o json | jq -r '.items[].spec.repositoryDigestMirrors[0].mirrors[0]'
+$ oc get imagecontentsourcepolicy -o json \
+  | jq -r '.items[].spec.repositoryDigestMirrors[0].mirrors[0]'
 ----
 
 . Get a payload image by running the following command:
@@ -30,14 +31,17 @@ $ oc get clusterversion version -ojsonpath='{.status.desired.image}'
 +
 [source,terminal]
 ----
-$ oc image extract --file /release-manifests/0000_50_installer_coreos-bootimages.yaml <payload_image> --confirm
+$ oc image extract \
+  --file /release-manifests/0000_50_installer_coreos-bootimages.yaml \
+  <payload_image> --confirm
 ----
 
 . Get the {op-system} image by running the following command:
 +
 [source,terminal]
 ----
-$ cat 0000_50_installer_coreos-bootimages.yaml | yq -r .data.stream | jq -r '.architectures.x86_64.images.kubevirt."digest-ref"'
+$ cat 0000_50_installer_coreos-bootimages.yaml | yq -r .data.stream \
+  | jq -r '.architectures.x86_64.images.kubevirt."digest-ref"'
 ----
 
 . Mirror the {op-system} image to your internal registry. Replace `<rhcos_image>` with your {op-system} image; for example, `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d9643ead36b1c026be664c9c65c11433c6cdf71bfd93ba229141d134a4a6dd94`. Replace `<internal_registry>` with the name of your internal registry; for example, `virthost.ostest.test.metalkube.org:5000/localimages/ocp-v4.0-art-dev`. Run the following command:

--- a/modules/hcp-uninstall-operator.adoc
+++ b/modules/hcp-uninstall-operator.adoc
@@ -25,7 +25,8 @@ If a hosted cluster is running, the HyperShift Operator does not uninstall, even
 +
 [source,terminal]
 ----
-$ oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-local-hosting","enabled": false}]}}}' <1>
+$ oc patch mce multiclusterengine --type=merge -p \// <1>
+  '{"spec":{"overrides":{"components":[{"name":"hypershift-local-hosting","enabled": false}]}}}'
 ----
 +
 <1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.

--- a/modules/hcp-update-node-pools.adoc
+++ b/modules/hcp-update-node-pools.adoc
@@ -16,7 +16,9 @@ The `.spec.release` field in the `NodePool` custom resource (CR) shows the versi
 +
 [source,terminal]
 ----
-$ oc patch nodepool <node_pool_name> -n <hosted_cluster_namespace> --type=merge -p '{"spec":{"nodeDrainTimeout":"60s","release":{"image":"<openshift_release_image>"}}}' <1> <2>
+$ oc patch nodepool <node_pool_name> -n <hosted_cluster_namespace> \// <1>
+  --type=merge \
+  -p '{"spec":{"nodeDrainTimeout":"60s","release":{"image":"<openshift_release_image>"}}}' <2>
 ----
 +
 <1> Replace `<node_pool_name>` and `<hosted_cluster_namespace>` with your node pool name and hosted cluster namespace, respectively.

--- a/modules/hcp-update-ocp-hc.adoc
+++ b/modules/hcp-update-ocp-hc.adoc
@@ -26,7 +26,10 @@ You can set the `.spec.release` field in the `HostedCluster` CR to update the co
 +
 [source,terminal]
 ----
-$ oc annotate hostedcluster -n <hosted_cluster_namespace> <hosted_cluster_name> "hypershift.openshift.io/force-upgrade-to=<openshift_release_image>" --overwrite <1> <2>
+$ oc annotate hostedcluster \
+  -n <hosted_cluster_namespace> <hosted_cluster_name> \// <1>
+  "hypershift.openshift.io/force-upgrade-to=<openshift_release_image>" \// <2>
+  --overwrite
 ----
 +
 <1> Replace `<hosted_cluster_name>` and `<hosted_cluster_namespace>` with your hosted cluster name and hosted cluster namespace, respectively.
@@ -37,7 +40,9 @@ $ oc annotate hostedcluster -n <hosted_cluster_namespace> <hosted_cluster_name> 
 +
 [source,terminal]
 ----
-$ oc patch hostedcluster <hosted_cluster_name> -n <hosted_cluster_namespace> --type=merge -p '{"spec":{"release":{"image":"<openshift_release_image>"}}}'
+$ oc patch hostedcluster <hosted_cluster_name> -n <hosted_cluster_namespace> \
+  --type=merge \
+  -p '{"spec":{"release":{"image":"<openshift_release_image>"}}}'
 ----
 
 
@@ -47,7 +52,8 @@ $ oc patch hostedcluster <hosted_cluster_name> -n <hosted_cluster_namespace> --t
 +
 [source,terminal]
 ----
-$ oc get -n <hosted_cluster_namespace> hostedcluster <hosted_cluster_name> -o yaml
+$ oc get -n <hosted_cluster_namespace> hostedcluster <hosted_cluster_name> \
+  -o yaml
 ----
 +
 .Example output

--- a/modules/hcp-virt-access.adoc
+++ b/modules/hcp-virt-access.adoc
@@ -34,7 +34,8 @@ The `kubeadmin` password secret is also Base64-encoded. You can decode it and us
 +
 [source,terminal]
 ----
-$ hcp create kubeconfig --namespace <hosted_cluster_namespace> --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
+$ hcp create kubeconfig --namespace <hosted_cluster_namespace> \
+  --name <hosted_cluster_name> > <hosted_cluster_name>.kubeconfig
 ----
 
 . After you save the `kubeconfig` file, you can access the hosted cluster by entering the following example command:

--- a/modules/hcp-virt-hc-base-domain.adoc
+++ b/modules/hcp-virt-hc-base-domain.adoc
@@ -50,7 +50,8 @@ example                   example-admin-kubeconfig         Partial    True      
 +
 [source,terminal]
 ----
-$ hcp create kubeconfig --name <hosted_cluster_name> > <hosted_cluster_name>-kubeconfig
+$ hcp create kubeconfig --name <hosted_cluster_name> \
+  > <hosted_cluster_name>-kubeconfig
 ----
 +
 [source,terminal]

--- a/modules/hcp-virt-ingress-dns.adoc
+++ b/modules/hcp-virt-ingress-dns.adoc
@@ -30,7 +30,9 @@ For the default ingress DNS to work properly, the cluster that hosts the KubeVir
 +
 [source,terminal]
 ----
-$ oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
+$ oc patch ingresscontroller -n openshift-ingress-operator default \
+  --type=json \
+  -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
 ----
 
 [NOTE]

--- a/modules/hcp-virt-load-balancer.adoc
+++ b/modules/hcp-virt-load-balancer.adoc
@@ -16,7 +16,9 @@ Set up the load balancer service that routes ingress traffic to the KubeVirt VMs
 +
 [source,terminal]
 ----
-$ oc --kubeconfig <hosted_cluster_name>-kubeconfig get services -n openshift-ingress router-nodeport-default -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}'
+$ oc --kubeconfig <hosted_cluster_name>-kubeconfig get services \
+  -n openshift-ingress router-nodeport-default \
+  -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}'
 ----
 +
 Note the HTTP node port value to use in the next step.
@@ -25,7 +27,9 @@ Note the HTTP node port value to use in the next step.
 +
 [source,terminal]
 ----
-$ oc --kubeconfig <hosted_cluster_name>-kubeconfig get services -n openshift-ingress router-nodeport-default -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}'
+$ oc --kubeconfig <hosted_cluster_name>-kubeconfig get services \
+  -n openshift-ingress router-nodeport-default \
+  -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}'
 ----
 +
 Note the HTTPS node port value to use in the next step.

--- a/modules/hcp-virt-prereqs.adoc
+++ b/modules/hcp-virt-prereqs.adoc
@@ -13,7 +13,9 @@ You must meet the following prerequisites to create an {product-title} cluster o
 +
 [source,terminal]
 ----
-$ oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
+$ oc patch ingresscontroller -n openshift-ingress-operator default \
+  --type=json \
+  -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
 ----
 * The {product-title} management cluster has {VirtProductName}, version 4.14 or later, installed on it. For more information, see "Installing OpenShift Virtualization using the web console".
 * The {product-title} management cluster is on-premise bare metal.
@@ -22,7 +24,8 @@ $ oc patch ingresscontroller -n openshift-ingress-operator default --type=json -
 +
 [source,terminal]
 ----
-$ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+$ oc patch storageclass ocs-storagecluster-ceph-rbd \
+  -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ----
 
 * You have a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see "Install OpenShift on any x86_64 platform with user-provisioned infrastructure".

--- a/modules/hcp-virt-scale-nodepool.adoc
+++ b/modules/hcp-virt-scale-nodepool.adoc
@@ -17,7 +17,8 @@ You can manually scale a node pool by using the `oc scale` command.
 NODEPOOL_NAME=${CLUSTER_NAME}-work
 NODEPOOL_REPLICAS=5
 
-$ oc scale nodepool/$NODEPOOL_NAME --namespace clusters --replicas=$NODEPOOL_REPLICAS
+$ oc scale nodepool/$NODEPOOL_NAME --namespace clusters \
+  --replicas=$NODEPOOL_REPLICAS
 ----
 
 . After a few moments, enter the following command to see the status of the node pool:

--- a/modules/hcp-virt-verify-hc.adoc
+++ b/modules/hcp-virt-verify-hc.adoc
@@ -28,7 +28,8 @@ clusters    example   4.12.2    example-admin-kubeconfig   Completed   True     
 +
 [source,terminal]
 ----
-$ hcp create kubeconfig --name <hosted_cluster_name> > <hosted_cluster_name>-kubeconfig
+$ hcp create kubeconfig --name <hosted_cluster_name> \
+  > <hosted_cluster_name>-kubeconfig
 ----
 +
 [source,terminal]

--- a/modules/hcp-virt-wildcard-dns.adoc
+++ b/modules/hcp-virt-wildcard-dns.adoc
@@ -14,7 +14,8 @@ Set up a wildcard DNS record or CNAME that references the external IP of the loa
 +
 [source,terminal]
 ----
-$ oc -n clusters-<hosted_cluster_name> get service <hosted-cluster-name>-apps -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+$ oc -n clusters-<hosted_cluster_name> get service <hosted-cluster-name>-apps \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
 ----
 +
 .Example output

--- a/modules/hosted-cluster-etcd-backup-restore-on-premise.adoc
+++ b/modules/hosted-cluster-etcd-backup-restore-on-premise.adoc
@@ -42,7 +42,8 @@ $ CONTROL_PLANE_NAMESPACE="${HOSTED_CLUSTER_NAMESPACE}-${CLUSTER_NAME}"
 +
 [source,terminal]
 ----
-$ oc patch -n ${HOSTED_CLUSTER_NAMESPACE} hostedclusters/${CLUSTER_NAME} -p '{"spec":{"pausedUntil":"true"}}' --type=merge
+$ oc patch -n ${HOSTED_CLUSTER_NAMESPACE} hostedclusters/${CLUSTER_NAME} \
+  -p '{"spec":{"pausedUntil":"true"}}' --type=merge
 ----
 
 . Next, take a snapshot of etcd by using one of the following methods:
@@ -66,26 +67,30 @@ $ ETCD_POD=etcd-0
 +
 [source,terminal]
 ----
-$ oc exec -n ${CONTROL_PLANE_NAMESPACE} -c etcd -t ${ETCD_POD} -- env ETCDCTL_API=3 /usr/bin/etcdctl \
---cacert /etc/etcd/tls/etcd-ca/ca.crt \
---cert /etc/etcd/tls/client/etcd-client.crt \
---key /etc/etcd/tls/client/etcd-client.key \
---endpoints=https://localhost:2379 \
-snapshot save /var/lib/snapshot.db
+$ oc exec -n ${CONTROL_PLANE_NAMESPACE} -c etcd -t ${ETCD_POD} -- \
+  env ETCDCTL_API=3 /usr/bin/etcdctl \
+  --cacert /etc/etcd/tls/etcd-ca/ca.crt \
+  --cert /etc/etcd/tls/client/etcd-client.crt \
+  --key /etc/etcd/tls/client/etcd-client.key \
+  --endpoints=https://localhost:2379 \
+  snapshot save /var/lib/snapshot.db
 ----
 
 ... Verify that the snapshot is successful by entering the following command:
 +
 [source,terminal]
 ----
-$ oc exec -n ${CONTROL_PLANE_NAMESPACE} -c etcd -t ${ETCD_POD} -- env ETCDCTL_API=3 /usr/bin/etcdctl -w table snapshot status /var/lib/snapshot.db
+$ oc exec -n ${CONTROL_PLANE_NAMESPACE} -c etcd -t ${ETCD_POD} -- \
+  env ETCDCTL_API=3 /usr/bin/etcdctl -w table snapshot status \
+  /var/lib/snapshot.db
 ----
 
 .. Make a local copy of the snapshot by entering the following command:
 +
 [source,terminal]
 ----
-$ oc cp -c etcd ${CONTROL_PLANE_NAMESPACE}/${ETCD_POD}:/var/lib/snapshot.db /tmp/etcd.snapshot.db
+$ oc cp -c etcd ${CONTROL_PLANE_NAMESPACE}/${ETCD_POD}:/var/lib/snapshot.db \
+  /tmp/etcd.snapshot.db
 ----
 
 ... Make a copy of the snapshot database from etcd persistent storage:
@@ -101,7 +106,9 @@ $ oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd
 +
 [source,terminal]
 ----
-$ oc cp -c etcd ${CONTROL_PLANE_NAMESPACE}/${ETCD_POD}:/var/lib/data/member/snap/db /tmp/etcd.snapshot.db
+$ oc cp -c etcd \
+  ${CONTROL_PLANE_NAMESPACE}/${ETCD_POD}:/var/lib/data/member/snap/db \
+  /tmp/etcd.snapshot.db
 ----
 
 . Next, scale down the etcd statefulset by entering the following command:
@@ -124,7 +131,8 @@ $ oc delete -n ${CONTROL_PLANE_NAMESPACE} pvc/data-etcd-1 pvc/data-etcd-2
 +
 [source,terminal]
 ----
-$ ETCD_IMAGE=$(oc get -n ${CONTROL_PLANE_NAMESPACE} statefulset/etcd -o jsonpath='{ .spec.template.spec.containers[0].image }')
+$ ETCD_IMAGE=$(oc get -n ${CONTROL_PLANE_NAMESPACE} statefulset/etcd \
+  -o jsonpath='{ .spec.template.spec.containers[0].image }')
 ----
 +
 ... Create a pod that allows access to etcd data:
@@ -178,14 +186,16 @@ $ oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd-data
 +
 [source,terminal]
 ----
-$ DATA_POD=$(oc get -n ${CONTROL_PLANE_NAMESPACE} pods --no-headers -l app=etcd-data -o name | cut -d/ -f2)
+$ DATA_POD=$(oc get -n ${CONTROL_PLANE_NAMESPACE} pods --no-headers \
+  -l app=etcd-data -o name | cut -d/ -f2)
 ----
 
 .. Copy an etcd snapshot into the pod by entering the following command:
 +
 [source,terminal]
 ----
-$ oc cp /tmp/etcd.snapshot.db ${CONTROL_PLANE_NAMESPACE}/${DATA_POD}:/var/lib/restored.snap.db
+$ oc cp /tmp/etcd.snapshot.db \
+  ${CONTROL_PLANE_NAMESPACE}/${DATA_POD}:/var/lib/restored.snap.db
 ----
 
 .. Remove old data from the `etcd-data` pod by entering the following commands:
@@ -204,7 +214,8 @@ $ oc exec -n ${CONTROL_PLANE_NAMESPACE} ${DATA_POD} -- mkdir -p /var/lib/data
 +
 [source,terminal]
 ----
-$ oc exec -n ${CONTROL_PLANE_NAMESPACE} ${DATA_POD} -- etcdutl snapshot restore /var/lib/restored.snap.db \
+$ oc exec -n ${CONTROL_PLANE_NAMESPACE} ${DATA_POD} -- \
+     etcdutl snapshot restore /var/lib/restored.snap.db \
      --data-dir=/var/lib/data --skip-hash-check \
      --name etcd-0 \
      --initial-cluster-token=etcd-cluster \
@@ -216,7 +227,8 @@ $ oc exec -n ${CONTROL_PLANE_NAMESPACE} ${DATA_POD} -- etcdutl snapshot restore 
 +
 [source,terminal]
 ----
-$ oc exec -n ${CONTROL_PLANE_NAMESPACE} ${DATA_POD} -- rm /var/lib/restored.snap.db
+$ oc exec -n ${CONTROL_PLANE_NAMESPACE} ${DATA_POD} -- \
+  rm /var/lib/restored.snap.db
 ----
 
 .. Delete data access deployment by entering the following command:
@@ -244,5 +256,6 @@ $ oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd -w
 +
 [source,terminal]
 ----
-$ oc patch -n ${HOSTED_CLUSTER_NAMESPACE} hostedclusters/${CLUSTER_NAME} -p '{"spec":{"pausedUntil":"null"}}' --type=merge
+$ oc patch -n ${HOSTED_CLUSTER_NAMESPACE} hostedclusters/${CLUSTER_NAME} \
+  -p '{"spec":{"pausedUntil":"null"}}' --type=merge
 ----

--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -40,7 +40,9 @@ endif::image-pull-secrets[]
 +
 [source,terminal]
 ----
-$ oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' ><pull_secret_location> <1>
+$ oc get secret/pull-secret -n openshift-config \
+  --template='{{index .data ".dockerconfigjson" | base64decode}}' \
+  ><pull_secret_location> <1>
 ----
 <1> Provide the path to the pull secret file.
 
@@ -62,7 +64,8 @@ Alternatively, you can perform a manual update to the pull secret file.
 +
 [source,terminal]
 ----
-$ oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=<pull_secret_location> <1>
+$ oc set data secret/pull-secret -n openshift-config \
+  --from-file=.dockerconfigjson=<pull_secret_location> <1>
 ----
 <1> Provide the path to the new pull secret file.
 +

--- a/modules/insights-operator-new-pull-secret-enable.adoc
+++ b/modules/insights-operator-new-pull-secret-enable.adoc
@@ -36,7 +36,9 @@ The file `pull-secret.txt` containing your `cloud.openshift.com` access token in
 +
 [source,terminal]
 ----
-$ oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > pull-secret
+$ oc get secret/pull-secret -n openshift-config \
+  --template='{{index .data ".dockerconfigjson" | base64decode}}' \
+  > pull-secret
 ----
 . Make a backup copy of your pull secret.
 +
@@ -51,7 +53,8 @@ $ cp pull-secret pull-secret-backup
 +
 [source,terminal]
 ----
-oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=pull-secret
+$ oc set data secret/pull-secret -n openshift-config \
+  --from-file=.dockerconfigjson=pull-secret
 ----
 
 It may take several minutes for the secret to update and your cluster to begin reporting.

--- a/modules/node-tuning-hosted-cluster.adoc
+++ b/modules/node-tuning-hosted-cluster.adoc
@@ -85,7 +85,8 @@ Now that you have created the `ConfigMap` object that contains a `Tuned` manifes
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" get tuned.tuned.openshift.io -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="$HC_KUBECONFIG" get tuned.tuned.openshift.io \
+  -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output
@@ -101,7 +102,8 @@ tuned-1    65s
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" get profile.tuned.openshift.io -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="$HC_KUBECONFIG" get profile.tuned.openshift.io \
+  -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output
@@ -121,7 +123,8 @@ If no custom profiles are created, the `openshift-node` profile is applied by de
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" debug node/nodepool-1-worker-1 -- chroot /host sysctl vm.dirty_ratio
+$ oc --kubeconfig="$HC_KUBECONFIG" \
+  debug node/nodepool-1-worker-1 -- chroot /host sysctl vm.dirty_ratio
 ----
 +
 .Example output

--- a/modules/scale-down-data-plane.adoc
+++ b/modules/scale-down-data-plane.adoc
@@ -72,7 +72,8 @@ To allow the node draining process to continue for a certain period of time, you
 +
 [source,terminal]
 ----
-$ oc scale nodepool/<nodepool_name> --namespace <hosted_cluster_namespace> --replicas=0
+$ oc scale nodepool/<nodepool_name> --namespace <hosted_cluster_namespace> \
+  --replicas=0
 ----
 +
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
Break long command-line prompts in Hosted Control Plane docs into multiple lines so that
the commands are visible without scrolling.

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-53162
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
