### PR TITLE
OCSDOCS13655: isn't it should be machine config nodes instead image config nodes?

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -731,8 +731,8 @@ For more information, see xref:../installing/installing_with_agent_based_install
 Updated boot images has been promoted to GA for Amazon Web Services (AWS) clusters. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
 
 [id="ocp-release-notes-machine-config-operator-imageconfignodes_{context}"]
-==== Expanded image config nodes information (Technology Preview)
-The image config nodes custom resource, that you can use to monitor the progress of machine configuration updates to nodes, now presents more information on the update. The output of the `oc get machineconfignodes` command now reports on the following and other conditions. You can use these statuses to follow the update, or troubleshoot the node if it experiences an error during the update:
+==== Expanded machine config nodes information (Technology Preview)
+The machine config nodes custom resource, which you can use to monitor the progress of machine configuration updates to nodes, now presents more information on the update. The output of the `oc get machineconfignodes` command now reports on the following and other conditions. You can use these statuses to follow the update, or troubleshoot the node if it experiences an error during the update:
 
 * If each node was cordoned and uncordoned
 * If each node was drained


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13665

Preview:
[OCP 4.18 release notes](https://90338--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes). As of 9:05 AM EDT on 3/17, the preview is not rendering correctly. Please search on _machine config nodes_ to see the updated text in place.