### PR TITLE
[Docs] ROX-28553: Update ACS redirects and version selector for RHACS 4.7 release

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -141,13 +141,13 @@ AddType text/vtt                            vtt
     # ACS Redirects to go to the latest version - change here when a new version drops
     # it should probably be best to combine the next few lines in one reg exp but for clarity keeping them separate
     # the first one redirects
-    RewriteRule ^acs/?$ /acs/4.6/welcome/index.html [R=301]
+    RewriteRule ^acs/?$ /acs/4.7/welcome/index.html [R=301]
     # redirect to the latest release notes
-    RewriteRule ^acs/release_notes/?$ /acs/4.6/release_notes/46-release-notes.html [R=301,NE]
+    RewriteRule ^acs/release_notes/?$ /acs/4.7/release_notes/47-release-notes.html [R=301,NE]
     # redirect from ACS CLoud Service page
-    RewriteRule ^acs/installing/install-ocp-operator.html /acs/4.6/installing/installing_ocp/init-bundle-ocp.html [NE,R=301]
-    RewriteRule ^acs/(\D.*)$ /acs/4.6/$1 [NE,R=301]
-    RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73|3\.74|4\.0|4\.1|4\.2|4\.3|4\.4|4\.5|4\.6)/?$ /acs/$1/welcome/index.html [L,R=301]
+    RewriteRule ^acs/installing/install-ocp-operator.html /acs/4.7/installing/installing_ocp/init-bundle-ocp.html [NE,R=301]
+    RewriteRule ^acs/(\D.*)$ /acs/4.7/$1 [NE,R=301]
+    RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73|3\.74|4\.0|4\.1|4\.2|4\.3|4\.4|4\.5|4\.6|4\.7)/?$ /acs/$1/welcome/index.html [L,R=301]
     #redirect for 4.0 Manage vulneribility page
     RewriteRule ^(acs/(?:4\.0/)?)?operating/manage-vulnerabilities\.html$ /acs/4.0/operating/manage-vulnerabilities/vulnerability-management.html [NE,R=301]
     #redirect for missing 4.3 page

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -325,6 +325,9 @@ openshift-acs:
     rhacs-docs-4.6:
       name: '4.6'
       dir: acs/4.6
+    rhacs-docs-4.7:
+      name: '4.7'
+      dir: acs/4.7
 microshift:
   name: Red Hat build of MicroShift
   author: OpenShift Documentation Project <openshift-docs@redhat.com>

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -260,6 +260,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="4.7">4.7</option>
               <option value="4.6">4.6</option>
               <option value="4.5">4.5</option>
               <option value="4.4">4.4</option>

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -251,6 +251,7 @@
               <div class="btn-group">
                 <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select version<span class="caret"></span></button>
                 <ul class="dropdown-menu" role="menu">
+                  <li><a href="acs/4.7/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 4.7</a></li>
                   <li><a href="acs/4.6/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 4.6</a></li>
                   <li><a href="acs/4.5/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 4.5</a></li>
                   <li><a href="acs/4.4/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 4.4</a></li>


### PR DESCRIPTION
Version(s):
4.7

For https://issues.redhat.com/browse/ROX-28553

Based on: https://github.com/openshift/openshift-docs/pull/73215