### PR TITLE
ROX-28197: Add plugin link for Backstage

### DIFF
--- a/modules/viewing-security-information-in-red-hat-developer-hub.adoc
+++ b/modules/viewing-security-information-in-red-hat-developer-hub.adoc
@@ -8,6 +8,8 @@
 
 By configuring and integrating the {rh-rhacs-first} plugin with {rh-rhdh-first}, you can access vulnerability data, assess risks, and take proactive security actions without leaving the {rh-rhdh} environment.
 
+Review the upstream plugin progress and details by visiting link:https://github.com/backstage/community-plugins[Community plugins for Backstage].
+
 .Prerequisites
 
 * You have enabled the {product-title-short} plugin installation in {rh-rhdh}.


### PR DESCRIPTION
Version(s): 4.7

[Issue](https://issues.redhat.com/browse/ROX-28197)

Link to docs preview:
https://90357--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/configuring-and-integrating-the-rhacs-plugin-with-red-hat-developer-hub.html#viewing-security-information-in-red-hat-developer-hub_configuring-and-integrating-the-rhacs-plugin-with-red-hat-developer-hub

QE review: **ACS has no QE, approved by SME**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Note to reviewers: Links to upstream repos are accepted in ACS.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
