### PR TITLE
Wrong namespace in 'RHCOS image layering' section when copying the entitled secret

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -101,7 +101,7 @@ RUN dnf install -y libreswan && \
     ostree container commit
 ----
 +
-Because libreswan requires additional {op-system-base} packages, the image must be built on an entitled {op-system-base} host. For RHEL entitlements to work, you must copy the `etc-pki-entitlement` secret into the `openshift-machine-api` namespace. 
+Because libreswan requires additional {op-system-base} packages, the image must be built on an entitled {op-system-base} host. For RHEL entitlements to work, you must copy the `etc-pki-entitlement` secret into the `openshift-machine-config-operator` namespace. 
 
 * *Third-party packages*. You can download and install RPMs from third-party organizations, such as the following types of packages:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-37531

Preview
[Example containerFiles](https://90358--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html) -- Switched  _`openshift-machine-api` namespace_ to  _`openshift-machine-config-operator` namespace_. Because of the flawed preview, please search for _you must copy the `etc-pki-entitlement` secret into the `openshift-machine-config-operator` namespace_ to see the updated docs. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

