### PR TITLE
OCPBUGS#48080: Updates to a dynamic plugin api example

### DIFF
--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -249,7 +249,7 @@ A component that creates a Navigation bar for a page. Routing is handled as part
 ----
 const HomePage: React.FC = (props) => {
     const page = {
-      href: '/home',
+      href: 'home',
       name: 'Home',
       component: () => <>Home</>
     }


### PR DESCRIPTION
OCPBUGS#48080: Updates to a dynamic plugin api example

The value in the `href` field should start with a `/`, but in practice adding slashes in the `href` fields causes issues with the urls. 

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OCPBUGS-48080

Link to docs preview:
https://90372--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/dynamic-plugins-reference.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
