### PR TITLE
OLS-1522: Add LLM credentials for rhelai and rhoai

### DIFF
--- a/modules/ols-creating-the-credentials-secret-using-cli.adoc
+++ b/modules/ols-creating-the-credentials-secret-using-cli.adoc
@@ -6,7 +6,7 @@
 [id="ols-creating-the-credentials-secret-using-cli_{context}"]
 = Creating the credentials secret by using the CLI
 
-Create a file that is associated with the API token used to access the API of your LLM provider. Typically, you use API tokens to authenticate your LLM provider. Alternatively, {azure-official} also supports authentication using {entra-id}.
+Create a file that is associated with the API token used to access the API of your large language model (LLM) provider. Typically, you use API tokens to authenticate your LLM provider. Alternatively, {azure-official} also supports authentication using {entra-id}.
 
 .Prerequisites
 
@@ -16,7 +16,7 @@ Create a file that is associated with the API token used to access the API of yo
 
 .Procedure 
 
-. Create a file that contains the following YAML content:
+. Create a YAML file that contains the content for the LLM provider that you are using.
 +
 [NOTE]
 ====
@@ -33,16 +33,42 @@ metadata:
   namespace: openshift-lightspeed
 type: Opaque
 stringData:
-  apitoken: <your_api_token> <1>
+  apitoken: <api_token> <1>
 ----
 <1> The `apitoken` is not `base64` encoded.
++
+.Credential secret for {rhelai}
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: v1
+data:
+  apitoken: <api_token>
+kind: Secret
+metadata:
+  name: rhelai-api-keys
+  namespace: openshift-lightspeed
+type: Opaque
+----
++
+.Credential secret for {rhoai}
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: v1
+data:
+  apitoken: <api_token>
+kind: Secret
+metadata:
+  name: rhoai-api-keys
+  namespace: openshift-lightspeed
+type: Opaque
+----
 +
 .Credential secret for {watsonx}
 [source,yaml,subs="attributes,verbatim"]
 ----
 apiVersion: v1
 data:
-  apitoken: <your_api_token> 
+  apitoken: <api_token> 
 kind: Secret
 metadata:
   name: watsonx-api-keys
@@ -55,7 +81,7 @@ type: Opaque
 ----
 apiVersion: v1
 data:
-  apitoken: <your_api_token> 
+  apitoken: <api_token> 
 kind: Secret
 metadata:
   name: azure-api-keys

--- a/modules/ols-creating-the-credentials-secret-using-web-console.adoc
+++ b/modules/ols-creating-the-credentials-secret-using-web-console.adoc
@@ -6,7 +6,7 @@
 [id="ols-creating-the-credentials-secret-using-web-console_{context}"]
 = Creating the credentials secret by using the web console
 
-Create a file that is associated with the API token used to access the API of your LLM provider. Typically, you use API tokens to authenticate your LLM provider. Alternatively, {azure-official} also supports authentication using {entra-id}.
+Create a file that is associated with the API token used to access the API of your large language model (LLM) provider. Typically, you use API tokens to authenticate your LLM provider. Alternatively, {azure-official} also supports authentication using {entra-id}.
 
 .Prerequisites
 
@@ -18,7 +18,7 @@ Create a file that is associated with the API token used to access the API of yo
 
 . Click *Add* in the upper-right corner of the {ocp-short-name} web console.
 
-. Paste the following YAML content into the text area:
+. Paste the YAML content for the LLM provider that you are using into the text area of the web console.
 +
 [NOTE]
 ====
@@ -35,16 +35,42 @@ metadata:
   namespace: openshift-lightspeed
 type: Opaque
 stringData:
-  apitoken: <your_api_token> <1>
+  apitoken: <api_token> <1>
 ----
 <1> The `apitoken` is not `base64` encoded.
++
+.Credential secret for {rhelai}
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: v1
+data:
+  apitoken: <api_token>
+kind: Secret
+metadata:
+  name: rhelai-api-keys
+  namespace: openshift-lightspeed
+type: Opaque
+----
++
+.Credential secret for {rhoai}
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: v1
+data:
+  apitoken: <api_token>
+kind: Secret
+metadata:
+  name: rhoai-api-keys
+  namespace: openshift-lightspeed
+type: Opaque
+----
 +
 .Credential secret for {watsonx}
 [source,yaml, subs="attributes,verbatim"]
 ----
 apiVersion: v1
 data:
-  apitoken: <your_api_token>
+  apitoken: <api_token>
 kind: Secret
 metadata:
   name: watsonx-api-keys
@@ -57,7 +83,7 @@ type: Opaque
 ----
 apiVersion: v1
 data:
-  apitoken: <your_api_token> 
+  apitoken: <api_token> 
 kind: Secret
 metadata:
   name: azure-api-keys


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1522

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
