### PR TITLE
OSDOCS#13646: Update the z-stream RN for 4.18.5

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2995,6 +2995,42 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.5
+[id="ocp-4-18-5_{context}"]
+=== RHSA-2025:2705 - {product-title} {product-version}.5 bug fix update and security update
+
+Issued: 18 March 2025
+
+{product-title} release {product-version}.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:2705[RHSA-2025:2705] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:2707[RHBA-2025:2707] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.5 --pullspecs
+----
+
+[id="ocp-4-18-5-bug-fixes_{context}"]
+==== Bug fixes
+
+ * Previously, during cluster creation, Machine API (MAPI) started and managed machines in an installer-provisioned infrastructure (IPI) deployed cluster on {ibm-cloud-title}. MAPI detected an unhealthy control plane node and flagged it for deletion, which destroyed the cluster. With this release, during cluster creation, all control plane nodes are restored. (link:https://issues.redhat.com/browse/OCPBUGS-52173[*OCPBUGS-52173*])
+
+ * Previously, the `managed-trust-bundle` volume mount and  'trusted-ca-bundle` config map were introduced as mandatory components. This requirement caused deployment failures for users who used their own public key infrastructure (PKI). The {product-title} API server expected the `trust-ca-bundle-managed` config map. With this release, these components are optional, allowing clusters to  deploy successfully without the `trusted-ca-bundle-managed` config map when the custom PKI is in use. (link:https://issues.redhat.com/browse/OCPBUGS-52516[*OCPBUGS-52516*])
+
+ * Previously, etcd compaction blocked the process when it took more than 10 ms to process a batch. With this release, the issue is fixed and the etcd compaction proceeds as expected. (link:https://issues.redhat.com/browse/OCPBUGS-51971[*OCPBUGS-51971*])
+
+ * Previously, Ampere ARM-based CPUs used a different CPU vendor identification identifier than other ARMs. The platform tuning matched the vendor identification and did not identify machines with ARM-based CPUs. With this release, the ARM detection is changed to use the architecture field, and machines with Ampere CPUs are properly tuned. (link:https://issues.redhat.com/browse/OCPBUGS-52484[*OCPBUGS-52484*])
+
+ * Previously, when you ran the `openshift-install agent create pxe-files` command, it created a temporary directory. This directory was not removed when the command completed. With this release, the temporary directory is removed when the command is entered. (link:https://issues.redhat.com/browse/OCPBUGS-52429[*OCPBUGS-52429*])
+
+ * Previously, the performance slowed down when `oc-mirror` started to use the Operator Lifecycle Manager (OLM) login to filter the catalog. With this release, this condition is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-52350[*OCPBUGS-52350*])
+
+[id="ocp-4-18-5-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.4
 [id="ocp-4-18-4_{context}"]
 === RHSA-2025:2449 - {product-title} {product-version}.4 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13646](https://issues.redhat.com//browse/OSDOCS-13646)

Link to docs preview:
[4.18.5](https://90410--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes#ocp-4-18-5_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for stream relnotes.

Additional information:
The errata URLs will return 404 until the go-live date of 3/18/25.