### PR TITLE
Minor correction to ROSA activation tutorial.

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
@@ -24,7 +24,7 @@ If you have received a private offer for the product, make sure to proceed accor
 
 == Prerequisites
 
-* Make sure to log in to the Red{nbsp}Hat account that you plan to associate with the AWS account where you have activated {hcp-title} in previous steps.
+* Log in to the Red{nbsp}Hat account that you want to associate with the AWS account that will activate the {hcp-title} product subscription.
 * The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to ROSA and used for account linking and billing.
 * All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {hcp-title} clusters.
 
@@ -87,7 +87,7 @@ Your AWS account must be linked to a single Red{nbsp}Hat organization.
 image::rosa-login-rh-account-7.png[]
 +
 * You can also register for a new Red{nbsp}Hat account or reset your password on this page.
-* Make sure to log in to the Red{nbsp}Hat account that you plan to associate with the AWS account where you have activated {hcp-title} in previous steps.
+* Log in to the Red{nbsp}Hat account that you want to associate with the AWS account that has activated the {hcp-title} product subscription.
 * The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to ROSA and used for account linking and billing.
 * All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {hcp-title} clusters.
 


### PR DESCRIPTION
Minor correction, clarifies meaning without changing it.

Version(s): 4.18+

Issue: N/A

Link to docs preview:
- https://90412--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.html - two instances in the same document, one as a prereq and one as a reminder during the procedure

QE review: N/A