### PR TITLE
Updating the note for windows must-gather prerequisites [OCPBUGS-53231]

### DIFF
--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -41,7 +41,8 @@ $ oc adm must-gather -- /usr/bin/gather_audit_logs
 +
 [NOTE]
 ====
-Audit logs are not collected as part of the default set of information to reduce the size of the files.
+. Audit logs are not collected as part of the default set of information to reduce the size of the files.
+. In Windows, the cwRsync client should be installed and added to the PATH for use with the oc rsync command.
 ====
 
 When you run `oc adm must-gather`, a new pod with a random name is created in a new project on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local` in the current working directory.

--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -42,7 +42,7 @@ $ oc adm must-gather -- /usr/bin/gather_audit_logs
 [NOTE]
 ====
 . Audit logs are not collected as part of the default set of information to reduce the size of the files.
-. In Windows, the cwRsync client should be installed and added to the PATH for use with the oc rsync command.
+* On a Windows operating system, install the `cwRsync` client and add to the `PATH`  variable for use with the `oc rsync` command.
 ====
 
 When you run `oc adm must-gather`, a new pod with a random name is created in a new project on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local` in the current working directory.


### PR DESCRIPTION
Updating the note for windows must-gather prerequisites

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-53231

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://90413--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/gathering-cluster-data.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
