### PR TITLE
TELCODOCS#2104: Support for resourceInjectorMatchCondition feature

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -108,8 +108,7 @@ include::snippets/technology-preview.adoc[]
 [id="about-network-resource-injector_{context}"]
 == About the Network Resources Injector
 
-The Network Resources Injector is a Kubernetes Dynamic Admission Controller
-application. It provides the following capabilities:
+The Network Resources Injector is a Kubernetes Dynamic Admission Controller application, which provides the following capabilities:
 
 * Mutation of resource requests and limits in a pod specification to add an SR-IOV resource name according to an SR-IOV network attachment definition annotation.
 * Mutation of a pod specification with a Downward API volume to expose pod annotations, labels, and huge pages requests and limits. Containers that run in the pod can access the exposed information as files under the `/etc/podnetinfo` path.
@@ -128,6 +127,29 @@ NAME                                      READY   STATUS    RESTARTS   AGE
 network-resources-injector-5cz5p          1/1     Running   0          10m
 network-resources-injector-dwqpx          1/1     Running   0          10m
 network-resources-injector-lktz5          1/1     Running   0          10m
+----
+
+By default, the `failurePolicy` field in the Network Resources Injector webhook is set to `Ignore`. This default setting prevents pod creation from being blocked if the webhook is unavailable.
+
+If you set the `failurePolicy` field to `Fail`, and the Network Resources Injector webhook is unavailable, the webhook attempts to mutate all pod creation and update requests. This behavior can block pod creation and disrupt normal cluster operations. To prevent such issues, you can enable the `featureGates.resourceInjectorMatchCondition` feature in the `SriovOperatorConfig` object to limit the scope of the Network Resources Injector webhook. If this feature is enabled, the webhook applies only to pods with the secondary network annotation `k8s.v1.cni.cncf.io/networks`.
+
+If you set the `failurePolicy` field to `Fail` after enabling the `resourceInjectorMatchCondition` feature, the webhook applies only to pods with the secondary network annotation `k8s.v1.cni.cncf.io/networks`. If the webhook is unavailable, pods without this annotation are still deployed, preventing unnecessary disruptions to cluster operations.
+
+The `featureGates.resourceInjectorMatchCondition` feature is disabled by default. To enable this feature, set the `featureGates.resourceInjectorMatchCondition` field to `true` in the `SriovOperatorConfig` object.
+
+.Example `SriovOperatorConfig` object configuration
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: sriov-network-operator
+spec:
+# ...
+  featureGates:
+    resourceInjectorMatchCondition: true
+# ...
 ----
 
 [id="disable-enable-network-resource-injector_{context}"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2104](https://issues.redhat.com/browse/TELCODOCS-2104)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [About the Network Resources Injector](https://90414--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.html#about-network-resource-injector_configuring-sriov-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->