### PR TITLE
OCPBUGS#41250: Fixed indent issue for globallyDisableIrqLoadBalancing

### DIFF
--- a/modules/installation-openstack-ovs-dpdk-performance-profile.adoc
+++ b/modules/installation-openstack-ovs-dpdk-performance-profile.adoc
@@ -39,9 +39,9 @@ spec:
         size: 1G
   nodeSelector:
     node-role.kubernetes.io/worker: ''
+  globallyDisableIrqLoadBalancing: true
   realTimeKernel:
     enabled: false
-    globallyDisableIrqLoadBalancing: true
 ----
 
 Insert values that are appropriate for your configuration for the `CPU_ISOLATED`, `CPU_RESERVED`, and `HUGEPAGES_COUNT` keys.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-41250](https://issues.redhat.com/browse/OCPBUGS-41250)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
-  [Performance profile template for clusters that use OVS-DPDK on OpenStack](https://90426--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html#cnf-create-performance-profiles-reference)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->