### PR TITLE
OSDOCS-13683:Added life cycle policy section to OSD docs

### DIFF
--- a/modules/osd-lifecycle-policy.adoc
+++ b/modules/osd-lifecycle-policy.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+// * upgrading/osd-upgrades.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="osd-lifecycle-policy_{context}"]
+= Life cycle policies and planning
+
+To plan an upgrade, review the _{product-title} update life cycle_ guide in the "Additional resources" section. The life cycle page includes release definitions, support and upgrade requirements, installation policy information, and life cycle dates.
+
+You can use update channels to decide which Red Hat OpenShift Container Platform minor version to update your clusters to. {product-title} supports updates only through the `stable` channel. To learn more about OpenShift update channels and releases, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/understanding-openshift-updates-1#understanding-update-channels-releases[Understanding update channels and releases].
+
+
+

--- a/upgrading/osd-upgrades.adoc
+++ b/upgrading/osd-upgrades.adoc
@@ -11,6 +11,12 @@ You can schedule automatic or manual upgrade policies to update the version of y
 
 Red Hat Site Reliability Engineers (SREs) monitor upgrade progress and remedy any issues encountered.
 
+include::modules/osd-lifecycle-policy.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* For more information about the {product-title} life cycle policy, see xref:../osd_architecture/osd_policy/osd-life-cycle.adoc#osd-life-cycle_life-cycle-overview[{product-title} update life cycle].
+
 include::modules/upgrade.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
This PR adds information on the OSD lifecycle to the OSD Upgrading docs.

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13683

Link to docs preview:
https://90427--ocpdocs-pr.netlify.app/openshift-dedicated/latest/upgrading/osd-upgrades.html

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
QE approval is not required.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
