### PR TITLE
OBSDOCS-1719: Remove a line that was added through cherry-picking

### DIFF
--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
@@ -69,7 +69,6 @@ can use the following measures to control the impact of unbound metrics attribut
 
 * Limit the number of samples that can be accepted per target scrape in user-defined projects
 * Limit the number of scraped labels, the length of label names, and the length of label values
-* Configure the intervals between consecutive scrapes and between Prometheus rule evaluations
 * Create alerts that fire when a scrape sample threshold is reached or when the target cannot be scraped
 
 [NOTE]

--- a/observability/monitoring/troubleshooting-monitoring-issues.adoc
+++ b/observability/monitoring/troubleshooting-monitoring-issues.adoc
@@ -37,7 +37,7 @@ include::modules/monitoring-determining-why-prometheus-is-consuming-disk-space.a
 .Additional resources
 ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../observability/monitoring/accessing-metrics/accessing-monitoring-apis-by-using-the-cli.adoc#accessing-monitoring-apis-by-using-the-cli[Accessing monitoring APIs by using the CLI]
-* xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc#setting-scrape-sample-and-label-limits-for-user-defined-projects_configuring-performance-and-scalability-uwm[Setting scrape intervals, evaluation intervals, and enforced limits for user-defined projects]
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc#setting-scrape-sample-and-label-limits-for-user-defined-projects_configuring-performance-and-scalability-uwm[Setting scrape sample and label limits for user-defined projects]
 endif::openshift-dedicated,openshift-rosa[]
 
 ifdef::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): enterprise-4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1719
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* https://90431--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.html#controlling-the-impact-of-unbound-attributes-in-user-defined-projects_configuring-performance-and-scalability-uwm
* https://90431--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/troubleshooting-monitoring-issues.html#determining-why-prometheus-is-consuming-disk-space_troubleshooting-monitoring-issues

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Removing the line that has not raised rebasing issues during manual cherry-picking and was therefore missed. It needs to be removed from 4.17. ALso repairing the link name that was also missed during manual cherry-picking. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
