### PR TITLE
OBSDOCS-1777: Fix logging docs build in OCP main

### DIFF
--- a/observability/logging/cluster-logging-support.adoc
+++ b/observability/logging/cluster-logging-support.adoc
@@ -29,44 +29,44 @@ The following table describes the supported {logging-uc} APIs.
 .Loki API support states
 [cols="3",options="header"]
 |===
-|CustomResourceDefinition (CRD)
-|ApiVersion
+|Custom resource definition (CRD)
+|`ApiVersion`
 |Support state
 
-|LokiStack
-|lokistack.loki.grafana.com/v1
+|`LokiStack`
+|`lokistack.loki.grafana.com/v1`
 |Supported from 5.5
 
-|RulerConfig
-|rulerconfig.loki.grafana/v1
+|`RulerConfig`
+|`rulerconfig.loki.grafana/v1`
 |Supported from 5.7
 
-|AlertingRule
-|alertingrule.loki.grafana/v1
+|`AlertingRule`
+|`alertingrule.loki.grafana/v1`
 |Supported from 5.7
 
-|RecordingRule
-|recordingrule.loki.grafana/v1
+|`RecordingRule`
+|`recordingrule.loki.grafana/v1`
 |Supported from 5.7
 
-|LogFileMetricExporter
-|LogFileMetricExporter.logging.openshift.io/v1alpha1
+|`LogFileMetricExporter`
+|`LogFileMetricExporter.logging.openshift.io/v1alpha1`
 |Supported from 5.8
 
-|ClusterLogForwarder
-|clusterlogforwarder.logging.openshift.io/v1
-|Supported from 4.5.
+|`ClusterLogForwarder`
+|`clusterlogforwarder.logging.openshift.io/v1`
+|Supported from 4.5
 |===
 
 include::modules/cluster-logging-maintenance-support-list.adoc[leveloffset=+1]
 include::modules/unmanaged-operators.adoc[leveloffset=+1]
 
 [id="cluster-logging-support-must-gather_{context}"]
-== Collecting logging data for Red Hat Support
+== Collecting logging data for Red{nbsp}Hat Support
 
 When opening a support case, it is helpful to provide debugging information about your cluster to Red{nbsp}Hat Support.
 
-You can use the xref:../../../support/gathering-cluster-data.adoc#gathering-cluster-data[must-gather tool] to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
+You can use the xref:../../support/gathering-cluster-data.adoc#gathering-cluster-data[must-gather tool] to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
 For prompt support, supply diagnostic information for both {product-title} and {logging}.
 
 include::modules/cluster-logging-must-gather-about.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): Needs merging only in the logging-docs-6.2 staging branch where the PR is pointing to.
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1777


Link to docs preview: No preview because the file is not a part of the topic map. 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.


Additional information:
This PR also removes Support exception for the Logging UI Plugin statement which is a part of https://issues.redhat.com/browse/OBSDOCS-1703. It was not removed earlier from this file because this file is not a part of topic map for OCP. Also please note that even though the Diff appears to show a completely new file, the file is simply  a copy of https://github.com/openshift/openshift-docs/blob/logging-docs-6.2/observability/logging/logging_release_notes/cluster-logging-support.adoc. 