### PR TITLE
TELCODOCS-2127: RN for kernelpagesize API

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -480,6 +480,11 @@ We will have details here when {product-title} {product-version} is released.
 [id="ocp-release-notes-scalability-and-performance_{context}"]
 === Scalability and performance
 
+[id="ocp-release-notes-scalability-and-performance_kernelpagesize_{context}"]
+==== Performance profile kernel page size configuration
+
+With this update, you can specify larger kernel page sizes to improve performance for memory-intensive, high-performance workloads on ARM infrastructure nodes with the realtime kernel disabled. For more information, see xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-configuring-kernal-page-size_cnf-low-latency-perf-profile[Configuring kernel page sizes].
+
 [id="ocp-release-notes-etcd-certificates_{context}"]
 === Security
 


### PR DESCRIPTION
[TELCODOCS-2127](https://issues.redhat.com//browse/TELCODOCS-2127): RN for kernelpagesize API

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/TELCODOCS-2127

Link to docs preview:
https://file.corp.redhat.com/rohennes/TELCODOCS-2127-RN/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-scalability-and-performance_kernelpagesize_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
