### PR TITLE
OSDOCS-12317: image mode for RHEL z-stream relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -25,16 +25,9 @@ For lifecycle information, see the link:https://access.redhat.com/product-life-c
 
 This release adds improvements related to the following components and concepts.
 
-//L3 major categories with features in each as L4s
-//[id="microshift-4-18-rhel_{context}"]
-//=== {op-system-base-full}
-//Image mode for RHEL here if GA; otherwise leave in TP
-
 [id="microshift-4-18-updating_{context}"]
 === Updating
 Updating two minor EUS versions in a single step is supported in 4.18. Updates for both single-version minor releases and patch releases are also supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
-
-//TODO add new features and enhancements as needed, follow doc TOC titles as L3s, then add L4 headings for each feature
 
 [id="microshift-4-18-configuring_{context}"]
 === Configuring
@@ -81,9 +74,13 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 [id="microshift-4-18-rhel-image-mode_{context}"]
 === {op-system-base-full} image mode Technology Preview feature
-You can install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
+* You can install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
++
+See xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-publish-bootc-image[Using image mode for RHEL with {microshift-short}] for more information.
 
-See xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-image[Installing and publishing a bootc image] for more information.
+[id="microshift-4-18-rhel-image-mode-image_{context}"]
+==== Image mode for RHEL image added for use with {microshift-short}
+* New for 20 March 2025: A `microshift-bootc` image is now available at the Red{nbsp}Hat Ecosystem catalog. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-publish-bootc-image[Installing and publishing a bootc image to a registry].
 
 [id="microshift-4-18-deprecated-and-removed-features_{context}"]
 == Deprecated and removed features


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-12317](https://issues.redhat.com/browse/OSDOCS-12317)

Link to docs preview:
[microshift-bootc image release note](https://90450--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-rhel-image-mode-image_release-notes)

Reviews:
- [x] QE approved this change.
- [x] SME approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Replaces https://github.com/openshift/openshift-docs/pull/89356

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
