### PR TITLE
Update installation-special-config-raid-intel-vroc.adoc

### DIFF
--- a/modules/installation-special-config-raid-intel-vroc.adoc
+++ b/modules/installation-special-config-raid-intel-vroc.adoc
@@ -38,7 +38,7 @@ $ mdadm -CR /dev/md/dummy -l0 -n2 /dev/md/imsm0 -z10M --assume-clean
 +
 [source,terminal]
 ----
-$ mdadm -CR /dev/md/coreos -l1 -n2 /dev/imsm0
+$ mdadm -CR /dev/md/coreos -l1 -n2 /dev/md/imsm0
 ----
 
 .. Stop both RAID0 and RAID1 member arrays and delete the dummy RAID0 array with the following commands:


### PR DESCRIPTION
[OCPBUGS-48299] Update installation-special-config-raid-intel-vroc.adoc
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18 and Below

Issue:
[OCPBUGS-48299](https://issues.redhat.com/browse/OCPBUGS-48299)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

When trying to follow the procedure as per Red Hat documentation, the below command fails:

$ mdadm -CR /dev/md/coreos -l1 -n2 /dev/imsm0

As it seems that the path to the imsm0 device is wrong, and the command should be:

$ mdadm -CR /dev/md/coreos -l1 -n2 /dev/md/imsm0

need to correct our relevant documentation. Also, it would be good to verify if there is a need to update the procedure.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
