### PR TITLE
ocpbugs#44266:Moving an endif so TP feature name renders correctly

### DIFF
--- a/cli_reference/tkn_cli/installing-tkn.adoc
+++ b/cli_reference/tkn_cli/installing-tkn.adoc
@@ -11,17 +11,22 @@ Use the CLI tool to manage {pipelines-title} from a terminal. The following sect
 ifndef::openshift-rosa,openshift-dedicated[]
 You can also find the URL to the latest binaries from the {product-title} web console by clicking the *?* icon in the upper-right corner and selecting *Command Line Tools*.
 endif::openshift-rosa,openshift-dedicated[]
+
+ifndef::openshift-enterprise,openshift-dedicated[]
+
 :FeatureName: Running {pipelines-title} on ARM hardware
 include::snippets/technology-preview.adoc[]
+
+endif::openshift-enterprise,openshift-dedicated[]
 
 [NOTE]
 ====
 Both the archives and the RPMs contain the following executables:
 
-* tkn
-* tkn-pac
+* `tkn`
+* `tkn-pac`
 ifndef::openshift-rosa,openshift-dedicated[]
-* opc
+* `opc`
 endif::openshift-rosa,openshift-dedicated[]
 ====
 ifndef::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
ocpbugs#44266:Moving an endif so TP feature name renders correctly
See https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/cli_tools/pipelines-cli-tkn#installing-tkn

I also edited so the ROSA TP message only shows up in ROSA.

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-44266

Link to docs preview:
https://90494--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/tkn_cli/installing-tkn.html
https://90494--ocpdocs-pr.netlify.app/openshift-dedicated/latest/cli_reference/tkn_cli/installing-tkn.html
https://90494--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/tkn_cli/installing-tkn.html

QE review:
- [ ] QE has approved this change.
Formatting update- No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
