### PR TITLE
OSDOCS-13272: adds 4.14.49 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -240,16 +240,7 @@ The CIDR notation for grouping IP addresses was removed from the `clusterNetwork
 +
 . View the iptable rules for the NodePort service by running the following command:
 +
-[source, terminal]
-----
-$ sudo iptables-save | grep NODEPORT
-----
-+
-.Example output
-[source, terminal]
-----
--A OUTPUT -j OVN-KUBE-NODEPORT
--A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 30326 -j DNAT --to-destination 10.43.95.170:80
+[source, terminal]microshift-4-14-release-notes.adocination 10.43.95.170:80
 ----
 OVN-Kubernetes configures the `OVN-KUBE-NODEPORT` iptable chain in the NAT table to match the packet with the destination port and Destination Network Address Translates (DNATs) the packet to the `clusterIP` service. The packet is then routed to the OVN network through the gateway bridge `br-ex` using routing rules on the host.
 +
@@ -691,5 +682,16 @@ For the latest images included with {microshift-short}, view the contents of the
 Issued: 22 January 2025
 
 {product-title} release 4.14.45 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:0366[RHBA-2025:0366] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0364[RHSA-2025:0364] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-49-dp_{context}"]
+=== RHBA-2025:2849 - {microshift-short} 4.14.49 bug fix and security update advisory
+
+Issued: 19 March 2025
+
+{microshift-short} release 4.14.49 is now available. With this release, {microshift-short} introduces a priority-based release cadence to provide the most important updates with the least disruption.
+
+The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:2849[RHBA-2025:2849] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:2710[RHSA-2025:2710] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-13272](https://issues.redhat.com//browse/OSDOCS-13272)

Link to docs preview:
[4-14-49-dp_release-notes]()

QE review:
- [ ] QE has approved this change.
