### PR TITLE
OSDOCS-13692: Updated dual-stack to single-stack for IPv6

### DIFF
--- a/modules/nw-dual-stack-convert-back-single-stack.adoc
+++ b/modules/nw-dual-stack-convert-back-single-stack.adoc
@@ -2,7 +2,12 @@
 [id="nw-dual-stack-convert-back-single-stack_{context}"]
 = Converting to a single-stack cluster network
 
-As a cluster administrator, you can convert your dual-stack cluster network to a single-stack cluster network.
+As a cluster administrator, you can convert your dual-stack cluster network to a single-stack cluster network. 
+
+[IMPORTANT]
+====
+If you originally converted your IPv4 single-stack cluster network to a dual-stack cluster, you can convert only back to the IPv4 single-stack cluster and not an IPv6 single-stack cluster network. The same restriction applies for converting back to an IPv6 single-stack cluster network. 
+====
 
 .Prerequisites
 
@@ -14,13 +19,12 @@ As a cluster administrator, you can convert your dual-stack cluster network to a
 
 .Procedure
 
-. Edit the `networks.config.openshift.io` custom resource (CR) by running the
-following command:
+. Edit the `networks.config.openshift.io` custom resource (CR) by running the following command:
 +
 [source,terminal]
 ----
 $ oc edit networks.config.openshift.io
 ----
 
-. Remove the IPv6 specific configuration that you have added to the `cidr` and `hostPrefix` fields in the previous procedure.
+. Remove the IPv4 or IPv6 configuration that you added to the `cidr` and the `hostPrefix` parameters from completing the "Converting to a dual-stack cluster network " procedure steps.
 

--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -56,7 +56,7 @@ If you already upgraded your cluster to {product-title} 4.16 or later and you ne
   path: /spec/serviceNetwork/-
   value: fd02::/112 <2>
 ----
-<1> Specify an object with the `cidr` and `hostPrefix` fields. The host prefix must be `64` or greater. The IPv6 Classless Inter-Domain Routing (CIDR) prefix must be large enough to accommodate the specified host prefix.
+<1> Specify an object with the `cidr` and `hostPrefix` parameters. The host prefix must be `64` or greater. The IPv6 Classless Inter-Domain Routing (CIDR) prefix must be large enough to accommodate the specified host prefix.
 <2> Specify an IPv6 CIDR with a prefix of `112`. Kubernetes uses only the lowest 16 bits. For a prefix of `112`, IP addresses are assigned from `112` to `128` bits.
 
 . Patch the cluster network configuration by entering the following command in your CLI:

--- a/modules/nw-ovn-k-day-2-masq-subnet.adoc
+++ b/modules/nw-ovn-k-day-2-masq-subnet.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-ovn-k-day-2-masq-subnet_{context}"]
-= Configuring the OVN-Kubernetes masquerade subnet as a Day 2 operation
+= Configuring the OVN-Kubernetes masquerade subnet as a post-installation operation
 
-You can change the masquerade subnet used by OVN-Kubernetes as a Day 2 operation in order to avoid conflicts with any existing subnets that are already in use in your environment.
+You can change the masquerade subnet used by OVN-Kubernetes as a post-installation operation to avoid conflicts with any existing subnets that are already in use in your environment.
 
 .Prerequisites
 
@@ -15,8 +15,8 @@ You can change the masquerade subnet used by OVN-Kubernetes as a Day 2 operation
 
 .Procedure
 
-. Change your cluster's masquerade subnet:
-
+* Change your cluster's masquerade subnet:
++
 ** For dualstack clusters using IPv6, run the following command:
 +
 [source,terminal]
@@ -25,11 +25,11 @@ $ oc patch networks.operator.openshift.io cluster --type=merge -p '{"spec":{"def
 ----
 +
 where:
-
++
 `ipv4_masquerade_subnet`:: Specifies an IP address to be used as the IPv4 masquerade subnet. This range cannot overlap with any other subnets used by {product-title} or on the host itself. In versions of {product-title} earlier than 4.17, the default value for IPv4 was `169.254.169.0/29`, and clusters that were upgraded to version 4.17 maintain this value. For new clusters starting from version 4.17, the default value is `169.254.0.0/17`. 
-
++
 `ipv6_masquerade_subnet`:: Specifies an IP address to be used as the IPv6 masquerade subnet. This range cannot overlap with any other subnets used by {product-title} or on the host itself. The default value for IPv6 is `fd69::/125`.
-
++
 ** For clusters using IPv4, run the following command:
 +
 [source,terminal]
@@ -38,5 +38,5 @@ $ oc patch networks.operator.openshift.io cluster --type=merge -p '{"spec":{"def
 ----
 +
 where:
-
++
 `ipv4_masquerade_subnet`::Specifies an IP address to be used as the IPv4 masquerade subnet. This range cannot overlap with any other subnets used by {product-title} or on the host itself. In versions of {product-title} earlier than 4.17, the default value for IPv4 was `169.254.169.0/29`, and clusters that were upgraded to version 4.17 maintain this value. For new clusters starting from version 4.17, the default value is `169.254.0.0/17`.

--- a/modules/nw-ovn-kubernetes-change-join-subnet.adoc
+++ b/modules/nw-ovn-kubernetes-change-join-subnet.adoc
@@ -16,7 +16,7 @@ You can change the join subnet used by OVN-Kubernetes to avoid conflicting with 
 
 .Procedure
 
-. To change the OVN-Kubernetes join subnet, enter the following command:
+* To change the OVN-Kubernetes join subnet, enter the following command:
 +
 [source,terminal]
 ----
@@ -48,7 +48,7 @@ $ oc get network.operator.openshift.io \
   -o jsonpath="{.items[0].spec.defaultNetwork}"
 ----
 +
-It can take up to 30 minutes for this change to take effect.
+The command operation can take up to 30 minutes for this change to take effect.
 +
 .Example output
 ----

--- a/modules/nw-ovn-kubernetes-change-transit-subnet.adoc
+++ b/modules/nw-ovn-kubernetes-change-transit-subnet.adoc
@@ -16,7 +16,7 @@ You can change the transit subnet used by OVN-Kubernetes to avoid conflicting wi
 
 .Procedure
 
-. To change the OVN-Kubernetes transit subnet, enter the following command:
+* To change the OVN-Kubernetes transit subnet, enter the following command:
 +
 [source,terminal]
 ----

--- a/networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc
+++ b/networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc
@@ -12,7 +12,7 @@ As a cluster administrator, you can change the IP address ranges that the OVN-Ku
 // Configuring the OVN-Kubernetes join subnet
 include::modules/nw-ovn-kubernetes-change-join-subnet.adoc[leveloffset=+1]
 
-//day 2 operation for changing masquerade subnet in ovn-k
+// Configuring the OVN-Kubernetes masquerade subnet as a post-installation operation
 include::modules/nw-ovn-k-day-2-masq-subnet.adoc[leveloffset=+1]
 
 // Configuring the OVN-Kubernetes transit subnet


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-13692](https://issues.redhat.com/browse/OSDOCS-13692)

Link to docs preview:

* [Converting to IPv4/IPv6 dual-stack networking](https://90524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html)
* [Configuring the OVN-Kubernetes masquerade subnet as a post-installation operation](https://90524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.html#nw-ovn-k-day-2-masq-subnet_configure-ovn-kubernetes-subnets)

- [x] SME has approved this change (Mat K.).
- [x] QE has approved this change (Gris Ge/Ross Brattain).
