### PR TITLE
OSSM-8598 Clarifying Optional bullet point in Sidecar injection

### DIFF
--- a/install/ossm-sidecar-injection-assembly.adoc
+++ b/install/ossm-sidecar-injection-assembly.adoc
@@ -18,5 +18,5 @@ include::modules/ossm-enabling-sidecar-injection.adoc[leveloffset=+1]
 == Additional resources
 * link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[About admission controllers] (Kubernetes documentation)
 * link:https://istio.io/latest/docs/ops/common-problems/injection/[Istio sidecar injection problems] (Istio documentation)
-* xref:../install/ossm-installing-openshift-service-mesh.adoc#deploying-book-info_ossm-about-bookinfo-application[Bookinfo application]
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#deploying-book-info_ossm-about-bookinfo-application[Deploying the Bookinfo application]
 * xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-creating-istiocni-resource[Scoping service mesh with discovery selectors]

--- a/modules/ossm-enabling-sidecar-injection.adoc
+++ b/modules/ossm-enabling-sidecar-injection.adoc
@@ -12,7 +12,7 @@ To demonstrate different approaches for configuring sidecar injection, the follo
 * You have installed the {SMProductName} Operator, created an `{istio}` resource, and the Operator has deployed {istio}.
 * You have created the `IstioCNI` resource, and the Operator has deployed the necessary `IstioCNI` pods.
 * You have created the namespaces that are to be part of the mesh, and they are discoverable by the Istio control plane.
-* Optional: You have deployed the workloads to be included in the mesh. In the following examples, the Bookinfo has been deployed to the `bookinfo` namespace, but sidecar injection (step 5) has not been configured.
+* Optional: You have deployed the workloads to be included in the mesh. In the following examples, the Bookinfo has been deployed to the `bookinfo` namespace, but sidecar injection (step 5) has not been configured. For more information, see "Deploying the Bookinfo application".
 
 [id="ossm-enabling-sidecar-injection-namespace-labels_{context}"]
 == Enabling sidecar injection with namespace labels


### PR DESCRIPTION
OSSM 3.0 

[OSSM-8598](https://issues.redhat.com//browse/OSSM-8598) Clarifying Optional bullet point in Sidecar injection

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
3.0 

Issue:
https://issues.redhat.com/browse/OSSM-8598

Link to docs preview:
https://90560--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-sidecar-injection-assembly.html#ossm-enabling-sidecar-injection_ossm-sidecar-injection-assembly

QE review:
QE is not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
