### PR TITLE
OSDOCS-13272-1: adds 4.14.49 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -693,3 +693,14 @@ Issued: 22 January 2025
 {product-title} release 4.14.45 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:0366[RHBA-2025:0366] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0364[RHSA-2025:0364] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-49-dp_{context}"]
+=== RHBA-2025:2849 - {microshift-short} 4.14.49 bug fix and security update advisory
+
+Issued: 19 March 2025
+
+{microshift-short} release 4.14.49 is now available. With this release, {microshift-short} introduces a priority-based release cadence to provide the most important updates with the least disruption.
+
+The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:2849[RHBA-2025:2849] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:2710[RHSA-2025:2710] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-13272](https://issues.redhat.com//browse/OSDOCS-13272)

Link to docs preview:
[4-14-49-dp_release-notes](https://90573--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-49-dp_release-notes)

QE review:
- [x] QE has approved this change.
