### PR TITLE
CP-OSDOCS-13596-417: corrects repo enablement commands MicroShift

### DIFF
--- a/modules/microshift-install-rpms.adoc
+++ b/modules/microshift-install-rpms.adoc
@@ -20,30 +20,25 @@ Use the following procedure to install {microshift-short} from an RPM package.
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-<4.18>-for-<9>-$(uname -m)-rpms \ # <1>
-    --enable fast-datapath-for-<9>-$(uname -m)-rpms # <2>
+    --enable rhocp-{ocp-version}-for-rhel-{op-system-version-major}-$(uname -m)-rpms \
+    --enable fast-datapath-for-rhel-{op-system-version-major}-$(uname -m)-rpms
 ----
-<1> Replace _<4.18>_ and _<9>_ with the compatible versions of your {microshift-short} and {op-system-base-full}.
-<2> Replace  _<9>_ with the compatible version of {op-system-base}.
 
 . For extended support (EUS) releases, also enable the EUS repositories by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-`$ sudo subscription-manager repos \
-    --enable rhel-<9>-for-x86_64-appstream-eus-rpms \ # <1>
-    --enable rhel-<9>-for-x86_64-baseos-eus-rpms` # <2>
+$ sudo subscription-manager repos \
+    --enable rhel-{op-system-version-major}-for-$(uname -m)-appstream-eus-rpms \
+    --enable rhel-{op-system-version-major}-for-$(uname -m)-baseos-eus-rpms
 ----
-<1> Replace _<9>_ with the compatible major version number of {op-system-base}.
-<2> Replace _<9>_ with the compatible major version number of {op-system-base}.
 
 . Avoid unintended future updates into an unsupported configuration by locking your operating system version with the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ sudo subscription-manager release --set=<9.4> command. # <1>
+$ sudo subscription-manager release --set={op-system-version}
 ----
-<1> Replace _<9.4>_ with the major and minor version of your compatible {op-system-base} system.
 
 . Install {microshift-short} by running the following command:
 +
@@ -92,4 +87,4 @@ $ sudo firewall-cmd --permanent --zone=trusted --add-source=169.254.169.1
 $ sudo firewall-cmd --reload
 ----
 
-If the Volume Group (VG) that you have prepared for {microshift-short} used the default name `rhel`, no further configuration is necessary. If you have used a different name, or if you want to change more configuration settings, see the Configuring {microshift-short} section.
+. If the Volume Group (VG) that you have prepared for {microshift-short} used the default name `rhel`, no further configuration is necessary. If you have used a different name, or if you want to change more configuration settings, see the "Using the {microshift-short} configuration file" section.


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13596](https://issues.redhat.com/browse/OSDOCS-13596)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
See https://github.com/openshift/openshift-docs/pull/90112

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
