### PR TITLE
OSSM-9074 Add HA note to InPlace Update Strategy

### DIFF
--- a/modules/ossm-about-inplace-strategy.adoc
+++ b/modules/ossm-about-inplace-strategy.adoc
@@ -7,3 +7,8 @@
 :context: ossm-about-inplace-strategy
 
 The `InPlace` strategy runs only one revision of the control plane at all times. When you perform an `InPlace` update, all of the workloads immediately connect to the new version of the control plane. In order to ensure compatibility between the sidecars and the control plane you cannot upgrade by more than one minor version at a time.
+
+[IMPORTANT]
+====
+Traffic disruption may occur during the upgrade process. To minimize the disruption, ensure that at least two replicas of `istiod` are running. Also, ensure that `PodDisruptionBudgets` fields are configured with a minimum availability of 1.
+====


### PR DESCRIPTION
OSSM 3.0

[OSSM-9074](https://issues.redhat.com//browse/OSSM-9074) Add HA note to InPlace Update Strategy

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
3.0

Issue:
https://issues.redhat.com/browse/OSSM-9074

Link to docs preview:
https://90577--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/update/ossm-updating-openshift-service-mesh.html#about-inplace-strategy_ossm-about-deployment-and-update-strategies

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
