### PR TITLE
OLS-1388: remove specific model namess from examples

### DIFF
--- a/modules/ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm.adoc
+++ b/modules/ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm.adoc
@@ -6,7 +6,7 @@
 [id="ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm_{context}"]
 = Configuring {ols-long} with a trust provider certificate for the LLM 
 
-This procedure explains how to configure {ols-long} with a trust provider certificate for the Large Language Model (LLM) provider.
+Configure {ols-long} with a trust provider certificate for the large language model (LLM) provider.
 
 [NOTE]
 ====
@@ -54,7 +54,7 @@ metadata:
 spec:
   ols:
     defaultProvider: rhelai
-    defaultModel: models/granite-7b-redhat-lab
+    defaultModel: models/<model_name>
     additionalCAConfigMapRef:
       name: trusted-certs <1>
 ----

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
@@ -6,17 +6,19 @@
 [id="ols-creating-lightspeed-custom-resource-file-using-cli_{context}"]
 = Creating the Lightspeed custom resource file using the CLI
 
-The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each Large Language Model (LLM) provider. Choose the configuration file that matches your LLM provider.
+The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each large language model (LLM) provider. To create the CR file, choose the configuration file for the LLM provider that you are using.
 
 .Prerequisites
 
 * You have access to the {ocp-short-name} CLI (oc) and are logged in as a user with the `cluster-admin` role. Alternatively, you are logged in to a user account that has permission to create a cluster-scoped CR file.
 
+* You have configured the LLM provider.
+
 * You have installed the {ols-long} Operator.
 
 .Procedure
 
-. Create an `OLSConfig` file that contains the YAML content for the LLM provider you use:
+. Create an `OLSConfig` file that contains the YAML content for the LLM provider you use.
 +
 .OpenAI CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -34,9 +36,9 @@ spec:
           name: credentials
         url: https://api.openai.com/v1
         models:
-          - name: gpt-3.5-turbo
+          - name: <model_name>
   ols:
-    defaultModel: gpt-3.5-turbo
+    defaultModel: <model_name>
     defaultProvider: myOpenai
 ----
 +
@@ -53,13 +55,13 @@ spec:
     - credentialsSecretRef:
         name: openai-api-keys
       models:
-      - name: models/granite-7b-redhat-lab
+      - name: models/<model_name>
       name: rhelai
       type: rhelai_vllm
       url: <URL> <1>
   ols:
     defaultProvider: rhelai
-    defaultModel: models/granite-7b-redhat-lab
+    defaultModel: models/<model_name>
     additionalCAConfigMapRef:
       name: openshift-service-ca.crt
 ----
@@ -78,15 +80,15 @@ spec:
     - credentialsSecretRef:
         name: openai-api-keys
       models:
-      - name: granite-8b-code-instruct-128k
+      - name: <model_name>
       name: red_hat_openshift_ai
       type: rhoai_vllm 
       url: <url> <1>
   ols:
     defaultProvider: red_hat_openshift_ai
-    defaultModel: granite-8b-code-instruct-128k
+    defaultModel: <model_name>
 ----
-<1> The URL endpoint must end with `v1` to be valid. For example, `\https://granite-8b-code-instruct.my-domain.com:443/v1`. 
+<1> The URL endpoint must end with `v1` to be valid. For example, `\https://<model_name>.<domain_name>.com:443/v1`. 
 +
 .{azure-openai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -102,12 +104,12 @@ spec:
           name: credentials
         deploymentName: <azure_ai_deployment_name>
         models:
-          - name: gpt-35-turbo-16k
+          - name: <model_name>
         name: myAzure
         type: azure_openai
         url: <azure_ai_deployment_url>
   ols:
-    defaultModel: gpt-35-turbo-16k
+    defaultModel: <model_name>
     defaultProvider: myAzure
 ----
 +
@@ -128,9 +130,9 @@ spec:
         url: <ibm_watsonx_deployment_name>
         projectId: <ibm_watsonx_project_id>
         models:
-          - name: ibm/granite-13b-chat-v2
+          - name: ibm/<model_name>
   ols:
-    defaultModel: ibm/granite-13b-chat-v2
+    defaultModel: ibm/<model_name>
     defaultProvider: myWatsonx
 ----
 

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
@@ -4,13 +4,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-creating-lightspeed-custom-resource-file-using-web-console_{context}"]
-= Creating the Lightspeed custom resource file using the web console
+= Creating the Lightspeed custom resource file by using the web console
 
-The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each Large Language Model (LLM) provider. Choose the configuration file that matches your LLM provider.
+The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each large language model (LLM) provider. To create the CR file, choose the configuration file for the LLM provider that you are using.
 
 .Prerequisites
 
 * You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role. Alternatively, you are logged in to a user account that has permission to create a cluster-scoped CR file.
+
+* You have configured the LLM provider.
 
 * You have installed the {ols-long} Operator.
 
@@ -18,7 +20,7 @@ The Custom Resource (CR) file contains information that the Operator uses to dep
 
 . Click *Add* in the upper-right corner of the {ocp-short-name} web console.
 
-. Paste the YAML content for the LLM provider you use into the text area of the web console:
+. Paste the YAML content for the LLM provider you use into the text area of the web console.
 +
 .OpenAI CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -36,9 +38,9 @@ spec:
           name: credentials
         url: https://api.openai.com/v1
         models:
-          - name: gpt-3.5-turbo
+          - name: <model_name>
   ols:
-    defaultModel: gpt-3.5-turbo
+    defaultModel: <model_name>
     defaultProvider: myOpenai
 ----
 +
@@ -55,13 +57,13 @@ spec:
     - credentialsSecretRef:
         name: openai-api-keys
       models:
-      - name: models/granite-7b-redhat-lab
+      - name: models/<model_name>
       name: rhelai
       type: rhelai_vllm
       url: <URL> <1>
   ols:
     defaultProvider: rhelai
-    defaultModel: models/granite-7b-redhat-lab
+    defaultModel: models/<model_name>
 ----
 <1> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`. 
 +
@@ -78,15 +80,15 @@ spec:
     - credentialsSecretRef:
         name: openai-api-keys
       models:
-      - name: granite-8b-code-instruct-128k
+      - name: <model_name>
       name: red_hat_openshift_ai
       type: rhoai_vllm 
       url: <url> <1>
   ols:
     defaultProvider: red_hat_openshift_ai
-    defaultModel: granite-8b-code-instruct-128k
+    defaultModel: <model_name>
 ----
-<1> The URL endpoint must end with `v1` to be valid. For example, `\https://granite-8b-code-instruct.my-domain.com:443/v1`. 
+<1> The URL endpoint must end with `v1` to be valid. For example, `\https://<model_name>.<domain_name>.com:443/v1`. 
 +
 .{azure-openai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -102,12 +104,12 @@ spec:
           name: credentials
         deploymentName: <azure_ai_deployment_name>
         models:
-          - name: gpt-35-turbo-16k
+          - name: <model_name>
         name: myAzure
         type: azure_openai
         url: <azure_ai_deployment_url>
   ols:
-    defaultModel: gpt-35-turbo-16k
+    defaultModel: <model_name>
     defaultProvider: myAzure
 ----
 +
@@ -128,9 +130,9 @@ spec:
         url: <ibm_watsonx_deployment_name>
         projectId: <ibm_watsonx_project_id>
         models:
-          - name: ibm/granite-13b-chat-v2
+          - name: ibm/<model_name>
   ols:
-    defaultModel: ibm/granite-13b-chat-v2
+    defaultModel: ibm/<model_name>
     defaultProvider: myWatsonx
 ----
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1388
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
