### PR TITLE
OSSM-8960 Product docs should only reference Red Hat maintained artifacts (bookinfo)

### DIFF
--- a/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
@@ -31,7 +31,7 @@ $ oc get crd gateways.gateway.networking.k8s.io &> /dev/null ||  { oc kustomize 
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/gateway-api/bookinfo-gateway.yaml -n bookinfo
+$ oc apply -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/bookinfo/gateway-api/bookinfo-gateway.yaml -n bookinfo
 ----
 +
 [NOTE]

--- a/modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc
@@ -33,7 +33,7 @@ This example uses a sample `ingress-gateway.yaml` https://raw.githubusercontent.
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/networking/bookinfo-gateway.yaml -n bookinfo
+$ oc apply -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/bookinfo/networking/bookinfo-gateway.yaml -n bookinfo
 ----
 +
 [NOTE]

--- a/modules/ossm-cert-manager-verifying-install.adoc
+++ b/modules/ossm-cert-manager-verifying-install.adoc
@@ -46,7 +46,7 @@ $ oc apply -n sample -f https://raw.githubusercontent.com/openshift-service-mesh
 +
 [source, terminal]
 ----
-$ oc apply -n sample -f https://raw.githubusercontent.com/istio/istio/refs/heads/master/samples/sleep/sleep.yaml
+$ oc apply -n sample -f https://raw.githubusercontent.com/openshift-service-mesh/istio/refs/heads/master/samples/sleep/sleep.yaml
 ----
 
 . Wait for both applications to become ready by running the following command:

--- a/modules/ossm-config-otel.adoc
+++ b/modules/ossm-config-otel.adoc
@@ -142,7 +142,7 @@ $ oc label namespace curl istio.io/rev=default
 +
 [source, terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
+$ oc apply -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
 ----
 
 . Generate traffic to the `productpage` pod to generate traces:

--- a/modules/ossm-deploying-bookinfo-application.adoc
+++ b/modules/ossm-deploying-bookinfo-application.adoc
@@ -41,7 +41,7 @@ In this example, the name of the Istio resource is `default`. If the Istio resou
 +
 [source,terminal]
 ----
-oc apply -f https://raw.githubusercontent.com/istio/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
+oc apply -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/bookinfo/platform/kube/bookinfo.yaml -n bookinfo
 ----
 
 .Verification

--- a/modules/ossm-verifying-multi-cluster-topology.adoc
+++ b/modules/ossm-verifying-multi-cluster-topology.adoc
@@ -5,18 +5,18 @@
 [id="ossm-verifying-multi-cluster-topology_{context}"]
 = Verifying a multi-cluster topology
 
-Deploy sample applications and verify traffic on a multi-cluster topology on two {ocp-product-title} clusters. 
+Deploy sample applications and verify traffic on a multi-cluster topology on two {ocp-product-title} clusters.
 
 [NOTE]
 ====
-In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster. 
+In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster.
 ====
 
 .Prerequisites
 
 * You have installed the {SMProduct} Operator on all of the clusters that comprise the mesh.
 
-* You have completed "Creating certificates for a multi-cluster mesh". 
+* You have completed "Creating certificates for a multi-cluster mesh".
 
 * You have completed "Applying certificates to a multi-cluster topology".
 
@@ -51,7 +51,7 @@ $ oc --context="${CTX_CLUSTER1}" label namespace sample istio-injection=enabled
 [source,terminal]
 ----
 $ oc --context="${CTX_CLUSTER1}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/helloworld/helloworld.yaml \
   -l service=helloworld -n sample
 ----
 
@@ -60,7 +60,7 @@ $ oc --context="${CTX_CLUSTER1}" apply \
 [source,terminal]
 ----
 $ oc --context="${CTX_CLUSTER1}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/helloworld/helloworld.yaml \
   -l version=v1 -n sample
 ----
 
@@ -69,7 +69,7 @@ $ oc --context="${CTX_CLUSTER1}" apply \
 [source,terminal]
 ----
 $ oc --context="${CTX_CLUSTER1}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/sleep/sleep.yaml -n sample
+  -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/sleep/sleep.yaml -n sample
 ----
 
 .. Wait for the `helloworld` application on the East cluster to return the `Ready` status condition by running the following command:
@@ -109,7 +109,7 @@ $ oc --context="${CTX_CLUSTER2}" label namespace sample istio-injection=enabled
 [source,terminal]
 ----
 $ oc --context="${CTX_CLUSTER2}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/helloworld/helloworld.yaml \
   -l service=helloworld -n sample
 ----
 
@@ -118,7 +118,7 @@ $ oc --context="${CTX_CLUSTER2}" apply \
 [source,terminal]
 ----
 $ oc --context="${CTX_CLUSTER2}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/helloworld/helloworld.yaml \
+  -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/helloworld/helloworld.yaml \
   -l version=v2 -n sample
 ----
 
@@ -127,7 +127,7 @@ $ oc --context="${CTX_CLUSTER2}" apply \
 [source,terminal]
 ----
 $ oc --context="${CTX_CLUSTER2}" apply \
-  -f https://raw.githubusercontent.com/istio/istio/${ISTIO_VERSION}/samples/sleep/sleep.yaml -n sample
+  -f https://raw.githubusercontent.com/openshift-service-mesh/istio/release-1.24/samples/sleep/sleep.yaml -n sample
 ----
 
 .. Wait for the `helloworld` application on the West cluster to return the `Ready` status condition by running the following command:
@@ -155,7 +155,7 @@ $ for i in {0..9}; do \
 done
 ----
 +
-Verify that you see responses from both clusters. This means version 1 and version 2 of the service can be seen in the responses. 
+Verify that you see responses from both clusters. This means version 1 and version 2 of the service can be seen in the responses.
 
 . For the West cluster, send 10 requests to the `helloworld` service:
 +
@@ -166,4 +166,4 @@ $ for i in {0..9}; do \
 done
 ----
 +
-Verify that you see responses from both clusters. This means version 1 and version 2 of the service can be seen in the responses. 
+Verify that you see responses from both clusters. This means version 1 and version 2 of the service can be seen in the responses.


### PR DESCRIPTION
OSSM 3.0

[OSSM-8960](https://issues.redhat.com//browse/OSSM-8960) Product docs should only reference Red Hat maintained artifacts (bookinfo)

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
3.0

Issue:
https://issues.redhat.com/browse/OSSM-8960#

Link to docs preview:
* https://90592--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-cert-manager.html#verifying-cert-manager-installation_ossm-cert-manager
* https://90592--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#deploying-book-info_ossm-about-bookinfo-application
* https://90592--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#ossm-accessing-bookinfo-application-using-istio-gateway-injection_ossm-about-accessing-bookinfo-application-using-gateway
* https://90592--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#ossm-accessing-bookinfo-application-using-gateway-api
* https://90592--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html#ossm-verifying-multi-cluster-topology_ossm-multi-cluster-topologies
* https://90592--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/traces/ossm-distr-tracing.html#ossm-config-otel_ossm-traces

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
