### PR TITLE
Additional steps to modify the parameter overprovisionRatio after the LVM cluster is created

### DIFF
--- a/modules/lvms-about-lvmcluster-cr.adoc
+++ b/modules/lvms-about-lvmcluster-cr.adoc
@@ -127,7 +127,20 @@ By default, this field is set to 90. The minimum value that you can set is 10, a
 |Specify a factor by which you can provision additional storage based on the available storage in the thin pool.
 
 For example, if this field is set to 10, you can provision up to 10 times the amount of available storage in the thin pool.
+You can modify this field after the LVM cluster has been created.
 
+To update the parameter, do any of the following tasks:
+
+* To edit the LVM Cluster, run the following command:
+[source,terminal]
+----
+$ oc edit lvmcluster <lvmcluster_name>
+----
+* To apply a patch, run the following command:
+[source,terminal]
+----
+$ oc patch lvmcluster <lvmcluster_name> -p <patch_file.yaml>
+----
 To disable over-provisioning, set this field to 1.
 
 |`thinPoolConfig.chunkSize`


### PR DESCRIPTION
Additional steps to modify the parameter overprovisionRatio after the LVM Cluster is created

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> 4.18+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/TELCODOCS-2218

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://90608--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
