### PR TITLE
OSDOCS-13692-19: Br-ex bridge TP on supported platforms

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -1268,10 +1268,15 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-|Customized `br-ex` bridge needed by OVN-Kuberenetes to use NMState
+|OVN-Kubernetes customized `br-ex` bridge on bare metal
 |General Availability
 |General Availability
 |General Availability
+
+|OVN-Kubernetes customized `br-ex` bridge on {vmw-short} and {rh-openstack}
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
 |Live migration to OVN-Kubernetes from OpenShift SDN
 |General Availability


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13634](https://issues.redhat.com/browse/OSDOCS-13634) and [OCPBUGS-53224](https://issues.redhat.com/browse/OCPBUGS-53224)

Link to docs preview:
* [4.19 Release Notes TP table section](https://90612--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-technology-preview-tables_release-notes)


- [x] SME has approved this change.
- [x] QE has approved this change.
