### PR TITLE
TELCODOCS-2127: Follow up PR to add limitation about real-time kernel

### DIFF
--- a/modules/configuring-kernal-page-size.adoc
+++ b/modules/configuring-kernal-page-size.adoc
@@ -10,7 +10,9 @@ Use the `kernelPageSize` specification in a performance profile to configure the
 
 [NOTE]
 ====
-For nodes with an x86_64 or AMD64 architecture, you can only specify `4k` for the `kernelPageSize` specification. For nodes with an AArch64 architecture, you can specify `4k` or `64k` for the `kernelPageSize` specification. The default value is `4k`.
+For nodes with an x86_64 or AMD64 architecture, you can only specify `4k` for the `kernelPageSize` specification. 
+For nodes with an AArch64 architecture, you can specify `4k` or `64k` for the `kernelPageSize` specification. You must disable the realtime kernel before you can use the `64k` option. 
+The default value is `4k`.
 ====
 
 .Prerequisites
@@ -33,11 +35,14 @@ metadata:
 #...
 spec:
     kernelPageSize: "64k" <1>
+    realTimeKernel:
+        enabled: false <2>
     nodeSelector:
-        node-role.kubernetes.io/worker: "" <2>
+        node-role.kubernetes.io/worker: "" <3>
 ----
 <1> This example specifies a kernel page size of `64k`. You can only specify `64k` for nodes with an AArch64 architecture. The default value is `4k`.
-<2> This example targets nodes with the `worker` role.
+<2> You must disable the realtime kernel to use the `64k` kernel page size option.
+<3> This example targets nodes with the `worker` role.
 
 . Apply the performance profile to the cluster:
 +


### PR DESCRIPTION
[TELCODOCS-2127](https://issues.redhat.com//browse/TELCODOCS-2127): Follow up PR to add limitation about real-time kernel

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2127

Link to docs preview:
https://90616--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html#cnf-page-size-optimization_cnf-low-latency-perf-profile

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
