### PR TITLE
[enterprise-4.13] OCPBUGS:38819 Calculation of Overcommit is wrong

### DIFF
--- a/modules/nodes-cluster-overcommit-resource-requests.adoc
+++ b/modules/nodes-cluster-overcommit-resource-requests.adoc
@@ -24,4 +24,4 @@ to resource limits, which can be set higher than requested resources. The
 difference between request and limit determines the level of overcommit;
 for instance, if a container is given a memory request of 1Gi and a memory limit
 of 2Gi, it is scheduled based on the 1Gi request being available on the node,
-but could use up to 2Gi; so it is 200% overcommitted.
+but could use up to 2Gi; so it is 100% overcommitted.


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/89628