### PR TITLE
[enterprise-4.13] OSDOCS12397: Incorrect tolerations example for scheduling pods on the infra nodes

### DIFF
--- a/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
+++ b/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
@@ -91,12 +91,12 @@ If a descheduler is used, pods violating node taints could be evicted from the c
 tolerations:
   - effect: NoExecute <1>
     key: node-role.kubernetes.io/infra <2>
-    operator: Exists <3>
+    operator: Equal <3>
     value: reserved <4>
 ----
 <1> Specify the effect that you added to the node.
 <2> Specify the key that you added to the node.
-<3> Specify the `Exists` Operator to require a taint with the key `node-role.kubernetes.io/infra` to be present on the node.
+<3> Specify the `Equal` Operator to require a taint with the key `node-role.kubernetes.io/infra` to be present on the node.
 <4> Specify the value of the key-value pair taint that you added to the node.
 +
 This toleration matches the taint created by the `oc adm taint` command. A pod with this toleration can be scheduled onto the infra node.


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/89490
