### PR TITLE
[OSDOCS#13703]:Fixed callout rendering issue in Understanding config map doc

### DIFF
--- a/modules/nodes-pods-secrets-certificates-creating.adoc
+++ b/modules/nodes-pods-secrets-certificates-creating.adoc
@@ -35,7 +35,7 @@ spec:
     targetPort: 9376
 ----
 +
-The certificate and key are in PEM format, stored in `tls.crt` and `tls.key`
+<1> The certificate and key are in PEM format, stored in `tls.crt` and `tls.key`
 respectively.
 
 . Create the service:

--- a/observability/logging/cluster-logging.adoc
+++ b/observability/logging/cluster-logging.adoc
@@ -11,40 +11,40 @@ As a cluster administrator, you can deploy {logging} on an {product-title} clust
 
 include::snippets/logging-kibana-dep-snip.adoc[]
 
-{product-title} cluster administrators can deploy {logging} by using Operators. For information, see xref :../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploying[Installing {logging}].
+{product-title} cluster administrators can deploy {logging} by using Operators. For information, see xref:../../observability/logging/cluster-logging-deploying.adoc#cluster-logging-deploying[Installing logging].
 
 The Operators are responsible for deploying, upgrading, and maintaining {logging}. After the Operators are installed, you can create a `ClusterLogging` custom resource (CR) to schedule {logging} pods and other resources necessary to support {logging}. You can also create a `ClusterLogForwarder` CR to specify which logs are collected, how they are transformed, and where they are forwarded to.
 
 [NOTE]
 ====
-Because the internal {product-title} Elasticsearch log store does not provide secure storage for audit logs, audit logs are not stored in the internal Elasticsearch instance by default. If you want to send the audit logs to the default internal Elasticsearch log store, for example to view the audit logs in Kibana, you must use the Log Forwarding API as described in xref :../../observability/logging/log_storage/logging-config-es-store.adoc#cluster-logging-elasticsearch-audit_logging-config-es-store[Forward audit logs to the log store].
+Because the internal {product-title} Elasticsearch log store does not provide secure storage for audit logs, audit logs are not stored in the internal Elasticsearch instance by default. If you want to send the audit logs to the default internal Elasticsearch log store, for example to view the audit logs in Kibana, you must use the Log Forwarding API as described in xref:../../observability/logging/log_storage/logging-config-es-store.adoc#cluster-logging-elasticsearch-audit_logging-config-es-store[Forward audit logs to the log store].
 ====
 
 include::modules/logging-architecture-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref :../../observability/logging/log_visualization/log-visualization-ocp-console.adoc#log-visualization-ocp-console[Log visualization with the web console]
+* xref:../../observability/logging/log_visualization/log-visualization-ocp-console.adoc#log-visualization-ocp-console[Log visualization with the web console]
 
 include::modules/cluster-logging-about.adoc[leveloffset=+1]
 
 ifdef::openshift-rosa,openshift-dedicated[]
 include::modules/cluster-logging-cloudwatch.adoc[leveloffset=+1]
-For information, see xref :../../observability/logging/log_collection_forwarding/log-forwarding.adoc#about-log-collection_log-forwarding[About log collection and forwarding].
+For information, see xref:../../observability/logging/log_collection_forwarding/log-forwarding.adoc#about-log-collection_log-forwarding[About log collection and forwarding].
 endif::[]
 
 include::modules/cluster-logging-json-logging-about.adoc[leveloffset=+2]
 
 include::modules/cluster-logging-collecting-storing-kubernetes-events.adoc[leveloffset=+2]
 
-For information, see xref :../../observability/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc#cluster-logging-eventrouter[About collecting and storing Kubernetes events].
+For information, see xref:../../observability/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc#cluster-logging-eventrouter[Collecting and storing Kubernetes events].
 
 include::modules/cluster-logging-troubleshoot-logging.adoc[leveloffset=+2]
 
 include::modules/cluster-logging-export-fields.adoc[leveloffset=+2]
 
-For information, see xref :../../observability/logging/cluster-logging-exported-fields.adoc#cluster-logging-exported-fields[About exporting fields].
+For information, see xref:../../observability/logging/cluster-logging-exported-fields.adoc#cluster-logging-exported-fields[Log record fields].
 
 include::modules/cluster-logging-eventrouter-about.adoc[leveloffset=+2]
 
-For information, see xref :../../observability/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc#cluster-logging-eventrouter[Collecting and storing Kubernetes events].
+For information, see xref:../../observability/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc#cluster-logging-eventrouter[Collecting and storing Kubernetes events].

--- a/observability/logging/log_visualization/log-visualization-ocp-console.adoc
+++ b/observability/logging/log_visualization/log-visualization-ocp-console.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-You can use the {product-title} web console to visualize log data by configuring the {log-plug}. Options for configuration are available during installation of {logging} on the web console. 
+You can use the {product-title} web console to visualize log data by configuring the {log-plug}. Options for configuration are available during installation of {logging} on the web console.
 
 If you have already installed {logging} and want to configure the plugin, use one of the following procedures.
 

--- a/snippets/logging-kibana-dep-snip.adoc
+++ b/snippets/logging-kibana-dep-snip.adoc
@@ -10,5 +10,5 @@
 
 [NOTE]
 ====
-The Kibana web console is now deprecated is planned to be removed in a future logging release.
+The Kibana web console is now deprecated and is planned to be removed in a future logging release.
 ====


### PR DESCRIPTION
This PR fixes a callout not rendering correctly and also some broken xrefs in the ROSA Logging doc.

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13703

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
QE approval is not required as this is just to fix broken xrefs and callouts not rendering correctly.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
