### PR TITLE
OSSM-8733 Add IstioRevisionTags to list of OSSM resources

### DIFF
--- a/modules/ossm-about-concepts-resources.adoc
+++ b/modules/ossm-about-concepts-resources.adoc
@@ -7,8 +7,6 @@
 
 {SMProductName} Operator manages the lifecycle of your Istio control planes. Instead of creating a new configuration schema, {SMProduct} Operator APIs are built around Istio's Helm chart APIs.
 
-//All installation and configuration options that are exposed by Istio's Helm charts are available through the {SMProduct} Operator Custom Resource Definition (CRD) `values` fields.
-
 [NOTE]
 ====
 * Though {SMProductName} APIs are built around Istio's Helm chart APIs, Helm charts are not supported.
@@ -78,6 +76,35 @@ You can think of the relationship between the `Istio` and `IstioRevision` resour
 
 Similarly, users create an `Istio` resource which instructs the {SMProduct} Operator to create a matching `IstioRevision` resource, which then in turn triggers the creation of the Istio control plane. To do that, the {SMProduct} Operator will copy all of your relevant configuration from the `Istio` resource to the `IstioRevision` resource.
 
+[id="istiorevisiontag-resource_{context}"]
+== IstioRevisionTag resource
+
+The `IstioRevisionTag` resource represents a stable revision tag that functions as an alias for Istio control plane revisions. With the stable tag, `prod`, you can use the label `istio.io/rev=prod` to inject proxies into your workloads. When you perform an upgrade to a control plane with a new revision name, you can update your tag to point to the new revision instead of having to relabel your workloads and namespaces. For more information, see link:https://istio.io/latest/docs/setup/upgrade/canary/#stable-revision-labels[Stable revision labels] (Istio documentation).
+
+You can use the `IstioRevisionTag` resource with the {SMProduct} Operator. Therefore you can reference both an `IstioRevision` and an `Istio` resource. When using an `Istio` resource, after you update your control plane, the underlying `IstioRevision` resource changes, and the {SMProduct} Operator automatically updates your revision tag. You only need to restart your deployments to re-inject the new proxies.
+
+The `IstioRevisionTag` has one field in its `spec:` field, `targetRef`, which can reference an `Istio` or `IstioRevision` resource. After deploying the `IstioRevisionTag`, you can use both the `istio.io/rev=default` and `istio-injection=enabled` labels to inject proxies into your workloads.
+
+[Important]
+====
+The `istio-injection` label can only be used for revisions and revision tags that have the name `default`, like the `IstioRevisionTag` resource in the following example:
+
+.Example `IstioRevisionTag` resource
+[source,yaml]
+----
+apiVersion: sailoperator.io/v1
+kind: IstioRevisionTag
+metadata:
+  name: default
+spec:
+  targetRef:
+    kind: Istio <1>
+    name: prod  <2>
+----
+<1> This value can be either `Istio` or `IstioRevision`.
+<2> The name of the `Istio` or `IstioRevision` resource.
+====
+
 [id="istiocni-resource_{context}"]
 == IstioCNI resource
 
@@ -102,9 +129,11 @@ spec:
       - kube-system
 ----
 
-//[role=_additional-resources]
+//commenting out in case it is needed when more resources are added
+//[role="_additional-resources"]
+//[id="additional-resources_{context}"]
 //== Additional resources
-//builds keep failing due to xrefs so removed until this gets merged. May return to this prior to OSSM 3.x GA.
+
 
 //== Kiali --> own module
 //== Tracing --> own module


### PR DESCRIPTION
OSSM 3.0

[OSSM-8733](https://issues.redhat.com//browse/OSSM-8733) Add IstioRevisionTags to list of OSSM resources

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
3.0

Issue:
https://issues.redhat.com/browse/OSSM-8733

Link to docs preview:
https://90659--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/about/ossm-about-concepts-assembly.html#istiorevisiontag-resource_ossm-about-concepts-assembly

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
