### PR TITLE
OSDOCS-13701:contentX reorg of SDN to OVN-K docs

### DIFF
--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -6,8 +6,8 @@ include::_attributes/common-attributes.adoc[]
 // Unique attribute for the version of the release notes.
 
 toc::[]
- 
-As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the OpenShift software-defined networking (SDN) plugin. 
+
+As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the OpenShift software-defined networking (SDN) plugin.
 
 [WARNING]
 ====
@@ -25,7 +25,7 @@ Offline migration::
 This is a manual process that includes some downtime. This method is primarily used for self-managed {product-title} deployments, and consider using this method when you cannot perform a limited live migration to the OVN-Kubernetes network plugin.
 
 [WARNING]
-==== 
+====
 For the limited live migration method only, do not automate the migration from OpenShift SDN to OVN-Kubernetes with a script or another tool such as Red{nbsp}Hat Ansible Automation Platform. This might cause outages or crash your {product-title} cluster.
 ====
 
@@ -34,29 +34,13 @@ For the limited live migration method only, do not automate the migration from O
 
 * xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin]
 
-// Offline migration to the OVN-Kubernetes network plugin overview
-include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-release[Understanding update channels and releases] 
-
-* xref:../../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-asynchronous-errata-updates_release-notes[Asynchronous errata updates]
-
-// How the offline migration process works
-include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
-
-// Migrating to the OVN-Kubernetes network plugin by using the offline migration method
-include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+2]
-
 // Limited live migration to the OVN-Kubernetes network plugin overview
 include::modules/nw-ovn-kubernetes-live-migration-about.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-release[Understanding update channels and releases] 
+* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-release[Understanding update channels and releases]
 
 * xref:../../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-asynchronous-errata-updates_release-notes[Asynchronous errata updates]
 
@@ -130,3 +114,19 @@ include::modules/live-migration-metrics-information.adoc[leveloffset=+3]
 - xref:../../networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc#deploying-egress-router-layer3-redirection[Deploying an egress router pod in redirect mode]
 
 * xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1]
+
+// Offline migration to the OVN-Kubernetes network plugin overview
+include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-release[Understanding update channels and releases]
+
+* xref:../../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-asynchronous-errata-updates_release-notes[Asynchronous errata updates]
+
+// How the offline migration process works
+include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
+
+// Migrating to the OVN-Kubernetes network plugin by using the offline migration method
+include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR moves the offline migration below the preferred method (live migration)
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-13701#:~:text=OpenShift%20Documentation-,OSDOCS%2D13701,-Reorg%20to%20move
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://90670--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
No QE or SME needed this is just moving content.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
