### PR TITLE
OSDOCS#13706: Adding docs for KDO 5.1.2

### DIFF
--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -12,6 +12,33 @@ These release notes track the development of the {descheduler-operator}.
 
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
 
+[id="descheduler-operator-release-notes-5.1.2"]
+== Release notes for {descheduler-operator} 5.1.2
+
+Issued: 1 May 2025
+
+The following advisory is available for the {descheduler-operator} 5.1.2:
+
+* link:https://access.redhat.com/errata/RHBA-2025:4334[RHBA-2025:4334]
+
+[id="descheduler-operator-5.1.2-new-features"]
+=== New features and enhancements
+
+* This release of the {descheduler-operator} adds a new Technology Preview descheduler profile called `DevKubeVirtRelieveAndMigrate`. This profile is only available for use with {VirtProductName}.
+// +
+// For more information, see xref:../../../virt/managing_vms/advanced_vm_management/virt-enabling-descheduler-evictions.adoc#virt-enabling-descheduler-evictions[Enabling descheduler evictions on virtual machines].
+
+[id="descheduler-operator-5.1.2-bug-fixes"]
+=== Bug fixes
+
+* Previously, when the `LifecycleAndUtilization` profile was enabled, pods from protected namespaces ([x-]`openshift-*`, `kube-system`, `hypershift`) could be evicted. Pods in these namespaces should never be evicted. With this release, these protected namespaces are now properly excluded from eviction when the `LifecycleAndUtilization` profile is enabled. (link:https://issues.redhat.com/browse/OCPBUGS-54414[*OCPBUGS-54414*])
+
+// No known issues to list
+// [id="descheduler-operator-5.1.2-known-issues"]
+// === Known issues
+//
+// * TODO
+
 [id="descheduler-operator-release-notes-5.1.1"]
 == Release notes for {descheduler-operator} 5.1.1
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-13706

Link to docs preview:
https://90677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-release-notes.html#descheduler-operator-release-notes-5.1.2

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**Note to reviewer**
~The advisory link doesn't work yet - I will get the URL on release day and will update the PR with it then.~
Advisory link is updated - ready to merge once I get the green light that the release is complete