### PR TITLE
OCPBUGS-28512: Added node reboot node to customize-certificates-repla…

### DIFF
--- a/modules/customize-certificates-replace-default-router.adoc
+++ b/modules/customize-certificates-replace-default-router.adoc
@@ -6,30 +6,20 @@
 [id="replacing-default-ingress_{context}"]
 = Replacing the default ingress certificate
 
-You can replace the default ingress certificate for all
-applications under the `.apps` subdomain. After you replace
-the certificate, all applications, including the web console
-and CLI, will have encryption provided by specified certificate.
+You can replace the default ingress certificate for all applications under the `.apps` subdomain. After you replace the certificate, all applications, including the web console and CLI, have encryption provided by the specified certificate.
 
 .Prerequisites
 
-* You must have a wildcard certificate for the fully qualified `.apps` subdomain
-and its corresponding private key. Each should be in a separate PEM format file.
-* The private key must be unencrypted. If your key is encrypted, decrypt it
-before importing it into {product-title}.
-* The certificate must include the `subjectAltName` extension showing
-`*.apps.<clustername>.<domain>`.
-* The certificate file can contain one or more certificates in a chain. The
-wildcard certificate must be the first certificate in the file. It can then be
-followed with any intermediate certificates, and the file should end with the
-root CA certificate.
+* You must have a wildcard certificate for the fully qualified `.apps` subdomain and its corresponding private key. Each should be in a separate PEM format file.
+* The private key must be unencrypted. If your key is encrypted, decrypt it before importing it into {product-title}.
+* The certificate must include the `subjectAltName` extension showing `*.apps.<clustername>.<domain>`.
+* The certificate file can contain one or more certificates in a chain. The file must list the wildcard certificate as the first certificate, followed by other intermediate certificates, and then ending with the root CA certificate.
 * Copy the root CA certificate into an additional PEM format file.
-* Verify that all certificates which include `-----END CERTIFICATE-----` also
-end with one carriage return after that line.
+* Verify that all certificates which include `-----END CERTIFICATE-----` also end with one carriage return after that line.
 
 .Procedure
 
-. Create a config map that includes only the root CA certificate used to sign the wildcard certificate:
+. Create a config map that includes only the root CA certificate that is used to sign the wildcard certificate:
 +
 [source,terminal]
 ----
@@ -37,7 +27,7 @@ $ oc create configmap custom-ca \
      --from-file=ca-bundle.crt=</path/to/example-ca.crt> \//<1>
      -n openshift-config
 ----
-<1> `</path/to/example-ca.crt>` is the path to the root CA certificate file on your local file system.
+<1> `</path/to/example-ca.crt>` is the path to the root CA certificate file on your local file system. For example, `/etc/pki/ca-trust/source/anchors`.
 
 . Update the cluster-wide proxy configuration with the newly created config map:
 +
@@ -47,6 +37,11 @@ $ oc patch proxy/cluster \
      --type=merge \
      --patch='{"spec":{"trustedCA":{"name":"custom-ca"}}}'
 ----
++
+[NOTE]
+====
+If you update only the trusted CA for your cluster, the MCO updates the `/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt` file and the Machine Config Controller (MCC) applies the trusted CA update to each node so that a node reboot is not required. Changing any other parameter in the `openshift-config-user-ca-bundle.crt` file, such as `noproxy`, results in the MCO rebooting each node in your cluster.
+====
 
 . Create a secret that contains the wildcard certificate chain and key:
 +
@@ -57,15 +52,11 @@ $ oc create secret tls <secret> \//<1>
      --key=</path/to/cert.key> \//<3>
      -n openshift-ingress
 ----
-<1> `<secret>` is the name of the secret that will contain the certificate chain
-and private key.
-<2> `</path/to/cert.crt>` is the path to the certificate chain on your local
-file system.
-<3> `</path/to/cert.key>` is the path to the private key associated
-with this certificate.
+<1> `<secret>` is the name of the secret that will contain the certificate chain and private key.
+<2> `</path/to/cert.crt>` is the path to the certificate chain on your local file system.
+<3> `</path/to/cert.key>` is the path to the private key associated with this certificate.
 
-. Update the Ingress Controller configuration with the newly created
-secret:
+. Update the Ingress Controller configuration with the newly created secret:
 +
 [source,terminal]
 ----
@@ -74,12 +65,10 @@ $ oc patch ingresscontroller.operator default \
      '{"spec":{"defaultCertificate": {"name": "<secret>"}}}' \//<1>
      -n openshift-ingress-operator
 ----
-<1> Replace `<secret>` with the name used for the secret in
-the previous step.
+<1> Replace `<secret>` with the name used for the secret in the previous step.
 +
 [IMPORTANT]
 ====
 To trigger the Ingress Operator to perform a rolling update, you must update the name of the secret.
-Because the kubelet automatically propagates changes to the secret in the volume mount, updating the secret contents does not trigger a rolling update.
-For more information, see this link:https://access.redhat.com/solutions/4542531[Red{nbsp}Hat Knowledgebase Solution].
+Because the kubelet automatically propagates changes to the secret in the volume mount, updating the secret contents does not trigger a rolling update. For more information, see this link:https://access.redhat.com/solutions/4542531[Red{nbsp}Hat Knowledgebase Solution].
 ====

--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -7,7 +7,7 @@
 [id="nw-proxy-configure-object_{context}"]
 = Enabling the cluster-wide proxy
 
-The `Proxy` object is used to manage the cluster-wide egress proxy. When a cluster is installed or upgraded without the proxy configured, a `Proxy` object is still generated but it will have a nil `spec`. For example:
+The `Proxy` object is used to manage the cluster-wide egress proxy. When a cluster is installed or upgraded without the proxy configured, a `Proxy` object is still generated but it has a nil `spec`. For example:
 
 [source,yaml]
 ----
@@ -21,16 +21,16 @@ spec:
 status:
 ----
 
-A cluster administrator can configure the proxy for {product-title} by modifying this `cluster` `Proxy` object.
-
 [NOTE]
 ====
 Only the `Proxy` object named `cluster` is supported, and no additional proxies can be created.
 ====
 
+A cluster administrator can configure the proxy for {product-title} by modifying the `cluster` `Proxy` object.
+
 [WARNING]
 ====
-Enabling the cluster-wide proxy causes the Machine Config Operator (MCO) to trigger node reboot.
+After you enable the cluster-wide proxy capability for your cluster and you save the `Proxy` object file, the Machine Config Operator (MCO) reboots all nodes in your cluster so that each node can access connections that exist outside of the cluster. You do not need to manually reboot these nodes.
 ====
 
 .Prerequisites
@@ -44,10 +44,10 @@ Enabling the cluster-wide proxy causes the Machine Config Operator (MCO) to trig
 +
 [NOTE]
 ====
-You can skip this step if the proxy's identity certificate is signed by an authority from the RHCOS trust bundle.
+You can skip this step if the identity certificate of the proxy is signed by an authority from the {op-system-first} trust bundle.
 ====
 
-.. Create a file called `user-ca-bundle.yaml` with the following contents, and provide the values of your PEM-encoded certificates:
+.. Create a file called `user-ca-bundle.yaml`, and provide the values of your PEM-encoded certificates:
 +
 [source,yaml]
 ----
@@ -63,10 +63,10 @@ metadata:
 <1> This data key must be named `ca-bundle.crt`.
 <2> One or more PEM-encoded X.509 certificates used to sign the proxy's
 identity certificate.
-<3> The config map name that will be referenced from the `Proxy` object.
-<4> The config map must be in the `openshift-config` namespace.
+<3> The config map name that is referenced from the `Proxy` object.
+<4> The config map must exist in the `openshift-config` namespace.
 
-.. Create the config map from this file:
+.. Create the config map from the `user-ca-bundle.yaml` file by entering the following command:
 +
 [source,terminal]
 ----
@@ -101,7 +101,7 @@ spec:
 +
 --
 <1> A proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be `http`.
-<2> A proxy URL to use for creating HTTPS connections outside the cluster. The URL scheme must be either `http` or `https`. Specify a URL for the proxy that supports the URL scheme. For example, most proxies will report an error if they are configured to use `https` but they only support `http`. This failure message may not propagate to the logs and can appear to be a network connection failure instead. If using a proxy that listens for `https` connections from the cluster, you may need to configure the cluster to accept the CAs and certificates that the proxy uses.
+<2> A proxy URL to use for creating HTTPS connections outside the cluster. The URL scheme must be either `http` or `https`. Specify a URL for the proxy that supports the URL scheme. For example, most proxies report an error if they are configured to use `https` but they only support `http`. This failure message may not propagate to the logs and can appear to be a network connection failure instead. If using a proxy that listens for `https` connections from the cluster, you might need to configure the cluster to accept the CAs and certificates that the proxy uses.
 <3> A comma-separated list of destination domain names, domains, IP addresses (or other network CIDRs), and port numbers to exclude proxying.
 +
 [NOTE]
@@ -112,13 +112,13 @@ Port numbers are only supported when configuring IPv6 addresses. Port numbers ar
 Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
 +
 If your `noproxy` field needs to include a domain address, you must explicitly specify that FQDN, or prefix-matched subdomain, in the `noproxy` field. You cannot use the IP address or CIDR range that encapsulates the domain. This is because the cluster does not wait for DNS to return the IP address before assigning the route connection, and checks explicitly against the request being made.
-For example, if you have a CIDR block value, such as `10.0.0.0/24`, for the `noproxy` field and attempt to access `\https://10.0.0.11`, it will match successfully. However, attempting to access `\https://exampleserver.externaldomain.com`, whose A record entry is `10.0.0.11`, will fail. An additional value of `.externaldomain.com` for your `noproxy` field is necessary.
+For example, if you have a CIDR block value, such as `10.0.0.0/24`, for the `noproxy` field and the field attempts to access `\https://10.0.0.11`, the addresses successfully match. However, attempting to access `\https://exampleserver.externaldomain.com`, whose A record entry is `10.0.0.11`, fails. An additional value of `.externaldomain.com` for your `noproxy` field is necessary.
 +
-If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
+If you scale up compute nodes that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
 +
 This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.
 <4> One or more URLs external to the cluster to use to perform a readiness check before writing the `httpProxy` and `httpsProxy` values to status.
-<5> A reference to the config map in the `openshift-config` namespace that contains additional CA certificates required for proxying HTTPS connections. Note that the config map must already exist before referencing it here. This field is required unless the proxy's identity certificate is signed by an authority from the RHCOS trust bundle.
+<5> A reference to the config map in the `openshift-config` namespace that contains additional CA certificates required for proxying HTTPS connections. Note that the config map must already exist before referencing it here. This field is required unless the proxy's identity certificate is signed by an authority from the {op-system} trust bundle.
 --
 
 . Save the file to apply the changes.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-29512](https://issues.redhat.com/browse/OCPBUGS-29512)

Link to docs preview:
* [Enabling the cluster-wide proxy](https://90698--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy#nw-proxy-configure-object_config-cluster-wide-proxy)
* [Replacing the default ingress certificate](https://90698--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/replacing-default-ingress-certificate.html#replacing-default-ingress_replacing-default-ingress)


- [x] SME has approved this change (Christian Passarelli/Will Russell)
- [x] QE has approved this change (Melvin Joseph).
