### PR TITLE
OSDOCS-13705: Resolving additional resources link for ROSA

### DIFF
--- a/networking/network_security/logging-network-security.adoc
+++ b/networking/network_security/logging-network-security.adoc
@@ -39,7 +39,9 @@ include::modules/nw-networkpolicy-audit-disable.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-enterprise[]
 * xref:../../networking/network_security/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+endif::openshift-rosa,openshift-enterprise[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../networking/network_security/egress_firewall/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.17
https://issues.redhat.com/browse/OSDOCS-13705

https://90699--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/logging-network-security.html

QE review:
- [ ] QE approval not needed for link update

