### PR TITLE
OADP-5817: Removed incorrect information regarding SSE-C Encryption

### DIFF
--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -57,26 +57,12 @@ The following procedure contains an example of a `spec:backupLocations` block th
 $ dd if=/dev/urandom bs=1 count=32 > sse.key
 ----
 
-.. Encode the `sse.key` by using Base64 and save the result as a file named `sse_encoded.key` by running the following command:
-+
-[source,terminal]
-----
-$ cat sse.key | base64 > sse_encoded.key
-----
-
-.. Link the file named `sse_encoded.key` to a new file named `customer-key` by running the following command:
-+
-[source,terminal]
-----
-$ ln -s sse_encoded.key customer-key
-----
-
 . Create an {product-title} secret:
 ** If you are initially installing and configuring {oadp-short}, create the AWS credential and encryption key secret at the same time by running the following command:
 +
 [source,terminal]
 ----
-$ oc create secret generic cloud-credentials --namespace openshift-adp --from-file cloud=<path>/openshift_aws_credentials,customer-key=<path>/sse_encoded.key
+$ oc create secret generic cloud-credentials --namespace openshift-adp --from-file cloud=<path>/openshift_aws_credentials,customer-key=<path>/sse.key
 ----
 ** If you are updating an existing installation, edit the values of the `cloud-credential` `secret` block of the `DataProtectionApplication` CR manifest, as in the following example:
 +


### PR DESCRIPTION
Version(s):
OCP 4.14 - 4.18

Issue:
[OADP-5817](https://issues.redhat.com/browse/OADP-5817)

Link to docs preview: https://90702--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-ssec-encrypted-backups_installing-oadp-aws 


QE review:
- [x] QE has approved this change.


