### PR TITLE
[enterprise-4.14] OADP-5659 Release Notes and Attribute Updates for OADP 1.4.4

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -39,9 +39,9 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.4.2
+:oadp-version: 1.4.4
 :oadp-version-1-3: 1.3.6
-:oadp-version-1-4: 1.4.2
+:oadp-version-1-4: 1.4.4
 :oadp-bsl-api: backupstoragelocations.velero.io
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -13,7 +13,7 @@ The release notes for {oadp-first} describe new features and enhancements, depre
 ====
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
 ====
-
+include::modules/oadp-1-4-4-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-3-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-2-release-notes.adoc[leveloffset=+1]
 

--- a/modules/oadp-1-4-4-release-notes.adoc
+++ b/modules/oadp-1-4-4-release-notes.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-4-release-notes_{context}"]
+= {oadp-short} 1.4.4 release notes
+
+{oadp-first} 1.4.4 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.3.
+
+[id="known-issues-1-4-4_{context}"]
+== Known issues
+
+.Issue with restoring stateful applications 
+When you restore a stateful application that uses the `azurefile-csi` storage class, the restore operation remains in the `Finalizing` phase. link:https://issues.redhat.com/browse/OADP-5508[(OADP-5508)]

--- a/modules/oadp-creating-restore-cr.adoc
+++ b/modules/oadp-creating-restore-cr.adoc
@@ -120,3 +120,8 @@ EOF
 done
 ----
 ====
+
+[NOTE]
+====
+When you restore a stateful application that uses the `azurefile-csi` storage class, the restore operation remains in the `Finalizing` phase. 
+====


### PR DESCRIPTION
### JIRA

* [OADP-5659 Release notes for OADP 1.4.4](https://issues.redhat.com/browse/OADP-5659)
* [OADP-5508 CSI Restore stuck in "Finalising" state when using azure File csi driver](https://issues.redhat.com/browse/OADP-5508)

### Version

* 4.14

Related to #89108 

Link to docs preview:
* [OADP 1.4.4 Release Notes](https://90752--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html#oadp-1-4-4-release-notes_oadp-1-4-release-notes)
* [Creating a Restore PR](https://90752--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.html#oadp-creating-restore-cr_restoring-applications)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
