### PR TITLE
TELCODOCS#2234: Release note to warn of issues with TPM disk encryption with certain firmwares

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2966,6 +2966,8 @@ For more information, see xref:../networking/ovn_kubernetes_network_provider/con
 
 * For dual-stack networking clusters that run on {rh-openstack}, when a Virtual IP (VIP) that is attached to a Floating IP (FIP) moves between master nodes, the association between VIP and FIP might stop working if the new master is on a different compute node. This issue occurs because OVN assumes that both IPv4 and IPv6 addresses on a shared Neutron port belong to the same node. (link:https://issues.redhat.com//browse/OCPBUGS-50599[OCPBUGS-50599])
 
+* Disk encryption with PCR 1 and PCR 7 protection fails on systems that automatically create additional Extensible Firmware Interface (EFI) entries during the boot operation. These extra entries modify EFI variables, preventing server attestation with PCR 1. (link:https://issues.redhat.com/browse/OCPBUGS-54593[*OCPBUGS-54593*])
+
 [id="ocp-telco-ran-4-18-known-issues_{context}"]
 
 * When you run Cloud-native Network Functions (CNF) latency tests on an {product-title} cluster, the test can sometimes return results greater than the latency threshold for the test; for example, 20 microseconds for `cyclictest` testing. This results in a test failure.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2234](https://issues.redhat.com/browse/TELCODOCS-2234)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Known issues](https://90756--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-known-issues_release-notes)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->