### PR TITLE
OSDOCS-13539-removed: Removed the OCPBUGS-43323 in configuring-ipsec-…

### DIFF
--- a/networking/network_security/configuring-ipsec-ovn.adoc
+++ b/networking/network_security/configuring-ipsec-ovn.adoc
@@ -12,11 +12,11 @@ IPsec is disabled by default. You can enable IPsec either during or after instal
 
 The following support limitations exist for IPsec on a {product-title} cluster:
 
-* You must disable IPsec before updating to {product-title} 4.15. There is a known issue that can cause interruptions in pod-to-pod communication if you update without disabling IPsec. (link:https://issues.redhat.com/browse/OCPBUGS-43323[*OCPBUGS-43323*])
 * On {ibm-cloud-name}, IPsec supports only NAT-T. Encapsulating Security Payload (ESP) is not supported on this platform.
 * If your cluster uses link:https://www.redhat.com/en/topics/containers/what-are-hosted-control-planes[{hcp}] for Red{nbsp}Hat {product-title}, IPsec is not supported for IPsec encryption of either pod-to-pod or traffic to external hosts.
 * Using ESP hardware offloading on any network interface is not supported if one or more of those interfaces is attached to Open vSwitch (OVS). Enabling IPsec for your cluster triggers the use of IPsec with interfaces attached to OVS. By default, {product-title} disables ESP hardware offloading on any interfaces attached to OVS.
 * If you enabled IPsec for network interfaces that are not attached to OVS, a cluster administrator must manually disable ESP hardware offloading on each interface that is not attached to OVS.
+* IPsec is not supported on {op-system-base-full} compute nodes because of a `libreswan` incompatiblility issue between a host and an `ovn-ipsec` container that exist in each compute node. See (link:https://issues.redhat.com/browse/OCPBUGS-53316[*OCPBUGS-53316*]).
 
 The following list outlines key tasks in the IPsec documentation:
 


### PR DESCRIPTION
Version(s):
4.15 to 4.18

Issue:
[OSDOCS-13539](https://issues.redhat.com/browse/OSDOCS-13539)

Link to docs preview:
[Configuring IPsec encryption](https://90760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn.html)

- [x] SME has approved this change (Periyasamy Palanisamy).
- [x] QE has approved this change (Huiran Wang).


Additional information:
[Slack](https://app.slack.com/client/E030G10V24F/C08DNAFC85T?selected_team_id=E030G10V24F)
