### PR TITLE
OCPBUGS-42701-418R: REST API doc update for disableMultiNetwork change

### DIFF
--- a/api-config.yaml
+++ b/api-config.yaml
@@ -439,10 +439,13 @@ apiMap:
   - kind: IngressClass
     group: networking.k8s.io
     version: v1
-#  - kind: IPAMClaim
-#    group: k8s.cni.cncf.io
-#    version: v1alpha1
+  - kind: IPAMClaim
+    group: k8s.cni.cncf.io
+    version: v1alpha1
   - kind: IPPool
+    group: whereabouts.cni.cncf.io
+    version: v1alpha1
+  - kind: NodeSlicePool
     group: whereabouts.cni.cncf.io
     version: v1alpha1
 # OpenShift SDN
@@ -469,9 +472,12 @@ apiMap:
     version: v1
   - kind: Service
     version: v1
-#  - kind: UserDefinedNetwork
-#    group: k8s.ovn.org
-#    version: v1
+  - kind: ClusterUserDefinedNetwork
+    group: k8s.ovn.org
+    version: v1 
+  - kind: UserDefinedNetwork
+    group: k8s.ovn.org
+    version: v1
 - name: Node APIs
   resources:
   - kind: Node
@@ -612,9 +618,9 @@ apiMap:
   - kind: InstallPlan
     group: operators.coreos.com
     version: v1alpha1
-#  - kind: OLM
-#    group: operator.openshift.io
-#    version: v1
+  - kind: OLM
+    group: operator.openshift.io
+    version: v1
   - kind: OLMConfig
     group: operators.coreos.com
     version: v1
@@ -688,6 +694,9 @@ apiMap:
     group: metal3.io
     version: v1alpha1
   - kind: Provisioning
+    group: metal3.io
+    version: v1alpha1
+  - kind: HostUpdatePolicy
     group: metal3.io
     version: v1alpha1
 - name: RBAC APIs


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OCPBUGS-42701](https://issues.redhat.com/browse/OCPBUGS-42701)

Link to docs preview:
* [disableMultiNetwork](https://90761--ocpdocs-pr.netlify.app/openshift-enterprise/latest/rest_api/operator_apis/network-operator-openshift-io-v1)

Add. resources:
* https://github.com/openshift/api/pull/2143/files
