### PR TITLE
TELCODOCS-2153: Added row to the table for the rhel9 image

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -53,10 +53,21 @@ ifndef::openshift-rosa,openshift-dedicated[]
 |Data collection for Local Storage Operator.
 
 |`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:v<installed_version_sandboxed_containers>`
-|Data collection for {sandboxed-containers-first}.
+|Data collection for {osc}.
 
-|`registry.redhat.io/workload-availability/node-healthcheck-must-gather-rhel8:v<installed-version-NHC>`
-|Data collection for the Red{nbsp}Hat Workload Availability Operators, including the Self Node Remediation (SNR) Operator, the Fence Agents Remediation (FAR) Operator, the Machine Deletion Remediation (MDR) Operator, the Node Health Check Operator (NHC) Operator, and the Node Maintenance Operator (NMO) Operator.
+|`registry.redhat.io/workload-availability/node-healthcheck-must-gather-rhel8:v<installed_version_NHC>`
+|Data collection for the Red{nbsp}Hat Workload Availability Operators, including the Self Node Remediation (SNR) Operator, the Fence Agents Remediation (FAR) Operator, the Machine Deletion Remediation (MDR) Operator, the Node Health Check (NHC) Operator, and the Node Maintenance Operator (NMO).
+
+Use this image if your NHC Operator version is *earlier than 0.9.0*.
+
+For more information, see the "Gathering data" section for the specific Operator in https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift/latest/html/remediation_fencing_and_maintenance/index[Remediation, fencing, and maintenance] (Workload Availability for Red Hat OpenShift documentation).
+
+|`registry.redhat.io/workload-availability/node-healthcheck-must-gather-rhel9:v<installed_version_NHC>`
+|Data collection for the Red{nbsp}Hat Workload Availability Operators, including the Self Node Remediation (SNR) Operator, the Fence Agents Remediation (FAR) Operator, the Machine Deletion Remediation (MDR) Operator, the Node Health Check (NHC) Operator, and the Node Maintenance Operator (NMO).
+
+Use this image if your NHC Operator version is *0.9.0. or later*.
+
+For more information, see the "Gathering data" section for the specific Operator in https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift/latest/html/remediation_fencing_and_maintenance/index[Remediation, fencing, and maintenance] (Workload Availability for Red Hat OpenShift documentation).
 
 |`registry.redhat.io/numaresources/numaresources-must-gather-rhel9:v<installed-version-nro>`
 |Data collection for the NUMA Resources Operator (NRO).


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-2153: Update RHWA/NHC must-gather Version
Applies to OCP version : 4.19, 4.18, 4.17, 4.16, 4.15, 4.14, 4.13, 4.12 

Preview: [Gathering data about specific features](https://90763--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data)

QE review completed by @razo7
Dev review completed by @frajamomo 
Peer review completed by @stesmith

Thank you.