### PR TITLE
OSSM-8284 Update OSSM3 + cert-manager docs for tp2

### DIFF
--- a/modules/ossm-cert-manager-installing-istio-resource.adoc
+++ b/modules/ossm-cert-manager-installing-istio-resource.adoc
@@ -35,10 +35,6 @@ spec:
     pilot:
       env:
         ENABLE_CA_SERVER: "false"
-      volumeMounts:
-        - mountPath: /tmp/var/run/secrets/istiod/tls
-          name: istio-csr-dns-cert
-          readOnly: true
 ----
 +
 [NOTE]

--- a/modules/ossm-cert-manager-verifying-install.adoc
+++ b/modules/ossm-cert-manager-verifying-install.adoc
@@ -25,7 +25,7 @@ $ oc new-project sample
 +
 [source, terminal]
 ----
-$ oc get istiorevisions
+$ oc get istios default -o jsonpath='{.status.activeRevisionName}'
 ----
 
 . Add the injection label for your active revision to the `sample` namespace by running the following command:


### PR DESCRIPTION
OSSM 3.0

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

[OSSM-8284](https://issues.redhat.com//browse/OSSM-8284) Update OSSM3 + cert-manager docs for tp2

Version(s):
3.0

Issue:
https://issues.redhat.com/browse/OSSM-8284

Link to docs preview:

* https://90764--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-cert-manager-assembly.html#installing-istio-resource_ossm-cert-manager-assembly
* https://90764--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-cert-manager-assembly.html#verifying-cert-manager-installation_ossm-cert-manager-assembly

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
