### PR TITLE
OCPBUGS-53394: Fixing conditionalization

### DIFF
--- a/modules/using-cluster-compare-telco-core.adoc
+++ b/modules/using-cluster-compare-telco-core.adoc
@@ -1,19 +1,17 @@
 // Module included in the following assemblies:
 //
-// *scalability_and_performance/cluster-compare/using-the-cluster-compare-plugin.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
 
 :_mod-docs-content-type: PROCEDURE
 
-[id="using-cluster-compare-telco_ref_{context}"]
-= Example: Comparing a cluster with the telco core reference configuration
+[id="using-cluster-compare-telco_core_{context}"]
+= Comparing a cluster with the {rds} reference configuration
 
-You can use the `cluster-compare` plugin to compare a reference configuration with a configuration from a live cluster or `must-gather` data.
+After you deploy a {rds} cluster, you can use the `cluster-compare` plugin to assess the cluster's compliance with the {rds} reference design specifications (RDS). The `cluster-compare` plugin is an OpenShift CLI (`oc`) plugin. The plugin uses a {rds} reference configuration to validate the cluster with the {rds} custom resources (CRs).
 
-This example compares a configuration from a live cluster with the telco core reference configuration. The telco core reference configuration is derived from the telco core reference design specifications (RDS). The telco core RDS is designed for clusters to support large scale telco applications including control plane and some centralized data plane functions.
+The plugin-specific reference configuration for {rds} is packaged in a container image with the {rds} CRs.
 
-The reference configuration is packaged in a container image with the telco core RDS.
-
-For further examples of using the `cluster-compare` plugin with the telco core and telco RAN distributed unit (DU) profiles, see the "Additional resources" section.
+For further information about the `cluster-compare` plugin, see "Understanding the cluster-compare plugin".
 
 .Prerequisites
 

--- a/modules/using-cluster-compare-telco-ran.adoc
+++ b/modules/using-cluster-compare-telco-ran.adoc
@@ -1,0 +1,130 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/cluster-compare/using-the-cluster-compare-plugin.adoc
+// * scalability_and_performance/telco_ran_du_ref_design_specs/telco-ran-du-rds.adoc
+// * scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// *scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.adoc
+// *scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc
+// *scalability_and_performance/cluster-compare/using-the-cluster-compare-plugin.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="using-cluster-compare-telco-ran_{context}"]
+= Comparing a cluster with the {rds} reference configuration
+
+After you deploy a {rds} cluster, you can use the `cluster-compare` plugin to assess the cluster's compliance with the {rds} reference design specifications (RDS). The `cluster-compare` plugin is an OpenShift CLI (`oc`) plugin. The plugin uses a {rds} reference configuration to validate the cluster with the {rds} custom resources (CRs).
+
+The plugin-specific reference configuration for {rds} is packaged in a container image with the {rds} CRs.
+
+For further information about the `cluster-compare` plugin, see "Understanding the cluster-compare plugin".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have credentials to access the `registry.redhat.io` container image registry.
+
+* You installed the `cluster-compare` plugin.
+
+.Procedure
+
+. Log on to the container image registry with your credentials by running the following command:
++
+[source,terminal]
+----
+$ podman login registry.redhat.io
+----
+
+. Extract the content from the `ztp-site-generate-rhel8` container image by running the following commands::
++
+[source,terminal,subs="attributes+"]
+----
+$ podman pull registry.redhat.io/openshift4/ztp-site-generate-rhel8:v{product-version}
+----
++
+[source,terminal]
+----
+$ mkdir -p ./out
+----
++
+[source,terminal,subs="attributes+"]
+----
+$ podman run --log-driver=none --rm registry.redhat.io/openshift4/ztp-site-generate-rhel8:v{product-version} extract /home/ztp --tar | tar x -C ./out
+----
+
+. Compare the configuration for your cluster to the reference configuration by running the following command:
++
+[source,terminal]
+----
+$ oc cluster-compare -r out/reference/metadata.yaml
+----
++
+.Example output
+[source,terminal]
+----
+...
+
+**********************************
+
+Cluster CR: config.openshift.io/v1_OperatorHub_cluster <1>
+Reference File: required/other/operator-hub.yaml <2>
+Diff Output: diff -u -N /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhub_cluster /tmp/LIVE-2569768241/config-openshift-io-v1_operatorhub_cluster
+--- /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhub_cluster	2024-12-12 14:13:22.898756462 +0000
++++ /tmp/LIVE-2569768241/config-openshift-io-v1_operatorhub_cluster	2024-12-12 14:13:22.898756462 +0000
+@@ -1,6 +1,6 @@
+ apiVersion: config.openshift.io/v1
+ kind: OperatorHub
+ metadata:
++  annotations: <3>
++    include.release.openshift.io/hypershift: "true"
+   name: cluster
+-spec:
+-  disableAllDefaultSources: true
+
+**********************************
+
+Summary <4>
+CRs with diffs: 11/12 <5>
+CRs in reference missing from the cluster: 40 <6>
+optional-image-registry:
+  image-registry:
+    Missing CRs: <7>
+    - optional/image-registry/ImageRegistryPV.yaml
+optional-ptp-config:
+  ptp-config:
+    One of the following is required:
+    - optional/ptp-config/PtpConfigBoundary.yaml
+    - optional/ptp-config/PtpConfigGmWpc.yaml
+    - optional/ptp-config/PtpConfigDualCardGmWpc.yaml
+    - optional/ptp-config/PtpConfigForHA.yaml
+    - optional/ptp-config/PtpConfigMaster.yaml
+    - optional/ptp-config/PtpConfigSlave.yaml
+    - optional/ptp-config/PtpConfigSlaveForEvent.yaml
+    - optional/ptp-config/PtpConfigForHAForEvent.yaml
+    - optional/ptp-config/PtpConfigMasterForEvent.yaml
+    - optional/ptp-config/PtpConfigBoundaryForEvent.yaml
+  ptp-operator-config:
+    One of the following is required:
+    - optional/ptp-config/PtpOperatorConfig.yaml
+    - optional/ptp-config/PtpOperatorConfigForEvent.yaml
+optional-storage:
+  storage:
+    Missing CRs:
+    - optional/local-storage-operator/StorageLV.yaml
+
+...
+
+No CRs are unmatched to reference CRs <8>
+Metadata Hash: 09650c31212be9a44b99315ec14d2e7715ee194a5d68fb6d24f65fd5ddbe3c3c <9>
+No patched CRs <10>
+----
+<1> The CR under comparison. The plugin displays each CR with a difference from the corresponding template.
+<2> The template matching with the CR for comparison.
+<3> The output in Linux diff format shows the difference between the template and the cluster CR.
+<4> After the plugin reports the line diffs for each CR, the summary of differences are reported.
+<5> The number of CRs in the comparison with differences from the corresponding templates.
+<6> The number of CRs represented in the reference configuration, but missing from the live cluster.
+<7> The list of CRs represented in the reference configuration, but missing from the live cluster.
+<8> The CRs that did not match to a corresponding template in the reference configuration.
+<9> The metadata hash identifies the reference configuration.
+<10> The list of patched CRs.

--- a/scalability_and_performance/cluster-compare/using-the-cluster-compare-plugin.adoc
+++ b/scalability_and_performance/cluster-compare/using-the-cluster-compare-plugin.adoc
@@ -24,5 +24,5 @@ include::modules/using-cluster-compare-telco-ref.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* xref:../../scalability_and_performance/telco-ran-du-rds.adoc#using-cluster-compare-telco_ref_ran-ref-design-crs[Comparing a cluster with the telco RAN DU reference configuration]
-* xref:../../scalability_and_performance/telco-core-rds.adoc#using-cluster-compare-telco_ref_telco-core[Comparing a cluster with the telco core reference configuration]
+* xref:../../scalability_and_performance/telco-ran-du-rds.adoc#using-cluster-compare-telco-ran_ran-ref-design-crs[Comparing a cluster with the telco RAN DU reference configuration]
+* xref:../../scalability_and_performance/telco-core-rds.adoc#using-cluster-compare-telco_core_telco-core[Comparing a cluster with the telco core reference configuration]

--- a/scalability_and_performance/telco-core-rds.adoc
+++ b/scalability_and_performance/telco-core-rds.adoc
@@ -214,7 +214,7 @@ Use the CRs to form the common baseline used in all the specific use models unle
 
 include::modules/telco-core-rds-container.adoc[leveloffset=+2]
 
-include::modules/using-cluster-compare-telco-ref.adoc[leveloffset=+2]
+include::modules/using-cluster-compare-telco-core.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/scalability_and_performance/telco-ran-du-rds.adoc
+++ b/scalability_and_performance/telco-ran-du-rds.adoc
@@ -150,10 +150,6 @@ You can extract the complete set of RAN DU CRs from the `ztp-site-generate` cont
 See xref:../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster[Preparing the {ztp} site configuration repository] for more information.
 ====
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.adoc#understanding-the-cluster-compare-plugin[Understanding the cluster-compare plugin]
-
 include::modules/telco-ran-crs-cluster-tuning.adoc[leveloffset=+2]
 
 include::modules/telco-ran-crs-day-2-operators.adoc[leveloffset=+2]
@@ -161,8 +157,12 @@ include::modules/telco-ran-crs-day-2-operators.adoc[leveloffset=+2]
 include::modules/telco-ran-crs-machine-configuration.adoc[leveloffset=+2]
 
 :context: ran-ref-design-crs
-include::modules/using-cluster-compare-telco-ref.adoc[leveloffset=+1]
+include::modules/using-cluster-compare-telco-ran.adoc[leveloffset=+1]
 :context: telco-ran-du
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.adoc#understanding-the-cluster-compare-plugin[Understanding the cluster-compare plugin]
 
 include::modules/ztp-telco-ran-software-versions.adoc[leveloffset=+1]
 


### PR DESCRIPTION
OCPBUGS-53394: Fixing incorrect conditionalization that is causing content to not display as expected.

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OCPBUGS-53394

Link to docs preview:
- https://90772--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cluster-compare/using-the-cluster-compare-plugin.html#using-cluster-compare-telco_ref_using-cluster-compare-plugin
- https://90772--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-core-rds.html#using-cluster-compare-telco_core_telco-core
- https://90772--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#using-cluster-compare-telco-ran_ran-ref-design-crs

No QE needed as there are no content changes. This is just reorganizing content to display correctly instead of overly complex conditionalization. 
