### PR TITLE
OSSM-8954 Add use of IstioRevisionTag to sidecar injection page

### DIFF
--- a/install/ossm-sidecar-injection.adoc
+++ b/install/ossm-sidecar-injection.adoc
@@ -11,6 +11,7 @@ To use {istio}’s capabilities within a service mesh, each pod needs a sidecar 
 include::modules/ossm-about-sidecar-injection.adoc[leveloffset=+1]
 include::modules/ossm-identifying-revision-name.adoc[leveloffset=+1]
 include::modules/ossm-enabling-sidecar-injection.adoc[leveloffset=+1]
+include::modules/ossm-enabling-sidecar-injection-istio-revision-tag-resource.adoc[leveloffset=+1]
 
 
 [role="_additional-resources"]
@@ -19,4 +20,5 @@ include::modules/ossm-enabling-sidecar-injection.adoc[leveloffset=+1]
 * link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[About admission controllers] (Kubernetes documentation)
 * link:https://istio.io/latest/docs/ops/common-problems/injection/[Istio sidecar injection problems] (Istio documentation)
 * xref:../install/ossm-installing-openshift-service-mesh.adoc#deploying-book-info_ossm-about-bookinfo-application[Deploying the Bookinfo application]
-* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-creating-istiocni-resource[Scoping service mesh with discovery selectors]
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-creating-istiocni-resource[Scoping the Service Mesh with discovery selectors]
+* xref:../about/ossm-about-concepts.adoc#istiorevisiontag-resource_ossm-about-concepts[IstioRevisionTag resource]

--- a/modules/ossm-enabling-sidecar-injection-istio-revision-tag-resource.adoc
+++ b/modules/ossm-enabling-sidecar-injection-istio-revision-tag-resource.adoc
@@ -1,0 +1,131 @@
+// Module included in the following assemblies:
+// install/ossm-sidecar-injection
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-enabling-sidecar-injection-istio-revision-tag-resource_{context}"]
+= Enabling sidecar injection with namespace labels and an IstioRevisionTag resource
+
+To use the `istio-injection=enabled` label when your revision name is not `default`, you must create an `IstioRevisionTag` resource with the name `default` that references your `Istio` resource.
+
+//Prereqs lifted from existing content https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/installing/ossm-sidecar-injection
+//any changes made will need to be part of refactoring Jira issue OSSM-9078 so content is consistent
+.Prerequisites
+
+* You have installed the {SMProductName} Operator, created an `{istio}` resource, and the Operator has deployed {istio}.
+* You have created the `IstioCNI` resource, and the Operator has deployed the necessary `IstioCNI` pods.
+* You have created the namespaces that are to be part of the mesh, and they are discoverable by the {istio} control plane.
+* Optional: You have deployed the workloads to be included in the mesh. In the following examples, the Bookinfo has been deployed to the `bookinfo` namespace, but sidecar injection (step 5 in "Deploying the Bookinfo application" procedure) has not been configured. For more information, see "Deploying the Bookinfo application".
+
+.Procedure
+
+. Find the name of your `Istio` resource by running the following command:
++
+[source,terminal]
+----
+$ oc get istio
+----
++
+.Example output
+[source,terminal]
+----
+NAME      REVISIONS   READY   IN USE   ACTIVE REVISION   STATUS    VERSION   AGE
+default   1           1       1        default-v1-24-3   Healthy   v1.24.3   11s
+----
++
+In this example, the `Istio` resource has the name `default`, but the underlying revision is called `default-v1-24-3`.
+
+. Create the `IstioRevisionTag` resource in a YAML file:
++
+.Example `IstioRevistionTag` resource YAML file
+[source,yaml]
+----
+apiVersion: sailoperator.io/v1
+kind: IstioRevisionTag
+metadata:
+  name: default
+spec:
+  targetRef:
+    kind: Istio
+    name: default
+----
+
+. Apply the `IstioRevisionTag` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f istioRevisionTag.yaml
+----
+
+. Verify that the `IstioRevisionTag` resource has been created successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get istiorevisiontags.sailoperator.io
+----
++
+.Example output
+[source,terminal]
+----
+NAME      STATUS    IN USE   REVISION          AGE
+default   Healthy   True     default-v1-24-3   4m23s
+----
++
+In this example, the new tag is referencing your active revision, `default-v1-24-3`. Now you can use the `istio-injection=enabled` label as if your revision was called `default`.
++
+//lifted from existing content https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/installing/ossm-sidecar-injection
+//any changes made will need to be part of refactoring Jira issue OSSM-9078 so content is consistent
+
+. Confirm that the pods are running without sidecars by running the following command. Any workloads that are already running in the desired namespace should show `1/1` containers in the `READY` column.
++
+[source,terminal]
+----
+$ oc get pods -n bookinfo
+----
++
+.Example output
+[source,terminal]
+----
+NAME                             READY   STATUS    RESTARTS   AGE
+details-v1-65cfcf56f9-gm6v7      1/1     Running   0          4m55s
+productpage-v1-d5789fdfb-8x6bk   1/1     Running   0          4m53s
+ratings-v1-7c9bd4b87f-6v7hg      1/1     Running   0          4m55s
+reviews-v1-6584ddcf65-6wqtw      1/1     Running   0          4m54s
+reviews-v2-6f85cb9b7c-w9l8s      1/1     Running   0          4m54s
+reviews-v3-6f5b775685-mg5n6      1/1     Running   0          4m54s
+----
+
+. Apply the injection label to the `bookinfo` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace bookinfo istio-injection=enabled \
+namespace/bookinfo labeled
+----
+
+. To ensure sidecar injection is applied, redeploy the workloads in the `bookinfo` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc -n bookinfo rollout restart deployments
+----
+
+.Verification
+
+. Verify the rollout by running the following command and confirming that the new pods display `2/2` containers in the `READY` column:
++
+[source,terminal]
+----
+$ oc get pods -n bookinfo
+----
++
+.Example output
+[source,terminal]
+----
+NAME                              READY   STATUS    RESTARTS   AGE
+details-v1-7745f84ff-bpf8f        2/2     Running   0          55s
+productpage-v1-54f48db985-gd5q9   2/2     Running   0          55s
+ratings-v1-5d645c985f-xsw7p       2/2     Running   0          55s
+reviews-v1-bd5f54b8c-zns4v        2/2     Running   0          55s
+reviews-v2-5d7b9dbf97-wbpjr       2/2     Running   0          55s
+reviews-v3-5fccc48c8c-bjktn       2/2     Running   0          55s
+----


### PR DESCRIPTION
OSSM 3.0

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

[OSSM-8954](https://issues.redhat.com//browse/OSSM-8954) Add use of IstioRevisionTag to sidecar injection page

Version(s):
3.0

Issue:
https://issues.redhat.com/browse/OSSM-8954

Link to docs preview:
https://90791--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-sidecar-injection.html#ossm-enabling-sidecar-injection-istio-revision-tag-resource_ossm-sidecar-injection

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Refactoring of ossm-enabling-sidecar-injection.adoc is covered by a separate Jira.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
