### PR TITLE
OCPBUGS-53243:  Fixing incorrect delimiters. Clarifying syntax.

### DIFF
--- a/modules/cluster-compare-manual-match.adoc
+++ b/modules/cluster-compare-manual-match.adoc
@@ -7,9 +7,15 @@
 [id="cluster-compare-manual-match_{context}"]
 = Configuring manual matching between CRs and templates
 
-For scenarios where the `cluster-compare` plugin's default matching does not work as expected, you can manually match a custom resource (CR) to a template. 
+In some cases, the `cluster-compare` plugin's default matching might not work as expected. You can manually define how a custom resource (CR) maps to a template by using a user configuration file.
 
-For example, if there is more than one CR in the cluster with the same `apiversion`, `kind`, `name`, and `namespace` fields, the plugin's default matching compares the CR that features the least differences. To control what CR the plugin chooses, you can create a user configuration YAML file with the manual matching configuration, then pass this configuration file to the `cluster-compare` command.
+By default, the plugin maps a CR to a template based on the `apiversion`, `kind`, `name`, and `namespace` fields. However, multiple templates might match a single CR. For example, this can occur in the following scenarios:
+
+* Multiple templates exist with the same `apiversion`, `kind`, `name`, and `namespace` fields.
+
+* Templates match any CR with a specific `apiversion` and `kind`, regardless of its `namespace` or `name`.
+
+When a CR matches multiple templates, the plugin uses a tie-breaking mechanism that selects the template with the fewest differences. To explicitly control which template the plugin chooses, you can create a user configuration YAML file that defines manual matching rules. You can pass this configuration file to the `cluster-compare` command to enforce the required template selection.
 
 .Procedure
 
@@ -18,12 +24,16 @@ For example, if there is more than one CR in the cluster with the same `apiversi
 .Example `user-config.yaml` file
 [source,yaml]
 ----
-correlationSettings:
-   manualCorrelation:
-      correlationPairs:
-         apps.v1.DaemonSet.kube-system.kindnet.yaml: "template_example.yaml" <1>
+correlationSettings: <1>
+   manualCorrelation: <2>
+      correlationPairs: <3>
+        ptp.openshift.io/v1_PtpConfig_openshift-ptp_grandmaster: optional/ptp-config/PtpOperatorConfig.yaml <4>
+        ptp.openshift.io/v1_PtpOperatorConfig_openshift-ptp_default: optional/ptp-config/PtpOperatorConfig.yaml
 ----
-<1> Specifies the CR and template pair to match. The CR specification uses the following format: `<apiversion>.<kind>.<namespace>.<name>`. For cluster scoped CRs that do not have a namespace, use the format `<apiversion>.<kind>.<name>`.
+<1> The `correlationSettings` section contains the manual correlation settings.
+<2> The `manualCorrelation` section specifies that manual correlation is enabled.
+<3> The `correlationPairs` section lists the CR and template pairs to manually match.
+<4> Specifies the CR and template pair to match. The CR specification uses the following format: `<apiversion>_<kind>_<namespace>_<name>`. For cluster-scoped CRs that do not have a namespace, use the following format: `<apiversion>_<kind>_<name>`. The path to the template must be relative to the `metadata.yaml` file.
 
 . Reference the user configuration file in a `cluster-compare` command by running the following command:
 +

--- a/modules/installing-cluster-compare.adoc
+++ b/modules/installing-cluster-compare.adoc
@@ -23,7 +23,7 @@ Install the `cluster-compare` plugin to compare a reference configuration with a
 +
 [source,terminal]
 ----
-$ podman login registry.access.redhat.com
+$ podman login registry.redhat.io
 ----
 
 . Create a container for the `cluster-compare` image by running the following command:


### PR DESCRIPTION
OCPBUGS-53243: Fixing incorrect delimiters. Clarifying syntax.

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OCPBUGS-53243

Link to docs preview:
- https://90796--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cluster-compare/advanced-ref-config-customization.html#cluster-compare-manual-match_advanced-ref-config-customization
- https://90796--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cluster-compare/installing-cluster-compare-plugin.html#installing-cluster-compare_installing-cluster-compare-plugin

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
