### PR TITLE
CNV - #30799 - Consider_creating_Role_instead_of_ClusterRole_for_cross_ns_cloning

### DIFF
--- a/modules/virt-creating-rbac-cloning-dvs.adoc
+++ b/modules/virt-creating-rbac-cloning-dvs.adoc
@@ -12,6 +12,11 @@ Create a new cluster role that enables permissions for all actions for the `data
 
 * You must have cluster admin privileges.
 
+[NOTE]
+====
+If you are a non-admin user that is an administrator for both the source and target namespaces, you can create a `Role` instead of a `ClusterRole` where appropriate.
+====
+
 .Procedure
 
 . Create a `ClusterRole` manifest:


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/CNV-30799?filter=-1

Link to docs preview:
https://90798--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-enabling-user-permissions-to-clone-datavolumes.html

QE review: N/A




