### PR TITLE
OSDOCS#12900: Increasing rec visibility

### DIFF
--- a/modules/cert-manager-operator-update-channels.adoc
+++ b/modules/cert-manager-operator-update-channels.adoc
@@ -13,8 +13,12 @@ Update channels are the mechanism by which you can declare the version of your {
 
 [id="stable-v1-channel_{context}"]
 == stable-v1 channel
+The `stable-v1` channel installs and updates the latest release version of the {cert-manager-operator}. Select the `stable-v1` channel if you want to use the latest stable release of the {cert-manager-operator}.
 
-The `stable-v1` channel is the default and suggested channel while installing the {cert-manager-operator}. The `stable-v1` channel installs and updates the latest release version of the {cert-manager-operator}. Select the `stable-v1` channel if you want to use the latest stable release of the {cert-manager-operator}.
+[NOTE]
+====
+The `stable-v1` channel is the default and suggested channel while installing the {cert-manager-operator}.
+====
 
 The `stable-v1` channel offers the following update approval strategies:
 

--- a/modules/customize-certificates-add-service-serving.adoc
+++ b/modules/customize-certificates-add-service-serving.adoc
@@ -31,10 +31,16 @@ Because the generated certificates contain wildcard subjects for headless servic
 $ oc annotate service <service_name> \//<1>
      service.beta.openshift.io/serving-cert-secret-name=<secret_name> //<2>
 ----
++
+--
 <1> Replace `<service_name>` with the name of the service to secure.
-<2> `<secret_name>` will be the name of the generated secret containing the
-certificate and key pair. For convenience, it is recommended that this
-be the same as `<service_name>`.
+<2> `<secret_name>` will be the name of the generated secret containing the certificate and key pair.
++
+[NOTE]
+====
+For convenience, it is recommended that this value be the same as `<service_name>`.
+====
+--
 +
 For example, use the following command to annotate the service `test1`:
 +

--- a/modules/network-observability-lokistack-ingestion-query.adoc
+++ b/modules/network-observability-lokistack-ingestion-query.adoc
@@ -5,7 +5,12 @@
 [id="network-observability-lokistack-configuring-ingestion{context}"]
 
 = LokiStack ingestion limits and health alerts
-The LokiStack instance comes with default settings according to the configured size. It is possible to override some of these settings, such as the ingestion and query limits. You might want to update them if you get Loki errors showing up in the Console plugin, or in `flowlogs-pipeline` logs. An automatic alert in the web console notifies you when these limits are reached.
+The LokiStack instance comes with default settings according to the configured size. It is possible to override some of these settings, such as the ingestion and query limits. An automatic alert in the web console notifies you when these limits are reached.
+
+[NOTE]
+====
+You might want to update the ingestion and query limits if you get Loki errors showing up in the Console plugin, or in `flowlogs-pipeline` logs.
+====
 
 Here is an example of configured limits:
 

--- a/modules/security-container-content-universal.adoc
+++ b/modules/security-container-content-universal.adoc
@@ -3,18 +3,18 @@
 // * security/container_security/security-container-content.adoc
 
 [id="security-container-content-universal_{context}"]
-= Creating redistributable images with UBI 
+= Creating redistributable images with UBI
 
 To create containerized applications, you typically start with a trusted base
 image that offers the components that are usually provided by the operating system.
 These include the libraries, utilities, and other features the application
 expects to see in the operating system's file system.
 
-Red Hat Universal Base Images (UBI) were created to encourage anyone building their
-own containers to start with one that is made entirely from Red Hat Enterprise
+Red{nbsp}Hat Universal Base Images (UBI) were created to encourage anyone building their
+own containers to start with one that is made entirely from Red{nbsp}Hat Enterprise
 Linux rpm packages and other content. These UBI images are updated regularly
 to keep up with security patches and free to use and redistribute with
-container images built to include your own software. 
+container images built to include your own software.
 
 Search the
 link:https://catalog.redhat.com/software/containers/explore[Red Hat Ecosystem Catalog]
@@ -26,20 +26,24 @@ be interested in these two general types of UBI images:
 `ubi8/ubi`, and `ubi9/ubi`), as well as minimal images based on those systems (`ubi7/ubi-minimal`, `ubi8/ubi-mimimal`, and ubi9/ubi-minimal). All of these images are preconfigured to point to free
 repositories of {op-system-base} software that you can add to the container images you build,
 using standard `yum` and `dnf` commands.
-Red Hat encourages people to use these images on other distributions,
++
+[NOTE]
+====
+Red{nbsp}Hat encourages people to use these images on other distributions,
 such as Fedora and Ubuntu.
+====
 
-* **Red Hat Software Collections**: Search the Red Hat Ecosystem Catalog
+* **Red{nbsp}Hat Software Collections**: Search the Red{nbsp}Hat Ecosystem Catalog
 for `rhscl/` to find images created to use as base images for specific types
 of applications. For example, there are Apache httpd ([x-]`rhscl/httpd-*`),
 Python ([x-]`rhscl/python-*`), Ruby ([x-]`rhscl/ruby-*`), Node.js
 ([x-]`rhscl/nodejs-*`) and Perl ([x-]`rhscl/perl-*`) rhscl images.
 
 Keep in mind that while UBI images are freely available and redistributable,
-Red Hat support for these images is only available through Red Hat
+Red{nbsp}Hat support for these images is only available through Red{nbsp}Hat
 product subscriptions.
 
 See
-link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index#using_red_hat_universal_base_images_standard_minimal_and_runtimes[Using Red Hat Universal Base Images]
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index#using_red_hat_universal_base_images_standard_minimal_and_runtimes[Using Red{nbsp}Hat Universal Base Images]
 in the Red Hat Enterprise Linux documentation for information on how to use and build on
 standard, minimal and init UBI images.

--- a/modules/security-hosts-vms-rhcos.adoc
+++ b/modules/security-hosts-vms-rhcos.adoc
@@ -31,4 +31,7 @@ Disabling SELinux on {op-system} is not supported.
 
 {op-system} is a version of {op-system-base-full} that is specially configured to work as control plane (master) and worker nodes on {product-title} clusters. So {op-system} is tuned to efficiently run container workloads, along with Kubernetes and {product-title} services.
 
+[NOTE]
+====
 To further protect {op-system} systems in {product-title} clusters, most containers, except those managing or monitoring the host system itself, should run as a non-root user. Dropping the privilege level or creating containers with the least amount of privileges possible is recommended best practice for protecting your own {product-title} clusters.
+====

--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -28,9 +28,14 @@ For the Ingress Controller, the minimum TLS version is converted from 1.0 to 1.1
 ====
 
 |`Intermediate`
-|This profile is the recommended configuration for the majority of clients. It is the  default TLS security profile for the Ingress Controller, kubelet, and control plane. The profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29[Intermediate compatibility] recommended configuration.
+|This profile is the default TLS security profile for the Ingress Controller, kubelet, and control plane. The profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29[Intermediate compatibility] recommended configuration.
 
 The `Intermediate` profile requires a minimum TLS version of 1.2.
+
+[NOTE]
+====
+This profile is the recommended configuration for the majority of clients.
+====
 
 |`Modern`
 |This profile is intended for use with modern clients that have no need for backwards compatibility. This profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility[Modern compatibility] recommended configuration.

--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -5,6 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: network_observability
 
 toc::[]
+
 Installing Loki is a recommended prerequisite for using the Network Observability Operator. You can choose to use xref:../../observability/network_observability/installing-operators.adoc#network-observability-without-loki_network_observability[Network Observability without Loki], but there are some considerations for doing this, described in the previously linked section.
 
 The {loki-op} integrates a gateway that implements multi-tenancy and authentication with Loki for data flow storage. The `LokiStack` resource manages Loki, which is a scalable, highly-available, multi-tenant log aggregation system, and a web proxy with {product-title} authentication. The `LokiStack` proxy uses {product-title} authentication to enforce multi-tenancy and facilitate the saving and indexing of data in Loki log stores.

--- a/security/network_bound_disk_encryption/nbde-managing-encryption-keys.adoc
+++ b/security/network_bound_disk_encryption/nbde-managing-encryption-keys.adoc
@@ -8,9 +8,16 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-The cryptographic mechanism to recreate the encryption key is based on the _blinded key_ stored on the node and the private key of the involved Tang servers. To protect against the possibility of an attacker who has obtained both the Tang server private key and the node’s encrypted disk, periodic rekeying is advisable.
+The cryptographic mechanism to recreate the encryption key is based on the _blinded key_ stored on the node and the private key of the involved Tang servers.
 
-You must perform the rekeying operation for every node before you can delete the old key from the Tang server. The following sections provide procedures for rekeying and deleting old keys.
+[NOTE]
+====
+To protect against the possibility of an attacker who has obtained both the Tang server private key and the node's encrypted disk, periodic rekeying is advisable.
+
+You must perform the rekeying operation for every node before you can delete the old key from the Tang server.
+====
+
+The following sections provide procedures for rekeying and deleting old keys.
 
 include::modules/nbde-backing-up-server-keys.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-12900](https://issues.redhat.com/browse/OSDOCS-12900)

Version(s): 4.12+

This PR increases the visibility of recommendations in the documentation by highlighting them with a NOTE admonition where appropriate. So far, only a few examples have been chosen as a proof of concept.

QE review:
I don't think this sort of formatting change needs a QE review but I'm happy to defer to the judgement of the peer reviewier.

Previews:

- [Understanding TLS security profiles](https://90806--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-tls.html#tls-profiles-understanding_nodes-nodes-tls) (Intermediate profile in TLS security profiles table)
- [Add a service certificate](https://90806--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/service-serving-certificate.html#add-service-certificate_service-serving-certificate) (step 1 of procedure)
- [stable-v1 channel](https://90806--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-install.html#stable-v1-channel_cert-manager-operator-install) (note in intro)
- [Creating redistributable images with UBI](https://90806--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/container_security/security-container-content.html#security-container-content-universal_security-container-content) (UBI entry of bullet list)
- [Securing containers on Red Hat Enterprise Linux CoreOS (RHCOS)](https://90806--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/container_security/security-hosts-vms.html#security-hosts-vms-rhcos_security-hosts-vms) (note at very end of section)
- [Tang server encryption key management](https://90806--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/network_bound_disk_encryption/nbde-managing-encryption-keys) (note in intro)