### PR TITLE
OSDOCS-13516-v16 moved the running line up to first line and put $ in…

### DIFF
--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -105,12 +105,11 @@ $ oc describe csr <csr_name> <1>
 $ oc adm certificate approve <csr_name>
 ----
 
-. After the control plane and worker nodes are ready, mark all the nodes in the cluster as schedulable.
-Run the following command:
+. After the control plane and compute nodes are ready, mark all the nodes in the cluster as schedulable by running the following command:
 +
 [source,terminal]
 ----
-for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do echo ${node} ; oc adm uncordon ${node} ; done
+$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do echo ${node} ; oc adm uncordon ${node} ; done
 ----
 
 . Verify that the cluster started properly.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-13516

Link to docs preview:
https://90821--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-restart.html

QE review:
- [ ] QE has approved this change.

