### PR TITLE
OSSM-8955 [DOC] Add text about using "latest" in the "version" field of the Istio CRD

### DIFF
--- a/modules/ossm-about-concepts-resources.adoc
+++ b/modules/ossm-about-concepts-resources.adoc
@@ -55,7 +55,7 @@ $ oc explain istios.spec.values
 ----
 //Helm charts can only be used with istio-csr and Helm charts are a temporary work around for istio-csr. This might get confusing for users, so a NOTE was added.
 
-To support canary updates of the control plane, {SMProduct} includes support for multiple Istio versions. You can select a version by setting  `spec.version` to the version you would like to install, prefixed with a `v`. You can update to a new version just by changing this field.
+To perform canary updates of the control plane, {SMProduct} supports multiple {istio} versions. You can set the `version` field to the new version by either using the full version or the `v<x>.<y>-latest` alias to automatically select the latest version for a specific minor version. For example, setting `v1.23-latest` ensures that the Operator maintains the latest version of {istio} 1.23.
 
 {SMProduct} supports two different update strategies for your control planes:
 


### PR DESCRIPTION
Change type: Doc update; Add text about using "latest" in the "version" field of the Istio CRD

Doc JIRA: https://issues.redhat.com/browse/OSSM-8955

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://90860--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/about/ossm-about-concepts.html#istio-resource_ossm-about-concepts

SME Review/QE Review: @FilipB @unsortedhashsets 
Peer Review: @xenolinux 