### PR TITLE
Bumping RHACM version variable as 2.13 is out :partying_face: 

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -56,7 +56,7 @@ endif::[]
 :rh-rhacm-title: Red Hat Advanced Cluster Management
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
 :rh-rhacm: RHACM
-:rh-rhacm-version: 2.12
+:rh-rhacm-version: 2.13
 :osc: OpenShift sandboxed containers
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift


### PR DESCRIPTION
Bumping RHACM version variable as 2.13 is out :partying_face: 

Version(s):
4.18+

No QE required