### PR TITLE
OCPBUGS-53240: Added back link to Installing the installing-operators…

### DIFF
--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -9,11 +9,6 @@ Installing Loki is a recommended prerequisite for using the Network Observabilit
 
 The {loki-op} integrates a gateway that implements multi-tenancy and authentication with Loki for data flow storage. The `LokiStack` resource manages Loki, which is a scalable, highly-available, multi-tenant log aggregation system, and a web proxy with {product-title} authentication. The `LokiStack` proxy uses {product-title} authentication to enforce multi-tenancy and facilitate the saving and indexing of data in Loki log stores.
 
-[NOTE]
-====
-The {loki-op} can also be used for configuring the LokiStack log store]. The Network Observability Operator requires a dedicated LokiStack separate from the {logging}.
-====
-
 include::modules/network-observability-without-loki.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-53240](https://issues.redhat.com/browse/OCPBUGS-53240)

Link to docs preview:
* [Installing the Network Observability Operator](https://90892--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html)

