### PR TITLE
[OSDOCS#12796] Correct network configuration CR to network.operator for global IP forwarding

### DIFF
--- a/modules/nw-metallb-configure-address-pool-vlan.adoc
+++ b/modules/nw-metallb-configure-address-pool-vlan.adoc
@@ -45,7 +45,7 @@ $ oc apply -f ipaddresspool-vlan.yaml
 +
 [source,terminal]
 ----
-$ oc edit network.config.openshift/cluster
+$ oc edit network.operator.openshift/cluster
 ----
 +
 .. Update the `spec.defaultNetwork.ovnKubernetesConfig` section to include the `gatewayConfig.ipForwarding` set to `Global`. It should look something like this:


### PR DESCRIPTION
The documentation was incorrectly pointing towards `network.config` instead of `network.operator` when modifying the global ipForwarding.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14 - 4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-12796

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
