### PR TITLE
OSSM-9084 Create assembly for supported versions table

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -5,8 +5,10 @@ Distros: openshift-service-mesh
 Topics:
 - Name: Service Mesh 3.x release notes
   File: ossm-release-notes
+- Name: Service Mesh 3.x version support tables
+  File: ossm-release-notes-version-support-tables
 - Name: Service Mesh 3.x feature support tables
-  File: ossm-release-notes-support-tables
+  File: ossm-release-notes-feature-support-tables
 ---
 Name: Migrating from Service Mesh 2 to Service Mesh 3
 Dir: migrating

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,12 @@ Module included in the following assemblies:
 [id="service-mesh-product-supported-versions_{context}"]
 = {SMProduct} supported versions
 
+See this following table to know supported versions in {SMProduct} 3.
+
+//Next writer for release notes: Update to say "the following tables" for 3.0.1.
+
+== {SMProduct} 3.0 supported versions
+
 [cols="1,1"]
 |===
 | Feature | Supported versions

--- a/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
+++ b/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
@@ -1,14 +1,14 @@
 :_mod-docs_content-type: ASSEMBLY
-[id="ossm-release-notes-support-tables"]
+[id="ossm-release-notes-feature-support-tables"]
 = {SMProductShortName} {SMProductVersion} feature support tables
 include::_attributes/common-attributes.adoc[]
 :context: ossm-release-notes-support-tables
 
 toc::[]
 
-These tables provide guidance on supported versions and feature availability in {SMProduct} 3.
+{SMProductVersion} feature support tables provide guidance on feature availability in {SMProduct} 3.
 
-[id="release-notes-definitions"]
+[id="release-notes-definitions_{context}"]
 == Definitions
 
 For {SMProductName} 3, features that are Generally Available (GA) are fully supported and are suitable for production use.
@@ -18,16 +18,6 @@ Technology Preview (TP) features are not supported with Red Hat production servi
 Developer Preview (DP) features are not supported by Red Hat in any way and are not functionally complete or production-ready. Do not use Developer Preview features for production or business-critical workloads. Developer Preview features provide early access to upcoming product features in advance of their possible inclusion in a Red Hat product offering, enabling customers to test functionality and provide feedback during the development process. These features might not have any documentation, are subject to change or removal at any time, and testing is limited. Red Hat might provide ways to submit feedback on Developer Preview features without an associated SLA.
 
 Not available (NA) features might not be available with {SMProductName} 3.
-
-include::modules/ossm-release-notes-supported-versions.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-[id="additional-resources-supported-versions_{context}"]
-.Additional resources
-
-* For the latest supported versions of {Kialiproduct}, {KialiServer}, and {SMPlugin}, see xref:../observability/kiali/ossm-console-plugin.adoc#ossm-install-console-plugin_ossm-console-plugin[Installing {SMPlugin}]
-
-//Note to next release notes writer: also update ossm-console-plugin
 
 include::modules/ossm-release-notes-sail-operator-apis.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-istio-deployment-lifecycle.adoc[leveloffset=+1]

--- a/ossm-release-notes/ossm-release-notes-version-support-tables.adoc
+++ b/ossm-release-notes/ossm-release-notes-version-support-tables.adoc
@@ -1,0 +1,19 @@
+:_mod-docs_content-type: ASSEMBLY
+[id="ossm-release-notes-version-support-tables"]
+= {SMProductShortName} version support tables
+include::_attributes/common-attributes.adoc[]
+:context: ossm-release-notes-version-support-tables
+
+toc::[]
+
+{SMProductName} supports the {SMProduct} 3 Operator, {SMProduct} `Istio` control plane resource, Envoy proxy, and the `IstioCNI` resource on supported versions of {ocp-product-title}.
+
+include::modules/ossm-release-notes-supported-versions.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources-supported-versions_{context}"]
+.Additional resources
+
+* For the latest supported versions of {Kialiproduct}, {KialiServer}, and the {SMPlugin}, see xref:../observability/kiali/ossm-console-plugin.adoc#ossm-install-console-plugin_ossm-console-plugin[Installing {SMPlugin}].
+
+//Note to next release notes writer: also update ossm-console-plugin

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -13,6 +13,9 @@ toc::[]
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
 
+//03/25/2025:
+//Gwynne is rotating off Service Mesh. For next writer and CS: Continue to refine the IA for rel notes. The structure and IA will likely make more sense as there are more z-streams and versions released, making it easier to see how best to lay rel notes out in docs.redhat. Should anything be its own tile to make it easier to find for users?
+
 include::modules/ossm-release-notes-3-0-new-features.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-0-known-issues.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-0-deprecated-removed-features.adoc[leveloffset=+1]
@@ -26,7 +29,8 @@ include::modules/ossm-release-notes-3-0-deprecated-removed-features.adoc[levelof
 [id="additional-resources-release-notes_{context}"]
 == Additional resources
 
-* xref:../ossm-release-notes/ossm-release-notes-support-tables.adoc#ossm-release-notes-support-tables[Service Mesh 3.0 feature support tables]
+* xref:../ossm-release-notes/ossm-release-notes-version-support-tables.adoc#ossm-release-notes-version-support-tables[Service Mesh version support]
+* xref:../ossm-release-notes/ossm-release-notes-feature-support-tables.adoc#ossm-release-notes-feature-support-tables[Service Mesh 3.0 feature support tables]
 * xref:../migrating/ossm-migrating-from-service-mesh-2-to-3.adoc#ossm-migrating-from-service-mesh-2-to-3[Migrating from {smproductshortname} 2 to {smproductshortname} 3]
 * xref:../migrating/checklists/ossm-migrating-read-me.adoc#ossm-migrating-read-me[Important information to know if you are migrating from {SMProduct} 2.6]
 * xref:../migrating/checklists/ossm-migrating-read-me.adoc#ossm-migrating-read-me-support-for-istioctl_ossm-migrating-read-me[Support for Istioctl]


### PR DESCRIPTION
OSSM 3.0

[OSSM-9084](https://issues.redhat.com//browse/OSSM-9084) Create assembly for supported versions table

Merge PR to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

And cherry picked to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s):
3.0

Issue:
https://issues.redhat.com/browse/OSSM-9084

Link to docs preview:
* https://90911--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html
* https://90911--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-feature-support-tables.html
* https://90911--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html#additional-resources-release-notes_ossm-release-notes


QE review:
QE review is not needed. This is a structural change only.

Additional information:
* Feature support tables are 3.0 as those may change for 3.1, but likely will not likely change for 3.0.1, 3.0.2, etc. 
* Version support tables are 3.x as they will change with each release.
* Service Mesh CS has been informed, so there may be other changes soon. This PR was already in flight so wants it completed and merged.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
