### PR TITLE
OSDOCS-13698: ROSA Classic: Upgrade clarification on temporary compute node

### DIFF
--- a/modules/rosa-how-upgrades-work.adoc
+++ b/modules/rosa-how-upgrades-work.adoc
@@ -37,7 +37,7 @@ The following are the high-level steps that occur during the ROSA (classic archi
 ** Identifying any Pod Disruption Budgets (PDBs) that can potentially block or delay the update of the nodes.
 ** Ensuring cluster Operators are available and healthy.
 ** Ensuring cluster critical alerts are not firing.
-. A temporary compute node is created in the cluster to allow for the scheduling of drained pods during the update.
+. A temporary compute node is created in each availability zone (AZ) in the cluster to allow for the scheduling of drained pods during the update.
 +
 [NOTE]
 ====


### PR DESCRIPTION
[OSDOCS-13698](https://issues.redhat.com//browse/OSDOCS-13698): ROSA Classic: Upgrade clarification on temporary compute node

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13698

Link to docs preview:
https://90916--ocpdocs-pr.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading-sts.html

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
