### PR TITLE
OCPBUGS#52991: Fixed typo for //home/dfitzmau/quay-instal/quay-postgr…

### DIFF
--- a/modules/mirror-registry-localhost-update.adoc
+++ b/modules/mirror-registry-localhost-update.adoc
@@ -16,7 +16,7 @@ When upgrading from version 1 to version 2, be aware of the following constraint
 ** You must not use the _mirror registry for Red{nbsp}Hat OpenShift_ user interface (UP).
 ** Do not access the `sqlite-storage` Podman volume during the upgrade.
 ** There is intermittent downtime of your mirror registry because it is restarted during the upgrade process.
-** PostgreSQL data is backed up under the `/$HOME/quay-instal/quay-postgres-backup/` directory for recovery.
+** PostgreSQL data is backed up under the `/$HOME/quay-install/quay-postgres-backup/` directory for recovery.
 ====
 
 .Prerequisites

--- a/modules/mirror-registry-remote-host-update.adoc
+++ b/modules/mirror-registry-remote-host-update.adoc
@@ -16,7 +16,7 @@ When upgrading from version 1 to version 2, be aware of the following constraint
 ** You must not use the _mirror registry for Red{nbsp}Hat OpenShift_ user interface (UP).
 ** Do not access the `sqlite-storage` Podman volume during the upgrade.
 ** There is intermittent downtime of your mirror registry because it is restarted during the upgrade process.
-** PostgreSQL data is backed up under the `/$HOME/quay-instal/quay-postgres-backup/` directory for recovery.
+** PostgreSQL data is backed up under the `/$HOME/quay-install/quay-postgres-backup/` directory for recovery.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OCPBUGS-52991](https://issues.redhat.com/browse/OCPBUGS-52991)

Link to docs preview:
* [Remote host](https://90933--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-creating-registry.html#mirror-registry-remote-host-update_installing-mirroring-creating-registry)
* [Local host](https://90933--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-creating-registry.html#mirror-registry-localhost-update_installing-mirroring-creating-registry)

