### PR TITLE
OCPBUGS-53444: Changed default parameter values in nw-sriov-configuri…

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -79,12 +79,9 @@ For single-node clusters, set this field to `true` after installing the Operator
 |`boolean`
 |Specifies whether to enable or disable the Operator Admission Controller webhook daemon set.
 
-
 |`spec.logLevel`
 |`integer`
-|Specifies the log verbosity level of the Operator.
-Set to `0` to show only the basic logs. Set to `2` to show all the available logs.
-By default, this field is set to `2`.
+|Specifies the log verbosity level of the Operator. By default, this field is set to `0`, which shows only basic logs. Set to `2` to show all the available logs.
 
 |`spec.featureGates`
 |`map[string]bool`


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-53444](https://issues.redhat.com/browse/OCPBUGS-53444) and [OCPBUGS-51361](https://issues.redhat.com/browse/OCPBUGS-51361)

Link to docs preview:
* [SR-IOV Network Operator config custom resource](https://90935--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.html#nw-sriov-operator-cr_configuring-sriov-operator)


- [x] SME has approved this change (Carlos Goncalves/Andrea Panattoni).
- [x] QE has approved this change (Evgeny Levin)

Add.resources

* https://issues.redhat.com/browse/OCPBUGS-54352
* https://github.com/openshift/openshift-docs/pull/91315

