### PR TITLE
[enterprise-4.15] OADP 5508: Moved the note closer to the intro

### DIFF
--- a/modules/oadp-creating-restore-cr.adoc
+++ b/modules/oadp-creating-restore-cr.adoc
@@ -8,6 +8,11 @@
 
 You restore a `Backup` custom resource (CR) by creating a `Restore` CR.
 
+[NOTE]
+====
+When you restore a stateful application that uses the `azurefile-csi` storage class, the restore operation remains in the `Finalizing` phase. 
+====
+
 .Prerequisites
 
 * You must install the OpenShift API for Data Protection (OADP) Operator.
@@ -119,9 +124,4 @@ EOF
     fi
 done
 ----
-====
-
-[NOTE]
-====
-When you restore a stateful application that uses the `azurefile-csi` storage class, the restore operation remains in the `Finalizing` phase. 
 ====


### PR DESCRIPTION
### JIRA

* [OADP-5508](https://issues.redhat.com/browse/OADP-5508)

### Version(s):
* 4.15

Link to docs preview:

* [Creating a Restore CR](https://90936--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.html#oadp-creating-restore-cr_restoring-applications)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR has a minor change regarding the placement of a note in the Creating a Restore CR module.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
