### PR TITLE
OSDOCS#12040: Adding admin-ack for updating from 4.18 to 4.19

### DIFF
--- a/modules/update-preparing-ack.adoc
+++ b/modules/update-preparing-ack.adoc
@@ -6,7 +6,7 @@
 [id="update-preparing-ack_{context}"]
 = Providing the administrator acknowledgment
 
-After you have evaluated your cluster for any removed APIs and have migrated any removed APIs, you can acknowledge that your cluster is ready to upgrade from {product-title} {ocp-nminus1} to {product-version}.
+After you have evaluated your cluster for any removed APIs and have migrated any removed APIs, you can acknowledge that your cluster is ready to upgrade from {product-title} 4.18 to 4.19.
 
 [WARNING]
 ====
@@ -23,5 +23,5 @@ Be aware that all responsibility falls on the administrator to ensure that all u
 +
 [source,terminal]
 ----
-$ oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.15-kube-1.29-api-removals-in-4.18":"true"}}' --type=merge
+$ oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.18-kube-1.32-api-removals-in-4.19":"true"}}' --type=merge
 ----

--- a/modules/update-preparing-evaluate-apirequestcount-workloads.adoc
+++ b/modules/update-preparing-evaluate-apirequestcount-workloads.adoc
@@ -25,14 +25,14 @@ For example:
 +
 [source,terminal]
 ----
-$ oc get apirequestcounts flowschemas.v1beta2.flowcontrol.apiserver.k8s.io -o yaml
+$ oc get apirequestcounts flowschemas.v1beta3.flowcontrol.apiserver.k8s.io -o yaml
 ----
 +
 You can also use `-o jsonpath` to extract the `username` and `userAgent` values from an `APIRequestCount` resource:
 +
 [source,terminal]
 ----
-$ oc get apirequestcounts flowschemas.v1beta2.flowcontrol.apiserver.k8s.io \
+$ oc get apirequestcounts flowschemas.v1beta3.flowcontrol.apiserver.k8s.io \
   -o jsonpath='{range .status.currentHour..byUser[*]}{..byVerb[*].verb}{","}{.username}{","}{.userAgent}{"\n"}{end}' \
   | sort -k 2 -t, -u | column -t -s, -NVERBS,USERNAME,USERAGENT
 ----

--- a/modules/update-preparing-evaluate-apirequestcount.adoc
+++ b/modules/update-preparing-evaluate-apirequestcount.adoc
@@ -26,9 +26,9 @@ $ oc get apirequestcounts
 ----
 NAME                                                                 REMOVEDINRELEASE   REQUESTSINCURRENTHOUR   REQUESTSINLAST24H
 ...
-flowschemas.v1beta2.flowcontrol.apiserver.k8s.io                     1.29               0                       3
+flowschemas.v1beta3.flowcontrol.apiserver.k8s.io                     1.32               0                       3
 ...
-prioritylevelconfigurations.v1beta2.flowcontrol.apiserver.k8s.io     1.29               0                       1
+prioritylevelconfigurations.v1beta3.flowcontrol.apiserver.k8s.io     1.32               0                       1
 ...
 ----
 +
@@ -50,6 +50,6 @@ $ oc get apirequestcounts -o jsonpath='{range .items[?(@.status.removedInRelease
 .Example output
 [source,terminal]
 ----
-1.29	flowschemas.v1beta2.flowcontrol.apiserver.k8s.io
-1.29	prioritylevelconfigurations.v1beta2.flowcontrol.apiserver.k8s.io
+1.32	flowschemas.v1beta3.flowcontrol.apiserver.k8s.io
+1.32	prioritylevelconfigurations.v1beta3.flowcontrol.apiserver.k8s.io
 ----

--- a/modules/update-preparing-list.adoc
+++ b/modules/update-preparing-list.adoc
@@ -5,21 +5,21 @@
 [id="update-preparing-list_{context}"]
 = Removed Kubernetes APIs
 
-{product-title} 4.16 uses Kubernetes 1.29, which removed the following deprecated APIs. You must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-29[Kubernetes documentation].
+{product-title} 4.19 uses Kubernetes 1.32, which removed the following deprecated APIs. You must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-32[Kubernetes documentation].
 
-.APIs removed from Kubernetes 1.29
+.APIs removed from Kubernetes 1.32
 [cols="2,2,2,1",options="header",]
 |===
 |Resource |Removed API |Migrate to |Notable changes
 
 |`FlowSchema`
-|`flowcontrol.apiserver.k8s.io/v1beta2`
-|`flowcontrol.apiserver.k8s.io/v1` or `flowcontrol.apiserver.k8s.io/v1beta3`
+|`flowcontrol.apiserver.k8s.io/v1beta3`
+|`flowcontrol.apiserver.k8s.io/v1`
 |No
 
 |`PriorityLevelConfiguration`
-|`flowcontrol.apiserver.k8s.io/v1beta2`
-|`flowcontrol.apiserver.k8s.io/v1` or `flowcontrol.apiserver.k8s.io/v1beta3`
-|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v129[Yes]
+|`flowcontrol.apiserver.k8s.io/v1beta3`
+|`flowcontrol.apiserver.k8s.io/v1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v132[Yes]
 
 |===

--- a/modules/update-preparing-migrate.adoc
+++ b/modules/update-preparing-migrate.adoc
@@ -5,4 +5,4 @@
 [id="update-preparing-migrate_{context}"]
 = Migrating instances of removed APIs
 
-For information about how to migrate removed Kubernetes APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-29[Deprecated API Migration Guide] in the Kubernetes documentation.
+For information about how to migrate removed Kubernetes APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-32[Deprecated API Migration Guide] in the Kubernetes documentation.

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="updating-cluster-prepare"]
-= Preparing to update to {product-title} 4.18
+= Preparing to update to {product-title} 4.19
 include::_attributes/common-attributes.adoc[]
 :context: updating-cluster-prepare
 
@@ -17,15 +17,11 @@ Learn more about administrative tasks that cluster admins must perform to succes
 [id="kube-api-removals_{context}"]
 == Kubernetes API removals
 
-There are no Kubernetes API removals in {product-title} 4.18.
+{product-title} 4.19 uses Kubernetes 1.32, which removed several deprecated Kubernetes APIs.
 
-// Commenting out this section because there are no APIs being removed in OCP 4.17 / Kube 1.30. But we'll need this section again for OCP 4.19 / Kube 1.32
-////
-{product-title} 4.16 uses Kubernetes 1.29, which removed several deprecated APIs.
+A cluster administrator must provide a manual acknowledgment before the cluster can be updated from {product-title} 4.18 to 4.19. This is to help prevent issues after upgrading to {product-title} 4.19, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this evaluation and migration is complete, the administrator can provide the acknowledgment.
 
-A cluster administrator must provide a manual acknowledgment before the cluster can be updated from {product-title} 4.15 to 4.16. This is to help prevent issues after upgrading to {product-title} 4.16, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this evaluation and migration is complete, the administrator can provide the acknowledgment.
-
-Before you can update your {product-title} 4.15 cluster to 4.16, you must provide the administrator acknowledgment.
+Before you can update your {product-title} 4.18 cluster to 4.19, you must provide the administrator acknowledgment.
 
 // Removed Kubernetes APIs
 include::modules/update-preparing-list.adoc[leveloffset=+2]
@@ -49,7 +45,6 @@ include::modules/update-preparing-migrate.adoc[leveloffset=+2]
 
 // Providing the administrator acknowledgment
 include::modules/update-preparing-ack.adoc[leveloffset=+2]
-////
 
 // Assessing the risk of conditional updates
 include::modules/update-preparing-conditional.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-12040

Link to docs preview:
https://90952--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#kube-api-removals_updating-cluster-prepare

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
