### PR TITLE
Clarifying VM support for PCA/C3

### DIFF
--- a/installing/installing_oci/installing-c3-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-c3-agent-based-installer.adoc
@@ -8,12 +8,6 @@ toc::[]
 
 You can use the Agent-based Installer to install a cluster on {oci-c3}, so that you can run cluster workloads on on-premise infrastructure while still using {oci-first} services.
 
-////
-Do I need to add a BM/VM support statement like the one below?
-
-Installing a cluster on {oci-c3-short} is supported for virtual-machines (VMs) and bare-metal machines.
-////
-
 [id="abi-oci-c3-process-checklist_{context}"]
 == Installation process workflow
 

--- a/installing/installing_oci/installing-pca-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-pca-agent-based-installer.adoc
@@ -8,12 +8,6 @@ toc::[]
 
 You can use the Agent-based Installer to install a cluster on {oci-pca}, so that you can run cluster workloads on on-premise infrastructure while still using {oci-first} services.
 
-////
-Do I need to add a BM/VM support statement like the one below?
-
-Installing a cluster on {oci-pca-short} is supported for virtual-machines (VMs) and bare-metal machines.
-////
-
 [id="abi-oci-pca-process-checklist_{context}"]
 == Installation process workflow
 

--- a/modules/abi-c3-resources-services.adoc
+++ b/modules/abi-c3-resources-services.adoc
@@ -6,7 +6,7 @@
 [id="abi-c3-resources-services_{context}"]
 = Creating {oci-c3-no-rt} infrastructure resources and services
 
-You must create an {oci-c3-short} environment on your virtual machine (VM) or bare-metal shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
+You must create an {oci-c3-short} environment on your virtual machine (VM) shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
 
 [IMPORTANT]
 ====

--- a/modules/abi-pca-resources-services.adoc
+++ b/modules/abi-pca-resources-services.adoc
@@ -6,7 +6,7 @@
 [id="abi-pca-resources-services_{context}"]
 = Creating {oci-pca-no-rt} infrastructure resources and services
 
-You must create an {oci-pca-short} environment on your virtual machine (VM) or bare-metal shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
+You must create an {oci-pca-short} environment on your virtual machine (VM) shape. By creating this environment, you can install {product-title} and deploy a cluster on an infrastructure that supports a wide range of cloud options and strong security policies. Having prior knowledge of {oci} components can help you with understanding the concept of {oci} resources and how you can configure them to meet your organizational needs.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Version(s): 4.18+

This PR corrects the Agent installation docs for Oracle C3 and PCA to specify that only virtual machine shapes are supported in these environments.


QE review:
- [x] QE has approved this change.

Previews: 

- [Creating Oracle Compute Cloud@Customer infrastructure resources and services](https://90970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-c3-agent-based-installer.html#abi-c3-resources-services_installing-c3-agent-based-installer) (removed BM reference)
- [Creating Oracle Private Cloud Appliance infrastructure resources and services](https://90970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-pca-agent-based-installer#abi-pca-resources-services_installing-pca-agent-based-installer) (removed BM reference)
