### PR TITLE
OSDOCS-13742: Double quoted <mode> in nw-ovn-ipsec-enable.adoc

### DIFF
--- a/modules/nw-ovn-ipsec-enable.adoc
+++ b/modules/nw-ovn-ipsec-enable.adoc
@@ -6,14 +6,17 @@
 [id="nw-ovn-ipsec-enable_{context}"]
 = Enabling IPsec encryption
 
-As a cluster administrator, you can enable pod-to-pod IPsec encryption and IPsec encryption between the cluster and external IPsec endpoints.
+As a cluster administrator, you can enable pod-to-pod IPsec encryption, IPsec encryption between the cluster, and external IPsec endpoints.
 
 You can configure IPsec in either of the following modes:
 
 - `Full`: Encryption for pod-to-pod and external traffic
 - `External`: Encryption for external traffic
 
-If you need to configure encryption for external traffic in addition to pod-to-pod traffic, you must also complete the "Configuring IPsec encryption for external traffic" procedure.
+[NOTE]
+====
+If you configure IPsec in `Full` mode, you must also complete the "Configuring IPsec encryption for external traffic" procedure.
+====
 
 .Prerequisites
 
@@ -27,23 +30,19 @@ If you need to configure encryption for external traffic in addition to pod-to-p
 +
 [source,terminal]
 ----
-$ oc patch networks.operator.openshift.io cluster --type=merge \
--p '{
+$ oc patch networks.operator.openshift.io cluster --type=merge -p \
+  '{
   "spec":{
     "defaultNetwork":{
       "ovnKubernetesConfig":{
         "ipsecConfig":{
-          "mode":<mode>
+          "mode":"<mode"> <1>
         }}}}}'
 ----
 +
-where:
-+
---
-`mode`:: Specify `External` to encrypt only traffic to external hosts or specify `Full` to encrypt pod to pod traffic and optionally traffic to external hosts. By default, IPsec is disabled.
---
+<1> Specify `External` to encrypt traffic to external hosts or specify `Full` to encrypt pod-to-pod traffic and, optionally, traffic to external hosts. By default, IPsec is disabled.
 
-. Optional: If you need to encrypt traffic to external hosts, complete the "Configuring IPsec encryption for external traffic" procedure.
+. Encrypt external traffic with IPsec by completing the "Configuring IPsec encryption for external traffic" procedure.
 
 .Verification
 
@@ -63,6 +62,7 @@ ovnkube-node-ck5fr                       8/8     Running   0              31m
 ovnkube-node-fr4ld                       8/8     Running   0              26m
 ovnkube-node-wgs4l                       8/8     Running   0              33m
 ovnkube-node-zfvcl                       8/8     Running   0              34m
+...
 ----
 
 . Verify that IPsec is enabled on your cluster by running the following command:
@@ -74,14 +74,9 @@ As a cluster administrator, you can verify that IPsec is enabled between pods on
 +
 [source,terminal]
 ----
-$ oc -n openshift-ovn-kubernetes rsh ovnkube-node-<XXXXX> ovn-nbctl --no-leader-only get nb_global . ipsec
+$ oc -n openshift-ovn-kubernetes rsh ovnkube-node-<XXXXX> ovn-nbctl --no-leader-only get nb_global . ipsec <1>
 ----
-+
---
-where:
-
-`<XXXXX>`:: Specifies the random sequence of letters for a pod from the previous step.
---
+<1> Where `<XXXXX>` specifies the random sequence of letters for a pod from the previous step.
 +
 .Example output
 [source,text]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-13742](https://issues.redhat.com/browse/OSDOCS-13742)

Link to docs preview:
* [Enabling IPsec encryption](https://90973--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn.html#nw-ovn-ipsec-enable_configuring-ipsec-ovn)

- [x] SME review (Nikolaos Stamatelopoulos)
- [x] QE review (Anurag Saxena) - check old optional statement.
