### PR TITLE
[Enterprise-4.12]OCPBUGS#36951: Updated networking sections with changes in external Ip and OVN-K behaviour

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-deploying-application/modules/nw-networkpolicy-optimize-ovn.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploying-application/modules/nw-networkpolicy-optimize-ovn.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/network_policy/about-network-policy.adoc
+// * networking/network_security/network_policy/about-network-policy.adoc
 
 [id="nw-networkpolicy-optimize-ovn_{context}"]
 = Optimizations for network policy with OVN-Kubernetes network plugin
@@ -106,11 +106,11 @@ You can apply this optimization when only multiple selectors are expressed as on
 [id="nw-networkpolicy-external-ip-ovn_{context}"]
 == NetworkPolicies and external IPs in OVN-Kubernetes
 
-In OVN-Kubernetes, `NetworkPolicies` enforce strict isolation rules. If a service is exposed using an external IP, `NetworkPolicies` can block access from other namespaces unless explicitly configured.
+In OVN-Kubernetes, the `NetworkPolicies` custom resource (CR) enforce strict isolation rules. If you expose a service by using an external IP, `NetworkPolicies` can block access from other namespaces unless explicitly configured.
 
-To allow access to external IPs across namespaces, create a `NetworkPolicy` that explicitly permits ingress from the required namespaces and ensures traffic is allowed to the designated service ports. Without allowing traffic to the required ports, access might still be restricted.
+To allow access to external IPs across namespaces, create a `NetworkPolicy` CR that explicitly permits ingress from the required namespaces and ensures traffic is allowed to the designated service ports. Without allowing traffic to the required ports, access might still be restricted.
 
-.Example output
+.Example `NetworkPolicy` CR
 [source,yaml]
 ----
   apiVersion: networking.k8s.io/v1

--- a/edge_computing/day_2_core_cnf_clusters/updating/modules/nw-ne-changes-externalip-ovn.adoc
+++ b/edge_computing/day_2_core_cnf_clusters/updating/modules/nw-ne-changes-externalip-ovn.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * understanding-networking.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-ne-changes-externalip-ovn_{context}"]
+= Understanding changes in external IP behavior with OVN-Kubernetes
+
+When migrating from OpenShift SDN to OVN-Kubernetes (OVN-K), services that use external IPs might become inaccessible across namespaces due to `NetworkPolicy` enforcement.
+
+In OpenShift SDN, external IPs were accessible across namespaces by default. However, in OVN-K, network policies strictly enforce multitenant isolation, preventing access to services exposed via external IPs from other namespaces.
+
+To ensure accessibility, consider the following alternatives:
+
+* Use an ingress or route: Instead of exposing services using external IPs, configure an ingress or route to allow external access while maintaining security controls.
+
+* Adjust `NetworkPolicies`: Modify `NetworkPolicy` rules to explicitly allow access from required namespaces and ensure that traffic is allowed to the designated service ports. Without allowing traffic to the required ports, access may still be blocked, even if the namespace is explicitly allowed.
+
+* Use a `LoadBalancer` service: If applicable, deploy a `LoadBalancer` service instead of relying on external IPs.
+
+For more information about configuring `NetworkPolicies`, see "About network policy".

--- a/modules/nw-ne-changes-externalip-ovn.adoc
+++ b/modules/nw-ne-changes-externalip-ovn.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * networking/understanding-networking.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-ne-changes-externalip-ovn_{context}"]
+= Understanding changes in external IP behavior with OVN-Kubernetes
+
+When migrating from OpenShift SDN to OVN-Kubernetes (OVN-K), services that use external IPs might become inaccessible across namespaces due to `NetworkPolicy` enforcement.
+
+In OpenShift SDN, external IPs were accessible across namespaces by default. However, in OVN-K, network policies strictly enforce multitenant isolation, preventing access to services exposed via external IPs from other namespaces.
+
+To ensure accessibility, consider the following alternatives:
+
+* Use an ingress or route: Instead of exposing services by using external IPs, configure an ingress or route to allow external access while maintaining security controls.
+
+* Adjust `NetworkPolicies`: Modify `NetworkPolicy` rules to explicitly allow access from required namespaces and ensure that traffic is allowed to the designated service ports. Without allowing traffic to the required ports, access might still be blocked, even if the namespace is explicitly allowed.
+
+* Use a `LoadBalancer` service: If applicable, deploy a `LoadBalancer` service instead of relying on external IPs.
+
+For more information on configuring NetworkPolicies, see "Configuring NetworkPolicies".

--- a/networking/understanding-networking.adoc
+++ b/networking/understanding-networking.adoc
@@ -5,24 +5,84 @@ include::_attributes/common-attributes.adoc[]
 :context: understanding-networking
 
 toc::[]
-Cluster Administrators have several options for exposing applications that run inside a cluster to external traffic and securing network connections:
 
-* Service types, such as node ports or load balancers
+Understanding the fundamentals of networking in {product-title} ensures efficient and secure communication within your clusters and is essential for effective network administration. Key elements of networking in your environment include understanding how pods and services communicate, the role of IP addresses, and the use of DNS for service discovery. 
 
-* API resources, such as `Ingress` and `Route`
+// Introduction
+include::modules/nw-understanding-networking-networking-in-OpenShift.adoc[leveloffset=+1]
 
-By default, Kubernetes allocates each pod an internal IP address for applications running within the pod. Pods and their containers can network, but clients outside the cluster do not have networking access. When you expose your application to external traffic, giving each pod its own IP address means that pods can be treated like physical hosts or virtual machines in terms of port allocation, networking, naming, service discovery, load balancing, application configuration, and migration.
+include::modules/nw-understanding-networking-common-practices.adoc[leveloffset=+2]
 
-[NOTE]
-====
-Some cloud platforms offer metadata APIs that listen on the 169.254.169.254 IP address, a link-local IP address in the IPv4 `169.254.0.0/16` CIDR block.
+include::modules/nw-understanding-networking-features.adoc[leveloffset=+2]
 
-This CIDR block is not reachable from the pod network. Pods that need access to these IP addresses must be given host network access by setting the `spec.hostNetwork` field in the pod spec to `true`.
+// Nodes, clusters, clients
+include::modules/nw-understanding-networking-nodes-clients-clusters.adoc[leveloffset=+1]
 
-If you allow a pod host network access, you grant the pod privileged access to the underlying network infrastructure.
-====
+include::modules/nw-understanding-networking-what-is-a-node.adoc[leveloffset=+2]
 
-include::modules/nw-ne-openshift-dns.adoc[leveloffset=+1]
-include::modules/nw-ne-openshift-ingress.adoc[leveloffset=+1]
-include::modules/nw-ne-comparing-ingress-route.adoc[leveloffset=+2]
-include::modules/nw-networking-glossary-terms.adoc[leveloffset=+1]
+include::modules/nw-understanding-networking-what-is-a-cluster.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-what-is-a-client.adoc[leveloffset=+2]
+
+// Concepts and components
+include::modules/nw-understanding-networking-concepts-components.adoc[leveloffset=+1]
+
+include::modules/nw-ne-changes-externalip-ovn.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../networking/network_security/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+
+//Pod communication
+include::modules/nw-understanding-networking-how-pods-communicate.adoc[leveloffset=+1]
+
+include::modules/nw-understanding-networking-pod-to-pod.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-pod-to-pod-example.adoc[leveloffset=+3]
+
+include::modules/nw-understanding-networking-service-to-pod.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-service-to-pod-example.adoc[leveloffset=+3]
+
+//Load balancing
+
+include::modules/nw-load-balancing-about.adoc[leveloffset=+1]
+
+include::modules/nw-load-balancing-configure.adoc[leveloffset=+2]
+
+include::modules/nw-load-balancing-configure-define-type.adoc[leveloffset=+3]
+
+include::modules/nw-load-balancing-configure-specify-behavior.adoc[leveloffset=+3]
+
+//DNS
+include::modules/nw-understanding-networking-dns.adoc[leveloffset=+1]
+
+include::modules/nw-understanding-networking-dns-terms.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-dns-example.adoc[leveloffset=+2]
+
+//Controls
+include::modules/nw-understanding-networking-controls.adoc[leveloffset=+1]
+
+//Routes and Ingress
+include::modules/nw-understanding-networking-routes-ingress.adoc[leveloffset=+1]
+
+include::modules/nw-understanding-networking-routes.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-ingress.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-routes-vs-ingress.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-routes-ingress-example.adoc[leveloffset=+2]
+
+// Security
+include::modules/nw-understanding-networking-security.adoc[leveloffset=+1]
+
+include::modules/nw-understanding-networking-exposing-applications.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-securing-connections.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-security-example.adoc[leveloffset=+2]
+
+include::modules/nw-understanding-networking-choosing-service-types.adoc[leveloffset=+2]


### PR DESCRIPTION
Cherry-picked [commit ID](7dd0ce94f1404512d8095f1d49ea91bc11049170) from this [PR](https://github.com/openshift/openshift-docs/pull/90329)

Version: 4.12

Issue:https://issues.redhat.com/browse/OCPBUGS-36951
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
