### PR TITLE
[Enterprise-4.14] OCPBUGS#36951: Updated networking sections with changes in external Ip and OVN-K behaviour

### DIFF
--- a/modules/nw-ne-changes-externalip-ovn.adoc
+++ b/modules/nw-ne-changes-externalip-ovn.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * networking/understanding-networking.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-ne-changes-externalip-ovn_{context}"]
+= Understanding changes in external IP behavior with OVN-Kubernetes
+
+When migrating from OpenShift SDN to OVN-Kubernetes (OVN-K), services that use external IPs might become inaccessible across namespaces due to `NetworkPolicy` enforcement.
+
+In OpenShift SDN, external IPs were accessible across namespaces by default. However, in OVN-K, network policies strictly enforce multitenant isolation, preventing access to services exposed via external IPs from other namespaces.
+
+To ensure accessibility, consider the following alternatives:
+
+* Use an ingress or route: Instead of exposing services by using external IPs, configure an ingress or route to allow external access while maintaining security controls.
+
+* Adjust `NetworkPolicies`: Modify `NetworkPolicy` rules to explicitly allow access from required namespaces and ensure that traffic is allowed to the designated service ports. Without allowing traffic to the required ports, access might still be blocked, even if the namespace is explicitly allowed.
+
+* Use a `LoadBalancer` service: If applicable, deploy a `LoadBalancer` service instead of relying on external IPs.
+
+For more information on configuring NetworkPolicies, see "Configuring NetworkPolicies".

--- a/modules/nw-networkpolicy-optimize-ovn.adoc
+++ b/modules/nw-networkpolicy-optimize-ovn.adoc
@@ -102,3 +102,40 @@ spec:
 ----
 +
 You can apply this optimization when only multiple selectors are expressed as one. In cases where selectors are based on different labels, it may not be possible to apply this optimization. In those cases, consider applying some new labels for network policy optimization specifically.
+
+[id="nw-networkpolicy-external-ip-ovn_{context}"]
+== NetworkPolicies and external IPs in OVN-Kubernetes
+
+In OVN-Kubernetes, `NetworkPolicies` enforce strict isolation rules. If a service is exposed using an external IP, `NetworkPolicies` can block access from other namespaces unless explicitly configured.
+
+To allow access to external IPs across namespaces, create a `NetworkPolicy` that explicitly permits ingress from the required namespaces and ensures traffic is allowed to the designated service ports. Without allowing traffic to the required ports, access might still be restricted.
+
+.Example output
+[source,yaml]
+----
+  apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    annotations:
+    name: <policy_name> <1>
+    namespace: openshift-ingress
+  spec:
+    ingress:
+    - ports:
+      - port: 80
+        protocol: TCP
+    - ports:
+      - port: 443
+        protocol: TCP
+    - from:
+      - namespaceSelector:
+          matchLabels:
+          kubernetes.io/metadata.name: <namespace_name> <2>
+    podSelector: {}
+    policyTypes:
+    - Ingress
+----
+<1> Specify the policy name. 
+<2> Specify the namespace name. 
+
+For more details, see "About network policy".

--- a/networking/understanding-networking.adoc
+++ b/networking/understanding-networking.adoc
@@ -26,3 +26,9 @@ include::modules/nw-ne-openshift-dns.adoc[leveloffset=+1]
 include::modules/nw-ne-openshift-ingress.adoc[leveloffset=+1]
 include::modules/nw-ne-comparing-ingress-route.adoc[leveloffset=+2]
 include::modules/nw-networking-glossary-terms.adoc[leveloffset=+1]
+
+include::modules/nw-ne-changes-externalip-ovn.adoc[leveloffset+=1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]


### PR DESCRIPTION
Cherry-picked [commit ID](7dd0ce94f1404512d8095f1d49ea91bc11049170) from this [PR](https://github.com/openshift/openshift-docs/pull/90329)

Version: 4.14

Issue:https://issues.redhat.com/browse/OCPBUGS-36951
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
