### PR TITLE
OCPBUGS-54148: Added PTP UDP OVNK primary interface note

### DIFF
--- a/networking/ptp/about-ptp.adoc
+++ b/networking/ptp/about-ptp.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Precision Time Protocol (PTP) is used to synchronize clocks in a network. When used in conjunction with hardware support, PTP is capable of sub-microsecond accuracy, and is more accurate than Network Time Protocol (NTP).
 
+[IMPORTANT]
+====
+If your `openshift-sdn` cluster with PTP uses the User Datagram Protocol (UDP) for hardware time stamping and you migrate to the OVN-Kubernetes plugin, the hardware time stamping cannot be applied to primary interface devices, such as an Open vSwitch (OVS) bridge. As a result, UDP version 4 configurations cannot work with a `br-ex` interface.
+====
+
 You can configure `linuxptp` services and use PTP-capable hardware in {product-title} cluster nodes.
 
 Use the {product-title} web console or OpenShift CLI (`oc`) to install PTP by deploying the PTP Operator. The PTP Operator creates and manages the `linuxptp` services and provides the following features:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-54148](https://issues.redhat.com/browse/OCPBUGS-54148)

Link to docs preview:
* [About Precision Time Protocol in OpenShift cluster nodes](https://90987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/about-ptp.html)

- [x] SME has approved this change (Christian Passarelli/comment in team-ocp-dsn doc).
- [x] QE has approved this change (Zhanqi Zhao).
