### PR TITLE
TELCODOCS-2208 PTP events REST API v2

### DIFF
--- a/modules/ptp-reference-deployment-and-service-crs-v2.adoc
+++ b/modules/ptp-reference-deployment-and-service-crs-v2.adoc
@@ -58,8 +58,6 @@ spec:
           args:
             - "--local-api-addr=consumer-events-subscription-service.cloud-events.svc.cluster.local:9043"
             - "--api-path=/api/ocloudNotifications/v2/"
-            - "--api-addr=127.0.0.1:8089"
-            - "--api-version=2.0"
             - "--http-event-publishers=ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
           env:
             - name: NODE_NAME

--- a/networking/ptp/ptp-events-rest-api-reference-v2.adoc
+++ b/networking/ptp/ptp-events-rest-api-reference-v2.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Use the following REST API v2 endpoints to subscribe the `cloud-event-consumer` application to Precision Time Protocol (PTP) events posted at `\http://localhost:9043/api/ocloudNotifications/v2` in the PTP events producer pod.
+Use the following REST API v2 endpoints to subscribe the `cloud-event-consumer` application to Precision Time Protocol (PTP) events posted at `\http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043/api/ocloudNotifications/v2` in the PTP events producer pod.
 
 * xref:../../networking/ptp/ptp-events-rest-api-reference-v2.adoc#api-ocloud-notifications-v2-subscriptions_{context}[`api/ocloudNotifications/v2/subscriptions`]
 ** `POST`: Creates a new subscription


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2208
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

- [Reference event consumer deployment and service CRs using PTP events REST API v2](https://90988--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/ptp-cloud-events-consumer-dev-reference-v2#ptp-reference-deployment-and-service-crs-v2_ptp-consumer)
- [PTP events REST API v2 reference](https://90988--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/ptp-events-rest-api-reference-v2)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @Bonnie-Block
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
