### PR TITLE
HCIDOCS-685: IPI Installation on Bare Metal needs UCS C-Series server details

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -32,12 +32,16 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 
 |====
 
-
 .Firmware compatibility for Cisco UCS hardware with Redfish virtual media
 [cols="1,1,1",options="header"]
 |====
 | Model | Management | Firmware versions
-| UCS X-Series servers footnote:[Installer-provisioned installation is supported for UCS M6 Platform and later.] | CIMC | 5.2(2) or later
-| UCS C-Series servers in UCS managed domain | CIMC | 4.3 or later
-
+| UCS X-Series servers | Intersight Managed Mode  | 5.2(2) or later
+| FI-Attached UCS C-Series servers | Intersight Managed Mode | 4.3 or later
+| Standalone UCS C-Series servers | Standalone / Intersight | 4.3 or later
 |====
+
+[NOTE]
+====
+Always confirm that your server supports {op-system-first} on link:https://ucshcltool.cloudapps.cisco.com/public/[UCSHCL].
+====


### PR DESCRIPTION
Added content from Cisco to the firmware table.

Fixes: [HCIDOCS-685](https://issues.redhat.com//browse/HCIDOCS-685)

See https://issues.redhat.com/browse/HCIDOCS-685 for additional details.

Preview URL: https://90992--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites

For release(s): 4.17, 4.18, 4.19
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
