### PR TITLE
OSDOCS-13718: 4.15.48 Release Note

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2779,6 +2779,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.48
+[id="ocp-4-15-48_{context}"]
+=== RHSA-2025:3055 - {product-title} 4.15.48 bug fix and security update
+
+Issued: 26 March 2025
+
+{product-title} release 4.15.48, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3055[RHSA-2025:3055] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3057[RHBA-2025:3057] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.48 --pullspecs
+----
+
+[id="ocp-4-15-48-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the availability set fault domain count was hardcoded to `2`. This value works in most regions on {azure-first} because the fault domain counts are typically at least `2`, but failed in the `centraluseuap` and `eastusstg` regions. With this release, the availability set fault domain count in a region is set dynamically so that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-53226[*OCPBUGS-53226*])
+
+* Previously, the `trusted-ca-bundle-managed` ConfigMap component was a mandatory component. If you attempted to use a custom Public Key Infrastructure (PKI), the deployment would fail because the OpenShift API server expected the presence of the `trusted-ca-bundle-managed` ConfigMap component. With this release, this component is optional so that you can deploy clusters without the `trusted-ca-bundle-managed` config map component when you use a custom PKI. (link:https://issues.redhat.com/browse/OCPBUGS-52896[*OCPBUGS-52896*])
+
+* Previously, the URL for the *Alert Rules* page on the web console was incorrect. With this release, the URL is fixed and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-52344[*OCPBUGS-52344*])
+
+* Previously, Operator Lifecycle Manager (OLM) sometimes concurrently resolved the same namespace in a cluster. As a consequence, subscriptions reached a terminal state of `ConstraintsNotSatisfiable` because two concurrent processes interacted with a subscription, which caused a CSV file to become unassociated. With this release, OLM no longer concurrently resolves namespaces, so that OLM correctly processes a subscription without leaving a CSV file in an unassociated state. (link:https://issues.redhat.com/browse/OCPBUGS-48662[*OCPBUGS-48662*])
+
+[id="ocp-4-15-48-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.15.47
 [id="ocp-4-15-47_{context}"]
 === RHSA-2025:2454 - {product-title} 4.15.47 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-13718](https://issues.redhat.com/browse/OSDOCS-13718)

Link to docs preview: https://91001--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-48_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (3/26)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
