### PR TITLE
OCPBUGS33047: Query with CRI-O pids_limit and how are the pods with multiple containers treated.

### DIFF
--- a/modules/cnf-configuring-kubelet-nro.adoc
+++ b/modules/cnf-configuring-kubelet-nro.adoc
@@ -4,7 +4,7 @@
 
 :_module-type: PROCEDURE
 [id="cnf-configuring-kubelet-config-nro_{context}"]
-= Creating a KubeletConfig CRD
+= Creating a KubeletConfig CR
 
 The recommended way to configure a single NUMA node policy is to apply a performance profile. Another way is by creating and applying a `KubeletConfig` custom resource (CR), as shown in the following procedure.
 

--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="create-a-kubeletconfig-crd-to-edit-kubelet-parameters_{context}"]
-= Creating a KubeletConfig CRD to edit kubelet parameters
+= Creating a KubeletConfig CR to edit kubelet parameters
 
 The kubelet configuration is currently serialized as an Ignition configuration, so it can be directly edited. However, there is also a new `kubelet-config-controller` added to the Machine Config Controller (MCC). This lets you use a `KubeletConfig` custom resource (CR) to edit the kubelet parameters.
 

--- a/modules/risks-setting-higher-process-id-limits.adoc
+++ b/modules/risks-setting-higher-process-id-limits.adoc
@@ -14,7 +14,15 @@ If you are running a large number of pods per node, and you have a high `podPids
 
 To find the maximum number of pods that you can run simultaneously on a single node without exceeding the PID maximum for the node, divide 3,650,000 by your `podPidsLimit` value. For example, if your `podPidsLimit` value is 16,384, and you expect the pods to use close to that number of process IDs, you can safely run 222 pods on a single node.
 
+ifdef::openshift-enterprise,openshift-origin[]
+[NOTE]
+====
+Memory, CPU, and available storage can also limit the maximum number of pods that can run simultaneously, even when the `podPidsLimit` value is set appropriately.
+====
+endif::openshift-enterprise,openshift-origin[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 Memory, CPU, and available storage can also limit the maximum number of pods that can run simultaneously, even when the `podPidsLimit` value is set appropriately. For more information, see "Planning your environment" and "Limits and scalability".
 ====
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/sd-understanding-process-id-limits.adoc
+++ b/modules/sd-understanding-process-id-limits.adoc
@@ -6,15 +6,45 @@
 [id="understanding-process-id-limits_{context}"]
 = Understanding process ID limits
 
+ifdef::openshift-enterprise,openshift-origin[]
+A process identifier (PID) is a unique identifier assigned by the Linux kernel to each process or thread currently running on a system. The number of processes that can run simultaneously on a system is limited to 4,194,304 by the Linux kernel. This number might also be affected by limited access to other system resources such as memory, CPU, and disk space.
+endif::openshift-enterprise,openshift-origin[]
+
 In {product-title}, consider these two supported limits for process ID (PID) usage before you schedule work on your cluster:
 
 * Maximum number of PIDs per pod.
 +
 The default value is 4,096 in {product-title} 4.11 and later. This value is controlled by the `podPidsLimit` parameter set on the node.
+ifdef::openshift-enterprise,openshift-origin[]
++
+You can view the current PID limit on a node by running the following command in a `chroot` environment:
++
+[source,terminal]
+----
+sh-5.1# cat /etc/kubernetes/kubelet.conf | grep -i pids
+----
++
+.Example output
+[source,terminal]
+----
+"podPidsLimit": 4096,
+----
++
+You can change the `podPidsLimit` by using a `KubeletConfig` object. See "Creating a KubeletConfig CR to edit kubelet parameters".
++
+Containers inherit the `podPidsLimit` value from the parent pod, so the kernel enforces the lower of the two limits. For example, if the container PID limit is set to the maximum, but the pod PID limit is `4096`, the PID limit of each container in the pod is confined to 4096.
+endif::openshift-enterprise,openshift-origin[]
 
+ifdef::openshift-enterprise,openshift-origin[]
+* Maximum number of PIDs per node.
++
+The default value depends on node resources. In {product-title}, this value is controlled by the `systemReserved` parameter in a kubelet configuration, which reserves PIDs on each node based on the total resources of the node. For more information, see "Allocating resources for nodes in an {product-title} cluster".
+endif::openshift-enterprise,openshift-origin[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Maximum number of PIDs per node.
 +
 The default value depends on link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.18/html-single/nodes/index#nodes-nodes-resources-configuring[node resources]. In {product-title}, this value is controlled by the link:https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved[`--system-reserved`] parameter, which reserves PIDs on each node based on the total resources of the node.
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 When a pod exceeds the allowed maximum number of PIDs per pod, the pod might stop functioning correctly and might be evicted from the node. See link:https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals-and-thresholds[the Kubernetes documentation for eviction signals and thresholds] for more information.
 

--- a/nodes/nodes/nodes-nodes-resources-configuring.adoc
+++ b/nodes/nodes/nodes-nodes-resources-configuring.adoc
@@ -20,6 +20,16 @@ To manually set resource values, you must use a kubelet config CR. You cannot us
 
 include::modules/nodes-nodes-resources-configuring-about.adoc[leveloffset=+1]
 
+include::modules/sd-understanding-process-id-limits.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/machine-configs-custom.adoc#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_machine-configs-custom[Creating a KubeletConfig CR to edit kubelet parameters]
+* xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring[Allocating resources for nodes in an {product-title} cluster]
+
+include::modules/risks-setting-higher-process-id-limits.adoc[leveloffset=+2]
+
 include::modules/nodes-nodes-resources-configuring-auto.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-resources-configuring-setting.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-33047

New section on PID limits. The text is taken from ROSA: [Configuring PID limits](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa-configuring-pid-limits#rosa-configuring-pid-limits). 

**OCP docs:**
[Understanding process ID limits](https://91004--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html#understanding-process-id-limits_nodes-nodes-resources-configuring) -- Existing file, used by ROSA. Added ifdefs to isolate core and ROSA. Added new text to the core section.
[Risks of setting higher process ID limits](https://91004--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html#risks-setting-higher-process-id-limits_nodes-nodes-resources-configuring) -- Existing file, used by ROSA. Added ifdefs to isolate core and ROSA.
[Creating a KubeletConfig CR to edit kubelet parameters](https://91004--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-custom#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_machine-configs-custom) -- Updated the module title while I was there. 

**ROSA docs should be unaffected:**
[Configuring PID limits](https://91004--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-configuring-pid-limits.html) -- [Current ROSA doc](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa-configuring-pid-limits)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
