### PR TITLE
OSDOCS#13717: Update the RN for 4.17.22 z-stream

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2879,6 +2879,32 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.22
+[id="ocp-4-17-22_{context}"]
+=== RHSA-2025:3059 - {product-title} {product-version}.22 bug fix, and security update advisory
+
+Issued: 26 March 2025
+
+{product-title} release {product-version}.22 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3059[RHSA-2025:3059] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:3061[RHSA-2025:3061] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.22 --pullspecs
+----
+
+[id="ocp-4-17-22-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, during cluster shutdown, a race condition prevented a stage `ostree` deployment from finalizing if the deployment was moved to a staging location during a reboot operation. With this release, a fix removes the race condition from the `ostree` deployment so that the staged deployment can finalize even during a reboot operation. (link:https://issues.redhat.com/browse/OCPBUGS-53225[*OCPBUGS-53225*])
+
+[id="ocp-4-17-22-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.21
 [id="ocp-4-17-21_{context}"]
 === RHSA-2025:2696 - {product-title} {product-version}.21 bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13717](https://issues.redhat.com/browse/OSDOCS-13717)

Link to docs preview:
[4.17.22](https://91005--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes#ocp-4-17-22_release-notes)

QE review:
- [ ] QE has approved this change.
n/a for z-stream RN

Additional information:
The errata URLs will return 404 until the go-live date of 03/26/25.