### PR TITLE
[WIP] OSDOCS-13195.1:Updated incident management sections of OSD and ROSA docs

### DIFF
--- a/modules/policy-incident.adoc
+++ b/modules/policy-incident.adoc
@@ -15,18 +15,25 @@ A Red Hat Site Reliability Engineer (SRE) maintains a centralized monitoring and
 
 [id="incident-management_{context}"]
 == Incident management
-An incident is an event that results in a degradation or outage of one or more Red Hat services. An incident can be raised by a customer or Customer Experience and Engagement (CEE) member through a support case, directly by the centralized monitoring and alerting system, or directly by a member of the SRE team.
+An incident is an event that results in a degradation or outage of one or more Red{nbsp}Hat services, and can affect service-level agreements (SLAs).
+
+Customers and Customer Experience and Engagement (CEE) members can raise an incident through a support case. The centralized monitoring and alerting system and members of the SRE team can also raise an incident directly.
 
 Depending on the impact on the service and customer, the incident is categorized in terms of link:https://access.redhat.com/support/offerings/production/sla[severity].
+
+Red{nbsp}Hat either sends out cluster notifications to affected individual clusters or changes the status at link:https://status.redhat.com[status.redhat.com] to reflect a wider incident. Cluster notifications are not sent for low-impact events, low-risk security updates, routine operations and maintenance, or minor, transient issues that are quickly resolved by SRE.
 
 The general workflow of how a new incident is managed by Red Hat:
 
 . An SRE first responder is alerted to a new incident, and begins an initial investigation.
 . After the initial investigation, the incident is assigned an incident lead, who coordinates the recovery efforts.
 . The incident lead manages all communication and coordination around recovery, including any relevant notifications or support case updates.
-. The incident is recovered.
-. The incident is documented and a root cause analysis is performed within 5 business days of the incident.
-. A root cause analysis (RCA) draft document is shared with the customer within 7 business days of the incident.
+. When the incident is resolved, a brief summary of the incident and resolution are provided in the customer-initiated support ticket. This summary helps the customers understand the incident and its resolution in more detail.
+
+If customers need additional information than the information provided in the support ticket they can request the following workflow:
+
+. The customer must request for the additional information within 5 business days of the incident resolution. After 5 business days, Red{nbsp}Hat may rotate the data logs and might not have access to data that resulted in the incident and its subsequent resolution.
+. Depending on the severity of the incident, Red{nbsp}Hat may provide additional details in the customer-initiated support ticket, may add a root case summary, or create a root cause analysis (RCA) draft document within an agreed timeframe.
 
 [id="backup-recovery_{context}"]
 == Backup and recovery

--- a/modules/rosa-policy-incident.adoc
+++ b/modules/rosa-policy-incident.adoc
@@ -115,9 +115,12 @@ When managing a new incident, Red{nbsp}Hat uses the following general workflow:
 . An SRE first responder is alerted to a new incident and begins an initial investigation.
 . After the initial investigation, the incident is assigned an incident lead, who coordinates the recovery efforts.
 . An incident lead manages all communication and coordination around recovery, including any relevant notifications and support case updates. If the status of a service changes or if Red{nbsp}Hat has a significant update on the progress, then the incident lead sends out an updated cluster notification.
-. The incident is recovered.
-. The incident is documented and a root cause analysis (RCA) is performed within 5 business days of the incident.
-. An RCA draft document will be shared with the customer within 7 business days of the incident.
+. When the incident is resolved, a brief summary of the incident and resolution are provided in the customer-initiated support ticket. This summary helps the customers understand the incident and its resolution in more detail.
+
+If customers need additional information than the information provided in the support ticket they can request the following workflow:
+
+. The customer must request for the additional information within 5 business days of the incident resolution. After 5 business days, Red{nbsp}Hat may rotate the data logs and might not have access to data that resulted in the incident and its subsequent resolution.
+. Depending on the severity of the incident, Red{nbsp}Hat may provide additional details in the customer-initiated support ticket, may add a root case summary, or create a root cause analysis (RCA) draft document within an agreed timeframe.
 
 Red{nbsp}Hat also assists with customer incidents raised through support cases.
 Red{nbsp}Hat can assist with activities including but not limited to:


### PR DESCRIPTION
This PR continues with updates from PR #90613 for the Incident management section of the RACI docs for OSD and ROSA.

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13195

Link to docs preview:
OSD: https://91028--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-process-security.html#incident-management_policy-process-security

ROSA: https://91028--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-incident-management_rosa-policy-responsibility-matrix

Peer review:
- [ ]  Peer reviewer has approved this change.

SME review:
- [ ]  SME has approved this change.

QE review:
-QE approval is not required as no changes to procedural information.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
