### PR TITLE
ROX-28674: Disable the policy as code feature

### DIFF
--- a/modules/policy-as-code-disable.adoc
+++ b/modules/policy-as-code-disable.adoc
@@ -12,8 +12,8 @@ The policy as code feature is automatically enabled when you install {product-ti
 
 To disable the policy as code feature, complete one of the following tasks, depending on the method you used to install {product-title-short}:
 
-* If you installed {product-title-short} by using the Operator, set the `spec.configAsCode.configAsCodeComponent` field to `Enabled`.
-* If you installed {product-title-short} by using Helm charts, set the `configAsCode.enabled` field in the `values.yaml` file to `true`.
+* If you installed {product-title-short} by using the Operator, set the `spec.configAsCode.configAsCodeComponent` field to `Disabled`.
+* If you installed {product-title-short} by using Helm charts, set the `configAsCode.enabled` field in the `values.yaml` file to `false`.
 * If you installed {product-title-short} by using the manifest installation method, also known as the `roxctl` method, delete the `config-controller` deployment by running the following command:
 +
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->



Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
RHACS v4.7

[Issue
](https://issues.redhat.com/browse/ROX-28674)

To disable the policy as code, required to specify `Disabled` instead of `Enabled` at the `spec.configAsCode.configAsCodeComponent`. In Helm case, `configAsCode.enabled` field should be `false` instead of `true`.

[Link to docs preview
](https://91030--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/custom-security-policies.html#policy-as-code-disable_custom-security-policies)

https://issues.redhat.com/browse/ROX-28674

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
