### PR TITLE
OCPBUGS-52971: Fixed 'managed' typo in configuring-multi-network-poli…

### DIFF
--- a/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
+++ b/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Administrators can use the `MultiNetworkPolicy` API to create multiple network policies that manage traffic for pods attached to secondary networks. For example, you can create policies that allow or deny traffic based on specific ports, IPs/ranges, or labels.
 
-Multi-network policies can be used to manage traffic on secondary networks in the cluster. They cannot managed the cluster's default network or primary network of user-defined networks. 
+Multi-network policies can be used to manage traffic on secondary networks in the cluster. These policies cannot manage the default cluster network or primary network of user-defined networks. 
 
 As a cluster administrator, you can configure a multi-network policy for any of the following network types:
 


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-52971](https://issues.redhat.com/browse/OCPBUGS-52971)

Link to docs preview:
* [Configuring multi-network policy](https://91035--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.html)

