### PR TITLE
OSDOCS-10226: Added NodeHasIntegrityFailure alert to the docs

### DIFF
--- a/modules/file-integrity-failure-alerts.adoc
+++ b/modules/file-integrity-failure-alerts.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-understanding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="file-integrity-failure-alerts_{context}"]
+= Prometheus alerts for File Integrity Operator
+
+The File Integrity Operator creates the following default alert in the Operator namespace when a Node has been in a failure state for more than 30 seconds:
+
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: file-integrity
+  namespace: openshift-file-integrity
+spec:
+  groups:
+  - name: node-failed
+    rules:
+    - alert: NodeHasIntegrityFailure
+      annotations:
+        description: Node {{ $labels.node }} has an an integrity check status of Failed for
+          more than 1 second.
+        summary: Node {{ $labels.node }} has a file integrity failure
+      expr: file_integrity_operator_node_failed{node=~".+"} * on(node) kube_node_info > 0 <1>
+      for: 1s
+      labels:
+        severity: warning
+----
+<1> The `expr` attribute defines the scope of the alert.

--- a/security/file_integrity_operator/file-integrity-operator-understanding.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-understanding.adoc
@@ -20,4 +20,5 @@ include::modules/file-integrity-understanding-file-integrity-node-statuses-objec
 include::modules/file-integrity-node-status.adoc[leveloffset=+1]
 include::modules/file-integrity-node-status-success.adoc[leveloffset=+2]
 include::modules/file-integrity-node-status-failure.adoc[leveloffset=+2]
+include::modules/file-integrity-failure-alerts.adoc[leveloffset=+1]
 include::modules/file-integrity-events.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-10226

Link to docs preview:
[Prometheus alerts for File Integrity Operator](https://91038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-understanding.html#file-integrity-failure-alerts_file-integrity-operator)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Based on the upstream [Integrity Failure Alerts](https://github.com/openshift/file-integrity-operator/blob/master/README.md#integrity-failure-alerts).