### PR TITLE
OCPBUGS-54166: Updats IP+subnet mask in patching-ovnk-address-ranges.…

### DIFF
--- a/modules/initiating-limited-live-migration.adoc
+++ b/modules/initiating-limited-live-migration.adoc
@@ -16,7 +16,7 @@ After you have checked the behavior of egress IP resources, egress firewall reso
 * You have created a recent backup of the etcd database.
 * The cluster is in a known good state without any errors.
 * Before migration to OVN-Kubernetes, a security group rule must be in place to allow UDP packets on port `6081` for all nodes on all cloud platforms.
-* If the `100.64.0.0/16` and `100.88.0.0/16` address ranges were previously in use by OpenShift-SDN, you have patched them. The first step of this procedure checks whether these address ranges are in use. If they are in use, see "Patching OVN-Kubernetes address ranges".
+* If the `100.64.0.0/16` and `100.88.0.0/16` address ranges were previously in use by OpenShift-SDN, you have patched them. A step in the procedure checks whether these address ranges are in use. If they are in use, see "Patching OVN-Kubernetes address ranges".
 * You have checked for egress IP resources, egress firewall resources, and multicast enabled namespaces.
 * You have removed any egress router pods before beginning the limited live migration. For more information about egress router pods, see "Deploying an egress router pod in redirect mode".
 * You have reviewed the "Considerations for limited live migration to the OVN-Kubernetes network plugin" section of this document.

--- a/modules/patching-ovnk-address-ranges.adoc
+++ b/modules/patching-ovnk-address-ranges.adoc
@@ -26,11 +26,11 @@ This is an optional procedure and must only be used if the migration was blocked
 
 .Procedure
 
-. If the `100.64.0.0/16` IP address range is already in use, enter the following command to patch it to a different range. The following example uses  `100.63.0.0/16`.
+. If the `100.64.0.0/16` IP address range is already in use, enter the following command to patch it to a different range. The following example uses `100.70.0.0/16`.
 +
 [source,terminal]
 ----
-$ oc patch network.operator.openshift.io cluster --type='merge' -p='{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipv4":{"internalJoinSubnet": "100.63.0.0/16"}}}}}'
+$ oc patch network.operator.openshift.io cluster --type='merge' -p='{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipv4":{"internalJoinSubnet": "100.70.0.0/16"}}}}}'
 ----
 
 . If the `100.88.0.0/16` IP address range is already in use, enter the following command to patch it to a different range. The following example uses  `100.99.0.0/16`.


### PR DESCRIPTION
Version(s):
4.15+4.16

Issue:
[OCPBUGS-54166](https://issues.redhat.com/browse/OCPBUGS-54166)

Link to docs preview:
[Patching OVN-Kubernetes address ranges](https://91041--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)

- [x] SME has approved this change (Tyler Walker).
- [x] QE has approved this change (Zhanqi Zhao).
