### PR TITLE
OCPBUGS-48234: added an xref to PriorityClass creation

### DIFF
--- a/modules/compliance-priorityclass.adoc
+++ b/modules/compliance-priorityclass.adoc
@@ -8,6 +8,10 @@
 
 In large scale environments, the default `PriorityClass` object can be too low to guarantee Pods execute scans on time. For clusters that must maintain compliance or guarantee automated scanning, it is recommended to set the `PriorityClass` variable to ensure the Compliance Operator is always given priority in resource constrained situations.
 
+.Prerequisites
+
+* Optional: You have created a `PriorityClass` object. For more information, see "Configuring priority and preemption" in the _Additional Resources_.
+
 .Procedure
 
 * Set the `PriorityClass` variable:

--- a/security/compliance_operator/co-scans/compliance-operator-advanced.adoc
+++ b/security/compliance_operator/co-scans/compliance-operator-advanced.adoc
@@ -12,6 +12,10 @@ include::modules/compliance-objects.adoc[leveloffset=+1]
 
 include::modules/compliance-priorityclass.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../nodes/pods/nodes-pods-priority.adoc#nodes-pods-priority-configuring_nodes-pods-priority[Configuring priority and preemption]
+
 include::modules/compliance-raw-tailored.adoc[leveloffset=+1]
 
 include::modules/compliance-rescan.adoc[leveloffset=+1]
@@ -24,7 +28,7 @@ include::modules/compliance-auto-update-remediations.adoc[leveloffset=+1]
 
 include::modules/compliance-custom-scc.adoc[leveloffset=+1]
 
-[id="additional-resources_compliance-operator-advanced"]
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
-* xref:../../../authentication/managing-security-context-constraints.adoc[Managing security context constraints]
+* xref:../../../authentication/managing-security-context-constraints.adoc#managing-pod-security-policies[Managing security context constraints]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-48234

Link to docs preview:
[Setting PriorityClass for ScanSetting scans](https://91045--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-advanced.html#compliance-priorityclass_compliance-advanced)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None
