### PR TITLE
MIG-1687: Release notes for MTC 1.8.6

### DIFF
--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,7 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-6.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-5.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-4.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-3.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-6.adoc
+++ b/modules/migration-mtc-release-notes-1-8-6.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-6_{context}"]
+= {mtc-full} 1.8.6 release notes
+
+[id="technical-changes-1-8-6_{context}"]
+== Technical changes
+
+.Multiple migration plans for a namespace is not supported
+
+{mtc-short} version 1.8.6 and later do not support multiple migration plans for a single namespace.
+
+.VM storage migration
+
+VM storage migration feature changes from Technology Preview (TP) status to being Generally Available (GA).
+
+[id="resolved-issues-1-8-6_{context}"]
+== Resolved issues
+
+{mtc-short} 1.8.6 has the following major resolved issues:
+
+.UI fails during a namespace search in the migration plan wizard
+
+When searching for a namespace in the *Select Namespace* step of the migration plan wizard, the user interface (UI) fails and disappears after clicking *Search*. The browser console shows a JavaScript error indicating that an undefined value has been accessed. This issue has been resolved in {mtc-short} 1.8.6. link:https://issues.redhat.com/browse/MIG-1704[(MIG-1704)]
+
+.Unable to create a migration plan due to a reconciliation failure
+
+In {mtc-short}, when creating a migration plan , the UI remains on *Persistent Volumes* and you cannot continue. This issue occurs due to a critical reconciliation failure and returns a 404 API error when you attempt to fetch the migration plan from the backend. These issues cause the migration plan to remain in a *Not Ready* state, and you are prevented from continuing. This issue has been resolved in {mtc-short} 1.8.6. link:https://issues.redhat.com/browse/MIG-1705[(MIG-1705)]
+
+.Migration process becomes fails to complete after the `StageBackup` phase
+
+When migrating a Django and PostgreSQL application, the migration becomes fails to complete after the `StageBackup` phase. Even though all the pods in the source namespace are healthy before the migration begins, after the migration and when terminating the pods on the source cluster, the Django pod fails with a `CrashLoopBackOff` error. This issue has been resolved in {mtc-short} 1.8.6. link:https://issues.redhat.com/browse/MIG-1707[(MIG-1707)]
+
+.Migration shown as succeeded despite a failed phase due to a misleading UI status
+
+After running a migration using {mtc-short}, the UI incorrectly indicates that the migration was successful, with the status shown as *Migration succeeded*. However, the Direct Volume Migration (DVM) phase failed. This misleading status appears on both the *Migration* and the *Migration Details* pages. This issue has been resolved in {mtc-short} 1.8.6. link:https://issues.redhat.com/browse/MIG-1711[(MIG-1711)] 
+
+.Persistent Volumes page hangs indefinitely for namespaces without persistent volume claims
+When a migration plan includes a namespace that does not have any persistent volume claims (PVCs), the *Persistent Volumes* selection page remains indefinitely with the following message shown: `Discovering persistent volumes attached to source projects...`. The page never completes loading, preventing you from proceeding with the migration. This issue has been resolved in {mtc-short} 1.8.6. link:https://issues.redhat.com/browse/MIG-1713[(MIG-1713)]
+
+[id="known-issues-1-8-6_{context}"]
+== Known issues
+
+{mtc-short} 1.8.6 has the following known issues:
+
+.Inconsistent reporting of migration failure status
+
+There is a discrepancy in the reporting of namespace migration status following a rollback and subsequent re-migration attempt when the migration plan is deliberately faulted. Although the Distributed Volume Migration (DVM) phase correctly registers a failure, this failure is not consistently reflected in the user interface (UI) or the migration plan's YAML representation. 
+
+This issue is not only limited to unusual or unexpected cases. In certain circumstances, such as when network restrictions are applied that cause the DVM phase to fail, the UI still reports the migration status as successful. This behavior is similar to what was previously observed in link:https://issues.redhat.com/browse/MIG-1711[MIG-1711] but occurs under different conditions. link:https://issues.redhat.com/browse/MIG-1719[(MIG-1719)] 


### PR DESCRIPTION
### JIRA

* [MIG-1687](https://issues.redhat.com/browse/MIG-1687)


### Version(s):

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19

### Link to docs preview:

* [MTC 1.8.6 release notes](https://91067--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes.html#migration-mtc-release-notes-1-8-6_mtc-release-notes)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
