### PR TITLE
OSDOCS#13277: Clarify certificate rotation, including not rotating CAs

### DIFF
--- a/microshift_troubleshooting/microshift-things-to-know.adoc
+++ b/microshift_troubleshooting/microshift-things-to-know.adoc
@@ -18,3 +18,7 @@ When such changes occur, some {microshift-short} components may stop functioning
 The threshold for clock changes is a time adjustment of greater than 10 seconds in either direction. Smaller drifts on regular time adjustments performed by the Network Time Protocol (NTP) service do not cause a restart.
 
 include::modules/microshift-certificate-lifetime.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../microshift_configuring/microshift_auth_security/microshift-custom-ca.adoc#microshift-custom-ca[Configuring custom certificate authorities].

--- a/modules/microshift-certificate-lifetime.adoc
+++ b/modules/microshift-certificate-lifetime.adoc
@@ -11,7 +11,7 @@
 . Short-lived certificates having certificate validity of one year.
 . Long-lived certificates having certificate validity of 10 years.
 
-Most server or leaf certificates are short-term.
+Most server or leaf certificates are short-lived.
 
 An example of a long-lived certificate is the client certificate for `system:admin user` authentication, or the certificate of the signer of the `kube-apiserver` external serving certificate.
 
@@ -19,9 +19,9 @@ An example of a long-lived certificate is the client certificate for `system:adm
 == Certificate rotation
 Certificates that are expired or close to their expiration dates need to be rotated to ensure continued {microshift-short} operation. When {microshift-short} restarts for any reason, certificates that are close to expiring are rotated. A certificate that is set to expire imminently, or has expired, can cause an automatic {microshift-short} restart to perform a rotation.
 
-[NOTE]
+[IMPORTANT]
 ====
-If the rotated certificate is a Certificate Authority, all of the certificates it signed rotate.
+If the rotated certificate is a {microshift-short} certificate authority (CA), then all of the signed certificates rotate. If you created any custom CAs, ensure the CAs manually rotate.
 ====
 
 [id="microshift-st-certificate-rotation_{context}"]
@@ -48,4 +48,4 @@ The following situations describe {microshift-short} actions during long-term ce
 .. When a long-term certificate is 8.5 to 9 years old, it is rotated when {microshift-short} starts or restarts.
 
 . Automatic restart for rotation:
-.. When a long-term certificate is more than 9 years old, {microshift-short} can automatically restart to rotate and apply a new certificate.
+.. When a long-term certificate is more than 9 years old, {microshift-short} might automatically restart so that it can rotate and apply a new certificate.

--- a/modules/microshift-custom-ca-proc.adoc
+++ b/modules/microshift-custom-ca-proc.adoc
@@ -42,7 +42,7 @@ apiServer:
 <2> Add the full path to the certificate key.
 <3> Optional. Add a list of explicit DNS names. Leading wildcards are allowed. If no names are provided, the implicit names are extracted from the certificates.
 
-. Restart the {microshift-service} to apply the certificates by running the following command:
+. Restart the {microshift-short} to apply the certificates by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-13722](https://issues.redhat.com//browse/OSDOCS-13722)

Link to docs preview:
[Certificate rotation](https://91079--ocpdocs-pr.netlify.app/microshift/latest/microshift_troubleshooting/microshift-things-to-know.html#microshift-certificate-rotation_microshift-things-to-know)
[Configuring custom certificate authorities](https://91079--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift_auth_security/microshift-custom-ca.html)

QE review:
- [ x] QE has approved this change.
