### PR TITLE
OSDOCS#13707: Updated supported platforms content

### DIFF
--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -7,21 +7,108 @@
 [id="supported-platforms-for-openshift-clusters_{context}"]
 = Supported platforms for {product-title} clusters
 
-In {product-title} {product-version}, you can install a cluster that uses installer-provisioned infrastructure on the following platforms:
+The following table describes which platforms are supported by the different methods available for installing {product-title} clusters:
 
-* Amazon Web Services (AWS)
-* Bare metal
-* Google Cloud Platform (GCP)
-* {ibm-cloud-name}
-* Microsoft Azure
-* Microsoft Azure Stack Hub
-* Nutanix
-* {rh-openstack-first}
-** The latest {product-title} release supports both the latest {rh-openstack} long-life release and intermediate release. For complete {rh-openstack} release compatibility, see the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-* VMware vSphere
+// Should `none` and `external` be mentioned in this table?
 
-For these clusters, all machines, including the computer that you run the installation process on, must have direct internet access to pull images for platform containers and provide telemetry data to Red Hat.
+.Supported platforms
+[cols=".^4s,.^1,.^1,.^1,.^1,options="header"]
+|====
+|Platform|Installer-provisioned infrastructure ^[1]^|User-provisioned infrastructure ^[2]^|Agent-based Installer|Assisted Installer
 
+|{aws-first}
+|X
+|X
+|
+|
+
+|Bare metal
+|X
+|X
+|X
+|X
+
+|External
+|
+|
+|X
+|X
+
+|{gcp-first}
+|X
+|X
+|
+|
+
+|{ibm-cloud-name} Classic
+|X
+|
+|
+|
+
+|{ibm-cloud-name} Virtual Private Cloud (VPC)
+|X
+|
+|
+|
+
+|{ibm-power-name}
+|
+|X
+|X
+|X
+
+|{ibm-z-name} or {ibm-linuxone-name}
+|
+|X
+|X
+|X
+
+|{azure-first}
+|X
+|X
+|
+|
+
+|{azure-full} Stack Hub
+|X
+|X
+|
+|
+
+|None
+|
+|
+|X
+|X
+
+|Nutanix
+|X
+|
+|
+|X
+
+|{oci-first-no-rt}
+|
+|
+|X
+|X
+
+|{rh-openstack-first} ^[3]^
+|X
+|X
+|
+|
+
+|{vmw-first}
+|X
+|X
+|X
+|X
+
+|====
+1. For installer-provisioned infrastructure: All machines, including the computer that you run the installation process on, must have direct internet access to pull images for platform containers and provide telemetry data to Red{nbsp}Hat.
++
 [IMPORTANT]
 ====
 After installation, the following changes are not supported:
@@ -30,22 +117,10 @@ After installation, the following changes are not supported:
 * Mixing cloud provider components. For example, using a persistent storage framework from a another platform on the platform where you installed the cluster.
 ====
 
-In {product-title} {product-version}, you can install a cluster that uses user-provisioned infrastructure on the following platforms:
+2. For user-provisioned infrastructure: Depending on the supported cases for the platform, you can perform installations on user-provisioned infrastructure so that you can run machines with full internet access, place your cluster behind a proxy, or perform a disconnected installation.
++
+In a disconnected installation, you can download the images that are required to install a cluster, place them in a mirror registry, and use that data to install your cluster. While you require internet access to pull images for platform containers, with a disconnected installation on vSphere or bare-metal infrastructure, your cluster machines do not require direct internet access.
 
-* AWS
-* Azure
-* Azure Stack Hub
-* Bare metal
-* GCP
-* {ibm-power-name}
-* {ibm-z-name} or {ibm-linuxone-name}
-* {rh-openstack}
-** The latest {product-title} release supports both the latest {rh-openstack} long-life release and intermediate release. For complete {rh-openstack} release compatibility, see the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-* VMware Cloud on AWS
-* VMware vSphere
+3. For {rh-openstack-first}: The latest {product-title} release supports both the latest {rh-openstack} long-life release and intermediate release. For complete {rh-openstack} release compatibility, see the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
-Depending on the supported cases for the platform, you can perform installations on user-provisioned infrastructure, so that you can run machines with full internet access, place your cluster behind a proxy, or perform a disconnected installation.
-
-In a disconnected installation, you can download the images that are required to install a cluster, place them in a mirror registry, and use that data to install your cluster. While you require internet access to pull images for platform containers, with a disconnected installation on vSphere or bare metal infrastructure, your cluster machines do not require direct internet access.
-
-The link:https://access.redhat.com/articles/4128421[OpenShift Container Platform 4.x Tested Integrations] page contains details about integration testing for different platforms.
+The link:https://access.redhat.com/articles/4128421[{product-title} 4.x Tested Integrations] page contains details about integration testing for different platforms.


### PR DESCRIPTION
[OSDOCS-13707](https://issues.redhat.com/browse/OSDOCS-13707)

Version(s): 4.18+

This PR adds information for the supported platforms available to the Agent-Based Installer and the Assisted Installer. It replaces two lists for IPI and UPI platforms with one table for every platform and every installation method.

QE review:
- [x] QE has approved this change.

Preview: [Supported platforms for OpenShift Container Platform clusters](https://91089--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/index.html#supported-platforms-for-openshift-clusters_ocp-installation-overview)