### PR TITLE
OSDOCS13031: Document the floor for CPU limits

### DIFF
--- a/modules/nodes-pods-understanding-requests-limits.adoc
+++ b/modules/nodes-pods-understanding-requests-limits.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-pods-using.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nodes-pods-understanding-requests-limits_{context}"]
+= Understanding resource requests and limits
+
+You can specify CPU and memory requests and limits for pods by using a pod spec, as shown in "Example pod configurations", or the specification for the controlling object of the pod.   
+
+CPU and memory _requests_ specify the minimum amount of a resource that a pod needs to run, helping {product-title} to schedule pods on nodes with sufficient resources. 
+
+CPU and memory _limits_ define the maximum amount of a resource that a pod can consume, preventing the pod from consuming excessive resources and potentially impacting other pods on the same node. 
+
+CPU and memory requests and limits are processed by using the following principles:
+
+* CPU limits are enforced by using CPU throttling. When a container approaches its CPU limit, the kernel restricts access to the CPU specified as the container's limit. As such, a CPU limit is a hard limit that the kernel enforces. {product-title} can allow a container to exceed its CPU limit for extended periods of time. However, container runtimes do not terminate pods or containers for excessive CPU usage.
++
+CPU limits and requests are measured in CPU units. One CPU unit is equivalent to 1 physical CPU core or 1 virtual core, depending on whether the node is a physical host or a virtual machine running inside a physical machine. Fractional requests are allowed. For example, when you define a container with a CPU request of `0.5`, you are requesting half as much CPU time than if you asked for `1.0` CPU. For CPU units, `0.1` is equivalent to the `100m`, which can be read as _one hundred millicpu_ or _one hundred millicores_. A CPU resource is always an absolute amount of resource, and is never a relative amount.
++
+[NOTE]
+====
+By default, the smallest amount of CPU that can be allocated to a pod is 10 mCPU. You can request resource limits lower than 10 mCPU in a pod spec. However, the pod would still be allocated 10 mCPU.
+====
+
+* Memory limits are enforced by the kernel by using out of memory (OOM) kills. When a container uses more than its memory limit, the kernel can terminate that container. However, terminations happen only when the kernel detects memory pressure. As such, a container that over allocates memory might not be immediately killed. This means memory limits are enforced reactively. A container can use more memory than its memory limit. If it does, the container can get killed.
++
+You can express memory as a plain integer or as a fixed-point number by using one of these quantity suffixes: `E`, `P`, `T`, `G`, `M`, or `k`. You can also use the power-of-two equivalents: `Ei`, `Pi`, `Ti`, `Gi`, `Mi`, or `Ki`. 
+
+If the node where a pod is running has enough of a resource available, it is possible for a container to use more CPU or memory resources than it requested. However, the container cannot exceed the corresponding limit. For example, if you set a container memory request of `256 MiB`, and that container is in a pod scheduled to a node with `8GiB` of memory and no other pods, the container can try to use more memory than the requested `256 MiB`.
+
+This behavior does not apply to CPU and memory limits. These limits are applied by the kubelet and the container runtime, and are enforced by the kernel. On Linux nodes, the kernel enforces limits by using cgroups. 
+
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+For Linux workloads, you can specify huge page resources. Huge pages are a Linux-specific feature where the node kernel allocates blocks of memory that are much larger than the default page size. For example, on a system where the default page size is 4KiB, you could specify a higher limit. For more information on huge pages, see "Huge pages".
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+
+

--- a/nodes/pods/nodes-pods-using.adoc
+++ b/nodes/pods/nodes-pods-using.adoc
@@ -19,6 +19,8 @@ include::modules/nodes-pods-using-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-using-example.adoc[leveloffset=+1]
 
+include::modules/nodes-pods-understanding-requests-limits.adoc[leveloffset=+1]
+
 // TODO: Add xrefs to ROSA HCP when distro is published.
 ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
@@ -26,3 +28,8 @@ ifndef::openshift-rosa-hcp[]
 
 * For more information on pods and storage see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage] and xref:../../storage/understanding-ephemeral-storage.adoc#understanding-ephemeral-storage[Understanding ephemeral storage].
 endif::openshift-rosa-hcp[]
+
+* xref:../../nodes/pods/nodes-pods-using.adoc#nodes-pods-using-example_nodes-pods-using-ssy[Example pod configurations]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+* xref:../../post_installation_configuration/node-tasks.adoc#post-install-huge-pages[Huge pages]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13031

Pulled down some of the [upstream text](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) around pod resource  requests and limits, from Mr. King's link's above, creating a new section in the OCP pod docs. 
Added a note about the 10mCPU lower limit and that you can specify less in the pod spec, but the lower request is ignored, per the Jira. 

Preview
[Understanding resource requests and limits -- New module](https://91091--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-using.html#nodes-pods-understanding-requests-limits_nodes-pods-using-ssy)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
