### PR TITLE
ROX-28429: Add compression layers supported in scanners

### DIFF
--- a/modules/scanning-images.adoc
+++ b/modules/scanning-images.adoc
@@ -172,6 +172,29 @@ Scanner can check for vulnerabilities in dependencies for the following programm
 |===
 . Only supported in Scanner V4.
 
+[id="supported-layer-compression-formats_{context}"]
+== Supported layer compression formats
+
+Container image layers are `.tar` file archives that might be compressed or uncompressed. StackRox Scanner and Scanner V4 support different formats as shown in the following table:
+
+[cols="1,1,1",options="header"]
+|===
+| Format | Stackrox Scanner Support | Scanner V4 Support
+| No compression
+| Yes
+| Yes
+
+|bzip2 | Yes | Yes
+
+|gzip | Yes | Yes
+
+|xz | Yes | No
+
+|zstd | No | Yes
+
+|===
+
+
 [id="supported-runtimes-frameworks_{context}"]
 == Supported runtimes and frameworks
 


### PR DESCRIPTION
Version(s):

4.5+

[Issue](https://issues.redhat.com/browse/ROX-28429)

[Link to docs preview
](https://91117--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html#supported-layer-compression-formats_examine-images-for-vulnerabilities)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
