### PR TITLE
OCPBUGS-42326: Added ETP=Local note to configuration-externalip.adoc

### DIFF
--- a/modules/configuration-externalip.adoc
+++ b/modules/configuration-externalip.adoc
@@ -26,9 +26,8 @@ As a cluster administrator, you must configure routing to externalIPs. You must 
 To use IP address blocks defined by `autoAssignCIDRs` in {product-title}, you must configure the necessary IP address assignment and routing for your host network.
 ====
 
-The following YAML describes a service with an external IP address configured:
+The following YAML shows a `Service` object with a configured external IP:
 
-.Example `Service` object with `spec.externalIPs[]` set
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/nw-egress-ips-object.adoc
+++ b/modules/nw-egress-ips-object.adoc
@@ -2,10 +2,16 @@
 //
 // * networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="nw-egress-ips-object_{context}"]
 = EgressIP object
 
 The following YAML describes the API for the `EgressIP` object. The scope of the object is cluster-wide; it is not created in a namespace.
+
+[IMPORTANT]
+====
+EgressIP selected pods cannot serve as backends for services with `externalTrafficPolicy` set to `Local`. If you try this configuration, service ingress traffic that targets the pods gets incorrectly rerouted to the egress node that hosts the EgressIP. This situation negatively impacts the handling of incoming service traffic and causes connections to drop. This leads to unavailable and non-functional services.
+====
 
 [source,yaml]
 ----
@@ -22,11 +28,8 @@ spec:
     ...
 ----
 <1> The name for the `EgressIPs` object.
-
 <2> An array of one or more IP addresses.
-
 <3> One or more selectors for the namespaces to associate the egress IP addresses with.
-
 <4> Optional: One or more selectors for pods in the specified namespaces to associate egress IP addresses with. Applying these selectors allows for the selection of a subset of pods within a namespace.
 
 The following YAML describes the stanza for the namespace selector:


### PR DESCRIPTION
Version(s):
4.12 to 4.15

Issue:
[OCPBUGS-42326](http://issues.redhat.com/browse/OCPBUGS-42326)

Link to docs preview:
* [Configuration for ExternalIP](https://91120--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-externalip.html#configuration-externalip_configuring-externalip)
* [EgressIP object](https://91120--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-object_configuring-egress-ips-ovn)


- [x] SME has approved this change (Vedanti Jaypurkar/Albert Cardenas (On paternity leave and is due back in two weeks' time))
- [x] QE has approved this change (Zhanqi Zhao).

https://github.com/openshift/openshift-docs/pull/76578/files
