### PR TITLE
TELCODOCS-2008 - 4.18/4.19 update coreos-install commands with --offl…

### DIFF
--- a/modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc
+++ b/modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc
@@ -4,6 +4,10 @@
 // * installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
 
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:restricted:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
 [id="installation-user-infra-machines-advanced-enabling-serial-console_{context}"]
 = Enabling the serial console for PXE and ISO installations
@@ -18,10 +22,20 @@ By default, the {op-system-first} serial console is disabled and all output is w
 +
 [source,terminal]
 ----
+ifndef::restricted[]
 $ coreos-installer install \
-  --console=tty0 \//<1>
-  --console=ttyS0,<options> \//<2>
-  --ignition-url=http://host/worker.ign /dev/disk/by-id/scsi-<serial_number>
+--console=tty0 \//<1>
+--console=ttyS0,<options> \//<2>
+--ignition-url=http://host/worker.ign /dev/disk/by-id/scsi-<serial_number>
+endif::[]
+ifdef::restricted[]
+$ coreos-installer install \
+--console=tty0 \//<1>
+--console=ttyS0,<options> \//<2>
+--ignition-url=http://host/worker.ign \
+--offline \
+/dev/disk/by-id/scsi-<serial_number>
+endif::[]
 ----
 +
 <1> The desired secondary console. In this case, the graphical console. Omitting this option will disable the graphical console.
@@ -36,3 +50,6 @@ A similar outcome can be obtained by using the `coreos-installer install --appen
 
 To configure a PXE installation, make sure the `coreos.inst.install_dev` kernel command line option is omitted, and use the shell prompt to run `coreos-installer` manually using the above ISO installation procedure.
 
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:!restricted:
+endif::[]

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -8,6 +8,9 @@
 ifeval::["{context}" == "installing-with-agent-based-installer"]
 :agent:
 endif::[]
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:restricted:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 ifndef::agent[]
@@ -54,8 +57,16 @@ system using available RHEL tools, such as `nmcli` or `nmtui`.
 +
 [source,terminal]
 ----
+ifndef::restricted[]
 $ sudo coreos-installer install --copy-network \
      --ignition-url=http://host/worker.ign /dev/disk/by-id/scsi-<serial_number>
+endif::[]
+ifdef::restricted[]
+$ sudo coreos-installer install --copy-network \
+--ignition-url=http://host/worker.ign \
+--offline \
+/dev/disk/by-id/scsi-<serial_number>
+endif::[]
 ----
 +
 [IMPORTANT]
@@ -232,8 +243,17 @@ This example preserves any partition in which the partition label begins with `d
 
 [source,terminal]
 ----
+ifndef::restricted[]
 # coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign \
-        --save-partlabel 'data*' /dev/disk/by-id/scsi-<serial_number>
+--save-partlabel 'data*' \
+/dev/disk/by-id/scsi-<serial_number>
+endif::[]
+ifdef::restricted[]
+# coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign \
+--save-partlabel 'data*' \
+--offline \
+/dev/disk/by-id/scsi-<serial_number>
+endif::[]
 ----
 
 The following example illustrates running the `coreos-installer` in a way that preserves
@@ -241,16 +261,32 @@ the sixth (6) partition on the disk:
 
 [source,terminal]
 ----
+ifndef::restricted[]
 # coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign \
-        --save-partindex 6 /dev/disk/by-id/scsi-<serial_number>
+--save-partindex 6 /dev/disk/by-id/scsi-<serial_number>
+endif::[]
+ifdef::restricted[]
+# coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign \
+--save-partindex 6 \
+--offline \
+/dev/disk/by-id/scsi-<serial_number>
+endif::[]
 ----
 
 This example preserves partitions 5 and higher:
 
 [source,terminal]
 ----
-# coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign
-        --save-partindex 5- /dev/disk/by-id/scsi-<serial_number>
+ifndef::restricted[]
+# coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign \
+--save-partindex 5- /dev/disk/by-id/scsi-<serial_number>
+endif::[]
+ifdef::restricted[]
+# coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign \
+--save-partindex 5- \
+--offline \
+/dev/disk/by-id/scsi-<serial_number>
+endif::[]
 ----
 
 In the previous examples where partition saving is used, `coreos-installer` recreates the partition immediately.
@@ -309,4 +345,7 @@ endif::agent[]
 
 ifeval::["{context}" == "installing-with-agent-based-installer"]
 :!agent:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:!restricted:
 endif::[]

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -13,6 +13,9 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :ibm-power:
 endif::[]
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:restricted:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-user-infra-machines-iso_{context}"]
@@ -126,7 +129,14 @@ It is possible to interrupt the {op-system} installation boot process to add ker
 +
 [source,terminal]
 ----
-$ sudo coreos-installer install --ignition-url=http://<HTTP_server>/<node_type>.ign <device> --ignition-hash=sha512-<digest> <1><2>
+ifdef::restricted[]
+$ sudo coreos-installer install --ignition-url=http://<HTTP_server>/<node_type>.ign <device> \ <1>
+--ignition-hash=sha512-<digest> --offline <2> 
+endif::[]
+ifndef::restricted[]
+$ sudo coreos-installer install --ignition-url=http://<HTTP_server>/<node_type>.ign <device> \ <1>
+--ignition-hash=sha512-<digest> <2>
+endif::[]
 ----
 <1> You must run the `coreos-installer` command by using `sudo`, because the `core` user does not have the required root privileges to perform the installation.
 <2> The `--ignition-hash` option is required when the Ignition config file is obtained through an HTTP URL to validate the authenticity of the Ignition config file on the cluster node. `<digest>` is the Ignition config file SHA512 digest obtained in a preceding step.
@@ -140,7 +150,16 @@ The following example initializes a bootstrap node installation to the `/dev/sda
 +
 [source,terminal]
 ----
-$ sudo coreos-installer install --ignition-url=http://192.168.1.2:80/installation_directory/bootstrap.ign /dev/sda --ignition-hash=sha512-a5a2d43879223273c9b60af66b44202a1d1248fc01cf156c46d4a79f552b6bad47bc8cc78ddf0116e80c59d2ea9e32ba53bc807afbca581aa059311def2c3e3b
+
+ifdef::restricted[]
+$ sudo coreos-installer install --ignition-url=http://192.168.1.2:80/installation_directory/bootstrap.ign /dev/sda \
+--ignition-hash=sha512-a5a2d43879223273c9b60af66b44202a1d1248fc01cf156c46d4a79f552b6bad47bc8cc78ddf0116e80c59d2ea9e32ba53bc807afbca581aa059311def2c3e3b \
+--offline
+endif::[]
+ifndef::restricted[]
+$ sudo coreos-installer install --ignition-url=http://192.168.1.2:80/installation_directory/bootstrap.ign /dev/sda \
+--ignition-hash=sha512-a5a2d43879223273c9b60af66b44202a1d1248fc01cf156c46d4a79f552b6bad47bc8cc78ddf0116e80c59d2ea9e32ba53bc807afbca581aa059311def2c3e3b
+endif::[]
 ----
 
 . Monitor the progress of the {op-system} installation on the console of the machine.
@@ -180,4 +199,7 @@ ifeval::["{context}" == "installing-ibm-power"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :!ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:!restricted:
 endif::[]

--- a/modules/rhcos-enabling-multipath.adoc
+++ b/modules/rhcos-enabling-multipath.adoc
@@ -4,6 +4,10 @@
 // * installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
 
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:restricted:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
 [id="rhcos-enabling-multipath_{context}"]
 = Enabling multipathing with kernel arguments on {op-system}
@@ -49,11 +53,21 @@ $ mpathconf --enable && systemctl start multipathd.service
 +
 [source,terminal]
 ----
+ifndef::restricted[]
 $ coreos-installer install /dev/mapper/mpatha \// <1>
 --ignition-url=http://host/worker.ign \
 --append-karg rd.multipath=default \
 --append-karg root=/dev/disk/by-label/dm-mpath-root \
 --append-karg rw
+endif::[]
+ifdef::restricted[]
+$ coreos-installer install /dev/mapper/mpatha \// <1>
+--ignition-url=http://host/worker.ign \
+--append-karg rd.multipath=default \
+--append-karg root=/dev/disk/by-label/dm-mpath-root \
+--append-karg rw \
+--offline
+endif::[]
 ----
 <1> Indicates the path of the single multipathed device.
 +
@@ -61,11 +75,21 @@ $ coreos-installer install /dev/mapper/mpatha \// <1>
 +
 [source,terminal]
 ----
+ifndef::restricted[]
 $ coreos-installer install /dev/disk/by-id/wwn-<wwn_ID> \// <1>
 --ignition-url=http://host/worker.ign \
 --append-karg rd.multipath=default \
 --append-karg root=/dev/disk/by-label/dm-mpath-root \
 --append-karg rw
+endif::[]
+ifdef::restricted[]
+$ coreos-installer install /dev/disk/by-id/wwn-<wwn_ID> \// <1>
+--ignition-url=http://host/worker.ign \
+--append-karg rd.multipath=default \
+--append-karg root=/dev/disk/by-label/dm-mpath-root \
+--append-karg rw \
+--offline
+endif::[]
 ----
 <1> Indicates the WWN ID of the target multipathed device. For example, `0xx194e957fcedb4841`.
 +
@@ -95,3 +119,7 @@ sh-4.2# exit
 ----
 +
 You should see the added kernel arguments.
+
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:!restricted:
+endif::[]

--- a/modules/rhcos-install-iscsi-ibft.adoc
+++ b/modules/rhcos-install-iscsi-ibft.adoc
@@ -4,6 +4,10 @@
 // * installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
 
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:restricted:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
 [id="rhcos-install-iscsi-ibft_{context}"]
 = Installing {op-system} on an iSCSI boot device using iBFT
@@ -40,12 +44,23 @@ $ mpathconf --enable && systemctl start multipathd.service
 +
 [source,text]
 ----
+ifndef::restricted[]
 $ coreos-installer install \
     /dev/mapper/mpatha \ <1>
     --append-karg rd.iscsi.firmware=1 \ <2>
     --append-karg rd.multipath=default \ <3>
     --console ttyS0 \
     --ignition-file <path_to_file>
+endif::[]
+ifdef::restricted[]
+$ coreos-installer install \
+    /dev/mapper/mpatha \ <1>
+    --append-karg rd.iscsi.firmware=1 \ <2>
+    --append-karg rd.multipath=default \ <3>
+    --console ttyS0 \
+    --ignition-file <path_to_file> \
+    --offline
+endif::[]
 ----
 <1> The path of a single multipathed device. If there are multiple multipath devices connected, or to be explicit, you can use the World Wide Name (WWN) symlink available in `/dev/disk/by-path`.
 <2> The iSCSI parameter is read from the BIOS firmware.
@@ -61,3 +76,7 @@ $ iscsiadm --mode node --logout=all
 ----
 
 This procedure can also be performed using the `coreos-installer iso customize` or `coreos-installer pxe customize` subcommands.
+
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:!restricted:
+endif::[]

--- a/modules/rhcos-install-iscsi-manual.adoc
+++ b/modules/rhcos-install-iscsi-manual.adoc
@@ -4,6 +4,10 @@
 // * installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
 
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:restricted:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
 [id="rhcos-install-iscsi-manual_{context}"]
 = Installing {op-system} manually on an iSCSI boot device
@@ -32,12 +36,23 @@ $ iscsiadm \
 +
 [source,text]
 ----
+ifndef::restricted[]
 $ coreos-installer install \
-    /dev/disk/by-path/ip-<IP_address>:<port>-iscsi-<target_iqn>-lun-<lun> \ <1>
-    --append-karg rd.iscsi.initiator=<initiator_iqn> \ <2>
-    --append.karg netroot=<target_iqn> \ <3>
-    --console ttyS0,115200n8
-    --ignition-file <path_to_file>
+/dev/disk/by-path/ip-<IP_address>:<port>-iscsi-<target_iqn>-lun-<lun> \ <1>
+--append-karg rd.iscsi.initiator=<initiator_iqn> \ <2>
+--append.karg netroot=<target_iqn> \ <3>
+--console ttyS0,115200n8
+--ignition-file <path_to_file>
+endif::[]
+ifdef::restricted[]
+$ coreos-installer install \
+/dev/disk/by-path/ip-<IP_address>:<port>-iscsi-<target_iqn>-lun-<lun> \ <1>
+--append-karg rd.iscsi.initiator=<initiator_iqn> \ <2>
+--append.karg netroot=<target_iqn> \ <3>
+--console ttyS0,115200n8 \
+--ignition-file <path_to_file> \
+--offline
+endif::[]
 ----
 <1> The location you are installing to. You must provide the IP address of the target portal, the associated port number, the target iSCSI node in IQN format, and the iSCSI logical unit number (LUN).
 <2> The iSCSI initiator, or client, name in IQN format. The initiator forms a session to connect to the iSCSI target.
@@ -53,3 +68,7 @@ $ iscsiadm --mode node --logoutall=all
 ----
 
 This procedure can also be performed using the `coreos-installer iso customize` or `coreos-installer pxe customize` subcommands.
+
+ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+:!restricted:
+endif::[]


### PR DESCRIPTION
[TELCODOCS-2008](https://issues.redhat.com//browse/TELCODOCS-2008) - 4.18/4.19 - for disconnected environments, update `coreos-install` commands with `--offline` parameter 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 

- 4.19 
- 4.18

<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2008
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Links to docs previews:
- [Installing RHCOS by using an ISO image](https://91124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#installation-user-infra-machines-iso_installing-restricted-networks-bare-metal)
- [Using advanced networking options for PXE and ISO installations](https://91124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#installation-user-infra-machines-iso_installing-restricted-networks-bare-metal)
- [Retaining existing partitions](https://91124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#installation-user-infra-machines-advanced_retaindisk_installing-restricted-networks-bare-metal)
- [Enabling the serial console for PXE and ISO installations](https://91124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#installation-user-infra-machines-advanced_retaindisk_installing-restricted-networks-bare-metal)
- [Enabling multipathing with kernel arguments on RHCOS](https://91124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#rhcos-enabling-multipath_installing-restricted-networks-bare-metal)
- [Installing RHCOS manually on an iSCSI boot device](https://91124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#rhcos-install-iscsi-manual_installing-restricted-networks-bare-metal)
- [Installing RHCOS on an iSCSI boot device using iBFT](https://91124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#rhcos-install-iscsi-ibft_installing-restricted-networks-bare-metal)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @sgoveas 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
