### PR TITLE
[OKD] 'Fedora Security Hardening' hyperlink broken

### DIFF
--- a/modules/security-hardening-what.adoc
+++ b/modules/security-hardening-what.adoc
@@ -6,13 +6,15 @@
 
 = Choosing what to harden in {op-system}
 ifdef::openshift-origin[]
-The link:https://docs.fedoraproject.org/en-US/Fedora/19/html/Security_Guide/chap-Security_Guide-Basic_Hardening.html[{op-system-base} Security Hardening] guide describes how you should approach security for any {op-system-base} system.
+For information on how to approach security for any {op-system-base} system, see the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9#Security[Security] category in the Red{nbsp}Hat Enterprise Linux 9 documentation.
+
+Use these documents to learn about managing security updates, security hardening, securing networks, and other security measures.  
 endif::[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-aro[]
-The link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/security_hardening/index#scanning-container-and-container-images-for-vulnerabilities_scanning-the-system-for-security-compliance-and-vulnerabilities[{op-system-base} 9 Security Hardening] guide describes how you should approach security for any {op-system-base} system.
-endif::[]
+For information on how to approach security for any {op-system-base} system, see the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/security_hardening/index#scanning-container-and-container-images-for-vulnerabilities_scanning-the-system-for-security-compliance-and-vulnerabilities[{op-system-base} 9 Security Hardening] guide.
 
 Use this guide to learn how to approach cryptography, evaluate vulnerabilities, and assess threats to various services.
 Likewise, you can learn how to scan for compliance standards, check file integrity, perform auditing, and encrypt storage devices.
+endif::[]
 
 With the knowledge of what features you want to harden, you can then decide how to harden them in {op-system}.


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/84083

Updated per Petr Bokoc in private slack.

No QE

Preview: 

**OCP:**
[Choosing what to harden in RHCOS](https://91125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/container_security/security-hardening#security-hardening-what_security-hardening) -- OCP docs remain unchanged. [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/security_and_compliance/container-security-1#security-hardening-what_security-hardening). 

**OKD:**
No previews available. Maybe manually test the link here? 
The [Security](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9#Security) category in the Red Hat Enterprise Linux 9 documentation...

![image](https://github.com/user-attachments/assets/32b39c46-6cf6-4abf-89fd-2e657ddd68ff)