### PR TITLE
OCPBUGS-52939: Added updating-cluster-prepare link to persistent-stor…

### DIFF
--- a/modules/persistent-storage-csi-migration-vsphere-to-4-14.adoc
+++ b/modules/persistent-storage-csi-migration-vsphere-to-4-14.adoc
@@ -6,6 +6,8 @@
 [id="persistent-storage-csi-migration-sc-vsphere-to-4-14_{context}"]
 = Updating from {product-title} 4.13 to 4.14
 
+Before you upgrade from {product-title} 4.13 to 4.14, ensure that you completed certain administrator tasks before you update your cluster so that the cluster update operation is succesful. For more information, see "Preparing to update to OpenShift Container Platform 4.14" (Installing on vSphere).
+
 If you are using vSphere in-tree persistent volumes (PVs) and want to update from {product-title} 4.13 to 4.14, first update vSphere vCenter and ESXI host to 7.0 Update 3L or 8.0 Update 2, otherwise the {product-title} update is blocked. After updating vSphere, your {product-title} update can occur and automatic Container Storage Interface (CSI) migration is enabled by default.
 
 Alternatively, if you do not want to update vSphere, you can proceed with an {product-title} update by performing an administrator acknowledgment:

--- a/storage/container_storage_interface/persistent-storage-csi-migration.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-migration.adoc
@@ -24,12 +24,23 @@ Migration includes significant consequences:
 * Migration can take a while to complete depending on how many nodes are on the cluster.
 ====
 
+// New installations of {product-title}
 include::modules/persistent-storage-csi-migration-vsphere-new-install.adoc[leveloffset=+2]
 
+// Updating from {product-title} 4.13 to 4.14
 include::modules/persistent-storage-csi-migration-vsphere-to-4-14.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/updating_clusters/preparing-to-update-a-cluster#updating-cluster-prepare[Preparing to update to {product-title} 4.14]
+
+// Updating from {product-title} 4.12 to 4.13
 include::modules/persistent-storage-csi-migration-vsphere-to-4-13.adoc[leveloffset=+2]
 
+// Using the web console to opt in to automatic CSI migration
 include::modules/persistent-storage-csi-migration-vsphere-enabling-migration-console.adoc[leveloffset=+2]
 
+// Using the CLI to opt in to automatic CSI migration
 include::modules/persistent-storage-csi-migration-vsphere-enabling-migration-cli.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OCPBUGS-52939](https://issues.redhat.com/browse/OCPBUGS-52939)

Link to docs preview:
[Updating from OpenShift Container Platform 4.13 to 4.14](https://91126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-migration.html#persistent-storage-csi-migration-sc-vsphere-to-4-14_persistent-storage-csi-migration)

- [ ] SME has approved this change.
- [ ] QE has approved this change.

