### PR TITLE
ROX-28666: release notes for 4.5.8 patch

### DIFF
--- a/release_notes/45-release-notes.adoc
+++ b/release_notes/45-release-notes.adoc
@@ -23,6 +23,7 @@ toc::[]
 |`4.5.5` | 22 November 2024
 |`4.5.6` | 11 February 2025
 |`4.5.7` | 10 March 2025
+|`4.5.8` | 31 March 2025
 
 |====
 
@@ -496,5 +497,19 @@ This release also addresses the following security vulnerabilities:
 * link:https://access.redhat.com/security/cve/cve-2025-1094[CVE-2025-1094]: PostgreSQL quoting APIs miss neutralizing quoting syntax in text that fails encoding validation.
 * link:https://osv.dev/vulnerability/GHSA-6wxm-mpqj-6jpf[GHSA-6wxm-mpqj-6jpf]: Insecure temporary file usage in `github.com/golang/glog`.
 * link:https://access.redhat.com/security/cve/cve-2025-22868[CVE-2025-22868]: Flaw in Golang in the token parsing component.
+
+[id="about-release-458_{context}"]
+== About release 4.5.8
+
+*Release date*: 31 March 2025
+
+This release of {product-title-short} includes the following bug fix:
+
+* Fixed a bug in which Scanner V4 performed TLS validation even for integrations that had TLS validation disabled.
+
+This release also addresses the following security vulnerabilities:
+
+* link:https://access.redhat.com/security/cve/cve-2025-22868[CVE-2025-22868] Flaw in the `golang.org/x/oauth2/jws` package.
+* link:https://access.redhat.com/security/cve/cve-2025-22869[CVE-2025-22869] Flaw in the `golang.org/x/crypto/ssh` package.
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):

4.5

[Issue](https://issues.redhat.com/browse/ROX-28666)

[Link to docs preview
](https://91127--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/45-release-notes.html#about-release-458_release-notes-45)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
