### PR TITLE
OADP-5881: fix typo in installing AWS module

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -30,7 +30,7 @@ include::modules/oadp-ssec-encrypted-backups.adoc[leveloffset=+2]
 [role="_additional-resources_1"]
 .Additional resources
 
-You can also download the file with the additional encryption key backed up with Velcro by running a different command. See xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#oadp-ssec-encrypted-backups-velero_installing-oadp-aws[Downloading a file with an SSE-C encryption key for files backed up by Velero].
+You can also download the file with the additional encryption key backed up with Velero by running a different command. See xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#oadp-ssec-encrypted-backups-velero_installing-oadp-aws[Downloading a file with an SSE-C encryption key for files backed up by Velero].
 
 include::modules/oadp-ssec-encrypted-backups-velero.adoc[leveloffset=+3]
 

--- a/modules/oadp-ssec-encrypted-backups-velero.adoc
+++ b/modules/oadp-ssec-encrypted-backups-velero.adoc
@@ -6,7 +6,7 @@
 [id="oadp-ssec-encrypted-backups-velero_{context}"]
 = Downloading a file with an SSE-C encryption key for files backed up by Velero
 
-When you are verifying an SSE-C encryption key, you can also download the file with the additional encryption key for files that were backed up with Velcro.
+When you are verifying an SSE-C encryption key, you can also download the file with the additional encryption key for files that were backed up with Velero.
 
 .Procedure
 


### PR DESCRIPTION
### JIRA

* [OADP-5881](https://issues.redhat.com/browse/OADP-5881)

### VERSIONS

* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19

###Link to docs preview:

* [Creating an OADP SSE-C encryption key for additional data security](Creating an OADP SSE-C encryption key for additional data security)

* [Downloading a file with an SSE-C encryption key for files backed up by Velero](Downloading a file with an SSE-C encryption key for files backed up by Velero)


### QE review:
- QE has *not* approved this change as it is a typo fix only. 




