### PR TITLE
OCPBUGS-52939-14: Added updating-cluster-prepare link to updating-clu…

### DIFF
--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -51,7 +51,7 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../../installing/installing_vsphere/installation-config-parameters-vsphere.adoc#deprecated-parameters-vsphere_installation-config-parameters-vsphere[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere CSI automatic migration]
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
@@ -41,7 +41,7 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../../installing/installing_vsphere/installation-config-parameters-vsphere.adoc#deprecated-parameters-vsphere_installation-config-parameters-vsphere[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere CSI automatic migration]
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -43,7 +43,7 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../../installing/installing_vsphere/installation-config-parameters-vsphere.adoc#deprecated-parameters-vsphere_installation-config-parameters-vsphere[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere CSI automatic migration]
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 

--- a/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
@@ -56,7 +56,7 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../../installing/installing_vsphere/installation-config-parameters-vsphere.adoc#deprecated-parameters-vsphere_installation-config-parameters-vsphere[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere CSI automatic migration]
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 

--- a/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
@@ -47,7 +47,7 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../../installing/installing_vsphere/installation-config-parameters-vsphere.adoc#deprecated-parameters-vsphere_installation-config-parameters-vsphere[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere CSI automatic migration]
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 

--- a/installing/installing_vsphere/upi/installing-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere.adoc
@@ -47,7 +47,7 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../../installing/installing_vsphere/installation-config-parameters-vsphere.adoc#deprecated-parameters-vsphere_installation-config-parameters-vsphere[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+* xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere CSI automatic migration]
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 

--- a/modules/persistent-storage-csi-migration-overview.adoc
+++ b/modules/persistent-storage-csi-migration-overview.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="persistent-storage-csi-migration-overview_{context}"]
-= Overview
+= Overview of CSI automatic migration
 
 This feature automatically migrates volumes that were provisioned using in-tree storage plugins to their counterpart Container Storage Interface (CSI) drivers.
 

--- a/modules/persistent-storage-csi-migration-vsphere.adoc
+++ b/modules/persistent-storage-csi-migration-vsphere.adoc
@@ -4,13 +4,15 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="persistent-storage-csi-migration-sc-vsphere_{context}"]
-= vSphere automatic migration
+= vSphere CSI automatic migration
 
 == New installations of {product-title}
+
 For new installations of {product-title} 4.13, or later, automatic migration is enabled by default.
 
 [id="updating-openshift_from_4.13_{context}"]
 == Updating from {product-title} 4.13 to 4.14
+
 If you are using vSphere in-tree persistent volumes (PVs) and want to update from {product-title} 4.13 to 4.14, update vSphere vCenter and ESXI host to 7.0 Update 3L or 8.0 Update 2, otherwise the {product-title} update is blocked. After updating vSphere, your {product-title} update can occur and automatic migration is enabled by default.
 
 Alternatively, if you do not want to update vSphere, you can proceed with an {product-title} update by performing an administrator acknowledgment:
@@ -27,6 +29,7 @@ If you do *not* update to vSphere 7.0 Update 3L or 8.0 Update 2 and use an admin
 
 [id="updating-openshift_from_4.12_{context}"]
 == Updating from {product-title} 4.12 to 4.14
+
 If you are using vSphere in-tree persistent volumes (PVs) and want to update from {product-title} 4.12 to 4.14, update vSphere vCenter and ESXI host to 7.0 Update 3L or 8.0 Update 2, otherwise the {product-title} update is blocked. After updating vSphere, your {product-title} update can occur and automatic migration is enabled by default.
 
 Alternatively, if you do not want to update vSphere, you can proceed with an {product-title} update by performing an administrator acknowledgment by running *both* of the following commands:

--- a/storage/container_storage_interface/persistent-storage-csi-migration.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-migration.adoc
@@ -8,11 +8,15 @@ toc::[]
 
 In-tree storage drivers that are traditionally shipped with {product-title} are being deprecated and replaced by their equivalent Container Storage Interface (CSI) drivers. {product-title} provides automatic migration for in-tree volume plugins to their equivalent CSI drivers.
 
+// Overview of CSI automatic migration
 include::modules/persistent-storage-csi-migration-overview.adoc[leveloffset=+1]
+
+// Storage class implications
 include::modules/persistent-storage-csi-migration-sc.adoc[leveloffset=+1]
 
 To change the default storage class, see xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#change-default-storage-class_persistent-storage-csi-sc-manage[Changing the default storage class].
 
+// vSphere CSI automatic migration
 include::modules/persistent-storage-csi-migration-vsphere.adoc[leveloffset=+1]
 
 ifndef::openshift-origin[]

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -12,7 +12,12 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
 
-Learn more about administrative tasks that cluster admins must perform to successfully initialize an update, as well as optional guidelines for ensuring a successful update.
+Cluster admins must complete certain administrative tasks to successfully initialize an update. Consider using optional guidelines for ensuring a successful update.
+
+[NOTE]
+====
+For a cluster that runs on {vmw-first}, you can use vSphere Container Storage Interface (CSI) automatic migration to provision in-tree storage plugins to their counterpart CSI drivers. For more information, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere CSI automatic migration].
+====
 
 [id="rhel-micro-architecture-update-requirements"]
 == {op-system-base} 9.2 micro-architecture requirement change
@@ -21,7 +26,7 @@ Learn more about administrative tasks that cluster admins must perform to succes
 
 [IMPORTANT]
 ====
-Without the correct micro-architecture requirements, the update process will fail. Make sure you purchase the appropriate subscription for each architecture. For more information, see link:https://access.redhat.com/products/red-hat-enterprise-linux#addl-arch[Get Started with Red Hat Enterprise Linux - additional architectures]
+Without the correct micro-architecture requirements, the update process fails. Ensure that you purchase the appropriate subscription for each architecture. For more information, see link:https://access.redhat.com/products/red-hat-enterprise-linux#addl-arch[Get Started with {op-system-base-full} - additional architectures]
 ====
 
 [id="kube-api-removals_{context}"]


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OCPBUGS-52939](https://issues.redhat.com/browse/OCPBUGS-52939)

Link to docs preview:

* [RHEL 9.2 micro-architecture requirement change](https://91159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#rhel-micro-architecture-update-requirements)
* [Updating from OpenShift Container Platform 4.13 to 4.14](https://91159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-migration.html#updating-openshift_from_4.13_persistent-storage-csi-migration)

- [x] SME has approved this change (Yiyong He).
- [x] QE has approved this change (Wei Duan).

