### PR TITLE
TELCODOCS-2099: Support for dual-port ordinary clock in PTP

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-dual-port-oc.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-dual-port-oc.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// * networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-linuxptp-services-oc-dual-port_{context}"]
+= Configuring linuxptp services as an ordinary clock with dual-port NIC redundancy
+
+You can configure `linuxptp` services (`ptp4l`, `phc2sys`) as an ordinary clock with dual-port NIC redundancy by creating a `PtpConfig` custom resource (CR) object.
+In a dual-port NIC configuration for an ordinary clock, if one port fails, the standby port takes over, maintaining PTP timing synchronization.
+
+:FeatureName: Configuring linuxptp services as an ordinary clock with dual-port NIC redundancy
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Install the PTP Operator.
+* The node uses an x86_64 architecture with a dual-port NIC.
+
+.Procedure
+
+. Create the following `PtpConfig` CR, and then save the YAML in the `oc-dual-port-ptp-config.yaml` file.
++
+.Example PTP ordinary clock dual-port configuration
+[source,yaml]
+----
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: ordinary-clock-1
+  namespace: openshift-ptp
+spec:
+  profile:
+  - name: oc-dual-port
+    phc2sysOpts: -a -r -n 24 -N 8 -R 16 -u 0 <1>
+    ptp4lConf: |- <2>
+      [ens3f2]
+      masterOnly 0
+      [ens3f3]
+      masterOnly 0
+
+      [global]
+      #
+      # Default Data Set
+      #
+      slaveOnly 1 <3>
+#...
+----
+<1> Specify the system config options for the `ptp4l` service.
+<2> Specify the interface configuration for the `ptp4l` service. In this example, setting `masterOnly 0` for the `ens3f2` and `ens3f3` interfaces enables both ports on the `ens3` interface to run as leader or follower clocks. In combination with the `slaveOnly 1` specification, this configuration ensures one port operates as the active ordinary clock, and the other port operates as a standby ordinary clock in the `Listening` port state. 
+<3> Configures `ptp4l` to run as an ordinary clock only.
+
+. Create the `PtpConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f oc-dual-port-ptp-config.yaml
+----
+
+.Verification
+
+. Check that the `PtpConfig` profile is applied to the node.
+
+.. Get the list of pods in the `openshift-ptp` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                            READY   STATUS    RESTARTS   AGE   IP               NODE
+linuxptp-daemon-4xkbb           1/1     Running   0          43m   10.1.196.24      compute-0.example.com
+linuxptp-daemon-tdspf           1/1     Running   0          43m   10.1.196.25      compute-1.example.com
+ptp-operator-657bbb64c8-2f8sj   1/1     Running   0          43m   10.129.0.61      control-plane-1.example.com
+----
+
+.. Check that the profile is correct. Examine the logs of the `linuxptp` daemon that corresponds to the node you specified in the `PtpConfig` profile. Run the following command:
++
+[source,terminal]
+----
+$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp -c linuxptp-daemon-container
+----
++
+.Example output
+[source,terminal]
+----
+I1115 09:41:17.117596 4143292 daemon.go:107] in applyNodePTPProfile
+I1115 09:41:17.117604 4143292 daemon.go:109] updating NodePTPProfile to:
+I1115 09:41:17.117607 4143292 daemon.go:110] ------------------------------------
+I1115 09:41:17.117612 4143292 daemon.go:102] Profile Name: oc-dual-port
+I1115 09:41:17.117616 4143292 daemon.go:102] Interface: ens787f1
+I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -2 --summary_interval -4
+I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r -n 24 -N 8 -R 16 -u 0
+I1115 09:41:17.117626 4143292 daemon.go:116] ------------------------------------
+----

--- a/modules/ptp-dual-ports-oc.adoc
+++ b/modules/ptp-dual-ports-oc.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * networking/ptp/about-ptp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ptp-dual-ports-oc_{context}"]
+= Using dual-port NICs to improve redundancy for PTP ordinary clocks
+
+{product-title} supports single and dual-port networking interface cards (NICs) as ordinary clocks for PTP timing. To improve redundancy, you can configure a dual-port NIC with one port as active and the other as standby.
+
+:FeatureName: Configuring linuxptp services as an ordinary clock with dual-port NIC redundancy
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+In this configuration, the ports in a dual-port NIC operate as follows:
+
+* The active port functions as an ordinary clock in the `Following` port state.
+
+* The standby port remains in the `Listening` port state.
+
+* If the active port fails, the standby port transitions to active to ensure continued PTP timing synchronization.
+
+* If both ports become faulty, the clock state moves to the `HOLDOVER` state, then the `FREERUN` state when the holdover timeout expires, before resyncing to a leader clock.
+
+[NOTE]
+====
+You can configure PTP ordinary clocks with added redundancy on `x86` architecture nodes with dual-port NICs only.
+====

--- a/networking/ptp/about-ptp.adoc
+++ b/networking/ptp/about-ptp.adoc
@@ -32,6 +32,8 @@ Before enabling PTP, ensure that NTP is disabled for the required nodes. You can
 
 include::modules/ptp-dual-nics.adoc[leveloffset=+1]
 
+include::modules/ptp-dual-ports-oc.adoc[leveloffset=+1]
+
 include::modules/ptp-linuxptp-introduction.adoc[leveloffset=+1]
 
 include::modules/ptp-overview-of-gnss-grandmaster-clock.adoc[leveloffset=+1]

--- a/networking/ptp/configuring-ptp.adoc
+++ b/networking/ptp/configuring-ptp.adoc
@@ -73,10 +73,14 @@ include::modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc[lev
 
 include::modules/nw-columbiaville-ptp-config-refererence.adoc[leveloffset=+2]
 
+include::modules/nw-ptp-configuring-linuxptp-services-dual-port-oc.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 
 * For a complete example CR that configures `linuxptp` services as an ordinary clock with PTP fast events, see xref:../../networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-ordinary-clock_configuring-ptp[Configuring linuxptp services as ordinary clock].
+
+* xref:../../networking/ptp/about-ptp.adoc#ptp-dual-ports-oc_about-ptp[Using dual-port NICs to improve redundancy for PTP ordinary clocks]
 
 include::modules/cnf-configuring-fifo-priority-scheduling-for-ptp.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-2099](https://issues.redhat.com//browse/TELCODOCS-2099): Support for dual-port ordinary clock in PTP

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2099

Link to docs preview:
- https://91166--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/about-ptp.html#ptp-dual-ports-oc_about-ptp
- https://91166--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp.html#configuring-linuxptp-services-oc-dual-port_configuring-ptp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
