### PR TITLE
[enterprise-4.15] Fix exposed CNVNamespace attribute in two code listings

### DIFF
--- a/modules/virt-applying-node-placement-rules.adoc
+++ b/modules/virt-applying-node-placement-rules.adoc
@@ -22,7 +22,7 @@ endif::openshift-rosa,openshift-dedicated[]
 
 . Edit the object in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ oc edit <resource_type> <resource_name> -n {CNVNamespace}
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://91177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-node-placement-virt-components.html#virt-applying-node-place-rules_virt-node-placement-virt-components
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
A manual cherry-pick for pull https://github.com/openshift/openshift-docs/pull/91134.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
