### PR TITLE
Adds an additional sentence calling out service unavailability

### DIFF
--- a/modules/images-configuration-blocked.adoc
+++ b/modules/images-configuration-blocked.adoc
@@ -56,7 +56,7 @@ status:
 Either the `blockedRegistries` registry or the `allowedRegistries` registry can be set, but not both.
 ====
 +
-The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, changes to the blocked registries appear in the `/etc/containers/registries.conf` file on each node.
+The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, changes to the blocked registries appear in the `/etc/containers/registries.conf` file on each node. During this period, you might experience service unavailability.
 
 ifndef::openshift-rosa,openshift-dedicated[]
 .Verification

--- a/modules/images-configuration-shortname.adoc
+++ b/modules/images-configuration-shortname.adoc
@@ -31,7 +31,7 @@ Potentially add the last line to the Ignoring image registry repository mirrorin
 ////
 ====
 
-The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, if the `containerRuntimeSearchRegistries` parameter is added, the MCO creates a file in the `/etc/containers/registries.conf.d` directory on each node with the listed registries. The file overrides the default list of unqualified search registries in the `/etc/containers/registries.conf` file. There is no way to fall back to the default list of unqualified search registries.
+The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. During this period, you might experience service unavailability. After the nodes return to the `Ready` state, if the `containerRuntimeSearchRegistries` parameter is added, the MCO creates a file in the `/etc/containers/registries.conf.d` directory on each node with the listed registries. The file overrides the default list of unqualified search registries in the `/etc/containers/registries.conf` file. There is no way to fall back to the default list of unqualified search registries.
 
 The `containerRuntimeSearchRegistries` parameter works only with the Podman and CRI-O container engines. The registries in the list can be used only in pod specs, not in builds and image streams.
 


### PR DESCRIPTION
Minimal change. From Urvashi: 


Urvashi Mohnani
  12:05 PM
Nope, this sounds good to me!

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-41922

Link to docs preview:
https://91194--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-configuration.html
https://91194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html
https://91194--ocpdocs-pr.netlify.app/openshift-rosa/latest/openshift_images/image-configuration.html

QE is not necessary. This is already implied in the documentation, but adding this sentence to make the call out more straight forward. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
