### PR TITLE
OSDOCS#12040: RNs for 4.19 removed kube APIs and admin-ack

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -429,6 +429,17 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 
 In {product-title} {product-version}, the installation program uses the Cluster API instead of Terraform to provision cluster infrastructure during installations on {ibm-cloud-title}.
 
+[id="ocp-4-19-admin-ack-updating_{context}"]
+==== Required administrator acknowledgment when updating from {product-title} 4.18 to 4.19
+
+{product-title} 4.19 uses Kubernetes 1.32, which removed several xref:../release_notes/ocp-4-19-release-notes.adoc#ocp-4-19-removed-kube-1-32-apis_{context}[deprecated APIs].
+
+A cluster administrator must provide manual acknowledgment before the cluster can be updated from {product-title} 4.18 to 4.19. This is to help prevent issues after updating to {product-title} 4.19, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
+
+All {product-title} 4.18 clusters require this administrator acknowledgment before they can be updated to {product-title} 4.19.
+
+For more information, see xref:../updating/preparing_for_updates/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.19].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 === Machine Config Operator
 
@@ -855,6 +866,27 @@ With this release, support for the installation of packaged-based {op-system-bas
 {op-system} image layering replaces this feature and supports installing additional packages on the base operating system of your worker nodes.
 
 For information on how to identify and remove {op-system-base} nodes in your cluster, see xref:../updating/preparing_for_updates/updating-cluster-prepare-past-4-18.adoc#updating-cluster-prepare-past-4-18[Preparing to update from {product-title} 4.18 to a newer version]. For more information on image layering, see xref:../machine_configuration/mco-coreos-layering.adoc#mco-coreos-layering[{op-system} image layering].
+
+[id="ocp-4-19-removed-kube-1-32-apis_{context}"]
+==== APIs removed from Kubernetes 1.32
+
+Kubernetes 1.32 removed the following deprecated APIs, so you must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-32[Kubernetes documentation].
+
+.APIs removed from Kubernetes 1.32
+[cols="2,2,2,1",options="header",]
+|===
+|Resource |Removed API |Migrate to |Notable changes
+
+|`FlowSchema`
+|`flowcontrol.apiserver.k8s.io/v1beta3`
+|`flowcontrol.apiserver.k8s.io/v1`
+|No
+
+|`PriorityLevelConfiguration`
+|`flowcontrol.apiserver.k8s.io/v1beta3`
+|`flowcontrol.apiserver.k8s.io/v1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v132[Yes]
+|===
 
 [id="ocp-4-19-future-deprecation_{context}"]
 === Notice of future deprecation


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-12040

Link to docs preview:
* https://91195--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-admin-ack-updating_release-notes
* https://91195--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-removed-kube-1-32-apis_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**Note to reviewer**: This is almost identical text to we've added in past releases (for example [4.16 here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/release_notes/ocp-4-16-release-notes#ocp-4-16-admin-ack-updating_release-notes)) release notes. Just the versions are different.