### PR TITLE
OSDOCS-13191#Resizing recovery

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1773,6 +1773,8 @@ Topics:
     File: persistent-storage-csi-group-snapshots
   - Name: CSI volume cloning
     File: persistent-storage-csi-cloning
+  - Name: CSI volume resizing
+    File: persistent-storage-csi-resizing
   - Name: Managing the default storage class
     File: persistent-storage-csi-sc-manage
   - Name: CSI automatic migration

--- a/modules/persistent-storage-csi-resizing-overview.adoc
+++ b/modules/persistent-storage-csi-resizing-overview.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-resizing.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="persistent-storage-csi-resizing-overview_{context}"]
+= Overview of CSI volume resizing
+
+To resize a volume, you do not have to manually interact with the storage back end or delete and recreate persistent volumes (PVs) and persistent volume claims (PVCs). 
+
+Shrinking persistent volumes is not supported.
+
+Although resizing is enabled by default, cluster administrators must opt-in to allow users to resize their volumes by setting the `allowVolumeExpansion` field to true in the applicable storage class. Only PVCs created from such storage classes can trigger volume expansion.

--- a/modules/persistent-storage-csi-resizing-procedure.adoc
+++ b/modules/persistent-storage-csi-resizing-procedure.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-resizing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="persistent-storage-csi-resizing-procedure_{context}"]
+= Resizing a CSI volume
+
+.Prerequisites
+* You are logged in to a running {product-title} cluster.
+* Your persistent volume claim (PVC) is created using a CSI driver that supports volume resizing.
+* Your storage back end is configured for dynamic provisioning.
+
+.Procedure
+
+To resize a volume:
+
+. Ensure that your storage class supports resizing:
++
+[source, yaml]
+.Sample storage class YAML file
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: <sc-name> <1>
+provisioner: <provisioner-name> <2>
+parameters:
+    type: gp2
+reclaimPolicy: Delete
+allowVolumeExpansion: true <3>
+----
+<1> Storage class name.
+<2> Provisioner name.
+<3> To allow resizing, the `allowVolumeExpansion` parameter must be set to `true`.
+
+. In the desired PVC, increase the `storage` field to trigger resizing:
++
+[source, yaml]
+.Sample PVC YAML file
+----
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: <pvc-name> <1>
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi <2>
+  storageClassName: <sc-name> <3>
+  volumeMode: Filesystem
+----
+<1> PVC name.
+<2> To resize the PVC, increase the value for the `storage` field. If the resize request fails or remains in a pending state, you can try again by entering another smaller resize value.
+<3> Ensure that the referenced storage class has the `allowVolumeExpansion` parameter set to `true`.

--- a/storage/container_storage_interface/persistent-storage-csi-resizing.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-resizing.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="persistent-storage-csi-resizing"]
+= CSI volume resizing
+include::_attributes/common-attributes.adoc[]
+:context: persistent-storage-csi-resizing
+
+toc::[]
+
+Resizing persistent volumes allows you to easily resize an existing volume by editing a persistent volume claim (PVC). 
+
+include::modules/persistent-storage-csi-resizing-overview.adoc[leveloffset=+1]
+
+For information about which Container Storage Interface (CSI) drivers support resizing, see xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#csi-drivers-supported_persistent-storage-csi[CSI drivers supported by {product-title}.]
+
+include::modules/persistent-storage-csi-resizing-procedure.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13191
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://91198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-resizing.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

PTAL: @gcharot, @gnufied, @chao007 
