### PR TITLE
OSDOCS-3371: Add roles and managed policy reference

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -692,6 +692,8 @@ Topics:
   File: using-service-accounts-as-oauth-client
 - Name: Assuming an AWS IAM role for a service account
   File: assuming-an-aws-iam-role-for-a-service-account
+- Name: Roles and AWS managed policy reference
+  File: rosa-aws-managed-policy-reference
 - Name: Scoping tokens
   File: tokens-scoping
 - Name: Using bound service account tokens

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -527,6 +527,8 @@ Topics:
   File: using-service-accounts-as-oauth-client
 - Name: Assuming an AWS IAM role for a service account
   File: assuming-an-aws-iam-role-for-a-service-account
+- Name: Roles and AWS managed policy reference
+  File: rosa-aws-managed-policy-reference
 - Name: Scoping tokens
   File: tokens-scoping
 - Name: Using bound service account tokens

--- a/authentication/rosa-aws-managed-policy-reference.adoc
+++ b/authentication/rosa-aws-managed-policy-reference.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="rosa-aws-managed-policy-reference"]
+= AWS managed policies and roles reference guide
+include::_attributes/common-attributes.adoc[]
+:context: rosa-aws-managed-policy-reference
+
+toc::[]
+
+The roles and AWS managed policies used by {product-title} (ROSA) can be divided into account-wide roles and policies and Operator roles and policies.
+
+The policies determine the allowed actions for each of the roles.
+ifdef::openshift-rosa[]
+See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources] for more details about the individual roles and policies. See xref:../rosa_planning/rosa-sts-ocm-role.adoc#rosa-sts-ocm-role[ROSA IAM role resource] for more details about trust policies.
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources] for more details about the individual roles and policies. See xref:../rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc#rosa-hcp-prepare-iam-roles-resources[Required IAM roles and resources] for more details on preparing these resources in your cluster.
+endif::openshift-rosa-hcp[]
+
+[NOTE]
+====
+link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-awsmanpol.html[AWS managed policies] are created and administered by AWS. The permissions defined within the AWS managed policies cannot be changed. They are used as part of the AWS STS security process that you can use to assign permissions to users, groups, and roles.
+
+If the permissions defined in an AWS managed policy are updated by AWS, the update will apply to all users, groups, and roles related to the policy. 
+====
+
+include::modules/rosa-roles-and-policies.adoc[leveloffset=+1]

--- a/modules/rosa-roles-and-policies.adoc
+++ b/modules/rosa-roles-and-policies.adoc
@@ -1,0 +1,168 @@
+// Module included in the following assemblies:
+//
+// * authentication/rosa-aws-managed-policy-reference.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rosa-roles-and-policies_{context}"]
+= AWS managed policies and roles
+
+ifdef::openshift-rosa-hcp[]
+[id="aws-managed-policies-hcp_{context}"]
+== AWS managed policies
+
+.AWS managed account policies
+[options="header",cols="2*"]
+|===
+| Policy 
+| Description 
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAManageSubscription.html[`ROSAManageSubscription`]
+| `ROSAManageSubscription` grants the AWS Marketplace permissions required for you to manage the ROSA subscription.
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAWorkerInstancePolicy.html[ROSAWorkerInstancePolicy]
+| You must have the ROSA worker AWS Identity Access Management (IAM) role with `ROSAWorkerInstancePolicy` attached before creating a cluster. 
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSASRESupportPolicy.html[ROSASRESupportPolicy]
+| You must attach `ROSASRESupportPolicy` to a support IAM role before creating a cluster. `ROSASRESupportPolicy` grants required permissions to Red Hat site reliability engineers (SRE) to directly observe, diagnose, and support AWS resources associated with ROSA clusters, including the ability to change ROSA cluster node state.
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAInstallerPolicy.html[ROSAInstallerPolicy]
+| You must attach `ROSAInstallerPolicy` to an IAM role named `<prefix>-ROSA-Worker-Role` before creating a cluster. `ROSAInstallerPolicy` allows the addition of any role that follows the `<prefix>-ROSA-Worker-Role` pattern to an instance profile. `ROSAInstallerPolicy` grants permissions to the installation program to manage AWS resources that support ROSA cluster installation.
+|===
+
+[NOTE]
+====
+You must attach Operator policies to an Operator IAM role to allow a ROSA cluster to make calls to other AWS services.
+====
+
+.AWS managed Operator policies
+[options="header",cols="2*"]
+|===
+| Policy 
+| Description 
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAAmazonEBSCSIDriverOperatorPolicy.html[ROSAAmazonEBSCSIDriverOperatorPolicy]
+| `ROSAAmazonEBSCSIDriverOperatorPolicy` grants permissions to the Amazon EBS CSI Driver Operator to install and maintain the Amazon EBS CSI driver on a ROSA cluster.
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAIngressOperatorPolicy.html[ROSAIngressOperatorPolicy]
+| `ROSAIngressOperatorPolicy` grants required permissions to the Ingress Operator to provision and manage load balancers and DNS configurations for ROSA clusters. The policy allows read access to tag values. The operator then filters the tag values for Route 53 resources to discover hosted zones. 
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAImageRegistryOperatorPolicy.html[ROSAImageRegistryOperatorPolicy]
+| `ROSAImageRegistryOperatorPolicy` grants permissions to the Image Registry Operator to provision and manage resources for the ROSA in-cluster image registry and dependent services, including S3, which allows the Operator to install and maintain the internal registry of a ROSA cluster.
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSACloudNetworkConfigOperatorPolicy.html[ROSACloudNetworkConfigOperatorPolicy]
+| `ROSACloudNetworkConfigOperatorPolicy` grants permissions to the Cloud Network Config Controller Operator to provision and manage networking resources for the ROSA cluster networking overlay. The Operator uses these permissions to manage private IP addresses for Amazon EC2 instances as part of the ROSA cluster.
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKubeControllerPolicy.html[ROSAKubeControllerPolicy]
+| `ROSAKubeControllerPolicy` grants permissions to the kube controller to manage Amazon EC2, Elastic Load Balancing, and AWS Key Management Service (KMS) resources for a ROSA cluster.
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSANodePoolManagementPolicy.html[ROSANodePoolManagementPolicy]
+| `ROSANodePoolManagementPolicy` grants permissions to the NodePool controller to describe, run, and terminate Amazon EC2 instances managed as worker nodes; and allows for disk encryption of the worker node root volume using AWS KMS keys.
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKMSProviderPolicy.html[ROSAKMSProviderPolicy]
+| `ROSAKMSProviderPolicy` grants permissions to the built-in AWS Encryption Provider to manage AWS KMS keys that support etcd data encryption. `ROSAKMSProviderPolicy` allows Amazon EC2 to use KMS keys that the AWS Encryption Provider provides to encrypt and decrypt etcd data. 
+
+| link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAControlPlaneOperatorPolicy.html[ROSAControlPlaneOperatorPolicy]
+| `ROSAControlPlaneOperatorPolicy` grants permissions to the Control Plane Operator to manage Amazon EC2 and Route 53 resources for ROSA clusters.
+
+|===
+
+[id="account-wide-roles-hcp_{context}"]
+== Account-wide roles
+* `<prefix>-HCP-ROSA-Worker-Role`
+* `<prefix>-HCP-ROSA-Support-Role`
+* `<prefix>-HCP-ROSA-Installer-Role`
+
+[id="operator-roles-hcp_{context}"]
+== Operator roles
+
+Certain policies are used by the cluster Operator roles, listed below. The Operator roles are created in a second step because they are dependent on an existing cluster name and cannot be created at the same time as the account-wide roles.
+
+* `<operator_role_prefix>-openshift-cluster-csi-drivers-ebs-cloud-credentials`
+* `<operator_role_prefix>-openshift-cloud-network-config-controller-cloud-credentials`
+* `<operator_role_prefix>-openshift-machine-api-aws-cloud-credentials`
+* `<operator_role_prefix>-openshift-cloud-credential-operator-cloud-credentials`
+* `<operator_role_prefix>-openshift-image-registry-installer-cloud-credentials`
+* `<operator_role_prefix>-openshift-ingress-operator-cloud-credentials`
+
+For the full `JSON` information for the AWS managed policies, see the link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/about-managed-policy-reference.html[AWS Managed Policy Reference guide]. 
+
+endif::openshift-rosa-hcp[]
+
+ifdef::openshift-rosa[]
+[id="aws-managed-policies_{context}"]
+== AWS managed policies
+
+.AWS managed account policies
+[options="header",cols="2*"]
+|===
+| Policy 
+| Description
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-account-policies.html#security-iam-id-based-policy-examples-rosa-classic-installer-policy[<prefix>-Installer-Role-Policy]
+| You must attach `<prefix>-Installer-Role-Policy` to an IAM role named `<prefix>-installer-role` before creating a ROSA cluster. `<prefix>-Installer-Role-Policy` grants permissions that allow the ROSA installer to manage the AWS resources that are needed for cluster creation.
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-account-policies.html#security-iam-id-based-policy-examples-rosa-classic-control-plane-policy[<prefix>-ControlPlane-Role-Policy]
+| You must attach `<prefix>-ControlPlane-Role-Policy` to an IAM role named `<prefix>-ControlPlane-Role` before creating a ROSA cluster. `<prefix>-ControlPlane-Role-Policy` grants permissions for ROSA to manage Amazon EC2 and Elastic Load Balancing resources that host the ROSA control plane, and to read KMS keys.
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-account-policies.html#security-iam-id-based-policy-examples-rosa-classic-worker-policy[<prefix>-Worker-Role-Policy]
+| You must attach `<prefix>-Worker-Role-Policy` to an IAM role named `<prefix>-Worker-Role`. `<prefix>-Worker-Role-Policy` grants permissions for ROSA to describe the EC2 instances running as worker nodes.
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-account-policies.html#security-iam-id-based-policy-examples-rosa-classic-support-policy[<prefix>-Support-Role-Policy]
+| You must attach `<prefix>-Support-Role-Policy` to an IAM role named `<prefix>-Support-Role`. `<prefix>-Support-Role-Policy` grants permissions to Red Hat site reliability engineers (SRE) to observe, diagnose, and support the AWS resources that ROSA classic clusters use, including the ability to change cluster node state.
+
+|===
+
+.AWS managed Operator policies
+[options="header",cols="2*"]
+|===
+| Policy 
+| Description 
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-operator-policies.html#security-iam-id-based-policy-examples-rosa-classic-ingress-operator-policy[<prefix>-openshift-ingress-operator-cloud-credentials]
+| `<prefix>-openshift-ingress-operator-cloud-credentials` grants permissions for the Ingress Operator to provision and manage load balancers and DNS configurations for external cluster access; and allows the Ingress Operator to read and filter Route 53 resource tag values to discover hosted zones.
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-operator-policies.html#security-iam-id-based-policy-examples-rosa-classic-csi-operator-policy[<prefix>-openshift-cluster-csi-drivers-ebs-cloud-credentials]
+| `<prefix>-openshift-cluster-csi-drivers-ebs-cloud-credentials` grants permissions for the Amazon EBS CSI Driver Operator to install and maintain the Amazon EBS CSI driver on a ROSA cluster.
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-operator-policies.html#security-iam-id-based-policy-examples-rosa-classic-machine-config-operator-policy[<prefix>-openshift-machine-api-aws-cloud-credentials]
+| `<prefix>-openshift-machine-api-aws-cloud-credentials` grants permissions for the Machine Config Operator to describe, run, and terminate Amazon EC2 instances managed as worker nodes; and allows for disk encryption of the worker node root volume using AWS KMS keys. 
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-operator-policies.html#security-iam-id-based-policy-examples-rosa-classic-cloud-credential-operator-policy[<prefix>-openshift-cloud-credential-operator-cloud-credentials]
+| `<prefix>-openshift-cloud-credential-operator-cloud-credentials` grants permissions for the Cloud Credential Operator to retrieve IAM user details, including access key IDs, attached inline policy documents, user creation date, path, user ID, and Amazon Resource Name (ARN). 
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-operator-policies.html#security-iam-id-based-policy-examples-rosa-classic-image-registry-operator-policy[<prefix>-openshift-image-registry-installer-cloud-credentials]
+| `<prefix>-openshift-image-registry-installer-cloud-credentials` grants permissions for the Image Registry Operator to provision and manage resources for the ROSA in-cluster image registry and dependent services, including Amazon S3. It is required so that the Operator can install and maintain the internal registry of a ROSA cluster. 
+
+| link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-operator-policies.html#security-iam-id-based-policy-examples-rosa-classic-cloud-network-config-controller-policy[<prefix>-openshift-cloud-network-config-controller-cloud-cr]
+| `<prefix>-openshift-cloud-network-config-controller-cloud-cr` grants required permissions for the Cloud Network Config Controller Operator to provision and manage networking resources for the ROSA cluster networking overlay. The Operator uses these permissions to manage private IP addresses for Amazon EC2 instances as part of the ROSA cluster.
+
+|===
+
+For the full `JSON` information for the following policies, see the link:https://docs.aws.amazon.com/rosa/latest/userguide/security-iam-rosa-classic-account-policies.html#security-iam-id-based-policy-examples-rosa-classic-support-policy[AWS _ROSA classic account policies_ documentation].
+
+[id="account-wide-roles_{context}"]
+== Account-wide roles
+
+* `ManagedOpenShift-Installer-Role`
+* `ManagedOpenShift-ControlPlane-Role`
+* `ManagedOpenShift-Worker-Role`
+* `ManagedOpenShift-Support-Role`
+
+
+[id="operator-roles_{context}"]
+== Operator roles
+
+Certain policies are used by the cluster Operator roles, listed below. The Operator roles are created in a second step because they are dependent on an existing cluster name and cannot be created at the same time as the account-wide roles.
+
+* `<cluster-name\>-xxxx-openshift-cluster-csi-drivers-ebs-cloud-credent`
+* `<cluster-name\>-xxxx-openshift-cloud-network-config-controller-cloud`
+* `<cluster-name\>-xxxx-openshift-machine-api-aws-cloud-credentials`
+* `<cluster-name\>-xxxx-openshift-cloud-credential-operator-cloud-crede`
+* `<cluster-name\>-xxxx-openshift-image-registry-installer-cloud-creden`
+* `<cluster-name\>-xxxx-openshift-ingress-operator-cloud-credentials`
+endif::openshift-rosa[]
+
+[NOTE]
+====
+Trust policies are created for each account-wide role and each Operator role.
+====

--- a/rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
+++ b/rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
@@ -50,7 +50,6 @@ ifdef::openshift-rosa-hcp[]
 See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-hcp-about-iam-resources[About IAM resources] for more details about the individual roles and policies. See xref:../rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc#rosa-hcp-prepare-iam-roles-resources[Required IAM roles and resources] for more details on preparing these resources in your cluster.
 endif::openshift-rosa-hcp[]
 +
---
 ** The following account-wide roles are required:
 
 *** `<prefix>-HCP-ROSA-Worker-Role`
@@ -71,7 +70,6 @@ endif::openshift-rosa-hcp[]
 *** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKubeControllerPolicy.html[ROSAKubeControllerPolicy]
 *** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAManageSubscription.html[ROSAManageSubscription]
 *** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSANodePoolManagementPolicy.html[ROSANodePoolManagementPolicy]
---
 +
 [NOTE]
 ====

--- a/welcome/cloud-experts-rosa-hcp-sts-explained.adoc
+++ b/welcome/cloud-experts-rosa-hcp-sts-explained.adoc
@@ -50,6 +50,10 @@ ifdef::openshift-rosa-hcp[]
 See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources] for more details about the individual roles and policies. See xref:../rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc#rosa-hcp-prepare-iam-roles-resources[Required IAM roles and resources] for more details on preparing these resources in your cluster.
 endif::openshift-rosa-hcp[]
 +
+[NOTE]
+====
+See xref:../authentication/rosa-aws-managed-policy-reference.adoc#rosa-roles-and-policies_rosa-aws-managed-policy-reference[AWS managed policies and roles] for a comprehensive view of the AWS managed policies.
+====
 --
 ** The account-wide roles are:
 
@@ -57,7 +61,7 @@ endif::openshift-rosa-hcp[]
 *** `<prefix>-HCP-ROSA-Support-Role`
 *** `<prefix>-HCP-ROSA-Installer-Role`
 
-** The account-wide AWS-managed policies are:
+** The account-wide AWS managed policies are:
 
 *** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAInstallerPolicy.html[ROSAInstallerPolicy]
 *** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAWorkerInstancePolicy.html[ROSAWorkerInstancePolicy]


### PR DESCRIPTION
Version(s):
4.18+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-3371

Link to docs preview:
**Intro**: https://91210--ocpdocs-pr.netlify.app/openshift-rosa/latest/welcome/cloud-experts-rosa-hcp-sts-explained#components-specific-to-rosa-hcp-with-sts
**HCP**: https://91210--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/rosa-aws-managed-policy-reference.html
**Classic**: https://91210--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/rosa-aws-managed-policy-reference.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
