### PR TITLE
OSDOCS#13614: Updating OKE content

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -7,108 +7,25 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As of 27 April 2020, Red Hat has decided to rename Red Hat OpenShift Container Engine to Red Hat {oke}
+As of 27 April 2020, Red{nbsp}Hat has decided to rename Red{nbsp}Hat OpenShift Container Engine to Red{nbsp}Hat {oke}
 to better communicate what value the product offering delivers.
 
 
 image::oke-about-ocp-stack-image.png[Red Hat {oke}]
 
-Red Hat {oke} is a product offering from Red Hat that lets
+Red{nbsp}Hat {oke} is a product offering from Red{nbsp}Hat that lets
 you use an enterprise class Kubernetes platform as a production platform for
 launching containers. You download and install {oke} the same way as {product-title}
 as they are the same binary distribution, but {oke} offers a subset of the
 features that {product-title} offers.
 
-[[about_oke_similarities_and_differences]]
+[id="oke-similarities-differences_{context}"]
 == Similarities and differences
-You can see the similarities and differences between {oke}
-and {product-title} in the following table:
 
-.Product comparison for {oke} and {product-title}
-|===
-2+| |{oke} |{product-title}
+For a list of similarities and differences between {oke}
+and {product-title}, see Table 1 of link:https://www.redhat.com/en/resources/self-managed-openshift-subscription-guide#section-13[Appendix 1: Self-managed OpenShift editions and what they include] in the "Self-managed Red{nbsp}Hat OpenShift subscription guide".
 
-2+h|Fully Automated Installers
-| Yes
-| Yes
-
-2+h|Over the Air Smart Upgrades
-| Yes
-| Yes
-
-2+h|Enterprise Secured Kubernetes
-| Yes
-| Yes
-
-2+h|Kubectl and oc automated command line
-| Yes
-| Yes
-
-2+h|Operator Lifecycle Manager (OLM)
-| Yes
-| Yes
-
-2+h|Administrator Web console
-| Yes
-| Yes
-
-2+h|OpenShift Virtualization
-| Yes
-| Yes
-
-2+h|User Workload Monitoring
-|
-| Yes
-
-2+h|Cluster Monitoring
-| Yes
-| Yes
-
-2+h|Cost Management SaaS Service
-| Yes
-| Yes
-
-2+h|Platform Logging
-|
-| Yes
-
-2+h|Developer Web Console
-|
-| Yes
-
-2+h|Developer Application Catalog
-|
-| Yes
-
-2+h|Source to Image and Builder Automation (Tekton)
-|
-| Yes
-
-2+h|OpenShift Service Mesh (Maistra, Kiali, and Jaeger)
-|
-| Yes
-
-2+h|OpenShift distributed tracing (Jaeger)
-|
-| Yes
-
-2+h|OpenShift Serverless (Knative)
-|
-| Yes
-
-2+h|OpenShift Pipelines (Jenkins and Tekton)
-|
-| Yes
-
-2+h|Embedded Component of {ibm-cloud-name} Pak and RHT MW Bundles
-|
-| Yes
-
-2+h|{osc}
-|
-| Yes
-
-|===
+// Should I also delete all of these subsections? They seem to elaborate on things mentioned in the table that I am removing.
 
 [[about_oke_core_kubernetes_and_container_orchestration]]
 === Core Kubernetes and container orchestration
@@ -231,125 +148,14 @@ deployments.
 * The `odo` developer command line.
 * The developer persona in the {product-title} web console.
 
-=== Feature summary
+[id="oke-feature-summary_{context}"]
+== Feature summary
 
-The following table is a summary of the feature availability in {oke} and {product-title}. Where applicable, it includes the name of the Operator that enables a feature.
+For a summary of the feature availability in {oke} and {product-title}, see Table 2 of link:https://www.redhat.com/en/resources/self-managed-openshift-subscription-guide#section-13[Appendix 1: Self-managed OpenShift editions and what they include] in the "Self-managed Red{nbsp}Hat OpenShift subscription guide".
 
-.Features in {oke} and {product-title}
-[%header, cols="h,,,"]
-|===
-| Feature | {oke} | {product-title} | Operator name
-| Fully Automated Installers (IPI) | Included | Included | N/A
-| Customizable Installers (UPI) | Included | Included | N/A
-| Disconnected Installation | Included | Included | N/A
-| {op-system-base-full} or {op-system-first} entitlement | Included | Included | N/A
-| Existing RHEL manual attach to cluster (BYO) | Included | Included | N/A
-| CRIO Runtime | Included | Included | N/A
-| Over the Air Smart Upgrades and Operating System ({op-system}) Management | Included | Included | N/A
-| Enterprise Secured Kubernetes | Included | Included | N/A
-| Kubectl and `oc` automated command line | Included | Included | N/A
-| Auth Integrations, RBAC, SCC, Multi-Tenancy Admission Controller | Included | Included | N/A
-| Operator Lifecycle Manager (OLM) | Included | Included | N/A
-| Administrator web console | Included | Included | N/A
-| OpenShift Virtualization | Included | Included | OpenShift Virtualization Operator
-| Compliance Operator provided by Red Hat | Included | Included | Compliance Operator
-| File Integrity Operator | Included | Included | File Integrity Operator
-| Gatekeeper Operator | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Gatekeeper Operator
-| Klusterlet | Not Included - Requires separate subscription | Not Included - Requires separate subscription | N/A
-| {descheduler-operator} provided by Red Hat | Included | Included | {descheduler-operator}
-| Local Storage provided by Red Hat | Included | Included | Local Storage Operator
-| Node Feature Discovery provided by Red Hat | Included | Included | Node Feature Discovery Operator
-| Performance Profile controller | Included | Included | N/A
-| PTP Operator provided by Red Hat | Included | Included | PTP Operator
-| Service Telemetry Operator provided by Red Hat | Not Included | Included | Service Telemetry Operator
-| SR-IOV Network Operator | Included | Included | SR-IOV Network Operator
-| Vertical Pod Autoscaler | Included | Included | Vertical Pod Autoscaler
-| Cluster Monitoring (Prometheus) | Included | Included | Cluster Monitoring
-| Device Manager (for example, GPU) | Included | Included | N/A
-| Log Forwarding | Included | Included | Red Hat OpenShift Logging Operator
-| Telemeter and Insights Connected Experience | Included | Included | N/A
-s| Feature s| {oke} s| {product-title} s| Operator name
-| OpenShift Cloud Manager SaaS Service | Included | Included | N/A
-| OVS and OVN SDN | Included | Included | N/A
-| MetalLB | Included | Included | MetalLB Operator
-| HAProxy Ingress Controller | Included | Included | N/A
-| Ingress Cluster-wide Firewall | Included | Included | N/A
-| Egress Pod and Namespace Granular Control | Included | Included | N/A
-| Ingress Non-Standard Ports | Included | Included | N/A
-| Multus and Available Multus Plugins | Included | Included | N/A
-| Network Policies | Included | Included | N/A
-| IPv6 Single and Dual Stack | Included | Included | N/A
-| CNI Plugin ISV Compatibility | Included | Included | N/A
-| CSI Plugin ISV Compatibility | Included | Included | N/A
-| RHT and {ibm-name} middleware à la carte purchases (not included in {product-title} or {oke}) | Included | Included | N/A
-| ISV or Partner Operator and Container Compatibility (not included in {product-title} or {oke}) | Included | Included | N/A
-| Embedded OperatorHub | Included | Included | N/A
-| Embedded Marketplace | Included | Included | N/A
-| Quay Compatibility (not included) | Included | Included | N/A
-| OpenShift API for Data Protection (OADP) | Included | Included | OADP Operator
-| RHEL Software Collections and RHT SSO Common Service (included) | Included | Included | N/A
-| Embedded Registry | Included | Included | N/A
-| Helm | Included | Included | N/A
-| User Workload Monitoring | Not Included | Included | N/A
-| Cost Management SaaS Service | Included | Included | Cost Management Metrics Operator
-| Platform Logging | Not Included | Included | Red Hat OpenShift Logging Operator
-| OpenShift Elasticsearch Operator provided by Red Hat | Not Included | Cannot be run standalone | N/A
-| Developer Web Console | Not Included | Included | N/A
-| Developer Application Catalog | Not Included | Included | N/A
-| Source to Image and Builder Automation (Tekton) | Not Included | Included | N/A
-| OpenShift Service Mesh | Not Included | Included | OpenShift Service Mesh Operator
-s| Feature s| {oke} s| {product-title} s| Operator name
-| Red Hat OpenShift Serverless | Not Included | Included | OpenShift Serverless Operator
-| Web Terminal provided by Red Hat | Not Included | Included | Web Terminal Operator
-| Red Hat OpenShift Pipelines Operator | Not Included | Included | OpenShift Pipelines Operator
-| Embedded Component of {ibm-cloud-name} Pak and RHT MW Bundles | Not Included | Included | N/A
-| Red Hat OpenShift GitOps | Not Included | Included | OpenShift GitOps
-| {openshift-dev-spaces-productname} | Not Included | Included | {openshift-dev-spaces-productname}
-| {openshift-local-productname} | Not Included | Included | N/A
-| Quay Bridge Operator provided by Red Hat | Not Included | Included | Quay Bridge Operator
-| Quay Container Security provided by Red Hat | Not Included | Included | Quay Operator
-| Red Hat OpenShift distributed tracing platform | Not Included | Included | Red Hat OpenShift distributed tracing platform Operator
-| Red Hat OpenShift Kiali | Not Included | Included | Kiali Operator
-| Metering provided by Red Hat (deprecated) | Not Included | Included | N/A
-| Migration Toolkit for Containers Operator | Not Included | Included | Migration Toolkit for Containers Operator
-| Cost management for OpenShift | Not included | Included | N/A
-| JBoss Web Server provided by Red Hat | Not included | Included | JWS Operator
-| Red Hat Build of Quarkus | Not included | Included | N/A
-| Kourier Ingress Controller | Not included | Included | N/A
-| RHT Middleware Bundles Sub Compatibility (not included in {product-title}) | Not included | Included | N/A
-| {ibm-cloud-name}  Pak Sub Compatibility (not included in {product-title}) | Not included | Included | N/A
-| OpenShift Do (`odo`) | Not included | Included | N/A
-| Source to Image and Tekton Builders | Not included | Included | N/A
-| OpenShift Serverless FaaS | Not included | Included | N/A
-| IDE Integrations | Not included | Included | N/A
-| {sandboxed-containers-first} | Not included | Not included | {sandboxed-containers-operator}
-| Windows Machine Config Operator | Community Windows Machine Config Operator included - no subscription required | Red Hat Windows Machine Config Operator included - Requires separate subscription | Windows Machine Config Operator
-| Red Hat Quay | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Quay Operator
-| Red Hat Advanced Cluster Management | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Advanced Cluster Management for Kubernetes
-| Red Hat Advanced Cluster Security | Not Included - Requires separate subscription | Not Included - Requires separate subscription | N/A
-| {rh-storage} | Not Included - Requires separate subscription | Not Included - Requires separate subscription | {rh-storage}
-s| Feature s| {oke} s| {product-title} s| Operator name
-| Ansible Automation Platform Resource Operator | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Ansible Automation Platform Resource Operator
-| Business Automation provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Business Automation Operator
-| Data Grid provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Data Grid Operator
-| Red Hat Integration provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Red Hat Integration Operator
-| Red Hat Integration - 3Scale provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | 3scale
-| Red Hat Integration - 3Scale APICast gateway provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | 3scale APIcast
-| Red Hat Integration - AMQ Broker | Not Included - Requires separate subscription | Not Included - Requires separate subscription | AMQ Broker
-| Red Hat Integration - AMQ Broker LTS | Not Included - Requires separate subscription | Not Included - Requires separate subscription |
-| Red Hat Integration - AMQ Interconnect | Not Included - Requires separate subscription | Not Included - Requires separate subscription | AMQ Interconnect
-| Red Hat Integration - AMQ Online | Not Included - Requires separate subscription | Not Included - Requires separate subscription |
-| Red Hat Integration - AMQ Streams | Not Included - Requires separate subscription | Not Included - Requires separate subscription | AMQ Streams
-| Red Hat Integration - Camel K | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Camel K
-| Red Hat Integration - Fuse Console | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Fuse Console
-| Red Hat Integration - Fuse Online | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Fuse Online
-| Red Hat Integration - Service Registry Operator | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Service Registry
-| API Designer provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | API Designer
-| JBoss EAP provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | JBoss EAP
-| Smart Gateway Operator | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Smart Gateway Operator
-| Kubernetes NMState Operator | Included | Included | N/A
-|===
+Where applicable, it includes the name of the Operator that enables a feature.
 
+[id="oke-subscription-limitations_{context}"]
 == Subscription limitations
 
 {oke} is a subscription offering that provides {product-title} with a limited set


### PR DESCRIPTION
[OSDOCS-13614](https://issues.redhat.com/browse/OSDOCS-13614)

Version(s): 4.17+

This PR replaces tables summarizing differences between OKE and OCP with links to the subscription guide, which has basically the same content but is maintained more regularly

QE review:
- [ ] QE has approved this change.

Preview: https://91213--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/oke_about.html#oke-similarities-differences_oke-about