### PR TITLE
OBSDOCS-1778: Remove COO pre-GA support notice in OCP 4.17

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3044,6 +3044,8 @@ Topics:
   - Name: Logging 6.0
     Dir: logging-6.0
     Topics:
+    - Name: Support
+      File: log60-cluster-logging-support
     - Name: Release notes
       File: log6x-release-notes
     - Name: About logging 6.0

--- a/observability/logging/logging-6.0/log6x-visual.adoc
+++ b/observability/logging/logging-6.0/log6x-visual.adoc
@@ -7,5 +7,3 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 Visualization for logging is provided by deploying the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator], which requires Operator installation.
-
-include::snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc[]

--- a/observability/logging/logging-6.1/log6x-visual-6.1.adoc
+++ b/observability/logging/logging-6.1/log6x-visual-6.1.adoc
@@ -7,5 +7,3 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 Visualization for logging is provided by deploying the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator], which requires Operator installation.
-
-include::snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc[]

--- a/observability/logging/logging-6.2/log6x-visual-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-visual-6.2.adoc
@@ -7,5 +7,3 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 Visualization for logging is provided by deploying the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator], which requires Operator installation.
-
-include::snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc[]


### PR DESCRIPTION
Version(s): 4.17

Issue: https://issues.redhat.com/browse/OBSDOCS-1778
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://91236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-visual.html
- https://91236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-visual-6.1.html
- https://91236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-visual-6.2.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
