### PR TITLE
OLS-918: Add additional resources to remote health monitoring

### DIFF
--- a/about/ols-about-openshift-lightspeed.adoc
+++ b/about/ols-about-openshift-lightspeed.adoc
@@ -21,13 +21,20 @@ include::modules/ols-about-rhelai.adoc[leveloffset=+2]
 include::modules/ols-about-rhoai.adoc[leveloffset=+2]
 include::modules/ols-about-data-use.adoc[leveloffset=+1]
 include::modules/ols-about-data-telemetry-transcript-and-feedback-collection.adoc[leveloffset=+1]
-include::modules/ols-about-remote-health-monitoring.adoc[leveloffset=+1]
+include::modules/ols-remote-health-monitoring-overview.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+// OpenShift Lightspeed is a layered product that publishes using the standalone doc approach. Links to core OCP have to use links instead of xref. 
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/support/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring[About remote health monitoring]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/support/remote-health-monitoring-with-connected-clusters#opting-out-remote-health-reporting[Opting out of remote health reporting]
+
 include::modules/ols-transcript-collection-overview.adoc[leveloffset=+2]
 include::modules/ols-feedback-collection-overview.adoc[leveloffset=+2]
 
+//The following resources are for the assembly, and link withing the standalone doc set
 [id="additional-resources_{context}"]
 == Additional resources
-
 * xref:../configure/ols-configuring-openshift-lightspeed.adoc#ols-creating-the-credentials-secret-using-web-console_ols-configuring-openshift-lightspeed[Creating the credential secret using the web console]
 * xref:../configure/ols-configuring-openshift-lightspeed.adoc#ols-creating-the-credentials-secret-using-cli_ols-configuring-openshift-lightspeed[Creating the credential secret using the CLI]
 * xref:../configure/ols-configuring-openshift-lightspeed.adoc#ols-creating-lightspeed-custom-resource-file-using-web-console_ols-configuring-openshift-lightspeed[Creating the Lightspeed custom resource file using the web console]

--- a/modules/ols-about-remote-health-monitoring.adoc
+++ b/modules/ols-about-remote-health-monitoring.adoc
@@ -1,8 +1,0 @@
-// This module is used in the following assemblies:
-// about/ols-about-openshift-lightspeed.adoc
-
-:_mod-docs-content-type: Concept
-[id="ols-about-remote-health-monitoring_{context}"]
-= About remote health monitoring 
-
-Red Hat records basic information using the Telemeter Client and the Insights Operator, which is generally referred to as Remote Health Monitoring in {ocp-short-name} clusters. The {ocp-short-name} documentation for remote health monitoring explains data collection and includes instructions for opting out. If you wish to disable transcript or feedback collection, you must follow the procedure for opting out of remote health monitoring. For more information, see "About remote health monitoring" in the {ocp-product-title} documentation.

--- a/modules/ols-remote-health-monitoring-overview.adoc
+++ b/modules/ols-remote-health-monitoring-overview.adoc
@@ -1,0 +1,8 @@
+// This module is used in the following assemblies:
+// about/ols-about-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: Concept
+[id="ols-about-remote-health-monitoring-overview_{context}"]
+= Remote health monitoring overview
+
+{red-hat} products record basic information by using the Telemeter Client and the Insights Operator, which is generally referred to as Remote Health Monitoring in {ocp-short-name} clusters. The {ocp-short-name} documentation for remote health monitoring explains data collection and includes instructions for opting out. To disable transcript or feedback collection, you must follow the procedure for opting out of remote health monitoring. For more information, see "About remote health monitoring" in the {ocp-product-title} documentation.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-918
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://91250--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/about/ols-about-openshift-lightspeed.html#ols-about-remote-health-monitoring-overview_ols-about-data-use

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
