### PR TITLE
ROX-28626: remove erroneous info about scanner v4

### DIFF
--- a/modules/fetching-vulnerability-definitions.adoc
+++ b/modules/fetching-vulnerability-definitions.adoc
@@ -5,22 +5,20 @@
 [id="fetching-vulnerability-definitions_{context}"]
 = Fetching vulnerability definitions
 
-//verify this info is still accurate
 In online mode, Central fetches the vulnerability definitions every 5 minutes from a single feed.
-This feed combines vulnerability definitions from upstream sources, and it refreshes every 3 hours.
+This feed combines vulnerability definitions from upstream sources, and it refreshes every 3 hours. The address of the feed is `\https://definitions.stackrox.io`.
 
-* The address of the feed is `\https://definitions.stackrox.io`.
-* You can change the default query frequency for Central and the StackRox Scanner by setting the `ROX_SCANNER_VULN_UPDATE_INTERVAL` environment variable:
-+
+You can change the frequency of the default query from Central to the `definitions.stackrox.io` feed by setting the `ROX_SCANNER_VULN_UPDATE_INTERVAL` environment variable. Run the following command:
+
 [source,terminal]
 ----
 $ oc -n stackrox set env deploy/central ROX_SCANNER_VULN_UPDATE_INTERVAL=<value> <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 
-Note the following guidance:
-
-* The StackRox Scanner's configuration map still has an `updater.interval` parameter for configuring the scanner's updating frequency, but it no longer includes the `fetchFromCentral` parameter.
-* Setting this environment variable is not supported for Scanner V4.
+This variable applies to the connection between Central and the `definitions.stackrox.io` feed. Both the StackRox Scanner and Scanner V4 use vulnerability data from Central that is obtained from this feed. The StackRox Scanner's config map still has an `updater.interval` parameter for configuring the scanner's updating frequency, but it no longer includes the `fetchFromCentral` parameter.
 
 For more information about the vulnerability sources that {product-title-short} uses, see "Vulnerability sources" in "{product-title} architecture".
+
+//Future work when time permits:
+// Take instructions for changing the frequency of fetching definitions and put them into a procedure module. Call that module from the operating/examine-images-for-vulnerabilities.adoc module.


### PR DESCRIPTION
Version(s):
4.5+

[Issue](https://issues.redhat.com/browse/ROX-28626)

[Link to docs preview
](https://91257--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html#fetching-vulnerability-definitions_examine-images-for-vulnerabilities)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
