### PR TITLE
OSDOCS-13191#Resizing recovery

### DIFF
--- a/modules/storage-expanding-csi-volumes.adoc
+++ b/modules/storage-expanding-csi-volumes.adoc
@@ -10,15 +10,11 @@
 
 You can use the Container Storage Interface (CSI) to expand storage volumes after they have already been created.
 
-CSI volume expansion does not support the following:
-
-* Recovering from failure when expanding volumes
-
-* Shrinking
+Shrinking persistent volumes (PVs) is _not_ supported.
 
 .Prerequisites
 
-* The underlying CSI driver supports resize.
+* The underlying CSI driver supports resize. See "CSI drivers supported by {product-title}" in the "Additional Resources" section.
 
 * Dynamic provisioning is used.
 
@@ -28,4 +24,4 @@ CSI volume expansion does not support the following:
 
 . For the persistent volume claim (PVC), set `.spec.resources.requests.storage` to the desired new size.
 
-. Watch the `status.conditions` field of the PVC to see if the resize has completed. {product-title} adds the `Resizing` condition to the PVC during expansion, which is removed after expansion completes.
+. Watch the `status.conditions` field of the PVC to see if the resize has completed. {product-title} adds the `Resizing` condition to the PVC during expansion, which is removed after expansion completes. 

--- a/modules/storage-expanding-recovering-failure.adoc
+++ b/modules/storage-expanding-recovering-failure.adoc
@@ -7,13 +7,21 @@
 [id="expanding-recovering-from-failure_{context}"]
 = Recovering from failure when expanding volumes
 
-If expanding underlying storage fails, the {product-title} administrator can manually recover the persistent volume claim (PVC) state and cancel the resize requests. Otherwise, the resize requests are continuously retried by the controller.
+If a resize request fails or remains in a pending state, you can try again by entering a different resize value in `.spec.resources.requests.storage` for the persistent volume claim (PVC). The new value must be larger than the original volume size.
+
+If you are still having issues, use the following procedure to recover.
 
 .Procedure
+If entering another smaller resize value in `.spec.resources.requests.storage` for the PVC does not work, do the following:
 
-. Mark the persistent volume (PV) that is bound to the PVC with the `Retain` reclaim policy. This can be done by editing the PV and changing `persistentVolumeReclaimPolicy` to `Retain`.
+. Mark the persistent volume (PV) that is bound to the PVC with the `Retain` reclaim policy. Change `persistentVolumeReclaimPolicy` to `Retain`.
+
 . Delete the PVC.
+
 . Manually edit the PV and delete the `claimRef` entry from the PV specs to ensure that the newly created PVC can bind to the PV marked `Retain`. This marks the PV as `Available`.
+
 . Re-create the PVC in a smaller size, or a size that can be allocated by the underlying storage provider.
+
 . Set the `volumeName` field of the PVC to the name of the PV. This binds the PVC to the provisioned PV only.
+
 . Restore the reclaim policy on the PV.

--- a/storage/expanding-persistent-volumes.adoc
+++ b/storage/expanding-persistent-volumes.adoc
@@ -23,6 +23,8 @@ include::modules/storage-expanding-recovering-failure.adoc[leveloffset=+1]
 endif::openshift-enterprise,openshift-webscale,openshift-origin[]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../storage/expanding-persistent-volumes.adoc#add-volume-expansion_expanding-persistent-volumes[Enabling volume expansion support]
 
-* The controlling `StorageClass` object has `allowVolumeExpansion` set to `true` (see xref:../storage/expanding-persistent-volumes.adoc#add-volume-expansion_expanding-persistent-volumes[Enabling volume expansion support]).
+* xref:../storage/container_storage_interface/persistent-storage-csi.adoc#csi-drivers-supported_persistent-storage-csi[CSI drivers supported by {product-title}]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13191
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://91258--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/expanding-persistent-volumes.html#expanding-recovering-from-failure_expanding-persistent-volumes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

PTAL: @gcharot @gnufied @chao007 
