### PR TITLE
OCPBUGS-54352 Default value seems to be set to false for the parameter enableInjector and enableOperatorWebhook

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -15,21 +15,20 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovOperatorConfig
 metadata:
-  name: default 
+  name: default <1>
   namespace: openshift-sriov-network-operator 
 spec:
   disableDrain: false
-  enableInjector: true
-  enableOperatorWebhook: true
+  enableInjector: true <2>
+  enableOperatorWebhook: true <3>
   logLevel: 2
   featureGates:
     metricsExporter: false
 ----
 +
-[NOTE]
-====
-The only valid name for the `SriovOperatorConfig` resource is `default` and it must be in the namespace where the Operator is deployed. 
-====
+<1> The only valid name for the `SriovOperatorConfig` resource is `default` and it must be in the namespace where the Operator is deployed. 
+<2> The `enableInjector` field, if not specified in the CR or explicitly set to `true`, defaults to `false` or `<none>`, preventing any `network-resources-injector` pod from running in the namespace. The recommended setting is `true`. 
+<3> The `enableOperatorWebhook` field, if not specified in the CR or explicitly set to true, defaults to `false` or `<none>`, preventing any `operator-webhook` pod from running in the namespace. The recommended setting is `true`. 
 
 .. Create the resource by running the following command:
 +
@@ -75,12 +74,11 @@ For single-node clusters, set this field to `true` after installing the Operator
 |`spec.enableInjector`
 |`boolean`
 |Specifies whether to enable or disable the Network Resources Injector daemon set.
-By default, this field is set to `true`.
 
 |`spec.enableOperatorWebhook`
 |`boolean`
 |Specifies whether to enable or disable the Operator Admission Controller webhook daemon set.
-By default, this field is set to `true`.
+
 
 |`spec.logLevel`
 |`integer`
@@ -113,7 +111,7 @@ The Network Resources Injector is a Kubernetes Dynamic Admission Controller appl
 * Mutation of resource requests and limits in a pod specification to add an SR-IOV resource name according to an SR-IOV network attachment definition annotation.
 * Mutation of a pod specification with a Downward API volume to expose pod annotations, labels, and huge pages requests and limits. Containers that run in the pod can access the exposed information as files under the `/etc/podnetinfo` path.
 
-By default, the Network Resources Injector is enabled by the SR-IOV Network Operator and runs as a daemon set on all control plane nodes. The following is an example of Network Resources Injector pods running in a cluster with three control plane nodes:
+The Network Resources Injector is enabled by the SR-IOV Network Operator when the `enableInjector` is set to `true` in the `SriovOperatorConfig` CR. The `network-resources-injector` pod runs as a daemon set on all control plane nodes. The following is an example of Network Resources Injector pods running in a cluster with three control plane nodes:
 
 [source,terminal]
 ----
@@ -155,7 +153,7 @@ spec:
 [id="disable-enable-network-resource-injector_{context}"]
 == Disabling or enabling the Network Resources Injector
 
-To disable or enable the Network Resources Injector, which is enabled by default, complete the following procedure.
+To disable or enable the Network Resources Injector, complete the following procedure.
 
 .Prerequisites
 
@@ -193,13 +191,12 @@ spec:
 [id="about-sr-iov-operator-admission-control-webhook_{context}"]
 == About the SR-IOV Network Operator admission controller webhook
 
-The SR-IOV Network Operator Admission Controller webhook is a Kubernetes Dynamic
-Admission Controller application. It provides the following capabilities:
+The SR-IOV Network Operator Admission Controller webhook is a Kubernetes Dynamic Admission Controller application. It provides the following capabilities:
 
 * Validation of the `SriovNetworkNodePolicy` CR when it is created or updated.
 * Mutation of the `SriovNetworkNodePolicy` CR by setting the default value for the `priority` and `deviceType` fields when the CR is created or updated.
 
-By default the SR-IOV Network Operator Admission Controller webhook is enabled by the Operator and runs as a daemon set on all control plane nodes.
+The SR-IOV Network Operator Admission Controller webhook is enabled by the Operator when the `enableOperatorWebhook` is set to `true` in the `SriovOperatorConfig` CR. The `operator-webhook` pod runs as a daemon set on all control plane nodes.
 
 [NOTE]
 ====
@@ -225,7 +222,7 @@ operator-webhook-rpfrl                    1/1     Running   0          16m
 [id="disable-enable-sr-iov-operator-admission-control-webhook_{context}"]
 == Disabling or enabling the SR-IOV Network Operator admission controller webhook
 
-To disable or enable the admission controller webhook, which is enabled by default, complete the following procedure.
+To disable or enable the admission controller webhook, complete the following procedure.
 
 .Prerequisites
 


### PR DESCRIPTION
[OCPBUGS-54352]: Default value seems to be set to false for the parameters enableInjector and enableOperatorWebhook in SriovOperatorConfig.spec.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-54352
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://91315--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
