### PR TITLE
OBSDOCS#1796: Improve troubleshooting monitoring issues: create new section about the AlertmanagerReceiversNotConfigured alert

### DIFF
--- a/modules/monitoring-resolving-the-alertmanagerreceiversnotconfigured-alert.adoc
+++ b/modules/monitoring-resolving-the-alertmanagerreceiversnotconfigured-alert.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * monitoring/troubleshooting-monitoring-issues.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="resolving-the-alertmanagerreceiversnotconfigured-alert_{context}"]
+= Resolving the AlertmanagerReceiversNotConfigured alert
+
+Every cluster that is deployed has the `AlertmanagerReceiversNotConfigured` alert firing by default. To resolve the issue, you must configure alert receivers.
+
+* For default platform monitoring, follow the steps in "Configuring alert notifications" in _Configuring core platform monitoring_.
+
+* For user workload monitoring, follow the steps in "Configuring alert notifications" in _Configuring user workload monitoring_.

--- a/observability/monitoring/troubleshooting-monitoring-issues.adoc
+++ b/observability/monitoring/troubleshooting-monitoring-issues.adoc
@@ -48,3 +48,12 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Resolving the KubePersistentVolumeFillingUp alert firing for Prometheus
 include::modules/monitoring-resolving-the-kubepersistentvolumefillingup-alert-firing-for-prometheus.adoc[leveloffset=+1]
+
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+// Resolving the AlertmanagerReceiversNotConfigured alert firing for Prometheus
+include::modules/monitoring-resolving-the-alertmanagerreceiversnotconfigured-alert.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/monitoring/configuring-core-platform-monitoring/configuring-alerts-and-notifications.adoc#configuring-alert-notifications_configuring-alerts-and-notifications[Configuring alert notifications for default platform monitoring]
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm.adoc#configuring-alert-notifications_configuring-alerts-and-notifications-uwm[Configuring alert notifications for user workload monitoring]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 and later
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1796
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://91320--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/troubleshooting-monitoring-issues.html#resolving-the-alertmanagerreceiversnotconfigured-alert_troubleshooting-monitoring-issues
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
