### PR TITLE
OSDOCS-13692: Updated dual-stack to single-stack for IPv6

### DIFF
--- a/modules/nw-dual-stack-convert-back-single-stack.adoc
+++ b/modules/nw-dual-stack-convert-back-single-stack.adoc
@@ -2,7 +2,12 @@
 [id="nw-dual-stack-convert-back-single-stack_{context}"]
 = Converting to a single-stack cluster network
 
-As a cluster administrator, you can convert your dual-stack cluster network to a single-stack cluster network.
+As a cluster administrator, you can convert your dual-stack cluster network to a single-stack cluster network. 
+
+[IMPORTANT]
+====
+If you originally converted your IPv4 single-stack cluster network to a dual-stack cluster, you can convert only back to the IPv4 single-stack cluster and not an IPv6 single-stack cluster network. The same restriction applies for converting back to an IPv6 single-stack cluster network. 
+====
 
 .Prerequisites
 
@@ -14,13 +19,12 @@ As a cluster administrator, you can convert your dual-stack cluster network to a
 
 .Procedure
 
-. Edit the `networks.config.openshift.io` custom resource (CR) by running the
-following command:
+. Edit the `networks.config.openshift.io` custom resource (CR) by running the following command:
 +
 [source,terminal]
 ----
 $ oc edit networks.config.openshift.io
 ----
 
-. Remove the IPv6 specific configuration that you have added to the `cidr` and `hostPrefix` fields in the previous procedure.
+. Remove the IPv4 or IPv6 configuration that you added to the `cidr` and the `hostPrefix` parameters from completing the "Converting to a dual-stack cluster network " procedure steps.
 

--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -56,7 +56,7 @@ If you already upgraded your cluster to {product-title} 4.16 or later and you ne
   path: /spec/serviceNetwork/-
   value: fd02::/112 <2>
 ----
-<1> Specify an object with the `cidr` and `hostPrefix` fields. The host prefix must be `64` or greater. The IPv6 Classless Inter-Domain Routing (CIDR) prefix must be large enough to accommodate the specified host prefix.
+<1> Specify an object with the `cidr` and `hostPrefix` parameters. The host prefix must be `64` or greater. The IPv6 Classless Inter-Domain Routing (CIDR) prefix must be large enough to accommodate the specified host prefix.
 <2> Specify an IPv6 CIDR with a prefix of `112`. Kubernetes uses only the lowest 16 bits. For a prefix of `112`, IP addresses are assigned from `112` to `128` bits.
 
 . Patch the cluster network configuration by entering the following command in your CLI:

--- a/modules/nw-ovn-kuberentes-change-join-subnet.adoc
+++ b/modules/nw-ovn-kuberentes-change-join-subnet.adoc
@@ -16,7 +16,7 @@ You can change the join subnet used by OVN-Kubernetes to avoid conflicting with 
 
 .Procedure
 
-. To change the OVN-Kubernetes join subnet, enter the following command:
+* To change the OVN-Kubernetes join subnet, enter the following command:
 +
 [source,terminal]
 ----
@@ -48,7 +48,7 @@ $ oc get network.operator.openshift.io \
   -o jsonpath="{.items[0].spec.defaultNetwork}"
 ----
 +
-It can take up to 30 minutes for this change to take effect.
+The command operation can take up to 30 minutes for this change to take effect.
 +
 .Example output
 ----

--- a/modules/nw-ovn-kuberentes-change-transit-subnet.adoc
+++ b/modules/nw-ovn-kuberentes-change-transit-subnet.adoc
@@ -16,7 +16,7 @@ You can change the transit subnet used by OVN-Kubernetes to avoid conflicting wi
 
 .Procedure
 
-. To change the OVN-Kubernetes transit subnet, enter the following command:
+* To change the OVN-Kubernetes transit subnet, enter the following command:
 +
 [source,terminal]
 ----

--- a/networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc
+++ b/networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc
@@ -9,5 +9,8 @@ toc::[]
 [role="_abstract"]
 As a cluster administrator, you can change the IP address ranges that the OVN-Kubernetes network plugin uses for the join and transit subnets.
 
+// Configuring the OVN-Kubernetes join subnet
 include::modules/nw-ovn-kuberentes-change-join-subnet.adoc[leveloffset=+1]
+
+// Configuring the OVN-Kubernetes transit subnet
 include::modules/nw-ovn-kuberentes-change-transit-subnet.adoc[leveloffset=+1]


### PR DESCRIPTION

Cherry pick of #90524 with commit 7ee66303a6a6336ec8136138e8a4ec5bc5443a39

Version(s):
4.16

Issue:
[OSDOCS-13692](https://issues.redhat.com/browse/OSDOCS-13692)

Link to docs preview:

