### PR TITLE
[enterprise-4.13] OSDOCS-13692: Updated dual-stack to single-stack for IPv6

### DIFF
--- a/modules/nw-dual-stack-convert-back-single-stack.adoc
+++ b/modules/nw-dual-stack-convert-back-single-stack.adoc
@@ -2,7 +2,12 @@
 [id="nw-dual-stack-convert-back-single-stack_{context}"]
 = Converting to a single-stack cluster network
 
-As a cluster administrator, you can convert your dual-stack cluster network to a single-stack cluster network.
+As a cluster administrator, you can convert your dual-stack cluster network to a single-stack cluster network. 
+
+[IMPORTANT]
+====
+If you originally converted your IPv4 single-stack cluster network to a dual-stack cluster, you can convert only back to the IPv4 single-stack cluster and not an IPv6 single-stack cluster network. The same restriction applies for converting back to an IPv6 single-stack cluster network. 
+====
 
 .Prerequisites
 
@@ -14,13 +19,12 @@ As a cluster administrator, you can convert your dual-stack cluster network to a
 
 .Procedure
 
-. Edit the `networks.config.openshift.io` custom resource (CR) by running the
-following command:
+. Edit the `networks.config.openshift.io` custom resource (CR) by running the following command:
 +
 [source,terminal]
 ----
 $ oc edit networks.config.openshift.io
 ----
 
-. Remove the IPv6 specific configuration that you have added to the `cidr` and `hostPrefix` fields in the previous procedure.
+. Remove the IPv4 or IPv6 configuration that you added to the `cidr` and the `hostPrefix` parameters from completing the "Converting to a dual-stack cluster network " procedure steps.
 

--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -21,7 +21,6 @@ After converting to dual-stack networking only newly created pods are assigned I
 
 . To specify IPv6 address blocks for the cluster and service networks, create a file containing the following YAML:
 +
---
 [source,yaml]
 ----
 - op: add
@@ -33,10 +32,8 @@ After converting to dual-stack networking only newly created pods are assigned I
   path: /spec/serviceNetwork/-
   value: fd02::/112 <2>
 ----
-<1> Specify an object with the `cidr` and `hostPrefix` fields. The host prefix must be `64` or greater. The IPv6 CIDR prefix must be large enough to accommodate the specified host prefix.
-
+<1> Specify an object with the `cidr` and `hostPrefix` parameters. The host prefix must be `64` or greater. The IPv6 Classless Inter-Domain Routing (CIDR) prefix must be large enough to accommodate the specified host prefix.
 <2> Specify an IPv6 CIDR with a prefix of `112`. Kubernetes uses only the lowest 16 bits. For a prefix of `112`, IP addresses are assigned from `112` to `128` bits.
---
 
 . To patch the cluster network configuration, enter the following command:
 +
@@ -46,11 +43,9 @@ $ oc patch network.config.openshift.io cluster \
   --type='json' --patch-file <file>.yaml
 ----
 +
---
 where:
 
 `file`:: Specifies the name of the file you created in the previous step.
---
 +
 .Example output
 [source,text]


### PR DESCRIPTION
Cherry pick of #90524 with commit 7ee66303a6a6336ec8136138e8a4ec5bc5443a39

Version(s):
4.13

Issue:
[OSDOCS-13692](https://issues.redhat.com/browse/OSDOCS-13692)

Link to docs preview:

