### PR TITLE
[enterprise-4.14] TELCODOCS-1843#Update GNSS sync status value in PTP HW Fast events

### DIFF
--- a/modules/cnf-fast-event-notifications-api-refererence.adoc
+++ b/modules/cnf-fast-event-notifications-api-refererence.adoc
@@ -176,10 +176,10 @@ OK
 Returns an array of `os-clock-sync-state`, `ptp-clock-class-change`, `lock-state`, and `gnss-sync-status` details for the cluster node.
 The system generates notifications when the relevant equipment state changes.
 
-* `os-clock-sync-state` notifications describe the host operating system clock synchronization state. Can be in `LOCKED` or `FREERUN` state.
+* `os-clock-sync-state` notifications describe the host operating system clock synchronization state. Valid states are `LOCKED` or `FREERUN`.
 * `ptp-clock-class-change` notifications describe the current state of the PTP clock class.
-* `lock-state` notifications describe the current status of the PTP equipment lock state. Can be in `LOCKED`, `HOLDOVER` or `FREERUN` state.
-* `gnss-sync-status` notifications describe the GPS synchronization state with regard to the external GNSS clock signal. Can be in `LOCKED` or `FREERUN` state.
+* `lock-state` notifications describe the current status of the PTP equipment lock state. Valid states are `LOCKED`, `HOLDOVER` or `FREERUN`.
+* `gnss-sync-status` notifications describe the GPS synchronization state with regard to the external GNSS clock signal. Valid states are `SYNCHRONIZED`, `ANTENNA_DISCONNECTED`, or `ACQUIRING_SYNC`.
 
 You can use equipment synchronization status subscriptions together to deliver a detailed view of the overall synchronization health of the system.
 
@@ -318,7 +318,7 @@ $ oc logs -f linuxptp-daemon-cvgr6 -n openshift-ptp -c cloud-event-proxy
         "resource": "/cluster/node/compute-1.example.com/ens2fx/master",
         "dataType": "notification",
         "valueType": "enumeration",
-        "value": "LOCKED"
+        "value": "SYNCHRONIZED"
       },
       {
         "resource": "/cluster/node/compute-1.example.com/ens2fx/master",


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1843
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://91340--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/using-ptp-events.html#api-ocloudnotifications-v1-publishers_using-ptp-hardware-fast-events-framework
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Cherry-picked from https://github.com/openshift/openshift-docs/pull/91338
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
