### PR TITLE
OSDOCS-13650-1: RPM typo update

### DIFF
--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -40,16 +40,16 @@ $ sudo subscription-manager repos \
 +
 [source,terminal]
 ----
-`$ sudo subscription-manager repos \
+$ sudo subscription-manager repos \
     --enable rhel-9-for-x86_64-appstream-eus-rpms \
-    --enable rhel-9-for-x86_64-baseos-eus-rpms`
+    --enable rhel-9-for-x86_64-baseos-eus-rpms
 ----
 
 . Avoid unintended future updates into an unsupported configuration by locking your operating system version with the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo subscription-manager release --set=<9.2> command. # <1>
+$ sudo subscription-manager release --set=_<9.2>_ # <1>
 ----
 <1> Replace _<9.2>_ with the major and minor version of your compatible {op-system-base} system, such as 9.2 or 9.3.
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com//browse/OSDOCS-13650

Link to docs preview:
https://91345--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually.html

QE review:
- [x] QE has approved this change.

PTAL: @jogeo 