### PR TITLE
ROX28722 Release notes for 4.6.4

### DIFF
--- a/release_notes/46-release-notes.adoc
+++ b/release_notes/46-release-notes.adoc
@@ -19,6 +19,7 @@ toc::[]
 |`4.6.1` | 18 December 2024
 |`4.6.2` | 4 February 2025
 |`4.6.3` | 10 March 2025
+|`4.6.4` | 31 March 2025
 
 |====
 
@@ -459,5 +460,27 @@ This release of {product-title-short} fixes the following security vulnerabiliti
 * link:https://access.redhat.com/security/cve/cve-2025-1094[CVE-2025-1094]: PostgreSQL quoting APIs miss neutralizing quoting syntax in text that fails encoding validation.
 * link:https://osv.dev/vulnerability/GHSA-6wxm-mpqj-6jpf[GHSA-6wxm-mpqj-6jpf]: Insecure temporary file usage in `github.com/golang/glog`.
 * link:https://access.redhat.com/security/cve/cve-2025-22868[CVE-2025-22868]: Flaw in Golang in the token parsing component.
+
+[id="about-release-464_{context}"]
+== About release 4.6.4
+
+*Release date*: 31 March 2025
+
+This release of {product-title-short} fixes the following bugs:
+
+//ROX-28192
+* Fixed an issue where Scanner V4 performed TLS validation even for integrations where TLS validation was disabled.
+
+//ROX-28495
+* Fixed an issue that prevented the "Container CPU Limit" field from being added to security policy rules.
+
+//ROX-28200
+* Fixed an issue where the *Network Policies* tab in the network graph detail view would hang in the PatternFly Code editor due to a potential issue with the Monaco-based text editor.
+
+This release of {product-title-short} fixes the following security vulnerabilities:
+
+* link:https://access.redhat.com/security/cve/cve-2025-27144[CVE-2025-27144]: Flaw in Go JOSE versions prior to 4.0.5.
+* link:https://access.redhat.com/security/cve/cve-2025-22868[CVE-2025-22868]: Flaw in Golang in the token parsing component.
+* link:https://access.redhat.com/security/cve/cve-2025-22869[CVE-2025-22869]: Flaw in `golang.org/x/crypto` Secure Shell (SSH) file transfer implementation.
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
replaces #91187 to squash commits before merging