### PR TITLE
Update log6x-loki-sizing.adoc

### DIFF
--- a/modules/log6x-loki-sizing.adoc
+++ b/modules/log6x-loki-sizing.adoc
@@ -85,7 +85,7 @@ It is not possible to change the number `1x` for the deployment size.
 |590Gi
 
 |Total disk requests if using the ruler
-|80Gi
+|60Gi
 |910Gi
 |750Gi
 |750Gi


### PR DESCRIPTION
1x.demo Total disk requests if using the ruler is 80Gi, but it is 60Gi.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> RHOCP 4.15 to 4.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->https://issues.redhat.com/browse/OBSDOCS-1781

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
