### PR TITLE
Adds important note to OMR ensuring that it's not intended to be used…

### DIFF
--- a/disconnected/mirroring/installing-mirroring-creating-registry.adoc
+++ b/disconnected/mirroring/installing-mirroring-creating-registry.adoc
@@ -10,6 +10,11 @@ The _mirror registry for Red Hat OpenShift_ is a small and streamlined container
 
 If you already have a container image registry, such as Red Hat Quay, you can skip this section and go straight to xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the OpenShift Container Platform image repository].
 
+[IMPORTANT]
+====
+The _mirror registry for Red Hat OpenShift_ is not intended to be a substitute for a production deployment of {quay}.
+====
+
 [id="prerequisites_installing-mirroring-creating-registry"]
 == Prerequisites
 


### PR DESCRIPTION
This was originally addressed in https://github.com/openshift/openshift-docs/pull/79511, but another ticket popped up. Wanted to add that as an important note at the beginning of the docs. 

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-54438

Link to docs preview:
https://91358--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-creating-registry.html

QE not needed. This is already mentioned in the Limitations section, but wanted to call it out sooner. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
