### PR TITLE
OSDOCS-9296: Updating Node Tuning Operator content for ROSA and Classic

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1330,6 +1330,9 @@ Distros: openshift-rosa
 Topics:
 - Name: Overview of nodes
   File: index
+- Name: Using the Node Tuning Operator
+  File: using-node-tuning-operator
+  Distros: openshift-rosa
 - Name: Working with pods
   Dir: pods
   Topics:

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1020,6 +1020,9 @@ Distros: openshift-rosa-hcp
 Topics:
 - Name: Overview of nodes
   File: index
+- Name: Using the Node Tuning Operator
+  File: using-node-tuning-operator
+  Distros: openshift-rosa-hcp
 - Name: Working with pods
   Dir: pods
   Topics:

--- a/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
+++ b/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
@@ -16,7 +16,7 @@ Use this process to access an example Node Tuning Operator specification.
 +
 [source,terminal]
 ----
-oc get tuned.tuned.openshift.io/default -o yaml -n openshift-cluster-node-tuning-operator
+$ oc get tuned.tuned.openshift.io/default -o yaml -n openshift-cluster-node-tuning-operator
 ----
 
 The default CR is meant for delivering standard node-level tuning for the {product-title} platform and it can only be modified to set the Operator Management state. Any other custom changes to the default CR will be overwritten by the Operator. For custom tuning, create your own Tuned CRs. Newly created CRs will be combined with the default CR and custom tuning applied to {product-title} nodes based on node or pod labels and profile priorities.

--- a/nodes/using-node-tuning-operator.adoc
+++ b/nodes/using-node-tuning-operator.adoc
@@ -1,0 +1,1 @@
+../scalability_and_performance/using-node-tuning-operator.adoc

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -31,6 +31,8 @@ include::modules/node-tuning-hosted-cluster.adoc[leveloffset=+1]
 
 include::modules/advanced-node-tuning-hosted-cluster.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../hosted_control_planes/index.adoc#hosted-control-planes-overview[{hcp-capital} overview]
+endif::openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
`enterprise-4.18+`

Issue:

This PR covers the following OSDOCS tickets:

1. **[OSDOCS-5963](https://issues.redhat.com/browse/OSDOCS-5963)**
2. **[OSDOCS-9296](https://issues.redhat.com/browse/OSDOCS-9296)**

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR combines several old JIRA tickets that update the Node Tuning Operator content.