### PR TITLE
[enterprise-4.19] OCPBUGS:48509 Configuring Linux cgroup docs are referencing to enabled psi which has been disabled with 4.16.7

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -187,11 +187,10 @@ spec:
   kernelArguments:
     systemd.unified_cgroup_hierarchy=0 <1>
     systemd.legacy_systemd_cgroup_controller=1 <2>
-    psi=1 <3>
+    psi=0
 ----
 <1> Disables cgroup v2.
 <2> Enables cgroup v1 in systemd.
-<3> Enables the Linux Pressure Stall Information (PSI) feature.
 
 . Check the nodes to see that scheduling on the nodes is disabled. This indicates that the change is being applied:
 +


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/89615