### PR TITLE
OSDOCS-11940: specify Arm nodes not yet available for Virtualization

### DIFF
--- a/modules/virt-supported-cluster-version.adoc
+++ b/modules/virt-supported-cluster-version.adoc
@@ -7,3 +7,8 @@
 = Supported cluster versions for {VirtProductName}
 
 {VirtProductName} {VirtVersion} is supported for use on {product-title} {product-version} clusters. To use the latest z-stream release of {VirtProductName}, you must first upgrade to the latest version of {product-title}.
+
+[NOTE]
+====
+{VirtProductName} is currently available on x86-64 CPUs. Arm-based nodes are not yet supported.
+====


### PR DESCRIPTION
[OSDOCS-11940](https://issues.redhat.com//browse/OSDOCS-11940): specify Arm nodes not yet available for Virtualization

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-11940

Link to docs preview:
OCP: https://91369--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt.html
ROSA Classic: https://91369--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/about_virt/about-virt.html
ROSA HCP: https://91369--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/virt/about_virt/about-virt.html

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
