### PR TITLE
OSDOCS#3814: Update the z-stream RN for 4.18.7

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2995,6 +2995,36 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.7
+[id="ocp-4-18-7_{context}"]
+=== RHBA-2025:3293 - {product-title} {product-version}.7 bug fix update 
+
+Issued: 01 April 2025
+
+{product-title} release {product-version}.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:3293[RHBA-2025:3293] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3295[RHBA-2025:3295] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.7 --pullspecs
+----
+
+[id="ocp-4-18-7-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when a proxy was configured, the installation program added the `machineNetwork` Classless Inter-Domain Routing (CIDR) to the `noProxy` field. If the `machineNetwork` CIDR was also configured by the user in `noProxy`, this resulted in a duplicate entry. A duplicate entry was not allowed by ignition and possibly prevented the host from booting properly. With this release, the fix ensures that the installation program does not add the `machineNetwork` CIDR to `noProxy` if it is already set. (link:https://issues.redhat.com/browse/OCPBUGS-53183[*OCPBUGS-53183*])
+
+* Previously, an `unable to read image` error message occurred when building the agent ISO in a disconnected setup. With this release, the error message does not appear. (link:https://issues.redhat.com/browse/OCPBUGS-52515[*OCPBUGS-52515*])
+
+* Previously, the code blocked the image import from a blocked registry. With this release, the image import from the registry is not blocked when the registry has mirrors configured. (link:https://issues.redhat.com/browse/OCPBUGS-52312[*OCPBUGS-52312*])
+
+[id="ocp-4-18-7-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.6
 [id="ocp-4-18-6_{context}"]
 === RHSA-2025:3066 - {product-title} {product-version}.6 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-3814](https://issues.redhat.com//browse/OSDOCS-3814)

Link to docs preview:
[4.18.7](https://91371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-7_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
 The errata URLs will return 404 until the go-live date of 04/01/25.
