### PR TITLE
OBSDOCS-1793: Logging Z-Stream Release Notes - 5.8.19

### DIFF
--- a/modules/logging-release-notes-5-8-19.adoc
+++ b/modules/logging-release-notes-5-8-19.adoc
@@ -1,0 +1,23 @@
+// module included in /logging/logging-5-8-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-19_{context}"]
+= Logging 5.8.19
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:3447[RHBA-2025:3447] and link:https://access.redhat.com/errata/RHSA-2025:3448[RHSA-2025:3448].
+
+[id="logging-release-notes-5-8-19-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]
+* link:https://access.redhat.com/security/cve/CVE-2020-11023[CVE-2020-11023]
+* link:https://access.redhat.com/security/cve/CVE-2024-2236[CVE-2024-2236]
+* link:https://access.redhat.com/security/cve/CVE-2024-2511[CVE-2024-2511]
+* link:https://access.redhat.com/security/cve/CVE-2024-3596[CVE-2024-3596]
+* link:https://access.redhat.com/security/cve/CVE-2024-4603[CVE-2024-4603]
+* link:https://access.redhat.com/security/cve/CVE-2024-4741[CVE-2024-4741]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+* link:https://access.redhat.com/security/cve/CVE-2024-12797[CVE-2024-12797]
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-24528[CVE-2025-24528]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
+* link:https://access.redhat.com/security/cve/CVE-2025-27610[CVE-2025-27610]

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-19.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-18.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-17.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.12, 4.13, 4.14, 4.15

Issue: https://issues.redhat.com/browse/OBSDOCS-1793

Link to docs preview: https://91372--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html#logging-release-notes-5-8-19_logging-5-8-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
