### PR TITLE
OCPBUGS-52488: Removed note from configuring-egress-ips-ovn.adoc

### DIFF
--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -11,17 +11,21 @@ As a cluster administrator, you can configure the OVN-Kubernetes Container Netwo
 
 [IMPORTANT]
 ====
-In an installer-provisioned infrastructure cluster, do not assign egress IP addresses to the infrastructure node that already hosts the ingress VIP. For more information, see the Red{nbsp}Hat Knowledgebase solution link:https://access.redhat.com/solutions/7069883[POD from the egress IP enabled namespace cannot access OCP route in an IPI cluster when the egress IP is assigned to the infra node that already hosts the ingress VIP].
+Configuring egress IPs is not supported for {hcp-title} clusters at this time. 
 ====
 
+// Egress IP address architectural design and implementation
 include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 
+// EgressIP object
 include::modules/nw-egress-ips-object.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa[]
+// The egressIPConfig object
 include::modules/nw-egress-ips-config-object.adoc[leveloffset=+1]
 endif::openshift-rosa[]
 
+// Labeling a node to host egress IP addresses
 include::modules/nw-egress-ips-node.adoc[leveloffset=+1]
 
 [id="configuring-egress-ips-next-steps"]


### PR DESCRIPTION
Cherry pick of #90684 with commit ID 21ff04d3ca35a095879546534a061d5d511101e8

Version(s):
4.15

Issue:
[OCPBUGS-52488](https://issues.redhat.com/browse/OCPBUGS-52488)

Link to docs preview:
https://91384--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html
