### PR TITLE
OBSDOCS#1326: Improve 'troubleshooting monitoring issues,  - post OCPBUGS#39126

### DIFF
--- a/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
+++ b/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
@@ -23,7 +23,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 .Procedure
 
-. Ensure that your project is not excluded from user workload monitoring. The following examples use the `ns1` project.
+. Ensure that your project and resources are not excluded from user workload monitoring. The following examples use the `ns1` project.
 
 .. Verify that the project _does not_ have the `openshift.io/user-monitoring=false` label attached:
 +
@@ -37,12 +37,25 @@ $ oc get namespace ns1 --show-labels | grep 'openshift.io/user-monitoring=false'
 The default label set for user workload projects is `openshift.io/user-monitoring=true`. However, the label is not visible unless you manually apply it.
 ====
 
+.. Verify that the `ServiceMonitor` and `PodMonitor` resources _do not_ have the `openshift.io/user-monitoring=false` label attached. The following example checks the `prometheus-example-monitor` service monitor.
++
+[source,terminal]
+----
+$ oc -n ns1 get servicemonitor prometheus-example-monitor --show-labels | grep 'openshift.io/user-monitoring=false'
+----
+
 .. If the label is attached, remove the label:
 +
 .Example of removing the label from the project
 [source,terminal]
 ----
 $ oc label namespace ns1 'openshift.io/user-monitoring-'
+----
++
+.Example of removing the label from the resource
+[source,terminal]
+----
+$ oc -n ns1 label servicemonitor prometheus-example-monitor 'openshift.io/user-monitoring-'
 ----
 +
 .Example output
@@ -66,7 +79,7 @@ $ oc -n ns1 get service prometheus-example-app -o yaml
     app: prometheus-example-app
 ----
 +
-.. Check that the `matchLabels` definition in the `ServiceMonitor` resource configuration matches the label output in the preceding step.
+.. Check that the `matchLabels` definition in the `ServiceMonitor` resource configuration matches the label output in the previous step.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 and later
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1326
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://91401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/troubleshooting-monitoring-issues.html#investigating-why-user-defined-metrics-are-unavailable_troubleshooting-monitoring-issues
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: this is done separately from https://github.com/openshift/openshift-docs/pull/91118 due to the difference in version in which this needs to be applied.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
