### PR TITLE
OLS-1614: Release Notes for Lightspeed 0.3.3

### DIFF
--- a/modules/ols-0-1-5-release-notes.adoc
+++ b/modules/ols-0-1-5-release-notes.adoc
@@ -7,7 +7,7 @@
 
 Issued: 12 September 2024
 
-{ols-official} 0.1.5 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.1.5 is now available on {ocp-product-title} 4.15 and later.
 
 [id="ols-0-1-5-enhancements_{context}"]
 == Enhancements

--- a/modules/ols-0-1-6-release-notes.adoc
+++ b/modules/ols-0-1-6-release-notes.adoc
@@ -5,7 +5,7 @@
 [id="ols-0-1-6-release-notes_{context}"]
 = {ols-long} version 0.1.6
 
-{ols-official} 0.1.6 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.1.6 is now available on {ocp-product-title} 4.15 and later.
 
 [id="ols-0-1-6-enhancements_{context}"]
 == Enhancements

--- a/modules/ols-0-1-7-release-notes.adoc
+++ b/modules/ols-0-1-7-release-notes.adoc
@@ -5,7 +5,7 @@
 [id="ols-0-1-7-release-notes_{context}"]
 = {ols-long} version 0.1.7
 
-{ols-official} 0.1.7 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.1.7 is now available on {ocp-product-title} 4.15 and later.
 
 [id="ols-0-1-7-enhancements_{context}"]
 == Enhancements

--- a/modules/ols-0-2-0-release-notes.adoc
+++ b/modules/ols-0-2-0-release-notes.adoc
@@ -5,7 +5,7 @@
 [id="ols-0-2-0-release-notes_{context}"]
 = {ols-long} version 0.2.0
 
-{ols-official} 0.2.0 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.2.0 is now available on {ocp-product-title} 4.15 and later.
 
 [id="ols-0-2-2-enhancements_{context}"]
 == Enhancements

--- a/modules/ols-0-2-1-release-notes.adoc
+++ b/modules/ols-0-2-1-release-notes.adoc
@@ -5,7 +5,7 @@
 [id="ols-0-2-1-release-notes_{context}"]
 = {ols-long} version 0.2.1
 
-{ols-official} 0.2.1 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.2.1 is now available on {ocp-product-title} 4.15 and later.
 
 [id="ols-0-2-1-enhancements_{context}"]
 == Enhancements

--- a/modules/ols-0-3-0-release-notes.adoc
+++ b/modules/ols-0-3-0-release-notes.adoc
@@ -5,11 +5,11 @@
 [id="ols-0-3-0-release-notes_{context}"]
 = {ols-long} version 0.3.0
 
-{ols-official} 0.3.0 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.3.0 is now available on {ocp-product-title} 4.15 and later.
 
 [IMPORTANT]
 ====
-{ols-official} is designed for FIPS. When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/compliance_activities_and_gov_standards#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
+{ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/compliance_activities_and_gov_standards#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
 ====
 
 [id="ols-0-3-0-enhancements_{context}"]

--- a/modules/ols-0-3-2-release-notes.adoc
+++ b/modules/ols-0-3-2-release-notes.adoc
@@ -5,11 +5,11 @@
 [id="ols-0-3-2-release-notes_{context}"]
 = {ols-long} version 0.3.2
 
-{ols-official} 0.3.2 is now available on {ocp-product-title} 4.15 or later.
+{ols-official} 0.3.2 is now available on {ocp-product-title} 4.15 and later.
 
 [IMPORTANT]
 ====
-{ols-official} is designed for FIPS. When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/compliance_activities_and_gov_standards#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
+{ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/compliance_activities_and_gov_standards#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
 ====
 
 [id="ols-0-3-2-enhancements_{context}"]

--- a/modules/ols-0-3-3-fixed-issues.adoc
+++ b/modules/ols-0-3-3-fixed-issues.adoc
@@ -1,0 +1,11 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-3-3-fixed-issues_{context}"]
+= Fixed issues
+
+The following issues are fixed with {ols-official} 0.3.3:
+
+* Previously, the {ols-long} Operator would attempt to reconcile the {ols-long} Service even when the API token key was missing. The Service did not start, and no error was generated. Now, the {ols-long} Operator checks that the secret holding the API token for the large language model (LLM) provider contains the `apitoken` key before reconciling the Service. If the token key is missing, the Operator generates an error message in the `status` field of the `OLSConfig` custom resource file. link:https://issues.redhat.com/browse/OLS-1449[OLS-1449].

--- a/modules/ols-0-3-3-release-notes.adoc
+++ b/modules/ols-0-3-3-release-notes.adoc
@@ -2,19 +2,21 @@
 // * lightspeed-docs-main/release_notes/ols-release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="ols-0-3-1-release-notes_{context}"]
-= {ols-long} version 0.3.1
+[id="ols-0-3-3-release-notes_{context}"]
+= {ols-long} version 0.3.3
 
-{ols-official} 0.3.1 is now available on {ocp-product-title} 4.15 and later.
+{ols-official} 0.3.3 is now available on {ocp-product-title} 4.15 and later.
 
 [IMPORTANT]
 ====
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/compliance_activities_and_gov_standards#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
 ====
 
-[id="ols-0-3-1-enhancements_{context}"]
+[id="ols-0-3-3-enhancements_{context}"]
 == Enhancements
 
-The following enhancements are made with {ols-official} 0.3.1:
+The following enhancements are made with {ols-official} 0.3.3:
 
-* Beginning with this release, {ols-long} streams large language model (LLM) responses, providing a faster response time and an improved user experience.
+* This release adds the ability to upload YAML files from your computer. You can attach a YAML file for any {k8s} resource to the prompt you send to the {ols-long} Service. Adding the file to the prompt provides additional context when the Service generates an answer.
+
+* This release adds a PostgreSQL database as the conversation cache. The conversation cache present in the PostgeSQL database is not backed up in the file system so the conversation cache is lost if the PostgreSQL pod restarts.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 The release notes highlight what is new and what has changed with each {ols-official} release.
 
+include::modules/ols-0-3-3-release-notes.adoc[leveloffset=+1]
+include::modules/ols-0-3-3-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-2-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-3-2-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-1-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1614
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://91414--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-0-3-3-release-notes_ols-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
