### PR TITLE
TELCODOCS-2150: Removing redundant flag

### DIFF
--- a/modules/ptp-configuring-dynamic-leap-seconds-handling-for-tgm.adoc
+++ b/modules/ptp-configuring-dynamic-leap-seconds-handling-for-tgm.adoc
@@ -36,9 +36,8 @@ Set the following options:
 +
 [source,yaml]
 ----
-phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -S 2 -s ens2f0 -n 24 <1>
+phc2sysOpts: -r -u 0 -m -N 8 -R 16 -S 2 -s ens2f0 -n 24 <1>
 ----
-<1> Set `-w` to force `phc2sys` to wait until `ptp4l` has synchronized the system hardware clock before starting its own synchronization process.
 +
 [NOTE]
 ====

--- a/snippets/ptp_PtpConfigDualCardGmWpc.yaml
+++ b/snippets/ptp_PtpConfigDualCardGmWpc.yaml
@@ -10,7 +10,7 @@ spec:
   profile:
     - name: "grandmaster"
       ptp4lOpts: "-2 --summary_interval -4"
-      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_nic1 -n 24
+      phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s $iface_nic1 -n 24
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10
       ptpSettings:

--- a/snippets/ptp_PtpConfigGmWpc.yaml
+++ b/snippets/ptp_PtpConfigGmWpc.yaml
@@ -8,7 +8,7 @@ spec:
   profile:
     - name: "grandmaster"
       ptp4lOpts: "-2 --summary_interval -4"
-      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -s $iface_master -n 24
+      phc2sysOpts: -r -u 0 -m -N 8 -R 16 -s $iface_master -n 24
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10
       ptpSettings:


### PR DESCRIPTION
[TELCODOCS-2150](https://issues.redhat.com//browse/TELCODOCS-2150): Removing redundant flag `-w`

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2150 

Link to docs preview:
- https://91420--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp.html#ptp-configuring-dynamic-leap-seconds-handling-for-tgm_configuring-ptp
- https://91420--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp.html#configuring-linuxptp-services-as-grandmaster-clock_configuring-ptp
- https://91420--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp.html#configuring-linuxptp-services-as-grandmaster-clock-dual-nic_configuring-ptp


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
