### PR TITLE
OSDOCS-13816: 4.16.38 RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3354,6 +3354,79 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.38
+[id="ocp-4-16-38_{context}"]
+=== RHSA-2025:3301 - {product-title} {product-version}.38 bug fix and security update
+
+Issued: 02 April 2025
+
+{product-title} release {product-version}.38 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3301[RHSA-2025:3301] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3303[RHBA-2025:3303] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.38 --pullspecs
+----
+
+[id="ocp-4-16-38-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, installing an {aws-short} cluster in either the Commercial Cloud Services (C2S) region or the Secret Commercial Cloud Services (SC2S) region failed because the installation program added unsupported security groups to the load balancer. With this release, the installation program no longer adds unsupported security groups to the load balancer. (link:https://issues.redhat.com/browse/OCPBUGS-53459[*OCPBUGS-53459*])
+
+* Previously, during cluster shutdown, a race condition prevented a stage `ostree` deployment from finalizing if the deployment was moved to a staging location during a reboot operation. With this release, a fix removes the race condition from the `ostree` deployment. (link:https://issues.redhat.com/browse/OCPBUGS-53313[*OCPBUGS-53313*])
+
+* Previously, the `trusted-ca-bundle-managed` ConfigMap component was a mandatory component. With this release, this component is optional and allows you to deploy clusters without the `trusted-ca-bundle-managed` ConfigMap component when you use a custom PKI. (link:https://issues.redhat.com/browse/OCPBUGS-52857[*OCPBUGS-52857*])
+
+* Previously, the *Observe* section on the web console did not show items contributed from plugins unless certain flags related to the monitoring were set. However, these flags prevented other plugins, such as logging or network observability from adding items to the *Observe* section. With this release, the monitoring flags are removed so that other plugins can add items to the *Observe* section. (link:https://issues.redhat.com/browse/OCPBUGS-52851[*OCPBUGS-52851*])
+
+* Previously, the *Cluster Settings* page would not properly render during a cluster update if the `ClusterVersion` did not receive a `Completed` update. With this release, the *Cluster Setting* page properly renders even if the `ClusterVersion` has not received a `Completed` update. (link:https://issues.redhat.com/browse/OCPBUGS-52450[*OCPBUGS-52450*])
+
+* Previously, the cluster autoscaler occasionally left a node with a `PreferNoSchedule` taint during deletion. With this release, the maximum bulk deletion limit is disabled so that nodes with this taint no longer remain after deletion. (link:https://issues.redhat.com/browse/OCPBUGS-52329[*OCPBUGS-52329*])
+
+* Previously, when the OVN-Kubernetes network plugin and the Kubernetes-NMState Operator interacted with each other, unexpected connection profiles persisted on disk storage. These connection profiles sometimes caused the `ovs-configuration` service to fail when restarted. With this release, the connection profiles are fixed so the issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-52310[*OCPBUGS-52310*])
+
+* Previously, the alert links on the *Alert rules* page of the *Developer* perspective included external labels to invalid links. This happened because the URL for the *Alerts* page did not expect external labels. With this release, the external labels are no longer added to the alert URL so the alert links are accurate. (link:https://issues.redhat.com/browse/OCPBUGS-52252[*OCPBUGS-52252*])
+
+* Previously, when a worker node tried to join a cluster, the rendezvous node rebooted before the process was completed. This caused the installation to be unsuccessful. With this release, a patch is applied that fixes the racing condition and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-51362[*OCPBUGS-51362*])
+
+* Previously, installations could fail when the Assisted Installer agent attempted to pull images because the timeout time of thirty seconds was too short. With this release, the timeout time has been extended, and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-51346[*OCPBUGS-51346*])
+
+* Previously, for the Agent-based Installer, all host validation status logs referred to the name of the first-registered host. As a result, you could not determine the problem host when a host validation failed. With this release, the correct host is identified in each log message. (link:https://issues.redhat.com/browse/OCPBUGS-51207[*OCPBUGS-51207*])
+
+* Previously, the DNS-based egress firewall incorrectly prevented the creation of a firewall rule that contained a DNS name in uppercase characters. With this release, a fix no longer prevents a DNS name in uppercase characters. (link:https://issues.redhat.com/browse/OCPBUGS-51074[*OCPBUGS-51074*])
+
+* Previously, the control plane Operator did not honor the set `_PROXY` environment variables when it checked the API endpoint availability. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-50993[*OCPBUGS-50993*])
+
+* Previously, the availability set fault domain count was hardcoded to `2`. This value works in most regions, but failed in the `centraluseuap` and `eastusstg` regions. With this release, the availability set fault domain count is set dynamically for a region so that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-50966[*OCPBUGS-50966*])
+
+* Previously, a connectivity issue related to the auto-configuration of IPv6 addresses caused significant downtime during a live migration with LocalNet. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-50595[*OCPBUGS-50595*])
+
+* Previously, when a pod ran on a node with the egress IPv6 assigned to it, the pod was unable to communicate with the Kubernetes service in a dual stack cluster. This resulted in dropped traffic with the IP family. With this release, the risk of dropped traffic is eliminated. (link:https://issues.redhat.com/browse/OCPBUGS-50594[*OCPBUGS-50594*])
+
+* Previously, a custom Security Context Constraint (SCC) impacted pods that the Cluster Version Operator generated from receiving a cluster version upgrade. With this release, {product-title} now sets a default SCC to each pod, so that any custom SCC created does not impact a pod. (link:https://issues.redhat.com/browse/OCPBUGS-50590[*OCPBUGS-50590*])
+
+* Previously, you could not install an cluster on {aws-short} in the `ap-southeast-5` region or other regions because the {product-title} internal registry did not support these regions. With this release, the internal registry is updated to include the following regions so that this issue no longer occurs:
++
+** `ap-southeast-5`
+** `ap-southeast-7`
+** `ca-west-1`
+** `il-central-1`
+** `mx-central-1`
++
+(link:https://issues.redhat.com/browse/OCPBUGS-49696[*OCPBUGS-49696*])
+
+* Previously, a hosted cluster using the no-egress feature in ROSA and a container registry accessed through Amazon Virtual Private Cloud (VPC) endpoint failed to install because the `imagestreams` used by the container registry could not resolve. This was caused by the Konnectivity proxy using the `openshift-apiserver` in the control plane to resolve registry names with cloud API suffixes. With this release, the Konnectivity proxy resolves and routes hostnames consistently. (link:https://issues.redhat.com/browse/OCPBUGS-46466[*OCPBUGS-46466*])
+
+* Previously, the URL for the *Alert Rules* page on the web console was incorrect. With this release, the URL is fixed and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-46388[*OCPBUGS-46388*])
+
+* Previously, the persistent volume claim (PVC) from a hosted cluster was removed from a virtual machine (VM) after the VM was rebooted. However, the `VolumeAttachment` resource was not removed and this caused issues for the cluster as it expected the PVC to be attached to the VM. With this release, the `VolumeAttachment` resource is removed after a VM is rebooted so the issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-44622[*OCPBUGS-44622*])
+
+[id="ocp-4-16-38-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.37
 [id="ocp-4-16-37_{context}"]
 === RHSA-2025:1907 - {product-title} {product-version}.37 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-13816](https://issues.redhat.com/browse/OSDOCS-13816)

Link to docs preview:
https://91467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-38_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (4/2/25)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
