### PR TITLE
ROX-21229: Remove incorrect network graph info

### DIFF
--- a/modules/simulate-network-policies-ng20.adoc
+++ b/modules/simulate-network-policies-ng20.adoc
@@ -17,8 +17,9 @@ The Network Graph does not display the generated policies in the visualization. 
 . In the {product-title-short} portal, go to *Network Graph*.
 . Select a cluster, and then select one or more namespaces.
 . On the network graph header, select *Network policy generator*.
-. Optional: To generate a YAML file with network policies to use in the simulation, click *Generate and simulate network policies*. For more information, see "Generating network policies in the network graph".
-. Upload a YAML file of a network policy that you want to use in the simulation. The network graph view displays what your proposed network policies would achieve. Perform the following steps:
+. You can perform the following actions:
+** Generate a YAML file with network policies to use in the simulation by clicking *Generate and simulate network policies*. For more information, see "Generating network policies in the network graph".
+** Upload a YAML file of a network policy that you want to use in the simulation by performing the following steps:
 .. Click *Upload YAML* and then select the file.
 .. Click *Open*. The system displays a message to indicate the processing status of the uploaded policy.
 . You can view active YAML files that correspond to the current network policies by clicking the *View active YAMLS* tab, and then selecting policies from the drop-down list. You can also perform the following actions:


### PR DESCRIPTION
Version(s):

4.5+

[Issue]([ROX-21229](https://issues.redhat.com/browse/ROX-21229))

[Link to docs preview
](https://91469--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-network-policies.html#simulate-network-policies-ng20_manage-network-policies)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
