### PR TITLE
OSDOCS:13913 Add reason for no Node Disrupt Policy for /etc/containers/registries.conf.d

### DIFF
--- a/modules/machine-config-node-disruption-example.adoc
+++ b/modules/machine-config-node-disruption-example.adoc
@@ -71,6 +71,8 @@ status:
   observedGeneration: 9
 ----
 
+The default node disruption policy does not contain a policy for changes to the `/etc/containers/registries.conf.d` file. This is because both {product-title} and {op-system-base-full} use the `registries.conf.d` file to specify aliases for image short names. It is recommended that you always pull an image by its fully-qualified name. This is particularly important with public registries, because the image might not deploy if the public registry requires authentication. You can create a user-defined policy to use with the `/etc/containers/registries.conf.d` file, if you need to use image short names. 
+
 In the following example, when changes are made to the SSH keys, the MCO drains the cluster nodes, reloads the `crio.service`, reloads the systemd configuration, and restarts the `crio-service`.
 
 .Example node disruption policy for an SSH key change


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13913

Follow-up of https://github.com/openshift/openshift-docs/pull/91440, which was closed in error.

Preview
Example node disruption policies -> [Default node disruption policy](https://91476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-node-disruption#machine-config-node-disruption-example_machine-configs-configure) - Paragraph after code block.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
