### PR TITLE
OSDOCS-12848: Added /etc/resolv.conf modification to resolve DNS conn…

### DIFF
--- a/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
+++ b/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
@@ -92,6 +92,30 @@ metadata:
 EOF
 ----
 
+. If your cluster has problems with the DNS health check probe because of DNS connectivity issues, you can add the following DNS host name configuration to the `NMState` CRD to build in health checks that can resolve these issues:
++
+[source,terminal]
+----
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate
+spec:
+  probeConfiguration:
+    dns:
+      host: redhat.com
+# ...
+----
++
+.. Apply the DNS host name configuration to your cluster network by running the following command. Ensure that you replace `<filename>` with the name of your CRD file.
++
+[source,yaml]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
 . Verify that all pods for the NMState Operator are in a `Running` state:
 +
 [source,terminal]

--- a/modules/k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc
+++ b/modules/k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc_{context}"]
+= Creating a custom DNS host name to resolve DNS connectivity issues
+
+In a disconnected environment where the external DNS server cannot be reached, you can resolve Kubernetes NMState Operator health probe issues by specifying a custom DNS host name in the `NMState` custom resource definition (CRD). 
+
+.Procedure
+
+. Add the DNS host name configuration to the `NMState` CRD of your cluster:
++
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate
+spec:
+  probeConfiguration:
+    dns:
+      host: redhat.com
+# ...
+----
+
+. Apply the DNS host name configuration to your cluster network by running the following command. Ensure that you replace `<filename>` with the name of your CRD file.
++
+[source,yaml]
+----
+$ oc apply -f <filename>.yaml
+----
+
+
+
+

--- a/modules/k8s-nmstate-troubleshooting-dns-disconnected-env.adoc
+++ b/modules/k8s-nmstate-troubleshooting-dns-disconnected-env.adoc
@@ -6,7 +6,7 @@
 [id="troubleshooting-dns-disconnected-env_{context}"]
 = Troubleshooting DNS connectivity issues in a disconnected environment
 
-If you experience DNS connectivity issues when configuring `nmstate` in a disconnected environment, you can configure the DNS server to resolve the list of name servers for the domain `root-servers.net`.
+If you experience health check probe issues when configuring `nmstate` in a disconnected environment, you can configure the DNS server to resolve the custom domain name instead of the default `root-servers.net` domain.
 
 [IMPORTANT]
 ====
@@ -15,8 +15,7 @@ Ensure that the DNS server includes a name server (NS) entry for the `root-serve
 
 == Configuring the bind9 DNS named server  
 
-For a cluster configured to query a `bind9` DNS server, you can add the `root-servers.net` zone to a configuration file that contains at least one NS record.
-For example you can use the `/var/named/named.localhost` as a zone file that already matches this criteria.
+For a cluster configured to query a `bind9` DNS server, you can add the `root-servers.net` zone to a configuration file that contains at least one DNS record. For example you can use the `/var/named/named.localhost` as a zone file that already matches this criteria.
 
 .Procedure
 

--- a/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
@@ -14,8 +14,14 @@ This includes issues such as:
 * The host loses connection to the default gateway.
 * The host loses connection to the API server.
 
+// Troubleshooting an incorrect node network configuration policy configuration
 include::modules/virt-troubleshooting-incorrect-policy-config.adoc[leveloffset=+1]
 
+// Troubleshooting DNS connectivity issues in a disconnected environment
 include::modules/k8s-nmstate-troubleshooting-dns-disconnected-env.adoc[leveloffset=+1]
 
+// Creating a custom DNS host name to resolve DNS connectivity issues
+include::modules/k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc[leveloffset=+2]
+
+// Configuring the dnsmasq DNS server
 include::modules/k8s-nmstate-troubleshooting-dns-disconnected-env-dnsmasq.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-12848](https://issues.redhat.com/browse/OSDOCS-12848)

Link to docs preview:
* [Creating a custom DNS host name to resolve DNS connectivity issues](https://91520--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.html#k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc_k8s-nmstate-troubleshooting-node-network)
* [Installing the Kubernetes NMState Operator by using the CLI](https://91520--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html#installing-the-kubernetes-nmstate-operator-CLI_k8s-nmstate-operator)


- [x] SME has approved this change (Mat K).
- [x] QE has approved this change (Ross.B).

