### PR TITLE
CNV#54770: 4.17.7 HCO bump

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -105,7 +105,7 @@ endif::[]
 //openshift virtualization (cnv)
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.17
-:HCOVersion: 4.17.5
+:HCOVersion: 4.17.7
 :CNVNamespace: openshift-cnv
 :CNVOperatorDisplayName: OpenShift Virtualization Operator
 :CNVSubscriptionSpecSource: redhat-operators


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-54770](https://issues.redhat.com//browse/CNV-54770)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: N/A
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This release has shipped. 4.17.6 was a candidate release so the HCO version is going up by two instead of one.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
