### PR TITLE
Tainting nodes fail for Daemonsets

### DIFF
--- a/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
+++ b/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
@@ -78,6 +78,8 @@ spec:
 +
 These examples place a taint on `node1` that has the `node-role.kubernetes.io/infra` key and the `NoSchedule` taint effect. Nodes with the `NoSchedule` effect schedule only pods that tolerate the taint, but allow existing pods to remain scheduled on the node. 
 +
+If you added a `NoSchedule` taint to the infrastructure node, any pods that are controlled by a daemon set on that node are marked as `misscheduled`. You must either delete the pods or add a toleration to the pods as shown in the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods]. Note that you cannot add a toleration to a daemon set object that is managed by an operator.
++
 [NOTE]
 ====
 If a descheduler is used, pods violating node taints could be evicted from the cluster.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-43624

Previews:
Machine management -> Creating infrastructure machine sets -> [Binding infrastructure node workloads using taints and tolerations](https://91556--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#binding-infra-node-workloads-using-taints-tolerations_creating-infrastructure-machinesets) -- New paragraph in step 1b, after tip.
Postinstallation configuration -> Cluster tasks -> [Binding infrastructure node workloads using taints and tolerations](https://91556--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#binding-infra-node-workloads-using-taints-tolerations_post-install-cluster-tasks) -- New paragraph in step 1b, after tip.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
