### PR TITLE
OSDOCS-13286: adds RHOAI relnote MicroShift

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -30,4 +30,5 @@
 :ov: OVMS
 :rpm-repo-version: rhocp-4.19
 :rhde-version: 4
+:rhoai: Red{nbsp}Hat OpenShift AI Self-Managed
 :VirtProductName: OpenShift Virtualization

--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -37,9 +37,6 @@ Updates for both single-version minor releases and patch releases are supported.
 
 //TODO add new features and enhancements as needed, follow doc TOC titles as L3s, then add L4 headings for each feature
 
-//[id="microshift-4-19-example-ra-feature_{context}"]
-//==== Example RA feature here
-
 [id="microshift-4-19-configuring_{context}"]
 === Configuring
 
@@ -51,8 +48,8 @@ Updates for both single-version minor releases and patch releases are supported.
 ==== {microshift-short} control plane enhanced with TLS
 With this release, configurable transport layer security (TLS) protocols on internal control plane components are enabled to help prevent known insecure protocols, ciphers, or algorithms from accessing the applications you run on {microshift-short}. You use either the TLS 1.2 or TLS 1.3 with {microshift-short}. For more information, see xref:../microshift_configuring/microshift_auth_security/microshift-tls-config.adoc#microshift-tls-config[Configuring TLS security profiles].
 
-[id="microshift-4-19-running-apps_{context}"]
-=== Running applications
+//[id="microshift-4-19-running-apps_{context}"]
+//=== Running applications
 
 [id="microshift-4-19-greenboot-updated_{context}"]
 ==== Check application health with the {microshift-short} healthcheck command
@@ -87,8 +84,13 @@ Some features in this release are currently in Technology Preview. These experim
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
-//[id="microshift-4-19-rhoai_{context}"]
-//=== Example Red Hat AI feature
+[id="microshift-4-19-ai_{context}"]
+=== Red{nbsp}Hat OpenShift AI with {microshift-short}
+
+[id="microshift-4-19-example-ra-feature_{context}"]
+==== Serve your trained models on edge deployments
+
+With this release, a streamlined version of Red{nbsp}Hat OpenShift AI (RHOAI) can be used to serve artificial intelligence or machine learning (AI/ML) models on {microshift-short}. Develop and train your AI models in the data center or cloud, then deploy them to the edge where these models can make decisions without a human user. For more information, see xref:../microshift_ai/microshift-rhoai.adoc#microshift-rhoai[Using Red{nbsp}Hat OpenShift AI with {microshift-short}].
 
 //TODO Gateway API might TP with this 4.19; there is no current epic. Discuss with PM as the release approaches.
 
@@ -152,6 +154,11 @@ See the https://docs.openshift.com/container-platform/4.19/release_notes/ocp-4-1
 See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.6_release_notes/index[Release Notes for Red{nbsp}Hat Enterprise Linux 9.6] for more information about {op-system-base}.
 //Use the latest compatible RHEL, expected to be 9.6
 
+[id="microshift-4-19-additional-release-notes-rhoai_{context}"]
+=== {rhoai} release notes
+See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest-1/html/release_notes/index[Release notes] for more information about {rhoai}.
+//TODO rhoai has a faster release cadence than OCP; get `latest` tag working
+
 [id="microshift-4-19-asynchronous-errata-updates_{context}"]
 == Asynchronous errata updates
 
@@ -167,7 +174,7 @@ Red{nbsp}Hat Customer Portal user accounts must have systems registered and cons
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
 [id="microshift-4-19-0-dp_{context}"]
-=== RHEA-2025:1234 - {microshift-short} 4.19. bug fix and security update advisory
+=== RHEA-2025:1234 - {microshift-short} 4.19.0 bug fix and security update advisory
 
 Issued: XX Month 2025
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13286](https://issues.redhat.com/browse/OSDOCS-13286)

Link to docs preview:
[Tech Preview/AI](https://91557--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-tech-preview_release-notes)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.

Additional information:
Feature PR, https://github.com/openshift/openshift-docs/pull/89987

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
