### PR TITLE
OSDOCS-13858: adds microshift-ai RPM to alt install guide

### DIFF
--- a/microshift_install_rpm_opt/microshift-install-optional-rpms.adoc
+++ b/microshift_install_rpm_opt/microshift-install-optional-rpms.adoc
@@ -34,11 +34,9 @@ include::modules/microshift-install-rpms-olm.adoc[leveloffset=+2]
 .Additional resources
 * xref:../microshift_running_apps/microshift_operators/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]
 
-
-//include::modules/microshift-install-rhoai.adoc[leveloffset=+2]
+include::modules/microshift-rhoai-install.adoc[leveloffset=+2]
 
 //additional resources for installing RHOAI
-//[role="_additional-resources"]
-//.Additional resources
-//* xref:../microshift_ai/microshift-ai.adoc#microshift-ai[Using Red{nbsp}Hat OpenShift AI with {microshift-short}]
-//should be an attribute for rhoai by the time this merges
+[role="_additional-resources"]
+.Additional resources
+* xref:../microshift_ai/microshift-rhoai.adoc#microshift-rh-openshift-ai[Using {rhoai} with {microshift-short}]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-13858](https://issues.redhat.com/browse/OSDOCS-13858)

Link to docs preview:
[Installing RHOAI RPM](https://91558--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm_opt/microshift-install-optional-rpms.html#microshift-rhoai-install_microshift-install-optional-rpm)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Feature PR, https://github.com/openshift/openshift-docs/pull/89987
Release note, https://github.com/openshift/openshift-docs/pull/91557

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
