### PR TITLE
OCPBUGS54500: The example of nodeDisruptionPolicy is incorrect

### DIFF
--- a/modules/machine-config-node-disruption-example.adoc
+++ b/modules/machine-config-node-disruption-example.adoc
@@ -113,7 +113,7 @@ spec:
       - restart:
           serviceName: chronyd.service
         type: Restart
-        path: /etc/chrony.conf
+      path: /etc/chrony.conf
     - actions:
       - type: None
       path: /var/run


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-54500

Preview: [Example node disruption policy for a configuration file change](https://91559--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-node-disruption.html#machine-config-node-disruption-example_machine-configs-configure)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
