### PR TITLE
Fixed the database permission details

### DIFF
--- a/modules/central-configuration-options-operator.adoc
+++ b/modules/central-configuration-options-operator.adoc
@@ -98,7 +98,11 @@ This parameter has the following constraints:
 * Connection string must be in keyword/value format as described in the PostgreSQL documentation. For more information, see the links in the *Additional resources* section.
 * Postgres 15 is the recommended and supported version. Red{nbsp}Hat has deprecated the support for Postgres 13 and will remove it in the newer versions of {product-title-short}.
 * Connections through PGBouncer are not supported.
-* User must be a superuser who can create and delete databases.
+* You must have the following permissions on the database:
+  ** Connection rights to the database.
+  ** Usage and create privileges on the schema.
+  ** Select, insert, update, and delete privileges on all tables.
+  ** Usage privileges on all sequences in the schema.
 
 | `central.db.tolerations`
 | If the node selector selects tainted nodes, use this parameter to specify a taint toleration key, value, and effect for Central DB. This parameter is mainly used for infrastructure nodes.


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-27873

The user requirements for an external database connection in the provided tables were incorrectly specified as requiring a superuser with database creation and deletion privileges. This PR updates the requirements.

Preview: https://91563--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp.html

Cherry-pick in:
- rhacs-docs-4.6
- rhacs-docs-4.7
- rhacs-docs-4.8
