### PR TITLE
OCPBUGS-46596-feat: Moved ec2:DescribeInstanceTypeOffering as a requi…

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -40,6 +40,7 @@ cluster, the IAM user requires the following permissions:
 * `ec2:DescribeInstanceCreditSpecifications`
 * `ec2:DescribeInstances`
 * `ec2:DescribeInstanceTypes`
+* `ec2:DescribeInstanceTypeOfferings`
 * `ec2:DescribeInternetGateways`
 * `ec2:DescribeKeyPairs`
 * `ec2:DescribeNatGateways`
@@ -300,7 +301,6 @@ If you are managing your cloud provider credentials with mint mode, the IAM user
 .Optional permissions for instance and quota checks for installation
 [%collapsible]
 ====
-* `ec2:DescribeInstanceTypeOfferings`
 * `servicequotas:ListAWSDefaultServiceQuotas`
 ====
 


### PR DESCRIPTION
Version(s):
4.19 only

Issue:
[OCPBUGS-46596](https://issues.redhat.com/browse/OCPBUGS-46596)

Link to docs preview:
[Required AWS permissions for the IAM user: Configuring an AWS account](https://91581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions_installing-aws-account)
[Required AWS permissions for the IAM user: Installation requirements for user-provisioned infrastructure on AWS](https://91581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/upi-aws-installation-reqs.html#installation-aws-permissions_upi-aws-installation-reqs)

- [x] SME has approved this change (Marco Braga).
- [x] QE has approved this change (Yunfei Jiang).

