### PR TITLE
[enterprise-4.16] OCPBUGS54500: The example of nodeDisruptionPolicy is incorrect

### DIFF
--- a/modules/machine-config-node-disruption-example.adoc
+++ b/modules/machine-config-node-disruption-example.adoc
@@ -97,7 +97,7 @@ spec:
       - restart:
           serviceName: chronyd.service
         type: Restart
-        path: /etc/chrony.conf
+      path: /etc/chrony.conf
 ----
 
 In the following example, when changes are made to the `auditd.service`	systemd unit, the MCO drains the cluster nodes, reloads the `crio.service`, reloads the systemd manager configuration, and restarts the `crio.service`.


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/91559