### PR TITLE
OSDOCS-13972: Documented the 4.18.8 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3014,6 +3014,59 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.8
+[id="ocp-4-18-8_{context}"]
+=== RHSA-2025:3577 - {product-title} {product-version}.8 bug fix update and security update
+
+Issued: 09 April 2025
+
+{product-title} release {product-version}.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3577[RHSA-2025:3577] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3579[RHBA-2025:3579] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.8 --pullspecs
+----
+
+[id="ocp-4-18-8-known-issues_{context}"]
+==== Known issues
+
+* IPsec is not supported on {op-system-base-full} compute nodes because of a `libreswan` incompatiblility issue between a host and an `ovn-ipsec` container that exist in each compute node. (link:https://issues.redhat.com/browse/OCPBUGS-52949[*OCPBUGS-52949*]).
+
+[id="ocp-4-18-8-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, sometimes network interface controllers (NICs) attached to virtual machines (VMs) that ran on {azure-first} failed because the NICs were in a `ProvisioningFailed` state. With this release, the Machine API controller now checks the provisioning status of a NIC and refreshes the VMs on a regular basis. If a NIC is in `ProvisioningFailed` state, the VM now fails so that you have a better indication of the issue for troubleshooting purposes. (link:https://issues.redhat.com/browse/OCPBUGS-54355[*OCPBUGS-54355*]) 
+
+// SME review
+* Previously, selecting the *All projects* option on the *VolumeSnapshot* page of the web console in the *Administrator* perspective resulted in a `404: Page Not Found` error. With this release, a fix ensures that when you select the *All projects* option on the *VolumeSnapshot* page, the page shows results as expected without an error. (link:https://issues.redhat.com/browse/OCPBUGS-54269[*OCPBUGS-54269*])
+
+* Previously, the oc-mirror plugin v2 `delete` plugin had a typographical error in its `--help` argument output; the `--generate` listing stated `cahce` instead of `cache`. With this release, the typographical error is fixed to state `cache` in the `--generate` listing description. (link:https://issues.redhat.com/browse/OCPBUGS-54205[*OCPBUGS-54205*])
+
+* Previously, the output of the `oc-mirror --v2 version` command was missing the version information. With this release, the output from the command now correctly shows the version number. (link:https://issues.redhat.com/browse/OCPBUGS-53388[*OCPBUGS-53388*])
+
+* Previously, an update to the {ibm-cloud-name} Cloud Internet Services (CIS) implementation impacted the upstream Terraform plugin. If you attempted to create an external-facing cluster on {ibm-cloud-name}, the following error occurred:
++
+[source,terminal]
+----
+ERROR Error: Plugin did not respond
+ERROR
+ERROR   with module.cis.ibm_cis_dns_record.kubernetes_api_internal[0],
+ERROR   on cis/main.tf line 27, in resource "ibm_cis_dns_record" "kubernetes_api_internal":
+ERROR   27: resource "ibm_cis_dns_record" "kubernetes_api_internal" 
+----
++
+With this release, you can use the installation program to create an external cluster on {product-title} without the plugin issue. (link:https://issues.redhat.com/browse/OCPBUGS-53453[*OCPBUGS-53453*])
+
+* Previously, the Container Storage Interface (CSI) driver for the {gcp-first} persistent disk (PD) did not support the `hyperdisk-balanced` volume type when the `ReadWriteMany` (RWX) access mode was set. If you attempted to provision a `hyperdisk-balanced` volume with this configuration, an error occurred that suggested mounting the volume with RWX access mode enabled was not possible. With this release, you can now mount a `hyperdisk-balanced` volume when the RWX access mode is enabled so that this issue no longer persists. See the {gcp-short} documentation for further limitations when using Hyperdisk volumes in multi-writer mode. (link:https://issues.redhat.com/browse/OCPBUGS-44769[*OCPBUGS-44769*])
+
+[id="ocp-4-18-8-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.7
 [id="ocp-4-18-7_{context}"]
 === RHBA-2025:3293 - {product-title} {product-version}.7 bug fix update 


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13972](https://issues.redhat.com/browse/OSDOCS-13972)

Link to docs preview:
* [4.18.8](https://91601--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-8_release-notes)

