### PR TITLE
adding a step to rebase against main to the prow config instructions

### DIFF
--- a/scripts/prow/README.adoc
+++ b/scripts/prow/README.adoc
@@ -41,6 +41,8 @@ To add a new job to Prow CI, run the following commands:
 
 . Switch to you `openshift-docs` directory.
 
+. Check out the `main` branch, fetch from upstream, and rebase against upstream.
+
 . Create the new branch config by running the `add-new-prow-config.sh` script passing the `$VERSION`, `$BRANCH` and `$DISTROS` variables, for example:
 +
 [source,terminal]


### PR DESCRIPTION
The last two folks who have asked me about issues in setting up prow jobs wound up with older sets of tests. I think that running the command in `openshift-docs `from a freshly-rebased `main` branch should fix that.

@gaurav-nelson, PTAL?