### PR TITLE
OCPBUGS-52653 updated the tar code in step 3 and also added sentence in step 3 about unique cluster ID

### DIFF
--- a/modules/gathering-data-network-logs.adoc
+++ b/modules/gathering-data-network-logs.adoc
@@ -22,12 +22,12 @@ $ oc adm must-gather -- gather_network_logs
 ====
 By default, the `must-gather` tool collects the OVN `nbdb` and `sbdb` databases from all of the nodes in the cluster. Adding the `-- gather_network_logs` option to include additional logs that contain OVN-Kubernetes transactions for OVN `nbdb` database.
 ====
-. Create a compressed file from the `must-gather` directory that was just created in your working directory. For example, on a computer that uses a Linux operating system, run the following command:
+.  Create a compressed file from the `must-gather` directory that was just created in your working directory. Make sure you provide the date and cluster ID for the unique must-gather data. For more information about how to find the cluster ID, see link:https://access.redhat.com/solutions/5280291[How to find the cluster-id or name on OpenShift cluster]. For example, on a computer that uses a Linux operating system, run the following command:
 +
 [source,terminal]
 ----
-$ tar cvaf must-gather.tar.gz must-gather.local.472290403699006248 <1>
+$ tar cvaf must-gather-`date +"%m-%d-%Y-%H-%M-%S"`-<cluster_id>.tar.gz <must_gather_local_dir><1>
 ----
-<1> Replace `must-gather-local.472290403699006248` with the actual directory name.
+<1> Replace `<must_gather_local_dir>` with the actual directory name.
 
 . Attach the compressed file to your support case on the link:https://access.redhat.com/support/cases/#/case/list[the *Customer Support* page] of the Red Hat Customer Portal.

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -371,15 +371,13 @@ $ oc adm must-gather \
 <2> The must-gather image for KubeVirt
 
 ifndef::openshift-origin[]
-. Create a compressed file from the `must-gather` directory that was just created in your working directory. For example, on a computer that uses a Linux
-operating system, run the following command:
+. Create a compressed file from the `must-gather` directory that was just created in your working directory. Make sure you provide the date and cluster ID for the unique must-gather data. For more information about how to find the cluster ID, see link:https://access.redhat.com/solutions/5280291[How to find the cluster-id or name on OpenShift cluster]. For example, on a computer that uses a Linux operating system, run the following command:
 +
 [source,terminal]
 ----
-$ tar cvaf must-gather.tar.gz must-gather.local.5421342344627712289/ <1>
+$ tar cvaf must-gather-`date +"%m-%d-%Y-%H-%M-%S"`-<cluster_id>.tar.gz <must_gather_local_dir> <1>
 ----
-<1> Make sure to replace `must-gather-local.5421342344627712289/` with the
-actual directory name.
+<1> Replace `<must_gather_local_dir>` with the actual directory name.
 
 . Attach the compressed file to your support case on the link:https://access.redhat.com/support/cases/#/case/list[the *Customer Support* page] of the Red Hat Customer Portal.
 endif::openshift-origin[]

--- a/modules/support-gather-data.adoc
+++ b/modules/support-gather-data.adoc
@@ -75,14 +75,13 @@ Because this command picks a random control plane node by default, the pod might
 Contact Red Hat Support for the recommended resources to gather.
 ====
 
-. Create a compressed file from the `must-gather` directory that was just created in your working directory. For example, on a computer that uses a Linux
-operating system, run the following command:
+. Create a compressed file from the `must-gather` directory that was just created in your working directory. Make sure you provide the date and cluster ID for the unique must-gather data. For more information about how to find the cluster ID, see link:https://access.redhat.com/solutions/5280291[How to find the cluster-id or name on OpenShift cluster]. For example, on a computer that uses a Linux operating system, run the following command:
 +
 [source,terminal]
 ----
-$ tar cvaf must-gather.tar.gz must-gather.local.5421342344627712289/ <1>
+$ tar cvaf must-gather-`date +"%m-%d-%Y-%H-%M-%S"`-<cluster_id>.tar.gz <must_gather_local_dir> <1>
 ----
-<1> Make sure to replace `must-gather-local.5421342344627712289/` with the actual directory name.
+<1> Replace `<must_gather_local_dir>` with the actual directory name.
 
 ifndef::openshift-origin[]
 . Attach the compressed file to your support case on the link:https://access.redhat.com/support/cases/#/case/list[the *Customer Support* page] of the Red Hat Customer Portal.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-52653

Link to docs preview:
https://91615--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/gathering-cluster-data.html
https://91615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html
https://91615--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/gathering-cluster-data.html
https://91615--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/gathering-cluster-data.html


QE review:
- [x] QE has approved this change.

The following topic steps should have the same information:

- Gathering data about your cluster for Red Hat Support  (step 3)
- Gathering data about specific features (step 4)
- Gathering network logs (step 2)

