### PR TITLE
[enterprise-4.12] OCPBUGS-31917 added a note that states latency profiles do not suppor...

### DIFF
--- a/modules/nodes-cluster-worker-latency-profiles-about.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-about.adoc
@@ -118,4 +118,9 @@ The Kubernetes Controller Manager waits for 5 minutes to consider a node unhealt
 | 60s
 
 |===
+endif::openshift-rosa,openshift-dedicated[]
 
+[NOTE]
+====
+The latency profiles do not support custom machine config pools, only the default worker machine config pools.
+====


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/87859