### PR TITLE
MCO updated several 'Module included in' metadata

### DIFF
--- a/installing/installing_openstack/installing-openstack-user-sr-iov.adoc
+++ b/installing/installing_openstack/installing-openstack-user-sr-iov.adoc
@@ -69,7 +69,7 @@ include::modules/networking-osp-enabling-vfio-noiommu.adoc[leveloffset=+2]
 
 [NOTE]
 ====
-After you apply the machine config to the machine pool, you can xref:../../post_installation_configuration/machine-configuration-tasks.adoc#checking-mco-status_post-install-machine-configuration-tasks[watch the machine config pool status] to see when the machines are available.
+After you apply the machine config to the machine pool, you can xref:../../machine_configuration/machine-config-index.adoc#checking-mco-status_machine-config-overview[watch the machine config pool status] to see when the machines are available.
 ====
 
 // TODO: If bullet one of Next steps is truly required for this flow, these topics (in full or in part) could be added here rather than linked to.

--- a/modules/checking-mco-node-status-configuring.adoc
+++ b/modules/checking-mco-node-status-configuring.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/machine-configuration-tasks.adoc
+// * machine_configuration/machine-config-index.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="checking-mco-node-status-congifuring_{context}"]
@@ -130,7 +130,7 @@ Status:
     Status:                True
     Type:                  Drained
     Last Transition Time:  2025-01-14T15:45:55Z
-# ...  
+# ...
   Config Version:
     Current:            rendered-master-8110974a5cea69dff5b263237b58abd8
     Desired:            rendered-worker-823ff8dc2b33bf444709ed7cd2b9855b

--- a/modules/checking-mco-node-status.adoc
+++ b/modules/checking-mco-node-status.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/machine-configuration-tasks.adoc
+// * machine_configuration/machine-config-index.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="checking-mco-node-status_{context}"]

--- a/modules/checking-mco-status-certs.adoc
+++ b/modules/checking-mco-status-certs.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/machine-configuration-tasks.adoc
+// * machine_configuration/machine-config-index.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="checking-mco-status-certs_{context}"]

--- a/modules/machine-config-node-disruption-config.adoc
+++ b/modules/machine-config-node-disruption-config.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/machine-configuration-tasks.adoc
+// * machine_configuration/machine-config-node-disruption_machine-configs-configure.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="machine-config-node-disruption-config_{context}"]
@@ -60,10 +60,10 @@ spec:
         type: Restart
       name: test.service
 ----
-<1> Specifies the node disruption policy. 
+<1> Specifies the node disruption policy.
 <2> Specifies a list of machine config file definitions and actions to take to changes on those paths. This list supports a maximum of 50 entries.
 <3> Specifies the series of actions to be executed upon changes to the specified files. Actions are applied in the order that they are set in this list. This list supports a maximum of 10 entries.
-<4> Specifies that the listed service is to be reloaded upon changes to the specified files. 
+<4> Specifies that the listed service is to be reloaded upon changes to the specified files.
 <5> Specifies the full name of the service to be acted upon. 
 <6> Specifies the location of a file that is managed by a machine config. The actions in the policy apply when changes are made to the file in `path`.
 <7> Specifies a list of service names and actions to take upon changes to the SSH keys in the cluster.

--- a/modules/machine-config-node-disruption-example.adoc
+++ b/modules/machine-config-node-disruption-example.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/machine-configuration-tasks.adoc
+// * machine_configuration/machine-config-node-disruption_machine-configs-configure.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="machine-config-node-disruption-example_{context}"]
@@ -71,7 +71,7 @@ status:
   observedGeneration: 9
 ----
 
-The default node disruption policy does not contain a policy for changes to the `/etc/containers/registries.conf.d` file. This is because both {product-title} and {op-system-base-full} use the `registries.conf.d` file to specify aliases for image short names. It is recommended that you always pull an image by its fully-qualified name. This is particularly important with public registries, because the image might not deploy if the public registry requires authentication. You can create a user-defined policy to use with the `/etc/containers/registries.conf.d` file, if you need to use image short names. 
+The default node disruption policy does not contain a policy for changes to the `/etc/containers/registries.conf.d` file. This is because both {product-title} and {op-system-base-full} use the `registries.conf.d` file to specify aliases for image short names. It is recommended that you always pull an image by its fully-qualified name. This is particularly important with public registries, because the image might not deploy if the public registry requires authentication. You can create a user-defined policy to use with the `/etc/containers/registries.conf.d` file, if you need to use image short names.
 
 In the following example, when changes are made to the SSH keys, the MCO drains the cluster nodes, reloads the `crio.service`, reloads the systemd configuration, and restarts the `crio-service`.
 

--- a/modules/machineconfig-garbage-collect-removing.adoc
+++ b/modules/machineconfig-garbage-collect-removing.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/machine-configuration-tasks.adoc
+// * machine_configuration/machine-configs-garbage-collection.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="machineconfig-garbage-collect-removing_{context}"]

--- a/modules/machineconfig-garbage-collect-viewing.adoc
+++ b/modules/machineconfig-garbage-collect-viewing.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/machine-configuration-tasks.adoc
+// * machine_configuration/machine-configs-garbage-collection.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="machineconfig-garbage-collect-viewing_{context}"]

--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/machine-configuration-tasks.adoc
+// * machine_configuration/mco-update-boot-images.adoc
 // * nodes/nodes-nodes-managing.adoc
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/mco-update-boot-images.adoc
+++ b/modules/mco-update-boot-images.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/machine-configuration-tasks.adoc
+// * machine_configuration/mco-update-boot-images.adoc
 // * nodes/nodes-nodes-managing.adoc
 
 :_mod-docs-content-type: PROCEDURE


### PR DESCRIPTION
In 4.16, we re-organized the Machine Config docs from an assembly in the Postinstallation book to its own book. Missed updating the _Module included in the following assemblies:_ metadata in a few files, and one link in a file that I do not think is being used. 

No issue
No preview
No QE