### PR TITLE
[enterprise-4.17] Ocpbugs 51308-417-1

### DIFF
--- a/modules/nw-route-override-cni.adoc
+++ b/modules/nw-route-override-cni.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-route-override-cni_{context}"]
+= Configuring routes using the route-override plugin on an additional network
+
+The following object describes the configuration parameters for the `route-override` CNI plugin:
+
+.Route override CNI plugin JSON configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`type`
+|`string`
+|The name of the CNI plugin to configure: `route-override`.
+
+|`flushroutes`
+|`boolean`
+|Optional: Set to `true` to flush any existing routes.
+
+|`flushgateway`
+|`boolean`
+|Optional: Set to `true` to flush the default route namely the gateway route.
+
+|`delroutes`
+|`object`
+|Optional: Specify the list of routes to delete from the container namespace.
+
+|`addroutes`
+|`object`
+|Optional: Specify the list of routes to add to the container namespace. Each route is a dictionary with `dst` and optional `gw` fields. If `gw` is omitted, the plugin uses the default gateway value.
+
+|`skipcheck`
+|`boolean`
+|Optional: Set this to `true` to skip the check command. By default, CNI plugins verify the network setup during the container lifecycle. When modifying routes dynamically with `route-override`, skipping this check ensures the final configuration reflects the updated routes.
+|====
+
+[id="nw-route-override-config-example_{context}"]
+== Route-override plugin configuration example
+
+The `route-override` CNI is a type of CNI that it is designed to be used when chained with a parent CNI. It does not operate independently, but relies on the parent CNI to first create the network interface and assign IP addresses before it can modify the routing rules.
+
+The following example configures an additional network named `mymacvlan`. The parent CNI creates a network interface attached to `eth1` and assigns an IP address in the `192.168.1.0/24` range using `host-local` IPAM. The `route-override` CNI is then chained to the parent CNI and modifies the routing rules by flushing existing routes, deleting the route to `192.168.0.0/24`, and adding a new route for `192.168.0.0/24` with a custom gateway. 
+
+[source,json]
+----
+{
+    "cniVersion": "0.3.0",
+    "name": "mymacvlan",
+    "plugins": [
+        {
+            "type": "macvlan",         <1>      
+            "master": "eth1",
+            "mode": "bridge",
+            "ipam": {
+                "type": "host-local",
+                "subnet": "192.168.1.0/24"
+            }
+        },
+        {
+            "type": "route-override",    <2>   
+            "flushroutes": true,
+            "delroutes": [
+                {
+                    "dst": "192.168.0.0/24"
+                }
+            ],
+            "addroutes": [
+                {
+                    "dst": "192.168.0.0/24",
+                    "gw": "10.1.254.254"
+                }
+            ]
+        }
+    ]
+}
+----
+
+<1> The parent CNI creates a network interface attached to `eth1`.
+<2> The chained `route-override` CNI modifies the routing rules. 

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -15,6 +15,7 @@ As a cluster administrator, you can configure an additional network for your clu
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[MACVLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-tap-object_configuring-additional-network[TAP]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuration-ovnk-additional-networks_configuring-additional-network[OVN-Kubernetes]
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-route-override-cni_configuring-additional-network[Route-override]
 
 [id="approaches-managing-additional-network_{context}"]
 == Approaches to managing an additional network
@@ -176,6 +177,9 @@ include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 
 // Configuration for a TAP additional network
 include::modules/nw-multus-tap-object.adoc[leveloffset=+2]
+
+// Configuration for route-override additional network
+include::modules/nw-route-override-cni.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc
+++ b/networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc
@@ -26,6 +26,9 @@ include::modules/nw-multus-macvlan-object.adoc[leveloffset=+1]
 // Configuration for a TAP additional network
 include::modules/nw-multus-tap-object.adoc[leveloffset=+1]
 
+// Configuration for a route-override additional network
+include::modules/nw-route-override-cni.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -68,3 +68,5 @@ networks in your cluster:
 * *TAP*: xref:../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc#nw-multus-tap-object_configuring-additional-network-cni[Configure a TAP-based additional network] to create a tap device inside the container namespace. A TAP device enables user space programs to send and receive network packets.
 
 * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configure an SR-IOV based additional network] to allow pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.
+
+* *route-override*: xref:../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc#nw-route-override-cni_configuring-additional-network-cni[Configure a `route-override` based additional network] to allow pods to override and set routes.


### PR DESCRIPTION
[OCPBUGS-51308]: Missing route-override

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-51308
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://91600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html
- https://91600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: NOT an exact Cherry Pick but created new PR to address content  from https://github.com/openshift/openshift-docs/commit/b0220dc32f438c20be15f04939e2e9fde333ffaa xref: [https://github.com/https://github.com/openshift/openshift-docs/pull/90561]. Already merged to main however auto CP to 4.17 failed. I created this PR of branch 4.17. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->