### PR TITLE
CNV-38746: Added known issue to 4.16 release notes

### DIFF
--- a/virt/release_notes/virt-4-16-release-notes.adoc
+++ b/virt/release_notes/virt-4-16-release-notes.adoc
@@ -183,9 +183,12 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 * The Pod Disruption Budget (PDB) prevents pod disruptions for migratable virtual machine images. If the PDB detects pod disruption, then `openshift-monitoring` sends a `PodDisruptionBudgetAtLimit` alert every 60 minutes for virtual machine images that use the `LiveMigrate` eviction strategy. (link:https://issues.redhat.com/browse/CNV-33834[*CNV-33834*])
 ** As a workaround, xref:../../observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc#silencing-alerts-adm_managing-alerts-as-an-administrator[silence alerts].
 
-//[discrete]
-//[id="virt-4-16-ki-networking_{context}"]
-//==== Networking
+[discrete]
+[id="virt-4-16-ki-networking_{context}"]
+==== Networking
+//CNV-38746
+* When you update from {product-title} 4.12 to a newer minor version, VMs that use the `cnv-bridge` Container Network Interface (CNI) fail to live migrate. (link:https://access.redhat.com/solutions/7069807[])
+** As a workaround, change the `spec.config.type` field in your `NetworkAttachmentDefinition` manifest from `cnv-bridge` to `bridge` before performing the update.
 
 
 [discrete]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-38746](https://issues.redhat.com//browse/CNV-38746)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://91652--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-16-release-notes.html#virt-4-16-known-issues_virt-4-16-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: See note below
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is a copy of the 4.14 PR https://github.com/openshift/openshift-docs/pull/91251 that has passed all reviews
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
