### PR TITLE
OCP MC docs don't highlight that Butane .version is different than z-stream OCP version

### DIFF
--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -22,7 +22,7 @@ and other settings.
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 [source,yaml,subs="attributes+"]

--- a/modules/containers-signature-verify-enable.adoc
+++ b/modules/containers-signature-verify-enable.adoc
@@ -13,7 +13,7 @@ Enabling container signature validation for Red Hat Container Registries require
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 [source,yaml,subs="attributes+"]

--- a/modules/installation-special-config-chrony.adoc
+++ b/modules/installation-special-config-chrony.adoc
@@ -32,7 +32,7 @@ to your nodes as a machine config.
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 [source,yaml,subs="attributes+"]

--- a/modules/machineconfig-modify-journald.adoc
+++ b/modules/machineconfig-modify-journald.adoc
@@ -20,7 +20,7 @@ This procedure describes how to modify `journald` rate limiting settings in the 
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 [source,yaml,subs="attributes+"]

--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -91,7 +91,6 @@ where:
 ** If your hardware MTU is specified in a NetworkManager connection configuration, complete the following steps. This approach is the default for {product-title} if you do not explicitly specify your network configuration with DHCP, a kernel command line, or some other method. Your cluster nodes must all use the same underlying network configuration for the following procedure to work unmodified.
 
 ... Find the primary network interface by entering the following command:
-
 +
 [source,terminal]
 ----
@@ -125,6 +124,11 @@ where:
 
 .... Create the following Butane config in the `control-plane-interface.bu` file:
 +
+[NOTE]
+====
+include::snippets/butane-version.adoc[]
+====
++
 [source,yaml, subs="attributes+"]
 ----
 variant: openshift
@@ -144,6 +148,11 @@ storage:
 <2> Specify the local filename for the updated NetworkManager configuration file from the previous step.
 
 .... Create the following Butane config in the `worker-interface.bu` file:
++
+[NOTE]
+====
+include::snippets/butane-version.adoc[]
+====
 +
 [source,yaml, subs="attributes+"]
 ----

--- a/modules/nw-ovn-ipsec-north-south-enable.adoc
+++ b/modules/nw-ovn-ipsec-north-south-enable.adoc
@@ -121,6 +121,11 @@ $ oc create -f ipsec-config.yaml
 
 .. To create Butane config files for the control plane and worker nodes, enter the following command:
 +
+[NOTE]
+====
+include::snippets/butane-version.adoc[]
+====
++
 [source,terminal,subs="attributes+"]
 ----
 $ for role in master worker; do

--- a/modules/rhcos-load-firmware-blobs.adoc
+++ b/modules/rhcos-load-firmware-blobs.adoc
@@ -14,10 +14,10 @@ Because the default location for firmware blobs in `/usr/lib` is read-only, you 
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
-.Butane config file for custom firmware blob
 +
+.Butane config file for custom firmware blob
 [source,yaml,subs="attributes+"]
 ----
 variant: openshift

--- a/modules/troubleshooting-enabling-kdump-day-one.adoc
+++ b/modules/troubleshooting-enabling-kdump-day-one.adoc
@@ -25,6 +25,11 @@ Create a `MachineConfig` object for cluster-wide configuration:
 
 . Create a Butane config file, `99-worker-kdump.bu`, that configures and enables kdump:
 +
+[NOTE]
+====
+include::snippets/butane-version.adoc[]
+====
++
 [source,yaml,subs="attributes+"]
 ----
 variant: openshift

--- a/modules/virt-binding-devices-vfio-driver.adoc
+++ b/modules/virt-binding-devices-vfio-driver.adoc
@@ -28,7 +28,7 @@ $ lspci -nnv | grep -i nvidia
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 .Example

--- a/snippets/butane-version.adoc
+++ b/snippets/butane-version.adoc
@@ -1,0 +1,17 @@
+// Text snippet included in the following modules:
+//
+// * modules/about-crio.adoc
+// * modules/nodes-containers-using.adoc
+// * modules/cluster-logging-systemd-scaling.adoc
+// * modules/containers-signature-verify-enable.adoc
+// * modules/machineconfig-modify-journald.adoc
+// * modules/nw-cluster-mtu-change.adoc
+// * modules/nw-ovn-ipsec-north-south-enable.adoc
+// * modules/rhcos-load-firmware-blobs.adoc
+// * modules/troubleshooting-enabling-kdump-day-one.adoc
+// * modules/virt-binding-devices-vfio-driver.adoc
+// * updating/updating_a_cluster/updating-bootloader-rhcos.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+The link:https://coreos.github.io/butane/specs/[Butane version] you specify in the config file should match the {product-title} version and always ends in `0`. For example, `{product-version}.0`. See "Creating machine configs with Butane" for information about Butane.

--- a/updating/updating_a_cluster/updating-bootloader-rhcos.adoc
+++ b/updating/updating_a_cluster/updating-bootloader-rhcos.adoc
@@ -90,7 +90,7 @@ The boot loader update operation generally completes quickly thus the risk is lo
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 .Example output


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-6592

Added/edited a note to include a snippet that contains information about the Butane version used in Butane configs. I plan to make this addition/change in two PRs, to keep the size down. 

Preview:
[modules/cluster-logging-systemd-scaling.adoc](https://github.com/openshift/openshift-docs/pull/91674/files#diff-eee64eee1549e282ade83e77b15480f39cba4cc23ba9c93b67b0033f9591044b) The associated module is commented-out in the topic map.
[Enabling signature verification for Red Hat Container Registries](https://91674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/container_security/security-container-signature#containers-signature-verify-enable_security-container-signature) -- Added/Edited note in Step 1
[Configuring journald settings](https://91674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure#machineconfig-modify-journald_machine-configs-configure) -- Added/Edited note in Step 1
[Configuring chrony time service](https://91674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure#installation-special-config-chrony_machine-configs-configure) -- Added/Edited note in Step 1
[Changing the cluster network MTU](https://91674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu#nw-cluster-mtu-change_changing-cluster-network-mtu) -- Added/Edited note in Steps 2.iii.A and 2.iii.B 
[Configuring IPsec encryption for external traffic](https://91674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn#nw-ovn-ipsec-north-south-enable_configuring-ipsec-ovn) -- Added/Edited note in Step 3
[Loading custom firmware blobs in the machine config manifest](https://91674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure#rhcos-load-firmware-blobs_machine-configs-configure) -- Added/Edited note in Step 1
[Enabling kdump on day-1](https://91674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operating-system-issues#enabling-kdump-day-one) -- Step 1
[Binding PCI devices to the VFIO driver](https://91674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-configuring-pci-passthrough#virt-binding-devices-vfio-driver_virt-configuring-pci-passthrough) -- Added/Edited note in Step 2
[Updating the bootloader automatically via a machine config](https://91674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-bootloader-rhcos#updating-the-bootloader-automatically-via-a-machine-config) - Added/Edited note in Step 1

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
