### PR TITLE
OSDOCS-5612: Labeling the default machine pool

### DIFF
--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
@@ -56,6 +56,26 @@ You cannot change the machine pool node type or size. The machine pool node type
 ====
 * You can add a label to each added machine pool.
 
+.Procedure
+
+* *Optional:* Add a label to the default machine pool after configuration by using the default machine pool labels and running the following command:
++
+[source,terminal]
+---- 
+$ rosa edit machinepool -c <cluster_name> <machinepool_name> -i
+----
++
+.Example input
++
+[source,terminal]
+----
+$ rosa edit machinepool -c mycluster worker -i
+? Enable autoscaling: No
+? Replicas: 3
+? Labels: mylabel=true
+I: Updated machine pool 'worker' on cluster 'mycluster'
+----
+
 ifdef::openshift-rosa-hcp[]
 === Machine pool upgrade requirements
 


### PR DESCRIPTION
[OSDOCS-5612](https://issues.redhat.com//browse/OSDOCS-5612): Labeling the default machine pool

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-5612

Link to docs preview:
ROSA HCP: https://91675--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html
ROSA Classic: https://91675--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
