### PR TITLE
OCPBUGS-54643 - Update docs contain typos - fix for the reported bug

### DIFF
--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -24,35 +24,30 @@ You cannot downgrade {microshift-short} with this process. Downgrades are not su
 
 .Procedure
 
-. For all lifecycles, enable the repository for your release by running the following command:
+. For all lifecycles, enable the repository for the release you want to update to by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-<x.y>-for-<9>-$(uname -m)-rpms \ # <1>
-    --enable fast-datapath-for-<9>-$(uname -m)-rpms # <2>
+    --enable rhocp-{ocp-version}-for-rhel-{op-system-version-major}-$(uname -m)-rpms \
+    --enable fast-datapath-for-rhel-{op-system-version-major}-$(uname -m)-rpms
 ----
-<1> Replace _<x.y>_ and _<9>_ with the compatible versions of your {microshift-short} and {op-system-base-full}.
-<2> Replace  _<9>_ with the compatible version of {op-system-base}.
 
 . For extended support (EUS) releases, also enable the EUS repositories by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-`$ sudo subscription-manager repos \
-    --enable rhel-<9>-for-x86_64-appstream-eus-rpms \ # <1>
-    --enable rhel-<9>-for-x86_64-baseos-eus-rpms` # <2>
+$ sudo subscription-manager repos \
+    --enable rhel-{op-system-version-major}-for-$(uname -m)-appstream-eus-rpms \ 
+    --enable rhel-{op-system-version-major}-for-$(uname -m)-baseos-eus-rpms 
 ----
-<1> Replace _<9>_ with the compatible major version number of {op-system-base}.
-<2> Replace _<9>_ with the compatible major version number of {op-system-base}.
 
 . Avoid unintended future updates into an unsupported configuration by locking your operating system version with the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ sudo subscription-manager release --set=<9.4> command. # <1>
+$ sudo subscription-manager release --set={op-system-version}
 ----
-<1> Replace _<9.4>_ with the major and minor version of your compatible {op-system-base} system.
 
 . Update the {microshift-short} RPMs by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.14, 4.15, 4.16, 4.17, 4.18, 4.19

Issue:
https://issues.redhat.com/browse/OCPBUGS-54643

Link to docs preview:
https://91678--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually.html

QE review:
- [x] QE has approved this change.