### PR TITLE
Update logging-loki-pod-placement.adoc

### DIFF
--- a/modules/logging-loki-pod-placement.adoc
+++ b/modules/logging-loki-pod-placement.adoc
@@ -84,15 +84,6 @@ spec:
       - effect: NoExecute
         key: node-role.kubernetes.io/infra
         value: reserved
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        value: reserved
-      - effect: NoExecute
-        key: node-role.kubernetes.io/infra
-        value: reserved
     indexGateway:
       nodeSelector:
         node-role.kubernetes.io/infra: ""


### PR DESCRIPTION
- Need to remove additional nodeSelector and tolerations from Lokistack CR
- Here is the documentation link:  https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/logging/scheduling-resources#logging-loki-pod-placement_logging-taints-tolerations
- nodeSelector and tolerations are mentioned twice under the distributor field of Lokistack CR.  
~~~
    distributor:
      nodeSelector:
        node-role.kubernetes.io/infra: ""
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/infra
        value: reserved
      - effect: NoExecute
        key: node-role.kubernetes.io/infra
        value: reserved
      nodeSelector:
        node-role.kubernetes.io/infra: ""
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/infra
        value: reserved
      - effect: NoExecute
        key: node-role.kubernetes.io/infra
        value: reserved 
~~~

- values for both nodeSelector and tolerations are the same.
- Keeping it twice is not required and it is an unnecessary configuration.
- Hence we need to remove additional nodeSelector and tolerations from the documentation.

- Here is the updated look: 
~~~
    distributor:
      nodeSelector:
        node-role.kubernetes.io/infra: ""
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/infra
        value: reserved
      - effect: NoExecute
        key: node-role.kubernetes.io/infra
        value: reserved 
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.12, RHOCP 4.13, RHOCP 4.14, RHOCP 4.15, RHOCP 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1836#

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://91679--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/logging/scheduling_resources/logging-node-selectors.html
https://91679--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/logging/scheduling_resources/logging-taints-tolerations.html
https://91679--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/scheduling_resources/logging-node-selectors.html
https://91679--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/scheduling_resources/logging-taints-tolerations.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
