### PR TITLE
Update logging-loki-storage-aws.adoc

### DIFF
--- a/modules/logging-loki-storage-aws.adoc
+++ b/modules/logging-loki-storage-aws.adoc
@@ -36,8 +36,8 @@ You can create the Loki object storage secret manually by running the following 
 [source,terminal,subs="+quotes"]
 ----
 $ oc -n openshift-logging create secret generic "logging-loki-aws" \
---from-literal=bucketnames="<s3_bucket_name>" \
---from-literal=region="<bucket_region>" \
---from-literal=audience="<oidc_audience>" <1>
+  --from-literal=bucketnames="<s3_bucket_name>" \
+  --from-literal=region="<bucket_region>" \
+  --from-literal=audience="<oidc_audience>" <1>
 ----
 <1> Optional annotation, default value is `openshift`.


### PR DESCRIPTION
- Incorrect command structure in Loki Object Storage documentation
- Here is the doc link for AWS storage: https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/logging/log-storage-4#logging-loki-storage-aws_installing-log-storage
- the "-" signs are incorrectly placed below the "$" symbol.
- However, they should be aligned parallel to the "oc" command, where the command begins.
- Here is the updated look of the command: 
~~~
$ oc -n openshift-logging create secret generic "logging-loki-aws" \
  --from-literal=bucketnames="<s3_bucket_name>" \
  --from-literal=region="<bucket_region>" \
  --from-literal=audience="<oidc_audience>" 1  
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.12, RHOCP 4.13, RHOCP 4.14, RHOCP 4.15, RHOCP 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1837

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
