### PR TITLE
OBSDOCS-1723: Port the "Installing Logging" sections to 5.8 and 6.y

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3030,6 +3030,8 @@ Topics:
       File: log6x-release-notes-6.2
     - Name: About logging 6.2
       File: log6x-about-6.2
+    - Name: Installing Logging
+      File: 6x-cluster-logging-deploying-6.2
     - Name: Configuring log forwarding
       File: log6x-clf-6.2
     - Name: Configuring LokiStack storage
@@ -3047,6 +3049,8 @@ Topics:
       File: log6x-release-notes-6.1
     - Name: About logging 6.1
       File: log6x-about-6.1
+    - Name: Installing Logging
+      File: 6x-cluster-logging-deploying-6.1
     - Name: Configuring log forwarding
       File: log6x-clf-6.1
     - Name: Configuring LokiStack storage

--- a/modules/log6x-logging-clo-cli-install.adoc
+++ b/modules/log6x-logging-clo-cli-install.adoc
@@ -1,0 +1,163 @@
+// Module is included in the following assemblies:
+//
+// 
+:_mod-docs-content-type: PROCEDURE
+[id="log6x-installing-logging-operator_{context}"]
+= Installing {clo} by using the CLI
+
+Install {clo} on your {product-title} cluster to collect and forward logs to a log store by using the {oc-first}.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You installed the {oc-first}.
+* You installed and configured {loki-op}.
+* You have created the `openshift-logging` namespace.
+
+.Procedure
+
+. Create an `OperatorGroup` object:
++
+.Example `OperatorGroup` object
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging # <1>
+spec:
+  upgradeStrategy: Default
+----
+<1> You must specify `openshift-logging` as the namespace.
+
+. Apply the `OperatorGroup` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+. Create a `Subscription` object for {clo}:
++
+.Example `Subscription` object
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging # <1>
+spec:
+  channel: stable-6.<y> # <2>
+  installPlanApproval: Automatic # <3>
+  name: cluster-logging
+  source: redhat-operators # <4>
+  sourceNamespace: openshift-marketplace
+----
+<1> You must specify `openshift-logging` as the namespace.
+<2> Specify `stable-6.<y>` as the channel.
+<3> If the approval strategy in the subscription is set to `Automatic`, the update process initiates as soon as a new operator version is available in the selected channel. If the approval strategy is set to `Manual`, you must manually approve pending updates.
+<4> Specify `redhat-operators` as the value. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the `CatalogSource` object that you created when you configured Operator Lifecycle Manager (OLM).
+
+. Apply the `Subscription` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+. Create a service account to be used by the log collector:
++
+[source,terminal]
+----
+$ oc create sa logging-collector -n openshift-logging
+----
+
+. Assign the necessary permissions to the service account for the collector to be able to collect and forward logs. In this example, the collector is provided permissions to collect logs from both infrastructure and application logs.
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z logging-collector -n openshift-logging
+$ oc adm policy add-cluster-role-to-user collect-application-logs -z logging-collector -n openshift-logging
+$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z logging-collector -n openshift-logging
+----
+
+. Create a `ClusterLogForwarder` CR:
++
+.Example `ClusterLogForwarder` CR
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging # <1>
+spec:
+  serviceAccount:
+    name: logging-collector # <2>
+  outputs:
+  - name: lokistack-out
+    type: lokiStack # <3>
+    lokiStack:
+      target: # <4>
+        name: logging-loki 
+        namespace: openshift-logging
+      authentication:
+        token:
+          from: serviceAccount
+    tls:
+      ca:
+        key: service-ca.crt
+        configMapName: openshift-service-ca.crt
+  pipelines:
+  - name: infra-app-logs
+    inputRefs: # <5>
+    - application
+    - infrastructure
+    outputRefs:
+    - lokistack-out
+----
+<1> You must specify the `openshift-logging` namespace.
+<2> Specify the name of the service account created before.
+<3> Select the `lokiStack` output type to send logs to the `LokiStack` instance.
+<4> Point the `ClusterLogForwarder` to the `LokiStack` instance created earlier.
+<5> Select the log output types you want to send to the `LokiStack` instance.
+
+. Apply the `ClusterLogForwarder CR` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+. Verify the installation by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-logging
+----
++
+.Example output
+[source,terminal]
+----
+$ oc get pods -n openshift-logging
+NAME                                               READY   STATUS    RESTARTS   AGE
+cluster-logging-operator-fb7f7cf69-8jsbq           1/1     Running   0          98m
+instance-222js                                     2/2     Running   0          18m
+instance-g9ddv                                     2/2     Running   0          18m
+instance-hfqq8                                     2/2     Running   0          18m
+instance-sphwg                                     2/2     Running   0          18m
+instance-vv7zn                                     2/2     Running   0          18m
+instance-wk5zz                                     2/2     Running   0          18m
+logging-loki-compactor-0                           1/1     Running   0          42m
+logging-loki-distributor-7d7688bcb9-dvcj8          1/1     Running   0          42m
+logging-loki-gateway-5f6c75f879-bl7k9              2/2     Running   0          42m
+logging-loki-gateway-5f6c75f879-xhq98              2/2     Running   0          42m
+logging-loki-index-gateway-0                       1/1     Running   0          42m
+logging-loki-ingester-0                            1/1     Running   0          42m
+logging-loki-querier-6b7b56bccc-2v9q4              1/1     Running   0          42m
+logging-loki-query-frontend-84fb57c578-gq2f7       1/1     Running   0          42m
+----

--- a/modules/log6x-logging-clo-gui-install.adoc
+++ b/modules/log6x-logging-clo-gui-install.adoc
@@ -1,0 +1,163 @@
+:_mod-docs-content-type: PROCEDURE
+[id="log6x-installing-logging-operator-using-web-console_{context}"]
+= Installing {clo} by using the web console
+
+Install {clo} on your {product-title} cluster to collect and forward logs to a log store from the OperatorHub by using the {product-title} web console.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You have access to the {product-title} web console.
+* You installed and configured {loki-op}.
+
+.Procedure
+
+. In the {product-title} web console *Administrator* perspective, go to *Operators* -> *OperatorHub*.
+
+. Type {clo} in the *Filter by keyword* field. Click *{clo}* in the list of available Operators, and then click *Install*.
+
+. Select *stable-x.y* as the *Update channel*. The latest version is already selected in the *Version* field.
++
+The {clo} must be deployed to the {logging} namespace `openshift-logging`, so the *Installation mode* and *Installed Namespace* are already selected. If this namespace does not already exist, it will be created for you.
+
+. Select *Enable Operator-recommended cluster monitoring on this namespace.*
++
+This option sets the `openshift.io/cluster-monitoring: "true"` label in the `Namespace` object. You must select this option to ensure that cluster monitoring scrapes the `openshift-logging` namespace.
+
+. For *Update approval* select *Automatic*, then click *Install*.
++
+If the approval strategy in the subscription is set to *Automatic*, the update process initiates as soon as a new operator version is available in the selected channel. If the approval strategy is set to *Manual*, you must manually approve pending updates.
++
+[NOTE]
+====
+An Operator might display a `Failed` status before the installation completes. If the operator installation completes with an `InstallSucceeded` message, refresh the page.
+====
+
+. While the operator installs, create the service account that will be used by the log collector to collect the logs. 
+
+.. Click the *+* in the top right of the screen to access the *Import YAML* page. 
+
+.. Enter the YAML definition for the service account. 
++
+.Example `ServiceAccount` object
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logging-collector # <1>
+  namespace: openshift-logging # <2>
+----
+<1> Note down the name used for the service account `logging-collector` to use it later when creating the `ClusterLogForwarder` resource.
+<2> Set the namespace to `openshift-logging` because that is the namespace for deploying the `ClusterLogForwarder` resource.
+
+.. Click the *Create* button.
+
+. Create the `ClusterRoleBinding` objects to grant the necessary permissions to the log collector for accessing the logs that you want to collect and to write the log store, for example infrastructure and application logs.
+
+.. Click the *+* in the top right of the screen to access the *Import YAML* page. 
+
+.. Enter the YAML definition for the `ClusterRoleBinding` resources.
++
+.Example `ClusterRoleBinding` resources
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logging-collector:write-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logging-collector-logs-writer # <1>
+subjects:
+- kind: ServiceAccount
+  name: logging-collector
+  namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logging-collector:collect-application
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collect-application-logs # <2>
+subjects:
+- kind: ServiceAccount
+  name: logging-collector
+  namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: logging-collector:collect-infrastructure
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collect-infrastructure-logs # <3>
+subjects:
+- kind: ServiceAccount
+  name: logging-collector
+  namespace: openshift-logging
+----
+<1> The cluster role to allow the log collector to write logs to LokiStack.
+<2> The cluster role to allow the log collector to collect logs from applications.
+<3> The cluster role to allow the log collector to collect logs from infrastructure.
+
+.. Click the *Create* button.
+
+. Go to the *Operators* -> *Installed Operators* page. Select the  operator and click the *All instances* tab.
+
+. After granting the necessary permissions to the service account, navigate to the *Installed Operators* page. Select the {clo} under the *Provided APIs*, find the *ClusterLogForwarder* resource and click *Create Instance*.
+
+. Select *YAML view*, and then use the following template to create a `ClusterLogForwarder` CR:
++
+.Example `ClusterLogForwarder` CR
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging # <1>
+spec:
+  serviceAccount:
+    name: logging-collector # <2>
+  outputs:
+  - name: lokistack-out
+    type: lokiStack # <3>
+    lokiStack:
+      target: # <4>
+        name: logging-loki 
+        namespace: openshift-logging
+      authentication:
+        token:
+          from: serviceAccount
+    tls:
+      ca:
+        key: service-ca.crt
+        configMapName: openshift-service-ca.crt
+  pipelines:
+  - name: infra-app-logs
+    inputRefs: # <5>
+    - application
+    - infrastructure
+    outputRefs:
+    - lokistack-out
+----
+<1> You must specify `openshift-logging` as the namespace.
+<2> Specify the name of the service account created earlier.
+<3> Select the `lokiStack` output type to send logs to the `LokiStack` instance.
+<4> Point the `ClusterLogForwarder` to the `LokiStack` instance created earlier.
+<5> Select the log output types you want to send to the `LokiStack` instance.
+
+. Click *Create*.
+
+.Verification
+. In the *ClusterLogForwarder* tab verify that you see your `ClusterLogForwarder` instance.
+
+. In the *Status* column, verify that you see the messages: 
+
+* `Condition: observability.openshift.io/Authorized`
+* `observability.openshift.io/Valid, Ready`

--- a/modules/log6x-logging-loki-cli-install.adoc
+++ b/modules/log6x-logging-loki-cli-install.adoc
@@ -1,0 +1,207 @@
+// Module is included in the following assemblies:
+//
+// * observability/logging/log_storage/installing-log-storage.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="log6x-logging-loki-cli-install_{context}"]
+= Installing the {loki-op} by using the CLI
+
+Install {loki-op} on your {product-title} cluster to manage the log store `Loki` by using the {product-title} command-line interface (CLI). You can deploy and configure the `Loki` log store by reconciling the resource LokiStack with the {loki-op}.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You installed the {oc-first}.
+* You have access to a supported object store. For example: AWS S3, Google Cloud Storage, Azure, Swift, Minio, or {rh-storage}.
+
+.Procedure
+
+. Create a `Namespace` object for {loki-op}:
++
+.Example `Namespace` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat # <1>
+  labels:
+    openshift.io/cluster-monitoring: "true" # <2>
+----
+<1> You must specify `openshift-operators-redhat` as the namespace. To enable monitoring for the operator, configure Cluster Monitoring Operator to scrape metrics from the `openshift-operators-redhat` namespace and not the `openshift-operators` namespace. The `openshift-operators` namespace might contain community operators, which are untrusted and could publish a metric with the same name as an {product-title} metric, causing conflicts.
+<2> A string value that specifies the label as shown to ensure that cluster monitoring scrapes the `openshift-operators-redhat` namespace.
+
+. Apply the `Namespace` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+. Create an `OperatorGroup` object.
++
+.Example `OperatorGroup` object
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: loki-operator
+  namespace: openshift-operators-redhat # <1>
+spec:
+  upgradeStrategy: Default
+----
+<1> You must specify `openshift-operators-redhat` as the namespace.
+
+. Apply the `OperatorGroup` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+. Create a `Subscription` object for {loki-op}:
++
+.Example `Subscription` object
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: loki-operator
+  namespace: openshift-operators-redhat # <1>
+spec:
+  channel: stable-6.<y> # <2>
+  installPlanApproval: Automatic # <3>
+  name: loki-operator
+  source: redhat-operators # <4>
+  sourceNamespace: openshift-marketplace
+----
+<1> You must specify `openshift-operators-redhat` as the namespace.
+<2> Specify `stable-6.<y>` as the channel.
+<3> If the approval strategy in the subscription is set to `Automatic`, the update process initiates as soon as a new operator version is available in the selected channel. If the approval strategy is set to `Manual`, you must manually approve pending updates.
+<4> Specify `redhat-operators` as the value. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the `CatalogSource` object that you created when you configured Operator Lifecycle Manager (OLM).
+
+. Apply the `Subscription` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+. Create a `namespace` object for deploy the LokiStack:
++
+.Example `namespace` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging # <1>
+  labels:
+    openshift.io/cluster-monitoring: "true" # <2>
+----
+<1> The `openshift-logging` namespace is dedicated for all {logging} workloads.
+<2> A string value that specifies the label, as shown, to ensure that cluster monitoring scrapes the `openshift-logging` namespace.
+
+. Apply the `namespace` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+. Create a secret with the credentials to access the object storage. For example, create a secret to access {aws-first} s3.
++
+.Example `Secret` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: logging-loki-s3 # <1>
+  namespace: openshift-logging
+stringData: # <2>
+  access_key_id: <access_key_id>
+  access_key_secret: <access_secret>
+  bucketnames: s3-bucket-name
+  endpoint: https://s3.eu-central-1.amazonaws.com
+  region: eu-central-1
+----
+<1> Use the name `logging-loki-s3` to match the name used in LokiStack.
+<2> For the contents of the secret see the Loki object storage section.
++
+--
+include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]
+--
+
+. Apply the `Secret` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+. Create a `LokiStack` CR:
++
+.Example `LokiStack` CR
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki # <1>
+  namespace: openshift-logging # <2>
+spec:
+  size: 1x.small # <3>
+  storage:
+    schemas:
+    - version: v13
+      effectiveDate: "<yyyy>-<mm>-<dd>" # <4>
+    secret:
+      name: logging-loki-s3 # <5>
+      type: s3 # <6>
+  storageClassName: <storage_class_name> # <7>
+  tenants:
+    mode: openshift-logging # <8>
+----
+<1> Use the name `logging-loki`.
+<2> You must specify `openshift-logging` as the namespace.
+<3> Specify the deployment size. Supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`. Additionally, `1x.pico` is supported starting with {logging} 6.1.
+<4> For new installations this date should be set to the equivalent of "yesterday", as this will be the date from when the schema takes effect.
+<5> Specify the name of your log store secret.
+<6> Specify the corresponding storage type.
+<7> Specify the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. You can list the available storage classes for your cluster by using the `oc get storageclasses` command.
+<8> The `openshift-logging` mode is the default tenancy mode where a tenant is created for log types, such as audit, infrastructure, and application. This enables access control for individual users and user groups to different log streams.
+
+
+. Apply the `LokiStack` CR object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+* Verify the installation by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-logging
+----
++
+.Example output
+[source,terminal]
+----
+$ oc get pods -n openshift-logging
+NAME                                               READY   STATUS    RESTARTS   AGE
+logging-loki-compactor-0                           1/1     Running   0          42m
+logging-loki-distributor-7d7688bcb9-dvcj8          1/1     Running   0          42m
+logging-loki-gateway-5f6c75f879-bl7k9              2/2     Running   0          42m
+logging-loki-gateway-5f6c75f879-xhq98              2/2     Running   0          42m
+logging-loki-index-gateway-0                       1/1     Running   0          42m
+logging-loki-ingester-0                            1/1     Running   0          42m
+logging-loki-querier-6b7b56bccc-2v9q4              1/1     Running   0          42m
+logging-loki-query-frontend-84fb57c578-gq2f7       1/1     Running   0          42m
+----

--- a/modules/log6x-logging-loki-gui-install.adoc
+++ b/modules/log6x-logging-loki-gui-install.adoc
@@ -1,0 +1,137 @@
+// Module is included in the following assemblies:
+//
+// * observability/logging/log_storage/installing-log-storage.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="log6x-logging-loki-gui-install_{context}"]
+= Installing {logging-uc} by using the web console
+
+Install {loki-op} on your {product-title} cluster to manage the log store `Loki` from the OperatorHub by using the {product-title} web console. You can deploy and configure the `Loki` log store by reconciling the resource LokiStack with the {loki-op}.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You have access to the {product-title} web console.
+* You have access to a supported object store (AWS S3, Google Cloud Storage, Azure, Swift, Minio, {rh-storage}).
+
+.Procedure
+
+. In the {product-title} web console *Administrator* perspective, go to *Operators* -> *OperatorHub*.
+
+. Type {loki-op} in the *Filter by keyword* field. Click *{loki-op}* in the list of available Operators, and then click *Install*.
++
+[IMPORTANT]
+====
+The Community {loki-op} is not supported by Red{nbsp}Hat.
+====
+
+. Select *stable-x.y* as the *Update channel*.
++
+The {loki-op} must be deployed to the global Operator group namespace `openshift-operators-redhat`, so the *Installation mode* and *Installed Namespace* are already selected. If this namespace does not already exist, it will be created for you.
+
+. Select *Enable Operator-recommended cluster monitoring on this namespace.*
++
+This option sets the `openshift.io/cluster-monitoring: "true"` label in the `Namespace` object. You must select this option to ensure that cluster monitoring scrapes the `openshift-operators-redhat` namespace.
+
+. For *Update approval* select *Automatic*, then click *Install*.
++
+If the approval strategy in the subscription is set to *Automatic*, the update process initiates as soon as a new Operator version is available in the selected channel. If the approval strategy is set to *Manual*, you must manually approve pending updates.
++
+[NOTE]
+====
+An Operator might display a `Failed` status before the installation completes. If the Operator install completes with an `InstallSucceeded` message, refresh the page.
+====
+
+. While the Operator installs, create the namespace to which the log store will be deployed.
+
+.. Click *+* in the top right of the screen to access the *Import YAML* page. 
+
+.. Add the YAML definition for the `openshift-logging` namespace:
++
+.Example `namespace` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging # <1>
+  labels:
+    openshift.io/cluster-monitoring: "true" # <2>
+----
+<1> The `openshift-logging` namespace is dedicated for all {logging} workloads.
+<2> A string value that specifies the label, as shown, to ensure that cluster monitoring scrapes the `openshift-logging` namespace.
+
+.. Click *Create*.
+
+. Create a secret with the credentials to access the object storage.
+
+.. Click *+* in the top right of the screen to access the *Import YAML* page. 
+
+.. Add the YAML definition for the secret. For example, create a secret to access Amazon Web Services (AWS) s3:
++
+.Example `Secret` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: logging-loki-s3 <1>
+  namespace: openshift-logging <2>
+stringData: <3>
+  access_key_id: <access_key_id>
+  access_key_secret: <access_key>
+  bucketnames: s3-bucket-name
+  endpoint: https://s3.eu-central-1.amazonaws.com
+  region: eu-central-1
+----
+<1> Note down the name used for the secret `logging-loki-s3` to use it later when creating the `LokiStack` resource.
+<2> Set the namespace to `openshift-logging` as that will be the namespace used to deploy `LokiStack`.
+<3> For the contents of the secret see the Loki object storage section.
++
+--
+include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]
+--
+
+.. Click *Create*.
+
+. Navigate to the *Installed Operators* page. Select the {loki-op} under the *Provided APIs* find the *LokiStack* resource and click *Create Instance*.
+
+. Select *YAML view*, and then use the following template to create a `LokiStack` CR:
++
+--
+.Example `LokiStack` CR
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki # <1>
+  namespace: openshift-logging # <2>
+spec:
+  size: 1x.small # <3>
+  storage:
+    schemas:
+    - version: v13
+      effectiveDate: "<yyyy>-<mm>-<dd>"
+    secret:
+      name: logging-loki-s3 # <4>
+      type: s3 # <5>
+  storageClassName: <storage_class_name> # <6>
+  tenants:
+    mode: openshift-logging # <7>
+----
+<1> Use the name `logging-loki`.
+<2> You must specify `openshift-logging` as the namespace.
+<3> Specify the deployment size. Supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`. Additionally, 1x.pico is supported starting with {logging} 6.1.
+<4> Specify the name of your log store secret.
+<5> Specify the corresponding storage type.
+<6> Specify the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. You can list the available storage classes for your cluster by using the `oc get storageclasses` command.
+<7> The `openshift-logging` mode is the default tenancy mode where a tenant is created for log types, such as audit, infrastructure, and application. This enables access control for individual users and user groups to different log streams.
+--
+
+. Click *Create*.
+
+.Verification
+
+. In the *LokiStack* tab veriy that you see your `LokiStack` instance.
+. In the *Status* column, verify that you see the message `Condition: Ready` with a green checkmark.

--- a/observability/logging/logging-6.0/6x-cluster-logging-deploying-6.0.adoc
+++ b/observability/logging/logging-6.0/6x-cluster-logging-deploying-6.0.adoc
@@ -1,0 +1,60 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+
+[id="installing-logging-6-0"]
+= Installing Logging
+:context: installing-logging-6-0
+
+toc::[]
+
+{product-title} Operators use custom resources (CRs) to manage applications and their components. You provide high-level configuration and settings through the CR. The Operator translates high-level directives into low-level actions, based on best practices embedded within the logic of the Operator. A custom resource definition (CRD) defines a CR and lists all the configurations available to users of the Operator. Installing an Operator creates the CRDs to generate CRs.
+
+
+To get started with {logging}, you must install the following Operators:
+
+* {loki-op} to manage your log store.
+* {clo} to manage log collection and forwarding.
+* {coo-first} to manage visualization.
+
+You can use either the {product-title} web console or the {product-title} CLI to install or configure {logging}.
+
+[IMPORTANT]
+====
+You must configure the {clo} after the {loki-op}.
+====
+
+
+ifdef::openshift-origin[]
+[id="prerequisites_cluster-logging-deploying_{context}"]
+== Prerequisites
+* You have downloaded the {cluster-manager-url-pull} as shown in "Obtaining the installation program" in the installation documentation for your platform.
++
+If you have the pull secret, add the `redhat-operators` catalog to the `OperatorHub` custom resource (CR) as shown in "Configuring {product-title} to use Red{nbsp}Hat Operators".
+endif::[]
+
+[id="installing-loki-and-logging-cli_{context}"]
+== Installation by using the CLI
+
+The following sections describe installing the {loki-op} and the {clo} by using the CLI.
+
+include::modules/log6x-logging-loki-cli-install.adoc[leveloffset=+2]
+include::modules/log6x-logging-clo-cli-install.adoc[leveloffset=+2]
+
+[id="installing-loki-and-logging-gui_{context}"]
+== Installation by using the web console
+
+The following sections describe installing the {loki-op} and the {clo} by using the web console.
+
+include::modules/log6x-logging-loki-gui-install.adoc[leveloffset=+2]
+include::modules/log6x-logging-clo-gui-install.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+ifdef::openshift-enterprise,openshift-origin[]
+* xref:../../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#ovn-k-network-policy[About OVN-Kubernetes network policy]
+endif::[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html[About the OVN-Kubernetes default Container Network Interface (CNI) network provider]
+endif::[]

--- a/observability/logging/logging-6.1/6x-cluster-logging-deploying-6.1.adoc
+++ b/observability/logging/logging-6.1/6x-cluster-logging-deploying-6.1.adoc
@@ -1,0 +1,60 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="installing-logging-6-1"]
+= Installing Logging
+:context: installing-logging-6-1
+
+toc::[]
+
+{product-title} Operators use custom resources (CRs) to manage applications and their components. You provide high-level configuration and settings through the CR. The Operator translates high-level directives into low-level actions, based on best practices embedded within the logic of the Operator. A custom resource definition (CRD) defines a CR and lists all the configurations available to users of the Operator. Installing an Operator creates the CRDs to generate CRs.
+
+
+To get started with {logging}, you must install the following Operators:
+
+* {loki-op} to manage your log store.
+* {clo} to manage log collection and forwarding.
+* {coo-first} to manage visualization.
+
+You can use either the {product-title} web console or the {product-title} CLI to install or configure {logging}.
+
+[IMPORTANT]
+====
+You must configure the {clo} after the {loki-op}.
+====
+
+
+ifdef::openshift-origin[]
+[id="prerequisites_cluster-logging-deploying_{context}"]
+== Prerequisites
+* You have downloaded the {cluster-manager-url-pull} as shown in "Obtaining the installation program" in the installation documentation for your platform.
++
+If you have the pull secret, add the `redhat-operators` catalog to the `OperatorHub` custom resource (CR) as shown in "Configuring {product-title} to use Red{nbsp}Hat Operators".
+endif::[]
+
+
+[id="installing-loki-and-logging-cli_{context}"]
+== Installation by using the CLI
+
+The following sections describe installing the {loki-op} and the {clo} by using the CLI.
+
+include::modules/log6x-logging-loki-cli-install.adoc[leveloffset=+2]
+include::modules/log6x-logging-clo-cli-install.adoc[leveloffset=+2]
+
+[id="installing-loki-and-logging-gui_{context}"]
+== Installation by using the web console
+
+The following sections describe installing the {loki-op} and the {clo} by using the web console.
+
+include::modules/log6x-logging-loki-gui-install.adoc[leveloffset=+2]
+include::modules/log6x-logging-clo-gui-install.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+ifdef::openshift-enterprise,openshift-origin[]
+* xref:../../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#ovn-k-network-policy[About OVN-Kubernetes network policy]
+endif::[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html[About the OVN-Kubernetes default Container Network Interface (CNI) network provider]
+endif::[]

--- a/observability/logging/logging-6.2/6x-cluster-logging-deploying-6.2.adoc
+++ b/observability/logging/logging-6.2/6x-cluster-logging-deploying-6.2.adoc
@@ -1,0 +1,60 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+
+[id="installing-logging-6-2"]
+= Installing Logging
+:context: installing-logging-6-2
+
+toc::[]
+
+{product-title} Operators use custom resources (CRs) to manage applications and their components. You provide high-level configuration and settings through the CR. The Operator translates high-level directives into low-level actions, based on best practices embedded within the logic of the Operator. A custom resource definition (CRD) defines a CR and lists all the configurations available to users of the Operator. Installing an Operator creates the CRDs to generate CRs.
+
+
+To get started with {logging}, you must install the following Operators:
+
+* {loki-op} to manage your log store.
+* {clo} to manage log collection and forwarding.
+* {coo-first} to manage visualization.
+
+You can use either the {product-title} web console or the {product-title} CLI to install or configure {logging}.
+
+
+[IMPORTANT]
+====
+You must configure the {clo} after the {loki-op}.
+====
+
+ifdef::openshift-origin[]
+[id="prerequisites_cluster-logging-deploying_{context}"]
+== Prerequisites
+* You have downloaded the {cluster-manager-url-pull} as shown in "Obtaining the installation program" in the installation documentation for your platform.
++
+If you have the pull secret, add the `redhat-operators` catalog to the `OperatorHub` custom resource (CR) as shown in "Configuring {product-title} to use Red{nbsp}Hat Operators".
+endif::[]
+
+[id="installing-loki-and-logging-cli_{context}"]
+== Installation by using the CLI
+
+The following sections describe installing the {loki-op} and the {clo} by using the CLI.
+
+include::modules/log6x-logging-loki-cli-install.adoc[leveloffset=+2]
+include::modules/log6x-logging-clo-cli-install.adoc[leveloffset=+2]
+
+[id="installing-loki-and-logging-gui_{context}"]
+== Installation by using the web console
+
+The following sections describe installing the {loki-op} and the {clo} by using the web console.
+
+include::modules/log6x-logging-loki-gui-install.adoc[leveloffset=+2]
+include::modules/log6x-logging-clo-gui-install.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+ifdef::openshift-enterprise,openshift-origin[]
+* xref:../../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#ovn-k-network-policy[About OVN-Kubernetes network policy]
+endif::[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html[About the OVN-Kubernetes default Container Network Interface (CNI) network provider]
+endif::[]

--- a/observability/logging/logging_release_notes/cluster-logging-deploying.adoc
+++ b/observability/logging/logging_release_notes/cluster-logging-deploying.adoc
@@ -1,0 +1,48 @@
+:_mod-docs-content-type: ASSEMBLY
+:context: cluster-logging-deploying
+[id="cluster-logging-deploying"]
+= Installing Logging
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+
+toc::[]
+
+{product-title} Operators use custom resources (CRs) to manage applications and their components. You provide high-level configuration and settings through the CR. The Operator translates high-level directives into low-level actions, based on best practices embedded within the logic of the Operator. A custom resource definition (CRD) defines a CR and lists all the configurations available to users of the Operator. Installing an Operator creates the CRDs to generate CRs.
+
+[IMPORTANT]
+====
+You must install the {clo} after the log store Operator.
+====
+
+You deploy {logging} by installing the {loki-op} to manage your log store, followed by the {clo} to manage the components of logging. You can use either the {product-title} web console or the {oc-first} to install or configure {logging}.
+
+[TIP]
+====
+You can alternatively apply all example objects.
+====
+
+ifdef::openshift-origin[]
+[id="prerequisites_cluster-logging-deploying_{context}"]
+== Prerequisites
+* You have downloaded the {cluster-manager-url-pull} as shown in "Obtaining the installation program" in the installation documentation for your platform.
++
+If you have the pull secret, add the `redhat-operators` catalog to the `OperatorHub` custom resource (CR) as shown in "Configuring {product-title} to use Red{nbsp}Hat Operators".
+endif::[]
+
+--
+include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]
+--
+
+include::modules/logging-loki-cli-install.adoc[leveloffset=+1]
+
+include::modules/logging-loki-gui-install.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+ifdef::openshift-enterprise,openshift-origin[]
+* xref:../../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#ovn-k-network-policy[About OVN-Kubernetes network policy]
+endif::[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html[About the OVN-Kubernetes default Container Network Interface (CNI) network provider]
+endif::[]


### PR DESCRIPTION
Version(s): 4.18

Issue: https://issues.redhat.com/browse/OBSDOCS-1723

Link to docs preview:

- https://91681--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/6x-cluster-logging-deploying-6.1.html
- https://91681--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/6x-cluster-logging-deploying-6.2.html

QE review: Not required as this is a manual cherry-pick

Additional information:
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/89053

Please note that there are some review comments that need to be applied to the content, for example: https://github.com/openshift/openshift-docs/pull/90136#discussion_r1993478559. If there are any comments in this PR they will be applied in a separate PR so that the changes can be applied to both 4.18 and 4.17 branches. 