### PR TITLE
OBSDOCS#1800: Small fixes for 'Enabling a separate Alertmanager instance for user-defined alert routing'

### DIFF
--- a/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -24,7 +24,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have enabled monitoring for user-defined projects.
 endif::[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 
@@ -47,8 +47,8 @@ metadata:
 data:
   config.yaml: |
     alertmanager:
-      enabled: true <1>
-      enableAlertmanagerConfig: true <2>
+      enabled: true # <1>
+      enableAlertmanagerConfig: true # <2>
 ----
 <1> Set the `enabled` value to `true` to enable a dedicated instance of the Alertmanager for user-defined projects in a cluster. Set the value to `false` or omit the key entirely to disable the Alertmanager for user-defined projects.
 If you set this value to `false` or if the key is omitted, user-defined alerts are routed to the default platform Alertmanager instance.
@@ -63,7 +63,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 +
 [source,terminal]
 ----
-# oc -n openshift-user-workload-monitoring get alertmanager
+$ oc -n openshift-user-workload-monitoring get alertmanager
 ----
 +
 .Example output
@@ -81,7 +81,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 +
 [source,terminal]
 ----
-# oc -n openshift-user-workload-monitoring get pods
+$ oc -n openshift-user-workload-monitoring get pods
 ----
 +
 .Example output


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 and later
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1800
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  https://91686--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.html#enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing_preparing-to-configure-the-monitoring-stack-uwm
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
