### PR TITLE
OSDOCS-13983: Removed localnet network as primary from UDN

### DIFF
--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -91,7 +91,6 @@ where:
 ** If your hardware MTU is specified in a NetworkManager connection configuration, complete the following steps. This approach is the default for {product-title} if you do not explicitly specify your network configuration with DHCP, a kernel command line, or some other method. Your cluster nodes must all use the same underlying network configuration for the following procedure to work unmodified.
 
 ... Find the primary network interface by entering the following command:
-
 +
 [source,terminal]
 ----

--- a/networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
+++ b/networking/multiple_networks/primary_networks/about-user-defined-networks.adoc
@@ -10,7 +10,7 @@ Before the implementation of user-defined networks (UDN), the OVN-Kubernetes CNI
 
 While the Kubernetes design is useful for simple deployments, this Layer 3 topology restricts customization of primary network segment configurations, especially for modern multi-tenant deployments.
 
-UDN improves the flexibility and segmentation capabilities of the default Layer 3 topology for a Kubernetes pod network by enabling custom Layer 2, Layer 3, and localnet network segments, where all these segments are isolated by default. These segments act as either primary or secondary networks for container pods and virtual machines that use the default OVN-Kubernetes CNI plugin. UDNs enable a wide range of network architectures and topologies, enhancing network flexibility, security, and performance.
+UDN improves the flexibility and segmentation capabilities of the default Layer 3 topology for a Kubernetes pod network by enabling custom Layer 2 and Layer 3 network segments, where all these segments are isolated by default. These segments act as either primary or secondary networks for container pods and virtual machines that use the default OVN-Kubernetes CNI plugin. UDNs enable a wide range of network architectures and topologies, enhancing network flexibility, security, and performance.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-13983](https://issues.redhat.com/browse/OSDOCS-13983)

Link to docs preview:
* [localnet topology](https://91697--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html)


- [x] SME has approved this change (Enrique Pastora)
- [x] QE has approved this change (Arti Sood).

