### PR TITLE
OSDOCS-13973 documented 4.12.75 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5122,3 +5122,23 @@ $ oc adm release info 4.12.74 --pullspecs
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
+// 4.12.75
+[id="ocp-4-12-75_{context}"]
+=== RHSA-2025:3573 - {product-title} 4.12.75 bug fix and security update
+
+Issued: 10 April 2025
+
+{product-title} release 4.12.75 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3573[RHSA-2025:3573] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3575[RHBA-2025:3575] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.75 --pullspecs
+----
+
+[id="ocp-4-12-75-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-13973

Link to docs preview:
https://91748--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html

Reviewer: The errata URLs are not available until  the go-live-date of 04-10-2025

