### PR TITLE
OSDOCS-13986: adds greenboot updates relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -54,8 +54,10 @@ With this release, configurable transport layer security (TLS) protocols on inte
 [id="microshift-4-19-running-apps_{context}"]
 === Running applications
 
-//[id="microshift-4-19-example-ra-feature_{context}"]
-//==== Example RA feature here
+[id="microshift-4-19-greenboot-updated_{context}"]
+==== Check application health with the {microshift-short} healthcheck command
+
+With this release, you can use the `microshift healthcheck` command with various options to run a basic health check on your applications. For more information, see xref:../microshift_running_apps/microshift-greenboot-workload-scripts.adoc#microshift-greenboot-workload-scripts_microshift-greenboot-workload-scripts[Greenboot workload health check scripts].
 
 [id="microshift-4-19-support_{context}"]
 === Support
@@ -90,9 +92,27 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 //See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
 
-//[id="microshift-4-19-deprecated-and-removed-features_{context}"]
-//== Deprecated and removed features
-//add deprecated and removed user-facing or deployment-impacting features here
+[id="microshift-4-19-deprecated-and-removed-features_{context}"]
+== Deprecated and removed features
+
+Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in and continues to be supported, but will be removed in a future release. Deprecated features and functionality are not recommended for new deployments.
+
+[id="microshift-4-19-app-greenboot-script-deprecated_{context}"]
+=== Greenboot application health check script functions deprecated
+
+The following functions related to checking workload health in the `/usr/share/microshift/functions/greenboot.sh` script are deprecated:
+
+* `wait_for`
+* `namespace_images_downloaded`
+* `namespace_deployment_ready`
+* `namespace_daemonset_ready`
+* `namespace_pods_ready`
+* `namespace_pods_not_restarting`
+* `print_failure_logs`
+* `log_failure_cmd`
+* `log_script_exit`
+* `lvmsDriverShouldExist`
+* `csiComponentShouldBeDeploy`
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
 [id="microshift-4-19-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13986](https://issues.redhat.com/browse/OSDOCS-13986)

Link to docs preview:
[Feature update release note](https://91750--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-running-apps_release-notes)
[Deprecated script notice](https://91750--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-app-greenboot-script-deprecated_release-notes)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Feature PR, https://github.com/openshift/openshift-docs/pull/91739

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
