### PR TITLE
OCPBUGS-54675: Add permissions for using keys for encryption

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -200,6 +200,12 @@ If your organization’s security policies require a more restrictive set of per
 * `cloudkms.keyRings.list`
 ====
 
+.Required permissions when using Key Management Service (KMS) keys for encryption
+[%collapsible]
+====
+* `cloudkms.cryptoKeyVersions.useToEncrypt`
+====
+
 .Optional Images permissions for installation
 [%collapsible]
 ====

--- a/modules/minimum-required-permissions-upi-gcp.adoc
+++ b/modules/minimum-required-permissions-upi-gcp.adoc
@@ -199,6 +199,12 @@ If your organization’s security policies require a more restrictive set of per
 * `cloudkms.keyRings.list`
 ====
 
+.Required permissions when using Key Management Service (KMS) keys for encryption
+[%collapsible]
+====
+* `cloudkms.cryptoKeyVersions.useToEncrypt`
+====
+
 .Required Images permissions for installation
 [%collapsible]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

OCPBUGS-54675: Add permissions for using keys for encryption

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

4.19+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Link to this bug: https://issues.redhat.com/browse/OCPBUGS-54675

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

After adding https://issues.redhat.com/browse/OCPBUGS-52203, the permission cloudkms.cryptoKeyVersions.useToEncrypt is required when a user wants to use the key for data encryption. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

@brendan-daly-red-hat
@jianli-wei
