### PR TITLE
OSDOCS-13974: Documented the 4.14.50 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3400,6 +3400,39 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.50
+[id="ocp-4-14-50_{context}"]
+=== RHSA-2025:3569 - {product-title} 4.14.50 bug fix and security update
+
+Issued: 09 April 2025
+
+{product-title} release 4.14.50, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3569[RHSA-2025:3569] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.50 --pullspecs
+----
+
+[id="ocp-4-14-50-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, installing a cluster on {vmw-first} required specifying the full path to the {vmw-short} datastore. With this release, the installation program accepts full paths and relative paths to the datastore. (link:https://issues.redhat.com/browse/OCPBUGS-54260[*OCPBUGS-54260*])
+
+* Previously, the *Cluster Settings* page would not properly render during a cluster update if the `ClusterVersion` did not receive a `Completed` update. With this release, the *Cluster Setting* page properly renders even if the `ClusterVersion` has not received a `Completed` update. (link:https://issues.redhat.com/browse/OCPBUGS-54167[*OCPBUGS-54167*])
+
+* Previously, incorrect addresses were being passed to the Kubernetes EndpointSlice on a cluster. This issue prevented the installation of the MetalLB Operator on an Agent-based cluster in an IPv6 disconnected environment. With this release, a fix modified the address evaluation method. Red{nbsp}Hat Marketplace pods can now successfully connect to the cluster API server so that the installation of MetalLB Operator and handling of ingress traffic in IPv6 disconnected environments can occur. (link:https://issues.redhat.com/browse/OCPBUGS-53314[*OCPBUGS-53314*])
+
+* Previously, a code migration operation failed to process external labels correctly on the *Home* > *Overview* > *Status* pane on the *Administrator perspective* of the web console. These external labels are required to prevent silenced alert notifications from getting added to *Status* pane. Because the *Status* pane did not handle external labels correctly, the pane provided links to *Alert detail* pages but generated a "no matching alerts found" message when you clicked on a link. With this release, the *Status* pane accepts external labels so clicking on an alert links to the correct *Alert detail* page. (link:https://issues.redhat.com/browse/OCPBUGS-51118[*OCPBUGS-51118*])
+
+[id="ocp-4-14-50-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.49
 [id="ocp-4-14-49_{context}"]
 === RHSA-2025:2710 - {product-title} 4.14.49 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-13974](https://issues.redhat.com/browse/OSDOCS-13974)

Link to docs preview:
[4.14.50](https://91765--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-50_release-notes)
