### PR TITLE
OCPBUGS-48479: Adding MHC exception to Pausing MHC cluster update …

### DIFF
--- a/modules/machine-health-checks-pausing.adoc
+++ b/modules/machine-health-checks-pausing.adoc
@@ -8,7 +8,12 @@
 [id="machine-health-checks-pausing_{context}"]
 = Pausing a MachineHealthCheck resource
 
-During the update process, nodes in the cluster might become temporarily unavailable. In the case of worker nodes, the machine health check might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, pause all the `MachineHealthCheck` resources before updating the cluster.
+During the update process, nodes in the cluster might become temporarily unavailable. In the case of worker nodes, the `MachineHealthCheck` resources might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, pause all the `MachineHealthCheck` resources before updating the cluster.
+
+[NOTE]
+====
+Some `MachineHealthCheck` resources might not need to be paused. If your `MachineHealthCheck` resource relies on unrecoverable conditions, pausing that MHC is unnecessary.
+====
 
 .Prerequisites
 


### PR DESCRIPTION
…step

Updating to add an exception note for one of the MachineHealthCheck resources that does not need to be paused during this step.

Version(s):
4.14+

Issue:
[OCPBUGS-48479](https://issues.redhat.com/browse/OCPBUGS-48479)

Link to docs preview:
https://91781--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/updating/disconnected-update.html
https://91781--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
