### PR TITLE
OSDOCS-13979 NetObserv Release Notes 1.8.1

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -13,6 +13,21 @@ These release notes track the development of the Network Observability Operator 
 
 For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
 
+[id="network-observability-operator-release-notes-1-8-1_{context}"]
+== Network Observability Operator 1.8.1
+The following advisory is available for the Network Observability Operator 1.8.1:
+
+* link:https://access.redhat.com/errata/RHSA-2025:3867[Network Observability Operator 1.8.1]
+
+[id="network-observability-operator-CVE-1-8-1_{context}"]
+=== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
+
+[id="network-observability-operator-1-8-1-bug-fixes_{context}"]
+=== Bug fixes
+* This fix ensures that the *Observe* menu appears only once in future versions of {product-title}. (link:https://issues.redhat.com/browse/NETOBSERV-2139[*NETOBSERV-2139*])
+
 [id="network-observability-operator-release-notes-1-8_{context}"]
 == Network Observability Operator 1.8.0
 The following advisory is available for the Network Observability Operator 1.8.0:
@@ -145,14 +160,14 @@ The following enhancements are available for the eBPF agent:
 * You can now use two ports for transport protocols (TCP, UDP, or SCTP) filtering rules.
 * You can now filter on transport ports with a wildcard protocol by leaving the protocol field empty.
 
-For more information, see xref:../../observability/network_observability/flowcollector-api.adoc#spec-agent-ebpf-advanced[FlowCollector API specifications]. 
+For more information, see xref:../../observability/network_observability/flowcollector-api.adoc#spec-agent-ebpf-advanced[FlowCollector API specifications].
 
 [id="network-observability-cli-1-7_{context}"]
 ==== Network Observability CLI
 The Network Observability CLI (`oc netobserv`), is now generally available. The following enhancements have been made since the 1.6 Technology Preview release:
 * There are now eBPF enrichment filters for packet capture similar to flow capture.
 * You can now use filter `tcp_flags` with both flow and packets capture.
-* The auto-teardown option is available when max-bytes or max-time is reached. 
+* The auto-teardown option is available when max-bytes or max-time is reached.
 For more information, see xref:../../observability/network_observability/netobserv_cli/netobserv-cli-install.adoc#network-observability-netoberv-cli-about_netobserv-cli-install[Network Observability CLI] and link:https://access.redhat.com/errata/RHEA-2024:8264[Network Observability CLI 1.7.0].
 
 [id="network-observability-operator-1-7-bug-fixes_{context}"]
@@ -264,7 +279,7 @@ You can create custom metrics out of flowlogs data by using the `FlowMetrics` AP
 
 [id="network-observability-eBPF-performance-enhancements-1.6_{context}"]
 ==== eBPF performance enhancements
-Experience improved performances of the eBPF agent, in terms of CPU and memory, with the following updates: 
+Experience improved performances of the eBPF agent, in terms of CPU and memory, with the following updates:
 
 * The eBPF agent now uses TCX webhooks instead of TC.
 * The *NetObserv / Health* dashboard has a new section that shows eBPF metrics.
@@ -273,10 +288,10 @@ Experience improved performances of the eBPF agent, in terms of CPU and memory, 
 
 [IMPORTANT]
 =====
-With the duplicated flows update, the *Interface* and *Interface Direction* fields in the *Network Traffic* table are renamed to *Interfaces* and *Interface Directions*, so any bookmarked *Quick filter* queries using these fields need to be updated to `interfaces` and `ifdirections`. 
+With the duplicated flows update, the *Interface* and *Interface Direction* fields in the *Network Traffic* table are renamed to *Interfaces* and *Interface Directions*, so any bookmarked *Quick filter* queries using these fields need to be updated to `interfaces` and `ifdirections`.
 =====
 
-For more information, see xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-netobserv-dashboard-ebpf-agent-alerts_network_observability[Using the eBPF agent alert] 
+For more information, see xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-netobserv-dashboard-ebpf-agent-alerts_network_observability[Using the eBPF agent alert]
 and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-quickfilternw-observe-network-traffic[Quick filters].
 
 
@@ -342,13 +357,13 @@ You can create Prometheus alerts for the *Netobserv* dashboard using DNS, Packet
 You can configure the `FlowCollector` resource to collect information about the cluster availability zones. This configuration enriches the network flow data with the link:https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone[`topology.kubernetes.io/zone`] label value applied to the nodes. For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-zonesnw-observe-network-traffic[Working with availability zones].
 
 [id="network-observability-enhanced-configuration-and-ui-1.5"]
-==== Notable enhancements 
+==== Notable enhancements
 The 1.5 release of the Network Observability Operator adds improvements and new capabilities to the {product-title} web console plugin and the Operator configuration.
 
 [discrete]
 [id="performance-enhancements-1.5"]
 ===== Performance enhancements
-* The `spec.agent.ebpf.kafkaBatchSize` default is changed from `10MB` to `1MB` to enhance eBPF performance when using Kafka. 
+* The `spec.agent.ebpf.kafkaBatchSize` default is changed from `10MB` to `1MB` to enhance eBPF performance when using Kafka.
 +
 [IMPORTANT]
 =====
@@ -361,8 +376,8 @@ When upgrading from an existing installation, this new value is not set automati
 
 * There are new panels added to the *Overview* view for DNS and RTT: Min, Max, P90, P99.
 * There are new panel display options added:
-** Focus on one panel while keeping others viewable but with smaller focus. 
-** Switch graph type. 
+** Focus on one panel while keeping others viewable but with smaller focus.
+** Switch graph type.
 ** Show *Top* and *Overall*.
 * A collection latency warning is shown in the *Custom time range* pop-up window.
 * There is enhanced visibility for the contents of the *Manage panels* and *Manage columns* pop-up windows.
@@ -395,7 +410,7 @@ With this fix, the status only becomes `Ready` when all of the underlying compon
 === Known issues
 * When trying to access the web console, cache issues on OCP 4.14.10 prevent access to the *Observe* view. The web console shows the error message: `Failed to get a valid plugin manifest from /api/plugins/monitoring-plugin/`. The recommended workaround is to update the cluster to the latest minor version. If this does not work, you need to apply the workarounds described in this link:https://access.redhat.com/solutions/7052408[Red Hat Knowledgebase article].(link:https://issues.redhat.com/browse/NETOBSERV-1493[*NETOBSERV-1493*])
 
-* Since the 1.3.0 release of the Network Observability Operator, installing the Operator causes a warning kernel taint to appear. The reason for this error is that the Network Observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive. 
+* Since the 1.3.0 release of the Network Observability Operator, installing the Operator causes a warning kernel taint to appear. The reason for this error is that the Network Observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.
 
 [id="network-observability-operator-release-notes-1-4-2"]
 == Network Observability Operator 1.4.2


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13979 NetObserve Release Notes 1.8.1

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-13979

Link to docs preview:
https://91782--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-release-notes-1-8-1_network-observability-operator-release-notes-v0

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Moved from Service Mesh, so this is my first PR for NETOBSERV. ~~My understanding is that the advisory link is added at the last minute as it depends on Konflux. Submitting for peer review now, without the advisory link since it is not available yet, since there is a bug fix.~~
* A number of extra spaces were automatically removed, hence the M rather than S sizing.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
