### PR TITLE
OSDOCS-13985: updates multus in config.yaml MicroShift

### DIFF
--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -249,6 +249,10 @@ container_memory_working_set_bytes{container=`router`,namespace=`openshift-ingre
 |String
 |Deploys the Open Virtual Networking - Kubernetes (OVN-K) network plugin as the default container network interface (CNI) when empty or set to `"ovnk"`. Supported values are empty, `""` or `"ovnk"`. Setting to `"none"` removes the CNI and is not recommended. Only OVN-K is managed by {microshift-short}.
 
+|`network.multus.status`
+|`string`
+|Controls the deployment of the Multus Container Network Interface (CNI). Default status is `Disabled`. If you set the value to `Enabled`, the Multus CNI cannot be deleted.
+
 |`network.serviceNetwork`
 |IP address block
 |A block of virtual IP addresses for Kubernetes services. IP address pool for services. IPv4 is the default. Dual-stack entries are supported. The first entry in this field is immutable after {microshift-short} starts. Default range is `10.43.0.0/16`.

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -42,11 +42,17 @@ dns:
 etcd:
   memoryLimitMB: 0
 ingress:
+  certificateSecret: router-certs-default
+  clientTLS:
+    allowedSubjectPatterns:
+    clientCA:
+      name: ""
+    clientCertificatePolicy: ""
   defaultHTTPVersion: 1
   forwardedHeaderPolicy: ""
-  httpCompression:
-      mimeTypes:
-          - ""
+httpCompression:
+    mimeTypes:
+      - ""
   httpEmptyRequestsPolicy: Respond
   listenAddress:
     - ""
@@ -80,22 +86,26 @@ network:
   clusterNetwork:
     - 10.42.0.0/16
   cniPlugin: ""
+  multus:
+    status: Disabled # <2>
   serviceNetwork:
     - 10.43.0.0/16
   serviceNodePortRange: 30000-32767
 node:
   hostnameOverride: ""
-  nodeIP: "" # <2>
+  nodeIP: "" # <3>
   nodeIPv6: ""
 storage:
-  driver: "" # <3>
-  optionalCsiComponents: # <4>
+  driver: "" # <4>
+  optionalCsiComponents: # <5>
     - ""
 telemetry:
-    endpoint: https://infogw.api.openshift.com
-    status: Enabled
+  endpoint: https://infogw.api.openshift.com
+  proxy: ""
+  status: Enabled
 ----
 <1> Calculated based on the address of the service network.
-<2> The IP address of the default route.
-<3> Default null value deploys Logical Volume Managed Storage (LVMS).
-<4> Default null value deploys `snapshot-controller`.
+<2> Controls the deployment of the Multus Container Network Interface (CNI).
+<3> The IP address of the default route.
+<4> Default null value deploys Logical Volume Managed Storage (LVMS).
+<5> Default null value deploys `snapshot-controller`.

--- a/modules/microshift-install-multus-rpm.adoc
+++ b/modules/microshift-install-multus-rpm.adoc
@@ -6,11 +6,11 @@
 [id="microshift-installing-multus_{context}"]
 = Installing the multiple networks plugin
 
-Use this procedure to install the {microshift-short} Multus CNI plugin alongside a new {microshift-short} installation. The {microshift-short} Multus Container Network Interface (CNI) plugin is not installed by default. If you want to attach additional networks to a pod for high-performance network configurations, install the `microshift-multus` RPM package.
+You can install the {microshift-short} Multus Container Network Interface (CNI) plugin alongside a new {microshift-short} installation. If you want to attach additional networks to a pod for high-performance network configurations, install the `microshift-multus` RPM package.
 
 [IMPORTANT]
 ====
-Uninstalling the {microshift-short} Multus CNI is not supported.
+The {microshift-short} Multus CNI plugin manifests are included in the {microshift-short} binary. To enable multiple networks, you can either set the value in the {microshift-short} `config.yaml` file to `Enabled`, or use the configuration snippet in the `microshift-multus` RPM. Uninstalling the {microshift-short} Multus CNI is not supported in either case.
 ====
 
 .Procedure
@@ -28,6 +28,7 @@ If you create your custom resources (CRs) while you are completing your installa
 ====
 
 .Next steps
+
 . Continue with your new {microshift-short} installation, including any add-ons.
 
 . Create the custom resources (CRs) needed for your {microshift-short} Multus CNI plugin.


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-13985](https://issues.redhat.com/browse/OSDOCS-13985)

Link to docs preview:
https://91783--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html
https://91783--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm_opt/microshift-install-optional-rpms.html
https://91783--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-cni.html

Reviews:
- [x] QE approved this change.
- [x] SME approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Release note is here, https://github.com/openshift/openshift-docs/pull/91786.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
