### PR TITLE
OSDOCS-14001: adds multus update to relnotes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -72,6 +72,13 @@ With this release, {microshift-short} adds the Telemeter API. Lightweight attrib
 //[id="microshift-4-19-storage-docs-update_{context}"]
 //==== Updated content in the storage section
 
+[id="microshift-4-19-notable-technical-changes_{context}"]
+== Notable technical changes
+
+[id="microshift-4-19-multus-standard-install_{context}"]
+=== Multus CNI manifests included in the {microshift-short} RPM
+
+With this release, the {microshift-short} RPM includes the {microshift-short} multiple networking plug-in. To deploy the Multus container network interface (CNI), you can either set the value in the {microshift-short} configuration file, or install the `microshift-multus` RPM, which contains a configuration snippet. For more information, see xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-cni-multus[About using multiple networks].
 
 [id="microshift-4-19-tech-preview_{context}"]
 == Technology Preview features


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14001](https://issues.redhat.com/browse/OSDOCS-14001)

Link to docs preview:
[multus change release note](https://91786--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-multus-standard-install_release-notes)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Main doc updates are here, https://github.com/openshift/openshift-docs/pull/91783

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
