### PR TITLE
OSDOCS#13693: attempting table format fix

### DIFF
--- a/modules/agent-configuration-parameters.adoc
+++ b/modules/agent-configuration-parameters.adoc
@@ -21,7 +21,7 @@ These settings are used for installation only, and cannot be modified after inst
 Required Agent configuration parameters are described in the following table:
 
 .Required parameters
-[cols=".^2l,.^3,.^5a",options="header"]
+[cols=".^2l,.^4,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 


### PR DESCRIPTION
[OSDOCS-13693](https://issues.redhat.com/browse/OSDOCS-13693)

Version(s): 4.14+

This PR is attempting to fix the formatting of the table in [this section](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installing_an_on-premise_cluster_with_the_agent-based_installer/installation-config-parameters-agent#agent-configuration-parameters-required_installation-config-parameters-agent), where the first column is unreadable, and at certain browser page widths there is not even an "expand table" icon in the top right corner.

QE review:
N/A

Preview:  [Required configuration parameters](https://91791--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html#agent-configuration-parameters-required_installation-config-parameters-agent)


Additional information:
Honestly not much to review here. Unfortunately we only have previews for the old docs site, and seeing as this issue exists solely in the new site, I feel like I can only try out one solution at a time and wait until the change is live to really see if I fixed it. Any ideas on how to handle this differently are welcome haha.