### PR TITLE
[enterprise-4.14] OCPBUGS-53444: Changed default parameter values in nw-sriov-configuri…

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -64,13 +64,10 @@ By default, this field is set to `true`.
 |`spec.enableOperatorWebhook`
 |`boolean`
 |Specifies whether to enable or disable the Operator Admission Controller webhook daemon set.
-By default, this field is set to `true`.
 
 |`spec.logLevel`
 |`integer`
-|Specifies the log verbosity level of the Operator.
-Set to `0` to show only the basic logs. Set to `2` to show all the available logs.
-By default, this field is set to `2`.
+|Specifies the log verbosity level of the Operator. By default, this field is set to `0`, which shows only basic logs. Set to `2` to show all the available logs.
 
 |====
 


### PR DESCRIPTION
Cherry pick of #90935 with commit ID ed6ec6aae2f37c801df7feeff1a2fd611fabc06e

Version(s):
4.14

Issue:
[OCPBUGS-51361](https://issues.redhat.com/browse/OCPBUGS-51361)

Link to docs preview:
https://91812--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html

