### PR TITLE
Clarification regarding modifying masquerade subnet post installation

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -865,7 +865,7 @@ For more information about this feature, see xref:../networking/multiple_network
 [id="ocp-4-16-networking-changing-ovn-kubernetes-network-plugin-internal-range_{context}"]
 ==== Support for changing the OVN-Kubernetes network plugin internal IP address ranges
 
-If you use the OVN-Kubernetes network plugin, you can configure the transit, join, and masquerade subnets. The transit, join and masquerade subnets can be configured either during cluster installation or after. The subnet defaults are:
+If you use the OVN-Kubernetes network plugin, you can configure the transit, join, and masquerade subnets during cluster installation. You can change the join and transit CIDR ranges after installation. The subnet defaults are:
 
 - Transit subnet: `100.88.0.0/16` and `fd97::/64`
 - Join subnet: `100.64.0.0/16` and `fd98::/64`


### PR DESCRIPTION
There was wrong information regarding Masquerade subnet to be change post installation in release-note of OCP v4.16.

Current:

> If you use the OVN-Kubernetes network plugin, you can configure the transit, join, and masquerade subnets. The transit, join and masquerade subnets can be configured either during cluster installation or after. The subnet defaults are: 

![Current Info Release Note](https://github.com/user-attachments/assets/354259a7-1931-4177-a618-b7f7d00ea33c)

Link : https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/release_notes/ocp-4-16-release-notes#ocp-4-16-networking-changing-ovn-kubernetes-network-plugin-internal-range_release-notes

Expected:

> As in official doc of v4.16 it is mentioned that only Join and Transit can be change post installation.

![Official Doc Info](https://github.com/user-attachments/assets/e7cd7533-f35b-4090-9b9e-0e1dbd18fe6a)

Link : https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html-single/networking/index#cidr-range-definitions

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-14011