### PR TITLE
OSDOCS-14012: adds cniplugin field MicroShift config

### DIFF
--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -245,6 +245,10 @@ container_memory_working_set_bytes{container=`router`,namespace=`openshift-ingre
 |IP address block
 |A block of IP addresses from which pod IP addresses are allocated. IPv4 is the default network. Dual-stack entries are supported. The first entry in this field is immutable after {microshift-short} starts. Default range is `10.42.0.0/16`.
 
+|`network.cniPlugin`
+|String
+|Deploys the Open Virtual Networking - Kubernetes (OVN-K) network plugin as the default container network interface (CNI) when empty or set to `"ovnk"`. Supported values are empty, `""` or `"ovnk"`. Setting to `"none"` removes the CNI and is not recommended. Only OVN-K is managed by {microshift-short}.
+
 |`network.serviceNetwork`
 |IP address block
 |A block of virtual IP addresses for Kubernetes services. IP address pool for services. IPv4 is the default. Dual-stack entries are supported. The first entry in this field is immutable after {microshift-short} starts. Default range is `10.43.0.0/16`.

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -79,6 +79,7 @@ manifests:
 network:
   clusterNetwork:
     - 10.42.0.0/16
+  cniPlugin: ""
   serviceNetwork:
     - 10.43.0.0/16
   serviceNodePortRange: 30000-32767


### PR DESCRIPTION
Version(s):
4.18, 4.19+

Issue:
[OSDOCS-14012](https://issues.redhat.com/browse/OSDOCS-14012)

Link to docs preview:
https://91829--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-yaml-default_microshift-configuring

https://91829--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml#microshift-config-parameters-table_microshift-configuring

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
