### PR TITLE
OSDOCS#13256: Adding an additional learning resources page

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -73,6 +73,8 @@ Topics:
   File: dev-app-web-console
 - Name: Deploying an application by using the CLI
   File: dev-app-cli
+- Name: Additional hands-on learning
+  File: additional-tutorials
 ---
 Name: Architecture
 Dir: architecture

--- a/tutorials/additional-tutorials.adoc
+++ b/tutorials/additional-tutorials.adoc
@@ -1,0 +1,111 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="additional-tutorials"]
+= Additional hands-on learning
+include::_attributes/common-attributes.adoc[]
+:context: additional-tutorials
+
+toc::[]
+
+Red{nbsp}Hat provides many additional learning resources for administrators and developers to gain hands-on experience with {product-title}.
+
+[id="learning-paths_{context}"]
+== Red{nbsp}Hat Developer learning paths
+
+The Red{nbsp}Hat Developer program provides several learning paths for developers to get started working with {product-title}.
+
+The following table lists several recommended learning paths for {product-title}:
+
+.Red{nbsp}Hat Developer learning paths
+[cols="1,1",options="header"]
+|===
+
+|Learning path
+|Description
+
+|link:https://developers.redhat.com/learn/openshift/foundations-openshift[Foundations of OpenShift]
+|This learning path covers basic Red{nbsp}Hat OpenShift concepts and how to create and deploy applications through various methods.
+
+|link:https://developers.redhat.com/learn/openshift/using-openshift[Using OpenShift]
+|This learning path covers managing cluster access, database operations, and resource management.
+
+|link:https://developers.redhat.com/learn/openshift/develop-on-openshift[Developing applications on OpenShift]
+|This learning path covers deploying applications from source code and images, and developing with Node.js.
+
+|link:https://developers.redhat.com/learn/openshift/how-deploy-full-stack-javascript-applications-openshift[How to deploy full-stack JavaScript applications in OpenShift]
+|This learning path covers how to deploy a full-stack JavaScript application in an {product-title} cluster.
+
+|link:https://developers.redhat.com/learn/openshift/store-persistent-data-red-hat-openshift-using-pvcs[Store persistent data in Red{nbsp}Hat OpenShift using PVCs]
+|This learning path covers how to create and use persistent volume claims (PVCs) for persistent storage in {product-title}.
+
+|===
+
+For the full list of available Red{nbsp}Hat Developer learning paths for {product-title}, see link:https://developers.redhat.com/learn/openshift[OpenShift and Kubernetes learning].
+
+[id="training-courses_{context}"]
+== Red{nbsp}Hat Training courses
+
+Red{nbsp}Hat Training offers a variety of courses, both online and in-person, both free and paid, to help you learn Red{nbsp}Hat OpenShift and related technologies.
+
+The following tables list several recommended training courses for {product-title}, both for developers and administrators:
+
+.Red{nbsp}Hat Training courses for developers
+[cols="1,1",options="header"]
+|===
+
+|Course
+|Description
+
+|link:https://www.redhat.com/en/services/training/do101-introduction-openshift-applications[DO101: Introduction to OpenShift Applications]
+|This course helps developers learn to deploy, scale, and troubleshoot applications in {product-title}.
+
+|link:https://www.redhat.com/en/services/training/do188-red-hat-open-shift-development-introduction-containers-with-podman[DO188: Red{nbsp}Hat OpenShift Development I: Introduction to Containers with Podman]
+|This course helps developers learn to build, run, and manage containers with Podman and {product-title}.
+
+|link:https://www.redhat.com/en/services/training/red-hat-openshift-developer-ii-building-and-deploying-cloud-native-applications[DO288: Red{nbsp}Hat OpenShift Developer II: Building and Deploying Cloud-native Applications]
+|This course helps developers learn to design, build, and deploy containerized software applications on an {product-title} cluster.
+
+|===
+
+.Red{nbsp}Hat Training courses for administrators
+[cols="1,1",options="header"]
+|===
+
+|Course
+|Description
+
+|link:https://www.redhat.com/en/services/training/red-hat-openshift-administration-i-operating-a-production-cluster[DO180: Red{nbsp}Hat OpenShift Administration I: Operating a Production Cluster]
+|This course helps cluster administrators learn to manage {product-title} clusters and collaborate with developers to support application workloads.
+
+|link:https://www.redhat.com/en/services/training/red-hat-openshift-administration-ii-configuring-a-production-cluster[DO280: Red{nbsp}Hat OpenShift Administration II: Configuring a Production Cluster]
+|This course helps cluster administrators learn to configure security features, manage Operators, and perform cluster updates.
+
+|link:https://www.redhat.com/en/services/training/do322-red-hat-openshift-installation-lab[DO322: Red{nbsp}Hat OpenShift Installation Lab]
+|This course helps cluster administrators learn to install {product-title} clusters in various environments.
+
+|===
+
+For the full list of available courses, see link:https://www.redhat.com/en/services/training-and-certification[Red{nbsp}Hat Training and Certification]. You can also take the link:https://skills.ole.redhat.com/en[skills assessment] to get recommendations for where to start learning.
+
+[id="cheat-sheets_{context}"]
+== Red{nbsp}Hat cheat sheets
+
+Red{nbsp}Hat provides several cheat sheets that provide quick references of common {oc-first} commands for working with {product-title}.
+
+The following table lists several recommended cheat sheets for {product-title}:
+
+.Red{nbsp}Hat cheat sheets
+[cols="1,1",options="header"]
+|===
+
+|Cheat sheet
+|Description
+
+|link:https://developers.redhat.com/cheat-sheets/red-hat-openshift-container-platform[Red{nbsp}Hat OpenShift Cheat Sheet]
+|This cheat sheet provides many {oc-first} commands for managing an application's lifecycle.
+
+|link:https://developers.redhat.com/cheat-sheets/openshift-command-line-essentials-cheat-sheet[OpenShift command line essentials cheat sheet]
+|This cheat sheet provides a quick look at several essential {oc-first} commands, such as creating applications, debugging, and editing deployments.
+
+|===
+
+For the full list of available cheat sheets, see link:https://developers.redhat.com/cheat-sheets[Red{nbsp}Hat Developer cheat sheets].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-13256

Link to docs preview:
https://91831--ocpdocs-pr.netlify.app/openshift-enterprise/latest/tutorials/additional-tutorials.html

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
