### PR TITLE
MTC 1.8.6 does not support multiple migplans per namespace

### DIFF
--- a/modules/migration-creating-migration-plan-cam.adoc
+++ b/modules/migration-creating-migration-plan-cam.adoc
@@ -29,6 +29,11 @@ The migration plan name must not exceed 253 lower-case alphanumeric characters (
 . Click *Next*.
 . Select the projects for migration.
 . Optional: Click the edit icon beside a project to change the target namespace.
++
+[WARNING]
+====
+{mtc-full} 1.8.6 and later versions do not support multiple migration plans for a single namespace.
+====
 . Click *Next*.
 . Select a *Migration type* for each PV:
 


### PR DESCRIPTION
### JIRA

* [MIG-1720](https://issues.redhat.com/browse/MIG-1720)

### Version(s):

* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19

### Link to docs preview:

* [Migrating 3 to 4 - Creating a migration plan in the MTC web console](https://91832--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/migrating-applications-3-4.html#migration-creating-migration-plan-cam_migrating-applications-3-4)
* [Creating a migration plan in the MTC web console](https://91832--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/migrating-applications-with-mtc.html#migration-creating-migration-plan-cam_migrating-applications-with-mtc)

### QE review:
- [X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/91832#pullrequestreview-2772730062)

