### PR TITLE
OSSM-9119 2.6.7 (At Stage): [DOC] Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -187,7 +187,7 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.6
+:SMProductVersion: 2.6.7
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-5-10.adoc
+++ b/modules/ossm-release-2-5-10.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-5-10_{context}"]
+= {SMProductName} version 2.5.10
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.7 and is supported on {product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+[id="ossm-release-2-5-10-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.18.7
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali Server
+|1.73.20
+|===

--- a/modules/ossm-release-2-6-7.adoc
+++ b/modules/ossm-release-2-6-7.adoc
@@ -3,16 +3,18 @@
 // * service_mesh/v2x/servicemesh-release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="ossm-release-2-6-6_{context}"]
-= {SMProductName} version 2.6.6
+[id="ossm-release-2-6-7_{context}"]
+= {SMProductName} version 2.6.7
 
-This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.6, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.6, 2.5.9, and 2.4.15.
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.7, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.7 and 2.5.10.
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
 
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
 You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
-[id="ossm-release-2-6-6-components_{context}"]
+[id="ossm-release-2-6-7-components_{context}"]
 == Component updates
 
 |===
@@ -25,10 +27,5 @@ You can use the most current version of the {KialiProduct} with all supported ve
 |1.28.7
 
 |Kiali Server
-|1.73.19
+|1.73.20
 |===
-
-[id="ossm-new-features-2-6-6_{context}"]
-== New features
-
-* With this update, the Operator for {SMProductName} 2.6 is renamed to {SMProductName} 2 to align with the release of {SMProductName} 3.0 and improve clarity.

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -10,6 +10,10 @@ toc::[]
 
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
+include::modules/ossm-release-2-6-7.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-5-10.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-6.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-5-9.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.7 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-9119

Fix Version: 4.14+

Doc Preview: https://91833--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-7_ossm-release-notes

QE Review: @pbajjuri20 @unsortedhashsets 
Peer Review: @rh-tokeefe 