### PR TITLE
OSSM-9210 OSSM 3.0.1 (At Stage): [DOC] Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,10 +17,10 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.0
+:SMProductVersion: 3.0.1
 //service mesh v2
 //Update when there is a new 2.6.z release
-:SMv2Version: 2.6.6
+:SMv2Version: 2.6.7
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio
@@ -102,7 +102,7 @@
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
 //service mesh v2
-:SMProductVersion: 3.0.0
+:SMProductVersion: 3.0.1
 :MaistraVersion: 3.0
 //Jaeger
 //Deprecated

--- a/modules/ossm-release-notes-3-0-1.adoc
+++ b/modules/ossm-release-notes-3-0-1.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-0-1_{context}"]
+= {SMProductName} version 3.0.1
+
+This release of {SMProductName} is included with the {SMProductName} Operator 3.0.1 and is supported on {ocp-product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {ocp-product-title} 4.14 and later. For supported component versions for 3.0.1, see "Service Mesh version support tables".

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -1,27 +1,24 @@
-////
-Module included in the following assemblies:
-* service-mesh-docs-main/ossm-release-notes-support-tables.adoc
-////
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes-version-support-tables.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="service-mesh-product-supported-versions_{context}"]
+[id="ossm-release-notes-supported-versions_{context}"]
 = {SMProduct} supported versions
 
-See this following table to know supported versions in {SMProduct} 3.
+See the following table for information about {SMProduct} 3.0.1 supported versions.
 
-//Next writer for release notes: Update to say "the following tables" for 3.0.1.
-
-== {SMProduct} 3.0 supported versions
+== {SMProduct} 3.0.1 supported versions
 
 [cols="1,1"]
 |===
 | Feature | Supported versions
 
 |{SMProduct} 3 Operator
-|{SMProductVersion}
+|3.0.1
 
 |{SMProduct} `Istio` control plane resource
-|{istio-latest}
+|1.24.4
 
 |{ocp-product-title}
 |4.14+
@@ -30,7 +27,31 @@ See this following table to know supported versions in {SMProduct} 3.
 | 1.32.4
 
 | `IstioCNI` resource
-| {istio-latest} ^[1]^
+| 1.24.4 ^[1]^
+|===
+
+See the following table for information about {SMProduct} 3 supported versions.
+
+== {SMProduct} 3.0 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.0
+
+|{SMProduct} `Istio` control plane resource
+|1.24.3
+
+|{ocp-product-title}
+|4.14+
+
+| Envoy proxy
+| 1.32.4
+
+| `IstioCNI` resource
+| 1.24.3 ^[1]^
 |===
 
 . The `Istio` control plane and `IstioCNI` resources can be upgraded in any order, as long as their version difference is within one minor version.

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,7 @@ For additional information about the {SMProductName} life cycle and supported pl
 //03/25/2025:
 //Gwynne is rotating off Service Mesh. For next writer and CS: Continue to refine the IA for rel notes. The structure and IA will likely make more sense as there are more z-streams and versions released, making it easier to see how best to lay rel notes out in docs.redhat. Should anything be its own tile to make it easier to find for users?
 
+include::modules/ossm-release-notes-3-0-1.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-0-new-features.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-0-known-issues.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-0-deprecated-removed-features.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.0.1 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-9210

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: 

- Release notes: https://91835--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html#ossm-release-3-0-1_ossm-release-notes

- Version support table: https://91835--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-0-1-supported-versions

QE Review: @pbajjuri20 
Peer Review: @rh-tokeefe 