### PR TITLE
Explain headlined options

### DIFF
--- a/nodes/clusters/nodes-cluster-overcommit.adoc
+++ b/nodes/clusters/nodes-cluster-overcommit.adoc
@@ -85,9 +85,22 @@ include::modules/nodes-qos-about-swap.adoc[leveloffset=+2]
 
 include::modules/nodes-cluster-overcommit-configure-nodes.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-overcommit-node-enforcing_nodes-cluster-overcommit[Disabling or enforcing CPU limits using CPU CFS quotas]
+* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-overcommit-node-resources_nodes-cluster-overcommit[Reserving resources for system processes]
+* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#qos-about-reserve_nodes-cluster-overcommit[Understanding how to reserve memory across quality of service tiers]
+
 include::modules/nodes-cluster-overcommit-node-enforcing.adoc[leveloffset=+2]
 
 include::modules/nodes-cluster-overcommit-node-resources.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring[Allocating resources for nodes]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/nodes-cluster-overcommit-node-disable.adoc[leveloffset=+2]
 
@@ -103,7 +116,6 @@ include::modules/nodes-cluster-overcommit-project-disable.adoc[leveloffset=+2]
 == Additional resources
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../applications/deployments/managing-deployment-processes.adoc#deployments-triggers_deployment-operations[Setting deployment resources]
-* xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring[Allocating resources for nodes]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../nodes/clusters/nodes-cluster-limit-ranges.adoc#nodes-cluster-limit-ranges[Restrict resource consumption with limit ranges]

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -130,9 +130,20 @@ include::modules/nodes-qos-about-swap.adoc[leveloffset=+2]
 
 include::modules/nodes-cluster-overcommit-configure-nodes.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../post_installation_configuration/node-tasks.adoc#nodes-cluster-overcommit-node-enforcing_post-install-node-tasks[Disabling or enforcing CPU limits using CPU CFS quotas]
+* xref:../post_installation_configuration/node-tasks.adoc#nodes-cluster-overcommit-node-resources_post-install-node-tasks[Reserving resources for system processes]
+* xref:../post_installation_configuration/node-tasks.adoc#qos-about-reserve_post-install-node-tasks[Understanding how to reserve memory across quality of service tiers]
+
 include::modules/nodes-cluster-overcommit-node-enforcing.adoc[leveloffset=+2]
 
 include::modules/nodes-cluster-overcommit-node-resources.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring[Allocating resources for nodes]
 
 include::modules/nodes-cluster-overcommit-node-disable.adoc[leveloffset=+2]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-54535

Previews
OCP
Nodes -> Cluster -> Configuring your cluster to place pods on overcommited nodes -> [Understanding nodes overcommitment](https://91849--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-overcommit-configure-nodes_nodes-cluster-overcommit) - Added three Additional Resources to the assembly after this module. 
Reserving resources for system processes -> [Reserving resources for system processes](https://91849--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-overcommit-node-resources_nodes-cluster-overcommit) - Moved the Allocating Resources for Nodes link from the end of the assembly to after this module.

Postinstallation -> Node tasks -> [Understanding nodes overcommitment](https://91849--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks#nodes-cluster-overcommit-configure-nodes_post-install-node-tasks) - Added three Additional Resources to the assembly after this module. 
Postinstallation -> Node tasks -> [Reserving resources for system processes](https://91849--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks#nodes-cluster-overcommit-node-resources_post-install-node-tasks) - Added the Allocating Resources for Nodes link after this module.

ROSA/OSD 
Nodes -> Cluster -> Configuring your cluster to place pods on overcommited nodes -> [Understanding nodes overcommitment](https://91849--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/clusters/nodes-cluster-overcommit) - No changes [Current docs](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/nodes/working-with-clusters#nodes-cluster-overcommit)
Nodes -> Cluster -> Configuring your cluster to place pods on overcommited nodes -> [Understanding nodes overcommitment](https://91849--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/clusters/nodes-cluster-overcommit) - No changes [Current docs](https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/nodes/working-with-clusters#nodes-cluster-overcommit)

No QE. Adding links only (and moving a link, too).