### PR TITLE
OCPBUGS#53088: Apply MachineConfig when moving etcd to a different disk

### DIFF
--- a/modules/move-etcd-different-disk.adoc
+++ b/modules/move-etcd-different-disk.adoc
@@ -182,6 +182,13 @@ spec:
 ----
 <1> Replace `<encoded_etcd_find_secondary_device_script>` with the encoded script contents that you noted.
 
+. Apply the created `MachineConfig` YAML file:
++
+[source,terminal]
+----
+$ oc create -f etcd-mc.yml
+----
+
 .Verification steps
 
 * Run the `grep /var/lib/etcd /proc/mounts` command in a debug shell for the node to ensure that the disk is mounted:


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OCPBUGS-53088](https://issues.redhat.com/browse/OCPBUGS-53088)

Link to docs preview:
[Moving etcd to a different disk](https://91854--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html#move-etcd-different-disk_recommended-etcd-practices)

QE review:
- [x] QE has approved this change.

Additional information:

N/A
