### PR TITLE
OSDOCS-13820: Adding Kueue about docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -10,25 +10,12 @@
 :toc-title:
 :imagesdir: images
 :prewrap!:
-// n-1 and n+1 OCP versions relative to the current branch's {product-version} attr
-:ocp-nminus1: 4.17
-:ocp-nplus1: 4.19
 // Operating system attributes
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :op-system: RHCOS
 :op-system-lowercase: rhcos
 :op-system-base: RHEL
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
-:op-system-version: 9.x
-:op-system-version-9: 9
-ifdef::openshift-origin[]
-:op-system-first: Fedora CoreOS (FCOS)
-:op-system: FCOS
-:op-system-lowercase: fcos
-:op-system-base: Fedora
-:op-system-base-full: Fedora
-:op-system-version: 35
-endif::[]
 :tsb-name: Template Service Broker
 :kebab: image:kebab.png[title="Options menu"]
 :ai-full: Assisted Installer
@@ -48,8 +35,6 @@ endif::[]
 // Pipelines
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: OpenShift Pipelines
-:pipelines-ver: pipelines-1.18
-:pipelines-version-number: 1.18
 :tekton-chains: Tekton Chains
 :tekton-hub: Tekton Hub
 :artifact-hub: Artifact Hub
@@ -64,13 +49,9 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.6
-:MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
 :SMPluginShort: OSSMC plugin
-//Service Mesh v1
-:SMProductVersion1x: 1.1.18.2
 //OLM
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
@@ -143,4 +124,4 @@ endif::[]
 :mce: multicluster engine for Kubernetes Operator
 :mce-short: multicluster engine Operator
 //Kueue
-:kueue-s: Kueue
+:ocp-full: Red Hat OpenShift Container Platform

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -1,11 +1,11 @@
 ---
 openshift-kueue:
-  name: Red Hat OpenShift Build of Kueue
+  name: Red Hat build of Kueue
   author: OpenShift documentation team <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation
   site_url: https://docs.openshift.com/
   branches:
     kueue-docs-1.0:
-      name: '1.0.0'
+      name: '1.0'
       dir: kueue

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -29,3 +29,5 @@ Distros: openshift-kueue
 Topics:
 - Name: Welcome
   File: index
+- Name: About Red Hat build of Kueue
+  File: about-kueue

--- a/welcome/about-kueue.adoc
+++ b/welcome/about-kueue.adoc
@@ -1,0 +1,53 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="about-kueue"]
+= About {product-title}
+:context: about-kueue
+
+toc::[]
+
+{product-title} is a Kubernetes-native system that manages access to resources for jobs.
+{product-title} can determine when a job waits, is admitted to start by creating pods, or should be _preempted_, meaning that active pods for that job are deleted.
+
+[NOTE]
+====
+In the context of {product-title}, a job can be defined as a one-time or on-demand task that runs to completion.
+====
+
+{product-title} is based on the link:https://kueue.sigs.k8s.io/docs/[Kueue] open source project.
+
+{product-title} is compatible with environments that use heterogeneous, elastic resources. This means that the environment has many different resource types, and those resources are capable of dynamic scaling.
+
+{product-title} does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components.
+
+{product-title} supports all-or-nothing semantics. This means that either an entire job with all of its components is admitted to the cluster, or the entire job is rejected if it does not fit on the cluster.
+
+// Personas
+[id="about-kueue-personas"]
+== Personas
+
+Different personas exist in a {product-title} workflow.
+
+Batch administrators:: Batch administrators manage the cluster infrastructure and establish quotas and queues.
+Batch users:: Batch users run jobs on the cluster. Examples of batch users might be researchers, AI/ML engineers, or data scientists.
+Serving users:: Serving users run jobs on the cluster. For example, to expose a trained AI/ML model for inference.
+Platform developers:: Platform developers integrate {product-title} with other software. They might also contribute to the Kueue open source project.
+
+[id="about-kueue-workflow"]
+== Workflow overview
+// TODO: add diagram?
+
+The {product-title} workflow can be described at a high level as follows:
+
+. Batch administrators create and configure `ResourceFlavor`, `LocalQueue`, and `ClusterQueue` resources.
+. User personas create jobs on the cluster.
+. The Kubernetes API server validates and accepts job data.
+. {product-title} admits jobs based on configured options, such as order or quota. It injects affinity into the job by using resource flavors, and creates a `Workload` object that corresponds to each job.
+. The applicable controller for the job type creates pods.
+. The Kubernetes scheduler assigns pods to a node in the cluster.
+. The Kubernetes cluster autoscaler provisions more nodes as required.
+
+////
+TODO:Add docs explaining different job / workload types
+These can be added as we add stories / docs for different use cases
+////

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -8,4 +8,4 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Welcome to the official {product-title} documentation, where you can learn about {kueue-s} and start exploring its features.
+Welcome to the official {product-title} documentation, where you can learn about {product-title} and start exploring its features.


### PR DESCRIPTION
Version(s):
Merge to `kueue-docs` branch only. For Kueue GA docs.

Issue:
https://issues.redhat.com/browse/OSDOCS-13820

Link to docs preview:
- https://91855--ocpdocs-pr.netlify.app/openshift-kueue/latest/welcome/about-kueue.html
- https://91855--ocpdocs-pr.netlify.app/openshift-kueue/latest/welcome/index.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
