### PR TITLE
HCCDOC-3725 Fix doc bug in Insights Operator DVO task for obfuscating…

### DIFF
--- a/modules/obfuscating-dvo-data.adoc
+++ b/modules/obfuscating-dvo-data.adoc
@@ -7,7 +7,11 @@
 [id="obfuscating-deployment-validation-operator-data_{context}"]
 = Obfuscating Deployment Validation Operator data
 
-Cluster administrators can configure the Insights Operator to obfuscate data from the Deployment Validation Operator (DVO), if the Operator is installed. When the `workload_names` value is added to the *insights-config* `ConfigMap` object, workload names—rather than UIDs—are displayed in Insights for Openshift, making them more recognizable for cluster administrators. 
+By default, when you install the Deployment Validation Operator (DVO), the name and unique identifier (UID) of a resource are included in the data that is captured and processed by the Insights Operator for {product-title}. 
+If you are a cluster administrator, you can configure the Insights Operator to obfuscate data from the Deployment Validation Operator (DVO).
+For example, you can obfuscate workload names in the archive file that is then sent to Red{nbsp}Hat.
+
+To obfuscate the name of resources, you must manually set the `obfuscation` attribute in the `insights-config` `ConfigMap` object to include the `workload_names` value, as outlined in the following procedure.
 
 .Prerequisites
 
@@ -19,7 +23,7 @@ Cluster administrators can configure the Insights Operator to obfuscate data fro
 .Procedure
 
 . Go to *Workloads* -> *ConfigMaps* and select *Project: openshift-insights*.
-. Click on the *insights-config* `ConfigMap` object to open it.
+. Click the `insights-config` `ConfigMap` object to open it.
 . Click *Actions* and select *Edit ConfigMap*.
 . Click the *YAML view* radio button.
 . In the file, set the `obfuscation` attribute with the `workload_names` value.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

The description of what happens when `workload_names` is used in the insights-config is incorrect. When the `workload_names` value is used, workload names are not displayed—they are obfuscated, and UIDs are used to reference the objects instead. By default (without `workload_names`), both the resource name and UID are shown.

Link to docs - https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/support/remote-health-monitoring-with-connected-clusters#obfuscating-deployment-validation-operator-data_using-insights-operator


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18
4.17
4.16
4.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/HCCDOC-3725

(The scope of this PR is to fix the doc bug. We will be revisiting the content from a content journey perspective later.)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://91856--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/remote_health_monitoring/using-insights-operator.html
https://91856--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html
https://91856--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/remote_health_monitoring/using-insights-operator.html
https://91856--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/remote_health_monitoring/using-insights-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
