### PR TITLE
OCPBUGS-54731: Distinguished among IPI and UPI in nw-dual-stack-conve…

### DIFF
--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -9,14 +9,14 @@ As a cluster administrator, you can convert your single-stack cluster network to
 After converting your cluster to use dual-stack networking, you must re-create any existing pods for them to receive IPv6 addresses, because only new pods are assigned IPv6 addresses.
 ====
 
-Converting a single-stack cluster network to a dual-stack cluster network consists of creating patches and applying them to the cluster's network and infrastructure. You can convert to a dual-stack cluster network for a cluster that runs on installer-provisioned infrastructure.
+Converting a single-stack cluster network to a dual-stack cluster network consists of creating patches and applying them to the network and infrastructure of the cluster. You can convert to a dual-stack cluster network for a cluster that runs on either installer-provisioned infrastructure or user-provisioned infrastructure.
 
 [NOTE]
 ====
 Each patch operation that changes `clusterNetwork`, `serviceNetwork`, `apiServerInternalIPs`, and `ingressIP` objects triggers a restart of the cluster. Changing the `MachineNetworks` object does not cause a reboot of the cluster.
 ====
 
-If you need to add IPv6 virtual IPs (VIPs) for API and Ingress services to an existing dual-stack-configured cluster, you need to patch only the cluster's infrastructure and not the cluster's network.
+On installer-provisioned infrastructure only, if you need to add IPv6 virtual IPs (VIPs) for API and Ingress services to an existing dual-stack-configured cluster, you need to patch only the infrastructure and not the network for the cluster.
 
 [IMPORTANT]
 ====
@@ -74,7 +74,9 @@ $ oc patch network.config.openshift.io cluster \// <1>
 network.config.openshift.io/cluster patched
 ----
 
-. Specify IPv6 VIPs for API and Ingress services for your cluster. Create a YAML configuration patch file that has a similar configuration to the following example:
+. On installer-provisioned infrastructure where you added IPv6 VIPs for API and Ingress services, complete the following steps:
++
+.. Specify IPv6 VIPs for API and Ingress services for your cluster. Create a YAML configuration patch file that has a similar configuration to the following example:
 +
 [source,yaml]
 ----
@@ -90,16 +92,18 @@ network.config.openshift.io/cluster patched
 ----
 <1> Ensure that you specify an address block for the `machineNetwork` network where your machines operate. You must select both API and Ingress IP addresses for the machine network.
 <2> Ensure that you specify each file path according to your platform. The example demonstrates a file path on a bare-metal platform.
-
-
-. Patch the infrastructure by entering the following command in your CLI:
 +
-[source,terminal,subs="+quotes,"]
+.. Patch the infrastructure by entering the following command in your CLI:
++
+[source,terminal,subs="+quotes"]
 ----
-$ oc patch infrastructure cluster \// <1>
+$ oc patch infrastructure cluster \
   --type='json' --patch-file <file>.yaml
 ----
-<1> Where `file` specifies the name of your created YAML file.
++
+Where:
++
+<file>:: Specifies the name of your created YAML file.
 +
 .Example output
 [source,text]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-54731](https://issues.redhat.com/browse/OCPBUGS-54731)

Link to docs preview:
[Converting to a dual-stack cluster network](https://91857--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html)

- [x] SME has approved this change.
- [x] QE has approved this change.
