### PR TITLE
WMCO remove Hyper-V statements as it is not supported

### DIFF
--- a/windows_containers/understanding-windows-container-workloads.adoc
+++ b/windows_containers/understanding-windows-container-workloads.adoc
@@ -14,7 +14,7 @@ Multi-tenancy for clusters that have Windows nodes is not supported. Clusters ar
 
 Hostile multi-tenant clusters introduce security concerns in all Kubernetes environments. Additional security features like link:https://kubernetes.io/docs/concepts/policy/pod-security-policy/[pod security policies], or more fine-grained role-based access control (RBAC) for nodes, make exploiting your environment more difficult. However, if you choose to run hostile multi-tenant workloads, a hypervisor is the only security option you should use. The security domain for Kubernetes encompasses the entire cluster, not an individual node. For these types of hostile multi-tenant workloads, you should use physically isolated clusters.
 
-Windows Server Containers provide resource isolation using a shared kernel but are not intended to be used in hostile multitenancy scenarios. Scenarios that involve hostile multitenancy should use Hyper-V Isolated Containers to strongly isolate tenants.
+Windows Server Containers provide resource isolation using a shared kernel but are not intended to be used in hostile multitenancy scenarios.
 ====
 
 [role="_additional-resources"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-54734

Per [Slack](https://redhat-internal.slack.com/archives/CM4ERHBJS/p1744125137359419): Kubernetes does not support running Windows containers with Hyper-V isolation


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Needs Change Management announcement after merge.