### PR TITLE
CNV-52859: Configuring VM interface link state

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4780,6 +4780,8 @@ Topics:
     File: virt-connecting-vm-to-ovn-secondary-network
   - Name: Hot plugging secondary network interfaces
     File: virt-hot-plugging-network-interfaces
+  - Name: Setting VM interface link state
+    File: virt-setting-interface-link-state
   - Name: Connecting a VM to a service mesh
     File: virt-connecting-vm-to-service-mesh
   - Name: Configuring a dedicated network for live migration

--- a/modules/virt-configuring-interface-link-state.adoc
+++ b/modules/virt-configuring-interface-link-state.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-setting-interface-link-state.adoc
+
+:_mod-docs-content-type: PROCEDURE                                  
+[id="virt-configuring-interface-link-state_{context}"]
+= Setting the VM interface link state by using the CLI
+
+You can set the link state of a primary or secondary virtual machine (VM) network interface by using the CLI.
+
+.Prerequisites
+* You have installed the OpenShift CLI (`oc`).
+
+
+.Procedure
+. Edit the VM configuration to set the interface link state, as in the following example:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: my-vm
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          interfaces:
+            - name: default # <1>
+              state: down # <2>
+              masquerade: { }
+      networks:
+        - name: default
+          pod: { }
+# ...
+----
+<1> The name of the interface.
+<2> The state of the interface. The possible values are:
++
+* `up`: Represents an active network connection. This is the default if no value is specified.
+* `down`: Represents a network interface link that is switched off.
+* `absent`: Represents a network interface that is hot unplugged.
++
+[IMPORTANT]
+====
+If you have defined readiness or liveness probes to run VM health checks, setting the primary interface's link state to `down` causes the probes to fail. If a liveness probe fails, the VM is deleted and a new VM is created to restore responsiveness.
+====
+
+. Apply the `VirtualMachine` manifest:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+* Verify that the desired link state is set by checking the `status.interfaces.linkState` field of the `VirtualMachineInstance` manifest.
++
+[source,terminal]
+----
+$ oc get vmi <vmi-name>
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  name: my-vm
+spec:
+  domain:
+    devices:
+      interfaces:
+      - name: default
+        state: down
+        masquerade: { }
+  networks:
+  - name: default
+    pod: { }
+status:
+  interfaces:
+    - name: default
+      linkState: down
+# ...
+----

--- a/virt/vm_networking/virt-setting-interface-link-state.adoc
+++ b/virt/vm_networking/virt-setting-interface-link-state.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: ASSEMBLY                              
+[id="virt-setting-interface-link-state"]                                    
+= Managing the link state of a virtual machine interface                                               
+include::_attributes/common-attributes.adoc[]                  
+:context: virt-setting-interface-link-state                                   
+                                                               
+toc::[]                                                         
+
+You can manage the link state of a primary or secondary virtual machine (VM) interface by using the CLI. By specifying the link state, you can logically connect or disconnect the virtual network interface controller (vNIC) from a network.
+
+[NOTE]
+====
+{VirtProductName} does not support link state management for Single Root I/O Virtualization (SR-IOV) secondary network interfaces and their link states are not reported.
+====
+
+You can specify the desired link state when you first create a VM, by editing the configuration of an existing VM that is stopped or running, or when you hot plug a new network interface to a running VM. If you edit a running VM, you do not need to restart or migrate the VM for the changes to be applied. The current link state of a VM interface is reported in the `status.interfaces.linkState` field of the `VirtualMachineInstance` manifest.
+
+:FeatureName: Setting the VM interface link state
+include::snippets/technology-preview.adoc[]
+
+include::modules/virt-configuring-interface-link-state.adoc[leveloffset=+1]
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-52859](https://issues.redhat.com//browse/CNV-52859)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://91883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-setting-interface-link-state.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
