### PR TITLE
OSDOCS#13618: adding rsync prereq

### DIFF
--- a/modules/adding-node-iso-flags.adoc
+++ b/modules/adding-node-iso-flags.adoc
@@ -11,6 +11,7 @@ You can add a single node to your cluster by using command flags to specify conf
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`)
+* You have installed the Rsync utility
 * You have an active connection to your target cluster
 * You have a kubeconfig file available
 

--- a/modules/adding-node-iso-yaml.adoc
+++ b/modules/adding-node-iso-yaml.adoc
@@ -11,6 +11,7 @@ You can add one or more nodes to your cluster by using the `nodes-config.yaml` f
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`)
+* You have installed the Rsync utility
 * You have an active connection to your target cluster
 * You have a kubeconfig file available
 


### PR DESCRIPTION
[OSDOCS-13618](https://issues.redhat.com/browse/OSDOCS-13618)

Version(s): 4.17+

This PR adds a prerequisite to the procedures for adding nodes to on-prem clusters.

QE review:
- [x] QE has approved this change.

Previews:

- [Adding one or more nodes using a configuration file](https://91894--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso.html#adding-node-iso-yaml_adding-node-iso)
- [Adding a node with command flags](https://91894--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso.html#adding-node-iso-flags_adding-node-iso)
