### PR TITLE
VPA updateMode values show lower cased options which won't work in cluster

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-configuring.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-configuring.adoc
@@ -47,10 +47,10 @@ spec:
 <1> Specify the type of workload object you want this VPA to manage: `Deployment`, `StatefulSet`, `Job`, `DaemonSet`, `ReplicaSet`, or `ReplicationController`.
 <2> Specify the name of an existing workload object you want this VPA to manage.
 <3> Specify the VPA mode:
-* `auto` to automatically apply the recommended resources on pods associated with the controller. The VPA terminates existing pods and creates new pods with the recommended resource limits and requests.
-* `recreate` to automatically apply the recommended resources on pods associated with the workload object. The VPA terminates existing pods and creates new pods with the recommended resource limits and requests. The `recreate` mode should be used rarely, only if you need to ensure that the pods are restarted whenever the resource request changes.
-* `initial` to automatically apply the recommended resources when pods associated with the workload object are created. The VPA does not update the pods as it learns new resource recommendations.
-* `off` to only generate resource recommendations for the pods associated with the workload object. The VPA does not update the pods as it learns new resource recommendations and does not apply the recommendations to new pods.
+* `Auto` to automatically apply the recommended resources on pods associated with the controller. The VPA terminates existing pods and creates new pods with the recommended resource limits and requests.
+* `Recreate` to automatically apply the recommended resources on pods associated with the workload object. The VPA terminates existing pods and creates new pods with the recommended resource limits and requests. The `Recreate` mode should be used rarely, only if you need to ensure that the pods are restarted whenever the resource request changes.
+* `Initial` to automatically apply the recommended resources when pods associated with the workload object are created. The VPA does not update the pods as it learns new resource recommendations.
+* `Off` to only generate resource recommendations for the pods associated with the workload object. The VPA does not update the pods as it learns new resource recommendations and does not apply the recommendations to new pods.
 <4> Optional. Specify the containers you want to opt-out and set the mode to `Off`.
 <5> Optional. Specify an alternative recommender.
 

--- a/modules/nodes-pods-vertical-autoscaler-using-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-using-about.adoc
@@ -12,7 +12,7 @@ You use the VPA CR to associate a workload object and specify which mode the VPA
 
 * The `Auto` and `Recreate` modes automatically apply the VPA CPU and memory recommendations throughout the pod lifetime. The VPA deletes any pods in the project that are out of alignment with its recommendations. When redeployed by the workload object, the VPA updates the new pods with its recommendations.
 * The `Initial` mode automatically applies VPA recommendations only at pod creation.
-* The `Off` mode only provides recommended resource limits and requests, allowing you to manually apply the recommendations. The `off` mode does not update pods.
+* The `Off` mode only provides recommended resource limits and requests, allowing you to manually apply the recommendations. The `Off` mode does not update pods.
 
 You can also use the CR to opt-out certain containers from VPA evaluation and updates.
 
@@ -29,7 +29,7 @@ resources:
     memory: 100Mi
 ----
 
-After creating a VPA that is set to `auto`, the VPA learns the resource usage and deletes the pod. When redeployed, the pod uses the new resource limits and requests:
+After creating a VPA that is set to `Auto`, the VPA learns the resource usage and deletes the pod. When redeployed, the pod uses the new resource limits and requests:
 
 [source,yaml]
 ----
@@ -200,7 +200,7 @@ To obtain the most accurate recommendations from the VPA, wait at least 8 days f
 [id="nodes-pods-vertical-autoscaler-using-manual_{context}"]
 == Manually applying VPA recommendations
 
-To use the VPA to only determine the recommended CPU and memory values, create a VPA CR for a specific workload object with `updateMode` set to `off`.
+To use the VPA to only determine the recommended CPU and memory values, create a VPA CR for a specific workload object with `updateMode` set to `Off`.
 
 When the pods are created for that workload object, the VPA analyzes the CPU and memory needs of the containers and records those recommendations in the `status` field of the VPA CR. The VPA does not update the pods as it determines new resource recommendations.
 
@@ -266,7 +266,7 @@ spec:
 ----
 <1> The type of workload object you want this VPA CR to manage.
 <2> The name of the workload object you want this VPA CR to manage.
-<3> Set the mode to `Auto`, `Recreate`, or `Off`. The `Recreate` mode should be used rarely, only if you need to ensure that the pods are restarted whenever the resource request changes.
+<3> Set the mode to `Auto`, `Recreate`, `Initial`, or `Off`. The `Recreate` mode should be used rarely, only if you need to ensure that the pods are restarted whenever the resource request changes.
 <4> Specify the containers you want to opt-out and set `mode` to `Off`.
 
 For example, a pod has two containers, the same resource requests and limits:


### PR DESCRIPTION
The docs talking about VerticalPodAutoscaler .spec.updatePolicy.updateMode list a number of options for the value that are all listed in lower case.  However, using the lower case value will result in an error.
https://issues.redhat.com/browse/OCPBUGS-54694

[Using the Vertical Pod Autoscaler Operator](https://91896--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-configuring_nodes-pods-vertical-autoscaler)
[About Using the Vertical Pod Autoscaler Operator](https://91896--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-about_nodes-pods-vertical-autoscaler)