### PR TITLE
OSDOCS#13971: Update the z-stream RNs for 4.17.24

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2879,11 +2879,44 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.24
+[id="ocp-4-17-24_{context}"]
+=== RHSA-2025:3565 - {product-title} {product-version}.24 bug fix and security update advisory
+
+Issued: 9 April 2025
+
+{product-title} release {product-version}.24 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3565[RHSA-2025:3565] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3567[RHBA-2025:3567] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.24 --pullspecs
+----
+
+[id="ocp-4-17-24-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, an update to the {ibm-cloud-name} Cloud Internet Services (CIS) implementation impacted the upstream Terraform plugin. If you attempted to create an external-facing cluster on {ibm-cloud-name}, an error occurred. With this release, you can create an external cluster on {product-title} without the plugin issue. (link:https://issues.redhat.com/browse/OCPBUGS-54357[*OCPBUGS-54357*])
+
+* Previously, when users tried building the agent ISO in a disconnected setup, an error occurred. With this release, the setup completes without an error. (link:https://issues.redhat.com/browse/OCPBUGS-53378[*OCPBUGS-53378*])
+
+* Previously, the `ovn-ipsec-host` pod failed with a crash loop on RHEL worker nodes because of a missing shared library during the container execution. With this release, the `ovn-ipsec-host` pod successfully starts on the worker node without an error. (link:https://issues.redhat.com/browse/OCPBUGS-52951[*OCPBUGS-52951*])
+
+* Previously, the {olm-first} CSV annotation contained unexpected JSON data, which was successfully parsed, but then resulted in a runtime error when attempting to use the resulting value. With this release, JSON values from OLM annotations are validated before use, errors are logged, and the console does not fail when an unexpected JSON is received in an annotation. (link:https://issues.redhat.com/browse/OCPBUGS-51277[(*OCPBUGS-51277*)])
+
+[id="ocp-4-17-24-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
 // 4.17.23
 [id="ocp-4-17-23_{context}"]
-=== RHSA-2025:3297 - {product-title} {product-version}.23 bug fix, and security update advisory
+=== RHSA-2025:3297 - {product-title} {product-version}.23 bug fix and security update advisory
 
-Issued: 03 April 2025
+Issued: 3 April 2025
 
 {product-title} release {product-version}.23 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3297[RHSA-2025:3297] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3299[RHBA-2025:3299] advisory.
 
@@ -2937,7 +2970,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.22
 [id="ocp-4-17-22_{context}"]
-=== RHSA-2025:3059 - {product-title} {product-version}.22 bug fix, and security update advisory
+=== RHSA-2025:3059 - {product-title} {product-version}.22 bug fix and security update advisory
 
 Issued: 26 March 2025
 
@@ -2963,7 +2996,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.21
 [id="ocp-4-17-21_{context}"]
-=== RHSA-2025:2696 - {product-title} {product-version}.21 bug fix, and security update advisory
+=== RHSA-2025:2696 - {product-title} {product-version}.21 bug fix and security update advisory
 
 Issued: 19 March 2025
 
@@ -2997,7 +3030,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.20
 [id="ocp-4-17-20_{context}"]
-=== RHSA-2025:2445 - {product-title} {product-version}.20 bug fix, and security update advisory
+=== RHSA-2025:2445 - {product-title} {product-version}.20 bug fix and security update advisory
 
 Issued: 12 March 2025
 
@@ -3035,9 +3068,9 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.19
 [id="ocp-4-17-19_{context}"]
-=== RHSA-2025:1912 - {product-title} {product-version}.19 bug fix, and security update advisory
+=== RHSA-2025:1912 - {product-title} {product-version}.19 bug fix and security update advisory
 
-Issued: 05 March 2025
+Issued: 5 March 2025
 
 {product-title} release {product-version}.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:1912[RHSA-2025:1912] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1914[RHSA-2025:1914] advisory.
 
@@ -3071,7 +3104,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.18
 [id="ocp-4-17-18_{context}"]
-=== RHSA-2025:1703 - {product-title} {product-version}.18 bug fix, and security update advisory
+=== RHSA-2025:1703 - {product-title} {product-version}.18 bug fix and security update advisory
 
 Issued: 26 February 2025
 
@@ -3103,7 +3136,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.17
 [id="ocp-4-17-17_{context}"]
-=== RHSA-2025:1403 - {product-title} {product-version}.17 bug fix, and security update advisory
+=== RHSA-2025:1403 - {product-title} {product-version}.17 bug fix and security update advisory
 
 Issued: 18 February 2025
 
@@ -3146,7 +3179,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.16
 [id="ocp-4-17-16_{context}"]
-=== RHSA-2025:1120 - {product-title} {product-version}.16 bug fix, and security update advisory
+=== RHSA-2025:1120 - {product-title} {product-version}.16 bug fix and security update advisory
 
 Issued: 11 February 2025
 
@@ -3184,9 +3217,9 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.15
 [id="ocp-4-17-15_{context}"]
-=== RHSA-2025:0876 - {product-title} {product-version}.15 bug fix, and security update advisory
+=== RHSA-2025:0876 - {product-title} {product-version}.15 bug fix and security update advisory
 
-Issued: 05 February 2025
+Issued: 5 February 2025
 
 {product-title} release {product-version}.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:0876[RHSA-2025:0876] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0878[RHSA-2025:0878] advisory.
 
@@ -3214,7 +3247,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.14
 [id="ocp-4-17-14_{context}"]
-=== RHSA-2025:0654 - {product-title} {product-version}.14 bug fix, and security update advisory
+=== RHSA-2025:0654 - {product-title} {product-version}.14 bug fix and security update advisory
 
 Issued: 28 January 2025
 
@@ -3255,7 +3288,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.12
 [id="ocp-4-17-12_{context}"]
-=== RHSA-2025:0115 - {product-title} {product-version}.12 bug fix, and security update advisory
+=== RHSA-2025:0115 - {product-title} {product-version}.12 bug fix and security update advisory
 
 Issued: 14 January 2025
 
@@ -3276,9 +3309,9 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.11
 [id="ocp-4-17-11_{context}"]
-=== RHBA-2025:0023 - {product-title} {product-version}.11 bug fix, and security update advisory
+=== RHBA-2025:0023 - {product-title} {product-version}.11 bug fix and security update advisory
 
-Issued: 08 January 2025
+Issued: 8 January 2025
 
 {product-title} release {product-version}.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:0023[RHBA-2025:0023] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0026[RHBA-2025:0026] advisory.
 
@@ -3319,9 +3352,9 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.10
 [id="ocp-4-17-10_{context}"]
-=== RHBA-2024:11522 - {product-title} {product-version}.10 bug fix, and security update advisory
+=== RHBA-2024:11522 - {product-title} {product-version}.10 bug fix and security update advisory
 
-Issued: 02 January 2025
+Issued: 2 January 2025
 
 {product-title} release {product-version}.10 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:11522[RHBA-2024:11522] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:11525[RHBA-2024:11525] advisory.
 
@@ -3375,7 +3408,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.9
 [id="ocp-4-17-9_{context}"]
-=== RHBA-2024:11010 - {product-title} {product-version}.9 bug fix, and security update advisory
+=== RHBA-2024:11010 - {product-title} {product-version}.9 bug fix and security update advisory
 
 Issued: 19 December 2024
 
@@ -3424,7 +3457,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.8
 [id="ocp-4-17-8_{context}"]
-=== RHSA-2024:10818 - {product-title} {product-version}.8 bug fix, and security update advisory
+=== RHSA-2024:10818 - {product-title} {product-version}.8 bug fix and security update advisory
 
 Issued: 11 December 2024
 
@@ -3458,9 +3491,9 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.7
 [id="ocp-4-17-7_{context}"]
-=== RHSA-2024:10518 - {product-title} {product-version}.7 bug fix, and security update advisory
+=== RHSA-2024:10518 - {product-title} {product-version}.7 bug fix and security update advisory
 
-Issued: 03 December 2024
+Issued: 3 December 2024
 
 {product-title} release {product-version}.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:10518[RHSA-2024:10518] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10521[RHBA-2024:10521] advisory.
 
@@ -3496,7 +3529,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 //4.17.6
 [id="ocp-4-17-6_{context}"]
-=== RHBA-2024:10137 - {product-title} {product-version}.6 bug fix, and security update advisory
+=== RHBA-2024:10137 - {product-title} {product-version}.6 bug fix and security update advisory
 
 Issued: 26 November 2024
 
@@ -3550,7 +3583,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 //4.17.5
 [id="ocp-4-17-5_{context}"]
-=== RHSA-2024:9610 - {product-title} {product-version}.5 bug fix, and security update advisory
+=== RHSA-2024:9610 - {product-title} {product-version}.5 bug fix and security update advisory
 
 Issued: 19 November 2024
 
@@ -3588,7 +3621,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.4
 [id="ocp-4-17-4_{context}"]
-=== RHSA-2024:8981 - {product-title} {product-version}.4 bug fix, and security update advisory
+=== RHSA-2024:8981 - {product-title} {product-version}.4 bug fix and security update advisory
 
 Issued: 13 November 2024
 
@@ -3653,7 +3686,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.3
 [id="ocp-4-17-3_{context}"]
-=== RHSA-2024:8434 - {product-title} {product-version}.3 bug fix, and security update advisory
+=== RHSA-2024:8434 - {product-title} {product-version}.3 bug fix and security update advisory
 
 Issued: 29 October 2024
 
@@ -3704,7 +3737,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.2
 [id="ocp-4-17-2_{context}"]
-=== RHSA-2024:8229 - {product-title} {product-version}.2 bug fix, and security update advisory
+=== RHSA-2024:8229 - {product-title} {product-version}.2 bug fix and security update advisory
 
 Issued: 23 October 2024
 
@@ -3762,7 +3795,7 @@ To update an {product-title} 4.17 cluster to this latest release, see xref:../up
 
 // 4.17.1
 [id="ocp-4-17-1_{context}"]
-=== RHSA-2024:7922 - {product-title} {product-version}.1 bug fix, and security update advisory
+=== RHSA-2024:7922 - {product-title} {product-version}.1 bug fix and security update advisory
 
 Issued: 16 October 2024
 
@@ -3858,9 +3891,9 @@ To update an {product-title} 4.16 cluster to this latest release, see xref:../up
 
 //Update with relevant advisory information
 [id="ocp-4-17-0_{context}"]
-=== RHSA-2024:3718 - {product-title} {product-version}.0 image release, bug fix, and security update advisory
+=== RHSA-2024:3718 - {product-title} {product-version}.0 image release, bug fix and security update advisory
 
-Issued: 01 October 2024
+Issued: 1 October 2024
 
 {product-title} release {product-version}.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:3718[RHSA-2024:3718] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3722[RHSA-2024:3722] advisory.
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13971](https://issues.redhat.com//browse/OSDOCS-13971)

Link to docs preview:
[4.17.24](https://91900--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-24_release-notes)

QE review:
- [ ] QE has approved this change.
n/a for z-stream relnotes.

Additional information:
The errata URLs will return 404 until the go-live date of 4/9/25.
