### PR TITLE
OCPBUGS#52836: sysType needs to be a property of controlPlane.platform.powervs and compute.platform.powervs

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -533,6 +533,14 @@ endif::ibm-power-vs[]
 |Required if you use `compute`. Use this parameter to specify the cloud provider to host the worker machines. This parameter value must match the `controlPlane.platform` parameter value.
 ifdef::ibm-power-vs[]
 Example usage, `compute.platform.powervs.sysType`.
+
+|compute:
+  platform:
+    powervs:
+      sysType:
+|Defines the system type for the instance.
+|The available system types depend on the zone you want to target. Supported values are `e980`, `s922`, `e1080`, or `s1022`.
+
 endif::ibm-power-vs[]
 ifndef::agent[]
 |`aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
@@ -627,6 +635,13 @@ endif::vsphere[]
 |Required if you use `controlPlane`. Use this parameter to specify the cloud provider that hosts the control plane machines. This parameter value must match the `compute.platform` parameter value.
 ifdef::ibm-power-vs[]
 Example usage, `controlPlane.platform.powervs.processors`.
+
+|controlPlane:
+  platform:
+    powervs:
+      sysType:
+|Defines the system type for the instance.
+|The available system types depend on the zone you want to target. Supported values are `e980`, `s922`, `e1080`, or `s1022`.
 endif::ibm-power-vs[]
 ifndef::agent[]
 |`aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
@@ -775,12 +790,6 @@ ifdef::ibm-power-vs[]
     processors:
 |Defines the processing units for the instance.
 |The number of processors must be from .5 to 32 cores. The processors must be in increments of .25.
-
-|platform:
-  powervs:
-    sysType:
-|Defines the system type for the instance.
-|The system type must be `e980`, `s922`, `e1080`, or `s1022`. The available system types depend on the zone you want to target.
 
 |platform:
   powervs:


### PR DESCRIPTION


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19

Issue: https://issues.redhat.com/browse/OCPBUGS-52836

Link to docs preview:
https://91901--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs#installation-configuration-parameters_installation-config-parameters-ibm-power-vs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
