### PR TITLE
TELCODOCS-2105: Reverting changes as EPIC is now dropped from 4.19

### DIFF
--- a/modules/nw-egress-service-ovn.adoc
+++ b/modules/nw-egress-service-ovn.adoc
@@ -15,7 +15,6 @@ The following example configures the egress traffic to have the same source IP a
 * Install the OpenShift CLI (`oc`).
 * Log in as a user with `cluster-admin` privileges.
 * You configured MetalLB `BGPPeer` resources.
-* You use OVN-Kubernetes configured with the `gatewayConfig.routingViaHost` specification set to `true` only.
 
 .Procedure
 

--- a/modules/nw-metallb-configure-return-traffic-proc.adoc
+++ b/modules/nw-metallb-configure-return-traffic-proc.adoc
@@ -14,7 +14,7 @@ This example associates a VRF routing table with MetalLB and an egress service t
 ====
 * If you use the `sourceIPBy: "LoadBalancerIP"` setting in the `EgressService` CR, you must specify the load-balancer node in the `BGPAdvertisement` custom resource (CR).
 
-* To configure an egress service for pods behind a load balancer service, you must configure OVN-Kubernetes with the `gatewayConfig.routingViaHost` specification set to `true`. For more information about this configuration, see "Cluster Network Operator in {product-title}" in _Networking Operators_.
+* You can use the `sourceIPBy: "Network"` setting on clusters that use OVN-Kubernetes configured with the `gatewayConfig.routingViaHost` specification set to `true` only. Additionally, if you use the `sourceIPBy: "Network"` setting, you must schedule the application workload on nodes configured with the network VRF instance.
 ====
 
 .Prerequisites

--- a/modules/nw-metallb-configure-vrf-bgppeer.adoc
+++ b/modules/nw-metallb-configure-vrf-bgppeer.adoc
@@ -8,6 +8,9 @@
 
 You can expose a service through a virtual routing and forwarding (VRF) instance by associating a VRF on a network interface with a BGP peer.
 
+:FeatureName: Exposing a service through a VRF on a BGP peer
+include::snippets/technology-preview.adoc[]
+
 By using a VRF on a network interface to expose a service through a BGP peer, you can segregate traffic to the service, configure independent routing decisions, and enable multi-tenancy support on a network interface.
 
 [NOTE]

--- a/networking/metallb/metallb-configure-return-traffic.adoc
+++ b/networking/metallb/metallb-configure-return-traffic.adoc
@@ -10,6 +10,9 @@ As a cluster administrator, you can effectively manage traffic for pods behind a
 
 To achieve this functionality, learn how to implement virtual routing and forwarding (VRF) instances with MetalLB, and configure egress services.
 
+:FeatureName: Configuring symmetric traffic by using a VRF instance with MetalLB and an egress service
+include::snippets/technology-preview.adoc[]
+
 [id="challenges-of-managing-symmetric-routing-with-metallb"]
 == Challenges of managing symmetric routing with MetalLB
 
@@ -59,5 +62,3 @@ include::modules/nw-metallb-configure-return-traffic-proc.adoc[leveloffset=+1]
 * xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-host-vrf_k8s-nmstate-updating-node-network-config[Example: Network interface with a VRF instance node network configuration policy]
 
 * xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc#configuring-egress-traffic-loadbalancer-services[Configuring an egress service]
-
-* xref:../../networking/networking_operators/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator configuration object]

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc
@@ -8,10 +8,8 @@ toc::[]
 
 As a cluster administrator, you can configure egress traffic for pods behind a load balancer service by using an egress service.
 
-[NOTE]
-====
-To configure an egress service for pods behind a load balancer service, you must configure OVN-Kubernetes with the `gatewayConfig.routingViaHost` specification set to `true`. For more information about this configuration, see xref:../../networking/networking_operators/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator configuration object] in _Networking Operators_.
-====
+:FeatureName: Egress service
+include::snippets/technology-preview.adoc[]
 
 You can use the `EgressService` custom resource (CR) to manage egress traffic in the following ways:
 


### PR DESCRIPTION
[TELCODOCS-2105](https://issues.redhat.com//browse/TELCODOCS-2105) / [TELCODOCS-2106](https://issues.redhat.com//browse/TELCODOCS-2106): Reverting changes from #89322 as EPIC is now dropped from 4.19

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2105
https://issues.redhat.com/browse/TELCODOCS-2106

Link to docs preview:
- https://91903--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-bgp-peer-vrf_configure-metallb-bgp-peers
- https://91903--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-return-traffic.html
- https://91903--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.html

No QE content required, reverting content to previous state.
