### PR TITLE
MIG-1717-Removed conditions specific to OADP for the must-gather tool

### DIFF
--- a/modules/migration-using-must-gather.adoc
+++ b/modules/migration-using-must-gather.adoc
@@ -2,7 +2,6 @@
 //
 // * migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
 // * migration_toolkit_for_containers/troubleshooting-mtc.adoc
-// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="migration-using-must-gather_{context}"]
@@ -12,26 +11,14 @@ You can collect logs, metrics, and information about {local-product} custom reso
 
 The `must-gather` data must be attached to all customer cases.
 
-ifdef::troubleshooting-3-4,troubleshooting-mtc[]
 You can collect data for a one-hour or a 24-hour period and view the data with the Prometheus console.
-endif::[]
-ifdef::oadp-troubleshooting[]
-You can run the `must-gather` tool with the following data collection options:
 
-* Full `must-gather` data collection collects Prometheus metrics, pod logs, and Velero CR information for all namespaces where the OADP Operator is installed.
-* Essential `must-gather` data collection collects pod logs and Velero CR information for a specific duration of time, for example, one hour or 24 hours. Prometheus metrics and duplicate logs are not included.
-* `must-gather` data collection with timeout. Data collection can take a long time if there are many failed `Backup` CRs. You can improve performance by setting a timeout value.
-* Prometheus metrics data dump downloads an archive file containing the metrics data collected by Prometheus.
-endif::[]
 
 .Prerequisites
 
 * You must be logged in to the {product-title} cluster as a user with the `cluster-admin` role.
 * You must have the OpenShift CLI (`oc`) installed.
 
-ifdef::oadp-troubleshooting[]
-* You must use {op-system-base-full} {op-system-version-9} with {oadp-short} 1.4.
-endif::[]
 
 .Procedure
 
@@ -56,6 +43,7 @@ $ oc adm must-gather --image=registry.redhat.io/rhmtc/openshift-migration-must-g
 +
 This operation can take a long time. This command saves the data as the `must-gather/metrics/prom_data.tar.gz` file.
 endif::[]
+
 ifdef::troubleshooting-mtc[]
 * To collect data for the past 24 hours, run the following command:
 +
@@ -73,40 +61,4 @@ $ oc adm must-gather --image=registry.redhat.io/rhmtc/openshift-migration-must-g
 ----
 +
 This operation can take a long time. This command saves the data as the `must-gather/metrics/prom_data.tar.gz` file.
-endif::[]
-ifdef::oadp-troubleshooting[]
-* Full `must-gather` data collection, including Prometheus metrics:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc adm must-gather --image={must-gather-v1-4}
-----
-+
-The data is saved as `must-gather/must-gather.tar.gz`. You can upload this file to a support case on the link:https://access.redhat.com/[Red Hat Customer Portal].
-
-* Essential `must-gather` data collection, without Prometheus metrics, for a specific time duration:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc adm must-gather --image={must-gather-v1-4} \
-  -- /usr/bin/gather_<time>_essential <1>
-----
-<1> Specify the time in hours. Allowed values are `1h`, `6h`, `24h`, `72h`, or `all`, for example, `gather_1h_essential` or `gather_all_essential`.
-
-* `must-gather` data collection with timeout:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc adm must-gather --image={must-gather-v1-4} \
-  -- /usr/bin/gather_with_timeout <timeout> <1>
-----
-<1> Specify a timeout value in seconds.
-
-* Prometheus metrics data dump:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc adm must-gather --image={must-gather-v1-4} -- /usr/bin/gather_metrics_dump
-----
-This operation can take a long time. The data is saved as `must-gather/metrics/prom_data.tar.gz`.
 endif::[]


### PR DESCRIPTION
Version(s):
OCP 4.14-4.19

Issue:
[MIG-1717](https://issues.redhat.com/browse/MIG-1717)

Link to docs preview:

- For MTC - https://91906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/troubleshooting-mtc.html#migration-using-must-gather_troubleshooting-mtc
- For Migrating OCP from 3 to 4 - https://91906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/troubleshooting-3-4.html#migration-using-must-gather_troubleshooting-3-4

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR removes ifdef statement related to OADP. There is another new file created for using the [must-gather tool](https://github.com/openshift/openshift-docs/blob/21a925a0737468072e3a3e93e9e1459e425d9b90/backup_and_restore/application_backup_and_restore/using-the-must-gather-tool.adoc?plain=1#L2) with information only specific to OADP.
