### PR TITLE
OSSM-9336 Docs for understanding versioning, Service Mesh & Istio versions, and Operator Updates & Channels

### DIFF
--- a/modules/ossm-about-deployment-and-update-strategies.adoc
+++ b/modules/ossm-about-deployment-and-update-strategies.adoc
@@ -4,7 +4,6 @@
 :_mod-docs-content-type: Concept
 [id="ossm-about-deployment-and-update-strategies_{context}"]
 = About update strategies
-:context: ossm-about-deployment-and-update-strategies
 
 The update strategy affects how the update process is performed. For each mesh, you select one of two strategies:
 

--- a/modules/ossm-about-operator-update-process.adoc
+++ b/modules/ossm-about-operator-update-process.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// update/ossm-updating-openshift-service-mesh.adoc
+
+:_mod-docs-content-type: Concept
+[id="ossm-about-operator-update-process_{context}"]
+= About Operator update process
+
+The {SMProduct} Operator will upgrade automatically to the latest available version based on the selected channel when the *approval strategy* field is set to `Automatic` (default). If the *approval strategy* field is set to `Manual`, {olm-first} will generate an update request, which a cluster administrator must approve to update the Operator to the latest version.
+
+The Operator update process does not automatically update the {istio} control plane unless the `{istio}` resource version is set to an alias (for example, `vX.Y-latest`) and the `updateStrategy` is set to `InPlace`. This triggers a control plane update when a new version is available in the Operator. By default, the Operator will not update the {istio} control plane unless the `{istio}` resource is updated with a new version.

--- a/modules/ossm-understanding-operator-updates-and-channels.adoc
+++ b/modules/ossm-understanding-operator-updates-and-channels.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// update/ossm-updating-openshift-service-mesh.adoc
+
+:_mod-docs-content-type: Concept
+[id="ossm-understanding-operator-updates-and-channels_{context}"]
+= Understanding Operator updates and channels
+
+The {olm-first} manages Operators and their associated services by using channels to organize and distribute updates. Channels are a way to group related updates.
+
+To ensure that your {SMProduct} stays current with the latest security patches, bug fixes, and software updates, keep the {SMProduct} Operator up to date. The upgrade process depends on the configured channel and approval strategy.
+
+OLM provides the following channels for the {SMProduct} Operator:
+
+* *Stable* channel: tracks the most recent version of the {SMProduct} 3 Operator and the latest supported version of {istio}. This channel enables upgrades to new operator versions and corresponding {istio} updates as soon as they are released. Use the stable channel to stay current with the latest features, bug fixes, and security updates.
+
+* *Versioned* channel: restricts updates to patch-level releases within a specific minor version. For example, `stable-3.0` provides access to the latest `{SMProductVersion}` patch version. When a new patch release becomes available, you can upgrade the Operator to the newer patch version. To move to a newer minor release, you must manually switch to a different channel. You can use a versioned channel to maintain a consistent minor version while applying only patch updates.
+
+[NOTE]
+====
+You can find the *update strategy* field in the *Install Operator* section and under the sub-section *update approval*. The default value for the *update strategy* is `Automatic`.
+====

--- a/modules/ossm-understanding-sm-istio-versions.adoc
+++ b/modules/ossm-understanding-sm-istio-versions.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// update/ossm-updating-openshift-service-mesh.adoc
+
+:_mod-docs-content-type: Concept
+[id="ossm-understanding-sm-istio-versions_{context}"]
+= Understanding Service Mesh and Istio versions
+
+The most current {SMProduct} Operator version is {SMProductVersion}. This version supports the features listed in the "{SMProductShortName} {SMProductVersion} feature support tables". The {SMProduct} Operator includes additional {istio} releases for upgrades but supports only the latest {istio} version available for each Operator version. See the "{SMProductShortName} version support tables" to identify the supported {istio} version for each Operator release.

--- a/modules/ossm-understanding-versioning.adoc
+++ b/modules/ossm-understanding-versioning.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// update/ossm-updating-openshift-service-mesh.adoc
+
+:_mod-docs-content-type: Concept
+[id="ossm-understanding-versioning_{context}"]
+= Understanding versioning
+
+{product-title} follows Semantic Versioning for all product releases. Semantic Versioning uses a three-part version number in the format `X.Y.Z` to communicate the nature of changes in each release.
+
+X (Major version):: indicates significant updates that might include breaking changes, such as architectural shifts, API changes, or schema modifications.
+
+Y (Minor version):: introduces new features and enhancements while maintaining backward compatibility.
+
+Z (Patch version or z-stream release):: delivers critical bug fixes and security updates, such as Common Vulnerabilities and Exposures (CVEs) resolutions. Patch versions do not include new features.
+

--- a/update/ossm-updating-openshift-service-mesh.adoc
+++ b/update/ossm-updating-openshift-service-mesh.adoc
@@ -8,6 +8,17 @@ toc::[]
 
 The strategy you use to deploy a service mesh affects how you can update the mesh.
 
+include::modules/ossm-understanding-versioning.adoc[leveloffset=+1]
+include::modules/ossm-understanding-sm-istio-versions.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../ossm-release-notes/ossm-release-notes-feature-support-tables.adoc#ossm-release-notes-feature-support-tables[{SMProductShortName} {SMProductVersion} feature support tables]
+* xref:../ossm-release-notes/ossm-release-notes-version-support-tables.adoc#ossm-release-notes-version-support-tables[Service Mesh version support tables]
+
+include::modules/ossm-understanding-operator-updates-and-channels.adoc[leveloffset=+1]
+include::modules/ossm-about-operator-update-process.adoc[leveloffset=+2]
 include::modules/ossm-about-deployment-and-update-strategies.adoc[leveloffset=+1]
 include::modules/ossm-about-inplace-strategy.adoc[leveloffset=+1]
 include::modules/ossm-select-inplace-strategy.adoc[leveloffset=+2]


### PR DESCRIPTION
Change type: Doc update; OSSM docs for understanding versioning, Service Mesh & Istio versions, and Operator Updates & Channels

Doc JIRA: https://issues.redhat.com/browse/OSSM-9336

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

NOTE TO THE SME and QE: This PR only covers the following sections from the docs: *Understanding versioning*, *Understanding Service Mesh and Istio versions*, *Understanding Operator updates and channels*, and *About Operator update process*. The next sections will be updated in the upcoming/separate PRs. The main story is: [OSSM-8218](https://issues.redhat.com/browse/OSSM-8218)

Doc Preview: https://91920--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/update/ossm-updating-openshift-service-mesh#ossm-understanding-versioning_ossm-updating-openshift-service-mesh

SME Review/QE Review: @MaxBab @fjglira 
Peer Review: 