### PR TITLE
OSDOCS-13952#vSphere Operator now uses secret instead of config map

### DIFF
--- a/modules/persistent-storage-csi-vsphere-change-max-snapshot.adoc
+++ b/modules/persistent-storage-csi-vsphere-change-max-snapshot.adoc
@@ -19,35 +19,28 @@ For more VMware snapshot performance recommendations, see *_Additional resources
 
 .Procedure
 
-. Check the current config map by the running the following command:
+. Check the current secret by the running the following command:
 +
 [source, terminal]
 ----
-$ oc -n openshift-cluster-csi-drivers get cm/vsphere-csi-config -o yaml
+$ oc -n openshift-cluster-csi-drivers get secret/vsphere-csi-config-secret -o jsonpath='{.data.cloud\.conf}' | base64 -d
 ----
 +
 .Example output
 +
 [source, terminal]
 ----
-apiVersion: v1
-data:
-  cloud.conf: |+
-    # Labels with topology values are added dynamically via operator
-    [Global]
-    cluster-id = vsphere-01-cwv8p
+# Labels with topology values are added dynamically via operator
+[Global]
+cluster-id = vsphere-01-cwv8p
 
-    [VirtualCenter "vcenter.openshift.com"]
-    insecure-flag           = true
-    datacenters             = DEVQEdatacenter
-    migration-datastore-url = ds:///vmfs/volumes/vsan:527320283a8c3163-2faa6dc5949a3a28/
-
-kind: ConfigMap
-metadata:
-  creationTimestamp: "2024-03-06T09:46:40Z"
-  name: vsphere-csi-config
-  namespace: openshift-cluster-csi-drivers
-  resourceVersion: "126687"
+# Populate VCenters (multi) after here
+[VirtualCenter "vcenter.openshift.com"]
+insecure-flag           = true
+datacenters             = DEVQEdatacenter
+password                = "xxxxxxxx"
+user                    = "xxxxxxxx@devcluster.openshift.com"
+migration-datastore-url = ds:///vmfs/volumes/vsan:52c842f232751e0d-3253aadeac21ca82/
 ----
 +
 In this example, the global maximum number of snapshots is not configured, so the default value of 3 is applied.
@@ -59,6 +52,7 @@ In this example, the global maximum number of snapshots is not configured, so th
 [source, terminal]
 ----
 $ oc patch clustercsidriver/csi.vsphere.vmware.com --type=merge -p '{"spec":{"driverConfig":{"vSphere":{"globalMaxSnapshotsPerBlockVolume": 10}}}}'
+
 clustercsidriver.operator.openshift.io/csi.vsphere.vmware.com patched
 ----
 +
@@ -94,34 +88,26 @@ In this example, the vSAN limit is being changed to 7 (`granularMaxSnapshotsPerB
 +
 [source, terminal]
 ----
-$ oc -n openshift-cluster-csi-drivers get cm/vsphere-csi-config -o yaml
+$ oc -n openshift-cluster-csi-drivers get secret/vsphere-csi-config-secret -o jsonpath='{.data.cloud\.conf}' | base64 -d
 ----
 +
 .Example output
 +
 [source, terminal]
 ----
-apiVersion: v1
-data:
-  cloud.conf: |+
-    # Labels with topology values are added dynamically via operator
-    [Global]
-    cluster-id = vsphere-01-cwv8p
+# Labels with topology values are added dynamically via operator
+[Global]
+cluster-id = vsphere-01-cwv8p
 
-    [VirtualCenter "vcenter.openshift.com"]
-    insecure-flag           = true
-    datacenters             = DEVQEdatacenter
-    migration-datastore-url = ds:///vmfs/volumes/vsan:527320283a8c3163-2faa6dc5949a3a28/
+# Populate VCenters (multi) after here
+[VirtualCenter "vcenter.openshift.com"]
+insecure-flag           = true
+datacenters             = DEVQEdatacenter
+password                = "xxxxxxxx"
+user                    = "xxxxxxxx@devcluster.openshift.com"
+migration-datastore-url = ds:///vmfs/volumes/vsan:52c842f232751e0d-3253aadeac21ca82/
 
-    [Snapshot]
-    global-max-snapshots-per-block-volume = 10 <1>
-
-kind: ConfigMap
-metadata:
-  creationTimestamp: "2024-03-06T09:46:40Z"
-  name: vsphere-csi-config
-  namespace: openshift-cluster-csi-drivers
-  resourceVersion: "127118"
-  uid: f6968303-81d8-4048-99c1-d8211363d0fa
+[Snapshot]
+global-max-snapshots-per-block-volume = 10 <1>
 ----
 <1> `global-max-snapshots-per-block-volume` is now set to 10.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13952
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [CSI volume snapshots](https://91923--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-snapshots.html)
* [VMware vSphere CSI Driver Operator](https://91923--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

PTAL: @RomanBednar @duanwei33 
