### PR TITLE
HCIDOCS-689-v416: Fix OCP landing page 4.12 - 4.16

### DIFF
--- a/installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc
+++ b/installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc
@@ -6,11 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can install {product-title} on on-premise hardware or on-premise VMs by using the {ai-full}. Installing {product-title} by using the {ai-full} supports `x86_64`, `AArch64`, `ppc64le`, and `s390x` CPU architectures.
+You can install {product-title} on on-premise hardware or on-premise VMs by using the {ai-full}.
 
 include::modules/assisted-installer-using-the-assisted-installer.adoc[leveloffset=+1]
-
-[id="assisted-installer-api-support-policy"]
-== API support for the {ai-full}
-
-Supported APIs for the {ai-full} are stable for a minimum of three months from the announcement of deprecation.

--- a/modules/assisted-installer-using-the-assisted-installer.adoc
+++ b/modules/assisted-installer-using-the-assisted-installer.adoc
@@ -6,45 +6,6 @@
 [id="using-the-assisted-installer_{context}"]
 = Using the Assisted Installer
 
-The link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[{ai-full}] is a user-friendly installation solution offered on the link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[Red Hat Hybrid Cloud Console]. The {ai-full} supports the various deployment platforms with a focus on bare metal, Nutanix, and vSphere infrastructures.
+The {ai-full} for {product-title} is a user-friendly installation solution offered on the link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[{hybrid-console}]. The {ai-full} reduces installation complexity, enabling users to deploy and configure {product-title} clusters with minimal manual intervention.
 
-The {ai-full} provides installation functionality as a service. This software-as-a-service (SaaS) approach has the following advantages:
-
-* *Web user interface:* The web user interface performs cluster installation without the user having to create the installation configuration files manually.
-* *No bootstrap node:* A bootstrap node is not required when installing with the {ai-full}. The bootstrapping process executes on a node within the cluster.
-* *Hosting:* The {ai-full} hosts:
-** Ignition files
-** The installation configuration
-** A discovery ISO
-** The installer
-* *Streamlined installation workflow:* Deployment does not require in-depth knowledge of {product-title}. The {ai-full} provides reasonable defaults and provides the installer as a service, which:
-** Eliminates the need to install and run the {product-title} installer locally.
-** Ensures the latest version of the installer up to the latest tested z-stream releases. Older versions remain available, if needed.
-** Enables building automation by using the API without the need to run the {product-title} installer locally.
-* *Advanced networking:* The {ai-full} supports IPv4 networking with SDN and OVN, IPv6 and dual stack networking with OVN only, NMState-based static IP addressing, and an HTTP/S proxy. OVN is the default Container Network Interface (CNI) for OpenShift Container Platform 4.12 and later releases. SDN is supported up to {product-title} 4.14, but is not supported for {product-title} 4.15 and later releases.
-
-* *Preinstallation validation:* The {ai-full} validates the configuration before installation to ensure a high probability of success. The validation process includes the following checks:
-** Ensuring network connectivity
-** Ensuring sufficient network bandwidth
-** Ensuring connectivity to the registry
-** Ensuring time synchronization between cluster nodes
-** Verifying that the cluster nodes meet the minimum hardware requirements
-** Validating the installation configuration parameters
-* *REST API:* The {ai-full} has a REST API, enabling automation.
-
-The {ai-full} supports installing {product-title} on premises in a connected environment, including with an optional HTTP/S proxy. It can install the following:
-
-* Highly available {product-title} or {sno} (SNO)
-
-* {product-title} on bare metal, Nutanix, or vSphere with full platform integration, or other virtualization platforms without integration
-
-* Optional: {VirtProductName}, multicluster engine, {lvms-first}, and {rh-storage}
-+
-[NOTE]
-====
-Currently, {VirtProductName} and {lvms} are not supported on {ibm-z-name} (`s390x`) architecture.
-====
-
-The user interface provides an intuitive interactive workflow where automation does not exist or is not required. Users may also automate installations using the REST API.
-
-See the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[Assisted Installer for OpenShift Container Platform] documentation for details.
+See the https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2025[Assisted Installer for OpenShift Container Platform] documentation for details.


### PR DESCRIPTION
Version(s):
4.12, 4.13, 4,14, 4,15, 4.16

Issue:
https://issues.redhat.com/browse/HCIDOCS-689

Additional information:
Change already applied to versions 4.17 and later: https://github.com/openshift/openshift-docs/pull/91421 
Cherry pick failed for earlier versions.

Link to docs preview:
https://91938--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_on_prem_assisted/installing-on-prem-assisted.html

QE approval not required.



