### PR TITLE
[OCPBUGS-48096]: HCP proxy docs for mgmt clusters with secondary network

### DIFF
--- a/hosted_control_planes/hcp-networking.adoc
+++ b/hosted_control_planes/hcp-networking.adoc
@@ -18,6 +18,8 @@ include::modules/hcp-proxy-ignition.adoc[leveloffset=+1]
 include::modules/hcp-proxy-api.adoc[leveloffset=+1]
 //cp workloads that need access to external services and must use the proxy for the management cluster
 include::modules/hcp-proxy-mgmt-cluster.adoc[leveloffset=+1]
+//proxy configuration on the mgmt cluster when the hosted cluster has a secondary network and no default pod network
+include::modules/hcp-proxy-addl-network.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]

--- a/modules/hcp-proxy-addl-network.adoc
+++ b/modules/hcp-proxy-addl-network.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-networking.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-proxy-addl-network_{context}"]
+= Management cluster that uses a proxy and a hosted cluster with a secondary network and no default pod network
+
+If a management cluster uses a proxy configuration and you are configuring a hosted cluster with a secondary network but are not attaching the default pod network, add the CIDR of the secondary network to the proxy configuration. Specifically, you need to add the CIDR of the secondary network to the `noProxy` section of the proxy configuration for the management cluster. Otherwise, the Kubernetes API server will route some API requests through the proxy. In the hosted cluster configuration, the CIDR of the secondary network is automatically added to the `noProxy` section.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-48096
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://91942--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-networking.html#hcp-proxy-addl-network_hcp-networking
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
