### PR TITLE
TELCODOCS-2200#Update MaxInSpecOffset to 1500 for grandmaster clock configs

### DIFF
--- a/snippets/ptp_PtpConfigDualCardGmWpc.yaml
+++ b/snippets/ptp_PtpConfigDualCardGmWpc.yaml
@@ -21,7 +21,7 @@ spec:
           settings:
             LocalMaxHoldoverOffSet: 1500
             LocalHoldoverTimeout: 14400
-            MaxInSpecOffset: 100
+            MaxInSpecOffset: 1500
           pins: $e810_pins
           #  "$iface_nic1":
           #    "U.FL2": "0 2"

--- a/snippets/ptp_PtpConfigGmWpc.yaml
+++ b/snippets/ptp_PtpConfigGmWpc.yaml
@@ -19,7 +19,7 @@ spec:
           settings:
             LocalMaxHoldoverOffSet: 1500
             LocalHoldoverTimeout: 14400
-            MaxInSpecOffset: 100
+            MaxInSpecOffset: 1500
           pins: $e810_pins
           #  "$iface_master":
           #    "U.FL2": "0 2"

--- a/snippets/ztp_PtpConfigDualCardGmWpc.yaml
+++ b/snippets/ztp_PtpConfigDualCardGmWpc.yaml
@@ -23,7 +23,7 @@ spec:
           settings:
             LocalMaxHoldoverOffSet: 1500
             LocalHoldoverTimeout: 14400
-            MaxInSpecOffset: 100
+            MaxInSpecOffset: 1500
           pins: $e810_pins
           #  "$iface_nic1":
           #    "U.FL2": "0 2"

--- a/snippets/ztp_PtpConfigGmWpc.yaml
+++ b/snippets/ztp_PtpConfigGmWpc.yaml
@@ -21,7 +21,7 @@ spec:
           settings:
             LocalMaxHoldoverOffSet: 1500
             LocalHoldoverTimeout: 14400
-            MaxInSpecOffset: 100
+            MaxInSpecOffset: 1500
           pins: $e810_pins
           #  "$iface_master":
           #    "U.FL2": "0 2"


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.15, 4.16, 4.17, 4.18, 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2200
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://91979--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu#ztp-sno-du-configuring-ptp_sno-configure-for-vdu
- https://91979--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp#configuring-linuxptp-services-as-grandmaster-clock_configuring-ptp

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
