### PR TITLE
TELCODOCS-2099: RN for dual-port NIC ordinary clock - TP

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -447,6 +447,18 @@ We will have details here when {product-title} {product-version} is released.
 ==== Support for managing the Gateway API custom resource definition (CRD) lifecycle
 We will have details here when {product-title} {product-version} is released.
 
+[id="ocp-4-19-networking-ptp-dual-oc_{context}"]
+==== Dual-port NICs for improved redundancy in PTP ordinary clocks (Technology Preview)
+With this release, you can use a dual-port network interface controller (NIC) to improve redundancy for Precision Time Protocol (PTP) ordinary clocks.
+Available as a Technology Preview, in a dual-port NIC configuration for an ordinary clock, if one port fails, the standby port takes over, maintaining PTP timing synchronization.
+
+[NOTE]
+====
+You can configure PTP ordinary clocks with added redundancy on `x86` architecture nodes with dual-port NICs only.
+====
+
+For more information, see xref:../networking/ptp/about-ptp.adoc#ptp-dual-ports-oc_about-ptp[Using dual-port NICs to improve redundancy for PTP ordinary clocks].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 
@@ -1299,6 +1311,11 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Not Available
 |General Availability
+
+|Dual-port NIC for PTP ordinary clock
+|Not Available
+|Not Available
+|Technology Preview
 |====
 
 [discrete]


### PR DESCRIPTION
[TELCODOCS-2099](https://issues.redhat.com//browse/TELCODOCS-2099): RN for dual-port NIC ordinary clock - TP

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/TELCODOCS-2099

Link to docs preview:
https://92000--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-networking-ptp-dual-oc_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
