### PR TITLE
TELCODOCS-2099: Removing typo that uses "support" in relation to dual-port config for OC

### DIFF
--- a/modules/ptp-dual-ports-oc.adoc
+++ b/modules/ptp-dual-ports-oc.adoc
@@ -6,7 +6,7 @@
 [id="ptp-dual-ports-oc_{context}"]
 = Using dual-port NICs to improve redundancy for PTP ordinary clocks
 
-{product-title} supports single and dual-port networking interface cards (NICs) as ordinary clocks for PTP timing. To improve redundancy, you can configure a dual-port NIC with one port as active and the other as standby.
+{product-title} supports single-port networking interface cards (NICs) as ordinary clocks for PTP timing. To improve redundancy, you can configure a dual-port NIC with one port as active and the other as standby.
 
 :FeatureName: Configuring linuxptp services as an ordinary clock with dual-port NIC redundancy
 include::snippets/technology-preview.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS#2099](https://issues.redhat.com//browse/TELCODOCS-2099): Removing typo that uses "support" in relation to dual-port config for OC

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2099

Link to docs preview:
https://92017--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/about-ptp.html#ptp-dual-ports-oc_about-ptp

Typo, no need for review. The features introduces dual-port as TP