### PR TITLE
OSDOCS-14044: Small edit to enable region: Malaysia ap-southeast-5 

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -90,7 +90,7 @@ endif::rosa-with-hcp[]
 ifdef::rosa-with-hcp[]
 |ap-southeast-5
 |Malaysia
-|4.15.45; 4.16.34; 4.17.15
+|4.16.34; 4.17.15
 |Yes
 endif::rosa-with-hcp[]
 


### PR DESCRIPTION
[OSDOCS-14044](https://issues.redhat.com//browse/OSDOCS-14044): Small edit to enable region: Malaysia ap-southeast-5 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14044

Link to docs preview:
https://92018--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
