### PR TITLE
OCPBUGS#54799: fixing parameter values for ABI disk encryption

### DIFF
--- a/modules/installing-ocp-agent-encrypt.adoc
+++ b/modules/installing-ocp-agent-encrypt.adoc
@@ -51,6 +51,6 @@ diskEncryption:
     mode: tang <2>
     tangServers: "server1": "http://tang-server-1.example.com:7500" <3>
 ----
-<1> Specify which nodes to enable disk encryption on. Valid values are `none`, `all`, `master`, and `worker`.
+<1> Specify which nodes to enable disk encryption on. Valid values are `none`, `all`, `masters`, and `workers`.
 <2> Specify which disk encryption mode to use. Valid values are `tpmv2` and `tang`.
 <3> Optional: If you are using Tang, specify the Tang servers.


### PR DESCRIPTION
[OCPBUGS-54799](https://issues.redhat.com/browse/OCPBUGS-54799)

Version(s): 4.14+

This PR fixes incorrect parameter values documented in the disk encryption procedure for Agent-based installations.

QE review:
- [x] QE has approved this change.

Preview: https://92024--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-encrypt_installing-with-agent-based-installer