### PR TITLE
Update logging-loki-zone-fail-recovery.adoc

### DIFF
--- a/modules/logging-loki-zone-fail-recovery.adoc
+++ b/modules/logging-loki-zone-fail-recovery.adoc
@@ -28,7 +28,7 @@ The StatefulSet controller automatically attempts to reschedule pods in a failed
 +
 [source,terminal]
 ----
-oc get pods --field-selector status.phase==Pending -n openshift-logging
+$ oc get pods --field-selector status.phase==Pending -n openshift-logging
 ----
 +
 .Example `oc get pods` output
@@ -45,7 +45,7 @@ logging-loki-ruler-1           0/1     Pending   0          16m
 +
 [source,terminal]
 ----
-oc get pvc -o=json -n openshift-logging | jq '.items[] | select(.status.phase == "Pending") | .metadata.name' -r
+$ oc get pvc -o=json -n openshift-logging | jq '.items[] | select(.status.phase == "Pending") | .metadata.name' -r
 ----
 +
 .Example `oc get pvc` output
@@ -62,14 +62,14 @@ wal-logging-loki-ruler-1
 +
 [source,terminal]
 ----
-oc delete pvc __<pvc_name>__  -n openshift-logging
+$ oc delete pvc __<pvc_name>__  -n openshift-logging
 ----
 +
 . Then delete the pod(s) by running the following command:
 +
 [source,terminal]
 ----
-oc delete pod __<pod_name>__  -n openshift-logging
+$ oc delete pod __<pod_name>__  -n openshift-logging
 ----
 
 Once these objects have been successfully deleted, they should automatically be rescheduled in an available zone.
@@ -83,5 +83,5 @@ The PVCs might hang in the terminating state without being deleted, if PVC metad
 +
 [source,terminal]
 ----
-oc patch pvc __<pvc_name>__ -p '{"metadata":{"finalizers":null}}' -n openshift-logging
+$ oc patch pvc __<pvc_name>__ -p '{"metadata":{"finalizers":null}}' -n openshift-logging
 ----


### PR DESCRIPTION
- "$" sign is missing from Recovering Loki pods from failed zones docs
- Here is the documentation link:  https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/logging/log-storage-4#logging-loki-zone-fail-recovery_cluster-logging-loki

- All the steps are correctly mentioned, but the "$" sign is missing.
- "$" sign should be present before start of the every command. It is a standard format.

- Here are steps:

1. List the pods in Pending status by running the following command: 
~~~
oc get pods --field-selector status.phase==Pending -n openshift-logging
~~~
 
2. List the PVCs in Pending status by running the following command: 
~~~
oc get pvc -o=json -n openshift-logging | jq '.items[] | select(.status.phase == "Pending") | .metadata.name' -r 
~~~

3.Delete the PVC(s) for a pod by running the following command: 
~~~
oc delete pvc __<pvc_name>__  -n openshift-logging 
~~~

4.Then delete the pod(s) by running the following command: 
~~~
oc delete pod __<pod_name>__  -n openshift-logging
~~~

  =======================================

1.Remove the finalizer for each PVC by running the command below, then retry deletion. 
~~~
oc patch pvc __<pvc_name>__ -p '{"metadata":{"finalizers":null}}' -n openshift-logging
~~~

We need to add the "$" sign in above all command:

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13, RHOCP 4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1848

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://92040--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_storage/cluster-logging-loki.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
