### PR TITLE
HCIDOCS-684: add iDRAC permission required for installing BareMetal hosts using BMC 

### DIFF
--- a/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
+++ b/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
@@ -6,7 +6,7 @@
 [id='bmc-addressing-for-dell-idrac_{context}']
 = BMC addressing for Dell iDRAC
 
-The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
+The `address` configuration setting for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network. The `username` configuration for each `bmc` entry must specify a user with `Administrator` privileges.
 
 [source,yaml]
 ----
@@ -17,10 +17,11 @@ platform:
         role: <master | worker>
         bmc:
           address: <address> <1>
-          username: <user>
+          username: <user> <2>
           password: <password>
 ----
 <1> The `address` configuration setting specifies the protocol.
+<2> The `username` configuration setting must specify a user with `Administrator` privileges.
 
 For Dell hardware, Red Hat supports integrated Dell Remote Access Controller (iDRAC) virtual media, Redfish network boot, and IPMI.
 
@@ -29,9 +30,9 @@ For Dell hardware, Red Hat supports integrated Dell Remote Access Controller (iD
 [width="100%", cols="1,3", options="header"]
 |====
 |Protocol|Address Format
-|iDRAC virtual media| `idrac-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1`
-|Redfish network boot|`redfish://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1`
-|IPMI|`ipmi://<out-of-band-ip>`
+|iDRAC virtual media| `idrac-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1`
+|Redfish network boot|`redfish://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1`
+|IPMI|`ipmi://<out_of_band_ip>`
 |====
 
 [IMPORTANT]
@@ -61,7 +62,7 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: idrac-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1
+          address: idrac-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1
           username: <user>
           password: <password>
 ----
@@ -73,7 +74,7 @@ While it is recommended to have a certificate of authority for the out-of-band m
 Ensure the {product-title} cluster nodes have *AutoAttach* enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach*.
 ====
 
-The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+The following example demonstrates a Redfish configuration that uses the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -83,7 +84,7 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: idrac-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1
+          address: idrac-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1
           username: <user>
           password: <password>
           disableCertificateVerification: True
@@ -92,7 +93,7 @@ platform:
 [discrete]
 == Redfish network boot for iDRAC
 
-To enable Redfish, use `redfish://` or `redfish+http://` to disable transport layer security (TLS). The installer requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
+To enable Redfish, use `redfish://` or `redfish+http://` to disable transport layer security (TLS). The installation program requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -102,12 +103,12 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1
           username: <user>
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if you use self-signed certificates. The following example demonstrates a Redfish configuration that uses the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -117,7 +118,7 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1
           username: <user>
           password: <password>
           disableCertificateVerification: True


### PR DESCRIPTION
Added notes that Administrator privileges are required. Incorporated vale linter feedback.

Fixes: [HCIDOCS-684](https://issues.redhat.com//browse/HCIDOCS-684)

See https://issues.redhat.com/browse/HCIDOCS-684 for additional details.

Preview URL: https://92053--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#bmc-addressing-for-dell-idrac_ipi-install-installation-workflow

For release(s): 4.12-4.19
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
