### PR TITLE
OSDOCS-13972-date

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3018,7 +3018,7 @@ For any {product-title} release, always review the instructions on xref:../updat
 [id="ocp-4-18-8_{context}"]
 === RHSA-2025:3577 - {product-title} {product-version}.8 bug fix update and security update
 
-Issued: 09 April 2025
+Issued: 10 April 2025
 
 {product-title} release {product-version}.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3577[RHSA-2025:3577] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3579[RHBA-2025:3579] advisory.
 
@@ -3071,7 +3071,7 @@ To update an {product-title} 4.18 cluster to this latest release, see xref:../up
 [id="ocp-4-18-7_{context}"]
 === RHBA-2025:3293 - {product-title} {product-version}.7 bug fix update 
 
-Issued: 01 April 2025
+Issued: 3 April 2025
 
 {product-title} release {product-version}.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:3293[RHBA-2025:3293] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3295[RHBA-2025:3295] advisory.
 
@@ -3233,7 +3233,7 @@ To update an {product-title} 4.18 cluster to this latest release, see xref:../up
 [id="ocp-4-18-3_{context}"]
 === RHBA-2025:2229 - {product-title} {product-version}.3 bug fix update
 
-Issued: 06 March 2025
+Issued: 6 March 2025
 
 {product-title} release {product-version}.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:2229[RHBA-2025:2229] advisory.
 
@@ -3254,7 +3254,7 @@ To update an {product-title} 4.18 cluster to this latest release, see xref:../up
 [id="ocp-4-18-2_{context}"]
 === RHBA-2025:1904 - {product-title} {product-version}.2 image release, bug fix, and security update advisory
 
-Issued: 04 March 2025
+Issued: 4 March 2025
 
 {product-title} release {product-version}.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:1904[RHBA-2025:1904] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1908[RHSA-2025:1908] advisory.
 


### PR DESCRIPTION
The issued date for the 4.18.8 z-stream is the 10th of April, see https://errata.devel.redhat.com/advisory/147802:

![Screenshot From 2025-04-11 09-34-22](https://github.com/user-attachments/assets/ab40e890-bddf-40da-b58a-beb5aa2e4d8f)

Version(s):
4.18

Issue:
[OSDOCS-13972](https://issues.redhat.com/browse/OSDOCS-13972)

Link to docs preview:
https://92080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-8_release-notes


