### PR TITLE
Update log6x-cluster-logging-collector-log-forward-syslog.adoc

### DIFF
--- a/modules/log6x-cluster-logging-collector-log-forward-syslog.adoc
+++ b/modules/log6x-cluster-logging-collector-log-forward-syslog.adoc
@@ -88,12 +88,11 @@ You can add `namespace_name`, `pod_name`, and `container_name` elements to the `
     outputs:
     - name: syslogout
       syslog:
-        enrichment: KubernetesMinimal: true
+        enrichment: KubernetesMinimal
         facility: user
         payloadKey: message
         rfc: RFC3164
         severity: debug
-        tag: mytag
       type: syslog
       url: tls://syslog-receiver.example.com:6514
     pipelines:


### PR DESCRIPTION
correct example in Adding log source information to the message output :

Present example :
syslog:enrichment: KubernetesMinimal: true
Correct example:
syslog:enrichment: KubernetesMinimal

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: correct the example in "Adding log source information to the message output"

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> OCP version 4.18+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/OBSDOCS-1849

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://92081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-clf-6.2.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
