### PR TITLE
OCPBUGS-54148-sdn: Added PTP and OVNK limitation to SDN docs

### DIFF
--- a/modules/nw-ovn-kubernetes-live-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration-about.adoc
@@ -88,6 +88,8 @@ During the limited live migration, both OVN-Kubernetes and OpenShift SDN run in 
 
 * OVN-Kubernetes reserves the `100.64.0.0/16` and `100.88.0.0/16` IP address ranges. These subnets cannot be overlapped with any other internal or external network. If these IP addresses have been used by OpenShift SDN or any external networks that might communicate with this cluster, you must patch them to use a different IP address range before starting the limited live migration. See "Patching OVN-Kubernetes address ranges" for more information.
 
+* If your `openshift-sdn` cluster with Precision Time Protocol (PTP) uses the User Datagram Protocol (UDP) for hardware time stamping and you migrate to the OVN-Kubernetes plugin, the hardware time stamping cannot be applied to primary interface devices, such as an Open vSwitch (OVS) bridge. As a result, UDP version 4 configurations cannot work with a `br-ex` interface.
+
 * In most cases, the limited live migration is independent of the secondary interfaces of pods created by the Multus CNI plugin. However, if these secondary interfaces were set up on the default network interface controller (NIC) of the host, for example, using MACVLAN, IPVLAN, SR-IOV, or bridge interfaces with the default NIC as the control node, OVN-Kubernetes might encounter malfunctions. Users should remove such configurations before proceeding with the limited live migration.
 
 * When there are multiple NICs inside of the host, and the default route is not on the interface that has the Kubernetes NodeIP, you must use the offline migration instead.

--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -72,6 +72,8 @@ While the OVN-Kubernetes network plugin implements many of the capabilities pres
 
 * Before migrating to OVN-Kubernetes, ensure that the following IP address ranges are not in use: `100.64.0.0/16`, `169.254.169.0/29`, `100.88.0.0/16`, `fd98::/64`, `fd69::/125`, and `fd97::/64`. OVN-Kubernetes uses these ranges internally. Do not include any of these ranges in any other CIDR definitions in your cluster or infrastructure.
 
+* If your `openshift-sdn` cluster with Precision Time Protocol (PTP) uses the User Datagram Protocol (UDP) for hardware time stamping and you migrate to the OVN-Kubernetes plugin, the hardware time stamping cannot be applied to primary interface devices, such as an Open vSwitch (OVS) bridge. As a result, UDP version 4 configurations cannot work with a `br-ex` interface.
+
 * Like OpenShift SDN, OVN-Kubernetes resources require `ClusterAdmin` privileges. Migrating from OpenShift SDN to OVN-Kubernetes does not automatically update role-base access control (RBAC) resources. OpenShift SDN resources granted to a project administrator through the `aggregate-to-admin` `ClusterRole` must be manually reviewed and adjusted, as these changes are not included in the migration process.
 +
 After migration, manual verification of RBAC resources is required. 


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[OCPBUGS-54148](https://issues.redhat.com/browse/OCPBUGS-54148)

Link to docs preview:
* [Considerations for limited live migration to the OVN-Kubernetes network plugin](https://92083--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-live-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn)

- [x] SME has approved this change (Christian Passarelli/comment in team-ocp-dsn doc).
- [x] QE has approved this change (Zhanqi Zhao).
