### PR TITLE
[enterprise-4.16] OCP MC docs don't highlight that Butane .version is different than z-stream OCP version

### DIFF
--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -22,7 +22,7 @@ and other settings.
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 [source,yaml,subs="attributes+"]

--- a/modules/containers-signature-verify-enable.adoc
+++ b/modules/containers-signature-verify-enable.adoc
@@ -13,7 +13,7 @@ Enabling container signature validation for Red Hat Container Registries require
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 [source,yaml,subs="attributes+"]

--- a/modules/installation-special-config-chrony.adoc
+++ b/modules/installation-special-config-chrony.adoc
@@ -32,7 +32,7 @@ to your nodes as a machine config.
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 [source,yaml,subs="attributes+"]

--- a/modules/machineconfig-modify-journald.adoc
+++ b/modules/machineconfig-modify-journald.adoc
@@ -20,7 +20,7 @@ This procedure describes how to modify `journald` rate limiting settings in the 
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 [source,yaml,subs="attributes+"]

--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -141,6 +141,11 @@ where:
 
 .... Create the following Butane config in the `control-plane-interface.bu` file:
 +
+[NOTE]
+====
+include::snippets/butane-version.adoc[]
+====
++
 [source,yaml, subs="attributes+"]
 ----
 variant: openshift

--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -161,6 +161,11 @@ storage:
 
 .... Create the following Butane config in the `worker-interface.bu` file:
 +
+[NOTE]
+====
+include::snippets/butane-version.adoc[]
+====
++
 [source,yaml, subs="attributes+"]
 ----
 variant: openshift

--- a/modules/nw-ovn-ipsec-north-south-enable.adoc
+++ b/modules/nw-ovn-ipsec-north-south-enable.adoc
@@ -121,6 +121,11 @@ $ oc create -f ipsec-config.yaml
 
 .. To create Butane config files for the control plane and worker nodes, enter the following command:
 +
+[NOTE]
+====
+include::snippets/butane-version.adoc[]
+====
++
 [source,terminal,subs="attributes+"]
 ----
 $ for role in master worker; do

--- a/modules/rhcos-load-firmware-blobs.adoc
+++ b/modules/rhcos-load-firmware-blobs.adoc
@@ -14,10 +14,10 @@ Because the default location for firmware blobs in `/usr/lib` is read-only, you 
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
-.Butane config file for custom firmware blob
 +
+.Butane config file for custom firmware blob
 [source,yaml,subs="attributes+"]
 ----
 variant: openshift

--- a/modules/troubleshooting-enabling-kdump-day-one.adoc
+++ b/modules/troubleshooting-enabling-kdump-day-one.adoc
@@ -25,6 +25,11 @@ Create a `MachineConfig` object for cluster-wide configuration:
 
 . Create a Butane config file, `99-worker-kdump.bu`, that configures and enables kdump:
 +
+[NOTE]
+====
+include::snippets/butane-version.adoc[]
+====
++
 [source,yaml,subs="attributes+"]
 ----
 variant: openshift

--- a/modules/virt-binding-devices-vfio-driver.adoc
+++ b/modules/virt-binding-devices-vfio-driver.adoc
@@ -28,7 +28,7 @@ $ lspci -nnv | grep -i nvidia
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 .Example

--- a/snippets/butane-version.adoc
+++ b/snippets/butane-version.adoc
@@ -1,0 +1,17 @@
+// Text snippet included in the following modules:
+//
+// * modules/about-crio.adoc
+// * modules/nodes-containers-using.adoc
+// * modules/cluster-logging-systemd-scaling.adoc
+// * modules/containers-signature-verify-enable.adoc
+// * modules/machineconfig-modify-journald.adoc
+// * modules/nw-cluster-mtu-change.adoc
+// * modules/nw-ovn-ipsec-north-south-enable.adoc
+// * modules/rhcos-load-firmware-blobs.adoc
+// * modules/troubleshooting-enabling-kdump-day-one.adoc
+// * modules/virt-binding-devices-vfio-driver.adoc
+// * updating/updating_a_cluster/updating-bootloader-rhcos.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+The link:https://coreos.github.io/butane/specs/[Butane version] you specify in the config file should match the {product-title} version and always ends in `0`. For example, `{product-version}.0`. See "Creating machine configs with Butane" for information about Butane.

--- a/updating/updating_a_cluster/updating-bootloader-rhcos.adoc
+++ b/updating/updating_a_cluster/updating-bootloader-rhcos.adoc
@@ -90,7 +90,7 @@ The boot loader update operation generally completes quickly thus the risk is lo
 +
 [NOTE]
 ====
-See "Creating machine configs with Butane" for information about Butane.
+include::snippets/butane-version.adoc[]
 ====
 +
 .Example output


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/91674