### PR TITLE
OSDOCS-14021#adding port info

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -148,7 +148,7 @@ endif::ibm-z[]
 |N/A
 |Network reachability tests
 
-.3+|TCP
+.4+|TCP
 |`1936`
 |Metrics
 
@@ -159,6 +159,8 @@ the Cluster Version Operator on port `9099`.
 |`10250`-`10259`
 |The default ports that Kubernetes reserves
 
+|`22623`
+|The port handles traffic from the Machine Config Server and directs the traffic to the control plane machines.
 .6+|UDP
 |`4789`
 |VXLAN


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-14021

Link to docs preview:
This single update is displaying on these pages:

- [Network connectivity requirements ](https://92107--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs#installation-network-connectivity-user-infra_upi-vsphere-installation-reqs) (vSphere)
- [Network connectivity requirements ](https://92107--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic#installation-network-connectivity-user-infra_installing-platform-agnostic)(Installing on any platform)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
