### PR TITLE
[enterprise-4.15] - OCPBUGS-54643 - Update docs contain typos - fix for the reported bug

### DIFF
--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -27,31 +27,30 @@ You cannot downgrade {microshift-short} with this process. Downgrades are not su
 
 .Procedure
 
-. For all lifecycles, enable the repository for your release by running the following command:
+. For all lifecycles, enable the repository for the release you want to update to by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-4.15-for-9-$(uname -m)-rpms \
-    --enable fast-datapath-for-9-$(uname -m)-rpms
+    --enable rhocp-{ocp-version}-for-rhel-{op-system-version-major}-$(uname -m)-rpms \
+    --enable fast-datapath-for-rhel-{op-system-version-major}-$(uname -m)-rpms
 ----
 
 . For extended support (EUS) releases, also enable the EUS repositories by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-`$ sudo subscription-manager repos \
-    --enable rhel-9-for-x86_64-appstream-eus-rpms \
-    --enable rhel-9-for-x86_64-baseos-eus-rpms`
+$ sudo subscription-manager repos \
+    --enable rhel-{op-system-version-major}-for-$(uname -m)-appstream-eus-rpms \ 
+    --enable rhel-{op-system-version-major}-for-$(uname -m)-baseos-eus-rpms 
 ----
 
 . Avoid unintended future updates into an unsupported configuration by locking your operating system version with the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ sudo subscription-manager release --set=<9.2> command. # <1>
+$ sudo subscription-manager release --set={op-system-version}
 ----
-<1> Replace _<9.2>_ with the major and minor version of your compatible {op-system-base} system.
 
 . Update the {microshift-short} RPMs by running the following command:
 +


### PR DESCRIPTION
Cherry Picked from 8747090bbca1f6f4f8417bb6fc9e86fe76be2e7f xref: https://github.com/openshift/openshift-docs/pull/91678