### PR TITLE
OSSM-9066: Istioctl install instructions reference old Istio versions

### DIFF
--- a/install/ossm-istioctl-tool.adoc
+++ b/install/ossm-istioctl-tool.adoc
@@ -4,6 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: ossm-istioctl-tool
 
+toc::[]
+
 {SMProduct} 3 supports `istioctl`, the command line utility for the {istio} project that includes many diagnostic and debugging utilities.
 
 include::modules/ossm-support-for-istioctl.adoc[leveloffset=+1]

--- a/modules/ossm-installing-the-istioctl-tool.adoc
+++ b/modules/ossm-installing-the-istioctl-tool.adoc
@@ -1,33 +1,58 @@
 // Module included in the following assemblies:
 //
-// * service-mesh-docs-main/about/ossm-migrating-assembly.adoc
+// * service-mesh-docs-main/install/ossm-istioctl-tool.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-installing-the-istioctl-tool_{context}"]
 = Installing the Istioctl tool
 
+Install the `istioctl` command-line utility to debug and diagnose {istio} service mesh deployments.
+
 .Prerequisites
 
 * You have access to the {ocp-product-title} web console.
 
+* The {SMProduct} 3 Operator is installed and running.
+
+* You have created at least one `Istio` resource.
+
 .Procedure
 
-. In the {ocp-product-title} web console, click the question mark icon and select *Command Line Tools*.
+. Confirm which version of the `Istio` resource runs on the installation by running the following command:
++
+[source,terminal]
+----
+$ oc get istio -ojsonpath="{range .items[*]}{.spec.version}{'\n'}{end}" | sed s/^v// | sort
+----
++
+If there are multiple `Istio` resources with different versions, choose the latest version. The latest version is displayed last.
+
+. In the {ocp-product-title} web console, click the *Help* icon and select *Command Line Tools*.
 
 . Click *Download istioctl*. Choose the version and architecture that matches your system.
+  
+* link:https://mirror.openshift.com/pub/cgw/servicemesh/latest/istioctl-1.24.4-linux-amd64.tar.gz[Linux (x86_64, amd64)]
 
-* link:https://mirror.openshift.com/pub/cgw/servicemesh/1.23.0/[Version 1.23.0]
+* link:https://mirror.openshift.com/pub/cgw/servicemesh/latest/istioctl-1.24.4-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
 
-* link:https://mirror.openshift.com/pub/cgw/servicemesh/1.24.1/[Version 1.24.1]
+* link:https://mirror.openshift.com/pub/cgw/servicemesh/latest/istioctl-1.24.4-darwin-amd64.tar.gz[MacOS (x86_64, amd64)]
 
-* link:https://mirror.openshift.com/pub/cgw/servicemesh/latest/[Latest]
+* link:https://mirror.openshift.com/pub/cgw/servicemesh/latest/istioctl-1.24.4-darwin-arm64.tar.gz[MacOS on ARM (aarch64, arm64)]
 
-. Extract the `istioctl` binary by running the following command:
+* link:https://mirror.openshift.com/pub/cgw/servicemesh/latest/istioctl-1.24.4-windows-amd64.zip[Windows (x86_64, amd64)]
+
+. Extract the `istioctl` binary file.
+
+.. If you are using a Linux operating system, run the following command:
 +
 [source,terminal]
 ----
 $ tar xzf istioctl-<VERSION>-<OS>-<ARCH>.tar.gz
 ----
+
+.. If you are using an Apple Mac operating system, unpack and extract the archive.
+
+.. If you are using a Microsoft Windows operating system, use the zip software to extract the archive.
 
 . Move to the uncompressed directory by running the following command:
 +


### PR DESCRIPTION
Merge to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main
Cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s): 3.0

Issue: https://issues.redhat.com/browse/OSSM-9066
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://92133--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-istioctl-tool.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
