### PR TITLE
OSDOCS-14034 documented the 4.13.57 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4493,7 +4493,7 @@ To update an existing {product-title} 4.13 cluster to this latest release, see x
 
 Issued: 20 March 2025
 
-{product-title} release 4.13.56, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RRHSA-2025:2701[RHSA-2025:2701] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:2703[RHSA-2025:2703] advisory.
+{product-title} release 4.13.56, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:2701[RHSA-2025:2701] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:2703[RHSA-2025:2703] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -4505,5 +4505,26 @@ $ oc adm release info 4.13.56 --pullspecs
 ----
 
 [id="ocp-4-13-56-updating_{context}"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.13.57
+[id="ocp-4-13-57_{context}"]
+=== RHSA-2025:3780 - {product-title} 4.13.57 bug fix and security updates
+
+Issued: 17 April 2025
+
+{product-title} release 4.13.57, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3780[RHSA-2025:3780] advisory. There are no RPM packages for this update.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.57 --pullspecs
+----
+
+[id="ocp-4-13-57-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-14034

Link to docs preview:
https://92138--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-57_release-notes

QE review:
- [ ] QE has approved this change.


Reviewer: The errata URLs are not available until the go-live-date of 04-17-2025
