### PR TITLE
OBSDOCS-1843: Logging Z-Stream Release Notes - 6.2.1

### DIFF
--- a/modules/log6x-6-2-1-rn.adoc
+++ b/modules/log6x-6-2-1-rn.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.2/log6x-release-notes-6.2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-2-1_{context}"]
+= Logging 6.2.1 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:3908[RHBA-2025:3908].
+
+[id="logging-release-notes-6-2-1-bug-fixes_{context}"]
+== Bug Fixes
+
+* Before this update, application programming interface (API) audit logs collected from the management cluster used the `cluster_id` value from the management cluster. With this update, API audit logs use the `cluster_id` value from the guest cluster. (link:https://issues.redhat.com/browse/LOG-4445[LOG-4445])
+
+* Before this update, issuing the `oc explain obsclf.spec.filters` command did not list all the supported filters in the command output. With this update, all the supported filter types are listed in the command output. (link:https://issues.redhat.com/browse/LOG-6753[LOG-6753])
+
+
+* Before this update the log collector flagged a `ClusterLogForwarder` resource with multiple inputs to a LokiStack output as invalid due to  incorrect internal processing logic. This update fixes the issue. (link:https://issues.redhat.com/browse/LOG-6758[LOG-6758])
+
+* Before this update, issuing the `oc explain` command for the `clusterlogforwarder.spec.outputs.syslog` resource returned an incomplete result. With this update, the missing supported types for `rfc` and `enrichment` attributes are listed in the result correctly. (link:https://issues.redhat.com/browse/LOG-6869[LOG-6869])
+
+* Before this update, empty OpenTelemetry (OTEL) tuning configuration caused validation errors. With this update, validation rules have been updated to accept empty tuning configuration. (link:https://issues.redhat.com/browse/LOG-6878[LOG-6878])
+
+* Before this update the {clo} could not update the `securitycontextconstraint` resource that is required by the log collector. With this update, the required cluster role has been provided to the service account of the {clo}. As a result of which, {clo} can create or update the  `securitycontextconstraint` resource. (link:https://issues.redhat.com/browse/LOG-6879[LOG-6879])
+
+* Before this update, the API documentation for the  URL attribute of the `syslog` resource incorrectly mentioned the value `udps` as a supported value. With this update, all references to `udps` have been removed. (link:https://issues.redhat.com/browse/LOG-6896[LOG-6896])
+
+* Before this update, the {CLO} was intermittently unable to update the object in logs due to update conflicts. This update resolves the issue and prevents conflicts during object updates by using the `Patch()` function instead of the `Update()` function. (link:https://issues.redhat.com/browse/LOG-6953[LOG-6953])
+
+* Before this update, Loki ingesters that got into an unhealthy state due to networking issues stayed in that state even after the network recovered. With this update, you can configure  the {loki-op} to perform service discovery more often so that unhealthy ingesters can rejoin the group. (link:https://issues.redhat.com/browse/LOG-6992[LOG-6992])
+
+* Before this update, the Vector collector could not forward Open Virtual Network (OVN) and Auditd logs. With this update, the Vector collector can forward OVN and Auditd logs. (link:https://issues.redhat.com/browse/LOG-6997[LOG-6997])
+
+[id="logging-release-notes-6-2-1-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+* link:https://access.redhat.com/security/cve/CVE-2024-2236[CVE-2024-2236]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]

--- a/observability/logging/logging-6.2/log6x-release-notes-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-release-notes-6.2.adoc
@@ -1,9 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="log6x-release-notes-6-2"]
-= Logging 6.2
+= Logging 6.2 Release Notes
 :context: log6x-release-notes-6-2
 
 toc::[]
 
+include::modules/log6x-6-2-1-rn.adoc[leveloffset=+1]
 include::modules/log6x-6-2-0-rn.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.18, 4.17, 4.16

Issue: https://issues.redhat.com/browse/OBSDOCS-1843

Link to docs preview: https://92143--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-release-notes-6.2.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
