### PR TITLE
OSDOCS#14025: Removing note saying that modern profile isn't supporte…

### DIFF
--- a/modules/tls-profiles-ingress-configuring.adoc
+++ b/modules/tls-profiles-ingress-configuring.adoc
@@ -69,6 +69,7 @@ spec:
 <2> Specify the appropriate field for the selected type:
 * `old: {}`
 * `intermediate: {}`
+* `modern: {}`
 * `custom:`
 <3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
 

--- a/modules/tls-profiles-kubelet-configuring.adoc
+++ b/modules/tls-profiles-kubelet-configuring.adoc
@@ -33,7 +33,7 @@ spec:
 # ...
 ----
 
-You can see the ciphers and the minimum TLS version of the configured TLS security profile in the `kubelet.conf` file on a configured node. 
+You can see the ciphers and the minimum TLS version of the configured TLS security profile in the `kubelet.conf` file on a configured node.
 
 .Prerequisites
 
@@ -75,6 +75,7 @@ spec:
 <2> Specify the appropriate field for the selected type:
 * `old: {}`
 * `intermediate: {}`
+* `modern: {}`
 * `custom:`
 <3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
 <4> Optional: Specify the machine config pool label for the nodes you want to apply the TLS security profile.

--- a/modules/tls-profiles-kubernetes-configuring.adoc
+++ b/modules/tls-profiles-kubernetes-configuring.adoc
@@ -42,11 +42,6 @@ The TLS security profile defines the minimum TLS version and the TLS ciphers req
 
 You can see the configured TLS security profile in the `APIServer` custom resource (CR) under `Spec.Tls Security Profile`. For the `Custom` TLS security profile, the specific ciphers and minimum TLS version are listed.
 
-[NOTE]
-====
-The control plane does not support TLS `1.3` as the minimum TLS version; the `Modern` profile is not supported because it requires TLS `1.3`.
-====
-
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
@@ -84,6 +79,7 @@ spec:
 <2> Specify the appropriate field for the selected type:
 * `old: {}`
 * `intermediate: {}`
+* `modern: {}`
 * `custom:`
 <3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
 

--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -41,10 +41,6 @@ This profile is the recommended configuration for the majority of clients.
 |This profile is intended for use with modern clients that have no need for backwards compatibility. This profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility[Modern compatibility] recommended configuration.
 
 The `Modern` profile requires a minimum TLS version of 1.3.
-[NOTE]
-====
-In {product-title} 4.6, 4.7, and 4.8, the `Modern` profile is unsupported. If selected, the `Intermediate` profile is enabled.
-====
 
 |`Custom`
 |This profile allows you to define the TLS version and ciphers to use.


### PR DESCRIPTION
…d for control plane

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-14025

Link to docs preview:

* https://92144--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/tls-security-profiles.html#tls-profiles-kubernetes-configuring_tls-security-profiles
* https://92144--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/tls-security-profiles.html#tls-profiles-understanding_tls-security-profiles

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

~**Do not merge this until the eng PR merges**~ PR merged