### PR TITLE
OBSDOCS-1842: Logging Z-Stream Release Notes - 6.1.5

### DIFF
--- a/modules/log6x-6-1-5-rn.adoc
+++ b/modules/log6x-6-1-5-rn.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.1/log6x-release-notes-6.1.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-5_{context}"]
+= Logging 6.1.5 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHSA-2025:3907[RHSA-2025:3907].
+
+[id="logging-release-notes-6-1-5-enhancements_{context}"]
+== New features and enhancements
+
+* Before this update, time-based stream sharding was not enabled in Loki, which resulted in Loki being unable to save historical data. With this update, {loki-op} enables time-based stream sharding in Loki, which helps Loki save historical data. (link:https://issues.redhat.com/browse/LOG-6991[LOG-6991])
+
+[id="logging-release-notes-6-1-5-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the Vector collector could not forward Open Virtual Network (OVN) and Auditd logs. With this update, the Vector collector can forward OVN and Auditd logs. (link:https://issues.redhat.com/browse/LOG-6996[LOG-6996])
+
+[id="logging-release-notes-6-1-5-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-30204[CVE-2025-30204]
+
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].
+====

--- a/observability/logging/logging-6.1/log6x-release-notes-6.1.adoc
+++ b/observability/logging/logging-6.1/log6x-release-notes-6.1.adoc
@@ -1,10 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="log6x-release-notes-6-1"]
-= Logging 6.1
+= Logging 6.1 Release Notes
 :context: logging-6x-6.1
 
 toc::[]
+
+include::modules/log6x-6-1-5-rn.adoc[leveloffset=+1]
 
 include::modules/log6x-6-1-4-rn.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.18, 4.17

Issue: https://issues.redhat.com/browse/OBSDOCS-1842

Link to docs preview: https://92146--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-release-notes-6.1.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
