### PR TITLE
OBSDOCS-1841: Logging Z-Stream Release Notes - 6.0.7

### DIFF
--- a/modules/log6x-rn-6.0.7.adoc
+++ b/modules/log6x-rn-6.0.7.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-7_{context}"]
+= Logging 6.0.7
+
+This release includes link:https://access.redhat.com/errata/RHSA-2025:3905[RHSA-2025:3905].
+
+
+[id="logging-release-notes-6-0-7-enhancements_{context}"]
+== New features and enhancements
+
+* Before this update, time-based stream sharding was not enabled in Loki, which resulted in Loki being unable to save historical data. With this update, the {loki-op} enables time-based stream sharding in Loki, which helps Loki save historical data. (link:https://issues.redhat.com/browse/LOG-6990[LOG-6990])
+
+[id="logging-release-notes-6-0-7-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-30204[CVE-2025-30204]
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].
+====

--- a/observability/logging/logging-6.0/log6x-release-notes.adoc
+++ b/observability/logging/logging-6.0/log6x-release-notes.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/log6x-rn-6.0.7.adoc[leveloffset=+1]
+
 include::modules/log6x-rn-6.0.6.adoc[leveloffset=+1]
 
 include::modules/log6x-rn-6.0.5.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1841
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://92147--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
