### PR TITLE
OCPBUGS-54740#Add --show-template-functions to cluster-compare plugin options

### DIFF
--- a/modules/cluster-compare-reference-args.adoc
+++ b/modules/cluster-compare-reference-args.adoc
@@ -58,6 +58,9 @@ You must use a file path for the target template that is relative to the `metada
 | `--show-managed-fields` 
 | Specify `true` to include managed fields in the comparison.
 
+| `--show-template-functions`
+| Displays available template functions.
+
 | `-v`, `--verbose` 
 | Increases the verbosity of the plugin output.
 

--- a/modules/cluster-compare-templating-reference.adoc
+++ b/modules/cluster-compare-templating-reference.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+
+// *scalability_and_performance/cluster-compare/creating-a-reference-configuration.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="cluster-compare-templating-reference_{context}"]
+= Reference template functions
+
+The `cluster-compare` plugin supports all `sprig` library functions, except for the `env` and `expandenv` functions.
+See _Additional resources_ for the full list of `sprig` library functions.
+
+The following content describes the additional template functions for the `cluster-compare` plugin. 
+
+.Additional cluster-compare template functions
+[options="header"]
+[cols="2a,3a"]
+|====
+| Function | Description
+
+|`fromJson`
+|Parses the incoming string as a structured JSON object.
+
+|`fromJsonArray`
+|Parses the incoming string as a structured JSON array.
+
+|`fromYaml`
+|Parses the incoming string as a structured YAML object.
+
+|`fromYamlArray`
+|Parses the incoming string as a structured YAML array.
+
+|`toJson`
+|Renders incoming data as JSON while preserving object types.
+
+|`toToml`
+|Renders the incoming string as structured TOML data.
+
+|`toYaml`
+|Renders incoming data as YAML while preserving object types.
+
+|====

--- a/scalability_and_performance/cluster-compare/creating-a-reference-configuration.adoc
+++ b/scalability_and_performance/cluster-compare/creating-a-reference-configuration.adoc
@@ -14,6 +14,13 @@ include::modules/cluster-compare-template-groupings.adoc[leveloffset=+1]
 
 include::modules/cluster-compare-templating.adoc[leveloffset=+1]
 
+include::modules/cluster-compare-templating-reference.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://masterminds.github.io/sprig/[Sprig Function Documentation]
+
 include::modules/cluster-compare-exclude-metadata.adoc[leveloffset=+1]
 
 include::modules/cluster-compare-configure-inline-diff.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-54740
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://92178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cluster-compare/using-the-cluster-compare-plugin.html#cluster-compare-reference-args_using-cluster-compare-plugin

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
