### PR TITLE
[OCPBUGS-55015] Fix missing comma in NAD example

### DIFF
--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -102,7 +102,7 @@ The following JSON example configures a localnet secondary network:
   "subnets": "202.10.130.112/28",
   "vlanID": 33,
   "mtu": 1500,
-  "netAttachDefName": "ns1/localnet-network"
+  "netAttachDefName": "ns1/localnet-network",
   "excludeSubnets": "10.100.200.0/29"
 }
 ----


### PR DESCRIPTION
Added missing comma on example NAD JSON config for localnet secondary network topology.

Fixes OCPBUGS-55015

Version(s):
4.18, 4.17

Issue:
- https://issues.redhat.com/browse/OCPBUGS-55015

Link to docs preview:

https://92179--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.html

QE review:
- [x] QE has approved this change.

Additional information:
Found during UDN hackaton