### PR TITLE
OCPBUGS-55031: Fix ClusterUserDefinedNetwork example

### DIFF
--- a/modules/nw-cudn-cr.adoc
+++ b/modules/nw-cudn-cr.adoc
@@ -47,8 +47,8 @@ metadata:
 spec:
   namespaceSelector: # <2>
     matchLabels: # <3>
-    - "<example_namespace_one>":"" # <4>
-    - "<example_namespace_two>":"" # <4>
+      "<label_1_key>": "<label_1_value>" # <4>
+      "<label_2_key>": "<label_2_value>" # <4>
   network: # <5>
     topology: Layer2 # <6>
     layer2: # <7>
@@ -60,7 +60,7 @@ spec:
 <1> Name of your `ClusterUserDefinedNetwork` CR.
 <2> A label query over the set of namespaces that the cluster UDN CR applies to. Uses the standard Kubernetes `MatchLabel` selector. Must not point to `default` or `openshift-*` namespaces.
 <3> Uses the `matchLabels` selector type, where terms are evaluated with an `AND` relationship. 
-<4> Because the `matchLabels` selector type is used, provisions namespaces matching both `<example_namespace_one>` _and_ `<example_namespace_two>`.
+<4> Because the `matchLabels` selector type is used, provisions namespaces that contain both `<label_1_key>=<label_1_value>` and `<label_2_key>=<label_2_value>` labels.
 <5> Describes the network configuration.
 <6> The `topology` field describes the network configuration; accepted values are `Layer2` and `Layer3`. Specifying a `Layer2` topology type creates one logical switch that is shared by all nodes.
 <7> This field specifies the topology configuration. It can be `layer2` or `layer3`.


### PR DESCRIPTION
Its `matchLabels` section was depicted as an array, but it must be a dictionary

Version(s):

4.18, 4.17

Issue:

- https://issues.redhat.com/browse/OCPBUGS-55031

Link to docs preview:

- https://92194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html

QE review:
- [x] QE has approved this change.

Additional information: