### PR TITLE
OSDOCS#14032:  Update the z-stream RN for 4.18.9

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3016,6 +3016,62 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.9
+[id="ocp-4-18-9_{context}"]
+=== RHSA-2025:3775 - {product-title} {product-version}.9 bug fix update and security update
+
+Issued: 15 April 2025
+
+{product-title} release {product-version}.9 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3775[RHSA-2025:3775] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3777[RHBA-2025:3777] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.9 --pullspecs
+----
+
+[id="ocp-4-18-9-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the `manifest-topology.yaml` file was not added for the topology-related feature in {vmw-first}. With this release, the `manifest-topology.yaml` file is added for the topology-related feature and tested resulting in improved performance and enhanced end-user experience when using the topology feature. (link:https://issues.redhat.com/browse/OCPBUGS-54701[*OCPBUGS-54701*])
+
+* Previously, the OVN-Kubernetes container failed to start because of the incorrect handling of User-Defined Networks (UDN) in `EgressIP` logical router policies. Users experienced intermittent deployment failures on AWS, which led to prolonged downtime and service disruptions. With this release, the OVN-Kubernetes container starts successfully with UDNs configured. (link:https://issues.redhat.com/browse/OCPBUGS-54671[*OCPBUGS-54671*])
+
+* Previously, the identity provider (IdP) reconciler did not consider the additional trust bundle for customer proxies, leading to failed TLS certificate verification and IdP integration failures in hosted clusters. This resulted in service interruptions for end users. With this release, the TLS certificate verification problem is resolved, allowing the IdP to function correctly in hosted clusters with a proxy configuration that specifies an additional trust bundle, resulting in an improved end-user experience with seamless IdP integration. (link:https://issues.redhat.com/browse/OCPBUGS-54627[*OCPBUGS-54627*])
+
+* Previously, the control plane controller did not select the correct Cluster Version Operator (CVO) manifests for the required feature set. With this release, the control plane controller selects the correct CVO manifests, which are deployed for the hosted cluster. (link:https://issues.redhat.com/browse/OCPBUGS-54625[*OCPBUGS-54625*])
+
+* Previously, an issue arose when the expiration timestamp annotation on ignition tokens was reset, which should not occur. This led to the accumulation of outdated tokens, and caused resource mismanagement or security vulnerabilities within the cluster. With this release, this results in an improved end-user experience as the {hcp} Operator effectively cleans up expired ignition tokens, ensuring efficient resource management and enhancing system security. (link:https://issues.redhat.com/browse/OCPBUGS-54624[*OCPBUGS-54624*])
+
+* Previously, a bug occurred due to insufficient enforcement of a minimum number of services for {ibm-cloud-title} in the `HostedControlPlane` and `HostedCluster` specifications within the code. This issue led to potential data loss or incorrect processing of user-entered data, causing unexpected application behavior. With this release, the problem causing inaccurate data to display in the user interface is corrected, ensuring more reliable and precise information for end users. (link:https://issues.redhat.com/browse/OCPBUGS-54609[*OCPBUGS-54609*])
+
+* Previously, improper scoping of the Secret Janitor in the Hypershift Operator, which caused improper secret cleanup. This resulted in token secrets accumulating over time, disrupting the secret management process, while using annotation scoping with two instances of the Hypershift Operator. With this release, a fix ensures that the secret cleanup continues as expected in a Red{nbsp}Hat OpenShift Kubernetes Service (ROKS) cluster that is managed by the Hypershift Operator. The large amount of token secrets is eliminated and the proper secret management is maintained. (link:https://issues.redhat.com/browse/OCPBUGS-54498[*OCPBUGS-54498*])
+
+* Previously, a bug occurred due to the incorrect handling of the etcd URL, preventing access to the `Kyverno` service. This resulted in DNS errors during the `kyverno` validation, preventing users on a {product-title} cluster with {hcp} from creating additional test groups. With this release, users can create additional test groups without encountering DNS errors during the `kyverno` validation. (link:https://issues.redhat.com/browse/OCPBUGS-54411[*OCPBUGS-54411*])
+
+* Previously, insufficient permissions led to the persistence of the `disk.csi.azure.com/agent-not-ready=value:NoExecute` taint after creating {azure-first} disk Container Storage Interface (CSI) driver nodes. With this release, a fix disables the removal of the `not-ready` taint for {azure-short} disk CSI driver nodes, making the scheduler adhere to the `volume-attach-limit` value. (link:https://issues.redhat.com/browse/OCPBUGS-54383[*OCPBUGS-54383*])
+
+* Previously, containers that used the SELinux domain of `container_logreader_t` to view container logs on a host in the `/var/log` directorycould not access logs in the `/var/log/containers` subdirectory. This was because of a missing symbolic link. With this release, a symbolic link is created so the containers can access the logs in the `/var/log/containers` subdirectory. (link:https://issues.redhat.com/browse/OCPBUGS-54342[*OCPBUGS-54342*])
+
+* Previously, an image pull secret that was generated for the internal Image Registry was not regenerated until after the embedded credentials expired. This resulted in the image pull secrets being temporarily invalid. With this release, the image pull secrets are refreshed before the embedded credentials expire. (link:https://issues.redhat.com/browse/OCPBUGS-54304[*OCPBUGS-54304*])
+
+* Previously, the cluster autoscaler stopped scaling because of a failed machine in a machine set. This condition occurred due to inaccuracies in the way the cluster autoscaler counted machines in various non-running phases. With this release, the inaccuracies are fixed, allowing the cluster autoscaler to have an exact count. (link:https://issues.redhat.com/browse/OCPBUGS-53241[*OCPBUGS-53241*])
+
+* Previously, the telecom grandmaster (T-GM) status was incorrectly announced as `S2` before the digital phase-locked loop (DPLL) was locked during the global navigation satellite system (GNSS) holdover. This caused inaccurate synchronization. With this release, the `DPLL` state decision logic is modified to ensure that the T-GM status moves to `S2` only after both phase offsets are valid and DPLL is in "Locked Holdover Acquired" state. This guarantees that the T-GM status accurately reflects the DPLL state when the GNSS source starts. (link:https://issues.redhat.com/browse/OCPBUGS-52956[*OCPBUGS-52956*])
+
+* Previously, a User-Defined Network (UDN) pod that is not qualified to use egress IP address had to use its own UDN pod IP address instead of its node IP address as the source IP address in egressing packets. With this release, the UDN pod network is advertised correctly. (link:https://issues.redhat.com/browse/OCPBUGS-50965[*OCPBUGS-50965*])
+
+* Previously, when the cluster certificate authority (CA) bundle was updated with a custom CA bundle, a delay occurred for the change to reflect in the `insights-runtime-extractor` container. This issue occurred if the Insights Operator gathered data after the CA bundle was updated. With this release, a fix removes the delay and this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-48790[*OCPBUGS-48790*])
+
+* Previously, in {product-title} 4.17, a bug occurred because the code did not verify the load balancer IP address in the control plane subnet's Classless Inter-Domain Routing (CIDR) range. This resulted in the IP address existing outside of the valid range and caused a 400 error during the installation. With this release, this fix prevents the 400 error caused by private IP address conflicts, ensuring a successful deployment of private {product-title} clusters on {azure-short}. (link:https://issues.redhat.com/browse/OCPBUGS-43724[*OCPBUGS-43724*])
+
+[id="ocp-4-18-9-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.8
 [id="ocp-4-18-8_{context}"]
 === RHSA-2025:3577 - {product-title} {product-version}.8 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-14032](https://issues.redhat.com//browse/OSDOCS-14032)

Link to docs preview:
[4.18.9](https://92209--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-9_release-notes)

QE review:
- [ ] QE has approved this change.
n/a for z-stream RN

Additional information:
The errata URLs will return 404 until the go-live date of 4/15/25
