### PR TITLE
OLS-1365: Create supported architecture list

### DIFF
--- a/about/ols-about-openshift-lightspeed.adoc
+++ b/about/ols-about-openshift-lightspeed.adoc
@@ -14,6 +14,7 @@ include::modules/ols-openshift-requirements.adoc[leveloffset=+1]
 include::modules/ols-large-language-model-overview.adoc[leveloffset=+1]
 //Xavier wanted to remove vLLM until further testing is performed.
 //include::modules/ols-about-openshift-ai-vllm.adoc[leveloffset=+2]
+include::modules/ols-supported-platforms.adoc[leveloffset=+1]
 include::modules/ols-about-data-use.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/ols-supported-platforms.adoc
+++ b/modules/ols-supported-platforms.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/about/ols-about-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="supported-architecture_{context}"]
+= Supported architecture
+
+{ols-long} is only available on the {ocp-product-title} x86_64 architecture.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1365
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://92244--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/about/ols-about-openshift-lightspeed.html#supported-architecture_ols-large-language-model-overview

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
