### PR TITLE
PR for SRVLOGIC-98: Add "Authentication for OpenAPI services" section in the OSL docs 

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -116,7 +116,6 @@
 :ServerlessProductVersion: 1.35.0
 :ServerlessLogicQuarkusVersion: 3.8.6.redhat-00004
 :ServerlessLogicOrgKieVersion: 9.102.0.redhat-00005
-:ServerlessLogicOauthDependencyVersion: 2.9.0-lts
 :ServerlessLogicRegistryVersion: registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.35.0
 :ServerlessLogic-DDL-Script-url: link:https://maven.repository.redhat.com/ga/org/kie/kogito/kogito-ddl/9.102.0.redhat-00005/kogito-ddl-9.102.0.redhat-00005-db-scripts.zip[kogito-ddl-9.102.0.redhat-00005-db-scripts.zip]
 //service mesh v2

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -114,8 +114,9 @@
 :ServerlessLogicOperatorName: OpenShift Serverless Logic Operator
 :FunctionsProductName: OpenShift Serverless Functions
 :ServerlessProductVersion: 1.35.0
-:ServerlessLogicQuarkusVersion: 3.8.6.redhat-00004
+:ServerlessLogicQuarkusVersion: 3.15.3.redhat-00004
 :ServerlessLogicOrgKieVersion: 9.102.0.redhat-00005
+:ServerlessLogicOauthDependencyVersion: 2.9.0-lts
 :ServerlessLogicRegistryVersion: registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.35.0
 :ServerlessLogic-DDL-Script-url: link:https://maven.repository.redhat.com/ga/org/kie/kogito/kogito-ddl/9.102.0.redhat-00005/kogito-ddl-9.102.0.redhat-00005-db-scripts.zip[kogito-ddl-9.102.0.redhat-00005-db-scripts.zip]
 //service mesh v2

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -113,12 +113,12 @@
 :ServerlessOperatorName: OpenShift Serverless Operator
 :ServerlessLogicOperatorName: OpenShift Serverless Logic Operator
 :FunctionsProductName: OpenShift Serverless Functions
-:ServerlessProductVersion: 1.35.0
-:ServerlessLogicQuarkusVersion: 3.15.3.redhat-00004
-:ServerlessLogicOrgKieVersion: 9.102.0.redhat-00005
+:ServerlessProductVersion: 1.36.0
+:ServerlessLogicQuarkusVersion: 3.15.4.redhat-00001
+:ServerlessLogicOrgKieVersion: 9.103.0.redhat-00003
 :ServerlessLogicOauthDependencyVersion: 2.9.0-lts
-:ServerlessLogicRegistryVersion: registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.35.0
-:ServerlessLogic-DDL-Script-url: link:https://maven.repository.redhat.com/ga/org/kie/kogito/kogito-ddl/9.102.0.redhat-00005/kogito-ddl-9.102.0.redhat-00005-db-scripts.zip[kogito-ddl-9.102.0.redhat-00005-db-scripts.zip]
+:ServerlessLogicRegistryVersion: registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.36.0
+:ServerlessLogic-DDL-Script-url: link:https://maven.repository.redhat.com/ga/org/kie/kogito/kogito-ddl/9.103.0.redhat-00003/kogito-ddl-9.103.0.redhat-00003-db-scripts.zip[kogito-ddl-9.103.0.redhat-00003-db-scripts.zip]
 //service mesh v2
 :product-dedicated: Red Hat OpenShift Dedicated
 :SMProductName: Red Hat OpenShift Service Mesh

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -116,6 +116,7 @@
 :ServerlessProductVersion: 1.35.0
 :ServerlessLogicQuarkusVersion: 3.8.6.redhat-00004
 :ServerlessLogicOrgKieVersion: 9.102.0.redhat-00005
+:ServerlessLogicOauthDependencyVersion: 2.9.0-lts
 :ServerlessLogicRegistryVersion: registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.35.0
 :ServerlessLogic-DDL-Script-url: link:https://maven.repository.redhat.com/ga/org/kie/kogito/kogito-ddl/9.102.0.redhat-00005/kogito-ddl-9.102.0.redhat-00005-db-scripts.zip[kogito-ddl-9.102.0.redhat-00005-db-scripts.zip]
 //service mesh v2

--- a/modules/serverless-logic-security-config-auth-credentials-openapi.adoc
+++ b/modules/serverless-logic-security-config-auth-credentials-openapi.adoc
@@ -17,10 +17,10 @@ The security schemes defined in an OpenAPI specification file are global to all 
 .Prerequisites
 
 * You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
-* Your OpenAPI specification is defined in one or more security schemes.
+* Your OpenAPI specification includes one or more security schemes.
 * You have access to the OpenAPI specification files.
 * You have identified the schemes you want to configure `http-basic-example` or `api-key-example`.
-* You have access to the application properties file, the workflow `ConfigMap`, or environment variable setup.
+* You have access to the `application.properties` file, the workflow `ConfigMap`, or the `SonataFlow` CR.
 
 .Procedure
 
@@ -31,8 +31,8 @@ The security schemes defined in an OpenAPI specification file are global to all 
 quarkus.openapi-generator.[filename].auth.[security_scheme_name].[auth_property_name]
 ----
 +
-** `filename` is the sanitized name of the file containing the OpenAPI specification, such as security_example_json.
-** `security_scheme_name` is the sanitized name of the security scheme object definition in the OpenAPI specification file, such as http_basic_example or api_key_example.
+** `filename` is the sanitized name of the file containing the OpenAPI specification, such as security_example_json. To sanitize this name, you must replace all non-alphabetic characters with `_` underscores.
+** `security_scheme_name` is the sanitized name of the security scheme object definition in the OpenAPI specification file, such as `http_basic_example` or `api_key_example`. To sanitize this name, you must replace all non-alphabetic characters with `_` underscores.
 ** `auth_property_name` is the name of the property to configure, such as username. This property depends on the defined security scheme type.
 +
 [NOTE]
@@ -40,7 +40,7 @@ quarkus.openapi-generator.[filename].auth.[security_scheme_name].[auth_property_
 When you are using environment variables to configure properties, follow the MicroProfile environment variable mapping rules. You can replace all non-alphabetic characters in the property key with underscores `_`, and convert the entire key to uppercase.
 ====
 
-The following examples show how to provide these configuration properties using `application.properties`, a `ConfigMap` associated with your workflow, or environment variables defined in the `SonataFlow` CR: 
+The following examples show how to provide these configuration properties using `application.properties`, the `ConfigMap` associated with your workflow, or environment variables defined in the `SonataFlow` CR: 
 
 .Example of configuring the credentials by using the `application.properties` file
 [source,text]
@@ -64,6 +64,11 @@ metadata:
   name: example-workflow-props
   namespace: example-namespace
 ----
+
+[NOTE]
+====
+If the name of the workflow is `example-workflow`, the name of the `ConfigMap` with the user defined properties must be `example-workflow-props`.
+====
 
 .Example of configuring the credentials by using environment variables in the `SonataFlow` CR
 [source,yaml]

--- a/modules/serverless-logic-security-config-auth-credentials-openapi.adoc
+++ b/modules/serverless-logic-security-config-auth-credentials-openapi.adoc
@@ -34,7 +34,7 @@ quarkus.openapi-generator.[filename].auth.[security_scheme_name].[auth_property_
 ** `filename` is the sanitized name of the file containing the OpenAPI specification, such as security_example_json.
 ** `security_scheme_name` is the sanitized name of the security scheme object definition in the OpenAPI specification file, such as http_basic_example or api_key_example.
 ** `auth_property_name` is the name of the property to configure, such as username. This property depends on the defined security scheme type.
-
++
 [NOTE]
 ====
 When you are using environment variables to configure properties, follow the MicroProfile environment variable mapping rules. You can replace all non-alphabetic characters in the property key with underscores `_`, and convert the entire key to uppercase.

--- a/modules/serverless-logic-security-config-auth-credentials-openapi.adoc
+++ b/modules/serverless-logic-security-config-auth-credentials-openapi.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+// serverles-logic/serverless-logic-authentication-openapi-services
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-security-config-auth-credentials-openapi_{context}"]
+= Configuring authentication credentials for OpenAPI services
+
+To invoke OpenAPI service operations secured by authentication schemes, you must configure the corresponding credentials and parameters in your application. {ServerlessLogicProductName} uses these configurations to authenticate with the external services during workflow execution.
+
+This procedure describes how to define and apply the necessary configuration properties for security schemes declared in the OpenAPI specification file. You can use either `application.properties`, the `ConfigMap` associated to your workflow, or environment variables to provide these credentials.
+
+[NOTE]
+====
+The security schemes defined in an OpenAPI specification file are global to all the operations that are available in the same file. This means that the configurations set for a particular security scheme also apply to the other secured operations.
+====
+
+.Prerequisites
+
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* Your OpenAPI specification is defined in one or more security schemes.
+* You have access to the OpenAPI specification files.
+* You have identified the schemes you want to configure `http-basic-example` or `api-key-example`.
+* You have access to the application properties file, the workflow `ConfigMap`, or environment variable setup.
+
+.Procedure
+
+. Use the following format to compose your property keys:
++
+[source,text]
+----
+quarkus.openapi-generator.[filename].auth.[security_scheme_name].[auth_property_name]
+----
++
+* `filename` is the sanitized name of the file containing the OpenAPI specification, such as security_example_json.
+* `security_scheme_name` is the sanitized name of the security scheme object definition in the OpenAPI specification file, such as http_basic_example or api_key_example.
+* `auth_property_name` is the name of the property to configure, such as username. This property depends on the defined security scheme type.
+
+. Apply MicroProfile environment variable mapping rules and replace any non-alphabetic characters with underscores `_` as shown in the following example:
++
+[source,text]
+----
+export QUARKUS_OPENAPI_GENERATOR_SECURITY_EXAMPLE_JSON_AUTH_HTTP_BASIC_EXAMPLE_USERNAME=myuser
+export QUARKUS_OPENAPI_GENERATOR_SECURITY_EXAMPLE_JSON_AUTH_HTTP_BASIC_EXAMPLE_PASSWORD=mypassword
+----
+
+. Set the credentials by adding the configuration to your `application.properties`, workflow `ConfigMap` as follows: 
++
+[source,text]
+----
+quarkus.openapi-generator.security_example_json.auth.http_basic_example.username=myuser
+quarkus.openapi-generator.security_example_json.auth.http_basic_example.password=mypassword
+----

--- a/modules/serverless-logic-security-config-auth-credentials-openapi.adoc
+++ b/modules/serverless-logic-security-config-auth-credentials-openapi.adoc
@@ -7,7 +7,7 @@
 
 To invoke OpenAPI service operations secured by authentication schemes, you must configure the corresponding credentials and parameters in your application. {ServerlessLogicProductName} uses these configurations to authenticate with the external services during workflow execution.
 
-This procedure describes how to define and apply the necessary configuration properties for security schemes declared in the OpenAPI specification file. You can use either `application.properties`, the `ConfigMap` associated to your workflow, or environment variables to provide these credentials.
+This section describes how to define and apply the necessary configuration properties for security schemes declared in the OpenAPI specification file. You can use either `application.properties`, the `ConfigMap` associated with your workflow, or environment variables in the `SonataFlow` CR to provide these credentials.
 
 [NOTE]
 ====
@@ -24,29 +24,65 @@ The security schemes defined in an OpenAPI specification file are global to all 
 
 .Procedure
 
-. Use the following format to compose your property keys:
+* Use the following format to compose your property keys:
 +
 [source,text]
 ----
 quarkus.openapi-generator.[filename].auth.[security_scheme_name].[auth_property_name]
 ----
 +
-* `filename` is the sanitized name of the file containing the OpenAPI specification, such as security_example_json.
-* `security_scheme_name` is the sanitized name of the security scheme object definition in the OpenAPI specification file, such as http_basic_example or api_key_example.
-* `auth_property_name` is the name of the property to configure, such as username. This property depends on the defined security scheme type.
+** `filename` is the sanitized name of the file containing the OpenAPI specification, such as security_example_json.
+** `security_scheme_name` is the sanitized name of the security scheme object definition in the OpenAPI specification file, such as http_basic_example or api_key_example.
+** `auth_property_name` is the name of the property to configure, such as username. This property depends on the defined security scheme type.
 
-. Apply MicroProfile environment variable mapping rules and replace any non-alphabetic characters with underscores `_` as shown in the following example:
-+
-[source,text]
-----
-export QUARKUS_OPENAPI_GENERATOR_SECURITY_EXAMPLE_JSON_AUTH_HTTP_BASIC_EXAMPLE_USERNAME=myuser
-export QUARKUS_OPENAPI_GENERATOR_SECURITY_EXAMPLE_JSON_AUTH_HTTP_BASIC_EXAMPLE_PASSWORD=mypassword
-----
+[NOTE]
+====
+When you are using environment variables to configure properties, follow the MicroProfile environment variable mapping rules. You can replace all non-alphabetic characters in the property key with underscores `_`, and convert the entire key to uppercase.
+====
 
-. Set the credentials by adding the configuration to your `application.properties`, workflow `ConfigMap` as follows: 
-+
+The following examples show how to provide these configuration properties using `application.properties`, a `ConfigMap` associated with your workflow, or environment variables defined in the `SonataFlow` CR: 
+
+.Example of configuring the credentials by using the `application.properties` file
 [source,text]
 ----
 quarkus.openapi-generator.security_example_json.auth.http_basic_example.username=myuser
 quarkus.openapi-generator.security_example_json.auth.http_basic_example.password=mypassword
+----
+
+.Example of configuring the credentials by using the workflow `ConfigMap`
+[source,yaml]
+----
+apiVersion: v1
+data:
+  application.properties: |   
+    quarkus.openapi-generator.security_example_json.auth.http_basic_example.username=myuser
+    quarkus.openapi-generator.security_example_json.auth.http_basic_example.password=mypassword
+kind: ConfigMap
+metadata:
+  labels:
+    app: example-workflow
+  name: example-workflow-props
+  namespace: example-namespace
+----
+
+.Example of configuring the credentials by using environment variables in the `SonataFlow` CR
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: example-workflow
+  namespace: example-namespace
+  annotations:
+    sonataflow.org/description: Example Workflow
+    sonataflow.org/version: 0.0.1
+    sonataflow.org/profile: preview
+spec:
+  podTemplate:
+    container:
+      env:
+        - name: QUARKUS_OPENAPI_GENERATOR_SECURITY_EXAMPLE_JSON_AUTH_HTTP_BASIC_EXAMPLE_USERNAME
+          value: myuser
+        - name: QUARKUS_OPENAPI_GENERATOR_SECURITY_EXAMPLE_JSON_AUTH_HTTP_BASIC_EXAMPLE_PASSWORD
+          value: mypassowrd
 ----

--- a/modules/serverless-logic-security-example-api-key-authentication.adoc
+++ b/modules/serverless-logic-security-example-api-key-authentication.adoc
@@ -5,7 +5,7 @@
 [id="serverless-logic-security-example-api-key-authentication_{context}"]
 = Example of API key authentication
 
-The following example shows how to secure an OpenAPI service operation using the `apiKey` authentication scheme. The `security-example.json` file defines the `sayHelloApiKey` operation, which uses the `api-key-example` security scheme. You can configure the API key using application properties, the workflow `ConfigMap', or environment variables.
+The following example shows how to secure an OpenAPI service operation using the `apiKey` authentication scheme. The `security-example.json` file defines the `sayHelloApiKey` operation, which uses the `api-key-example` security scheme. You can configure the API key using application properties, the workflow `ConfigMap`, or environment variables.
 
 .Example OpenAPI specification with API key authentication
 [source,json]

--- a/modules/serverless-logic-security-example-api-key-authentication.adoc
+++ b/modules/serverless-logic-security-example-api-key-authentication.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+// serverles-logic/serverless-logic-authentication-openapi-services
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-security-example-api-key-authentication_{context}"]
+= Example of API key authentication
+
+The following example shows how to secure an OpenAPI service operation using the `apiKey` authentication scheme. The `security-example.json` file defines the `sayHelloApiKey` operation, which uses the `api-key-example` security scheme. You can configure the API key using application properties, the workflow `ConfigMap', or environment variables.
+
+.Example OpenAPI specification with API key authentication
+[source,json]
+----
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Api Key Scheme Example",
+    "version": "1.0"
+  },
+  "paths": {
+    "/hello-with-api-key": {
+      "get": {
+        "operationId": "sayHelloApiKey",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [{"api-key-example" : []}]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api-key-example": {
+        "type": "apiKey",
+        "name": "api-key-name",
+        "in": "header"
+      }
+    }
+  }
+}
+----
+
+In this example, the `sayHelloApiKey` operation is protected by the `api-key-example` security scheme, which uses an API key passed in the HTTP request header.
+
+[id="serverless-logic-security-supported-config-properties-api-key_{context}"]
+== Supported configuration properties for API key authentication
+
+You can use the following configuration property to configure the API key:
+
+[cols="2,1,1",options="header"]
+|====
+|Description 
+|Property key
+|Example
+
+|API Key
+|`quarkus.openapi-generator.[filename].auth.[security_scheme_name].api-key`
+|`quarkus.openapi-generator.security_example_json.auth.api_key_example.api-key=MY_KEY`
+
+|====
+
+You can replace `[filename]` with the sanitized OpenAPI file name `security_example_json` and `[security_scheme_name]` with the sanitized scheme name `api_key_example`. 
+
+The `apiKey` scheme type contains an additional `name` property that configures the key name to use when the Open API service is invoked. Also, the format to pass the key depends on the value of the `in` property.
+
+* When the value is `header`, the key is passed as an HTTP request parameter.
+
+* When the value is `cookie`, the key is passed as an HTTP cookie.
+
+* When the value is `query`, the key is passed as an HTTP query parameter.
+
+In the example, the key is passed in the HTTP header as `api-key-name: MY_KEY`.
+
+{ServerlessLogicProductName} manages this internally, so no additional configuration is required beyond setting the property value.

--- a/modules/serverless-logic-security-example-auth-token-propagation.adoc
+++ b/modules/serverless-logic-security-example-auth-token-propagation.adoc
@@ -66,6 +66,11 @@ The following example defines the `sayHelloOauth2` operation in the `security-ex
 
 You can use the following configuration keys to enable and customize token propagation:
 
+[NOTE]
+====
+The tokens are automatically passed to downstream services while the workflow is active. When the workflow enters a waiting state such as a timer or event-based pause, the token propagation stops. After the workflow resumes, tokens are not re-propagated automatically. You must manage re-authentication if needed.
+====
+
 [cols="2,1,1",options="header"]
 |====
 |Property key
@@ -82,24 +87,4 @@ You can use the following configuration keys to enable and customize token propa
 
 |====
 
-You can replace `[filename]` with the sanitized OpenAPI file name `security_example_json` and `[security_scheme_name]` with the sanitized scheme name `oauth_example`. 
-
-[NOTE]
-====
-The tokens are automatically passed to downstream services while the workflow is active. When the workflow enters a waiting state such as a timer or event-based pause, the token propagation stops. After the workflow resumes, tokens are not re-propagated automatically. You must manage re-authentication if needed.
-====
-
-.Example of applying token propagation in a `ConfigMap`
-
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: workflow-auth-config
-  namespace: my-namespace
-data:
-  application.properties: |
-    quarkus.openapi-generator.security_example_json.auth.oauth_example.token-propagation=true
-    quarkus.openapi-generator.security_example_json.auth.oauth_example.header-name=MyHeaderName
-----
+You can replace `[filename]` with the sanitized OpenAPI file name `security_example_json` and `[security_scheme_name]` with the sanitized scheme name `oauth_example`.

--- a/modules/serverless-logic-security-example-auth-token-propagation.adoc
+++ b/modules/serverless-logic-security-example-auth-token-propagation.adoc
@@ -7,7 +7,7 @@
 
 {ServerlessLogicProductName} supports token propagation for OpenAPI operations that use the `oauth2` or `http` bearer security scheme types. Token propagation enables your workflow to forward the authorization token it receives during workflow creation to downstream services.This feature is useful when your workflow needs to interact with third-party services on behalf of the client that initiated the request.
 
-You must configure token propagation individually for each security scheme. Once enabled, all OpenAPI operations secured using the same scheme will use the propagated token unless explicitly overridden.
+You must configure token propagation individually for each security scheme. After it is enabled, all OpenAPI operations secured using the same scheme uses the propagated token unless explicitly overridden.
 
 The following example defines the `sayHelloOauth2` operation in the `security-example.json` file. This operation uses the `oauth-example` security scheme with the `clientCredentials` flow:
 
@@ -68,7 +68,7 @@ You can use the following configuration keys to enable and customize token propa
 
 [NOTE]
 ====
-The tokens are automatically passed to downstream services while the workflow is active. When the workflow enters a waiting state such as a timer or event-based pause, the token propagation stops. After the workflow resumes, tokens are not re-propagated automatically. You must manage re-authentication if needed.
+The tokens are automatically passed to downstream services while the workflow is active. When the workflow enters a waiting state, such as a timer or event-based pause, the token propagation stops. After the workflow resumes, tokens are not re-propagated automatically. You must manage re-authentication if needed.
 ====
 
 [cols="2,1,1",options="header"]

--- a/modules/serverless-logic-security-example-auth-token-propagation.adoc
+++ b/modules/serverless-logic-security-example-auth-token-propagation.adoc
@@ -1,0 +1,105 @@
+// Module included in the following assemblies:
+// serverles-logic/serverless-logic-authentication-openapi-services
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-security-example-auth-token-propagation_{context}"]
+= Example of authorization token propagation
+
+{ServerlessLogicProductName} supports token propagation for OpenAPI operations that use the `oauth2` or `http` bearer security scheme types. Token propagation enables your workflow to forward the authorization token it receives during workflow creation to downstream services.This feature is useful when your workflow needs to interact with third-party services on behalf of the client that initiated the request.
+
+You must configure token propagation individually for each security scheme. Once enabled, all OpenAPI operations secured using the same scheme will use the propagated token unless explicitly overridden.
+
+The following example defines the `sayHelloOauth2` operation in the `security-example.json` file. This operation uses the `oauth-example` security scheme with the `clientCredentials` flow:
+
+.Example OpenAPI specification with token propagation
+[source,json]
+----
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Oauth2 Scheme Example",
+    "version": "1.0"
+  },
+  "paths": {
+    "/hello-with-oauth2": {
+      "get": {
+        "operationId": "sayHelloOauth2",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth-example": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth-example": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "authorizationUrl": "https://example.com/oauth",
+            "tokenUrl": "https://example.com/oauth/token",
+            "scopes": {}
+          }
+        }
+      }
+    }
+  }
+}
+----
+
+[id="serverless-logic-security-supported-config-properties-token-propagation_{context}"]
+== Supported configuration properties for authorization token propagation
+
+You can use the following configuration keys to enable and customize token propagation:
+
+[cols="2,1,1",options="header"]
+|====
+|Property key
+|Example
+|Description 
+
+|`quarkus.openapi-generator.[filename].auth.[security_scheme_name].token-propagation`
+|`quarkus.openapi-generator.security_example_json.auth.oauth_example.token-propagation=true`
+|Enables token propagation for all operations secured with the given scheme. Default is `false`.
+
+|`quarkus.openapi-generator.[filename].auth.[security_scheme_name].header-name`
+|`quarkus.openapi-generator.security_example_json.auth.oauth_example.header-name=MyHeaderName`
+|(Optional) Overrides the default Authorization header with a custom header name to read the token from.
+
+|====
+
+You can replace `[filename]` with the sanitized OpenAPI file name `security_example_json` and `[security_scheme_name]` with the sanitized scheme name `oauth_example`. 
+
+.Example of applying token propagation in a `ConfigMap`
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow-auth-config
+  namespace: my-namespace
+data:
+  application.properties: |
+    quarkus.openapi-generator.security_example_json.auth.oauth_example.token-propagation=true
+    quarkus.openapi-generator.security_example_json.auth.oauth_example.header-name=MyHeaderName
+----
+
+[NOTE]
+====
+The tokens are automatically passed to downstream services while the workflow is active. When the workflow enters a waiting state such as a timer or event-based pause, the token propagation stops. After the workflow resumes, tokens are not re-propagated automatically. You must manage re-authentication if needed.
+====

--- a/modules/serverless-logic-security-example-auth-token-propagation.adoc
+++ b/modules/serverless-logic-security-example-auth-token-propagation.adoc
@@ -84,6 +84,11 @@ You can use the following configuration keys to enable and customize token propa
 
 You can replace `[filename]` with the sanitized OpenAPI file name `security_example_json` and `[security_scheme_name]` with the sanitized scheme name `oauth_example`. 
 
+[NOTE]
+====
+The tokens are automatically passed to downstream services while the workflow is active. When the workflow enters a waiting state such as a timer or event-based pause, the token propagation stops. After the workflow resumes, tokens are not re-propagated automatically. You must manage re-authentication if needed.
+====
+
 .Example of applying token propagation in a `ConfigMap`
 
 [source,yaml]
@@ -98,8 +103,3 @@ data:
     quarkus.openapi-generator.security_example_json.auth.oauth_example.token-propagation=true
     quarkus.openapi-generator.security_example_json.auth.oauth_example.header-name=MyHeaderName
 ----
-
-[NOTE]
-====
-The tokens are automatically passed to downstream services while the workflow is active. When the workflow enters a waiting state such as a timer or event-based pause, the token propagation stops. After the workflow resumes, tokens are not re-propagated automatically. You must manage re-authentication if needed.
-====

--- a/modules/serverless-logic-security-example-basic-http-authentication.adoc
+++ b/modules/serverless-logic-security-example-basic-http-authentication.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+// serverles-logic/serverless-logic-authentication-openapi-services
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-security-example-basic-http-authentication_{context}"]
+= Example of basic HTTP authentication
+
+The following example shows how to secure a workflow operation using the HTTP basic authentication scheme. The `security-example.json` file defines an OpenAPI service with a single operation, `sayHelloBasic`, which uses the `http-basic-example` security scheme. You can configure credentials using application properties, the worfklow `ConfigMap`, or environment variables.
+
+.Example OpenAPI specification with HTTP basic authentication
+[source,json]
+----
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Http Basic Scheme Example",
+    "version": "1.0"
+  },
+  "paths": {
+    "/hello-with-http-basic": {
+      "get": {
+        "operationId": "sayHelloBasic",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [{"http-basic-example" : []}]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "http-basic-example": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}
+----
+
+In this example, the `sayHelloBasic` operation is secured using the `http-basic-example` scheme defined in the `securitySchemes` section. When invoking this operation in a workflow, you must configure the appropriate credentials.
+
+[id="serverless-logic-security-supported-config-properties-basic-http_{context}"]
+== Supported configuration properties for basic HTTP authentication
+
+You can use the following configuration keys to provide authentication credentials for the `http-basic-example` scheme:
+
+[cols="2,1,1",options="header"]
+|====
+|Description 
+|Property key
+|Example
+
+|Username credentials
+|`quarkus.openapi-generator.[filename].auth.[security_scheme_name].username`
+|`quarkus.openapi-generator.security_example_json.auth.http_basic_example.username=MY_USER`
+
+|Password credentials
+|`quarkus.openapi-generator.[filename].auth.[security_scheme_name].password`
+|`quarkus.openapi-generator.security_example_json.auth.http_basic_example.password=MY_PASSWD`
+
+|====
+
+You can replace `[filename]` with the sanitized OpenAPI file name `security_example_json` and `[security_scheme_name]` with the sanitized scheme name `http_basic_example`. 
+

--- a/modules/serverless-logic-security-example-bearer-token-authentication.adoc
+++ b/modules/serverless-logic-security-example-bearer-token-authentication.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+// serverles-logic/serverless-logic-authentication-openapi-services
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-security-example-bearer-token-authentication_{context}"]
+= Example of Bearer token authentication
+
+The following example shows how to secure an OpenAPI operation using the HTTP Bearer authentication scheme. The `security-example.json` file defines an OpenAPI service with the `sayHelloBearer` operation, which uses the `http-bearer-example` scheme for authentication. To access the secured operation during workflow execution, you must configure a Bearer token using application properties, the workflow `ConfigMap`, or environment variables.
+
+.Example OpenAPI specification with Bearer token authentication
+[source,json]
+----
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Http Bearer Scheme Example",
+    "version": "1.0"
+  },
+  "paths": {
+    "/hello-with-http-bearer": {
+      "get": {
+        "operationId": "sayHelloBearer",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "http-bearer-example": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "http-bearer-example": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}      
+----
+
+In this example, the `sayHelloBearer` operation is protected by the `http-bearer-example` scheme. You must define a valid Bearer token in your configuration to invoke this operation successfully.
+
+[id="serverless-logic-security-supported-config-properties-bearer-token_{context}"]
+== Supported configuration properties for Bearer token authentication
+
+You can use the following configuration property key to provide the Bearer token:
+
+[cols="2,1,1",options="header"]
+|====
+|Description 
+|Property key
+|Example
+
+|Bearer token
+|`quarkus.openapi-generator.[filename].auth.[security_scheme_name].bearer-token`
+|`quarkus.openapi-generator.security_example_json.auth.http_bearer_example.bearer-token=MY_TOKEN`
+
+|====
+
+You can replace `[filename]` with the sanitized OpenAPI file name `security_example_json` and `[security_scheme_name]` with the sanitized scheme name `http_bearer_example`. 
+

--- a/modules/serverless-logic-security-example-oauth-authentication.adoc
+++ b/modules/serverless-logic-security-example-oauth-authentication.adoc
@@ -65,7 +65,7 @@ In this example, the `sayHelloOauth2` operation is protected by the `oauth-examp
 OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this integration, you must add the Quarkus OIDC Client Filter extension to your project as shown in the following examples:
 
 .Example of adding extension using Maven
-[source,text]
+[source,xml]
 ----
 <dependency>
 <groupId>io.quarkus</groupId>
@@ -75,7 +75,7 @@ OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this 
 <dependency>
   <groupId>io.quarkiverse.openapi.generator</groupId>
   <artifactId>quarkus-openapi-generator-oidc</artifactId>
-  <version>{ServerlessLogicOauthDependencyVersion}</version>
+  <version>2.9.0-lts</version>
 </dependency>
 ----
 

--- a/modules/serverless-logic-security-example-oauth-authentication.adoc
+++ b/modules/serverless-logic-security-example-oauth-authentication.adoc
@@ -95,10 +95,11 @@ To access the secured operation, define an `OidcClient` configuration in your `a
 
 [source,terminal]
 ----
+# adjust these configurations according with the authentication service.
 quarkus.oidc-client.oauth_example.auth-server-url=https://example.com/oauth
 quarkus.oidc-client.oauth_example.token-path=/tokens
 quarkus.oidc-client.oauth_example.discovery-enabled=false
-quarkus.oidc-client.oauth_example.client-id=kogito-app
+quarkus.oidc-client.oauth_example.client-id=example-app
 quarkus.oidc-client.oauth_example.grant.type=client
 quarkus.oidc-client.oauth_example.credentials.client-secret.method=basic
 quarkus.oidc-client.oauth_example.credentials.client-secret.value=secret

--- a/modules/serverless-logic-security-example-oauth-authentication.adoc
+++ b/modules/serverless-logic-security-example-oauth-authentication.adoc
@@ -5,7 +5,7 @@
 [id="serverless-logic-security-example-oauth-authentication_{context}"]
 = Example of clientCredentials OAuth 2.0 authentication
 
-The following example shows how to secure an OpenAPI operation using the OAuth 2.0 `clientCredentials` flow. The OpenAPI specification defines the `sayHelloOauth2` operation, which uses the `oauth-example` security scheme. Unlike simpler authentication methods such as HTTP Basic or API keys, OAuth 2.0 authentication requires additional integration with the Quarkus OpenID Connect (OIDC) Client.
+The following example shows how to secure an OpenAPI operation using the OAuth 2.0 `clientCredentials` flow. The OpenAPI specification defines the `sayHelloOauth2` operation, which uses the `oauth-example` security scheme. Unlike simpler authentication methods, such as HTTP Basic or API keys, OAuth 2.0 authentication requires additional integration with the Quarkus OpenID Connect (OIDC) Client.
 
 .Example OpenAPI specification with OAuth 2.0
 [source,json]
@@ -128,6 +128,6 @@ quarkus.oidc-client.oauth_example.credentials.client-secret.value=secret
 
 In this configuration:
 
-* `oauth_example` matches the sanitized name of the `oauth-example` scheme in the OpenAPI file. The link between the sanitized scheme name and the corresponding `OidcClient` is by using that simple naming convention.
+* `oauth_example` matches the sanitized name of the `oauth-example` scheme in the OpenAPI file. The link between the sanitized scheme name and the corresponding `OidcClient` is achieved by using that simple naming convention.
 
 * The OidcClient handles token generation and renewal automatically during workflow execution.

--- a/modules/serverless-logic-security-example-oauth-authentication.adoc
+++ b/modules/serverless-logic-security-example-oauth-authentication.adoc
@@ -65,7 +65,7 @@ In this example, the `sayHelloOauth2` operation is protected by the `oauth-examp
 OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this integration, you must add the Quarkus OIDC Client Filter extension to your project as shown in the following examples:
 
 .Example of adding extension using Maven
-[source,xml,subs="attributes+"]
+[source,text,subs="attributes+"]
 ----
 <dependency>
   <groupId>io.quarkus</groupId>
@@ -83,9 +83,9 @@ OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this 
 .Example of adding extension using `gitops` profile
 
 Ensure that you configure the QUARKUS_EXTENSIONS build argument with the following value when building the workflow image:
-[source,terminal,subs="attributes+]
+[source,text,subs="attributes+"]
 ----
---build-arg=QUARKUS_EXTENSIONS=io.quarkus:quarkus-oidc-client-filter:{ServerlessLogicQuarkusVersion},io.quarkiverse.openapi.generator:quarkus-openapi-generator-oidc:{ServerlessLogicOauthDependencyVersion}
+$ --build-arg=QUARKUS_EXTENSIONS=io.quarkus:quarkus-oidc-client-filter:{ServerlessLogicQuarkusVersion},io.quarkiverse.openapi.generator:quarkus-openapi-generator-oidc:{ServerlessLogicOauthDependencyVersion}
 ----
 
 [id="serverless-logic-security-oidc-configuration_{context}"]

--- a/modules/serverless-logic-security-example-oauth-authentication.adoc
+++ b/modules/serverless-logic-security-example-oauth-authentication.adoc
@@ -65,7 +65,7 @@ In this example, the `sayHelloOauth2` operation is protected by the `oauth-examp
 OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this integration, you must add the Quarkus OIDC Client Filter extension to your project as shown in the following examples:
 
 .Example of adding extension using Maven
-[source,text,subs=attributes]
+[source,text]
 ----
 <dependency>
 <groupId>io.quarkus</groupId>

--- a/modules/serverless-logic-security-example-oauth-authentication.adoc
+++ b/modules/serverless-logic-security-example-oauth-authentication.adoc
@@ -65,7 +65,7 @@ In this example, the `sayHelloOauth2` operation is protected by the `oauth-examp
 OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this integration, you must add the Quarkus OIDC Client Filter extension to your project as shown in the following examples:
 
 .Example of adding extension using Maven
-[source,xml,subs=attributes]
+[source,text,subs=attributes]
 ----
 <dependency>
 <groupId>io.quarkus</groupId>

--- a/modules/serverless-logic-security-example-oauth-authentication.adoc
+++ b/modules/serverless-logic-security-example-oauth-authentication.adoc
@@ -62,9 +62,9 @@ In this example, the `sayHelloOauth2` operation is protected by the `oauth-examp
 [id="serverless-logic-security-oauth-support-oidc-client-filter-extention_{context}"]
 == OAuth 2.0 Support with the OIDC Client filter extension
 
-OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this integration, you must add the Quarkus OIDC Client Filter extension to your project as shown in the following examples:
+OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this integration, you must add the Quarkus OIDC Client Filter, and the Quarkus OpenApi Generator OIDC extensions to your project as shown in the following examples:
 
-.Example of adding extension using Maven
+.Example of adding extensions using Maven
 [source,text,subs="attributes+"]
 ----
 <dependency>
@@ -80,13 +80,34 @@ OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this 
 </dependency>
 ----
 
-.Example of adding extension using `gitops` profile
+.Example of adding extensions using `gitops` profile
 
 Ensure that you configure the QUARKUS_EXTENSIONS build argument with the following value when building the workflow image:
 [source,text,subs="attributes+"]
 ----
 $ --build-arg=QUARKUS_EXTENSIONS=io.quarkus:quarkus-oidc-client-filter:{ServerlessLogicQuarkusVersion},io.quarkiverse.openapi.generator:quarkus-openapi-generator-oidc:{ServerlessLogicOauthDependencyVersion}
 ----
+
+.Example of adding extensions using `preview` profile
+[source,text,subs="attributes+"]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform-example
+  namespace: example-namespace
+spec:
+  build:
+    template:
+      buildArgs:
+        - name: QUARKUS_EXTENSIONS
+          value: io.quarkus:quarkus-oidc-client-filter:{ServerlessLogicQuarkusVersion},io.quarkiverse.openapi.generator:quarkus-openapi-generator-oidc:{ServerlessLogicOauthDependencyVersion}
+----
+
+[NOTE]
+====
+The extensions that are added in the `SonataFlowPlatform` CR are included for all the workflows that you deploy in that namespace with the `preview` profile.
+====
 
 [id="serverless-logic-security-oidc-configuration_{context}"]
 == `OidcClient` configuration
@@ -97,7 +118,7 @@ To access the secured operation, define an `OidcClient` configuration in your `a
 ----
 # adjust these configurations according with the authentication service.
 quarkus.oidc-client.oauth_example.auth-server-url=https://example.com/oauth
-quarkus.oidc-client.oauth_example.token-path=/tokens
+quarkus.oidc-client.oauth_example.token-path=/token
 quarkus.oidc-client.oauth_example.discovery-enabled=false
 quarkus.oidc-client.oauth_example.client-id=example-app
 quarkus.oidc-client.oauth_example.grant.type=client

--- a/modules/serverless-logic-security-example-oauth-authentication.adoc
+++ b/modules/serverless-logic-security-example-oauth-authentication.adoc
@@ -1,0 +1,108 @@
+// Module included in the following assemblies:
+// serverles-logic/serverless-logic-authentication-openapi-services
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-security-example-oauth-authentication_{context}"]
+= Example of clientCredentials OAuth 2.0 authentication
+
+The following example shows how to secure an OpenAPI operation using the OAuth 2.0 `clientCredentials` flow. The OpenAPI specification defines the `sayHelloOauth2` operation, which uses the `oauth-example` security scheme. Unlike simpler authentication methods such as HTTP Basic or API keys, OAuth 2.0 authentication requires additional integration with the Quarkus OpenID Connect (OIDC) Client.
+
+.Example OpenAPI specification with OAuth 2.0
+[source,json]
+----
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Oauth2 Scheme Example",
+    "version": "1.0"
+  },
+  "paths": {
+    "/hello-with-oauth2": {
+      "get": {
+        "operationId": "sayHelloOauth2",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth-example": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth-example": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "authorizationUrl": "https://example.com/oauth",
+            "tokenUrl": "https://example.com/oauth/token",
+            "scopes": {}
+          }
+        }
+      }
+    }
+  }
+}
+----
+
+In this example, the `sayHelloOauth2` operation is protected by the `oauth-example` security scheme, which uses the `clientCredentials` flow for token-based authentication.
+
+[id="serverless-logic-security-oauth-support-oidc-client-filter-extention_{context}"]
+== OAuth 2.0 Support with the OIDC Client filter extension
+
+OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this integration, you must add the Quarkus OIDC Client Filter extension to your project as shown in the following examples:
+
+.Example of adding extension using Maven
+[source,xml,subs=attributes]
+----
+<dependency>
+<groupId>io.quarkus</groupId>
+  <artifactId>quarkus-oidc-client-filter</artifactId>
+</dependency>
+
+<dependency>
+  <groupId>io.quarkiverse.openapi.generator</groupId>
+  <artifactId>quarkus-openapi-generator-oidc</artifactId>
+  <version>{ServerlessLogicOauthDependencyVersion}</version>
+</dependency>
+----
+
+.Example of adding extension using Quarkus CLI
+[source,terminal]
+----
+$ quarkus extension add quarkus-oidc-client-filter
+----
+
+[id="serverless-logic-security-oidc-configuration_{context}"]
+== `OidcClient` configuration
+
+To access the secured operation, define an `OidcClient` configuration in your `application.properties` file. The configuration uses the sanitized security scheme name from the OpenAPI specification, in this case, `oauth_example` as follows:
+
+[source,terminal]
+----
+quarkus.oidc-client.oauth_example.auth-server-url=https://example.com/oauth
+quarkus.oidc-client.oauth_example.token-path=/tokens
+quarkus.oidc-client.oauth_example.discovery-enabled=false
+quarkus.oidc-client.oauth_example.client-id=kogito-app
+quarkus.oidc-client.oauth_example.grant.type=client
+quarkus.oidc-client.oauth_example.credentials.client-secret.method=basic
+quarkus.oidc-client.oauth_example.credentials.client-secret.value=secret
+----
+
+In this configuration:
+
+* `oauth_example` matches the sanitized name of the `oauth-example` scheme in the OpenAPI file. The link between the sanitized scheme name and the corresponding `OidcClient` is by using that simple naming convention.
+
+* The OidcClient handles token generation and renewal automatically during workflow execution.

--- a/modules/serverless-logic-security-example-oauth-authentication.adoc
+++ b/modules/serverless-logic-security-example-oauth-authentication.adoc
@@ -65,24 +65,27 @@ In this example, the `sayHelloOauth2` operation is protected by the `oauth-examp
 OAuth 2.0 token management is handled by a Quarkus `OidcClient`. To enable this integration, you must add the Quarkus OIDC Client Filter extension to your project as shown in the following examples:
 
 .Example of adding extension using Maven
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <dependency>
-<groupId>io.quarkus</groupId>
+  <groupId>io.quarkus</groupId>
   <artifactId>quarkus-oidc-client-filter</artifactId>
+  <version>{ServerlessLogicQuarkusVersion}</version>
 </dependency>
 
 <dependency>
   <groupId>io.quarkiverse.openapi.generator</groupId>
   <artifactId>quarkus-openapi-generator-oidc</artifactId>
-  <version>2.9.0-lts</version>
+  <version>{ServerlessLogicOauthDependencyVersion}</version>
 </dependency>
 ----
 
-.Example of adding extension using Quarkus CLI
-[source,terminal]
+.Example of adding extension using `gitops` profile
+
+Ensure that you configure the QUARKUS_EXTENSIONS build argument with the following value when building the workflow image:
+[source,terminal,subs="attributes+]
 ----
-$ quarkus extension add quarkus-oidc-client-filter
+--build-arg=QUARKUS_EXTENSIONS=io.quarkus:quarkus-oidc-client-filter:{ServerlessLogicQuarkusVersion},io.quarkiverse.openapi.generator:quarkus-openapi-generator-oidc:{ServerlessLogicOauthDependencyVersion}
 ----
 
 [id="serverless-logic-security-oidc-configuration_{context}"]

--- a/modules/serverless-logic-security-overview-openapi-service-authentication.adoc
+++ b/modules/serverless-logic-security-overview-openapi-service-authentication.adoc
@@ -7,7 +7,7 @@
 
 In {ServerlessLogicProductName}, you can secure OpenAPI service operations using the `Security Schemes` defined in the OpenAPI specification file. These schemes help define the authentication requirements for operations invoked within a workflow.
 
-The `Security Schemes` are declared in the `securitySchemes` section of the OpenAPI document. Each scheme specifies the type of authentication to apply, such as HTTP Basic or API key.
+The `Security Schemes` are declared in the `securitySchemes` section of the OpenAPI document. Each scheme specifies the type of authentication to apply, such as HTTP Basic, API key, and so on.
 
 When a workflow calls a secured operation, it references these defined schemes to determine the required authentication configuration.
 

--- a/modules/serverless-logic-security-overview-openapi-service-authentication.adoc
+++ b/modules/serverless-logic-security-overview-openapi-service-authentication.adoc
@@ -27,7 +27,7 @@ When a workflow calls a secured operation, it references these defined schemes t
 }
 ----
 
-If the OpenAPI file defines `Security Schemes` but does not include  `Security Requirements` for operations, the generator can be configured to create them by default. These defaults apply to operations without explicitly defined requirements.
+If the OpenAPI file defines `Security Schemes`, but does not include `Security Requirements` for operations, the generator can be configured to create them by default. These defaults apply to operations without explicitly defined requirements.
 
 To configure that scheme, you must use the `quarkus.openapi-generator.codegen.default-security-scheme` property. The `default-security-scheme` property is used only at code generation time and not during the runtime. The value must match any of the available schemes in `securitySchemes` section, such as `http-basic-example` or `api-key-example`:
 

--- a/modules/serverless-logic-security-overview-openapi-service-authentication.adoc
+++ b/modules/serverless-logic-security-overview-openapi-service-authentication.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+// serverles-logic/serverless-logic-authentication-openapi-services
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-security-overview-openapi-service-authentication_{context}"]
+= Overview of OpenAPI service authentication
+
+In {ServerlessLogicProductName}, you can secure OpenAPI service operations using the `Security Schemes` defined in the OpenAPI specification file. These schemes help define the authentication requirements for operations invoked within a workflow.
+
+The `Security Schemes` are declared in the `securitySchemes` section of the OpenAPI document. Each scheme specifies the type of authentication to apply, such as HTTP Basic or API key.
+
+When a workflow calls a secured operation, it references these defined schemes to determine the required authentication configuration.
+
+.Example security scheme definitions
+[source,json]
+----
+"securitySchemes": {
+  "http-basic-example": {
+    "type": "http",
+    "scheme": "basic"
+  },
+  "api-key-example": {
+    "type": "apiKey",
+    "name": "my-example-key",
+    "in": "header"
+  }
+}
+----
+
+If the OpenAPI file defines `Security Schemes` but does not include  `Security Requirements` for operations, the generator can be configured to create them by default. These defaults apply to operations without explicitly defined requirements.
+
+To configure that scheme, you must use the `quarkus.openapi-generator.codegen.default-security-scheme` property. The `default-security-scheme` property is used only at code generation time and not during the runtime. The value must match any of the available schemes in `securitySchemes` section, such as `http-basic-example` or `api-key-example`:
+
+.For Example
+[source,terminal]
+----
+$ quarkus.openapi-generator.codegen.default-security-scheme=http-basic-example
+----

--- a/serverless-logic/serverless-logic-managing-security/serverless-logic-authentication-openapi-services.adoc
+++ b/serverless-logic/serverless-logic-managing-security/serverless-logic-authentication-openapi-services.adoc
@@ -6,6 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To secure an OpenAPI service operation, define a security scheme by using the OpenAPI specification. These schemes are in the `Security Scheme Object` section of the OpenAPI specification file. When a workflow invokes an operation, it uses the defined security scheme to determine the required authentication configuration.
+To secure an OpenAPI service operation, define a `Security Scheme` by using the OpenAPI specification. These schemes are in the `securitySchemes` section of the OpenAPI specification file. You must configure the operation by adding add a `Security Requirement` that refers to that `Security Scheme`. When a workflow invokes such operation, that information is used to determine the required authentication configuration.
 
-//I will include more modules in smaller, incremental PRs to avoid having one large PR. Currently building the directory structure for the OSL content.
+This section outlines the supported authentication types and demonstrates how to configure them to access secured OpenAPI service operations within your workflows. 
+
+//All the modules here
+
+include::modules/serverless-logic-security-overview-openapi-service-authentication.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-security-config-auth-credentials-openapi.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-security-example-basic-http-authentication.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-security-example-bearer-token-authentication.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-security-example-api-key-authentication.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-security-example-oauth-authentication.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-security-example-auth-token-propagation.adoc[leveloffset=+1]

--- a/serverless-logic/serverless-logic-managing-security/serverless-logic-authentication-openapi-services.adoc
+++ b/serverless-logic/serverless-logic-managing-security/serverless-logic-authentication-openapi-services.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To secure an OpenAPI service operation, define a `Security Scheme` by using the OpenAPI specification. These schemes are in the `securitySchemes` section of the OpenAPI specification file. You must configure the operation by adding add a `Security Requirement` that refers to that `Security Scheme`. When a workflow invokes such operation, that information is used to determine the required authentication configuration.
+To secure an OpenAPI service operation, define a `Security Scheme` by using the OpenAPI specification. These schemes are in the `securitySchemes` section of the OpenAPI specification file. You must configure the operation by adding a `Security Requirement` that refers to that `Security Scheme`. When a workflow invokes such operation, that information is used to determine the required authentication configuration.
 
 This section outlines the supported authentication types and demonstrates how to configure them to access secured OpenAPI service operations within your workflows. 
 


### PR DESCRIPTION
**Affects version to cherry-pick:** `serverless-docs-1.36` 

**Tracking JIRA:** 
**Sub-task:** https://issues.redhat.com/browse/SRVLOGIC-97
**Main task:** https://issues.redhat.com/browse/SRVLOGIC-98

**Doc Previews:** [Authentication for OpenAPI services](https://92245--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-security/serverless-logic-authentication-openapi-services)

**Reviews:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->