### PR TITLE
[OSDOCS-14346]: Update naming of policy constraint for OSD on GCP

### DIFF
--- a/modules/ccs-gcp-customer-procedure.adoc
+++ b/modules/ccs-gcp-customer-procedure.adoc
@@ -30,7 +30,7 @@ Although the `EXTERNAL_NETWORK_TCP_UDP` load balancer type is not required when 
 ** This policy constraint is supported only if the cluster is created with *Enable Secure Boot support for Shielded VMs* selected during the initial cluster creation.
 * `constraints/compute.vmExternalIpAccess`
 ** This policy constraint is supported only when creating a private cluster with GCP Private Service Connect (PSC). For all other cluster types, this policy constraint is supported only after cluster creation.
-* `constraints/compute.trustedImageProjects policy`
+* `constraints/compute.trustedImageProjects`
 ** This policy constraint is supported only when the projects `redhat-marketplace-public`, `rhel-cloud`, and `rhcos-cloud` are included in the allowlist. If this policy constraint is enabled and these projects are not included in the allowlist, cluster creation will fail.
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-14346
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://92268--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure_gcp-ccs
QE review: NO QE needed. Typo.
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Removed the word "policy" from  `constraints/compute.trustedImageProjects`  b/c that is not part of the name. 

![image](https://github.com/user-attachments/assets/60f37536-d3c2-4d6a-8c77-f9198808e3dc)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
