### PR TITLE
OSDOCS-14020: Updated IPI/UPI vSphere vCenter data center explanations

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -4,6 +4,9 @@
 // * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
 // Note: The ifndef statements add content to IPI documents
+ifeval::["{context}" == "ipi-vsphere-installation-reqs"]
+:ipi:
+endif::[]
 ifeval::["{context}" == "upi-vsphere-installation-reqs"]
 :upi:
 endif::[]
@@ -130,7 +133,12 @@ endif::upi[]
 `VirtualMachine.Provisioning.DeployTemplate`
 
 |vSphere vCenter data center
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. See the "Minimum permissions for the Machine API" table.
+ifdef::ipi[]
+|The installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. See the "Minimum permissions for the Machine API" table.
+endif::upi[]
 |
 [%hardbreaks]
 `InventoryService.Tagging.ObjectAttachable`
@@ -260,7 +268,12 @@ endif::upi[]
 `"Virtual machine".Provisioning."Deploy template"`
 
 |vSphere vCenter data center
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
+ifdef::ipi[]
+|The installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
+endif::upi[]
 |
 [%hardbreaks]
 `"vSphere Tagging"."Assign or Unassign vSphere Tag on Object"`
@@ -315,6 +328,7 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 |False
 |Listed required privileges
 
+ifdef::ipi[]
 .2+|vSphere vCenter data center
 |Existing folder
 |False
@@ -323,6 +337,7 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 |Installation program creates the folder
 |True
 |Listed required privileges
+endif::ipi[]
 
 .2+|vSphere vCenter Cluster
 |Existing resource pool
@@ -475,7 +490,7 @@ ifndef::upi[]
 `VirtualMachine.Provisioning.DeployTemplate`
 
 |vSphere vCenter data center
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+|If the virtual machine folder does not already exist, the installation program creates the virtual machine folder. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
 |
 [%hardbreaks]
 `Folder.Create`
@@ -587,7 +602,12 @@ endif::upi[]
 `VirtualMachine.Provisioning.DeployTemplate`
 
 |vSphere vCenter data center
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+ifdef::ipi[]
+|If the virtual machine folder does not already exist, the installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+endif::upi[]
 |
 [%hardbreaks]
 `Resource.AssignVMToPool`
@@ -655,7 +675,12 @@ endif::upi[]
 `VirtualMachine.Config.AddRemoveDevice`
 
 |vSphere vCenter data center
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+ifdef::ipi[]
+|If the virtual machine folder does not already exist, the installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+endif::upi[]
 |
 [%hardbreaks]
 `VirtualMachine.Config.AddExistingDisk`
@@ -732,7 +757,12 @@ endif::upi[]
 `VirtualMachine.Provisioning.DeployTemplate`
 
 |vSphere vCenter data center
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
+ifdef::ipi[]
+|If the virtual machine folder does not already exist, the installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
+endif::upi[]
 |
 [%hardbreaks]
 `Resource.AssignVMToPool`
@@ -861,6 +891,9 @@ default. This record must be resolvable by both clients external to the cluster
 and from all the nodes within the cluster.
 |===
 
+ifeval::["{context}" == "ipi-vsphere-installation-reqs"]
+:!ipi:
+endif::[]
 ifeval::["{context}" == "upi-vsphere-installation-reqs"]
 :!upi:
 endif::[]

--- a/modules/machineset-vsphere-required-permissions.adoc
+++ b/modules/machineset-vsphere-required-permissions.adoc
@@ -68,7 +68,7 @@ If you cannot use an account with global administrative privileges, you must cre
 `VirtualMachine.Provisioning.Clone`
 
 |vSphere vCenter data center
-|If the installation program creates the virtual machine folder
+|If the installation program creates the virtual machine folder.
 |
 [%hardbreaks]
 `Resource.AssignVMToPool`


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-14020](https://issues.redhat.com/browse/OSDOCS-14020)

Link to docs preview:
* [IPI](https://92277--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html)
* [UPI](https://92277--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html)

- [x] SME has approved this change (Joe Callen).
- [x] QE has approved this change (Shang Gao).

https://github.com/openshift/installer/blob/main/pkg/types/vsphere/platform.go#L246-L252
https://github.com/openshift/installer/blob/730366cdf994addd363c50a45cc7da306c0d12b2/pkg/infrastructure/vsphere/clusterapi/clusterapi.go#L47-L57
