### PR TITLE
CMA 2.15.1-6 Release Notes

### DIFF
--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -10,6 +10,27 @@ The following release notes are for previous versions of the Custom Metrics Auto
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+[id="nodes-pods-autoscaling-custom-rn-2151-4_{context}"]
+== Custom Metrics Autoscaler Operator 2.15.1-4 release notes
+
+Issued: 31 March 2025
+
+This release of the Custom Metrics Autoscaler Operator 2.15.1-4 addresses Common Vulnerabilities and Exposures (CVEs). The following advisory is available for the Custom Metrics Autoscaler Operator: 
+
+* link:https://access.redhat.com/errata/RHSA-2025:3501[RHSA-2025:3501]
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2151-4-new-features_{context}"]
+=== New features and enhancements
+
+[id="nodes-pods-autoscaling-custom-rn-2151-4-new-features-arm_{context}"]
+==== CMA multi-arch builds
+With this version of the Custom Metrics Autoscaler Operator, you can now install and run the Operator on an ARM64 {product-title} cluster.
+
 [id="nodes-pods-autoscaling-custom-rn-2141-467_{context}"]
 == Custom Metrics Autoscaler Operator 2.14.1-467 release notes
 

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -56,23 +56,16 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |General availability
 |===
 
-[id="nodes-pods-autoscaling-custom-rn-2151-4_{context}"]
-== Custom Metrics Autoscaler Operator 2.15.1-4 release notes
+[id="nodes-pods-autoscaling-custom-rn-2151-6_{context}"]
+== Custom Metrics Autoscaler Operator 2.15.1-6 release notes
 
-Issued: 31 March 2025
+Issued: 17 April 2025
 
-This release of the Custom Metrics Autoscaler Operator 2.15.1-4 addresses Common Vulnerabilities and Exposures (CVEs). The following advisory is available for the Custom Metrics Autoscaler Operator: 
+This release of the Custom Metrics Autoscaler Operator 2.15.1-6 addresses Common Vulnerabilities and Exposures (CVEs). The following advisory is available for the Custom Metrics Autoscaler Operator: 
 
-* link:https://access.redhat.com/errata/RHSA-2025:3501[RHSA-2025:3501]
+* link:https://access.redhat.com/errata/RHSA-2025:3993[RHSA-2025:3993]
 
 [IMPORTANT]
 ====
 Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
 ====
-
-[id="nodes-pods-autoscaling-custom-rn-2151-4-new-features_{context}"]
-=== New features and enhancements
-
-[id="nodes-pods-autoscaling-custom-rn-2151-4-new-features-arm_{context}"]
-==== CMA multi-arch builds
-With this version of the Custom Metrics Autoscaler Operator, you can now install and run the Operator on an ARM64 {product-title} cluster.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14352

[Custom Metrics Autoscaler Operator 2.15.1-6 release notes](https://92288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2151-6_nodes-cma-autoscaling-custom-rn) -- Updated 2.15.1-4 to 2.15-1.6. 
[Custom Metrics Autoscaler Operator 2.15.1-4 release notes](https://92288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past#nodes-pods-autoscaling-custom-rn-2151-4_nodes-cma-autoscaling-custom-rn-past) -- Moved this section to Past Release Notes module **without change to text**. [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator#nodes-pods-autoscaling-custom-rn-2151-4_nodes-cma-autoscaling-custom-rn) for reference. 

Need link to advisory, which is not available until it is published, before merging.
