### PR TITLE
OLS-1561: OLS requires secret even when RHOAI does not require token authentication

### DIFF
--- a/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
@@ -53,19 +53,20 @@ spec:
   llm:
     providers:
     - credentialsSecretRef:
-        name: openai-api-keys
+        name: <rhelai_api_keys> <1>
       models:
       - name: models/<model_name>
       name: rhelai
       type: rhelai_vllm
-      url: <URL> <1>
+      url: <url> <2>
   ols:
     defaultProvider: rhelai
     defaultModel: models/<model_name>
     additionalCAConfigMapRef:
       name: openshift-service-ca.crt
 ----
-<1> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`. 
+<1> By default, the {rhelai} API key requires a token as part of the request. If your {rhelai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
+<2> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`. 
 +
 .{rhoai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -78,17 +79,18 @@ spec:
   llm:
     providers:
     - credentialsSecretRef:
-        name: openai-api-keys
+        name: <rhoai_api_keys> <1>
       models:
       - name: <model_name>
       name: red_hat_openshift_ai
       type: rhoai_vllm 
-      url: <url> <1>
+      url: <url> <2>
   ols:
     defaultProvider: red_hat_openshift_ai
     defaultModel: <model_name>
 ----
-<1> The URL endpoint must end with `v1` to be valid. For example, `\https://<model_name>.<domain_name>.com:443/v1`. 
+<1> By default, the {rhoai} API key requires a token as part of the request. If your {rhoai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
+<2> The URL endpoint must end with `v1` to be valid. For example, `\https://<model_name>.<domain_name>.com:443/v1`. 
 +
 .{azure-openai} CR file
 [source,yaml,subs="attributes,verbatim"]

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
@@ -55,17 +55,18 @@ spec:
   llm:
     providers:
     - credentialsSecretRef:
-        name: openai-api-keys
+        name: <rhelai_api_keys> <1>
       models:
       - name: models/<model_name>
       name: rhelai
       type: rhelai_vllm
-      url: <URL> <1>
+      url: <url> <2>
   ols:
     defaultProvider: rhelai
     defaultModel: models/<model_name>
 ----
-<1> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`. 
+<1> By default, the {rhelai} API key requires a token as part of the request. If your {rhelai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
+<2> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`. 
 +
 .{rhoai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -78,17 +79,18 @@ spec:
   llm:
     providers:
     - credentialsSecretRef:
-        name: openai-api-keys
+        name: <rhoai_api_keys> <1>
       models:
       - name: <model_name>
       name: red_hat_openshift_ai
       type: rhoai_vllm 
-      url: <url> <1>
+      url: <url> <2>
   ols:
     defaultProvider: red_hat_openshift_ai
     defaultModel: <model_name>
 ----
-<1> The URL endpoint must end with `v1` to be valid. For example, `\https://<model_name>.<domain_name>.com:443/v1`. 
+<1> By default, the {rhoai} API key requires a token as part of the request. If your {rhoai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
+<2> The URL endpoint must end with `v1` to be valid. For example, `\https://<model_name>.<domain_name>.com:443/v1`.
 +
 .{azure-openai} CR file
 [source,yaml,subs="attributes,verbatim"]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Developer Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1561

Link to docs preview:
Task using CLI:
 https://92299--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-creating-lightspeed-custom-resource-file-using-cli_ols-configuring-openshift-lightspeed

Task using web console:
https://92299--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-creating-lightspeed-custom-resource-file-using-web-console_ols-configuring-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
