### PR TITLE
PR for SRVCOM-3722: Release notes, known issues and bug fixes for 1.35.1

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -29,6 +29,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 // Release notes included, most to least recent
 
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-35-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-35-0.adoc[leveloffset=+1]
 // 1.35.0 additional resources
 [role="_additional-resources"]

--- a/modules/serverless-rn-1-35-1.adoc
+++ b/modules/serverless-rn-1-35-1.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-35-1_{context}"]
+= Red{nbsp}Hat {ServerlessProductName} 1.35.1
+
+{ServerlessProductName} 1.35.1 is now available. This release of {ServerlessProductName} addresses identified Common Vulnerabilities and Exposures (CVEs) to enhance security and reliability. Fixed issues and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="fixed-issues-1-35-1_{context}"]
+== Fixed issues
+
+* Previously, the `kafka-controller-post-install-1.35` job failed after installing `KnativeKafka` if the `KafkaChannel` feature was not enabled. This issue has been fixed. The post-install job now completes successfully, even when the `KafkaChannels` are disabled.
+
+* Previously, the `sinks.knative.dev` API group was missing from the KnativeEventing aggregate cluster roles. As a result, if you are a non-admin user the `oc get all` command failed with the following error message:
++
+[source,text]
+----
+jobsinks.sinks.knative.dev is forbidden: User "user" cannot list resource "jobsinks" in API group "sinks.knative.dev" in the namespace "test"
+----
++
+This issue has been resolved. The `sinks.knative.dev` API group is now included in the `knative-eventing-namespaced` aggregate cluster roles. You can now read and list sinks in your own namespaces if you have a `view`, `edit`, or `admin` role.
+
+[id="known-issues-1-35-1_{context}"]
+== Known issues
+
+* Currently, you cannot delete the cluster-scoped resources such as webhook configurations, that might remain after uninstalling, reinstalling, or upgrading KnativeServing or the {ServerlessOperatorName}. These leftover resources can block the reconciliation process and prevent KnativeServing from installing properly. When this issue occurs, you might see an error similar to the following:
++
+[source,text]
+----
+failed to apply non rbac manifest: Internal error occurred: failed calling webhook \"webhook.serving.knative.dev\": failed to call webhook: Post \"https://webhook.knative-serving.svc:443/?timeout=10s\": no endpoints available for service \"webhook\"
+----
++
+As a workaround, you can now manually delete the stuck webhook configurations so that the reconciliation can continue by running the following commands:
++
+[source,terminal]
+----
+$ oc delete mutatingwebhookconfiguration webhook.serving.knative.dev
+----
++
+[source,terminal]
+----
+$ oc delete validatingwebhookconfiguration config.webhook.serving.knative.dev validation.webhook.serving.knative.dev
+----


### PR DESCRIPTION
**Affects version to cherry-pick:** 
`serverless-docs-1.36` 
`serverless-docs-1.35` 

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3722

**Doc Previews:** [Release notes 1.35.1](https://92308--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-35-1_serverless-release-notes)