### PR TITLE
OCPBUGS-33247: Improving QoS pod based on docfooding feedback

### DIFF
--- a/modules/cnf-node-tuning-operator-creating-pod-with-guaranteed-qos-class.adoc
+++ b/modules/cnf-node-tuning-operator-creating-pod-with-guaranteed-qos-class.adoc
@@ -6,13 +6,43 @@
 [id="cnf-node-tuning-operator-creating-pod-with-guaranteed-qos-class_{context}"]
 = Creating a pod with a guaranteed QoS class
 
-Keep the following in mind when you create a pod that is given a QoS class of `Guaranteed`:
+You can create a pod with a quality of service (QoS) class of `Guaranteed` for high-performance workloads. Configuring a pod with a QoS class of `Guaranteed` ensures that the pod has priority access to the specified CPU and memory resources. 
 
-* Every container in the pod must have a memory limit and a memory request, and they must be the same.
-* Every container in the pod must have a CPU limit and a CPU request, and they must be the same.
+To create a pod with a QoS class of `Guaranteed`, you must apply the following specifications:
 
-The following example shows the configuration file for a pod that has one container. The container has a memory limit and a memory request, both equal to 200 MiB. The container has a CPU limit and a CPU request, both equal to 1 CPU.
+* Set identical values for the memory limit and memory request fields for each container in the pod.
+* Set identical values for CPU limit and CPU request fields for each container in the pod.
 
+In general, a pod with a QoS class of `Guaranteed` will not be evicted from a node. One exception is during resource contention caused by system daemons exceeding reserved resources. In this scenario, the `kubelet` might evict pods to preserve node stability, starting with the lowest priority pods.
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role
+
+* The OpenShift CLI (`oc`)
+
+.Procedure
+
+. Create a namespace for the pod by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace qos-example <1>
+----
+<1> This example uses the `qos-example` namespace.
++
+.Example output
+[source,terminal]
+----
+namespace/qos-example created
+----
+
+. Create the `Pod` resource:
+
+.. Create a YAML file that defines the `Pod` resource:
++
+--
+.Example `qos-example.yaml` file
 [source,yaml]
 ----
 apiVersion: v1
@@ -27,45 +57,56 @@ spec:
       type: RuntimeDefault
   containers:
   - name: qos-demo-ctr
-    image: <image-pull-spec>
+    image: quay.io/openshifttest/hello-openshift:openshift <1>
     resources:
       limits:
-        memory: "200Mi"
-        cpu: "1"
+        memory: "200Mi" <2>
+        cpu: "1" <3>
       requests:
-        memory: "200Mi"
-        cpu: "1"
+        memory: "200Mi" <4>
+        cpu: "1" <5>
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop: [ALL]
 ----
-
-. Create the pod:
-+
-[source,terminal]
-----
-$ oc  apply -f qos-pod.yaml --namespace=qos-example
-----
-
-. View detailed information about the pod:
-+
-[source,terminal]
-----
-$ oc get pod qos-demo --namespace=qos-example --output=yaml
-----
-+
-.Example output
-[source,yaml]
-----
-spec:
-  containers:
-    ...
-status:
-  qosClass: Guaranteed
-----
+<1> This example uses a public `hello-openshift` image.
+<2> Sets the memory limit to 200 MB.
+<3> Sets the CPU limit to 1 CPU.
+<4> Sets the memory request to 200 MB.
+<5> Sets the CPU request to 1 CPU.
 +
 [NOTE]
 ====
 If you specify a memory limit for a container, but do not specify a memory request, {product-title} automatically assigns a memory request that matches the limit. Similarly, if you specify a CPU limit for a container, but do not specify a CPU request, {product-title} automatically assigns a CPU request that matches the limit.
 ====
+--
+
+.. Create the `Pod` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f qos-example.yaml --namespace=qos-example
+----
++
+.Example output
+[source,terminal]
+----
+pod/qos-demo created
+----
+
+.Verification
+
+* View the `qosClass` value for the pod by running the following command:
++
+[source,terminal]
+----
+$ oc get pod qos-demo --namespace=qos-example --output=yaml | grep qosClass
+----
++
+.Example output
+[source,yaml]
+----
+    qosClass: Guaranteed
+----
+


### PR DESCRIPTION
OCPBUGS-33247: Improving QoS pod based on docfooding feedback

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-33247

Link to docs preview:
https://92312--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-provisioning-low-latency-workloads.html#cnf-node-tuning-operator-creating-pod-with-guaranteed-qos-class_cnf-provisioning-low-latency

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This was initiated as part of our internal content improvement efforts.
