### PR TITLE
OCPBUGS-55123: Fix `apiVersion` in compute machine set specs

### DIFF
--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -77,7 +77,7 @@ ifdef::infra[]
 endif::infra[]
       providerSpec:
         value:
-          apiVersion: azureproviderconfig.openshift.io/v1beta1
+          apiVersion: machine.openshift.io/v1beta1
           credentialsSecret:
             name: azure-cloud-credentials
             namespace: openshift-machine-api

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -82,7 +82,7 @@ ifdef::infra[]
 endif::infra[]
       providerSpec:
         value:
-          apiVersion: gcpprovider.openshift.io/v1beta1
+          apiVersion: machine.openshift.io/v1beta1
           canIPForward: false
           credentialsSecret:
             name: gcp-cloud-credentials

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -76,7 +76,7 @@ ifdef::infra[]
 endif::infra[]
       providerSpec:
         value:
-          apiVersion: vsphereprovider.openshift.io/v1beta1
+          apiVersion: machine.openshift.io/v1beta1
           credentialsSecret:
             name: vsphere-cloud-credentials
           diskGiB: 120


### PR DESCRIPTION
Version(s):
4.16+

Issue:
OCPBUGS-55123

Link to docs preview:
- [Sample YAML for a compute machine set custom resource on Azure](https://92348--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-azure_creating-infrastructure-machinesets) (infra)
- [Sample YAML for a compute machine set custom resource on GCP](https://92348--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-gcp_creating-infrastructure-machinesets) (infra)
- [Sample YAML for a compute machine set custom resource on vSphere](https://92348--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-vsphere_creating-infrastructure-machinesets) (infra)
- [Sample YAML for a compute machine set custom resource on Azure](https://92348--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-yaml-azure_creating-machineset-azure)
- [Sample YAML for a compute machine set custom resource on GCP](https://92348--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-yaml-gcp_creating-machineset-gcp)
- [Sample YAML for a compute machine set custom resource on vSphere](https://92348--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere.html#machineset-yaml-vsphere_creating-machineset-vsphere)

QE review:
- [x] QE has approved this change.

Additional information: