### PR TITLE
OSDOCS-14033-2:Release Note for 4.15.49

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2786,7 +2786,7 @@ For any {product-title} release, always review the instructions on xref:../updat
 
 Issued: 16 April 2025
 
-{product-title} release 4.15.49, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3790 [RHSA-2025:3790] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3792[RHBA-2025:3792] advisory.
+{product-title} release 4.15.49, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3790[RHSA-2025:3790] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:3792[RHBA-2025:3792] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -2800,7 +2800,7 @@ $ oc adm release info 4.15.49 --pullspecs
 [id="ocp-4-15-49-known-issues_{context}"]
 ==== Known issues
 
-* IPsec is not supported on {op-system-base-full} compute nodes because of a `libreswan` incompatiblility issue between a host and an `ovn-ipsec` container that exist in each compute node.  (link:https://issues.redhat.com/browse/OCPBUGS-36688[*OCPBUGS-36688*]) 
+* IPsec is not supported on {op-system-base-full} compute nodes because of a `libreswan` incompatiblility issue between a host and an `ovn-ipsec` container that exist in each compute node.  (link:https://issues.redhat.com/browse/OCPBUGS-36688[OCPBUGS-36688]) 
 
 [id="ocp-4-15-49-bug-fixes_{context}"]
 ==== Bug fixes


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-14033

Link to docs preview: https://92352--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html


QE review:
- [ ] QE has approved this change.

