### PR TITLE
OLS-1665: Update product coverage to make it clearer which products a…

### DIFF
--- a/modules/ols-about-product-coverage.adoc
+++ b/modules/ols-about-product-coverage.adoc
@@ -5,7 +5,12 @@
 [id="ols-about-product-coverage_{context}"]
 = About product coverage
 
-{ols-official} generates answers to questions based on the content in the official {ocp-product-title} product documentation. The documentation for the following products is not part of the {ocp-short-name} product documentation; therefore, {ols-short} has limited context for generating answers about these products:
+{ols-official} generates responses based on the content from the {ocp-product-title} product documentation.
+
+[id="product-exceptions_{context}"]
+== Product exceptions
+
+The {ocp-product-title} product documentation does not include information about all products in the {red-hat} portfolio. As a result, the {ols-official} service uses the large language model (LLM) you provide to produce output for the following products or components:
 
 * {builds-title}
 * {cluster-security-title}


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1665
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://92353--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/about/ols-about-openshift-lightspeed.html#ols-about-product-coverage_ols-about-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
