### PR TITLE
OSDOCS-13571: Adding warning message about mismatched service UIDs

### DIFF
--- a/modules/customize-certificates-understanding-service-serving.adoc
+++ b/modules/customize-certificates-understanding-service-serving.adoc
@@ -32,3 +32,9 @@ $ for I in $(oc get ns -o jsonpath='{range .items[*]} {.metadata.name}{"\n"} {en
       done
 ----
 ====
+
+
+[WARNING]
+====
+After you create the service, if you re-create the service, the secret will no longer have a matching service UID. A mismatched service UID will lead to an automatic certificate renewal failure.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.0+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13571](https://issues.redhat.com//browse/OSDOCS-13571)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://92367--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/service-serving-certificate.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
