### PR TITLE
Add Serverless and Service Mesh back to ROSA HCP topic map

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -25,126 +25,126 @@ Name: What's new
 Dir: rosa_release_notes
 Distros: openshift-rosa-hcp
 Topics:
-- Name: What's new with Red Hat OpenShift Service on AWS
-  File: rosa-release-notes
+  - Name: What's new with Red Hat OpenShift Service on AWS
+    File: rosa-release-notes
 ---
 Name: Introduction to ROSA
 Dir: rosa_architecture
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Welcome
-  File: index
-- Name: Legal notice
-  File: legal-notice
-- Name: ROSA with HCP overview
-  File: about-hcp
-- Name: AWS STS and ROSA with HCP explained
-  File: cloud-experts-rosa-hcp-sts-explained
-- Name: Architecture models
-  File: rosa-architecture-models
-- Name: Policies and service definition
-  Dir: rosa_policy_service_definition
-  Distros: openshift-rosa-hcp
-  Topics:
-  - Name: About availability for ROSA
-    File: rosa-policy-understand-availability
-  - Name: Overview of responsibilities for ROSA
-    File: rosa-policy-responsibility-matrix
-  - Name: ROSA with HCP service definition
-    File: rosa-hcp-service-definition
-  - Name: ROSA with HCP instance types
-    File: rosa-hcp-instance-types
-  - Name: ROSA with HCP update life cycle
-    File: rosa-hcp-life-cycle
-  - Name: SRE and service account access
-    File: rosa-sre-access
-  - Name: Understanding security for ROSA
-    File: rosa-policy-process-security
-#Temporarily included the following to keep working through xref errors
-- Name: About IAM resources
-  File: rosa-sts-about-iam-resources
-  Distros: openshift-rosa-hcp
+  - Name: Welcome
+    File: index
+  - Name: Legal notice
+    File: legal-notice
+  - Name: ROSA with HCP overview
+    File: about-hcp
+  - Name: AWS STS and ROSA with HCP explained
+    File: cloud-experts-rosa-hcp-sts-explained
+  - Name: Architecture models
+    File: rosa-architecture-models
+  - Name: Policies and service definition
+    Dir: rosa_policy_service_definition
+    Distros: openshift-rosa-hcp
+    Topics:
+      - Name: About availability for ROSA
+        File: rosa-policy-understand-availability
+      - Name: Overview of responsibilities for ROSA
+        File: rosa-policy-responsibility-matrix
+      - Name: ROSA with HCP service definition
+        File: rosa-hcp-service-definition
+      - Name: ROSA with HCP instance types
+        File: rosa-hcp-instance-types
+      - Name: ROSA with HCP update life cycle
+        File: rosa-hcp-life-cycle
+      - Name: SRE and service account access
+        File: rosa-sre-access
+      - Name: Understanding security for ROSA
+        File: rosa-policy-process-security
+  #Temporarily included the following to keep working through xref errors
+  - Name: About IAM resources
+    File: rosa-sts-about-iam-resources
+    Distros: openshift-rosa-hcp
 ---
 Name: Learning about ROSA
 Dir: rosa_learning
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Creating a cluster workshop
-  Dir: creating_cluster_workshop
-  Distros: openshift-rosa-hcp
-  Topics:
-  - Name: Deploying a cluster
-    File: learning-getting-started-hcp-for-hcp
-  - Name: Creating an admin user
-    File: learning-getting-started-admin
-  - Name: Setting up an identity provider
-    File: learning-getting-started-idp
-  - Name: Granting admin rights
-    File: learning-getting-started-admin-rights
-  - Name: Accessing your cluster
-    File: learning-getting-started-accessing
-  - Name: Managing worker nodes
-    File: learning-getting-started-managing-worker-nodes
-  - Name: Autoscaling
-    File: learning-getting-started-autoscaling
-  - Name: Upgrading your cluster
-    File: learning-getting-started-upgrading
-  - Name: Deleting your cluster
-    File: learning-getting-started-deleting
-  - Name: Obtaining support
-    File: learning-getting-started-support
-- Name: Deploying an application workshop
-  Dir: deploying_application_workshop
-  Topics:
-  - Name: Workshop overview
-    File: learning-lab-overview
-  - Name: Deployment
-    File: learning-deploying-application-deployment
-  - Name: Health Check
-    File: learning-deploying-application-health-check
-  - Name: Storage
-    File: learning-deploying-application-storage
-  - Name: ConfigMap, secrets, and environment variables
-    File: learning-deploying-configmaps-secrets-env-var
-  - Name: Networking
-    File: learning-deploying-application-networking
-  - Name: Scaling an application
-    File: learning-deploying-application-scaling
-  - Name: S2i deployments
-    File: learning-deploying-application-s2i-deployments
-  - Name: Using Source-to-Image (S2I) webhooks for automated deployment
-    File: learning-deploying-s2i-webhook-cicd
+  - Name: Creating a cluster workshop
+    Dir: creating_cluster_workshop
+    Distros: openshift-rosa-hcp
+    Topics:
+      - Name: Deploying a cluster
+        File: learning-getting-started-hcp-for-hcp
+      - Name: Creating an admin user
+        File: learning-getting-started-admin
+      - Name: Setting up an identity provider
+        File: learning-getting-started-idp
+      - Name: Granting admin rights
+        File: learning-getting-started-admin-rights
+      - Name: Accessing your cluster
+        File: learning-getting-started-accessing
+      - Name: Managing worker nodes
+        File: learning-getting-started-managing-worker-nodes
+      - Name: Autoscaling
+        File: learning-getting-started-autoscaling
+      - Name: Upgrading your cluster
+        File: learning-getting-started-upgrading
+      - Name: Deleting your cluster
+        File: learning-getting-started-deleting
+      - Name: Obtaining support
+        File: learning-getting-started-support
+  - Name: Deploying an application workshop
+    Dir: deploying_application_workshop
+    Topics:
+      - Name: Workshop overview
+        File: learning-lab-overview
+      - Name: Deployment
+        File: learning-deploying-application-deployment
+      - Name: Health Check
+        File: learning-deploying-application-health-check
+      - Name: Storage
+        File: learning-deploying-application-storage
+      - Name: ConfigMap, secrets, and environment variables
+        File: learning-deploying-configmaps-secrets-env-var
+      - Name: Networking
+        File: learning-deploying-application-networking
+      - Name: Scaling an application
+        File: learning-deploying-application-scaling
+      - Name: S2i deployments
+        File: learning-deploying-application-s2i-deployments
+      - Name: Using Source-to-Image (S2I) webhooks for automated deployment
+        File: learning-deploying-s2i-webhook-cicd
 ---
 Name: Tutorials
 Dir: cloud_experts_tutorials
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Tutorials overview
-  File: index
-- Name: ROSA with HCP activation and account linking
-  File: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
-- Name: ROSA with HCP private offer acceptance and sharing
-  File: cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing
-- Name: Deploying ROSA with a Custom DNS Resolver
-  File: cloud-experts-custom-dns-resolver
-- Name: Using AWS WAF and Amazon CloudFront to protect ROSA workloads
-  File: cloud-experts-using-cloudfront-and-waf
-- Name: Using AWS WAF and AWS ALBs to protect ROSA workloads
-  File: cloud-experts-using-alb-and-waf
-- Name: Deploying OpenShift API for Data Protection on a ROSA cluster
-  File: cloud-experts-deploy-api-data-protection
-- Name: AWS Load Balancer Operator on ROSA
-  File: cloud-experts-aws-load-balancer-operator
-- Name: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
-  File: cloud-experts-entra-id-idp
-- Name: Using AWS Secrets Manager CSI on ROSA with STS
-  File: cloud-experts-aws-secret-manager
-- Name: Using AWS Controllers for Kubernetes on ROSA
-  File: cloud-experts-using-aws-ack
-- Name: Dynamically issuing certificates using the cert-manager Operator on ROSA
-  File: cloud-experts-dynamic-certificate-custom-domain
-- Name: Assigning consistent egress IP for external traffic
-  File: cloud-experts-consistent-egress-ip
+  - Name: Tutorials overview
+    File: index
+  - Name: ROSA with HCP activation and account linking
+    File: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
+  - Name: ROSA with HCP private offer acceptance and sharing
+    File: cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing
+  - Name: Deploying ROSA with a Custom DNS Resolver
+    File: cloud-experts-custom-dns-resolver
+  - Name: Using AWS WAF and Amazon CloudFront to protect ROSA workloads
+    File: cloud-experts-using-cloudfront-and-waf
+  - Name: Using AWS WAF and AWS ALBs to protect ROSA workloads
+    File: cloud-experts-using-alb-and-waf
+  - Name: Deploying OpenShift API for Data Protection on a ROSA cluster
+    File: cloud-experts-deploy-api-data-protection
+  - Name: AWS Load Balancer Operator on ROSA
+    File: cloud-experts-aws-load-balancer-operator
+  - Name: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
+    File: cloud-experts-entra-id-idp
+  - Name: Using AWS Secrets Manager CSI on ROSA with STS
+    File: cloud-experts-aws-secret-manager
+  - Name: Using AWS Controllers for Kubernetes on ROSA
+    File: cloud-experts-using-aws-ack
+  - Name: Dynamically issuing certificates using the cert-manager Operator on ROSA
+    File: cloud-experts-dynamic-certificate-custom-domain
+  - Name: Assigning consistent egress IP for external traffic
+    File: cloud-experts-consistent-egress-ip
 # ---
 # Name: Getting started
 # Dir: rosa_getting_started
@@ -161,20 +161,20 @@ Name: Prepare your environment
 Dir: rosa_planning
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Prerequisites checklist for deploying ROSA with HCP
-  File: rosa-cloud-expert-prereq-checklist
-- Name: Detailed requirements for deploying ROSA with HCP
-  File: rosa-sts-aws-prereqs
-- Name: Required IAM roles and resources
-  File: rosa-hcp-prepare-iam-roles-resources
-- Name: ROSA with HCP limits and scalability
-  File: rosa-hcp-limits-scalability
-- Name: Required AWS service quotas
-  File: rosa-sts-required-aws-service-quotas
-- Name: Setting up your environment
-  File: rosa-sts-setting-up-environment
-- Name: Planning resource usage in your cluster
-  File: rosa-planning-environment
+  - Name: Prerequisites checklist for deploying ROSA with HCP
+    File: rosa-cloud-expert-prereq-checklist
+  - Name: Detailed requirements for deploying ROSA with HCP
+    File: rosa-sts-aws-prereqs
+  - Name: Required IAM roles and resources
+    File: rosa-hcp-prepare-iam-roles-resources
+  - Name: ROSA with HCP limits and scalability
+    File: rosa-hcp-limits-scalability
+  - Name: Required AWS service quotas
+    File: rosa-sts-required-aws-service-quotas
+  - Name: Setting up your environment
+    File: rosa-sts-setting-up-environment
+  - Name: Planning resource usage in your cluster
+    File: rosa-planning-environment
 # - Name: Preparing Terraform to install ROSA clusters
 #   File: rosa-understanding-terraform
 ---
@@ -182,157 +182,157 @@ Name: Install ROSA with HCP clusters
 Dir: rosa_hcp
 Distros: openshift-rosa-hcp
 Topics:
-- Name: ROSA with HCP quick start guide
-  File: rosa-hcp-quickstart-guide
-- Name: Creating ROSA with HCP clusters using the default options
-  File: rosa-hcp-sts-creating-a-cluster-quickly
-- Name: Creating ROSA with HCP clusters using a custom AWS KMS encryption key
-  File: rosa-hcp-creating-cluster-with-aws-kms-key
-- Name: Creating a private cluster on ROSA with HCP
-  File: rosa-hcp-aws-private-creating-cluster
-- Name: Creating a ROSA with HCP cluster with egress lockdown
-  File: rosa-hcp-egress-lockdown-install
-- Name: Creating ROSA with HCP clusters with external authentication
-  File: rosa-hcp-sts-creating-a-cluster-ext-auth
+  - Name: ROSA with HCP quick start guide
+    File: rosa-hcp-quickstart-guide
+  - Name: Creating ROSA with HCP clusters using the default options
+    File: rosa-hcp-sts-creating-a-cluster-quickly
+  - Name: Creating ROSA with HCP clusters using a custom AWS KMS encryption key
+    File: rosa-hcp-creating-cluster-with-aws-kms-key
+  - Name: Creating a private cluster on ROSA with HCP
+    File: rosa-hcp-aws-private-creating-cluster
+  - Name: Creating a ROSA with HCP cluster with egress lockdown
+    File: rosa-hcp-egress-lockdown-install
+  - Name: Creating ROSA with HCP clusters with external authentication
+    File: rosa-hcp-sts-creating-a-cluster-ext-auth
 ---
 Name: Web console
 Dir: web_console
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Web console overview
-  File: web-console-overview
-- Name: Accessing the web console
-  File: web-console
-- Name: Viewing cluster information
-  File: using-dashboard-to-get-cluster-information
-- Name: Adding user preferences
-  File: adding-user-preferences
-- Name: Dynamic plugins
-  Dir: dynamic-plugin
-  Distros: openshift-rosa-hcp
-  Topics:
-  - Name: Overview of dynamic plugins
-    File: overview-dynamic-plugin
-  - Name: Getting started with dynamic plugins
-    File: dynamic-plugins-get-started
-  - Name: Deploy your plugin on a cluster
-    File: deploy-plugin-cluster
-  - Name: Dynamic plugin example
-    File: dynamic-plugin-example
-  - Name: Dynamic plugin reference
-    File: dynamic-plugins-reference
-- Name: Web terminal
-  Dir: web_terminal
-  Distros: openshift-rosa-hcp
-  Topics:
-  - Name: Installing the web terminal
-    File: installing-web-terminal
-  - Name: Using the web terminal
-    File: odc-using-web-terminal
-  - Name: Troubleshooting the web terminal
-    File: troubleshooting-web-terminal
-  - Name: Uninstalling the web terminal
-    File: uninstalling-web-terminal
-- Name: About quick start tutorials
-  File: creating-quick-start-tutorials
-  Distros: openshift-rosa-hcp
+  - Name: Web console overview
+    File: web-console-overview
+  - Name: Accessing the web console
+    File: web-console
+  - Name: Viewing cluster information
+    File: using-dashboard-to-get-cluster-information
+  - Name: Adding user preferences
+    File: adding-user-preferences
+  - Name: Dynamic plugins
+    Dir: dynamic-plugin
+    Distros: openshift-rosa-hcp
+    Topics:
+      - Name: Overview of dynamic plugins
+        File: overview-dynamic-plugin
+      - Name: Getting started with dynamic plugins
+        File: dynamic-plugins-get-started
+      - Name: Deploy your plugin on a cluster
+        File: deploy-plugin-cluster
+      - Name: Dynamic plugin example
+        File: dynamic-plugin-example
+      - Name: Dynamic plugin reference
+        File: dynamic-plugins-reference
+  - Name: Web terminal
+    Dir: web_terminal
+    Distros: openshift-rosa-hcp
+    Topics:
+      - Name: Installing the web terminal
+        File: installing-web-terminal
+      - Name: Using the web terminal
+        File: odc-using-web-terminal
+      - Name: Troubleshooting the web terminal
+        File: troubleshooting-web-terminal
+      - Name: Uninstalling the web terminal
+        File: uninstalling-web-terminal
+  - Name: About quick start tutorials
+    File: creating-quick-start-tutorials
+    Distros: openshift-rosa-hcp
 ---
 Name: CLI tools
 Dir: cli_reference
 Distros: openshift-rosa-hcp
 Topics:
-- Name: CLI tools overview
-  File: index
-- Name: OpenShift CLI (oc)
-  Dir: openshift_cli
-  Topics:
-  - Name: Getting started with the OpenShift CLI
-    File: getting-started-cli
-  - Name: Configuring the OpenShift CLI
-    File: configuring-cli
-  - Name: Usage of oc and kubectl commands
-    File: usage-oc-kubectl
-  - Name: Managing CLI profiles
-    File: managing-cli-profiles
-  - Name: Extending the OpenShift CLI with plugins
-    File: extending-cli-plugins
- # - Name: Managing CLI plugins with Krew
-  #  File: managing-cli-plugins-krew
-  #  Distros: openshift-rosa-hcp
-  - Name: OpenShift CLI developer command reference
-    File: developer-cli-commands
-  - Name: OpenShift CLI administrator command reference
-    File: administrator-cli-commands
+  - Name: CLI tools overview
+    File: index
+  - Name: OpenShift CLI (oc)
+    Dir: openshift_cli
+    Topics:
+      - Name: Getting started with the OpenShift CLI
+        File: getting-started-cli
+      - Name: Configuring the OpenShift CLI
+        File: configuring-cli
+      - Name: Usage of oc and kubectl commands
+        File: usage-oc-kubectl
+      - Name: Managing CLI profiles
+        File: managing-cli-profiles
+      - Name: Extending the OpenShift CLI with plugins
+        File: extending-cli-plugins
+      # - Name: Managing CLI plugins with Krew
+      #  File: managing-cli-plugins-krew
+      #  Distros: openshift-rosa-hcp
+      - Name: OpenShift CLI developer command reference
+        File: developer-cli-commands
+      - Name: OpenShift CLI administrator command reference
+        File: administrator-cli-commands
+        Distros: openshift-rosa-hcp
+  - Name: Developer CLI (odo)
+    File: odo-important-update
+    # Dir: developer_cli_odo
     Distros: openshift-rosa-hcp
-- Name: Developer CLI (odo)
-  File: odo-important-update
-  # Dir: developer_cli_odo
-  Distros: openshift-rosa-hcp
-  # Topics:
-  # - Name: odo release notes
-  #  File: odo-release-notes
-  # - Name: Understanding odo
-  #  File: understanding-odo
-  # - Name: Installing odo
-  #  File: installing-odo
-  # - Name: Configuring the odo CLI
-  #  File: configuring-the-odo-cli
-  # - Name: odo CLI reference
-  #  File: odo-cli-reference
-- Name: Knative CLI (kn) for use with OpenShift Serverless
-  File: kn-cli-tools
-  Distros: openshift-rosa-hcp
-- Name: Pipelines CLI (tkn)
-  Dir: tkn_cli
-  Distros: openshift-rosa-hcp
-  Topics:
-  - Name: Installing tkn
-    File: installing-tkn
-  - Name: Configuring tkn
-    File: op-configuring-tkn
-  - Name: Basic tkn commands
-    File: op-tkn-reference
-- Name: opm CLI
-  Dir: opm
-  Distros: openshift-rosa-hcp
-  Topics:
-  - Name: Installing the opm CLI
-    File: cli-opm-install
-  - Name: opm CLI reference
-    File: cli-opm-ref
-- Name: Operator SDK
-  Dir: osdk
-  Distros: openshift-rosa-hcp
-  Topics:
-  - Name: Installing the Operator SDK CLI
-    File: cli-osdk-install
-  - Name: Operator SDK CLI reference
-    File: cli-osdk-ref
-- Name: ROSA CLI
-  Dir: rosa_cli
-  Distros: openshift-rosa-hcp
-  Topics:
-  # - Name: CLI and web console
-  #   File: rosa-cli-openshift-console
-  - Name: Getting started with the ROSA CLI
-    File: rosa-get-started-cli
-  - Name: Managing objects with the ROSA CLI
-    File: rosa-manage-objects-cli
-  - Name: Checking account and version information with the ROSA CLI
-    File: rosa-checking-acct-version-cli
-  - Name: Checking logs with the ROSA CLI
-    File: rosa-checking-logs-cli
-  - Name: Least privilege permissions for ROSA CLI commands
-    File: rosa-cli-permission-examples
-  - Name: Managing AWS billing accounts with the ROSA CLI
-    File: rosa-updating-billing-account-cli
+    # Topics:
+    # - Name: odo release notes
+    #  File: odo-release-notes
+    # - Name: Understanding odo
+    #  File: understanding-odo
+    # - Name: Installing odo
+    #  File: installing-odo
+    # - Name: Configuring the odo CLI
+    #  File: configuring-the-odo-cli
+    # - Name: odo CLI reference
+    #  File: odo-cli-reference
+  - Name: Knative CLI (kn) for use with OpenShift Serverless
+    File: kn-cli-tools
+    Distros: openshift-rosa-hcp
+  - Name: Pipelines CLI (tkn)
+    Dir: tkn_cli
+    Distros: openshift-rosa-hcp
+    Topics:
+      - Name: Installing tkn
+        File: installing-tkn
+      - Name: Configuring tkn
+        File: op-configuring-tkn
+      - Name: Basic tkn commands
+        File: op-tkn-reference
+  - Name: opm CLI
+    Dir: opm
+    Distros: openshift-rosa-hcp
+    Topics:
+      - Name: Installing the opm CLI
+        File: cli-opm-install
+      - Name: opm CLI reference
+        File: cli-opm-ref
+  - Name: Operator SDK
+    Dir: osdk
+    Distros: openshift-rosa-hcp
+    Topics:
+      - Name: Installing the Operator SDK CLI
+        File: cli-osdk-install
+      - Name: Operator SDK CLI reference
+        File: cli-osdk-ref
+  - Name: ROSA CLI
+    Dir: rosa_cli
+    Distros: openshift-rosa-hcp
+    Topics:
+      # - Name: CLI and web console
+      #   File: rosa-cli-openshift-console
+      - Name: Getting started with the ROSA CLI
+        File: rosa-get-started-cli
+      - Name: Managing objects with the ROSA CLI
+        File: rosa-manage-objects-cli
+      - Name: Checking account and version information with the ROSA CLI
+        File: rosa-checking-acct-version-cli
+      - Name: Checking logs with the ROSA CLI
+        File: rosa-checking-logs-cli
+      - Name: Least privilege permissions for ROSA CLI commands
+        File: rosa-cli-permission-examples
+      - Name: Managing AWS billing accounts with the ROSA CLI
+        File: rosa-updating-billing-account-cli
 ---
 Name: Red Hat OpenShift Cluster Manager
 Dir: ocm
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Red Hat OpenShift Cluster Manager
-  File: ocm-overview
+  - Name: Red Hat OpenShift Cluster Manager
+    File: ocm-overview
 #  - Name: Red Hat OpenShift Cluster Manager
 #    File: ocm-overview
 #  - Name: Using the OpenShift web console
@@ -345,200 +345,200 @@ Name: Support
 Dir: support
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Support overview
-  File: index
-- Name: Managing your cluster resources
-  File: managing-cluster-resources
-- Name: Approved Access
-  File: approved-access
-- Name: Getting support
-  File: getting-support
-- Name: Remote health monitoring with connected clusters
-  Dir: remote_health_monitoring
-  Topics:
-  - Name: About remote health monitoring
-    File: about-remote-health-monitoring
-  - Name: Showing data collected by remote health monitoring
-    File: showing-data-collected-by-remote-health-monitoring
-# cannot get resource "secrets" in API group "" in the namespace "openshift-config"
-#  - Name: Opting out of remote health reporting
-#    File: opting-out-of-remote-health-reporting
-# cannot get resource "secrets" in API group "" in the namespace "openshift-config"
-#  - Name: Enabling remote health reporting
-#    File: enabling-remote-health-reporting
-  - Name: Using Insights to identify issues with your cluster
-    File: using-insights-to-identify-issues-with-your-cluster
-  - Name: Using Insights Operator
-    File: using-insights-operator
-# Not supported per Michael McNeill
-# - Name: Using remote health reporting in a restricted network
-#   File: remote-health-reporting-from-restricted-network
-# cannot list resource "secrets" in API group "" in the namespace "openshift-config"
-#  - Name: Importing simple content access entitlements with Insights Operator
-#    File: insights-operator-simple-access
-- Name: Gathering data about your cluster
-  File: gathering-cluster-data
-- Name: Summarizing cluster specifications
-  File: summarizing-cluster-specifications
-- Name: Troubleshooting
-  Dir: troubleshooting
-  Topics:
-# rosa has own troubleshooting installations
-#  - Name: Troubleshooting installations
-#    File: troubleshooting-installations
-  - Name: Troubleshooting ROSA installations
-    File: rosa-troubleshooting-installations
-  - Name: Troubleshooting ROSA with HCP installations
-    File: rosa-troubleshooting-installations-hcp
-  - Name: Troubleshooting networking
-    File: rosa-troubleshooting-networking
-  - Name: Verifying node health
-    File: verifying-node-health
-#  cannot create resource "namespaces", cannot patch resource "nodes"
-#  - Name: Troubleshooting CRI-O container runtime issues
-#    File: troubleshooting-crio-issues
-# requires ostree, butane, and other plug-ins
-#  - Name: Troubleshooting operating system issues
-#    File: troubleshooting-operating-system-issues
-#    Distros: openshift-rosa
-# cannot patch resource "nodes", "nodes/proxy", "namespaces"
-#  - Name: Troubleshooting network issues
-#    File: troubleshooting-network-issues
-#    Distros: openshift-rosa
-  - Name: Troubleshooting Operator issues
-    File: troubleshooting-operator-issues
-  - Name: Investigating pod issues
-    File: investigating-pod-issues
-  - Name: Troubleshooting the Source-to-Image process
-    File: troubleshooting-s2i
-  - Name: Troubleshooting storage issues
-    File: troubleshooting-storage-issues
-# Not supported per WINC team
-#  - Name: Troubleshooting Windows container workload issues
-#    File: troubleshooting-windows-container-workload-issues
-  - Name: Investigating monitoring issues
-    File: investigating-monitoring-issues
-  - Name: Diagnosing OpenShift CLI (oc) issues
-    File: diagnosing-oc-issues
-  - Name: Troubleshooting expired offline access tokens
-    File: rosa-troubleshooting-expired-tokens
-  - Name: Troubleshooting IAM roles
-    File: rosa-troubleshooting-iam-resources
-  - Name: Troubleshooting cluster deployments
-    File: rosa-troubleshooting-deployments
-  - Name: Red Hat managed resources
-    File: sd-managed-resources
+  - Name: Support overview
+    File: index
+  - Name: Managing your cluster resources
+    File: managing-cluster-resources
+  - Name: Approved Access
+    File: approved-access
+  - Name: Getting support
+    File: getting-support
+  - Name: Remote health monitoring with connected clusters
+    Dir: remote_health_monitoring
+    Topics:
+      - Name: About remote health monitoring
+        File: about-remote-health-monitoring
+      - Name: Showing data collected by remote health monitoring
+        File: showing-data-collected-by-remote-health-monitoring
+      # cannot get resource "secrets" in API group "" in the namespace "openshift-config"
+      #  - Name: Opting out of remote health reporting
+      #    File: opting-out-of-remote-health-reporting
+      # cannot get resource "secrets" in API group "" in the namespace "openshift-config"
+      #  - Name: Enabling remote health reporting
+      #    File: enabling-remote-health-reporting
+      - Name: Using Insights to identify issues with your cluster
+        File: using-insights-to-identify-issues-with-your-cluster
+      - Name: Using Insights Operator
+        File: using-insights-operator
+  # Not supported per Michael McNeill
+  # - Name: Using remote health reporting in a restricted network
+  #   File: remote-health-reporting-from-restricted-network
+  # cannot list resource "secrets" in API group "" in the namespace "openshift-config"
+  #  - Name: Importing simple content access entitlements with Insights Operator
+  #    File: insights-operator-simple-access
+  - Name: Gathering data about your cluster
+    File: gathering-cluster-data
+  - Name: Summarizing cluster specifications
+    File: summarizing-cluster-specifications
+  - Name: Troubleshooting
+    Dir: troubleshooting
+    Topics:
+      # rosa has own troubleshooting installations
+      #  - Name: Troubleshooting installations
+      #    File: troubleshooting-installations
+      - Name: Troubleshooting ROSA installations
+        File: rosa-troubleshooting-installations
+      - Name: Troubleshooting ROSA with HCP installations
+        File: rosa-troubleshooting-installations-hcp
+      - Name: Troubleshooting networking
+        File: rosa-troubleshooting-networking
+      - Name: Verifying node health
+        File: verifying-node-health
+      #  cannot create resource "namespaces", cannot patch resource "nodes"
+      #  - Name: Troubleshooting CRI-O container runtime issues
+      #    File: troubleshooting-crio-issues
+      # requires ostree, butane, and other plug-ins
+      #  - Name: Troubleshooting operating system issues
+      #    File: troubleshooting-operating-system-issues
+      #    Distros: openshift-rosa
+      # cannot patch resource "nodes", "nodes/proxy", "namespaces"
+      #  - Name: Troubleshooting network issues
+      #    File: troubleshooting-network-issues
+      #    Distros: openshift-rosa
+      - Name: Troubleshooting Operator issues
+        File: troubleshooting-operator-issues
+      - Name: Investigating pod issues
+        File: investigating-pod-issues
+      - Name: Troubleshooting the Source-to-Image process
+        File: troubleshooting-s2i
+      - Name: Troubleshooting storage issues
+        File: troubleshooting-storage-issues
+      # Not supported per WINC team
+      #  - Name: Troubleshooting Windows container workload issues
+      #    File: troubleshooting-windows-container-workload-issues
+      - Name: Investigating monitoring issues
+        File: investigating-monitoring-issues
+      - Name: Diagnosing OpenShift CLI (oc) issues
+        File: diagnosing-oc-issues
+      - Name: Troubleshooting expired offline access tokens
+        File: rosa-troubleshooting-expired-tokens
+      - Name: Troubleshooting IAM roles
+        File: rosa-troubleshooting-iam-resources
+      - Name: Troubleshooting cluster deployments
+        File: rosa-troubleshooting-deployments
+      - Name: Red Hat managed resources
+        File: sd-managed-resources
 ---
 Name: Cluster administration
 Dir: rosa_cluster_admin
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Cluster notifications
-  File: rosa-cluster-notifications
-- Name: Configuring private connections
-  Dir: cloud_infrastructure_access
-  Topics:
+  - Name: Cluster notifications
+    File: rosa-cluster-notifications
   - Name: Configuring private connections
-    File: rosa-configuring-private-connections
-  - Name: Configuring AWS VPC peering
-    File: dedicated-aws-peering
-  - Name: Configuring AWS VPN
-    File: dedicated-aws-vpn
-  - Name: Configuring AWS Direct Connect
-    File: dedicated-aws-dc
-- Name: Cluster autoscaling
-  File: rosa-cluster-autoscaling
-- Name: Manage nodes using machine pools
-  Dir: rosa_nodes
-  Topics:
-  - Name: About machine pools
-    File: rosa-nodes-machinepools-about
-  - Name: Managing compute nodes
-    File: rosa-managing-worker-nodes
-# Local zones not yet implemented in HCP
-    # - Name: Configuring machine pools in Local Zones
-    #   File: rosa-nodes-machinepools-configuring
-  - Name: About autoscaling nodes on a cluster
-    File: rosa-nodes-about-autoscaling-nodes
-  - Name: Configuring cluster memory to meet container memory and risk requirements
-    File: nodes-cluster-resource-configure
-- Name: Configuring PID limits
-  File: rosa-configuring-pid-limits
-- Name: Managing multi-architecture clusters
-  File: rosa-multi-arch-cluster-managing
+    Dir: cloud_infrastructure_access
+    Topics:
+      - Name: Configuring private connections
+        File: rosa-configuring-private-connections
+      - Name: Configuring AWS VPC peering
+        File: dedicated-aws-peering
+      - Name: Configuring AWS VPN
+        File: dedicated-aws-vpn
+      - Name: Configuring AWS Direct Connect
+        File: dedicated-aws-dc
+  - Name: Cluster autoscaling
+    File: rosa-cluster-autoscaling
+  - Name: Manage nodes using machine pools
+    Dir: rosa_nodes
+    Topics:
+      - Name: About machine pools
+        File: rosa-nodes-machinepools-about
+      - Name: Managing compute nodes
+        File: rosa-managing-worker-nodes
+      # Local zones not yet implemented in HCP
+      # - Name: Configuring machine pools in Local Zones
+      #   File: rosa-nodes-machinepools-configuring
+      - Name: About autoscaling nodes on a cluster
+        File: rosa-nodes-about-autoscaling-nodes
+      - Name: Configuring cluster memory to meet container memory and risk requirements
+        File: nodes-cluster-resource-configure
+  - Name: Configuring PID limits
+    File: rosa-configuring-pid-limits
+  - Name: Managing multi-architecture clusters
+    File: rosa-multi-arch-cluster-managing
 ---
 Name: Security and compliance
 Dir: security
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Adding additional constraints for IP-based AWS role assumption
-  File: rosa-adding-additional-constraints-for-ip-based-aws-role-assumption
+  - Name: Adding additional constraints for IP-based AWS role assumption
+    File: rosa-adding-additional-constraints-for-ip-based-aws-role-assumption
 ---
 Name: Authentication and authorization
 Dir: authentication
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Authentication and authorization overview
-  File: index
-- Name: Understanding authentication
-  File: understanding-authentication
-# - Name: Configuring the internal OAuth server
-#   File: configuring-internal-oauth
-# - Name: Configuring OAuth clients
-#   File: configuring-oauth-clients
-- Name: Managing user-owned OAuth access tokens
-  File: managing-oauth-access-tokens
-# - Name: Understanding identity provider configuration
-#   File: understanding-identity-provider
-- Name: Configuring identity providers
-  File: sd-configuring-identity-providers
-# - Name: Configuring identity providers
-#   Dir: identity_providers
-#   Topics:
-#   - Name: Configuring an htpasswd identity provider
-#     File: configuring-htpasswd-identity-provider
-#   - Name: Configuring a Keystone identity provider
-#     File: configuring-keystone-identity-provider
-#   - Name: Configuring an LDAP identity provider
-#     File: configuring-ldap-identity-provider
-#   - Name: Configuring a basic authentication identity provider
-#     File: configuring-basic-authentication-identity-provider
-#   - Name: Configuring a request header identity provider
-#     File: configuring-request-header-identity-provider
-#   - Name: Configuring a GitHub or GitHub Enterprise identity provider
-#     File: configuring-github-identity-provider
-#   - Name: Configuring a GitLab identity provider
-#     File: configuring-gitlab-identity-provider
-#   - Name: Configuring a Google identity provider
-#     File: configuring-google-identity-provider
-#   - Name: Configuring an OpenID Connect identity provider
-#     File: configuring-oidc-identity-provider
-- Name: Using RBAC to define and apply permissions
-  File: using-rbac
-# - Name: Removing the kubeadmin user
-#   File: remove-kubeadmin
-#- Name: Configuring LDAP failover
-#  File: configuring-ldap-failover
-- Name: Understanding and creating service accounts
-  File: understanding-and-creating-service-accounts
-- Name: Using service accounts in applications
-  File: using-service-accounts-in-applications
-- Name: Using a service account as an OAuth client
-  File: using-service-accounts-as-oauth-client
-- Name: Assuming an AWS IAM role for a service account
-  File: assuming-an-aws-iam-role-for-a-service-account
-- Name: Scoping tokens
-  File: tokens-scoping
-- Name: Using bound service account tokens
-  File: bound-service-account-tokens
-- Name: Managing security context constraints
-  File: managing-security-context-constraints
-- Name: Understanding and managing pod security admission
-  File: understanding-and-managing-pod-security-admission
-# - Name: Impersonating the system:admin user
-#   File: impersonating-system-admin
-- Name: Syncing LDAP groups
-  File: ldap-syncing
+  - Name: Authentication and authorization overview
+    File: index
+  - Name: Understanding authentication
+    File: understanding-authentication
+  # - Name: Configuring the internal OAuth server
+  #   File: configuring-internal-oauth
+  # - Name: Configuring OAuth clients
+  #   File: configuring-oauth-clients
+  - Name: Managing user-owned OAuth access tokens
+    File: managing-oauth-access-tokens
+  # - Name: Understanding identity provider configuration
+  #   File: understanding-identity-provider
+  - Name: Configuring identity providers
+    File: sd-configuring-identity-providers
+  # - Name: Configuring identity providers
+  #   Dir: identity_providers
+  #   Topics:
+  #   - Name: Configuring an htpasswd identity provider
+  #     File: configuring-htpasswd-identity-provider
+  #   - Name: Configuring a Keystone identity provider
+  #     File: configuring-keystone-identity-provider
+  #   - Name: Configuring an LDAP identity provider
+  #     File: configuring-ldap-identity-provider
+  #   - Name: Configuring a basic authentication identity provider
+  #     File: configuring-basic-authentication-identity-provider
+  #   - Name: Configuring a request header identity provider
+  #     File: configuring-request-header-identity-provider
+  #   - Name: Configuring a GitHub or GitHub Enterprise identity provider
+  #     File: configuring-github-identity-provider
+  #   - Name: Configuring a GitLab identity provider
+  #     File: configuring-gitlab-identity-provider
+  #   - Name: Configuring a Google identity provider
+  #     File: configuring-google-identity-provider
+  #   - Name: Configuring an OpenID Connect identity provider
+  #     File: configuring-oidc-identity-provider
+  - Name: Using RBAC to define and apply permissions
+    File: using-rbac
+  # - Name: Removing the kubeadmin user
+  #   File: remove-kubeadmin
+  #- Name: Configuring LDAP failover
+  #  File: configuring-ldap-failover
+  - Name: Understanding and creating service accounts
+    File: understanding-and-creating-service-accounts
+  - Name: Using service accounts in applications
+    File: using-service-accounts-in-applications
+  - Name: Using a service account as an OAuth client
+    File: using-service-accounts-as-oauth-client
+  - Name: Assuming an AWS IAM role for a service account
+    File: assuming-an-aws-iam-role-for-a-service-account
+  - Name: Scoping tokens
+    File: tokens-scoping
+  - Name: Using bound service account tokens
+    File: bound-service-account-tokens
+  - Name: Managing security context constraints
+    File: managing-security-context-constraints
+  - Name: Understanding and managing pod security admission
+    File: understanding-and-managing-pod-security-admission
+  # - Name: Impersonating the system:admin user
+  #   File: impersonating-system-admin
+  - Name: Syncing LDAP groups
+    File: ldap-syncing
 # - Name: Managing cloud provider credentials
 #   Dir: managing_cloud_provider_credentials
 #   Topics:
@@ -557,285 +557,285 @@ Name: Upgrading
 Dir: upgrading
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Upgrading ROSA with HCP
-  File: rosa-hcp-upgrading
+  - Name: Upgrading ROSA with HCP
+    File: rosa-hcp-upgrading
 ---
 Name: CI/CD
 Dir: cicd
 Distros: openshift-rosa-hcp
 Topics:
-- Name: CI/CD overview
-  Dir: overview
-  Topics:
-  - Name: About CI/CD
-    File: index
-- Name: Builds using Shipwright
-  Dir: builds_using_shipwright
-  Topics:
-  - Name: Overview of Builds
-    File: overview-openshift-builds
-- Name: Builds using BuildConfig
-  Dir: builds
-  Topics:
-  - Name: Understanding image builds
-    File: understanding-image-builds
-  - Name: Understanding build configurations
-    File: understanding-buildconfigs
-  - Name: Creating build inputs
-    File: creating-build-inputs
-  - Name: Managing build output
-    File: managing-build-output
-  - Name: Using build strategies
-    File: build-strategies
-#  - Name: Custom image builds with Buildah
-#    File: custom-builds-buildah
-  - Name: Performing and configuring basic builds
-    File: basic-build-operations
-  - Name: Triggering and modifying builds
-    File: triggering-builds-build-hooks
-  - Name: Performing advanced builds
-    File: advanced-build-operations
-  - Name: Using Red Hat subscriptions in builds
-    File: running-entitled-builds
-  # Dedicated-admin cannot secure builds by strategy
-  # - Name: Securing builds by strategy
-  #   File: securing-builds-by-strategy
-  # Dedicated-admin cannot edit build configuration resources
-  # - Name: Build configuration resources
-  #   File: build-configuration
-  - Name: Troubleshooting builds
-    File: troubleshooting-builds
-#  - Name: Setting up additional trusted certificate authorities for builds
-#    File: setting-up-trusted-ca
-- Name: Pipelines
-  Dir: pipelines
-  Topics:
-  - Name: About OpenShift Pipelines
-    File: about-pipelines
-- Name: GitOps
-  Dir: gitops
-  Topics:
-  - Name: About OpenShift GitOps
-    File: about-redhat-openshift-gitops
-- Name: Jenkins
-  Dir: jenkins
-  Topics:
-  - Name: Configuring Jenkins images
-    File: images-other-jenkins
-  - Name: Jenkins agent
-    File: images-other-jenkins-agent
-  - Name: Migrating from Jenkins to OpenShift Pipelines
-    File: migrating-from-jenkins-to-openshift-pipelines
-  - Name: Important changes to OpenShift Jenkins images
-    File: important-changes-to-openshift-jenkins-images
+  - Name: CI/CD overview
+    Dir: overview
+    Topics:
+      - Name: About CI/CD
+        File: index
+  - Name: Builds using Shipwright
+    Dir: builds_using_shipwright
+    Topics:
+      - Name: Overview of Builds
+        File: overview-openshift-builds
+  - Name: Builds using BuildConfig
+    Dir: builds
+    Topics:
+      - Name: Understanding image builds
+        File: understanding-image-builds
+      - Name: Understanding build configurations
+        File: understanding-buildconfigs
+      - Name: Creating build inputs
+        File: creating-build-inputs
+      - Name: Managing build output
+        File: managing-build-output
+      - Name: Using build strategies
+        File: build-strategies
+      #  - Name: Custom image builds with Buildah
+      #    File: custom-builds-buildah
+      - Name: Performing and configuring basic builds
+        File: basic-build-operations
+      - Name: Triggering and modifying builds
+        File: triggering-builds-build-hooks
+      - Name: Performing advanced builds
+        File: advanced-build-operations
+      - Name: Using Red Hat subscriptions in builds
+        File: running-entitled-builds
+      # Dedicated-admin cannot secure builds by strategy
+      # - Name: Securing builds by strategy
+      #   File: securing-builds-by-strategy
+      # Dedicated-admin cannot edit build configuration resources
+      # - Name: Build configuration resources
+      #   File: build-configuration
+      - Name: Troubleshooting builds
+        File: troubleshooting-builds
+  #  - Name: Setting up additional trusted certificate authorities for builds
+  #    File: setting-up-trusted-ca
+  - Name: Pipelines
+    Dir: pipelines
+    Topics:
+      - Name: About OpenShift Pipelines
+        File: about-pipelines
+  - Name: GitOps
+    Dir: gitops
+    Topics:
+      - Name: About OpenShift GitOps
+        File: about-redhat-openshift-gitops
+  - Name: Jenkins
+    Dir: jenkins
+    Topics:
+      - Name: Configuring Jenkins images
+        File: images-other-jenkins
+      - Name: Jenkins agent
+        File: images-other-jenkins-agent
+      - Name: Migrating from Jenkins to OpenShift Pipelines
+        File: migrating-from-jenkins-to-openshift-pipelines
+      - Name: Important changes to OpenShift Jenkins images
+        File: important-changes-to-openshift-jenkins-images
 ---
 Name: Storage
 Dir: storage
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Storage overview
-  File: index
-- Name: Understanding ephemeral storage
-  File: understanding-ephemeral-storage
-- Name: Understanding persistent storage
-  File: understanding-persistent-storage
-- Name: Configuring persistent storage
-  Dir: persistent_storage
-  Topics:
-  - Name: Persistent storage using AWS Elastic Block Store
-    File: persistent-storage-aws
-- Name: Using Container Storage Interface (CSI)
-  Dir: container_storage_interface
-  Topics:
-  - Name: Configuring CSI volumes
-    File: persistent-storage-csi
-  - Name: Managing the default storage class
-    File: persistent-storage-csi-sc-manage
-  - Name: AWS Elastic Block Store CSI Driver Operator
-    File: persistent-storage-csi-ebs
-  - Name: AWS Elastic File Service CSI Driver Operator
-    File: persistent-storage-csi-aws-efs
-- Name: Generic ephemeral volumes
-  File: generic-ephemeral-vols
-- Name: Dynamic provisioning
-  File: dynamic-provisioning
+  - Name: Storage overview
+    File: index
+  - Name: Understanding ephemeral storage
+    File: understanding-ephemeral-storage
+  - Name: Understanding persistent storage
+    File: understanding-persistent-storage
+  - Name: Configuring persistent storage
+    Dir: persistent_storage
+    Topics:
+      - Name: Persistent storage using AWS Elastic Block Store
+        File: persistent-storage-aws
+  - Name: Using Container Storage Interface (CSI)
+    Dir: container_storage_interface
+    Topics:
+      - Name: Configuring CSI volumes
+        File: persistent-storage-csi
+      - Name: Managing the default storage class
+        File: persistent-storage-csi-sc-manage
+      - Name: AWS Elastic Block Store CSI Driver Operator
+        File: persistent-storage-csi-ebs
+      - Name: AWS Elastic File Service CSI Driver Operator
+        File: persistent-storage-csi-aws-efs
+  - Name: Generic ephemeral volumes
+    File: generic-ephemeral-vols
+  - Name: Dynamic provisioning
+    File: dynamic-provisioning
 ---
 Name: Registry
 Dir: registry
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Registry overview
-  File: index
-- Name: Image Registry Operator in Red Hat OpenShift Service on AWS
-  File: configuring-registry-operator
-- Name: Accessing the registry
-  File: accessing-the-registry
+  - Name: Registry overview
+    File: index
+  - Name: Image Registry Operator in Red Hat OpenShift Service on AWS
+    File: configuring-registry-operator
+  - Name: Accessing the registry
+    File: accessing-the-registry
 ---
 Name: Operators
 Dir: operators
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Operators overview
-  File: index
-- Name: Understanding Operators
-  Dir: understanding
-  Topics:
-  - Name: What are Operators?
-    File: olm-what-operators-are
-  - Name: Packaging format
-    File: olm-packaging-format
-  - Name: Common terms
-    File: olm-common-terms
-  - Name: Operator Lifecycle Manager (OLM)
-    Dir: olm
+  - Name: Operators overview
+    File: index
+  - Name: Understanding Operators
+    Dir: understanding
     Topics:
-    - Name: Concepts and resources
-      File: olm-understanding-olm
-    - Name: Architecture
-      File: olm-arch
-    - Name: Workflow
-      File: olm-workflow
-    - Name: Dependency resolution
-      File: olm-understanding-dependency-resolution
-    - Name: Operator groups
-      File: olm-understanding-operatorgroups
-    - Name: Multitenancy and Operator colocation
-      File: olm-colocation
-    - Name: Operator conditions
-      File: olm-operatorconditions
-    - Name: Metrics
-      File: olm-understanding-metrics
-    - Name: Webhooks
-      File: olm-webhooks
-  - Name: OperatorHub
-    File: olm-understanding-operatorhub
-  - Name: Red Hat-provided Operator catalogs
-    File: olm-rh-catalogs
-  - Name: Operators in multitenant clusters
-    File: olm-multitenancy
-  - Name: CRDs
-    Dir: crds
+      - Name: What are Operators?
+        File: olm-what-operators-are
+      - Name: Packaging format
+        File: olm-packaging-format
+      - Name: Common terms
+        File: olm-common-terms
+      - Name: Operator Lifecycle Manager (OLM)
+        Dir: olm
+        Topics:
+          - Name: Concepts and resources
+            File: olm-understanding-olm
+          - Name: Architecture
+            File: olm-arch
+          - Name: Workflow
+            File: olm-workflow
+          - Name: Dependency resolution
+            File: olm-understanding-dependency-resolution
+          - Name: Operator groups
+            File: olm-understanding-operatorgroups
+          - Name: Multitenancy and Operator colocation
+            File: olm-colocation
+          - Name: Operator conditions
+            File: olm-operatorconditions
+          - Name: Metrics
+            File: olm-understanding-metrics
+          - Name: Webhooks
+            File: olm-webhooks
+      - Name: OperatorHub
+        File: olm-understanding-operatorhub
+      - Name: Red Hat-provided Operator catalogs
+        File: olm-rh-catalogs
+      - Name: Operators in multitenant clusters
+        File: olm-multitenancy
+      - Name: CRDs
+        Dir: crds
+        Topics:
+          - Name: Managing resources from CRDs
+            File: crd-managing-resources-from-crds
+  - Name: User tasks
+    Dir: user
     Topics:
-    - Name: Managing resources from CRDs
-      File: crd-managing-resources-from-crds
-- Name: User tasks
-  Dir: user
-  Topics:
-  - Name: Creating applications from installed Operators
-    File: olm-creating-apps-from-installed-operators
-- Name: Administrator tasks
-  Dir: admin
-  Topics:
-  - Name: Adding Operators to a cluster
-    File: olm-adding-operators-to-cluster
-  - Name: Updating installed Operators
-    File: olm-upgrading-operators
-  - Name: Deleting Operators from a cluster
-    File: olm-deleting-operators-from-cluster
-  - Name: Configuring proxy support
-    File: olm-configuring-proxy-support
-  - Name: Viewing Operator status
-    File: olm-status
-  - Name: Managing Operator conditions
-    File: olm-managing-operatorconditions
-  - Name: Managing custom catalogs
-    File: olm-managing-custom-catalogs
-  - Name: Catalog source pod scheduling
-    File: olm-cs-podsched
-  - Name: Troubleshooting Operator issues
-    File: olm-troubleshooting-operator-issues
-- Name: Developing Operators
-  Dir: operator_sdk
-  Topics:
-  - Name: About the Operator SDK
-    File: osdk-about
-  - Name: Installing the Operator SDK CLI
-    File: osdk-installing-cli
-  - Name: Go-based Operators
-    Dir: golang
+      - Name: Creating applications from installed Operators
+        File: olm-creating-apps-from-installed-operators
+  - Name: Administrator tasks
+    Dir: admin
     Topics:
-#  Quick start excluded, because it requires cluster-admin permissions.
-#    - Name: Getting started
-#      File: osdk-golang-quickstart
-    - Name: Tutorial
-      File: osdk-golang-tutorial
-    - Name: Project layout
-      File: osdk-golang-project-layout
-    - Name: Updating Go-based projects
-      File: osdk-golang-updating-projects
-  - Name: Ansible-based Operators
-    Dir: ansible
+      - Name: Adding Operators to a cluster
+        File: olm-adding-operators-to-cluster
+      - Name: Updating installed Operators
+        File: olm-upgrading-operators
+      - Name: Deleting Operators from a cluster
+        File: olm-deleting-operators-from-cluster
+      - Name: Configuring proxy support
+        File: olm-configuring-proxy-support
+      - Name: Viewing Operator status
+        File: olm-status
+      - Name: Managing Operator conditions
+        File: olm-managing-operatorconditions
+      - Name: Managing custom catalogs
+        File: olm-managing-custom-catalogs
+      - Name: Catalog source pod scheduling
+        File: olm-cs-podsched
+      - Name: Troubleshooting Operator issues
+        File: olm-troubleshooting-operator-issues
+  - Name: Developing Operators
+    Dir: operator_sdk
     Topics:
-#  Quick start excluded, because it requires cluster-admin permissions.
-#    - Name: Getting started
-#      File: osdk-ansible-quickstart
-    - Name: Tutorial
-      File: osdk-ansible-tutorial
-    - Name: Project layout
-      File: osdk-ansible-project-layout
-    - Name: Updating Ansible-based projects
-      File: osdk-ansible-updating-projects
-    - Name: Ansible support
-      File: osdk-ansible-support
-    - Name: Kubernetes Collection for Ansible
-      File: osdk-ansible-k8s-collection
-    - Name: Using Ansible inside an Operator
-      File: osdk-ansible-inside-operator
-    - Name: Custom resource status management
-      File: osdk-ansible-cr-status
-  - Name: Helm-based Operators
-    Dir: helm
-    Topics:
-#  Quick start excluded, because it requires cluster-admin permissions.
-#    - Name: Getting started
-#      File: osdk-helm-quickstart
-    - Name: Tutorial
-      File: osdk-helm-tutorial
-    - Name: Project layout
-      File: osdk-helm-project-layout
-    - Name: Updating Helm-based projects
-      File: osdk-helm-updating-projects
-    - Name: Helm support
-      File: osdk-helm-support
-#  - Name: Hybrid Helm Operator  <= Tech Preview
-#    File: osdk-hybrid-helm
-#  - Name: Updating Hybrid Helm-based projects  (Technology Preview)
-#    File: osdk-hybrid-helm-updating-projects
-# - Name: Java-based Operators  <= Tech Preview
-#   Dir: java
-#   Topics:
-#   - Name: Getting started
-#     File: osdk-java-quickstart
-#   - Name: Tutorial
-#     File: osdk-java-tutorial
-#   - Name: Project layout
-#     File: osdk-java-project-layout
-#   - Name: Updating Java-based projects
-#     File: osdk-java-updating-projects
-  - Name: Defining cluster service versions (CSVs)
-    File: osdk-generating-csvs
-  - Name: Working with bundle images
-    File: osdk-working-bundle-images
-  - Name: Complying with pod security admission
-    File: osdk-complying-with-psa
-  - Name: Validating Operators using the scorecard
-    File: osdk-scorecard
-  - Name: Validating Operator bundles
-    File: osdk-bundle-validate
-  - Name: High-availability or single-node cluster detection and support
-    File: osdk-ha-sno
-  - Name: Configuring built-in monitoring with Prometheus
-    File: osdk-monitoring-prometheus
-  - Name: Configuring leader election
-    File: osdk-leader-election
-  - Name: Object pruning utility
-    File: osdk-pruning-utility
-  - Name: Migrating package manifest projects to bundle format
-    File: osdk-pkgman-to-bundle
-  - Name: Operator SDK CLI reference
-    File: osdk-cli-ref
-  - Name: Migrating to Operator SDK v0.1.0
-    File: osdk-migrating-to-v0-1-0
+      - Name: About the Operator SDK
+        File: osdk-about
+      - Name: Installing the Operator SDK CLI
+        File: osdk-installing-cli
+      - Name: Go-based Operators
+        Dir: golang
+        Topics:
+          #  Quick start excluded, because it requires cluster-admin permissions.
+          #    - Name: Getting started
+          #      File: osdk-golang-quickstart
+          - Name: Tutorial
+            File: osdk-golang-tutorial
+          - Name: Project layout
+            File: osdk-golang-project-layout
+          - Name: Updating Go-based projects
+            File: osdk-golang-updating-projects
+      - Name: Ansible-based Operators
+        Dir: ansible
+        Topics:
+          #  Quick start excluded, because it requires cluster-admin permissions.
+          #    - Name: Getting started
+          #      File: osdk-ansible-quickstart
+          - Name: Tutorial
+            File: osdk-ansible-tutorial
+          - Name: Project layout
+            File: osdk-ansible-project-layout
+          - Name: Updating Ansible-based projects
+            File: osdk-ansible-updating-projects
+          - Name: Ansible support
+            File: osdk-ansible-support
+          - Name: Kubernetes Collection for Ansible
+            File: osdk-ansible-k8s-collection
+          - Name: Using Ansible inside an Operator
+            File: osdk-ansible-inside-operator
+          - Name: Custom resource status management
+            File: osdk-ansible-cr-status
+      - Name: Helm-based Operators
+        Dir: helm
+        Topics:
+          #  Quick start excluded, because it requires cluster-admin permissions.
+          #    - Name: Getting started
+          #      File: osdk-helm-quickstart
+          - Name: Tutorial
+            File: osdk-helm-tutorial
+          - Name: Project layout
+            File: osdk-helm-project-layout
+          - Name: Updating Helm-based projects
+            File: osdk-helm-updating-projects
+          - Name: Helm support
+            File: osdk-helm-support
+      #  - Name: Hybrid Helm Operator  <= Tech Preview
+      #    File: osdk-hybrid-helm
+      #  - Name: Updating Hybrid Helm-based projects  (Technology Preview)
+      #    File: osdk-hybrid-helm-updating-projects
+      # - Name: Java-based Operators  <= Tech Preview
+      #   Dir: java
+      #   Topics:
+      #   - Name: Getting started
+      #     File: osdk-java-quickstart
+      #   - Name: Tutorial
+      #     File: osdk-java-tutorial
+      #   - Name: Project layout
+      #     File: osdk-java-project-layout
+      #   - Name: Updating Java-based projects
+      #     File: osdk-java-updating-projects
+      - Name: Defining cluster service versions (CSVs)
+        File: osdk-generating-csvs
+      - Name: Working with bundle images
+        File: osdk-working-bundle-images
+      - Name: Complying with pod security admission
+        File: osdk-complying-with-psa
+      - Name: Validating Operators using the scorecard
+        File: osdk-scorecard
+      - Name: Validating Operator bundles
+        File: osdk-bundle-validate
+      - Name: High-availability or single-node cluster detection and support
+        File: osdk-ha-sno
+      - Name: Configuring built-in monitoring with Prometheus
+        File: osdk-monitoring-prometheus
+      - Name: Configuring leader election
+        File: osdk-leader-election
+      - Name: Object pruning utility
+        File: osdk-pruning-utility
+      - Name: Migrating package manifest projects to bundle format
+        File: osdk-pkgman-to-bundle
+      - Name: Operator SDK CLI reference
+        File: osdk-cli-ref
+      - Name: Migrating to Operator SDK v0.1.0
+        File: osdk-migrating-to-v0-1-0
 #  ROSA customers can't configure/edit the cluster Operators
 #  - Name: Cluster Operators reference
 #    File: operator-reference
@@ -844,150 +844,150 @@ Name: Building applications
 Dir: applications
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Building applications overview
-  File: index
-- Name: Projects
-  Dir: projects
-  Topics:
-  - Name: Working with projects
-    File: working-with-projects
-#  cannot impersonate resource "users" in API group
-#  - Name: Creating a project as another user
-#    File: creating-project-other-user
-  - Name: Configuring project creation
-    File: configuring-project-creation
-- Name: Creating applications
-  Dir: creating_applications
-  Topics:
-  - Name: Creating applications using the Developer perspective
-    File: odc-creating-applications-using-developer-perspective
-  - Name: Creating applications from installed Operators
-    File: creating-apps-from-installed-operators
-  - Name: Creating applications using the CLI
-    File: creating-applications-using-cli
-- Name: Viewing application composition using the Topology view
-  File: odc-viewing-application-composition-using-topology-view
-# cannot create required namespace
-# - Name: Exporting applications
-#  File: odc-exporting-applications
-- Name: Working with Helm charts
-  Dir: working_with_helm_charts
-  Topics:
-  - Name: Understanding Helm
-    File: understanding-helm
-  - Name: Installing Helm
-    File: installing-helm
-  - Name: Configuring custom Helm chart repositories
-    File: configuring-custom-helm-chart-repositories
-  - Name: Working with Helm releases
-    File: odc-working-with-helm-releases
-- Name: Deployments
-  Dir: deployments
-  Topics:
-  - Name: Custom domains for applications
-    File: rosa-config-custom-domains-applications
-  - Name: Understanding Deployments and DeploymentConfigs
-    File: what-deployments-are
-  - Name: Managing deployment processes
-    File: managing-deployment-processes
-  - Name: Using deployment strategies
-    File: deployment-strategies
-  - Name: Using route-based deployment strategies
-    File: route-based-deployment-strategies
-- Name: Quotas
-  Dir: quotas
-  Topics:
-  - Name: Resource quotas per project
-    File: quotas-setting-per-project
-  - Name: Resource quotas across multiple projects
-    File: quotas-setting-across-multiple-projects
-- Name: Using config maps with applications
-  File: config-maps
-- Name: Monitoring project and application metrics using the Developer perspective
-  File: odc-monitoring-project-and-application-metrics-using-developer-perspective
-- Name: Monitoring application health
-  File: application-health
-- Name: Editing applications
-  File: odc-editing-applications
-- Name: Working with quotas
-  File: working-with-quotas
-- Name: Pruning objects to reclaim resources
-  File: pruning-objects
-- Name: Idling applications
-  File: idling-applications
-- Name: Deleting applications
-  File: odc-deleting-applications
-- Name: Using the Red Hat Marketplace
-  File: red-hat-marketplace
+  - Name: Building applications overview
+    File: index
+  - Name: Projects
+    Dir: projects
+    Topics:
+      - Name: Working with projects
+        File: working-with-projects
+      #  cannot impersonate resource "users" in API group
+      #  - Name: Creating a project as another user
+      #    File: creating-project-other-user
+      - Name: Configuring project creation
+        File: configuring-project-creation
+  - Name: Creating applications
+    Dir: creating_applications
+    Topics:
+      - Name: Creating applications using the Developer perspective
+        File: odc-creating-applications-using-developer-perspective
+      - Name: Creating applications from installed Operators
+        File: creating-apps-from-installed-operators
+      - Name: Creating applications using the CLI
+        File: creating-applications-using-cli
+  - Name: Viewing application composition using the Topology view
+    File: odc-viewing-application-composition-using-topology-view
+  # cannot create required namespace
+  # - Name: Exporting applications
+  #  File: odc-exporting-applications
+  - Name: Working with Helm charts
+    Dir: working_with_helm_charts
+    Topics:
+      - Name: Understanding Helm
+        File: understanding-helm
+      - Name: Installing Helm
+        File: installing-helm
+      - Name: Configuring custom Helm chart repositories
+        File: configuring-custom-helm-chart-repositories
+      - Name: Working with Helm releases
+        File: odc-working-with-helm-releases
+  - Name: Deployments
+    Dir: deployments
+    Topics:
+      - Name: Custom domains for applications
+        File: rosa-config-custom-domains-applications
+      - Name: Understanding Deployments and DeploymentConfigs
+        File: what-deployments-are
+      - Name: Managing deployment processes
+        File: managing-deployment-processes
+      - Name: Using deployment strategies
+        File: deployment-strategies
+      - Name: Using route-based deployment strategies
+        File: route-based-deployment-strategies
+  - Name: Quotas
+    Dir: quotas
+    Topics:
+      - Name: Resource quotas per project
+        File: quotas-setting-per-project
+      - Name: Resource quotas across multiple projects
+        File: quotas-setting-across-multiple-projects
+  - Name: Using config maps with applications
+    File: config-maps
+  - Name: Monitoring project and application metrics using the Developer perspective
+    File: odc-monitoring-project-and-application-metrics-using-developer-perspective
+  - Name: Monitoring application health
+    File: application-health
+  - Name: Editing applications
+    File: odc-editing-applications
+  - Name: Working with quotas
+    File: working-with-quotas
+  - Name: Pruning objects to reclaim resources
+    File: pruning-objects
+  - Name: Idling applications
+    File: idling-applications
+  - Name: Deleting applications
+    File: odc-deleting-applications
+  - Name: Using the Red Hat Marketplace
+    File: red-hat-marketplace
 ---
 Name: Backup and restore
 Dir: backup_and_restore
 Distros: openshift-rosa-hcp
 Topics:
-- Name: OADP Application backup and restore
-  Dir: application_backup_and_restore
-  Topics:
-  - Name: Introduction to OpenShift API for Data Protection
-    File: oadp-intro
-  - Name: OADP release notes
-    Dir: release-notes
+  - Name: OADP Application backup and restore
+    Dir: application_backup_and_restore
     Topics:
-    - Name: OADP 1.4 release notes
-      File: oadp-1-4-release-notes
-  - Name: OADP performance
-    Dir: oadp-performance
-    Topics:
-    - Name: OADP recommended network settings
-      File: oadp-recommended-network-settings
-  - Name: OADP features and plugins
-    File: oadp-features-plugins
-  - Name: OADP use cases
-    Dir: oadp-use-cases
-    Topics:
-    - Name: Backing up an application using OADP with ROSA STS
-      File: oadp-rosa-backup-restore
-    - Name: Backing up an application using OADP and ODF
-      File: oadp-usecase-backup-using-odf
-    - Name: Restoring a backup to a different namespace
-      File: oadp-usecase-restore-different-namespace
-    - Name: Including a self-signed CA certificate during backup
-      File: oadp-usecase-enable-ca-cert
-  - Name: Installing and configuring OADP
-    Dir: oadp-rosa
-    Topics:
-    - Name: Installing OADP
-      File: oadp-rosa-backing-up-applications
-# TODO: Include this when the Operators book is added to ROSA HCP
-#  - Name: Uninstalling OADP
-#    Dir: installing
-#    Topics:
-#    - Name: Uninstalling OADP
-#      File: uninstalling-oadp
-  - Name: OADP backing up
-    Dir: backing_up_and_restoring
-    Topics:
-    - Name: Backing up applications
-      File: backing-up-applications
-    - Name: Creating a Backup CR
-      File: oadp-creating-backup-cr
-# ROSA docs do not include CSI snapshots
-#    - Name: Backing up persistent volumes with CSI snapshots
-#      File: oadp-backing-up-pvs-csi-doc
-#    - Name: Backing up applications with File System Backup
-#      File: oadp-backing-up-applications-restic-doc
-    - Name: Creating backup hooks
-      File: oadp-creating-backup-hooks-doc
-    - Name: Scheduling backups using Schedule CR
-      File: oadp-scheduling-backups-doc
-    - Name: Deleting backups
-      File: oadp-deleting-backups
-#    - Name: About Kopia
-#      File: oadp-about-kopia
-  - Name: OADP restoring
-    Dir: backing_up_and_restoring
-    Topics:
-    - Name: Restoring applications
-      File: restoring-applications
+      - Name: Introduction to OpenShift API for Data Protection
+        File: oadp-intro
+      - Name: OADP release notes
+        Dir: release-notes
+        Topics:
+          - Name: OADP 1.4 release notes
+            File: oadp-1-4-release-notes
+      - Name: OADP performance
+        Dir: oadp-performance
+        Topics:
+          - Name: OADP recommended network settings
+            File: oadp-recommended-network-settings
+      - Name: OADP features and plugins
+        File: oadp-features-plugins
+      - Name: OADP use cases
+        Dir: oadp-use-cases
+        Topics:
+          - Name: Backing up an application using OADP with ROSA STS
+            File: oadp-rosa-backup-restore
+          - Name: Backing up an application using OADP and ODF
+            File: oadp-usecase-backup-using-odf
+          - Name: Restoring a backup to a different namespace
+            File: oadp-usecase-restore-different-namespace
+          - Name: Including a self-signed CA certificate during backup
+            File: oadp-usecase-enable-ca-cert
+      - Name: Installing and configuring OADP
+        Dir: oadp-rosa
+        Topics:
+          - Name: Installing OADP
+            File: oadp-rosa-backing-up-applications
+      # TODO: Include this when the Operators book is added to ROSA HCP
+      #  - Name: Uninstalling OADP
+      #    Dir: installing
+      #    Topics:
+      #    - Name: Uninstalling OADP
+      #      File: uninstalling-oadp
+      - Name: OADP backing up
+        Dir: backing_up_and_restoring
+        Topics:
+          - Name: Backing up applications
+            File: backing-up-applications
+          - Name: Creating a Backup CR
+            File: oadp-creating-backup-cr
+          # ROSA docs do not include CSI snapshots
+          #    - Name: Backing up persistent volumes with CSI snapshots
+          #      File: oadp-backing-up-pvs-csi-doc
+          #    - Name: Backing up applications with File System Backup
+          #      File: oadp-backing-up-applications-restic-doc
+          - Name: Creating backup hooks
+            File: oadp-creating-backup-hooks-doc
+          - Name: Scheduling backups using Schedule CR
+            File: oadp-scheduling-backups-doc
+          - Name: Deleting backups
+            File: oadp-deleting-backups
+      #    - Name: About Kopia
+      #      File: oadp-about-kopia
+      - Name: OADP restoring
+        Dir: backing_up_and_restoring
+        Topics:
+          - Name: Restoring applications
+            File: restoring-applications
 #  - Name: OADP and ROSA
 #    Dir: oadp-rosa
 #    Topics:
@@ -1018,199 +1018,199 @@ Name: Nodes
 Dir: nodes
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Overview of nodes
-  File: index
-- Name: Working with pods
-  Dir: pods
-  Topics:
-  - Name: About pods
-    File: nodes-pods-using
-  - Name: Viewing pods
-    File: nodes-pods-viewing
-  - Name: Configuring a cluster for pods
-    File: nodes-pods-configuring
-# Cannot create namespace to install VPA; revisit after Operator book converted
-# - Name: Automatically adjust pod resource levels with the vertical pod autoscaler
-#   File: nodes-pods-vertical-autoscaler
-  - Name: Providing sensitive data to pods
-    File: nodes-pods-secrets
-  - Name: Creating and using config maps
-    File: nodes-pods-configmaps
-# Cannot create required kubeletconfigs
-# - Name: Using Device Manager to make devices available to nodes
-#   File: nodes-pods-plugins
-  - Name: Including pod priority in pod scheduling decisions
-    File: nodes-pods-priority
-  - Name: Placing pods on specific nodes using node selectors
-    File: nodes-pods-node-selectors
-# Cannot create namespace to install Run Once; revisit after Operator book converted
-# - Name: Run Once Duration Override Operator
-#   Dir: run_once_duration_override
-#   Topics:
-#   - Name: Run Once Duration Override Operator overview
-#     File: index
-#   - Name: Run Once Duration Override Operator release notes
-#     File: run-once-duration-override-release-notes
-#   - Name: Overriding the active deadline for run-once pods
-#     File: run-once-duration-override-install
-#   - Name: Uninstalling the Run Once Duration Override Operator
-#     File: run-once-duration-override-uninstall
-- Name: Automatically scaling pods with the Custom Metrics Autoscaler Operator
-  Dir: cma
-  Topics:
-  - Name: Release notes
-    Dir: nodes-cma-rn
+  - Name: Overview of nodes
+    File: index
+  - Name: Working with pods
+    Dir: pods
     Topics:
-    - Name: Custom Metrics Autoscaler Operator release notes
-      File: nodes-cma-autoscaling-custom-rn
-    - Name: Past releases
-      File: nodes-cma-autoscaling-custom-rn-past
-  - Name: Custom Metrics Autoscaler Operator overview
-    File: nodes-cma-autoscaling-custom
-  - Name: Installing the custom metrics autoscaler
-    File: nodes-cma-autoscaling-custom-install
-  - Name: Understanding the custom metrics autoscaler triggers
-    File: nodes-cma-autoscaling-custom-trigger
-  - Name: Understanding the custom metrics autoscaler trigger authentications
-    File: nodes-cma-autoscaling-custom-trigger-auth
-  - Name: Pausing the custom metrics autoscaler
-    File: nodes-cma-autoscaling-custom-pausing
-  - Name: Gathering audit logs
-    File: nodes-cma-autoscaling-custom-audit-log
-  - Name: Gathering debugging data
-    File: nodes-cma-autoscaling-custom-debugging
-  - Name: Viewing Operator metrics
-    File: nodes-cma-autoscaling-custom-metrics
-  - Name: Understanding how to add custom metrics autoscalers
-    File: nodes-cma-autoscaling-custom-adding
-  - Name: Removing the Custom Metrics Autoscaler Operator
-    File: nodes-cma-autoscaling-custom-removing
-- Name: Controlling pod placement onto nodes (scheduling)
-  Dir: scheduling
-  Topics:
-  - Name: About pod placement using the scheduler
-    File: nodes-scheduler-about
-  - Name: Placing pods relative to other pods using pod affinity and anti-affinity rules
-    File: nodes-scheduler-pod-affinity
-  - Name: Controlling pod placement on nodes using node affinity rules
-    File: nodes-scheduler-node-affinity
-  - Name: Placing pods onto overcommited nodes
-    File: nodes-scheduler-overcommit
-# Per OSDOCS-9791, ROSA customers cannot add taints to individual nodes.
-#  - Name: Controlling pod placement using node taints
-#    File: nodes-scheduler-taints-tolerations
-  - Name: Placing pods on specific nodes using node selectors
-    File: nodes-scheduler-node-selectors
-  - Name: Controlling pod placement using pod topology spread constraints
-    File: nodes-scheduler-pod-topology-spread-constraints
-# - Name: Placing a pod on a specific node by name
-#   File: nodes-scheduler-node-names
-# - Name: Placing a pod in a specific project
-#   File: nodes-scheduler-node-projects
-# - Name: Keeping your cluster balanced using the descheduler
-#   File: nodes-scheduler-descheduler
-# Cannot create namespace to install Desceduler Operator; revisit after Operator book converted
-#  - Name: Evicting pods using the descheduler
-#   File: nodes-descheduler
-# Cannot create namespace to install Secondary Scheduler Operator; revisit after Operator book converted
-# - Name: Secondary scheduler
-#   Dir: secondary_scheduler
-#   Distros: openshift-enterprise
-#   Topics:
-#   - Name: Secondary scheduler overview
-#     File: index
-#   - Name: Secondary Scheduler Operator release notes
-#     File: nodes-secondary-scheduler-release-notes
-#   - Name: Scheduling pods using a secondary scheduler
-#     File: nodes-secondary-scheduler-configuring
-#   - Name: Uninstalling the Secondary Scheduler Operator
-#     File: nodes-secondary-scheduler-uninstalling
-- Name: Using jobs and daemon sets
-  Dir: jobs
-  Topics:
-  - Name: Running background tasks on nodes automatically with daemon sets
-    File: nodes-pods-daemonsets
-  - Name: Running tasks in pods using jobs
-    File: nodes-nodes-jobs
-- Name: Working with nodes
-  Dir: nodes
-  Topics:
-  - Name: Viewing and listing the nodes in your cluster
-    File: nodes-nodes-viewing
+      - Name: About pods
+        File: nodes-pods-using
+      - Name: Viewing pods
+        File: nodes-pods-viewing
+      - Name: Configuring a cluster for pods
+        File: nodes-pods-configuring
+      # Cannot create namespace to install VPA; revisit after Operator book converted
+      # - Name: Automatically adjust pod resource levels with the vertical pod autoscaler
+      #   File: nodes-pods-vertical-autoscaler
+      - Name: Providing sensitive data to pods
+        File: nodes-pods-secrets
+      - Name: Creating and using config maps
+        File: nodes-pods-configmaps
+      # Cannot create required kubeletconfigs
+      # - Name: Using Device Manager to make devices available to nodes
+      #   File: nodes-pods-plugins
+      - Name: Including pod priority in pod scheduling decisions
+        File: nodes-pods-priority
+      - Name: Placing pods on specific nodes using node selectors
+        File: nodes-pods-node-selectors
+  # Cannot create namespace to install Run Once; revisit after Operator book converted
+  # - Name: Run Once Duration Override Operator
+  #   Dir: run_once_duration_override
+  #   Topics:
+  #   - Name: Run Once Duration Override Operator overview
+  #     File: index
+  #   - Name: Run Once Duration Override Operator release notes
+  #     File: run-once-duration-override-release-notes
+  #   - Name: Overriding the active deadline for run-once pods
+  #     File: run-once-duration-override-install
+  #   - Name: Uninstalling the Run Once Duration Override Operator
+  #     File: run-once-duration-override-uninstall
+  - Name: Automatically scaling pods with the Custom Metrics Autoscaler Operator
+    Dir: cma
+    Topics:
+      - Name: Release notes
+        Dir: nodes-cma-rn
+        Topics:
+          - Name: Custom Metrics Autoscaler Operator release notes
+            File: nodes-cma-autoscaling-custom-rn
+          - Name: Past releases
+            File: nodes-cma-autoscaling-custom-rn-past
+      - Name: Custom Metrics Autoscaler Operator overview
+        File: nodes-cma-autoscaling-custom
+      - Name: Installing the custom metrics autoscaler
+        File: nodes-cma-autoscaling-custom-install
+      - Name: Understanding the custom metrics autoscaler triggers
+        File: nodes-cma-autoscaling-custom-trigger
+      - Name: Understanding the custom metrics autoscaler trigger authentications
+        File: nodes-cma-autoscaling-custom-trigger-auth
+      - Name: Pausing the custom metrics autoscaler
+        File: nodes-cma-autoscaling-custom-pausing
+      - Name: Gathering audit logs
+        File: nodes-cma-autoscaling-custom-audit-log
+      - Name: Gathering debugging data
+        File: nodes-cma-autoscaling-custom-debugging
+      - Name: Viewing Operator metrics
+        File: nodes-cma-autoscaling-custom-metrics
+      - Name: Understanding how to add custom metrics autoscalers
+        File: nodes-cma-autoscaling-custom-adding
+      - Name: Removing the Custom Metrics Autoscaler Operator
+        File: nodes-cma-autoscaling-custom-removing
+  - Name: Controlling pod placement onto nodes (scheduling)
+    Dir: scheduling
+    Topics:
+      - Name: About pod placement using the scheduler
+        File: nodes-scheduler-about
+      - Name: Placing pods relative to other pods using pod affinity and anti-affinity rules
+        File: nodes-scheduler-pod-affinity
+      - Name: Controlling pod placement on nodes using node affinity rules
+        File: nodes-scheduler-node-affinity
+      - Name: Placing pods onto overcommited nodes
+        File: nodes-scheduler-overcommit
+      # Per OSDOCS-9791, ROSA customers cannot add taints to individual nodes.
+      #  - Name: Controlling pod placement using node taints
+      #    File: nodes-scheduler-taints-tolerations
+      - Name: Placing pods on specific nodes using node selectors
+        File: nodes-scheduler-node-selectors
+      - Name: Controlling pod placement using pod topology spread constraints
+        File: nodes-scheduler-pod-topology-spread-constraints
+  # - Name: Placing a pod on a specific node by name
+  #   File: nodes-scheduler-node-names
+  # - Name: Placing a pod in a specific project
+  #   File: nodes-scheduler-node-projects
+  # - Name: Keeping your cluster balanced using the descheduler
+  #   File: nodes-scheduler-descheduler
+  # Cannot create namespace to install Desceduler Operator; revisit after Operator book converted
+  #  - Name: Evicting pods using the descheduler
+  #   File: nodes-descheduler
+  # Cannot create namespace to install Secondary Scheduler Operator; revisit after Operator book converted
+  # - Name: Secondary scheduler
+  #   Dir: secondary_scheduler
+  #   Distros: openshift-enterprise
+  #   Topics:
+  #   - Name: Secondary scheduler overview
+  #     File: index
+  #   - Name: Secondary Scheduler Operator release notes
+  #     File: nodes-secondary-scheduler-release-notes
+  #   - Name: Scheduling pods using a secondary scheduler
+  #     File: nodes-secondary-scheduler-configuring
+  #   - Name: Uninstalling the Secondary Scheduler Operator
+  #     File: nodes-secondary-scheduler-uninstalling
+  - Name: Using jobs and daemon sets
+    Dir: jobs
+    Topics:
+      - Name: Running background tasks on nodes automatically with daemon sets
+        File: nodes-pods-daemonsets
+      - Name: Running tasks in pods using jobs
+        File: nodes-nodes-jobs
   - Name: Working with nodes
-    File: nodes-nodes-working
-# cannot use oc adm cordon; cannot patch resource "machinesets"; cannot patch resource "nodes"
-#  - Name: Working with nodes
-#    File: nodes-nodes-working
-# cannot create resource "kubeletconfigs", "schedulers", "machineconfigs", "kubeletconfigs"
-#  - Name: Managing nodes
-#    File: nodes-nodes-managing
-# cannot create resource "kubeletconfigs"
-#  - Name: Managing graceful node shutdown
-#    File: nodes-nodes-graceful-shutdown
-# cannot create resource "kubeletconfigs"
-#  - Name: Managing the maximum number of pods per node
-#    File: nodes-nodes-managing-max-pods
-  - Name: Using the Node Tuning Operator
-    File: nodes-node-tuning-operator
-#  - Name: Remediating, fencing, and maintaining nodes
-#    File: nodes-remediating-fencing-maintaining-rhwa
-# Cannot create namespace needed to oc debug and reboot; revisit after Operator book converted
-#  - Name: Understanding node rebooting
-#    File: nodes-nodes-rebooting
-# cannot create resource "kubeletconfigs"
-#  - Name: Freeing node resources using garbage collection
-#    File: nodes-nodes-garbage-collection
-# cannot create resource "kubeletconfigs"
-#  - Name: Allocating resources for nodes
-#    File: nodes-nodes-resources-configuring
-# cannot create resource "kubeletconfigs"
-#  - Name: Allocating specific CPUs for nodes in a cluster
-#    File: nodes-nodes-resources-cpus
-# cannot create resource "kubeletconfigs"
-#  - Name: Configuring the TLS security profile for the kubelet
-#    File: nodes-nodes-tls
-#    Distros: openshift-rosa
-#  - Name: Monitoring for problems in your nodes
-#    File: nodes-nodes-problem-detector
-# cannot patch resource "nodes"
-#  - Name: Creating infrastructure nodes
-#    File: nodes-nodes-creating-infrastructure-nodes
-- Name: Working with containers
-  Dir: containers
-  Topics:
-  - Name: Understanding containers
-    File: nodes-containers-using
-  - Name: Using Init Containers to perform tasks before a pod is deployed
-    File: nodes-containers-init
-  - Name: Using volumes to persist container data
-    File: nodes-containers-volumes
-  - Name: Mapping volumes using projected volumes
-    File: nodes-containers-projected-volumes
-  - Name: Allowing containers to consume API objects
-    File: nodes-containers-downward-api
-  - Name: Copying files to or from a container
-    File: nodes-containers-copying-files
-  - Name: Executing remote commands in a container
-    File: nodes-containers-remote-commands
-  - Name: Using port forwarding to access applications in a container
-    File: nodes-containers-port-forwarding
-# cannot patch resource "configmaps"
-#  - Name: Using sysctls in containers
-#    File: nodes-containers-sysctls
-- Name: Working with clusters
-  Dir: clusters
-  Topics:
-  - Name: Viewing system event information in a cluster
-    File: nodes-containers-events
-  - Name: Analyzing cluster resource levels
-    File: nodes-cluster-resource-levels
-  - Name: Setting limit ranges
-    File: nodes-cluster-limit-ranges
-  - Name: Configuring cluster memory to meet container memory and risk requirements
-    File: nodes-cluster-resource-configure
-  - Name: Configuring your cluster to place pods on overcommited nodes
-    File: nodes-cluster-overcommit
+    Dir: nodes
+    Topics:
+      - Name: Viewing and listing the nodes in your cluster
+        File: nodes-nodes-viewing
+      - Name: Working with nodes
+        File: nodes-nodes-working
+      # cannot use oc adm cordon; cannot patch resource "machinesets"; cannot patch resource "nodes"
+      #  - Name: Working with nodes
+      #    File: nodes-nodes-working
+      # cannot create resource "kubeletconfigs", "schedulers", "machineconfigs", "kubeletconfigs"
+      #  - Name: Managing nodes
+      #    File: nodes-nodes-managing
+      # cannot create resource "kubeletconfigs"
+      #  - Name: Managing graceful node shutdown
+      #    File: nodes-nodes-graceful-shutdown
+      # cannot create resource "kubeletconfigs"
+      #  - Name: Managing the maximum number of pods per node
+      #    File: nodes-nodes-managing-max-pods
+      - Name: Using the Node Tuning Operator
+        File: nodes-node-tuning-operator
+  #  - Name: Remediating, fencing, and maintaining nodes
+  #    File: nodes-remediating-fencing-maintaining-rhwa
+  # Cannot create namespace needed to oc debug and reboot; revisit after Operator book converted
+  #  - Name: Understanding node rebooting
+  #    File: nodes-nodes-rebooting
+  # cannot create resource "kubeletconfigs"
+  #  - Name: Freeing node resources using garbage collection
+  #    File: nodes-nodes-garbage-collection
+  # cannot create resource "kubeletconfigs"
+  #  - Name: Allocating resources for nodes
+  #    File: nodes-nodes-resources-configuring
+  # cannot create resource "kubeletconfigs"
+  #  - Name: Allocating specific CPUs for nodes in a cluster
+  #    File: nodes-nodes-resources-cpus
+  # cannot create resource "kubeletconfigs"
+  #  - Name: Configuring the TLS security profile for the kubelet
+  #    File: nodes-nodes-tls
+  #    Distros: openshift-rosa
+  #  - Name: Monitoring for problems in your nodes
+  #    File: nodes-nodes-problem-detector
+  # cannot patch resource "nodes"
+  #  - Name: Creating infrastructure nodes
+  #    File: nodes-nodes-creating-infrastructure-nodes
+  - Name: Working with containers
+    Dir: containers
+    Topics:
+      - Name: Understanding containers
+        File: nodes-containers-using
+      - Name: Using Init Containers to perform tasks before a pod is deployed
+        File: nodes-containers-init
+      - Name: Using volumes to persist container data
+        File: nodes-containers-volumes
+      - Name: Mapping volumes using projected volumes
+        File: nodes-containers-projected-volumes
+      - Name: Allowing containers to consume API objects
+        File: nodes-containers-downward-api
+      - Name: Copying files to or from a container
+        File: nodes-containers-copying-files
+      - Name: Executing remote commands in a container
+        File: nodes-containers-remote-commands
+      - Name: Using port forwarding to access applications in a container
+        File: nodes-containers-port-forwarding
+  # cannot patch resource "configmaps"
+  #  - Name: Using sysctls in containers
+  #    File: nodes-containers-sysctls
+  - Name: Working with clusters
+    Dir: clusters
+    Topics:
+      - Name: Viewing system event information in a cluster
+        File: nodes-containers-events
+      - Name: Analyzing cluster resource levels
+        File: nodes-cluster-resource-levels
+      - Name: Setting limit ranges
+        File: nodes-cluster-limit-ranges
+      - Name: Configuring cluster memory to meet container memory and risk requirements
+        File: nodes-cluster-resource-configure
+      - Name: Configuring your cluster to place pods on overcommited nodes
+        File: nodes-cluster-overcommit
 #  - Name: Configuring the Linux cgroup version on your nodes
 #    File: nodes-cluster-cgroups-2
 #  - Name: Configuring the Linux cgroup version on your nodes
@@ -1240,440 +1240,544 @@ Name: Observability
 Dir: observability
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Observability overview
-  Dir: overview
-  Topics:
-  - Name: About Observability
-    File: index
-- Name: Monitoring
-  Dir: monitoring
-  Distros: openshift-rosa-hcp
-  Topics:
-  - Name: Monitoring overview
-    File: monitoring-overview
-  - Name: Accessing monitoring for user-defined projects
-    File: sd-accessing-monitoring-for-user-defined-projects
-  - Name: Configuring the monitoring stack
-    File: configuring-the-monitoring-stack
-  - Name: Disabling monitoring for user-defined projects
-    File: sd-disabling-monitoring-for-user-defined-projects
-  - Name: Enabling alert routing for user-defined projects
-    File: enabling-alert-routing-for-user-defined-projects
-  - Name: Managing metrics
-    File: managing-metrics
-  - Name: Managing alerts
-    File: managing-alerts
-  - Name: Reviewing monitoring dashboards
-    File: reviewing-monitoring-dashboards
-  - Name: Accessing third-party monitoring APIs
-    File: accessing-third-party-monitoring-apis
-  - Name: Troubleshooting monitoring issues
-    File: troubleshooting-monitoring-issues
-  - Name: Config map reference for the Cluster Monitoring Operator
-    File: config-map-reference-for-the-cluster-monitoring-operator
-- Name: Logging
-  Dir: logging
-  Distros: openshift-rosa-hcp
-  Topics:
-  - Name: Release notes
-    Dir: logging_release_notes
+  - Name: Observability overview
+    Dir: overview
     Topics:
-    - Name: Logging 5.9
-      File: logging-5-9-release-notes
-    - Name: Logging 5.8
-      File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
-  - Name: Support
-    File: cluster-logging-support
-  - Name: Troubleshooting logging
-    Dir: troubleshooting
+      - Name: About Observability
+        File: index
+  - Name: Monitoring
+    Dir: monitoring
+    Distros: openshift-rosa-hcp
     Topics:
-    - Name: Viewing Logging status
-      File: cluster-logging-cluster-status
-    - Name: Troubleshooting log forwarding
-      File: log-forwarding-troubleshooting
-    - Name: Troubleshooting logging alerts
-      File: troubleshooting-logging-alerts
-    - Name: Viewing the status of the Elasticsearch log store
-      File: cluster-logging-log-store-status
-  - Name: About Logging
-    File: cluster-logging
-  - Name: Installing Logging
-    File: cluster-logging-deploying
-  - Name: Updating Logging
-    File: cluster-logging-upgrading
-  - Name: Visualizing logs
-    Dir: log_visualization
+      - Name: Monitoring overview
+        File: monitoring-overview
+      - Name: Accessing monitoring for user-defined projects
+        File: sd-accessing-monitoring-for-user-defined-projects
+      - Name: Configuring the monitoring stack
+        File: configuring-the-monitoring-stack
+      - Name: Disabling monitoring for user-defined projects
+        File: sd-disabling-monitoring-for-user-defined-projects
+      - Name: Enabling alert routing for user-defined projects
+        File: enabling-alert-routing-for-user-defined-projects
+      - Name: Managing metrics
+        File: managing-metrics
+      - Name: Managing alerts
+        File: managing-alerts
+      - Name: Reviewing monitoring dashboards
+        File: reviewing-monitoring-dashboards
+      - Name: Accessing third-party monitoring APIs
+        File: accessing-third-party-monitoring-apis
+      - Name: Troubleshooting monitoring issues
+        File: troubleshooting-monitoring-issues
+      - Name: Config map reference for the Cluster Monitoring Operator
+        File: config-map-reference-for-the-cluster-monitoring-operator
+  - Name: Logging
+    Dir: logging
+    Distros: openshift-rosa-hcp
     Topics:
-    - Name: About log visualization
-      File: log-visualization
-    - Name: Log visualization with the web console
-      File: log-visualization-ocp-console
-    - Name: Viewing cluster dashboards
-      File: cluster-logging-dashboards
-    - Name: Log visualization with Kibana
-      File: logging-kibana
-  - Name: Configuring your Logging deployment
-    Dir: config
+      - Name: Release notes
+        Dir: logging_release_notes
+        Topics:
+          - Name: Logging 5.9
+            File: logging-5-9-release-notes
+          - Name: Logging 5.8
+            File: logging-5-8-release-notes
+          - Name: Logging 5.7
+            File: logging-5-7-release-notes
+      - Name: Support
+        File: cluster-logging-support
+      - Name: Troubleshooting logging
+        Dir: troubleshooting
+        Topics:
+          - Name: Viewing Logging status
+            File: cluster-logging-cluster-status
+          - Name: Troubleshooting log forwarding
+            File: log-forwarding-troubleshooting
+          - Name: Troubleshooting logging alerts
+            File: troubleshooting-logging-alerts
+          - Name: Viewing the status of the Elasticsearch log store
+            File: cluster-logging-log-store-status
+      - Name: About Logging
+        File: cluster-logging
+      - Name: Installing Logging
+        File: cluster-logging-deploying
+      - Name: Updating Logging
+        File: cluster-logging-upgrading
+      - Name: Visualizing logs
+        Dir: log_visualization
+        Topics:
+          - Name: About log visualization
+            File: log-visualization
+          - Name: Log visualization with the web console
+            File: log-visualization-ocp-console
+          - Name: Viewing cluster dashboards
+            File: cluster-logging-dashboards
+          - Name: Log visualization with Kibana
+            File: logging-kibana
+      - Name: Configuring your Logging deployment
+        Dir: config
+        Topics:
+          - Name: Configuring CPU and memory limits for Logging components
+            File: cluster-logging-memory
+        #- Name: Configuring systemd-journald and Fluentd
+        #  File: cluster-logging-systemd
+      - Name: Log collection and forwarding
+        Dir: log_collection_forwarding
+        Topics:
+          - Name: About log collection and forwarding
+            File: log-forwarding
+          - Name: Log output types
+            File: logging-output-types
+          - Name: Enabling JSON log forwarding
+            File: cluster-logging-enabling-json-logging
+          - Name: Configuring log forwarding
+            File: configuring-log-forwarding
+          - Name: Configuring the logging collector
+            File: cluster-logging-collector
+          - Name: Collecting and storing Kubernetes events
+            File: cluster-logging-eventrouter
+      - Name: Log storage
+        Dir: log_storage
+        Topics:
+          - Name: About log storage
+            File: about-log-storage
+          - Name: Installing log storage
+            File: installing-log-storage
+          - Name: Configuring the LokiStack log store
+            File: cluster-logging-loki
+          - Name: Configuring the Elasticsearch log store
+            File: logging-config-es-store
+      - Name: Logging alerts
+        Dir: logging_alerts
+        Topics:
+          - Name: Default logging alerts
+            File: default-logging-alerts
+          - Name: Custom logging alerts
+            File: custom-logging-alerts
+      - Name: Performance and reliability tuning
+        Dir: performance_reliability
+        Topics:
+          - Name: Flow control mechanisms
+            File: logging-flow-control-mechanisms
+          - Name: Filtering logs by content
+            File: logging-content-filtering
+          - Name: Filtering logs by metadata
+            File: logging-input-spec-filtering
+      - Name: Scheduling resources
+        Dir: scheduling_resources
+        Topics:
+          - Name: Using node selectors to move logging resources
+            File: logging-node-selectors
+          - Name: Using tolerations to control logging pod placement
+            File: logging-taints-tolerations
+      - Name: Uninstalling Logging
+        File: cluster-logging-uninstall
+      - Name: Exported fields
+        File: cluster-logging-exported-fields
+      - Name: API reference
+        Dir: api_reference
+        Topics:
+          #  - Name: 5.8 Logging API reference
+          #    File: logging-5-8-reference
+          #  - Name: 5.7 Logging API reference
+          #    File: logging-5-7-reference
+          - Name: 5.6 Logging API reference
+            File: logging-5-6-reference
+      - Name: Glossary
+        File: logging-common-terms
+---
+Name: Service Mesh
+Dir: service_mesh
+Distros: openshift-rosa
+Topics:
+  # Tech Preview
+  # - Name: Service Mesh 3.x
+  #  Dir: v3x
+  #  Topics:
+  #  - Name: OpenShift Service Mesh 3.0 TP1 overview
+  #    File: ossm-service-mesh-3-0-overview
+  - Name: Service Mesh 2.x
+    Dir: v2x
     Topics:
-    - Name: Configuring CPU and memory limits for Logging components
-      File: cluster-logging-memory
-    #- Name: Configuring systemd-journald and Fluentd
-    #  File: cluster-logging-systemd
-  - Name: Log collection and forwarding
-    Dir: log_collection_forwarding
+      - Name: About OpenShift Service Mesh
+        File: ossm-about
+      - Name: Service Mesh 2.x release notes
+        File: servicemesh-release-notes
+      - Name: Service Mesh architecture
+        File: ossm-architecture
+      - Name: Service Mesh deployment models
+        File: ossm-deployment-models
+      - Name: Service Mesh and Istio differences
+        File: ossm-vs-community
+      - Name: Preparing to install Service Mesh
+        File: preparing-ossm-installation
+      - Name: Installing the Operators
+        File: installing-ossm
+      - Name: Creating the ServiceMeshControlPlane
+        File: ossm-create-smcp
+      - Name: Adding workloads to a service mesh
+        File: ossm-create-mesh
+      - Name: Enabling sidecar injection
+        File: prepare-to-deploy-applications-ossm
+      - Name: Upgrading Service Mesh
+        File: upgrading-ossm
+      - Name: Managing users and profiles
+        File: ossm-profiles-users
+      - Name: Security
+        File: ossm-security
+      - Name: Traffic management
+        File: ossm-traffic-manage
+      - Name: Metrics, logs, and traces
+        File: ossm-observability
+      - Name: Performance and scalability
+        File: ossm-performance-scalability
+      - Name: Deploying to production
+        File: ossm-deploy-production
+      - Name: Federation
+        File: ossm-federation
+      - Name: Extensions
+        File: ossm-extensions
+      - Name: 3scale WebAssembly for 2.1
+        File: ossm-threescale-webassembly-module
+      - Name: 3scale Istio adapter for 2.0
+        File: threescale-adapter
+      - Name: Troubleshooting Service Mesh
+        File: ossm-troubleshooting-istio
+      - Name: Control plane configuration reference
+        File: ossm-reference-smcp
+      - Name: Kiali configuration reference
+        File: ossm-reference-kiali
+      - Name: Jaeger configuration reference
+        File: ossm-reference-jaeger
+      - Name: Uninstalling Service Mesh
+        File: removing-ossm
+# Service Mesh 1.x is tech preview
+# - Name: Service Mesh 1.x
+#  Dir: v1x
+#  Topics:
+#  - Name: Service Mesh 1.x release notes
+#    File: servicemesh-release-notes
+#  - Name: Service Mesh architecture
+#    File: ossm-architecture
+#  - Name: Service Mesh and Istio differences
+#    File: ossm-vs-community
+#  - Name: Preparing to install Service Mesh
+#    File: preparing-ossm-installation
+#  - Name: Installing Service Mesh
+#    File: installing-ossm
+#  - Name: Security
+#    File: ossm-security
+#  - Name: Traffic management
+#    File: ossm-traffic-manage
+#  - Name: Deploying applications on Service Mesh
+#    File: prepare-to-deploy-applications-ossm
+#  - Name: Data visualization and observability
+#    File: ossm-observability
+#  - Name: Custom resources
+#    File: ossm-custom-resources
+#  - Name: 3scale Istio adapter for 1.x
+#    File: threescale-adapter
+#  - Name: Removing Service Mesh
+#    File: removing-ossm
+---
+Name: Serverless
+Dir: serverless
+Distros: openshift-rosa
+Topics:
+  - Name: About Serverless
+    Dir: about
     Topics:
-    - Name: About log collection and forwarding
-      File: log-forwarding
-    - Name: Log output types
-      File: logging-output-types
-    - Name: Enabling JSON log forwarding
-      File: cluster-logging-enabling-json-logging
-    - Name: Configuring log forwarding
-      File: configuring-log-forwarding
-    - Name: Configuring the logging collector
-      File: cluster-logging-collector
-    - Name: Collecting and storing Kubernetes events
-      File: cluster-logging-eventrouter
-  - Name: Log storage
-    Dir: log_storage
-    Topics:
-    - Name: About log storage
-      File: about-log-storage
-    - Name: Installing log storage
-      File: installing-log-storage
-    - Name: Configuring the LokiStack log store
-      File: cluster-logging-loki
-    - Name: Configuring the Elasticsearch log store
-      File: logging-config-es-store
-  - Name: Logging alerts
-    Dir: logging_alerts
-    Topics:
-    - Name: Default logging alerts
-      File: default-logging-alerts
-    - Name: Custom logging alerts
-      File: custom-logging-alerts
-  - Name: Performance and reliability tuning
-    Dir: performance_reliability
-    Topics:
-    - Name: Flow control mechanisms
-      File: logging-flow-control-mechanisms
-    - Name: Filtering logs by content
-      File: logging-content-filtering
-    - Name: Filtering logs by metadata
-      File: logging-input-spec-filtering
-  - Name: Scheduling resources
-    Dir: scheduling_resources
-    Topics:
-    - Name: Using node selectors to move logging resources
-      File: logging-node-selectors
-    - Name: Using tolerations to control logging pod placement
-      File: logging-taints-tolerations
-  - Name: Uninstalling Logging
-    File: cluster-logging-uninstall
-  - Name: Exported fields
-    File: cluster-logging-exported-fields
-  - Name: API reference
-    Dir: api_reference
-    Topics:
-  #  - Name: 5.8 Logging API reference
-  #    File: logging-5-8-reference
-  #  - Name: 5.7 Logging API reference
-  #    File: logging-5-7-reference
-    - Name: 5.6 Logging API reference
-      File: logging-5-6-reference
-  - Name: Glossary
-    File: logging-common-terms
+      - Name: Serverless overview
+        File: about-serverless
 ---
 Name: Virtualization
 Dir: virt
 Distros: openshift-rosa-hcp
 Topics:
-- Name: About
-  Dir: about_virt
-  Topics:
-  - Name: About OpenShift Virtualization
-    File: about-virt
-    Distros: openshift-rosa-hcp
-  - Name: About OKD Virtualization
-    File: about-virt
-    Distros: openshift-origin
-  - Name: Security policies
-    File: virt-security-policies
-  - Name: Architecture
-    File: virt-architecture
-    Distros: openshift-rosa-hcp
-#- Name: Release notes
-#  Dir: release_notes
-#  Topics:
-#  - Name: OpenShift Virtualization release notes
-#    File: virt-release-notes-placeholder
-#    Distros: openshift-rosa
-- Name: Getting started
-  Dir: getting_started
-  Topics:
-  - Name: Getting started with OpenShift Virtualization
-    File: virt-getting-started
-    Distros: openshift-rosa-hcp
-  - Name: Getting started with OKD Virtualization
-    File: virt-getting-started
-    Distros: openshift-origin
-  - Name: virtctl and libguestfs
-    File: virt-using-the-cli-tools
-    Distros: openshift-rosa-hcp
-- Name: Installing
-  Dir: install
-  Topics:
-  - Name: Preparing your cluster
-    File: preparing-cluster-for-virt
-  - Name: Installing OpenShift Virtualization
-    File: installing-virt
-  - Name: Uninstalling OpenShift Virtualization
-    File: uninstalling-virt
-- Name: Post-installation configuration
-  Dir: post_installation_configuration
-  Topics:
+  - Name: About
+    Dir: about_virt
+    Topics:
+      - Name: About OpenShift Virtualization
+        File: about-virt
+        Distros: openshift-rosa-hcp
+      - Name: About OKD Virtualization
+        File: about-virt
+        Distros: openshift-origin
+      - Name: Security policies
+        File: virt-security-policies
+      - Name: Architecture
+        File: virt-architecture
+        Distros: openshift-rosa-hcp
+  #- Name: Release notes
+  #  Dir: release_notes
+  #  Topics:
+  #  - Name: OpenShift Virtualization release notes
+  #    File: virt-release-notes-placeholder
+  #    Distros: openshift-rosa
+  - Name: Getting started
+    Dir: getting_started
+    Topics:
+      - Name: Getting started with OpenShift Virtualization
+        File: virt-getting-started
+        Distros: openshift-rosa-hcp
+      - Name: Getting started with OKD Virtualization
+        File: virt-getting-started
+        Distros: openshift-origin
+      - Name: virtctl and libguestfs
+        File: virt-using-the-cli-tools
+        Distros: openshift-rosa-hcp
+  - Name: Installing
+    Dir: install
+    Topics:
+      - Name: Preparing your cluster
+        File: preparing-cluster-for-virt
+      - Name: Installing OpenShift Virtualization
+        File: installing-virt
+      - Name: Uninstalling OpenShift Virtualization
+        File: uninstalling-virt
   - Name: Post-installation configuration
-    File: virt-post-install-config
-  - Name: Node placement rules
-    File: virt-node-placement-virt-components
-  - Name: Network configuration
-    File: virt-post-install-network-config
-  - Name: Storage configuration
-    File: virt-post-install-storage-config
-  - Name: Configuring certificate rotation
-    File: virt-configuring-certificate-rotation
-- Name: Updating
-  Dir: updating
-  Topics:
-  - Name: Updating OpenShift Virtualization
-    File: upgrading-virt
-    Distros: openshift-rosa-hcp
-- Name: Creating a virtual machine
-  Dir: creating_vm
-  Topics:
-#  - Name: Overview
-#    File: virt-basic-vm-overview
-#  - Name: Setting up your environment
-#    File: virt-setting-up-environment
-  - Name: Creating VMs from instance types
-    File: virt-creating-vms-from-instance-types
-  - Name: Creating VMs from templates
-    File: virt-creating-vms-from-templates
-- Name: Advanced VM creation
-  Dir: creating_vms_advanced
-  Topics:
-#  - Name: Overview
-#    File: virt-advanced-vm-overview
-  - Name: Creating VMs in the web console
-    Dir: creating_vms_advanced_web
+    Dir: post_installation_configuration
     Topics:
-    - Name: Creating VMs from Red Hat images
-      File: virt-creating-vms-from-rh-images-overview
-    - Name: Creating VMs by importing images from web pages
-      File: virt-creating-vms-from-web-images
-    - Name: Creating VMs by uploading images
-      File: virt-creating-vms-uploading-images
-    - Name: Cloning VMs
-      File: virt-cloning-vms
-  - Name: Creating VMs using the CLI
-    Dir: creating_vms_cli
+      - Name: Post-installation configuration
+        File: virt-post-install-config
+      - Name: Node placement rules
+        File: virt-node-placement-virt-components
+      - Name: Network configuration
+        File: virt-post-install-network-config
+      - Name: Storage configuration
+        File: virt-post-install-storage-config
+      - Name: Configuring certificate rotation
+        File: virt-configuring-certificate-rotation
+  - Name: Updating
+    Dir: updating
     Topics:
-    - Name: Creating virtual machines from the command line
-      File: virt-creating-vms-from-cli
-    - Name: Creating VMs by using container disks
-      File: virt-creating-vms-from-container-disks
-    - Name: Creating VMs by cloning PVCs
-      File: virt-creating-vms-by-cloning-pvcs
-- Name: Managing VMs
-  Dir: managing_vms
-  Topics:
-  - Name: Installing the QEMU guest agent and VirtIO drivers
-    File: virt-installing-qemu-guest-agent
-  - Name: Connecting to VM consoles
-    File: virt-accessing-vm-consoles
-  - Name: Configuring SSH access to VMs
-    File: virt-accessing-vm-ssh
-  - Name: Editing virtual machines
-    File: virt-edit-vms
-  - Name: Editing boot order
-    File: virt-edit-boot-order
-  - Name: Deleting virtual machines
-    File: virt-delete-vms
-  - Name: Exporting virtual machines
-    File: virt-exporting-vms
-  - Name: Managing virtual machine instances
-    File: virt-manage-vmis
-  - Name: Controlling virtual machine states
-    File: virt-controlling-vm-states
-  - Name: Using virtual Trusted Platform Module devices
-    File: virt-using-vtpm-devices
-  - Name: Managing virtual machines with OpenShift Pipelines
-    File: virt-managing-vms-openshift-pipelines
-  - Name: Advanced virtual machine management
-    Dir: advanced_vm_management
+      - Name: Updating OpenShift Virtualization
+        File: upgrading-virt
+        Distros: openshift-rosa-hcp
+  - Name: Creating a virtual machine
+    Dir: creating_vm
     Topics:
-    - Name: Working with resource quotas for virtual machines
-      File: virt-working-with-resource-quotas-for-vms
-    - Name: Specifying nodes for virtual machines
-      File: virt-specifying-nodes-for-vms
-    - Name: Configuring the default CPU model
-      File: virt-configuring-default-cpu-model
-    - Name: UEFI mode for virtual machines
-      File: virt-uefi-mode-for-vms
-    - Name: Configuring PXE booting for virtual machines
-      File: virt-configuring-pxe-booting
-# Huge pages not supported in ROSA
-#   - Name: Using huge pages with virtual machines
-#     File: virt-using-huge-pages-with-vms
-# CPU Manager not supported in ROSA
-#   - Name: Enabling dedicated resources for a virtual machine
-#     File: virt-dedicated-resources-vm
-    - Name: Scheduling virtual machines
-      File: virt-schedule-vms
-# Cannot create required machine config in ROSA as required
-#   - Name: Configuring PCI passthrough
-#     File: virt-configuring-pci-passthrough
-# Cannot create required machine config in ROSA as required
-#   - Name: Configuring virtual GPUs
-#     File: virt-configuring-virtual-gpus
-# Feature is TP, thus not supported in ROSA
-#   - Name: Enabling descheduler evictions on virtual machines
-#     File: virt-enabling-descheduler-evictions
-    - Name: About high availability for virtual machines
-      File: virt-high-availability-for-vms
-    - Name: Control plane tuning
-      File: virt-vm-control-plane-tuning
-# Need to review following are supported:
-#   - Name: Assigning compute resources
-#     File: virt-assigning-compute-resources
-#   - Name: About multi-queue functionality
-#     File: virt-about-multi-queue
-  - Name: VM disks
-    Dir: virtual_disks
+      #  - Name: Overview
+      #    File: virt-basic-vm-overview
+      #  - Name: Setting up your environment
+      #    File: virt-setting-up-environment
+      - Name: Creating VMs from instance types
+        File: virt-creating-vms-from-instance-types
+      - Name: Creating VMs from templates
+        File: virt-creating-vms-from-templates
+  - Name: Advanced VM creation
+    Dir: creating_vms_advanced
     Topics:
-    - Name: Hot-plugging VM disks
-      File: virt-hot-plugging-virtual-disks
-    - Name: Expanding VM disks
-      File: virt-expanding-vm-disks
-# Need to check if supported:
-#   - Name: Configuring shared volumes
-#     File: virt-configuring-shared-volumes-for-vms
-    - Name: Migrating VM disks to a different storage class
-      File: virt-migrating-storage-class
-- Name: Networking
-  Dir: vm_networking
-  Topics:
-  - Name: Networking configuration overview
-    File: virt-networking-overview
-  - Name: Connecting a VM to the default pod network
-    File: virt-connecting-vm-to-default-pod-network
-  - Name: Connecting a VM to a primary user-defined network
-    File: virt-connecting-vm-to-primary-udn
-  - Name: Exposing a VM by using a service
-    File: virt-exposing-vm-with-service
-# Not supported in ROSA/OSD
-#  - Name: Connecting a VM to a Linux bridge network
-#    File: virt-connecting-vm-to-linux-bridge
-#  - Name: Connecting a VM to an SR-IOV network
-#    File: virt-connecting-vm-to-sriov
-#  - Name: Using DPDK with SR-IOV
-#    File: virt-using-dpdk-with-sriov
-  - Name: Connecting a VM to an OVN-Kubernetes secondary network
-    File: virt-connecting-vm-to-ovn-secondary-network
-  - Name: Hot plugging secondary network interfaces
-    File: virt-hot-plugging-network-interfaces
-  - Name: Connecting a VM to a service mesh
-    File: virt-connecting-vm-to-service-mesh
-  - Name: Configuring a dedicated network for live migration
-    File: virt-dedicated-network-live-migration
-  - Name: Configuring and viewing IP addresses
-    File: virt-configuring-viewing-ips-for-vms
-# Tech Preview features not supported in ROSA/OSD
-#  - Name: Accessing a VM by using the cluster FQDN
-#    File: virt-accessing-vm-secondary-network-fqdn
-  - Name: Managing MAC address pools for network interfaces
-    File: virt-using-mac-address-pool-for-vms
-- Name: Storage
-  Dir: storage
-  Topics:
-  - Name: Storage configuration overview
-    File: virt-storage-config-overview
-  - Name: Configuring storage profiles
-    File: virt-configuring-storage-profile
-  - Name: Managing automatic boot source updates
-    File: virt-automatic-bootsource-updates
-  - Name: Reserving PVC space for file system overhead
-    File: virt-reserving-pvc-space-fs-overhead
-  - Name: Configuring local storage by using HPP
-    File: virt-configuring-local-storage-with-hpp
-  - Name: Enabling user permissions to clone data volumes across namespaces
-    File: virt-enabling-user-permissions-to-clone-datavolumes
-  - Name: Configuring CDI to override CPU and memory quotas
-    File: virt-configuring-cdi-for-namespace-resourcequota
-  - Name: Preparing CDI scratch space
-    File: virt-preparing-cdi-scratch-space
-  - Name: Using preallocation for data volumes
-    File: virt-using-preallocation-for-datavolumes
-  - Name: Managing data volume annotations
-    File: virt-managing-data-volume-annotations
-# Virtual machine live migration
-- Name: Live migration
-  Dir: live_migration
-  Topics:
-  - Name: About live migration
-    File: virt-about-live-migration
-  - Name: Configuring live migration
-    File: virt-configuring-live-migration
-  - Name: Initiating and canceling live migration
-    File: virt-initiating-live-migration
-# Node maintenance mode
-- Name: Nodes
-  Dir: nodes
-  Topics:
-  - Name: Node maintenance
-    File: virt-node-maintenance
-  - Name: Managing node labeling for obsolete CPU models
-    File: virt-managing-node-labeling-obsolete-cpu-models
-  - Name: Preventing node reconciliation
-    File: virt-preventing-node-reconciliation
-# Hiding in ROSA as user cannot cordon and drain nodes
-#  - Name: Deleting a failed node to trigger VM failover
-#    File: virt-triggering-vm-failover-resolving-failed-node
-- Name: Monitoring
-  Dir: monitoring
-  Topics:
-  - Name: Monitoring overview
-    File: virt-monitoring-overview
-# Hiding in ROSA/OSD as TP not supported
-#  - Name: Cluster checkup framework
-#    File: virt-running-cluster-checkups
-  - Name: Prometheus queries for virtual resources
-    File: virt-prometheus-queries
-  - Name: Virtual machine custom metrics
-    File: virt-exposing-custom-metrics-for-vms
-  - Name: Virtual machine health checks
-    File: virt-monitoring-vm-health
-  - Name: Runbooks
-    File: virt-runbooks
-- Name: Support
-  Dir: support
-  Topics:
-  - Name: Support overview
-    File: virt-support-overview
-  - Name: Collecting data for Red Hat Support
-    File: virt-collecting-virt-data
-    Distros: openshift-rosa-hcp
-  - Name: Troubleshooting
-    File: virt-troubleshooting
-- Name: Backup and restore
-  Dir: backup_restore
-  Topics:
-  - Name: Backup and restore by using VM snapshots
-    File: virt-backup-restore-snapshots
-  - Name: Backing up and restoring virtual machines
-    File: virt-backup-restore-overview
+      #  - Name: Overview
+      #    File: virt-advanced-vm-overview
+      - Name: Creating VMs in the web console
+        Dir: creating_vms_advanced_web
+        Topics:
+          - Name: Creating VMs from Red Hat images
+            File: virt-creating-vms-from-rh-images-overview
+          - Name: Creating VMs by importing images from web pages
+            File: virt-creating-vms-from-web-images
+          - Name: Creating VMs by uploading images
+            File: virt-creating-vms-uploading-images
+          - Name: Cloning VMs
+            File: virt-cloning-vms
+      - Name: Creating VMs using the CLI
+        Dir: creating_vms_cli
+        Topics:
+          - Name: Creating virtual machines from the command line
+            File: virt-creating-vms-from-cli
+          - Name: Creating VMs by using container disks
+            File: virt-creating-vms-from-container-disks
+          - Name: Creating VMs by cloning PVCs
+            File: virt-creating-vms-by-cloning-pvcs
+  - Name: Managing VMs
+    Dir: managing_vms
+    Topics:
+      - Name: Installing the QEMU guest agent and VirtIO drivers
+        File: virt-installing-qemu-guest-agent
+      - Name: Connecting to VM consoles
+        File: virt-accessing-vm-consoles
+      - Name: Configuring SSH access to VMs
+        File: virt-accessing-vm-ssh
+      - Name: Editing virtual machines
+        File: virt-edit-vms
+      - Name: Editing boot order
+        File: virt-edit-boot-order
+      - Name: Deleting virtual machines
+        File: virt-delete-vms
+      - Name: Exporting virtual machines
+        File: virt-exporting-vms
+      - Name: Managing virtual machine instances
+        File: virt-manage-vmis
+      - Name: Controlling virtual machine states
+        File: virt-controlling-vm-states
+      - Name: Using virtual Trusted Platform Module devices
+        File: virt-using-vtpm-devices
+      - Name: Managing virtual machines with OpenShift Pipelines
+        File: virt-managing-vms-openshift-pipelines
+      - Name: Advanced virtual machine management
+        Dir: advanced_vm_management
+        Topics:
+          - Name: Working with resource quotas for virtual machines
+            File: virt-working-with-resource-quotas-for-vms
+          - Name: Specifying nodes for virtual machines
+            File: virt-specifying-nodes-for-vms
+          - Name: Configuring the default CPU model
+            File: virt-configuring-default-cpu-model
+          - Name: UEFI mode for virtual machines
+            File: virt-uefi-mode-for-vms
+          - Name: Configuring PXE booting for virtual machines
+            File: virt-configuring-pxe-booting
+          # Huge pages not supported in ROSA
+          #   - Name: Using huge pages with virtual machines
+          #     File: virt-using-huge-pages-with-vms
+          # CPU Manager not supported in ROSA
+          #   - Name: Enabling dedicated resources for a virtual machine
+          #     File: virt-dedicated-resources-vm
+          - Name: Scheduling virtual machines
+            File: virt-schedule-vms
+          # Cannot create required machine config in ROSA as required
+          #   - Name: Configuring PCI passthrough
+          #     File: virt-configuring-pci-passthrough
+          # Cannot create required machine config in ROSA as required
+          #   - Name: Configuring virtual GPUs
+          #     File: virt-configuring-virtual-gpus
+          # Feature is TP, thus not supported in ROSA
+          #   - Name: Enabling descheduler evictions on virtual machines
+          #     File: virt-enabling-descheduler-evictions
+          - Name: About high availability for virtual machines
+            File: virt-high-availability-for-vms
+          - Name: Control plane tuning
+            File: virt-vm-control-plane-tuning
+      # Need to review following are supported:
+      #   - Name: Assigning compute resources
+      #     File: virt-assigning-compute-resources
+      #   - Name: About multi-queue functionality
+      #     File: virt-about-multi-queue
+      - Name: VM disks
+        Dir: virtual_disks
+        Topics:
+          - Name: Hot-plugging VM disks
+            File: virt-hot-plugging-virtual-disks
+          - Name: Expanding VM disks
+            File: virt-expanding-vm-disks
+          # Need to check if supported:
+          #   - Name: Configuring shared volumes
+          #     File: virt-configuring-shared-volumes-for-vms
+          - Name: Migrating VM disks to a different storage class
+            File: virt-migrating-storage-class
+  - Name: Networking
+    Dir: vm_networking
+    Topics:
+      - Name: Networking configuration overview
+        File: virt-networking-overview
+      - Name: Connecting a VM to the default pod network
+        File: virt-connecting-vm-to-default-pod-network
+      - Name: Connecting a VM to a primary user-defined network
+        File: virt-connecting-vm-to-primary-udn
+      - Name: Exposing a VM by using a service
+        File: virt-exposing-vm-with-service
+      # Not supported in ROSA/OSD
+      #  - Name: Connecting a VM to a Linux bridge network
+      #    File: virt-connecting-vm-to-linux-bridge
+      #  - Name: Connecting a VM to an SR-IOV network
+      #    File: virt-connecting-vm-to-sriov
+      #  - Name: Using DPDK with SR-IOV
+      #    File: virt-using-dpdk-with-sriov
+      - Name: Connecting a VM to an OVN-Kubernetes secondary network
+        File: virt-connecting-vm-to-ovn-secondary-network
+      - Name: Hot plugging secondary network interfaces
+        File: virt-hot-plugging-network-interfaces
+      - Name: Connecting a VM to a service mesh
+        File: virt-connecting-vm-to-service-mesh
+      - Name: Configuring a dedicated network for live migration
+        File: virt-dedicated-network-live-migration
+      - Name: Configuring and viewing IP addresses
+        File: virt-configuring-viewing-ips-for-vms
+      # Tech Preview features not supported in ROSA/OSD
+      #  - Name: Accessing a VM by using the cluster FQDN
+      #    File: virt-accessing-vm-secondary-network-fqdn
+      - Name: Managing MAC address pools for network interfaces
+        File: virt-using-mac-address-pool-for-vms
+  - Name: Storage
+    Dir: storage
+    Topics:
+      - Name: Storage configuration overview
+        File: virt-storage-config-overview
+      - Name: Configuring storage profiles
+        File: virt-configuring-storage-profile
+      - Name: Managing automatic boot source updates
+        File: virt-automatic-bootsource-updates
+      - Name: Reserving PVC space for file system overhead
+        File: virt-reserving-pvc-space-fs-overhead
+      - Name: Configuring local storage by using HPP
+        File: virt-configuring-local-storage-with-hpp
+      - Name: Enabling user permissions to clone data volumes across namespaces
+        File: virt-enabling-user-permissions-to-clone-datavolumes
+      - Name: Configuring CDI to override CPU and memory quotas
+        File: virt-configuring-cdi-for-namespace-resourcequota
+      - Name: Preparing CDI scratch space
+        File: virt-preparing-cdi-scratch-space
+      - Name: Using preallocation for data volumes
+        File: virt-using-preallocation-for-datavolumes
+      - Name: Managing data volume annotations
+        File: virt-managing-data-volume-annotations
+  # Virtual machine live migration
+  - Name: Live migration
+    Dir: live_migration
+    Topics:
+      - Name: About live migration
+        File: virt-about-live-migration
+      - Name: Configuring live migration
+        File: virt-configuring-live-migration
+      - Name: Initiating and canceling live migration
+        File: virt-initiating-live-migration
+  # Node maintenance mode
+  - Name: Nodes
+    Dir: nodes
+    Topics:
+      - Name: Node maintenance
+        File: virt-node-maintenance
+      - Name: Managing node labeling for obsolete CPU models
+        File: virt-managing-node-labeling-obsolete-cpu-models
+      - Name: Preventing node reconciliation
+        File: virt-preventing-node-reconciliation
+  # Hiding in ROSA as user cannot cordon and drain nodes
+  #  - Name: Deleting a failed node to trigger VM failover
+  #    File: virt-triggering-vm-failover-resolving-failed-node
+  - Name: Monitoring
+    Dir: monitoring
+    Topics:
+      - Name: Monitoring overview
+        File: virt-monitoring-overview
+      # Hiding in ROSA/OSD as TP not supported
+      #  - Name: Cluster checkup framework
+      #    File: virt-running-cluster-checkups
+      - Name: Prometheus queries for virtual resources
+        File: virt-prometheus-queries
+      - Name: Virtual machine custom metrics
+        File: virt-exposing-custom-metrics-for-vms
+      - Name: Virtual machine health checks
+        File: virt-monitoring-vm-health
+      - Name: Runbooks
+        File: virt-runbooks
+  - Name: Support
+    Dir: support
+    Topics:
+      - Name: Support overview
+        File: virt-support-overview
+      - Name: Collecting data for Red Hat Support
+        File: virt-collecting-virt-data
+        Distros: openshift-rosa-hcp
+      - Name: Troubleshooting
+        File: virt-troubleshooting
+  - Name: Backup and restore
+    Dir: backup_restore
+    Topics:
+      - Name: Backup and restore by using VM snapshots
+        File: virt-backup-restore-snapshots
+      - Name: Backing up and restoring virtual machines
+        File: virt-backup-restore-overview
 #  - Name: Removed topics (Placeholder for topics removed from topic map)
 #    Dir: Removed_topics
 #    Topics:


### PR DESCRIPTION
The Serverless and Service Mesh books were inadvertently dropped from the ROSA HCP topic map. This PR adds them back in.

Version(s):
enterprise-4.18+

Issue:
N/A

Link to docs preview:

QE review:
N/A
