### PR TITLE
Add Serverless and Service Mesh to ROSA HCP topic map

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1386,6 +1386,110 @@ Topics:
   - Name: Glossary
     File: logging-common-terms
 ---
+Name: Service Mesh
+Dir: service_mesh
+Distros: openshift-rosa-hcp
+Topics:
+# Tech Preview
+# - Name: Service Mesh 3.x
+#  Dir: v3x
+#  Topics:
+#  - Name: OpenShift Service Mesh 3.0 TP1 overview
+#    File: ossm-service-mesh-3-0-overview
+- Name: Service Mesh 2.x
+  Dir: v2x
+  Topics:
+  - Name: About OpenShift Service Mesh
+    File: ossm-about
+  - Name: Service Mesh 2.x release notes
+    File: servicemesh-release-notes
+  - Name: Service Mesh architecture
+    File: ossm-architecture
+  - Name: Service Mesh deployment models
+    File: ossm-deployment-models
+  - Name: Service Mesh and Istio differences
+    File: ossm-vs-community
+  - Name: Preparing to install Service Mesh
+    File: preparing-ossm-installation
+  - Name: Installing the Operators
+    File: installing-ossm
+  - Name: Creating the ServiceMeshControlPlane
+    File: ossm-create-smcp
+  - Name: Adding workloads to a service mesh
+    File: ossm-create-mesh
+  - Name: Enabling sidecar injection
+    File: prepare-to-deploy-applications-ossm
+  - Name: Upgrading Service Mesh
+    File: upgrading-ossm
+  - Name: Managing users and profiles
+    File: ossm-profiles-users
+  - Name: Security
+    File: ossm-security
+  - Name: Traffic management
+    File: ossm-traffic-manage
+  - Name: Metrics, logs, and traces
+    File: ossm-observability
+  - Name: Performance and scalability
+    File: ossm-performance-scalability
+  - Name: Deploying to production
+    File: ossm-deploy-production
+  - Name: Federation
+    File: ossm-federation
+  - Name: Extensions
+    File: ossm-extensions
+  - Name: 3scale WebAssembly for 2.1
+    File: ossm-threescale-webassembly-module
+  - Name: 3scale Istio adapter for 2.0
+    File: threescale-adapter
+  - Name: Troubleshooting Service Mesh
+    File: ossm-troubleshooting-istio
+  - Name: Control plane configuration reference
+    File: ossm-reference-smcp
+  - Name: Kiali configuration reference
+    File: ossm-reference-kiali
+  - Name: Jaeger configuration reference
+    File: ossm-reference-jaeger
+  - Name: Uninstalling Service Mesh
+    File: removing-ossm
+# Service Mesh 1.x is tech preview
+# - Name: Service Mesh 1.x
+#  Dir: v1x
+#  Topics:
+#  - Name: Service Mesh 1.x release notes
+#    File: servicemesh-release-notes
+#  - Name: Service Mesh architecture
+#    File: ossm-architecture
+#  - Name: Service Mesh and Istio differences
+#    File: ossm-vs-community
+#  - Name: Preparing to install Service Mesh
+#    File: preparing-ossm-installation
+#  - Name: Installing Service Mesh
+#    File: installing-ossm
+#  - Name: Security
+#    File: ossm-security
+#  - Name: Traffic management
+#    File: ossm-traffic-manage
+#  - Name: Deploying applications on Service Mesh
+#    File: prepare-to-deploy-applications-ossm
+#  - Name: Data visualization and observability
+#    File: ossm-observability
+#  - Name: Custom resources
+#    File: ossm-custom-resources
+#  - Name: 3scale Istio adapter for 1.x
+#    File: threescale-adapter
+#  - Name: Removing Service Mesh
+#    File: removing-ossm
+---
+Name: Serverless
+Dir: serverless
+Distros: openshift-rosa-hcp
+Topics:
+- Name: About Serverless
+  Dir: about
+  Topics:
+  - Name: Serverless overview
+    File: about-serverless
+---
 Name: Virtualization
 Dir: virt
 Distros: openshift-rosa-hcp


### PR DESCRIPTION
The Serverless and Service Mesh books were inadvertently removed from the ROSA HCP topic map. This PR adds them back.

Version(s):
enterprise-4.18+

Issue:
N/A

Link to docs preview:
* Serverless: https://92374--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/serverless/about/about-serverless
* Service Mesh: https://92374--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/service_mesh/v2x/ossm-about

QE review:
N/A
