### PR TITLE
OBSDOCS-1749: Add section about uiplugin in installing logging

### DIFF
--- a/modules/log6x-installing-the-logging-ui-plug-in-cli.adoc
+++ b/modules/log6x-installing-the-logging-ui-plug-in-cli.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.2/6x-cluster-logging-deploying-6.2.adoc
+
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-04-18
+:_mod-docs-content-type: PROCEDURE
+
+[id="installing-the-logging-ui-plugin-cli_{context}"]
+= Installing the Logging UI plugin by using the CLI
+
+Install the Logging UI plugin by using the command-line interface (CLI) so that you can visualize logs.
+ 
+.Prerequisites
+* You have administrator permissions.
+* You installed the {oc-first}.
+* You installed and configured {loki-op}.
+
+.Procedure
+. Install the {coo-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/cluster_observability_operator/installing-cluster-observability-operators[Installing the Cluster Observability Operator].
+
+. Create a `UIPlugin` custom resource (CR):
++
+.Example `UIPlugin` CR
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: logging  # <1>
+spec:
+  type: Logging  # <2>
+  logging:
+    lokiStack:
+      name: logging-loki  # <3>
+----
+<1> Set `name` to `logging`.
+<2> Set `type` to `Logging`.
+<3> The `name` value must match the name of your LokiStack instance.
++
+[NOTE]
+====
+If you did not install LokiStack in the `openshift-logging` namespace, set the LokiStack namespace under the `lokiStack` configuration. 
+====
+
+. Apply the `UIPlugin` CR object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+. Access the {product-title} web console, and refresh the page if a pop-up message instructs you to do so.
+. Navigate to the *Observe → Logs* panel, where you can run LogQL queries. You can also query logs for individual pods from the *Aggregated Logs* tab of a specific pod.

--- a/modules/log6x-installing-the-logging-ui-plug-in-gui.adoc
+++ b/modules/log6x-installing-the-logging-ui-plug-in-gui.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.2/6x-cluster-logging-deploying-6.2.adoc
+
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-04-18
+:_mod-docs-content-type: PROCEDURE
+
+[id="installing-the-logging-ui-plugin_gui{context}"]
+= Installing the Logging UI plugin by using the web console
+
+Install the Logging UI plugin by using the web console so that you can visualize logs.
+ 
+.Prerequisites
+* You have administrator permissions.
+* You have access to the {product-title} web console.
+* You installed and configured {loki-op}.
+
+.Procedure
+. Install the {coo-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/cluster_observability_operator/installing-cluster-observability-operators[Installing the Cluster Observability Operator].
+
+. Navigate to the *Installed Operators* page. Under *Provided APIs*, select *ClusterObservabilityOperator*. Find the `UIPlugin` resource and click *Create Instance*.
+
+. Select the YAML view, and then use the following template to create a `UIPlugin` custom resource (CR):
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: logging  # <1>
+spec:
+  type: Logging  # <2>
+  logging:
+    lokiStack:
+      name: logging-loki  # <3>
+----
+<1> Set `name` to `logging`.
+<2> Set `type` to `Logging`.
+<3> The `name` value must match the name of your LokiStack instance.
++
+[NOTE]
+====
+If you did not install LokiStack in the `openshift-logging` namespace, set the LokiStack namespace under the `lokiStack` configuration. 
+====
+
+. Click *Create*.
+
+.Verification
+
+. Refresh the page when a pop-up message instructs you to do so. 
+. Navigate to the *Observe → Logs* panel, where you can run LogQL queries. You can also query logs for individual pods from the *Aggregated Logs* tab of a specific pod.

--- a/observability/logging/logging-6.1/6x-cluster-logging-deploying-6.1.adoc
+++ b/observability/logging/logging-6.1/6x-cluster-logging-deploying-6.1.adoc
@@ -39,7 +39,10 @@ endif::[]
 The following sections describe installing the {loki-op} and the {clo} by using the CLI.
 
 include::modules/log6x-logging-loki-cli-install.adoc[leveloffset=+2]
+
 include::modules/log6x-logging-clo-cli-install.adoc[leveloffset=+2]
+
+nclude::modules/log6x-installing-the-logging-ui-plug-in-cli.adoc[leveloffset=+2]
 
 [id="installing-loki-and-logging-gui_{context}"]
 == Installation by using the web console
@@ -47,7 +50,11 @@ include::modules/log6x-logging-clo-cli-install.adoc[leveloffset=+2]
 The following sections describe installing the {loki-op} and the {clo} by using the web console.
 
 include::modules/log6x-logging-loki-gui-install.adoc[leveloffset=+2]
+
 include::modules/log6x-logging-clo-gui-install.adoc[leveloffset=+2]
+
+include::modules/log6x-installing-the-logging-ui-plug-in-gui.adoc[leveloffset=+2]
+
 
 [role="_additional-resources"]
 .Additional resources

--- a/observability/logging/logging-6.2/6x-cluster-logging-deploying-6.2.adoc
+++ b/observability/logging/logging-6.2/6x-cluster-logging-deploying-6.2.adoc
@@ -39,7 +39,10 @@ endif::[]
 The following sections describe installing the {loki-op} and the {clo} by using the CLI.
 
 include::modules/log6x-logging-loki-cli-install.adoc[leveloffset=+2]
+
 include::modules/log6x-logging-clo-cli-install.adoc[leveloffset=+2]
+
+include::modules/log6x-installing-the-logging-ui-plug-in-cli.adoc[leveloffset=+2]
 
 [id="installing-loki-and-logging-gui_{context}"]
 == Installation by using the web console
@@ -47,7 +50,10 @@ include::modules/log6x-logging-clo-cli-install.adoc[leveloffset=+2]
 The following sections describe installing the {loki-op} and the {clo} by using the web console.
 
 include::modules/log6x-logging-loki-gui-install.adoc[leveloffset=+2]
+
 include::modules/log6x-logging-clo-gui-install.adoc[leveloffset=+2]
+
+include::modules/log6x-installing-the-logging-ui-plug-in-gui.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s): 4.18, 4.17, 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1749
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

- https://92388--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/6x-cluster-logging-deploying-6.2.html#installing-the-logging-ui-plug-in-cli_installing-logging-6-2
- https://92388--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/6x-cluster-logging-deploying-6.2.html#installing-the-logging-ui-plug-in_guiinstalling-logging-6-2

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
