### PR TITLE
OSDOCS-14344: adds OTEL for AI model-server metrics MicroShift

### DIFF
--- a/microshift_ai/microshift-rhoai.adoc
+++ b/microshift_ai/microshift-rhoai.adoc
@@ -64,6 +64,8 @@ include::modules/microshift-rhoai-servingruntimes-ex.adoc[leveloffset=+1]
 
 include::modules/microshift-rhoai-inferenceservice-ex.adoc[leveloffset=+1]
 
+include::modules/microshift-rhoai-export-metrics-otel.adoc[leveloffset=+2]
+
 include::modules/microshift-inferenceservice-more-options.adoc[leveloffset=+2]
 
 include::modules/microshift-rhoai-model-serving-rt-verify.adoc[leveloffset=+1]

--- a/modules/microshift-inferenceservice-more-options.adoc
+++ b/modules/microshift-inferenceservice-more-options.adoc
@@ -2,9 +2,9 @@
 //
 // * microshift_ai/microshift-rhoai.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="microshift-rhoai-inferenceservice-more-options_{context}"]
-= More InferenceService CRD options
+= More InferenceService CR options
 
 The inference service YAML file can include many different options. For example, you can include a `resources` section that is passed first to the deployment and then to the pod, so that the model server gets access to your hardware through the device plugin.
 

--- a/modules/microshift-rhoai-export-metrics-otel.adoc
+++ b/modules/microshift-rhoai-export-metrics-otel.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * microshift_ai/microshift-rhoai.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-rhoai-export-metrics-otel_{context}"]
+= Exporting model-server metrics by using Open Telemetry
+
+You can export model-server metrics by using Open Telemetry if you installed the `microshift-observability` RPM for {microshift-short}.
+
+[NOTE]
+====
+You can alternatively get the Prometheus-format metrics of the model server by making a request on the `/metrics` endpoint. See "Getting the model-server metrics" for more information.
+====
+
+.Prerequisites
+
+* You configured the `ServingRuntimes` CR.
+* You have root user access to your machine.
+* The {oc-first} is installed.
+* You installed the `microshift-observability` RPM.
+* Your {microshift-short} Open Telemetry configuration includes the Prometheus Receiver. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/red_hat_build_of_opentelemetry/configuring-the-collector#prometheus-receiver_otel-collector-receivers[Prometheus Receiver].
+
+.Procedure
+
+* Add the following Open Telemetry annotation to your `InferenceService` custom resource:
++
+.Example `InferenceService` object with Open Telemetry
+[source,yaml]
+----
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: ovms-resnet50
+#...
+  annotations:
+    prometheus.io/scrape: "true"
+#...
+----

--- a/modules/microshift-rhoai-get-model-server-metrics.adoc
+++ b/modules/microshift-rhoai-get-model-server-metrics.adoc
@@ -8,6 +8,11 @@
 
 After making a query, you can get the model server's metrics to identify bottlenecks, optimize resource allocation, and ensure efficient infrastructure utilization.
 
+[NOTE]
+====
+You can alternatively configure Open Telemetry for {microshift-short} to get model-server metrics. See "Adding Open Telemetry to an InferenceService custom resource" for more information.
+====
+
 .Prerequisites
 
 * The {microshift-short} cluster is running.


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-14344](https://issues.redhat.com/browse/OSDOCS-14344)

Link to docs preview:
[Adding OTEL to an InferenceService CR](https://92392--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-inferenceservice-otel_microshift-rh-openshift-ai)
[Adding OTEL note to model metrics module](https://92392--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-inferenceservice-otel_microshift-rh-openshift-ai)

Reviews:
- [x] QE approved this change.
- [x] SME approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
