### PR TITLE
OSDOCS-13304: adds image mode GA to release notes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -27,8 +27,11 @@ This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s
 //[id="microshift-4-19-rhel_{context}"]
-//=== {op-system-base-full}
-//Image mode for RHEL here if GA; otherwise leave in TP
+=== {op-system-base-full}
+
+[id="microshift-4-19-rhel-image-mode_{context}"]
+==== {op-system-base} image mode (General Availablity)
+Installing {microshift-short} by using a bootc container image is now generally available. Previously available as a Technology Preview feature, {op-system-image} is a deployment method that uses a container-native approach to build, deploy, and manage the operating system as a `rhel-bootc` container image. See xref:../microshift_install_bootc/microshift-about-rhel-image-mode.adoc#microshift-about-rhel-image-mode[Understanding image mode for RHEL with {microshift-short}] for more information.
 
 //4.19 is not an EUS release
 [id="microshift-4-19-updating_{context}"]
@@ -48,8 +51,8 @@ Updates for both single-version minor releases and patch releases are supported.
 ==== {microshift-short} control plane enhanced with TLS
 With this release, configurable transport layer security (TLS) protocols on internal control plane components are enabled to help prevent known insecure protocols, ciphers, or algorithms from accessing the applications you run on {microshift-short}. You use either the TLS 1.2 or TLS 1.3 with {microshift-short}. For more information, see xref:../microshift_configuring/microshift_auth_security/microshift-tls-config.adoc#microshift-tls-config[Configuring TLS security profiles].
 
-//[id="microshift-4-19-running-apps_{context}"]
-//=== Running applications
+[id="microshift-4-19-running-apps_{context}"]
+=== Running applications
 
 [id="microshift-4-19-greenboot-updated_{context}"]
 ==== Check application health with the {microshift-short} healthcheck command
@@ -91,15 +94,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 ==== Serve your trained models on edge deployments
 
 With this release, a streamlined version of Red{nbsp}Hat OpenShift AI (RHOAI) can be used to serve artificial intelligence or machine learning (AI/ML) models on {microshift-short}. Develop and train your AI models in the data center or cloud, then deploy them to the edge where these models can make decisions without a human user. For more information, see xref:../microshift_ai/microshift-rhoai.adoc#microshift-rhoai[Using Red{nbsp}Hat OpenShift AI with {microshift-short}].
-
-//TODO Gateway API might TP with this 4.19; there is no current epic. Discuss with PM as the release approaches.
-
-//TODO verify the status of image mode; might GA with this release
-//[id="microshift-4-19-rhel-image-mode_{context}"]
-//=== {op-system-base-full} image mode Technology Preview feature
-//* You can install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
-
-//See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
 
 [id="microshift-4-19-deprecated-and-removed-features_{context}"]
 == Deprecated and removed features
@@ -156,7 +150,7 @@ See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9
 
 [id="microshift-4-19-additional-release-notes-rhoai_{context}"]
 === {rhoai} release notes
-See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest-1/html/release_notes/index[Release notes] for more information about {rhoai}.
+See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/release_notes/index[Release notes] for more information about {rhoai}.
 //TODO rhoai has a faster release cadence than OCP; get `latest` tag working
 
 [id="microshift-4-19-asynchronous-errata-updates_{context}"]


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13304](https://issues.redhat.com/browse/OSDOCS-13304)

Link to docs preview:
[Image mode for RHEL in RHEL section](https://92406--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#redhat-enterprise-linux-rhel)

Reviews:
- [x] QE approved this change.
- [x] SME approved this change.

Additional information:
Feature updates, https://github.com/openshift/openshift-docs/pull/92407

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
