### PR TITLE
OSDOCS-13305: update image mode docs for GA MicroShift

### DIFF
--- a/microshift_install_bootc/microshift-about-rhel-image-mode.adoc
+++ b/microshift_install_bootc/microshift-about-rhel-image-mode.adoc
@@ -8,10 +8,6 @@ toc::[]
 
 You can embed {microshift-short} into an operating system image using image mode for {op-system-base-full}.
 
-:FeatureName: Image mode for {op-system-base}
-
-include::snippets/technology-preview.adoc[]
-
 include::modules/microshift-install-bootc-conc.adoc[leveloffset=+1]
 
 [id="_additional-resources_microshift-install-rhel-image-mode_{context}"]

--- a/microshift_install_bootc/microshift-install-bootc-image.adoc
+++ b/microshift_install_bootc/microshift-install-bootc-image.adoc
@@ -8,10 +8,6 @@ toc::[]
 
 {microshift-short} is built and published as image mode containers. When installing a {op-system-base-full} bootable container image with {microshift-short}, use either a prebuilt bootable container image or build your own custom bootable container image.
 
-:FeatureName: Image mode for {op-system-base}
-
-include::snippets/technology-preview.adoc[]
-
 include::modules/microshift-install-bootc-workflow.adoc[leveloffset=+1]
 
 [id="microshift-get-build-bootc-image_{context}"]

--- a/microshift_install_bootc/microshift-install-running-bootc-image-vm.adoc
+++ b/microshift_install_bootc/microshift-install-running-bootc-image-vm.adoc
@@ -8,10 +8,6 @@ toc::[]
 
 Use the bootable container image as an installation source to set up a {op-system-base-full} virtual machine.
 
-:FeatureName: Image mode for {op-system-base}
-
-include::snippets/technology-preview.adoc[]
-
 include::modules/microshift-install-bootc-prepare-kickstart.adoc[leveloffset=+1]
 
 include::modules/microshift-install-bootc-creating-vm.adoc[leveloffset=+1]

--- a/modules/microshift-install-bootc-build-image.adoc
+++ b/modules/microshift-install-bootc-build-image.adoc
@@ -8,11 +8,6 @@
 
 Build your {op-system-base-full} that contains {microshift-short} as a bootable container image by using a Containerfile.
 
-[IMPORTANT]
-====
-Image mode for {op-system-base} is Technology Preview. Using a bootc image in production environments is not supported.
-====
-
 .Prerequisites
 
 * A {op-system-base} {op-system-version} host with an active Red{nbsp}Hat subscription for building {microshift-short} bootc images and running containers.

--- a/modules/microshift-install-bootc-conc.adoc
+++ b/modules/microshift-install-bootc-conc.adoc
@@ -6,14 +6,14 @@
 [id="microshift-bootc-conc_{context}"]
 = About image mode for {op-system-base-full}
 
-Image mode for {op-system-base-full} is a Technology Preview deployment method that uses a container-native approach to build, deploy, and manage the operating system as a bootc image. By using bootc, you can build, deploy, and manage the operating system as if it is any other container.
+By using image mode for {op-system-base}, you can use the same tools and techniques for the operating system that you use with application containers. Image mode for {op-system-base} is a deployment method that uses a container-native approach to build, deploy, and manage the operating system as a `rhel-bootc` image.
 
 * This container image uses standard OCI or Docker containers as a transport and delivery format for base operating system updates.
 * A bootc image includes a Linux kernel that is used to start the operating system.
 * By using bootc containers, developers, operations administrators, and solution providers can all use the same container-native tools and techniques.
 
-Image mode splits the creation and installation of software changes into two steps: one on a build system and one on a running target system.
+Image mode for {op-system-base} splits the creation and installation of software changes into two steps: one on a build system and one on a running target system.
 
-* In the build-system step, a Podman build inspects the RPM files available for installation, determines any dependencies, and creates an ordered list of chained steps to complete, with the end result being a new operating system available to install.
+* In the build-system step, a Podman build inspects the RPM files available for installation, determines any dependencies, and creates an ordered list of chained steps to complete. Along with any other system configuration steps taking place, the end result is a new operating system available to install.
 
-* In the running-target-system step, a bootc update downloads, unpacks, and makes the new operating system bootable alongside the currently running system. Local configuration changes are carried forward to the new operating system, but do not take effect until the system is rebooted and the new operating system image replaces the running image.
+* In the running-target-system step, a bootc update downloads, unpacks, and prepares the new operating system to be started alongside the currently running system. Local configuration changes are carried forward to the new operating system. These changes take effect only when the system is restarted and the new operating system image replaces the previously running one.

--- a/modules/microshift-install-bootc-get-published-image.adoc
+++ b/modules/microshift-install-bootc-get-published-image.adoc
@@ -6,7 +6,7 @@
 [id="microshift-install-bootc-get-published-image_{context}"]
 = Getting the published bootc image for {microshift-short}
 
-You can find and use the {microshift-short} container images to install {op-system-base-full}.
+You can find and use the {microshift-short} container images to install {op-system-image}.
 
 .Prerequisites
 

--- a/modules/microshift-install-bootc-workflow.adoc
+++ b/modules/microshift-install-bootc-workflow.adoc
@@ -6,19 +6,19 @@
 [id="microshift-install-rhel-image-mode-conc_{context}"]
 = The image mode for {op-system-base} with {microshift-short} workflow
 
-To use image mode for {op-system-base}, ensure that the following resources are available:
+Before you use {op-system-image}, ensure that the following resources are available:
 
 * A {op-system-base} {op-system-version} host with an active Red{nbsp}Hat subscription for building {microshift-short} bootc images.
-* A remote registry for storing and accessing bootc images.
-* You can use image mode for RHEL with a {microshift-short} cluster on AArch64 or x86_64 system architectures.
+* A remote registry for storing and accessing `rhel-bootc` images.
+* An AArch64 or x86_64 system architecture.
 
-The workflow for using image mode with {microshift-short} includes the following steps:
+The workflow for using {op-system-image} with {microshift-short} includes the following steps:
 
-. Find and use a prebuilt {microshift-short} container image to install {op-system-base-full}.
-. Build a custom {microshift-short} container image if the prebuilt {microshift-short} container image requires customization.
+. Find and use a prebuilt {microshift-short} container image to install {op-system-base}.
+. If the prebuilt {microshift-short} container image requires customization, build a custom {microshift-short} container image.
 . Run the container image.
 
 [IMPORTANT]
 ====
-The `rpm-ostree` file system is not supported in image mode. Do not use the `rpm-ostree` file system to modify deployments that use image mode.
+The `rpm-ostree` file system used by {op-system-ostree} is not supported in {op-system-image}. Do not use the `rpm-ostree` file system to modify deployments that use {op-system-image}.
 ====


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-13305](https://issues.redhat.com/browse/OSDOCS-13305)

Link to docs preview:
https://92407--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-about-rhel-image-mode.html
https://92407--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-bootc-image.html

Reviews:
- [x] QE approved this change.
- [x] SME approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Release note, https://github.com/openshift/openshift-docs/pull/92406

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
