### PR TITLE
Nodes fix swap memory part 1

### DIFF
--- a/modules/nodes-nodes-swap-memory.adoc
+++ b/modules/nodes-nodes-swap-memory.adoc
@@ -23,8 +23,8 @@ Enabling swap memory can negatively impact workload performance and out-of-resou
 To enable swap memory, create a `kubeletconfig` custom resource (CR) to set the `swapbehavior` parameter. You can set limited or unlimited swap memory:
 
 * Limited: Use the `LimitedSwap` value to limit how much swap memory workloads can use. Any workloads on the node that are not managed by {product-title} can still use swap memory. The `LimitedSwap` behavior depends on whether the node is running with Linux control groups link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[version 1 (cgroups v1)] or link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[version 2 (cgroup v2)]:
-** cgroup v1: {product-title} workloads can use any combination of memory and swap, up to the pod's memory limit, if set.
-** cgroup v2: {product-title} workloads cannot use swap memory.
+** cgroup v2: {product-title} workloads can use any combination of memory and swap, up to the pod's memory limit, if set.
+** cgroup v1: {product-title} workloads cannot use swap memory.
 
 * Unlimited: Use the `UnlimitedSwap` value to allow workloads to use as much swap memory as they request, up to the system limit.
 


### PR DESCRIPTION
The docs about enabling swap memory are incorrect that cgroup v2 clusters cannot use limited swap memory. It should be cgroup v1 cluster cannot use limited swap.

4.12+

Preview: [Enabling swap memory use on nodes](https://92409--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#nodes-nodes-swap-memory_nodes-nodes-managing) - First paragraph, first bullet, fixed sub-bullets.

See the current docs: [Enabling swap memory use on nodes](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/working-with-nodes#nodes-nodes-swap-memory_nodes-nodes-managing)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Related to https://github.com/openshift/openshift-docs/pull/92421