### PR TITLE
OSDOCS#13693: attempting table format fix again

### DIFF
--- a/modules/agent-configuration-parameters.adoc
+++ b/modules/agent-configuration-parameters.adoc
@@ -21,7 +21,7 @@ These settings are used for installation only, and cannot be modified after inst
 Required Agent configuration parameters are described in the following table:
 
 .Required parameters
-[cols=".^2l,.^4,.^3a",options="header"]
+[cols=".^4l,.^4,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 


### PR DESCRIPTION
[OSDOCS-13693](https://issues.redhat.com/browse/OSDOCS-13693)

Version(s): 4.14+

This PR is attempting, for a second time, to fix the formatting of the table in [this section](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installing_an_on-premise_cluster_with_the_agent-based_installer/installation-config-parameters-agent#agent-configuration-parameters-required_installation-config-parameters-agent), where the first column is unreadable, and at certain browser page widths there is not even an "expand table" icon in the top right corner.

QE review:
N/A

Preview: https://92410--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html#agent-configuration-parameters-required_installation-config-parameters-agent