### PR TITLE
OSDOCS#14382: adding nutanix platform to Agent docs

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -124,7 +124,7 @@ ifndef::agent[]
 |The configuration for the specific platform upon which to perform the installation: `aws`, `baremetal`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
 endif::agent[]
 ifdef::agent[]
-|The configuration for the specific platform upon which to perform the installation: `baremetal`, `external`, `none`, or `vsphere`.
+|The configuration for the specific platform upon which to perform the installation: `baremetal`, `external`, `none`, `vsphere`, or `nutanix`.
 endif::agent[]
 |Object
 

--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -61,10 +61,13 @@ Recommended cluster resources for the following topologies:
 |HA cluster|3 to 5|2 and above |8 vCPUs|16 GB of RAM|120 GB
 |====
 
+// These supported platforms are also documented in nodes/nodes/nodes-nodes-adding-node-iso.adoc and installation-configuration-parameters.adoc
+
 In the `install-config.yaml`, specify the platform on which to perform the installation. The following platforms are supported:
 
 * `baremetal`
 * `vsphere`
+* `nutanix`
 * `external`
 * `none`
 +

--- a/nodes/nodes/nodes-nodes-adding-node-iso.adoc
+++ b/nodes/nodes/nodes-nodes-adding-node-iso.adoc
@@ -26,6 +26,7 @@ The following platforms are supported for this method of adding nodes:
 
 * `baremetal`
 * `vsphere`
+* `nutanix`
 * `none`
 * `external`
 


### PR DESCRIPTION
[OSDOCS-14382](https://issues.redhat.com/browse/OSDOCS-14382)

Version(s): 4.19+

This PR adds `nutanix` as a supported value for the `platform` parameter in the Agent docs.

QE review:
- [x] QE has approved this change.

Previews:

- [Recommended resources for topologies](https://92419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#agent-based-installer-recommended-resources_preparing-to-install-with-agent-based-installer)
- [Required configuration parameters](https://92419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#installation-configuration-parameters-required_installation-config-parameters-agent)
- [Supported platforms](https://92419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso#supported-platforms_adding-node-iso) (node adding procedure)