### PR TITLE
OSDOCS-13641: Compliance Operator 1.7.0 release notes

### DIFF
--- a/modules/compliance-scansetting-cr.adoc
+++ b/modules/compliance-scansetting-cr.adoc
@@ -12,5 +12,5 @@ To increase the default CPU and memory limits of the Compliance Operator, see _I
 
 [IMPORTANT]
 ====
-Increasing the memory limit for the Compliance Operator or the scanner pods is needed if the default limits are not sufficient and the Operator or scanner pods are ended by the Out Of Memory (OOM) process.
+Increasing the memory limit for the Compliance Operator or the scanner pods is needed if the default limits are not sufficient and the Operator or scanner pods are ended by the Out Of Memory (OOM) process. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/compliance-operator#compliance-increasing-operator-limits_compliance-troubleshooting[Increasing Compliance Operator resource limits]. 
 ====

--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -28,12 +28,13 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Supported platforms
 
 |ocp4-cis ^[1]^
-|CIS Red Hat OpenShift Container Platform Benchmark v1.5.0
+|CIS Red Hat OpenShift Container Platform Benchmark v1.7.0
 |Platform
 |link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] ^[1]^
 |`x86_64`
  `ppc64le`
  `s390x`
+ `aarch64`
 |
 
 |ocp4-cis-1-4 ^[3]^
@@ -54,13 +55,24 @@ The following tables reflect the latest available profiles in the Compliance Ope
  `s390x`
 |
 
+|ocp4-cis-1-7
+|CIS Red Hat OpenShift Container Platform Benchmark v1.7.0
+|Platform
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] ^[4]^
+|`x86_64`
+ `ppc64le`
+ `s390x`
+ `aarch64`
+|
+
 |ocp4-cis-node ^[1]^
-|CIS Red Hat OpenShift Container Platform Benchmark v1.5.0
+|CIS Red Hat OpenShift Container Platform Benchmark v1.7.0
 |Node ^[2]^
 |link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] ^[4]^
 |`x86_64`
  `ppc64le`
  `s390x`
+ `aarch64`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |ocp4-cis-node-1-4 ^[3]^
@@ -81,12 +93,27 @@ The following tables reflect the latest available profiles in the Compliance Ope
  `s390x`
 |{product-rosa} with {hcp} (ROSA HCP)
 
+|ocp4-cis-node-1-7
+|CIS Red Hat OpenShift Container Platform Benchmark v1.7.0
+|Node ^[2]^
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] ^[4]^
+|`x86_64`
+ `ppc64le`
+ `s390x`
+ `aarch64`
+|{product-rosa} with {hcp} (ROSA HCP)
+
 |===
 [.small]
 1. The  `ocp4-cis` and `ocp4-cis-node` profiles maintain the most up-to-date version of the CIS benchmark as it becomes available in the Compliance Operator. If you want to adhere to a specific version, such as CIS v1.4.0, use the `ocp4-cis-1-4` and `ocp4-cis-node-1-4` profiles.
 2. Node profiles must be used with the relevant Platform profile. For more information, see _Compliance Operator profile types_.
 3. CIS v1.4.0 is superceded by CIS v1.5.0. It is recommended to apply the latest profile to your environment.
 4. To locate the CIS {product-title} v4 Benchmark, go to  link:https://www.cisecurity.org/benchmark/kubernetes[CIS Benchmarks] and click *Download Latest CIS Benchmark*, where you can then register to download the benchmark.
+
+[id="bsi-profiles_{context}"]
+== BSI Profile Support
+
+BSI (Bundesamt für Sicherheit in der Informationstechnik, Germany’s Federal Office for Information Security) compliance is legally mandated under Germany’s IT Security Act (IT-Sicherheitsgesetz) for critical infrastructure sectors like energy, healthcare, and telecommunications. With the release of Compliance Operator 1.7.0, BSI compliance checks for Block SYS.1.6 Containerization and Block APP.4.4 Kubernetes are now available. For more information, see link:https://access.redhat.com/articles/7045834[*BSI Quick Check*].  
 
 [id="e8-profiles_{context}"]
 == Essential Eight compliance profiles
@@ -200,6 +227,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |`x86_64`
  `ppc64le`
  `s390x`
+ `aarch64`
 |
 
 |ocp4-moderate-node ^[1]^
@@ -209,6 +237,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |`x86_64`
  `ppc64le`
  `s390x`
+ `aarch64`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |ocp4-moderate-node-rev-4
@@ -218,6 +247,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |`x86_64`
  `ppc64le`
  `s390x`
+ `aarch64`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |ocp4-moderate-rev-4
@@ -227,6 +257,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |`x86_64`
  `ppc64le`
  `s390x`
+ `aarch64`
 |
 
 |rhcos4-moderate ^[1]^
@@ -234,6 +265,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node
 |link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 |`x86_64`
+ `aarch64`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |rhcos4-moderate-rev-4
@@ -241,6 +273,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node
 |link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 |`x86_64`
+ `aarch64`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |===
@@ -306,6 +339,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Platform
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
+ `ppc64le`
 |
 
 |ocp4-pci-dss-3-2 ^[3]^
@@ -322,6 +356,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Platform
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
+ `ppc64le`
 |
 
 |ocp4-pci-dss-node ^[1]^
@@ -329,6 +364,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node ^[2]^
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library] 
 |`x86_64`
+ `ppc64le`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |ocp4-pci-dss-node-3-2 ^[3]^
@@ -345,8 +381,10 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node ^[2]^
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
+ `ppc64le`
 |{product-rosa} with {hcp} (ROSA HCP)
 |===
+
 [.small]
 1. The  `ocp4-pci-dss` and `ocp4-pci-dss-node` profiles maintain the most up-to-date version of the PCI-DSS standard as it becomes available in the Compliance Operator. If you want to adhere to a specific version, such as PCI-DSS v3.2.1, use the `ocp4-pci-dss-3-2` and `ocp4-pci-dss-node-3-2` profiles.
 2. Node profiles must be used with the relevant Platform profile. For more information, see _Compliance Operator profile types_.
@@ -371,6 +409,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Platform
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
 |`x86_64`
+ `ppc64le`
 |
 
 |ocp4-stig-node ^[1]^
@@ -378,6 +417,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node ^[2]^
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
 |`x86_64`
+ `ppc64le`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |ocp4-stig-node-v1r1 ^[3]^
@@ -385,6 +425,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node ^[2]^
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
 |`x86_64`
+ `ppc64le`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |ocp4-stig-node-v2r1
@@ -392,6 +433,15 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node ^[2]^
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
 |`x86_64`
+ `ppc64le`
+|{product-rosa} with {hcp} (ROSA HCP)
+
+|ocp4-stig-node-v2r2
+|Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG) for Red Hat Openshift V2R2
+|Node ^[2]^
+|link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
+|`x86_64`
+ `ppc64le`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |ocp4-stig-v1r1 ^[3]^
@@ -399,6 +449,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Platform
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
 |`x86_64`
+ `ppc64le`
 |
 
 |ocp4-stig-v2r1
@@ -406,6 +457,15 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Platform
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
 |`x86_64`
+ `ppc64le`
+|
+
+|ocp4-stig-v2r2
+|Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG) for Red Hat Openshift V2R2
+|Platform
+|link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
+|`x86_64`
+ `ppc64le`
 |
 
 |rhcos4-stig
@@ -413,6 +473,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
 |`x86_64`
+ `ppc64le`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |rhcos4-stig-v1r1 ^[3]^
@@ -420,6 +481,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG] ^[3]^
 |`x86_64`
+ `ppc64le`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |rhcos4-stig-v2r1
@@ -427,6 +489,15 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |Node
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
 |`x86_64`
+ `ppc64le`
+|{product-rosa} with {hcp} (ROSA HCP)
+
+|rhcos4-stig-v2r2
+|Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG) for Red Hat Openshift V2R2
+|Node
+|link:https://public.cyber.mil/stigs/downloads/[DISA-STIG]
+|`x86_64`
+ `ppc64le`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |===

--- a/modules/running-compliance-scans.adoc
+++ b/modules/running-compliance-scans.adoc
@@ -13,6 +13,11 @@ You can run a scan using the Center for Internet Security (CIS) profiles. For co
 For all-in-one control plane and worker nodes, the compliance scan runs twice on the worker and control plane nodes. The compliance scan might generate inconsistent scan results. You can avoid inconsistent results by defining only a single role in the `ScanSetting` object.
 ====
 
+[IMPORTANT]
+====
+Compliance Operator scans report `INCONSISTENT` on clusters with multi-architecture compute machines whether the control plane uses `aarch64` or `x86` CPUs. This is due to the same rule behaving differently on different architectures. This should only be applicable for node scans, where the Compliance Operator aggregates results from multiple nodes into a single result.
+====
+
 For more information about inconsistent scan results, see link:https://access.redhat.com/solutions/6970861[Compliance Operator shows INCONSISTENT scan result with worker node].
 
 .Procedure

--- a/security/compliance_operator/co-management/compliance-operator-installation.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-installation.adoc
@@ -15,7 +15,7 @@ The Compliance Operator might report incorrect results on managed platforms, suc
 
 [IMPORTANT]
 ====
-Before deploying the Compliance Operator, you are required to define persistent storage in your cluster to store the raw results output. For more information, see xref:../../../storage/understanding-persistent-storage.adoc#persistent-storage-overview_understanding-persistent-storage[Persistant storage overview] and xref:../../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#overview[Managing the default storage class].
+Before deploying the Compliance Operator, you are required to define persistent storage in your cluster to store the raw results output. For more information, see xref:../../../storage/understanding-persistent-storage.adoc#persistent-storage-overview_understanding-persistent-storage[Persistent storage overview] and xref:../../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#overview[Managing the default storage class].
 ====
 
 include::modules/compliance-operator-console-installation.adoc[leveloffset=+1]

--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -17,6 +17,54 @@ To access the latest release, see xref:../../security/compliance_operator/co-man
 
 For more information on compliance support for all Red{nbsp}Hat products, see link:https://access.redhat.com/compliance[Product Compliance].
 
+
+[id="compliance-operator-release-notes-1-7-0_{context}"]
+== OpenShift Compliance Operator 1.7.0
+
+The following advisory is available for the OpenShift Compliance Operator 1.7.0:
+
+* link:https://access.redhat.com/errata/RHBA-2025:3728[RHBA-2025:3728 - OpenShift Compliance Operator 1.7.0 bug fix and enhancement update]
+
+[id="compliance-operator-1-7-0-new-features-and-enhancements_{context}"]
+=== New features and enhancements
+
+* A `must-gather` extension is now available for the Compliance Operator installed on `aarch64`, `x86`, `ppc64le`, and `s390x` architectures. The `must-gather` tool provides crucial configuration details to Red Hat Customer Support and engineering. For more information, see xref:../../security/compliance_operator/co-support.adoc#compliance-must-gather_co-support[Using the must-gather tool for the Compliance Operator].
+
+* CIS Benchmark Support has been added to Compliance Operator 1.7.0. The profile supported is CIS OpenShift Benchmark 1.7.0. For more information, see (link:https://issues.redhat.com/browse/CMP-3081[*CMP-3081*])
+
+* Compliance Operator is now supported on `aarch64` architecture for CIS OpenShift Benchmark 1.7.0 and FedRAMP Moderate Revision 4. For more information, see (link:https://issues.redhat.com/browse/CMP-2960[*CMP-2960*])
+
+* Compliance Operator 1.7.0 now supports OpenShift DISA STIG V2R2 profiles for OpenShift and RHCOS. For more information, see (link:https://issues.redhat.com/browse/CMP-3142[*CMP-3142*])
+
+* Compliance Operator 1.7.0 now supports deprecation of old, unsupported profile versions, such as deprecation of CIS 1.4 profiles, CIS 1.5 profiles, DISA STIG V1R1 profiles and DISA STIG V2R1 profiles. For more information, see (link:https://issues.redhat.com/browse/CMP-3149[*CMP-3149*])
+
+* With this release of Compliance Operator 1.7.0, the deprecation of older CIS and DISA STIG profiles mean that these older profiles will no longer be supported with the appearance of Compliance Operator 1.8.0. For more information, see (link:https://issues.redhat.com/browse/CMP-3284[*CMP-3284*])
+
+* With this release of Compliance Operator 1.7.0, BSI profile support is added for OpenShift. For more information, refer to the KCS article link:https://access.redhat.com/articles/7045834[*BSI Quick Check*] and link:https://access.redhat.com/compliance/bsi[*BSI Compliance Summary*].
+
+[id="compliance-operator-1-7-0-bug-fixes_{context}"]
+=== Bug fixes
+
+* Before this release, Compliance Operator would provide an unneeded remediation recommendation due to differences in filesystem structure for the `s390x` architecture. With this release, the Compliance Operator now recognizes the differences in filesystem structure and does not provide the misleading remediation. With this update, the rule is now more clearly defined. (link:https://issues.redhat.com/browse/OCPBUGS-33194[*OCPBUGS-33194*])
+
+* Previously, the instructions for rule `ocp4-etcd-unique-ca` did not work for OpenShift 4.17 and later. With this update, the instructions and actionable steps are corrected. (link:https://issues.redhat.com/browse/OCPBUGS-42350[*OCPBUGS-42350*])
+
+* When using the Compliance Operator with Cluster Logging Operator (CLO) version 6.0, various rules would fail. This is due to backwards incompatible changes to the CRDs that CLO uses. The Compliance Operator relies on those CRDs to verify logging functionality. The CRDs have been corrected to support the PCI-DSS profiles with CLO. (link:https://issues.redhat.com/browse/OCPBUGS-43229[*OCPBUGS-43229*])
+
+* After installing Cluster Logging Operator (CLO) 6.0, users found that the ComplianceCheckResult `ocp4-cis-audit-log-forwarding-enabled` was failing because there was a change in the APIversion of the `clusterlogforwarder` resource. Log collection and forwarding configurations are now specified under the new API, part of the observability.openshift.io API group. (link:https://issues.redhat.com/browse/OCPBUGS-43585[*OCPBUGS-43585*])
+
+* For previous releases of Compliance Operator, the scans would generate an error log for the reconcile loop on the Operator pod. With this release, the Compliance Operator controller logic is more stable. (link:https://issues.redhat.com/browse/OCPBUGS-51267[*OCPBUGS-51267*])
+
+* Previously, the rules `file-integrity-exists` or `file-integrity-notification-enabled` would fail on `aarch64` OpenShift clusters. With this update, these rules evaluate as `NOT-APPLICABLE` on `aarch64` systems. (link:https://issues.redhat.com/browse/OCPBUGS-52884[*OCPBUGS-52884*])
+
+* Before this release of the Compliance Operator, the rule `kubelet-configure-tls-cipher-suites` failed for the API server ciphers, resulting in `E2E-FAILURE` status. The rule has been updated to check new ciphers from RFC 8446, which are included with OpenShift 4.18. The rule is now being evaluated correctly. (link:https://issues.redhat.com/browse/OCPBUGS-54212[*OCPBUGS-54212*])
+
+* Previously, the Compliance Operator platform scan would fail and produce the message `failed to parse Ignition config`. With this release, the Compliance Operator is safe to run on 4.19 clusters, when that version of OpenShift is available to customers. (link:https://issues.redhat.com/browse/OCPBUGS-54403[*OCPBUGS-54403*])
+
+* Before this release of Compliance Operator, several rules were not platform aware, creating unneeded errors. Now that the rules have been properly ported to other architectures, those rules run correctly and users can observe some Compliance Check Results reporting `NOT-APPLICABLE` appropriately, depending on the architecture they are using. (link:https://issues.redhat.com/browse/OCPBUGS-53041[*OCPBUGS-53041*])
+
+* Previously, the rule `file-groupowner-ovs-conf-db-hugetlbf` would fail unexpectedly. With this release, the rule fails only when this is the needed result. (link:http://issues.redhat.com/browse/OCPBUGS-55180[*OCPBUGS-55190*])
+
 [id="compliance-operator-release-notes-1-6-2_{context}"]
 == OpenShift Compliance Operator 1.6.2
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13641
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview for the 1.7.0 release notes: https://92420--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html

Statement about mixed arches at the top of the installation guide: 
https://92420--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-scans.html

Supported Compliance Operator Scans: Added CIS 1.7.0 for both NODE and PLATFORM:
https://92420--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-supported-profiles.html

Fixed typo. Only one letter changed in the word "Persistent":
https://92420--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-management/compliance-operator-installation.html

Added link for ScanSetting Custom Resource: 
https://92420--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-scans.html


<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

NOTE TO REVIEWERS: This PR is for release notes for Compliance Operator 1.7.0. This is an asynchronous release which updates release notes for all of OCP Docs 4.12+ with the updates provided in this release of the Compliance Operator. There are also associated documentation changes for all the new features brought in by this release. Those changes are all the extra previews. They are all small changes, but enough of them pushed the release note to a size "L". 

Link to errata for reference: https://errata.devel.redhat.com/advisory/147955 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
