### PR TITLE
Nodes swap memory fix 2

### DIFF
--- a/modules/nodes-nodes-swap-memory.adoc
+++ b/modules/nodes-nodes-swap-memory.adoc
@@ -1,38 +1,43 @@
 // Module included in the following assemblies:
 //
-// * nodes/nodes/nodes-nodes-managing.:_mod-docs-content-type: PROCEDURE
+// * nodes/nodes/nodes-nodes-managing.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nodes-nodes-swap-memory_{context}"]
 
-= Enabling swap memory use on nodes
+= Allowing swap memory use on nodes
 
-:FeatureName: Enabling swap memory use on nodes
+You can allow workloads on the cluster nodes to use swap memory.
+
+:FeatureName: Swap memory support on nodes
 include::snippets/technology-preview.adoc[]
 
 [NOTE]
 ====
-Enabling swap memory is only available for container-native virtualization (CNV) users or use cases.
+Swap memory support is available only for container-native virtualization (CNV) users or use cases.
 ====
+
+To allow swap memory usage on your nodes, create a `kubeletconfig` custom resource (CR) to set the `failSwapOn` parameter to `false`. 
+
+Optionally, you can control swap memory usage by {product-title} workloads on those nodes by setting the `swapBehavior` parameter to one of the following values:
+
+* `NoSwap` prevents {product-title} worloads from using swap memory.  
+* `LimitedSwap` allows {product-title} workloads that fall under the Burstable QoS class to use swap memory.
+
+Regardless of the `swapBehavior` setting, any workloads that are not managed by {product-title} on that node can still use swap memory if the `failSwapOn` parameter is `false`.
+
+Because the kubelet will not start in the presence of swap memory without this configuration, you must allow swap memory in {product-title} before enabling swap memory on the nodes. If there is no swap memory present on a node, enabling swap memory in {product-title} has no effect.
 
 [WARNING]
 ====
-Enabling swap memory can negatively impact workload performance and out-of-resource handling. Do not enable swap memory on control plane nodes.
+Using swap memory can negatively impact workload performance and out-of-resource handling. Do not enable swap memory on control plane nodes.
 ====
-
-To enable swap memory, create a `kubeletconfig` custom resource (CR) to set the `swapbehavior` parameter. You can set limited or unlimited swap memory:
-
-* Limited: Use the `LimitedSwap` value to limit how much swap memory workloads can use. Any workloads on the node that are not managed by {product-title} can still use swap memory. The `LimitedSwap` behavior depends on whether the node is running with Linux control groups link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[version 1 (cgroups v1)] or link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[version 2 (cgroup v2)]:
-** cgroup v2: {product-title} workloads can use any combination of memory and swap, up to the pod's memory limit, if set.
-** cgroup v1: {product-title} workloads cannot use swap memory.
-
-* Unlimited: Use the `UnlimitedSwap` value to allow workloads to use as much swap memory as they request, up to the system limit.
-
-Because the kubelet will not start in the presence of swap memory without this configuration, you must enable swap memory in {product-title} before enabling swap memory on the nodes. If there is no swap memory present on a node, enabling swap memory in {product-title} has no effect.
 
 .Prerequisites
 
 * You have a running {product-title} cluster that uses version 4.10 or later.
+
+* Your cluster is configured to use cgroup v2. Swap memory is not supported on nodes in clusters that use cgroup v1.
 
 * You are logged in to the cluster as a user with administrative privileges.
 
@@ -42,8 +47,6 @@ Because the kubelet will not start in the presence of swap memory without this c
 ====
 Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
 ====
-
-* If cgroup v2 is enabled on a node, you must enable swap accounting on the node, by setting the `swapaccount=1` kernel argument.
 
 .Procedure
 
@@ -73,6 +76,9 @@ spec:
 #...
 ----
 <1> Set to `false` to enable swap memory use on the associated nodes. Set to `true` to disable swap memory use.
-<2> Specify the swap memory behavior. If unspecified, the default is `LimitedSwap`.
+<2> Optional: Specify the swap memory behavior for {product-title} pods.
++
+* `NoSwap`: {product-title} pods cannot use swap. This is the default.
+* `LimitedSwap`: {product-title} pods of Burstable QoS class only are permitted to employ swap.
 
-. Enable swap memory on the machines.
+. Enable swap memory on the nodes by setting the `swapaccount=1` kernel argument and configure swap memory as needed.


### PR DESCRIPTION
The docs about enabling swap memory are incorrect that cgroup v2 clusters cannot use limited swap memory. It should be cgroup v1 cluster cannot use limited swap.

Also: 
* Removes references to Unlimited Swap (removed in [OCP 4.17/Kubernetes v 1.30](https://github.com/kubernetes/kubernetes/pull/122745/commits/6a4e19a4ec9e11b77c9357375df4cadd8229836f)) 
* Replaces it with NoSwap (added in [OCP 4.17/Kubernetes v 1.30](https://github.com/kubernetes/kubernetes/pull/122745/commits/6a4e19a4ec9e11b77c9357375df4cadd8229836f))
*  Re-organizes and re-writes some of the text for clarity and to tighten things up a bit.

See the current docs: [Enabling swap memory use on nodes](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/working-with-nodes#nodes-nodes-swap-memory_nodes-nodes-managing)

4.17+

Preview: [Allowing swap memory use on nodes](https://92421--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#nodes-nodes-swap-memory_nodes-nodes-managing): 
- Slight re-write of title for clarity
- Added intro paragraph
- Moved one of the (ick) stacked admonitions to the end of the section, right before the prereqs
- Reworked the three paragraphs following the (ick) stacked admonitions
- Added new prereq bullet 2.
- Removed (former) prereq bullet 4 (after the NOTE), as it is the same as Step 3, I think, and should come after the procedure.
- Procedure Step 2, call-out two, reworded, added `NoSwap`.
- Procedure Step 3, reworded.  

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Related to: https://github.com/openshift/openshift-docs/pull/92409