### PR TITLE
OSDOCS#14369: Update the z-stream RNs for 4.18.10

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3016,6 +3016,50 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.10
+[id="ocp-4-18-10_{context}"]
+=== RHSA-2025:4019 - {product-title} {product-version}.10 bug fix update and security update
+
+Issued: 22 April 2025
+
+{product-title} release {product-version}.10 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4019[RHSA-2025:4019] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4021[RHBA-2025:4021] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.10 --pullspecs
+----
+
+[id="ocp-4-18-10-enhancements_{context}"]
+==== Enhancements
+
+* In the bootstrap phase of the installation process, the Transport Layer Security (TLS) between the `metal3` `httpd` server and the node's Baseboard Management Controller (BMC) is enabled by default in {product-title} 4.18 and later. The `httpd` server is on port 6183 instead of port 6180 when TLS is enabled. Disable the TLS setting by adding 'disableVirtualMediaTLS: true' to the provisioning custom resource (CR) file that is created on the disk. (link:https://issues.redhat.com/browse/OCPBUGS-39404[OCPBUGS-39404])
+
+
+[id="ocp-4-18-10-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the Prometheus remote-write proxy configuration was not correctly applied to the Prometheus user workload custom resource (CR), which caused communication and data collection problems in the cluster. With this release, the user workload monitoring (UWM) Prometheus configurations, including user workload Prometheus, correctly inherit the proxy settings from the cluster proxy resource. (link:https://issues.redhat.com/browse/OCPBUGS-38655[OCPBUGS-38655])
+
+* Previously, when running {op-system-first} in an active environment, the `rpm-ostree-fix-shadow-mode.service` systemd service that used to run caused that service to fail. With this release, the `rpm-ostree-fix-shadow-mode.service` systemd service does not activate when {op-system} does not run from an installed environment. (link:https://issues.redhat.com/browse/OCPBUGS-41625[OCPBUGS-41625])
+
+* Previously, an incorrect component import in the `SimpleSelect.tsx` file caused an undefined function `r` function in the `react-dom.production.min.js` file. This component caused error messages on the *Dashboards* and *Metrics* pages related to dropdown lists. With this release, the dropdown lists on the affected pages function correctly, eliminating the error message. (link:https://issues.redhat.com/browse/OCPBUGS-42845[OCPBUGS-42845])
+
+* Previously, an error in the rotation logic of the image pull secret controller's secret token caused a temporary, invalid token for authentication. As a consequence, the image pull process was disrupted. With this release, the updated image pull secret controller eliminates the period when the token is not valid while the token rotates. As a result, the image pull process is smooth and continuous. (link:https://issues.redhat.com/browse/OCPBUGS-54304[OCPBUGS-54304])
+
+* Previously, an error occurred in {hcp}-managed clusters because of the omission of the `shutdown-watch-termination-grace-period` setting in the `kube-apiserver` configuration. This error led to the unstable shutdown of applications in {hcp}-managed clusters. With this release, an update improves the shutdown process of applications in {hcp}-managed clusters, providing a grace period for the `kube-apiserver` configuration. During a shutdown, the application stability is improved and potential errors are decreased. (link:https://issues.redhat.com/browse/OCPBUGS-53404[OCPBUGS-53404])
+
+* Previously, an issue with the version of the `github.com/sherine-k/catalog-filter` element stopped, causing instability in the mirroring process. With this release, the `github.com/sherine-k/catalog-filter` element in the `go.mod` file is updated, which solves the problem and ensures a stable and reliable mirroring process. (link:https://issues.redhat.com/browse/OCPBUGS-54727[OCPBUGS-54727])
+
+* Previously, an iteration counter increment omission in the `scrapeCache` setting led to an incorrect series count for subsequent scrapes. As a result, monitoring was interrupted and data could potentially be lost during the Prometheus scrape process. With this release, an update ensures uninterrupted monitoring, because Prometheus continues scraping and processing data while parsing errors. (link:https://issues.redhat.com/browse/OCPBUGS-54940[OCPBUGS-54940])
+
+[id="ocp-4-18-10-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.9
 [id="ocp-4-18-9_{context}"]
 === RHSA-2025:3775 - {product-title} {product-version}.9 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-14369](https://issues.redhat.com//browse/OSDOCS-14369)

Link to docs preview:
[4.18.10](https://92422--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-10_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream relnotes

Additional information:
The errata URLs will return 404 until the go-live date of 04/22/25.