### PR TITLE
TELCODOCS#2285: Updated docs for hardwareTuning field to be more accurate

### DIFF
--- a/modules/ztp-recommended-cluster-kernel-config.adoc
+++ b/modules/ztp-recommended-cluster-kernel-config.adoc
@@ -31,7 +31,7 @@ spec:
 You can use hardware tuning to tune CPU frequencies for reserved and isolated core CPUs.
 For FlexRAN like applications, hardware vendors recommend that you run CPU frequencies below the default provided frequencies.
 It is highly recommended that, before setting any frequencies, you refer to the hardware vendor’s guidelines for maximum frequency settings for your processor generation.
-This example shows the frequencies for reserved and isolated CPUs for Sapphire Rapid hardware:
+This example sets the frequencies for reserved and isolated CPUs to 2500 MHz:
 +
 [source,yaml]
 ----
@@ -52,7 +52,7 @@ spec:
           enabled: true
       hardwareTuning:
           isolatedCpuFreq: 2500000
-          reservedCpuFreq: 2800000
+          reservedCpuFreq: 2500000
 ----
 
 . Ensure that the `performance-patch` profile in the `Tuned` CR configures the correct CPU isolation set that matches the `isolated` CPU set in the related `PerformanceProfile` CR, for example:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2285](https://issues.redhat.com/browse/TELCODOCS-2285)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Recommended cluster kernel configuration](https://92424--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-vdu-validating-cluster-tuning.html#ztp-recommended-cluster-kernel-config_vdu-config-ref)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->