### PR TITLE
OSDOCS-14370: Documented the 4.17.26 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2879,6 +2879,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.26
+[id="ocp-4-17-26_{context}"]
+=== RHSA-2025:4012 - {product-title} {product-version}.26 bug fix and security update advisory
+
+Issued: 24 April 2025
+
+{product-title} release {product-version}.26 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4012[RHSA-2025:4012] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4014[RHBA-2025:4014] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.26 --pullspecs
+----
+
+[id="ocp-4-17-26-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when you attempted to create a validating webhook for a resource that was managed by the `oauth` API server, the validating webhook was not created. This issue occurred because of a communication issue with the `oauth` API server and the data plane. With this release, a Konnectivity proxy sidecar has been added to bridge communications between the `oauth` API server and the data plane so that you can now create a validating webhook for any resource that the `oauth` API server manages.  (link:https://issues.redhat.com/browse/OCPBUGS-54841[*OCPBUGS-54841*])
+
+* Previously, virtual machines (VMs) in a cluster that ran on {azure-first} failed because the attached network interface controller (NIC) was in a `ProvisioningFailed` state. With this release, the Machine API controller now checks the provisioning status of a NIC and refreshes the VMs on a regular basis to prevent this issue. (link:https://issues.redhat.com/browse/OCPBUGS-54393[*OCPBUGS-54393*]) 
+
+* Previously, the installation program malfunctioned if it attempted to retrieve {gcp-full} tags over an unstable network, or when it could not reach the GCP server. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-51210[*OCPBUGS-51210*]) 
+
+* Previously, a User Datagram Protocol (UDP) packet that was larger than the maximum transmission unit (MTU) value set for the cluster, could not be sent to the endpoint of the packet by using a service. With this release, the pod IP address is used instead of the service IP address regardless of the packet size, so that the UDP packet can be sent to the endpoint. (link:https://issues.redhat.com/browse/OCPBUGS-50579[*OCPBUGS-50579*])
+
+[id="ocp-4-17-26-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.25
 [id="ocp-4-17-25_{context}"]
 === RHSA-2025:3798 - {product-title} {product-version}.25 bug fix and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-14370](https://issues.redhat.com/browse/OSDOCS-14370)

Link to docs preview:
* [4.17.26](https://92433--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-26_release-notes)



