### PR TITLE
OSDOCS-14042: fixing OPENSHIFT_HA_VRRP_ID_OFFSET default value

### DIFF
--- a/modules/nw-ipfailover-configuration.adoc
+++ b/modules/nw-ipfailover-configuration.adoc
@@ -154,7 +154,7 @@ spec:
         - name: OPENSHIFT_HA_MONITOR_PORT <5>
           value: "30060"
         - name: OPENSHIFT_HA_VRRP_ID_OFFSET <6>
-          value: "0"
+          value: "10"
         - name: OPENSHIFT_HA_REPLICA_COUNT <7>
           value: "2" #Must match the number of replicas in the deployment
         - name: OPENSHIFT_HA_USE_UNICAST
@@ -201,7 +201,7 @@ spec:
 <3> The number of groups to create for VRRP. If not set, a group is created for each virtual IP range specified with the `OPENSHIFT_HA_VIP_GROUPS` variable.
 <4> The interface name that IP failover uses to send VRRP traffic. By default, `eth0` is used.
 <5> The IP failover pod tries to open a TCP connection to this port on each VIP. If connection is established, the service is considered to be running. If this port is set to `0`, the test always passes. The default value is `80`.
-<6> The offset value used to set the virtual router IDs. Using different offset values allows multiple IP failover configurations to exist within the same cluster. The default offset is `0`, and the allowed range is `0` through `255`.
+<6> The offset value used to set the virtual router IDs. Using different offset values allows multiple IP failover configurations to exist within the same cluster. The default offset is `10`, and the allowed range is `0` through `255`.
 <7> The number of replicas to create. This must match `spec.replicas` value in IP failover deployment configuration. The default value is `2`.
 <8> The name of the `iptables` chain to automatically add an `iptables` rule to allow the VRRP traffic on. If the value is not set, an `iptables` rule is not added. If the chain does not exist, it is not created, and Keepalived operates in unicast mode. The default is `INPUT`.
 <9> The full path name in the pod file system of a script that is run whenever the state changes.

--- a/modules/nw-ipfailover-environment-variables.adoc
+++ b/modules/nw-ipfailover-environment-variables.adoc
@@ -32,8 +32,8 @@ If your cluster uses the OVN-Kubernetes network plugin, set this value to `br-ex
 |The list of IP address ranges to replicate. This must be provided. For example, `1.2.3.4-6,1.2.3.9`.
 
 |`OPENSHIFT_HA_VRRP_ID_OFFSET`
-|`0`
-|The offset value used to set the virtual router IDs. Using different offset values allows multiple IP failover configurations to exist within the same cluster. The default offset is `0`, and the allowed range is `0` through `255`.
+|`10`
+|The offset value used to set the virtual router IDs. Using different offset values allows multiple IP failover configurations to exist within the same cluster. The default offset is `10`, and the allowed range is `0` through `255`.
 
 |`OPENSHIFT_HA_VIP_GROUPS`
 |


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-14042](https://issues.redhat.com//browse/OSDOCS-14042)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
