### PR TITLE
OCPBUGS-55213 Bad command line example for troubleshooting MetalLB

### DIFF
--- a/modules/nw-metallb-troubleshoot-bgp.adoc
+++ b/modules/nw-metallb-troubleshoot-bgp.adoc
@@ -5,7 +5,6 @@
 [id="nw-metallb-troubleshoot-bgp_{context}"]
 = Troubleshooting BGP issues
 
-The BGP implementation that Red Hat supports uses FRRouting (FRR) in a container in the `speaker` pods.
 As a cluster administrator, if you need to troubleshoot BGP configuration issues, you need to run commands in the FRR container.
 
 .Prerequisites
@@ -16,27 +15,25 @@ As a cluster administrator, if you need to troubleshoot BGP configuration issues
 
 .Procedure
 
-. Display the names of the `speaker` pods:
+. Display the names of the `frr-k8s` pods by running the following command:
 +
 [source,terminal]
 ----
-$ oc get -n metallb-system pods -l component=speaker
+$ oc -n metallb-system get pods -l component=frr-k8s
 ----
 +
 .Example output
 [source,text]
 ----
 NAME            READY   STATUS    RESTARTS   AGE
-speaker-66bth   4/4     Running   0          56m
-speaker-gvfnf   4/4     Running   0          56m
-...
+frr-k8s-thsmw   6/6     Running   0          109m
 ----
 
-. Display the running configuration for FRR:
+. Display the running configuration for FRR by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec -n metallb-system speaker-66bth -c frr -- vtysh -c "show running-config"
+$ oc exec -n metallb-system frr-k8s-thsmw -c frr -- vtysh -c "show running-config"
 ----
 +
 .Example output
@@ -45,11 +42,13 @@ Building configuration...
 
 Current configuration:
 !
-frr version 7.5.1_git
+frr version 8.5.3
 frr defaults traditional
 hostname some-hostname
 log file /etc/frr/frr.log informational
 log timestamp precision 3
+no ip forwarding
+no ipv6 forwarding
 service integrated-vtysh-config
 !
 router bgp 64500  <1>
@@ -107,11 +106,11 @@ end
 <3> If you configured BFD, confirm that the BFD profile is associated with the correct BGP peer and that the BFD profile appears in the command output.
 <4> Confirm that the `network <ip-address-range>` lines match the IP address ranges that you specified in address pool custom resources that you added.
 
-. Display the BGP summary:
+. Display the BGP summary by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec -n metallb-system speaker-66bth -c frr -- vtysh -c "show bgp summary"
+$ oc exec -n metallb-system frr-k8s-thsmw -c frr -- vtysh -c "show bgp summary"
 ----
 +
 .Example output
@@ -144,11 +143,11 @@ Total number of neighbors 2
 <2> Output that shows `0` messages received and messages sent indicates a BGP peer that does not have a BGP session.
 Check network connectivity and the BGP configuration of the BGP peer.
 
-. Display the BGP peers that received an address pool:
+. Display the BGP peers that received an address pool by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec -n metallb-system speaker-66bth -c frr -- vtysh -c "show bgp ipv4 unicast 203.0.113.200/30"
+$ oc exec -n metallb-system frr-k8s-thsmw -c frr -- vtysh -c "show bgp ipv4 unicast 203.0.113.200/30"
 ----
 +
 Replace `ipv4` with `ipv6` to display the BGP peers that received an IPv6 address pool.


### PR DESCRIPTION
[OCPBUGS-55213]: Bad command line example for troubleshooting MetalLB

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18, 4.19 main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-55213
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://92473--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-troubleshoot-support.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
