### PR TITLE
Docs for MCO-836 [GA] Machine Config Node

### DIFF
--- a/modules/checking-mco-node-status-configuring.adoc
+++ b/modules/checking-mco-node-status-configuring.adoc
@@ -3,41 +3,12 @@
 // * machine_configuration/machine-config-index.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="checking-mco-node-status-congifuring_{context}"]
+[id="checking-mco-node-status-configuring_{context}"]
 = Checking machine config node status
 
-During the update of a machine config pool (MCP), you can monitor the progress of all control plane and worker nodes in your cluster by using the `oc get machineconfignodes` and `oc describe machineconfignodes` commands. These commands provide information that can be helpful if issues arise during the update and you need to troubleshoot a node.
-
-You cannot use these commands with custom machine config pools.
+During the update of a machine config pool (MCP), you can monitor the progress of all of the nodes in your cluster by using the `oc get machineconfignodes` and `oc describe machineconfignodes` commands. These commands provide information that can be helpful if issues arise during the update and you need to troubleshoot a node.
 
 For more information on the meaning of these fields, see "About checking machine config node status."
-
-.Prerequisites
-
-* You enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`:
-+
-[source,terminal]
-----
-$ oc edit featuregate cluster
-----
-+
-.Example `FeatureGate` CR
-[source,yaml]
-----
-apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
-spec:
-  featureSet: TechPreviewNoUpgrade
-----
-+
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
-====
-+
-After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
 
 .Procedure
 
@@ -70,13 +41,13 @@ $ oc get machineconfignodes -o wide
 .Example output
 [source,text]
 ----
-NAME                                       POOLNAME   DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED   UPDATEPREPARED   UPDATEEXECUTED   UPDATEPOSTACTIONCOMPLETE   UPDATECOMPLETE   RESUMED   UPDATECOMPATIBLE   UPDATEDFILESANDOS   CORDONEDNODE   DRAINEDNODE   REBOOTEDNODE   RELOADEDCRIO   UNCORDONEDNODE
-ci-ln-g6dr34b-72292-g9btv-master-0         master     rendered-master-d4e122320b351cdbe1df59ddb63ddcfc   rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   False     True             Unknown          False                      False            False     True               Unknown             False          False         False          False          False
-ci-ln-g6dr34b-72292-g9btv-master-1         master     rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   True      False            False            False                      False            False     False              False               False          False         False          False          False
-ci-ln-g6dr34b-72292-g9btv-master-2         master     rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   True      False            False            False                      False            False     False              False               False          False         False          False          False
-ci-ln-g6dr34b-72292-g9btv-worker-a-sjh5r   worker     rendered-worker-671b88c8c569fa3f60dc1a27cf9c91f2   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   False     True             Unknown          False                      False            False     True               Unknown             False          False         False          False          False
-ci-ln-g6dr34b-72292-g9btv-worker-b-xthbz   worker     rendered-worker-d5534cb730e5e108905fc285c2a42b6c   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   True      False            False            False                      False            False     False              False               False          False         False          False          False
-ci-ln-g6dr34b-72292-g9btv-worker-c-gnpd6   worker     rendered-worker-d5534cb730e5e108905fc285c2a42b6c   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   True      False            False            False                      False            False     False              False               False          False         False          False          False
+NAME                                       POOLNAME   DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED   UPDATEPREPARED   UPDATEEXECUTED   UPDATEPOSTACTIONCOMPLETE   UPDATECOMPLETE   RESUMED   UPDATEDFILESANDOS   CORDONEDNODE   DRAINEDNODE   REBOOTEDNODE   UNCORDONEDNODE
+ci-ln-g6dr34b-72292-g9btv-master-0         master     rendered-master-d4e122320b351cdbe1df59ddb63ddcfc   rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   False     True             Unknown          False                      False            False     Unknown             False          False         False          False
+ci-ln-g6dr34b-72292-g9btv-master-1         master     rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   True      False            False            False                      False            False     False               False          False         False          False
+ci-ln-g6dr34b-72292-g9btv-master-2         master     rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   rendered-master-6f2064fcb36d2a914de5b0c660dc49ff   True      False            False            False                      False            False     False               False          False         False          False
+ci-ln-g6dr34b-72292-g9btv-worker-a-sjh5r   worker     rendered-worker-671b88c8c569fa3f60dc1a27cf9c91f2   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   False     True             Unknown          False                      False            False     Unknown             False          False         False          False
+ci-ln-g6dr34b-72292-g9btv-worker-b-xthbz   worker     rendered-worker-d5534cb730e5e108905fc285c2a42b6c   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   True      False            False            False                      False            False     False               False          False         False          False
+ci-ln-g6dr34b-72292-g9btv-worker-c-gnpd6   worker     rendered-worker-d5534cb730e5e108905fc285c2a42b6c   rendered-worker-d5534cb730e5e108905fc285c2a42b6c   True      False            False            False                      False            False     False               False          False         False          False
 ----
 
 * Check the update status of nodes in a specific machine config pool by running the following command:
@@ -85,6 +56,10 @@ ci-ln-g6dr34b-72292-g9btv-worker-c-gnpd6   worker     rendered-worker-d5534cb730
 ----
 $ oc get machineconfignodes $(oc get machineconfignodes -o json | jq -r '.items[]|select(.spec.pool.name=="<pool_name>")|.metadata.name') <1>
 ----
++
+where:
+
+`<pool_name>`:: Specifies the name of the machine config pool.
 +
 .Example output
 [source,text]
@@ -105,35 +80,60 @@ $ oc describe machineconfignode/<node_name>
 .Example output
 [source,text]
 ----
-Name:         <node_name>
-Namespace:
-Labels:       <none>
-Annotations:  <none>
-API Version:  machineconfiguration.openshift.io/v1alpha1
-Kind:         MachineConfigNode
-Metadata:
-  Creation Timestamp:  2023-10-17T13:08:58Z
-  Generation:          1
-  Resource Version:    49443
-  UID:                 4bd758ab-2187-413c-ac42-882e61761b1d
-Spec:
-  Node Ref:
-    Name:         <node_name>
-  Pool:
-    Name:         master
-  ConfigVersion:
-    Desired: rendered-worker-823ff8dc2b33bf444709ed7cd2b9855b
-Status:
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigNode
+metadata:
+  creationTimestamp: "2025-04-28T18:52:16Z"
+  generation: 3
+  name: ci-ln-921r7qk-72292-kxv95-worker-a-zmxrr
+  ownerReferences:
+  - apiVersion: v1
+    kind: Node
+    name: ci-ln-921r7qk-72292-kxv95-worker-a-zmxrr
+    uid: e548a8d1-4f16-42cd-9234-87ac5aede6c1
+  resourceVersion: "62331"
+  uid: 11d96e07-582d-4569-a84a-9d8c5229a551
+spec:
+  configVersion:
+    desired: rendered-worker-1930ca7433b7f0153286a3f04e4cb57b
+  node:
+    name: ci-ln-921r7qk-72292-kxv95-worker-a-zmxrr
+  pool:
+    name: worker
+status:
+  conditions:
 # ...
-    Message:               Drained node. The drain is complete as the desired drainer matches current drainer: drain-rendered-worker-01f27f752eb84eba917450e43636b210
-    Reason:                UpdateExecutedDrained
-    Status:                True
-    Type:                  Drained
-    Last Transition Time:  2025-01-14T15:45:55Z
+    lastTransitionTime: 2025-04-23T14:55:31Z
+    message: Update Compatible. Post Cfg Actions: [] Drain Required: true
+    reason: UpdatePrepared
+    status: True
+    type: UpdatePrepared
 # ...
-  Config Version:
-    Current:            rendered-master-8110974a5cea69dff5b263237b58abd8
-    Desired:            rendered-worker-823ff8dc2b33bf444709ed7cd2b9855b
-  Observed Generation:  6
+    lastTransitionTime: 2025-04-23T14:55:31Z
+    message: Draining node. The drain will not be complete until desired drainer drain-rendered-worker-1930ca7433b7f0153286a3f04e4cb57b
+      matches current drainer uncordon-rendered-worker-a9673968884f1ea42c26edcd914af907
+    reason: UpdateExecutedDrained
+    status: True
+    type: Drained
+# ...
+    lastTransitionTime: 2025-04-23T14:55:31Z
+    message: Cordoned node. The node is reporting Unschedulable = true
+    reason: UpdateExecutedCordoned
+    status: True
+    type: Cordoned
+# ...
+  - lastTransitionTime: "2025-04-28T18:52:16Z"
+    message: This node has not yet entered the NodeDegraded phase
+    reason: NotYetOccurred
+    status: "False"
+    type: NodeDegraded
+# ...
+  configversion:
+    current: rendered-worker-8110974a5cea69dff5b263237b58abd8
+    desired: rendered-worker-1930ca7433b7f0153286a3f04e4cb57b
+  observedgeneration:  4
+  pinnedImageSets:
+  - desiredGeneration: 1
+    name: worker-pinned-images
 # ...  
 ----

--- a/modules/checking-mco-node-status.adoc
+++ b/modules/checking-mco-node-status.adoc
@@ -6,37 +6,31 @@
 [id="checking-mco-node-status_{context}"]
 = About checking machine config node status
 
-If you make changes to the default control plane or worker nodes in your cluster, for example by using a machine config or kubelet config, you can get detailed information about the progress of the node updates by using the machine config nodes custom resource. Any change that results in a new machine config triggers the node update process.
+If you make changes to a machine config pool (MCP) that results in a new machine config, for example by using a `MachineConfig` or `KubeletConfig` object, you can get detailed information about the progress of the node updates by using the machine config nodes custom resource. 
 
-You can view this detailed information for nodes in the `control plane` and `worker` machine config pools that were created upon {product-title} installation. You cannot use custom machine config pools.
-
-The `MachineConfigNode` custom resource allows you to monitor the progress of individual node updates as they move through the upgrade phases. This information can be helpful with troubleshooting if one of the nodes has an issue during the update. The custom resource reports where in the update process the node is at the moment, the phases that have completed, and the phases that are remaining.
-
-:FeatureName: The machine config node custom resource
-include::snippets/technology-preview.adoc[]
+The `MachineConfigNode` custom resource allows you to monitor the progress of individual node updates as they move through the update phases. This information can be helpful with troubleshooting if one of the nodes has an issue during the update. The custom resource reports where in the update process the node is at the moment, the phases that have completed, and the phases that are remaining.
 
 The node update process consists of the following phases and subphases that are tracked by the machine config node custom resource, explained with more detail later in this section:
 
 * *Update Prepared*. The MCO stops the configuration drift monitoring process and verifies that the newly-created machine config can be applied to a node.
-** *UpdateCompatible*
-* *Update Executed*. The MCO cordons and drains the node and applies the new machine config to the node's files and operating system, as needed. It contains the following sub-phases:
+* *Update Executed*. The MCO cordons and drains the node and applies the new machine config to the node files and operating system, as needed. It contains the following sub-phases:
 ** *Cordoned*
 ** *Drained*
 ** *AppliedFilesAndOS*
 * *PinnedImageSetsProgressing* The MCO is performing the steps needed to pin and pre-load container images. 
 * *PinnedImageSetsDegraded* The pinned image process failed. You can view the reason for the failure by using the `oc describe machineconfignode` command, as described later in this section.
-* *Update Post update action*. The MCO reboots the node or reloads CRI-O, as needed.
-** *RebootedNode*
-** *ReloadedCRIO*
-* *Update Complete*. The MCO uncordons the nodes, updates the node state to the cluster, and resumes producing node metrics.
-** *Updated*
+* *NodeDegraded* The node update failed. You can view the reason for the failure by using the `oc describe machineconfignode` command, as described later in this section.
+* *Update Post update action* The MCO is reloading CRI-O, as needed.
+* *Rebooted Node* The MCO is rebooting the node, as needed.
+* *Update Complete*. The MCO is uncordoning the node, updating the node state to the cluster, and resumes producing node metrics. It contains the following sub-phase:
 ** *Uncordoned*
-* *Resumed*. The MCO restarts the config drift monitor process and the node returns to operational state.
+* *Updated* The MCO completed a node update and the current config version of the node is equal to the desired updated version.
+* *Resumed*. The MCO restarted the config drift monitor process and the node returns to operational state.
 
 As the update moves through these phases, you can query the `MachineConfigNode` custom resource, which reports one of the following conditions for each phase:
 
-* `True`. The phase is complete on that node or the MCO has started that phase on that node.
-* `False`.  The phase is either being executed or will not be executed on that node.
+* `True`. The phase is complete on that node.
+* `False`.  The phase has not yet started or will not be executed on that node.
 * `Unknown`. The phase is either being executed on that node or has an error. If the phase has an error, you can use the `oc describe machineconfignodes` command for more information, as described later in this section.
 
 For example, consider a cluster with a newly-created machine config:
@@ -49,6 +43,7 @@ $ oc get machineconfig
 .Example output
 [source,text]
 ----
+NAME                                               GENERATEDBYCONTROLLER                      IGNITIONVERSION   AGE
 # ...
 rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   c00e2c941bc6e236b50e0bf3988e6c790cf2bbb2   3.4.0             6d15h
 rendered-master-a386c2d1550b927d274054124f58be68   c00e2c941bc6e236b50e0bf3988e6c790cf2bbb2   3.4.0             7m26s
@@ -57,8 +52,8 @@ rendered-worker-01f27f752eb84eba917450e43636b210   c00e2c941bc6e236b50e0bf3988e6
 rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   c00e2c941bc6e236b50e0bf3988e6c790cf2bbb2   3.4.0             7m26s <2>
 # ...
 ----
-<1> The current machine config for the control plane and worker nodes.
-<2> A newly-created machine config that is being applied to the control plane and worker nodes.
+<1> The current machine config for the worker nodes.
+<2> The newly-created machine config that is being applied to the worker nodes.
 
 You can watch as the nodes are updated with the new machine config:
 
@@ -70,13 +65,13 @@ $ oc get machineconfignodes
 .Example output
 [source,text]
 ----
-NAME                                       POOLNAME   DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED
-ci-ln-ds73n5t-72292-9xsm9-master-0         master     rendered-master-a386c2d1550b927d274054124f58be68   rendered-master-a386c2d1550b927d274054124f58be68   True
-ci-ln-ds73n5t-72292-9xsm9-master-1         master     rendered-master-a386c2d1550b927d274054124f58be68   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   False
-ci-ln-ds73n5t-72292-9xsm9-master-2         master     rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   True
-ci-ln-ds73n5t-72292-9xsm9-worker-a-2d8tz   worker     rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   True <1>
-ci-ln-ds73n5t-72292-9xsm9-worker-b-gw5sd   worker     rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-01f27f752eb84eba917450e43636b210   False <2>
-ci-ln-ds73n5t-72292-9xsm9-worker-c-t227w   worker     rendered-worker-01f27f752eb84eba917450e43636b210   rendered-worker-01f27f752eb84eba917450e43636b210   True <3>
+NAME                                       POOLNAME      DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED
+ci-ln-ds73n5t-72292-9xsm9-master-0         master        rendered-master-a386c2d1550b927d274054124f58be68   rendered-master-a386c2d1550b927d274054124f58be68   True
+ci-ln-ds73n5t-72292-9xsm9-master-1         master        rendered-master-a386c2d1550b927d274054124f58be68   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   False
+ci-ln-ds73n5t-72292-9xsm9-master-2         master        rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   True
+ci-ln-ds73n5t-72292-9xsm9-worker-a-2d8tz   worker-cnf    rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   True <1>
+ci-ln-ds73n5t-72292-9xsm9-worker-b-gw5sd   worker        rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-01f27f752eb84eba917450e43636b210   False <2>
+ci-ln-ds73n5t-72292-9xsm9-worker-c-t227w   worker        rendered-worker-01f27f752eb84eba917450e43636b210   rendered-worker-01f27f752eb84eba917450e43636b210   True <3>
 ----
 <1> This node has been updated. The new machine config, `rendered-worker-f351f6947f15cd0380514f4b1c89f8f2`, is shown as the desired and current machine configs.
 <2> This node is currently being updated to the new machine config. The previous and new machine configs are shown as the desired and current machine configs, respectively.
@@ -90,7 +85,7 @@ ci-ln-ds73n5t-72292-9xsm9-worker-c-t227w   worker     rendered-worker-01f27f752e
 |`POOLNAME` |The name of the machine config pool associated with that node.
 |`DESIREDCONFIG` |The name of the new machine config that the node updates to.
 |`CURRENTCONFIG` |The name of the current machine configuration on that node.
-|`UPDATED` a|Indicates if the node has been updated with one of the following conditions:
+|`UPDATED` a|Indicates if the node has been updated by using one of the following conditions:
 
 * If `False`, the node is being updated to the new machine configuration shown in the `DESIREDCONFIG` field.
 * If `True`, and the `CURRENTCONFIG` matches the new machine configuration shown in the `DESIREDCONFIG` field, the node has been updated.
@@ -109,13 +104,13 @@ $ oc get machineconfignodes -o wide
 [source,text]
 ----
 $ oc get machineconfignode -o wide
-NAME                                       POOLNAME   DESIREDCONFIG                                      CURRENTCONFIG                                      UPDATED   UPDATEPREPARED   UPDATEEXECUTED   UPDATEPOSTACTIONCOMPLETE   UPDATECOMPLETE   RESUMED   UPDATECOMPATIBLE   UPDATEDFILESANDOS   CORDONEDNODE   DRAINEDNODE   REBOOTEDNODE   RELOADEDCRIO   UNCORDONEDNODE
-ci-ln-ds73n5t-72292-9xsm9-master-0         master     rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   True      False            False            False                      False            False     False              False               False          False         False          False          False
-ci-ln-ds73n5t-72292-9xsm9-master-1         master     rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   True      False            False            False                      False            False     False              False               False          False         False          False          False
-ci-ln-ds73n5t-72292-9xsm9-master-2         master     rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   True      False            False            False                      False            False     False              False               False          False         False          False          False
-ci-ln-ds73n5t-72292-9xsm9-worker-a-2d8tz   worker     rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   True      False            False            False                      False            False     False              False               False          False         False          False          False
-ci-ln-ds73n5t-72292-9xsm9-worker-b-gw5sd   worker     rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-01f27f752eb84eba917450e43636b210   False     True             True             Unknown                    False            False     True               True                True           True          Unknown        False          False
-ci-ln-ds73n5t-72292-9xsm9-worker-c-t227w   worker     rendered-worker-01f27f752eb84eba917450e43636b210   rendered-worker-01f27f752eb84eba917450e43636b210   True      False            False            False                      False            False     False              False               False          False         False          False          False
+NAME                                       POOLNAME    DESIREDCONFIG                                      CURRENTCONFIG                                         UPDATED   UPDATEPREPARED   UPDATEEXECUTED   UPDATEPOSTACTIONCOMPLETE   UPDATECOMPLETE   RESUMED   UPDATEDFILESANDOS   CORDONEDNODE   DRAINEDNODE   REBOOTEDNODE   UNCORDONEDNODE
+ci-ln-ds73n5t-72292-9xsm9-master-0         master      rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67      True      False            False            False                      False            False     False               False          False         False          False
+ci-ln-ds73n5t-72292-9xsm9-master-1         master      rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67      True      False            False            False                      False            False     False               False          False         False          False
+ci-ln-ds73n5t-72292-9xsm9-master-2         master      rendered-master-23cf200e4ee97daa6e39fdce24c9fb67   rendered-master-23cf200e4ee97daa6e39fdce24c9fb67      True      False            False            False                      False            False     False               False          False         False          False
+ci-ln-ds73n5t-72292-9xsm9-worker-a-2d8tz   worker-cnf  rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-f351f6947f15cd0380514f4b1c89f8f2      True      False            False            False                      False            False     False               False          False         False          False
+ci-ln-ds73n5t-72292-9xsm9-worker-b-gw5sd   worker      rendered-worker-f351f6947f15cd0380514f4b1c89f8f2   rendered-worker-01f27f752eb84eba917450e43636b210      False     True             True             Unknown                    False            False     True                True           True          Unknown        False
+ci-ln-ds73n5t-72292-9xsm9-worker-c-t227w   worker      rendered-worker-01f27f752eb84eba917450e43636b210   rendered-worker-01f27f752eb84eba917450e43636b210      True      False            False            False                      False            False     False               False          False         False          False
 ----
 
 In addition to the fields defined in the previous table, the `-o wide` output displays the following fields:
@@ -129,12 +124,10 @@ In addition to the fields defined in the previous table, the `-o wide` output di
 |`UPDATEPOSTACTIONCOMPLETE` |Indicates if the MCO has executed the post-update actions on the node.
 |`UPDATECOMPLETE` |Indicates if the MCO has completed the update on the node.
 |`RESUMED` |Indicates if the node has resumed normal processes.
-|`UPDATECOMPATIBLE` |Indicates if the MCO has determined it can execute the update on the node.
 |`UPDATEDFILESANDOS` |Indicates if the MCO has updated the node files and operating system.
 |`CORDONEDNODE` |Indicates if the MCO has marked the node as not schedulable.
 |`DRAINEDNODE` |Indicates if the MCO has drained the node.
 |`REBOOTEDNODE` |Indicates if the MCO has restarted the node.
-|`RELOADEDCRIO` |Indicates if the MCO has restarted the CRI-O service.
 |`UNCORDONEDNODE` |Indicates if the MCO has marked the node as schedulable.
 |===
 
@@ -147,107 +140,99 @@ $ oc describe machineconfignode/<machine_config_node_name> -o yaml
 
 .Example output
 [source,text]
-----
-Name:         <machine_config_node_name> <1>
-Namespace:
-Labels:       <none>
-Annotations:  <none>
-API Version:  machineconfiguration.openshift.io/v1alpha1
-Kind:         MachineConfigNode
-Metadata:
-  Creation Timestamp:  2023-10-17T13:08:58Z
-  Generation:          1
-  Resource Version:    49443
-  UID:                 4bd758ab-2187-413c-ac42-882e61761b1d
-Spec:
-  Node Ref:
-    Name:         <node_name>
-  Pool:
-    Name:         worker
-  ConfigVersion:
-    Desired: rendered-worker-f351f6947f15cd0380514f4b1c89f8f2 <2>
-Status:
-  Conditions:
-    Last Transition Time:  2025-01-14T17:01:16Z
-    Message:               Node ci-ln-ds73n5t-72292-9xsm9-worker-b-gw5sd needs an update
-    Reason:                Updated
-    Status:                False
-    Type:                  Updated
-    Last Transition Time:  2025-01-14T17:01:18Z
-    Message:               Update is Compatible.
-    Reason:                UpdateCompatible
-    Status:                True
-    Type:                  UpdatePrepared
-    Last Transition Time:  2025-01-14T17:04:08Z
-    Message:               Updated the Files and OS on disk as a part of the in progress phase
-    Reason:                AppliedFilesAndOS
-    Status:                True
-    Type:                  UpdateExecuted
-    Last Transition Time:  2025-01-14T17:04:08Z
-    Message:               Node will reboot into config rendered-worker-db01b33f959e5645a721da50a6db1fbb
-    Reason:                RebootedNode
-    Status:                Unknown
-    Type:                  UpdatePostActionComplete
-    Last Transition Time:  2025-01-14T16:04:27Z
-    Message:               Action during update to rendered-worker-f351f6947f15cd0380514f4b1c89f8f2: UnCordoned Node as part of completing upgrade phase
-    Reason:                Uncordoned
-    Status:                False
-    Type:                  UpdateComplete
-    Last Transition Time:  2025-01-14T16:04:27Z
-    Message:               Action during update to rendered-worker-f351f6947f15cd0380514f4b1c89f8f2: In desired config rendered-worker-01f27f752eb84eba917450e43636b210. Resumed normal operations.
-    Reason:                Resumed
-    Status:                False
-    Type:                  Resumed
-    Last Transition Time:  2025-01-14T17:01:18Z
-    Message:               Update Compatible. Post Cfg Actions []: Drain Required: true
-    Reason:                UpdatePreparedUpdateCompatible
-    Status:                True
-    Type:                  UpdateCompatible
-    Last Transition Time:  2025-01-14T17:03:57Z
-    Message:               Drained node. The drain is complete as the desired drainer matches current drainer: drain-rendered-worker-db01b33f959e5645a721da50a6db1fbb
-    Reason:                UpdateExecutedDrained
-    Status:                True
-    Type:                  Drained
-    Last Transition Time:  2025-01-14T17:04:08Z
-    Message:               Applied files and new OS config to node. OS did not need an update. SSH Keys did not need an update
-    Reason:                UpdateExecutedAppliedFilesAndOS
-    Status:                True
-    Type:                  AppliedFilesAndOS
-    Last Transition Time:  2025-01-14T17:01:23Z
-    Message:               Cordoned node. The node is reporting Unschedulable = true
-    Reason:                UpdateExecutedCordoned
-    Status:                True
-    Type:                  Cordoned
-    Last Transition Time:  2025-01-14T17:04:08Z
-    Message:               Upgrade requires a reboot. Currently doing this as the post update action.
-    Reason:                UpdatePostActionCompleteRebootedNode
-    Status:                Unknown
-    Type:                  RebootedNode
-    Last Transition Time:  2025-01-14T15:30:57Z
-    Message:               This node has not yet entered the ReloadedCRIO phase
-    Reason:                NotYetOccured
-    Status:                False
-    Type:                  ReloadedCRIO
-    Last Transition Time:  2025-01-14T16:04:27Z
-    Message:               Action during update to rendered-worker-f351f6947f15cd0380514f4b1c89f8f2: UnCordoned node. The node is reporting Unschedulable = false
-    Reason:                UpdateCompleteUncordoned
-    Status:                False
-    Type:                  Uncordoned
-    Last Transition Time:  2025-01-14T16:04:07Z
-    Message:               All is good
-    Reason:                AsExpected
-    Status:                False
-    Type:                  PinnedImageSetsDegraded
-    Last Transition Time:  2025-01-14T16:04:07Z
-    Message:               All pinned image sets complete
-    Reason:                AsExpected
-    Status:                False
-    Type:                  PinnedImageSetsProgressing
-  Config Version:
-    Current:            rendered-worker-01f27f752eb84eba917450e43636b210 <3>
-    Desired:            rendered-worker-f351f6947f15cd0380514f4b1c89f8f2
-  Observed Generation:  6
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigNode
+metadata:
+  creationTimestamp: "2025-04-28T18:40:29Z"
+  generation: 3
+  name: <machine_config_node_name> <1>
 # ...
+spec:
+  configVersion:
+    desired: rendered-master-34f96af2e41acb615410b97ce1c819e6 <2>
+  node:
+    name: ci-ln-921r7qk-72292-kxv95-master-0
+  pool:
+    name: master
+status:
+  conditions:
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: All pinned image sets complete
+    reason: AsExpected
+    status: "False"
+    type: PinnedImageSetsProgressing
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: This node has not yet entered the UpdatePrepared phase
+    reason: NotYetOccurred
+    status: "False"
+    type: UpdatePrepared
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: This node has not yet entered the UpdateExecuted phase
+    reason: NotYetOccurred
+    status: "False"
+    type: UpdateExecuted
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: This node has not yet entered the UpdatePostActionComplete phase
+    reason: NotYetOccurred
+    status: "False"
+    type: UpdatePostActionComplete
+  - lastTransitionTime: "2025-04-28T18:42:08Z"
+    message: 'Action during update to rendered-master-34f96af2e41acb615410b97ce1c819e6:
+      Uncordoned Node as part of completing upgrade phase'
+    reason: Uncordoned
+    status: "False"
+    type: UpdateComplete
+  - lastTransitionTime: "2025-04-28T18:42:08Z"
+    message: 'Action during update to rendered-master-34f96af2e41acb615410b97ce1c819e6:
+      In desired config . Resumed normal operations.'
+    reason: Resumed
+    status: "False"
+    type: Resumed
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: This node has not yet entered the Drained phase
+    reason: NotYetOccurred
+    status: "False"
+    type: Drained
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: This node has not yet entered the AppliedFilesAndOS phase
+    reason: NotYetOccurred
+    status: "False"
+    type: AppliedFilesAndOS
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: This node has not yet entered the Cordoned phase
+    reason: NotYetOccurred
+    status: "False"
+    type: Cordoned
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: This node has not yet entered the RebootedNode phase
+    reason: NotYetOccurred
+    status: "False"
+    type: RebootedNode
+  - lastTransitionTime: "2025-04-28T18:42:08Z"
+    message: Node ci-ln-921r7qk-72292-kxv95-master-0 Updated
+    reason: Updated
+    status: "True"
+    type: Updated
+  - lastTransitionTime: "2025-04-28T18:42:08Z"
+    message: 'Action during update to rendered-master-34f96af2e41acb615410b97ce1c819e6:
+      UnCordoned node. The node is reporting Unschedulable = false'
+    reason: UpdateCompleteUncordoned
+    status: "False"
+    type: Uncordoned
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: This node has not yet entered the NodeDegraded phase
+    reason: NotYetOccurred
+    status: "False"
+    type: NodeDegraded
+  - lastTransitionTime: "2025-04-28T18:41:09Z"
+    message: All is good
+    reason: AsExpected
+    status: "False"
+    type: PinnedImageSetsDegraded
+  configVersion:
+    current: rendered-master-34f96af2e41acb615410b97ce1c819e6 <3>
+    desired: rendered-master-34f96af2e41acb615410b97ce1c819e6
+  observedGeneration: 4
 ----
 <1> The `MachineConfigNode` object name.
 <2> The new machine configuration. This field updates after the MCO validates the machine config in the `UPDATEPREPARED` phase, then the status adds the new configuration.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14404
[Updates needed](https://docs.google.com/document/d/1ec3yLXYCMA5fX5Mmy6oY84OdMpH0EylOqXqXfIKVPmE/edit?tab=t.0)

Previews:
[About checking machine config node status](https://92503--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#checking-mco-node-status_machine-config-overview):
* Updated the list of phases and subphases; 
* Updated output of `oc get machineconfignode -o wide` command to remove the `UPDATECOMPATIBLE` and `RELOADEDCRIO` columns;
* Removed the following description of each; replaced the output of the `oc describe machineconfignode/<machine_config_node_name> -o yaml` command.

[Checking machine config node status](https://92503--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#checking-mco-node-status-configuring_machine-config-overview): 
* Edited intro to remove the custom machine config pool restriction; 
* Added custom mcp to the output for the `oc get machineconfignodes` command; 
* Updated output of `oc get machineconfignode -o wide` command to remove the `UPDATECOMPATIBLE` and `RELOADEDCRIO` columns; 
* Added callout to command; updated output of `oc describe machineconfignode/<node_name>` command. 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
