### PR TITLE
OCPBUGS-54949:adding the missing double quote in example

### DIFF
--- a/modules/secrets-store-vault.adoc
+++ b/modules/secrets-store-vault.adoc
@@ -284,7 +284,7 @@ spec:
     objects:  |
       - secretPath: "secret/data/example1"
         objectName: "testSecret1"
-        secretKey: "testSecret1
+        secretKey: "testSecret1"
 ----
 <1> Specify the name for the secret provider class.
 <2> Specify the namespace for the secret provider class.


### PR DESCRIPTION
Version(s):
4.16 +

Issue:
[OCPBUGS-54949](https://issues.redhat.com/browse/OCPBUGS-54949)

Link to docs preview:
[Mounting secrets from HashiCorp Vault](https://92535--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-vault_nodes-pods-secrets-store)

QE review:
- [x] QE has approved
