### PR TITLE
OLS-1642: Create release notes for OLS 0.3.4

### DIFF
--- a/modules/ols-0-3-4-fixed-issues.adoc
+++ b/modules/ols-0-3-4-fixed-issues.adoc
@@ -1,0 +1,15 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-3-4-fixed-issues_{context}"]
+= Fixed issues
+
+The following issues are fixed with {ols-official} 0.3.4:
+
+* Previously, when you tried to attach logs to an {ols-long} query, the entire {ols-short} window and icon disappeared. Now, when you attach logs to a query the {ols-short} window and icon remain accessible. link:https://issues.redhat.com/browse/OLS-1634[OLS-1634].
+
+* In earlier versions, the {ols-long} Operator failed to validate the large language model (LLM) provider credential settings on the {azure-official} platform with {entra-id}. Now, the Operator can validate the LLM credential settings on the {azure-official} platform with {entra-id}. link:https://issues.redhat.com/browse/OLS-1630[OLS-1630].
+
+* Previously, the {ols-long} Operator could not use additional CA certificates to connect to {rhelai} or {rhoai}, preventing secure calls to the large language model (LLM) provider. This release adds support for custom CA certificates, enabling authenticated connections to {rhelai} or {rhoai}. link:https://issues.redhat.com/browse/OLS-1527[OLS-1527].

--- a/modules/ols-0-3-4-release-notes.adoc
+++ b/modules/ols-0-3-4-release-notes.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-3-4-release-notes_{context}"]
+= {ols-long} version 0.3.4
+
+{ols-official} 0.3.4 is now available on {ocp-product-title} 4.15 and later.
+
+[IMPORTANT]
+====
+{ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/compliance_activities_and_gov_standards#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
+====
+
+[id="ols-0-3-4-enhancements_{context}"]
+== Enhancements
+
+The following enhancements are made with {ols-official} 0.3.4:
+
+* Beginning with this release, the `NetworkPolicy` resource can limit the ingress traffic to the {ols-long} components.
+

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 The release notes highlight what is new and what has changed with each {ols-official} release.
 
+include::modules/ols-0-3-4-release-notes.adoc[leveloffset=+1]
+include::modules/ols-0-3-4-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-3-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-3-3-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-2-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1642
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://92540--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-0-3-4-release-notes_ols-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
