### PR TITLE
[enterprise-4.16] OSDOCS#13277: Clarify certificate rotation, including not rotating CAs

### DIFF
--- a/microshift_troubleshooting/microshift-things-to-know.adoc
+++ b/microshift_troubleshooting/microshift-things-to-know.adoc
@@ -18,3 +18,7 @@ When such changes occur, some {microshift-short} components may stop functioning
 The threshold for clock changes is a time adjustment of greater than 10 seconds in either direction. Smaller drifts on regular time adjustments performed by the Network Time Protocol (NTP) service do not cause a restart.
 
 include::modules/microshift-certificate-lifetime.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../microshift_configuring/microshift-custom-ca.adoc#microshift-custom-ca[Configuring custom certificate authorities].


### PR DESCRIPTION
This PR CPs the commit from PR# 91079 to enterprise-4.16.

Version(s):
4.16

Issue:
[OSDOCS-13277](https://issues.redhat.com//browse/OSDOCS-13277)

Link to docs preview:
[Security certificate lifetime](https://92541--ocpdocs-pr.netlify.app/microshift/latest/microshift_troubleshooting/microshift-things-to-know.html#microshift-certificate-lifetime_microshift-things-to-know)

QE review:
- [ ] QE has approved this change.
N/A
