### PR TITLE
standalone logging docs - release notes for 6.0

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3,6 +3,8 @@ Name: About OpenShift Logging
 Dir: about
 Distros: openshift-logging
 Topics:
+- Name: Release notes
+  File: logging-release-notes-6-0
 - Name: Logging overview
   File: about-logging
 - Name: Cluster logging support

--- a/about/logging-release-notes-6-0.adoc
+++ b/about/logging-release-notes-6-0.adoc
@@ -1,0 +1,110 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="logging-release-notes-6-0"]
+= Release notes
+:context: logging-release-notes-6-0
+
+toc::[]
+
+include::modules/logging-release-notes-6-0-7.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-0-6.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-0-5.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-0-4.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-0-3.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-0-2.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-0-1.adoc[leveloffset=+1]
+
+[id="log6x0-release-notes"]
+== Logging 6.0.0
+This release includes link:https://access.redhat.com/errata/RHBA-2024:6693[{logging-uc} {for} Bug Fix Release 6.0.0]
+
+include::snippets/logging-compatibility-snip.adoc[]
+
+.Upstream component versions
+[options="header"]
+|===
+
+| {logging} Version 6+| Component Version
+
+| Operator | `eventrouter` | `logfilemetricexporter` | `loki` | `lokistack-gateway` | `opa-openshift` | `vector`
+
+|6.0 | 0.4 | 1.1 | 3.1.0 | 0.1 | 0.1 | 0.37.1
+
+|===
+
+[id="log6x-release-notes-6-0-0-removal-notice"]
+== Removal notice
+
+* With this release, {logging} no longer supports the `ClusterLogging.logging.openshift.io` and `ClusterLogForwarder.logging.openshift.io` custom resources. Refer to the product documentation for details on the replacement features. (link:https://issues.redhat.com/browse/LOG-5803[LOG-5803])
+
+* With this release, {logging} no longer manages or deploys log storage (such as Elasticsearch), visualization (such as Kibana), or Fluentd-based log collectors. (link:https://issues.redhat.com/browse/LOG-5368[LOG-5368])
+
+[NOTE]
+====
+In order to continue to use Elasticsearch and Kibana managed by the elasticsearch-operator, the administrator must modify those object's ownerRefs before deleting the ClusterLogging resource.
+====
+
+[id="log6x-release-notes-6-0-0-enhancements"]
+== New features and enhancements
+
+* This feature introduces a new architecture for {logging} {for} by shifting component responsibilities to their relevant Operators, such as for storage, visualization, and collection. It introduces the `ClusterLogForwarder.observability.openshift.io` API for log collection and forwarding. Support for the `ClusterLogging.logging.openshift.io` and `ClusterLogForwarder.logging.openshift.io` APIs, along with the Red Hat managed Elastic stack (Elasticsearch and Kibana), is removed. Users are encouraged to migrate to the Red Hat `LokiStack` for log storage. Existing managed Elasticsearch deployments can be used for a limited time. Automated migration for log collection is not provided, so administrators need to create a new ClusterLogForwarder.observability.openshift.io specification to replace their previous custom resources. Refer to the official product documentation for more details. (link:https://issues.redhat.com/browse/LOG-3493[LOG-3493])
+
+* With this release, the responsibility for deploying the {logging} view plugin shifts from the {clo} to the {coo-first}. For new log storage installations that need visualization, the {coo-full} and the associated UIPlugin resource must be deployed. Refer to the link:https://docs.openshift.com/container-platform/latest/observability/cluster_observability_operator/cluster-observability-operator-overview.html#cluster-observability-operator-overview[Cluster Observability Operator Overview] product documentation for more details. (link:https://issues.redhat.com/browse/LOG-5461[LOG-5461])
+
+* This enhancement sets default requests and limits for Vector collector deployments' memory and CPU usage based on Vector documentation recommendations. (link:https://issues.redhat.com/browse/LOG-4745[LOG-4745])
+
+* This enhancement updates Vector to align with the upstream version v0.37.1. (link:https://issues.redhat.com/browse/LOG-5296[LOG-5296])
+
+* This enhancement introduces an alert that triggers when log collectors buffer logs to a node's file system and use over 15% of the available space, indicating potential back pressure issues. (link:https://issues.redhat.com/browse/LOG-5381[LOG-5381])
+
+* This enhancement updates the selectors for all components to use common Kubernetes labels. (link:https://issues.redhat.com/browse/LOG-5906[LOG-5906])
+
+* This enhancement changes the collector configuration to deploy as a ConfigMap instead of a secret, allowing users to view and edit the configuration when the ClusterLogForwarder is set to Unmanaged. (link:https://issues.redhat.com/browse/LOG-5599[LOG-5599])
+
+* This enhancement adds the ability to configure the Vector collector log level using an annotation on the ClusterLogForwarder, with options including trace, debug, info, warn, error, or off. (link:https://issues.redhat.com/browse/LOG-5372[LOG-5372])
+
+* This enhancement adds validation to reject configurations where Amazon CloudWatch outputs use multiple AWS roles, preventing incorrect log routing. (link:https://issues.redhat.com/browse/LOG-5640[LOG-5640])
+* This enhancement removes the Log Bytes Collected and Log Bytes Sent graphs from the metrics dashboard. (link:https://issues.redhat.com/browse/LOG-5964[LOG-5964])
+
+* This enhancement updates the must-gather functionality to only capture information for inspecting Logging 6.0 components, including Vector deployments from ClusterLogForwarder.observability.openshift.io resources and the Red Hat managed LokiStack. (link:https://issues.redhat.com/browse/LOG-5949[LOG-5949])
+
+* This enhancement improves Azure storage secret validation by providing early warnings for specific error conditions. (link:https://issues.redhat.com/browse/LOG-4571[LOG-4571])
+
+* This enhancement updates the `ClusterLogForwarder` API to follow the Kubernetes standards. (link:https://issues.redhat.com/browse/LOG-5977[LOG-5977])
++
+.Example of a new configuration in the `ClusterLogForwarder` custom resource for the updated API
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: <name>
+spec:
+  outputs:
+  - name: <output_name>
+    type: <output_type>
+    <output_type>:
+      tuning:
+         deliveryMode: AtMostOnce
+----
+
+[id="log6x-release-notes-6-0-0-technology-preview-features"]
+== Technology Preview features
+
+* This release introduces a Technology Preview feature for log forwarding using OpenTelemetry. A new output type,` OTLP`, allows sending JSON-encoded log records using the OpenTelemetry data model and resource semantic conventions. (link:https://issues.redhat.com/browse/LOG-4225[LOG-4225])
+
+[id="log6x-release-notes-6-0-0-bug-fixes"]
+== Bug fixes
+
+* Before this update, the `CollectorHighErrorRate` and `CollectorVeryHighErrorRate` alerts were still present. With this update, both alerts are removed in the {logging} 6.0 release but might return in a future release. (link:https://issues.redhat.com/browse/LOG-3432[LOG-3432])
+
+[id="log6x-release-notes-6-0-0-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-34397[CVE-2024-34397]

--- a/modules/logging-release-notes-6-0-1.adoc
+++ b/modules/logging-release-notes-6-0-1.adoc
@@ -1,0 +1,33 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-1_{context}"]
+= Logging 6.0.1
+This release includes link:https://access.redhat.com/errata/RHSA-2024:8315[OpenShift Logging Bug Fix Release 6.0.1].
+
+// 4.17
+
+[id="openshift-logging-6-0-1-bug-fixes_{context}"]
+== Bug fixes
+
+* With this update, the default memory limit for the collector has been increased from 1024 Mi to 2024 Mi. However, users should always adjust their resource limits according to their cluster specifications and needs. (link:https://issues.redhat.com/browse/LOG-6180[LOG-6180])
+
+* Before this update, the Loki Operator failed to add the default `namespace` label to all `AlertingRule` resources, which caused the User-Workload-Monitoring Alertmanager to skip routing these alerts. This update adds the rule namespace as a label to all alerting and recording rules, resolving the issue and restoring proper alert routing in Alertmanager.
+(link:https://issues.redhat.com/browse/LOG-6151[LOG-6151])
+
+* Before this update, the LokiStack ruler component view did not initialize properly, causing an invalid field error when the ruler component was disabled. This update ensures that the component view initializes with an empty value, resolving the issue.
+(link:https://issues.redhat.com/browse/LOG-6129[LOG-6129])
+
+* Before this update, it was possible to set `log_source` in the prune filter, which could lead to inconsistent log data. With this update, the configuration is validated before being applied, and any configuration that includes `log_source` in the prune filter is rejected.
+(link:https://issues.redhat.com/browse/LOG-6202[LOG-6202])
+
+[id="openshift-logging-6-0-1-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-24791[CVE-2024-24791]
+* link:https://access.redhat.com/security/cve/CVE-2024-34155[CVE-2024-34155]
+* link:https://access.redhat.com/security/cve/CVE-2024-34156[CVE-2024-34156]
+* link:https://access.redhat.com/security/cve/CVE-2024-34158[CVE-2024-34158]
+* link:https://access.redhat.com/security/cve/CVE-2024-6104[CVE-2024-6104]
+* link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+* link:https://access.redhat.com/security/cve/CVE-2024-45490[CVE-2024-45490]
+* link:https://access.redhat.com/security/cve/CVE-2024-45491[CVE-2024-45491]
+* link:https://access.redhat.com/security/cve/CVE-2024-45492[CVE-2024-45492]

--- a/modules/logging-release-notes-6-0-2.adoc
+++ b/modules/logging-release-notes-6-0-2.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-2_{context}"]
+= Logging 6.0.2
+This release includes link:https://access.redhat.com/errata/RHBA-2024:10051[RHBA-2024:10051].
+
+[id="logging-release-notes-6-0-2-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, Loki did not correctly load some configurations, which caused issues when using Alibaba Cloud or IBM Cloud object storage. This update fixes the configuration-loading code in Loki, resolving the issue. (link:https://issues.redhat.com/browse/LOG-5325[LOG-5325])
+
+* Before this update, the collector would discard audit log messages that exceeded the configured threshold. This modifies the audit configuration thresholds for the maximum line size as well as the number of bytes read during a read cycle. (link:https://issues.redhat.com/browse/LOG-5998[LOG-5998])
+
+* Before this update, the Cluster Logging Operator did not watch and reconcile resources associated with an instance of a ClusterLogForwarder like it did in prior releases. This update modifies the operator to watch and reconcile all resources it owns and creates. (link:https://issues.redhat.com/browse/LOG-6264[LOG-6264])
+
+* Before this update, log events with an unknown severity level sent to Google Cloud Logging would trigger a warning in the vector collector, which would then default the severity to 'DEFAULT'. With this update, log severity levels are now standardized to match Google Cloud Logging specifications, and audit logs are assigned a severity of 'INFO'. (link:https://issues.redhat.com/browse/LOG-6296[LOG-6296])
+
+* Before this update, when infrastructure namespaces were included in application inputs, the `log_type` was set as `application`. With this update, the `log_type` of infrastructure namespaces included in application inputs is set to `infrastructure`. (link:https://issues.redhat.com/browse/LOG-6354[LOG-6354])
+
+* Before this update, specifying a value for the `syslog.enrichment` field of the ClusterLogForwarder added `namespace_name`, `container_name`, and `pod_name` to the messages of non-container logs. With this update, only container logs include `namespace_name`, `container_name`, and `pod_name` in their messages when `syslog.enrichment` is set. (link:https://issues.redhat.com/browse/LOG-6402[LOG-6402])
+
+[id="logging-release-notes-6-0-2-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+* link:https://access.redhat.com/security/cve/CVE-2024-6232[CVE-2024-6232]

--- a/modules/logging-release-notes-6-0-3.adoc
+++ b/modules/logging-release-notes-6-0-3.adoc
@@ -1,0 +1,41 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-3_{context}"]
+= Logging 6.0.3
+
+This release includes link:https://access.redhat.com/errata/RHBA-2024:10991[RHBA-2024:10991].
+
+[id="logging-release-notes-6-0-3-enhancements_{context}"]
+== New features and enhancements
+
+* With this update, the {loki-op} supports the configuring of the workload identity federation on the {gcp-first} by using the Cluster Credential Operator (CCO) in {product-title} 4.17 or later. (link:https://issues.redhat.com/browse/LOG-6421[LOG-6421])
+
+[id="logging-release-notes-6-0-3-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the collector used the default settings to collect audit logs, which did not account for back pressure from output receivers. With this update, the audit log collection is optimized for file handling and log reading. (link:https://issues.redhat.com/browse/LOG-6034[LOG-6034])
+
+* Before this update, any namespace containing `openshift` or `kube` was treated as an infrastructure namespace. With this update, only the following namespaces are treated as infrastructure namespaces: `default`, `kube`, `openshift`, and namespaces that begin with `openshift-` or `kube-`. (link:https://issues.redhat.com/browse/LOG-6204[LOG-6204])
+
+* Before this update, an input receiver service was repeatedly created and deleted, causing issues with mounting the TLS secrets. With this update, the service is created once and only deleted if it is not defined in the `ClusterLogForwarder` custom resource. (link:https://issues.redhat.com/browse/LOG-6343[LOG-6343])
+
+* Before this update, pipeline validation might enter an infinite loop if a name was a substring of another name. With this update, stricter name equality checks prevent the infinite loop. (link:https://issues.redhat.com/browse/LOG-6352[LOG-6352])
+
+* Before this update, the collector alerting rules included the summary and message fields. With this update, the collector alerting rules include the summary and description fields. (link:https://issues.redhat.com/browse/LOG-6406[LOG-6406])
+
+* Before this update, setting up the custom audit inputs in the `ClusterLogForwarder` custom resource with configured `LokiStack` output caused errors due to the nil pointer dereference. With this update, the Operator performs the nil checks, preventing such errors. (link:https://issues.redhat.com/browse/LOG-6441[LOG-6441])
+
+* Before this update, the collector did not correctly mount the `/var/log/oauth-server/` path, which prevented the collection of the audit logs. With this update, the volume mount is added, and the audit logs are collected as expected. (link:https://issues.redhat.com/browse/LOG-6486[LOG-6486])
+
+* Before this update, the collector did not correctly mount the `oauth-apiserver` audit log file. As a result, such audit logs were not collected. With this update, the volume mount is correctly mounted, and the logs are collected as expected. (link:https://issues.redhat.com/browse/LOG-6543[LOG-6543])
+
+[id="logging-release-notes-6-0-3-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]
+* link:https://access.redhat.com/security/cve/CVE-2024-2511[CVE-2024-2511]
+* link:https://access.redhat.com/security/cve/CVE-2024-3596[CVE-2024-3596]
+* link:https://access.redhat.com/security/cve/CVE-2024-4603[CVE-2024-4603]
+* link:https://access.redhat.com/security/cve/CVE-2024-4741[CVE-2024-4741]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+* link:https://access.redhat.com/security/cve/CVE-2024-10963[CVE-2024-10963]
+* link:https://access.redhat.com/security/cve/CVE-2024-50602[CVE-2024-50602]

--- a/modules/logging-release-notes-6-0-4.adoc
+++ b/modules/logging-release-notes-6-0-4.adoc
@@ -1,0 +1,31 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-4_{context}"]
+= Logging 6.0.4
+This release includes link:https://access.redhat.com/errata/RHBA-2025:1228[RHBA-2025:1228].
+
+[id="logging-release-notes-6-0-4-enhancements_{context}"]
+== New features and enhancements
+
+* This enhancement adds `OTel` semantic stream labels to the `lokiStack` output so that you can query logs by using both `ViaQ` and `OTel` stream labels.
+(link:https://issues.redhat.com/browse/LOG-6580[LOG-6580])
+
+[id="logging-release-notes-6-0-4-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the Operator used a cached client to fetch the `SecurityContextConstraint` cluster resource, which could result in an error when the cache is invalid. With this update, the Operator now always retrieves data from the API server instead of using the cache.
+(link:https://issues.redhat.com/browse/LOG-6130[LOG-6130])
+
+* Before this update, the Vector startup script attempted to delete buffer lock files during startup. With this update, the Vector startup script no longer attempts to delete buffer lock files during startup.
+(link:https://issues.redhat.com/browse/LOG-6348[LOG-6348])
+
+* Before this update, a bug in the `must-gather` script for the `cluster-logging-operator` prevented the `LokiStack` from being gathered correctly when it existed. With this update, the `LokiStack` is gathered correctly.
+(link:https://issues.redhat.com/browse/LOG-6499[LOG-6499])
+
+* Before this update, the collector metrics dashboard could get removed after an Operator upgrade due to a race condition during the change from the old to the new pod deployment. With this update, labels are added to the dashboard `ConfigMap` to identify the upgraded deployment as the current owner so that it will not be removed.
+(link:https://issues.redhat.com/browse/LOG-6608[LOG-6608])
+
+* Before this update, the logging `must-gather` did not collect resources such as `UIPlugin`, `ClusterLogForwarder`, `LogFileMetricExporter` and `LokiStack` CR. With this update, these resources are now collected in their namespace directory instead of the cluster-logging one.
+(link:https://issues.redhat.com/browse/LOG-6654[LOG-6654])
+
+* Before this update, Vector did not retain process information, such as the program name, app-name, procID, and other details, when forwarding journal logs by using the syslog protocol. This could lead to the loss of important information. With this update, the Vector collector now preserves all required process information, and the data format adheres to the specifications of `RFC3164` and `RFC5424`.
+(link:https://issues.redhat.com/browse/LOG-6659[LOG-6659])

--- a/modules/logging-release-notes-6-0-5.adoc
+++ b/modules/logging-release-notes-6-0-5.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-5_{context}"]
+= Logging 6.0.5
+This release includes link:https://access.redhat.com/errata/RHBA-2025:1986[RHBA-2025:1986].
+
+[id="logging-release-notes-6-0-5-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2020-11023[CVE-2020-11023]
+* link:https://access.redhat.com/security/cve/CVE-2024-9287[CVE-2024-9287]
+* link:https://access.redhat.com/security/cve/CVE-2024-12797[CVE-2024-12797]

--- a/modules/logging-release-notes-6-0-6.adoc
+++ b/modules/logging-release-notes-6-0-6.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-6_{context}"]
+= Logging 6.0.6
+This release includes link:https://access.redhat.com/errata/RHSA-2025:3132[RHSA-2025:3132].
+
+[id="logging-release-notes-6-0-6-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, the Logging Operator deployed the collector config map with output configurations that were not referenced by any inputs. With this update, the Operator adds validation to fail the `ClusterLogForwarder` custom resource if an output configuration is not referenced by any inputs, preventing the deployment of the collector.
+(link:https://issues.redhat.com/browse/LOG-6759[LOG-6759])
+
+[id="logging-release-notes-6-0-6-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
+* link:https://access.redhat.com/security/cve/CVE-2025-27144[CVE-2025-27144]
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].
+====

--- a/modules/logging-release-notes-6-0-7.adoc
+++ b/modules/logging-release-notes-6-0-7.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-7_{context}"]
+= Logging 6.0.7
+
+This release includes link:https://access.redhat.com/errata/RHSA-2025:3905[RHSA-2025:3905].
+
+
+[id="logging-release-notes-6-0-7-enhancements_{context}"]
+== New features and enhancements
+
+* Before this update, time-based stream sharding was not enabled in Loki, which resulted in Loki being unable to save historical data. With this update, the {loki-op} enables time-based stream sharding in Loki, which helps Loki save historical data. (link:https://issues.redhat.com/browse/LOG-6990[LOG-6990])
+
+[id="logging-release-notes-6-0-7-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-30204[CVE-2025-30204]
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].
+====


### PR DESCRIPTION

Version(s):
standalone-logging-docs-6.0

Issue:
standalone logging

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
