### PR TITLE
OCPBUGS-35084: Configuration verification warning for running vsphere virtual hardware template

### DIFF
--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -22,6 +22,11 @@ Once converted from a template, do not power on the virtual machine.
 ====
 
 . Update the virtual machine (VM) in the {vmw-full} client. Complete the steps outlined in link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-60768C2F-72E1-42E0-8A17-CA76849F2950.html[Upgrade the Compatibility of a Virtual Machine Manually] ({vmw-full} documentation).
++
+[IMPORTANT]
+====
+If you modified the VM settings, those changes might reset after moving to a newer virtual hardware. Please review that all your configured settings are still in place after your upgrade before proceeding to the next step.
+====
 . Convert the VM in the {vmw-short} client to a template by right-clicking on the VM and then selecting **Template -> Convert to Template**.  
 +
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-35084](https://issues.redhat.com/browse/OCPBUGS-35084)

Link to docs preview:
https://92543--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
