### PR TITLE
OSDOCS-14170: Created doc for enabled port isolation Linux bridge CNI…

### DIFF
--- a/modules/virt-linux-bridge-nad-port-isolation.adoc
+++ b/modules/virt-linux-bridge-nad-port-isolation.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-linux-bridge-nad-port-isolation.adoc_{context}"]
+= Enabling port isolation for a Linux bridge NAD
+
+You can enable port isolation for a Linux bridge network attachment definition (NAD) so that virtual machines (VMs) or pods that run on the same virtual LAN (VLAN) can operate in isolation from one another. The Linux bridge NAD creates a virtual bridge, or _virtual switch_, between network interfaces and the physical network.
+
+Isolating ports in this way can provide enhanced security for VM workloads that run on the same node. 
+
+.Prerequisites
+
+* For VMs, you configured either a static or dynamic IP address for each VM. See "Configuring IP addresses for virtual machines".
+* You created a Linux bridge NAD by using either the web console or the command-line interface. 
+
+.Procedure
+
+. Edit the Linux bridge NAD by setting `portIsolation` to `true`:
++
+[source,yaml]
+----
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bridge-network 
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/br1 
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "bridge-network", <1>
+      "type": "bridge", <2>
+      "bridge": "br1", <3>
+      "preserveDefaultVlan": false,
+      "vlan": 100,
+      "disableContainerInterface": false,
+      "portIsolation": true <4>
+    }
+# ...
+----
+<1> The name for the configuration. The name must match the the value in the `metadata.name` of the NAD.
+<2> The actual name of the Container Network Interface (CNI) plugin that provides the network for this network attachment definition. Do not change this field unless you want to use a different CNI.
+<3> The name of the Linux bridge that is configured on the node. The name must match the interface bridge name defined in the NodeNetworkConfigurationPolicy manifest.
+<4> Enables or disables port isolation on the virtual bridge. Default value is `false`. When set to `true`, each VM or pod is assigned to an isolated port. The virtual bridge prevents traffic from one isolated port from reaching another isolated port.
+
+. Apply the configuration:
++
+[source,terminal]
+----
+$ oc apply -f example-vm.yaml
+----
+
+. Optional: If you edited a running virtual machine, you must restart it for the changes to take effect.

--- a/virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
@@ -26,9 +26,18 @@ include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+1]
 
 You can create a Linux bridge network attachment definition (NAD) by using the {product-title} web console or command line.
 
+// Creating a Linux bridge NAD by using the web console
 include::modules/virt-creating-linux-bridge-nad-web.adoc[leveloffset=+2]
 
+// Creating a Linux bridge NAD by using the command line
 include::modules/virt-creating-linux-bridge-nad-cli.adoc[leveloffset=+2]
+
+// Enabling port isolation for a Linux bridge NAD
+include::modules/virt-linux-bridge-nad-port-isolation.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../virt/vm_networking/virt-configuring-viewing-ips-for-vms.adoc#configuring-ips_virt-configuring-viewing-ips-for-vms[Configuring IP addresses for virtual machines]
 
 [id="configuring-vm-network-interface"]
 == Configuring a VM network interface


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-14170](https://issues.redhat.com/browse/OSDOCS-14170)

Link to docs preview:
[Enabling port isolation for a Linux bridge NAD](https://92544--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge.html#virt-linux-bridge-nad-port-isolation.adoc_virt-connecting-vm-to-linux-bridge)


- [x] SME has approved this change (Or Mergi/ Petr Horacek).
- [x] QE has approved this change (Weibin Liang/Yossi Segev).

