### PR TITLE
OSDOCS#14412:Update the OPP product releases for OCP 4.18

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -38,32 +38,32 @@
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
 // These variable are the current product release versions for the OPP products
-:ocp-supported-version: 4.17
-:rhacs-version: 4.6
-:quay-version: 3.13
-:rhacm-version: 2.12
-:odf-version: 4.17
+:ocp-supported-version: 4.18
+:rhacs-version: 4.7
+:quay-version: 3.14
+:rhacm-version: 2.13
+:odf-version: 4.18
 // These variables are for the immediate past 4 OPP product versions that are in the compatibility table
-:ocp-supported-version-1: 4.16
-:rhacs-version-1: 4.5
-:quay-version-1: 3.12
-:rhacm-version-1: 2.11
-:odf-version-1: 4.16
-:ocp-supported-version-2: 4.15
-:rhacs-version-2: 4.4
-:quay-version-2: 3.11
-:rhacm-version-2: 2.10
-:odf-version-2: 4.15
-:ocp-supported-version-3: 4.14
-:rhacs-version-3: 4.3
-:quay-version-3: 3.10
-:rhacm-version-3: 2.9
-:odf-version-3: 4.14
-:ocp-supported-version-4: 4.12
-:rhacs-version-4: 3.7.4
-:quay-version-4: 3.8
-:rhacm-version-4: 2.7
-:odf-version-4: 4.12
+:ocp-supported-version-1: 4.17
+:rhacs-version-1: 4.6
+:quay-version-1: 3.13
+:rhacm-version-1: 2.12
+:odf-version-1: 4.17
+:ocp-supported-version-2: 4.16
+:rhacs-version-2: 4.5
+:quay-version-2: 3.12
+:rhacm-version-2: 2.11
+:odf-version-2: 4.16
+:ocp-supported-version-3: 4.15
+:rhacs-version-3: 4.4
+:quay-version-3: 3.11
+:rhacm-version-3: 2.10
+:odf-version-3: 4.15
+:ocp-supported-version-4: 4.14
+:rhacs-version-4: 4.3
+:quay-version-4: 3.10
+:rhacm-version-4: 2.9
+:odf-version-4: 4.14
 // Following variables are required for publishing using PV2
 :product-title: OpenShift Platform Plus
 :product-version: .1

--- a/modules/opp-architecture-compatibility-matrix.adoc
+++ b/modules/opp-architecture-compatibility-matrix.adoc
@@ -13,13 +13,10 @@
 This table is updated after each product release is tested and verified with the latest {ocp} release. Use the versions in the matrix for the optimal performance.
 ====
 
-[cols="1,1,1,1,1"]
+.Verified product versions
+[cols="1,1,1,1,1,options=header"]
 |===
-|{ocp}
-|{rh-rhacm}
-|{acs}
-|{quay}
-|{rh-storage-essentials-first}
+|{ocp} |{rh-rhacm} |{acs} |{quay} |{rh-storage-essentials-first}
 
 |{ocp-supported-version}
 |{rhacm-version}


### PR DESCRIPTION
Version(s):
This PR is based on the ‘opp-docs-main’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add the ‘Continuous Release’ milestone to this PR.

Issue:
[OSDOCS-14412](https://issues.redhat.com//browse/OSDOCS-14412)

Link to docs preview:
[compatibility matrix](https://92562--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture.html)

QE review:
- [x] QE has approved this change.

Additional information:
The product versions that are listed might not be the latest available version for the product. The versions listed in the compatibility matrix are the latest verified versions for OPP.
