### PR TITLE
OSDOCS-10620 adding signBlob to 4.12-4.14

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -172,6 +172,12 @@ For more information, see "Required roles for using passthrough credentials mode
 * `iam.roles.get`
 ====
 
+.Required permissions when authenticating without a service account key
+[%collapsible]
+====
+* `iam.serviceAccounts.signBlob`
+====
+
 .Optional Images permissions for installation
 [%collapsible]
 ====


### PR DESCRIPTION

Version(s):
4.12, 4.13, 4.14 (This is based on 4.14, I will try cherrypicks to 4.13 and 4.12 due to the simplicity of the change and create separate PRs if necessary)

Issue:
https://issues.redhat.com/browse/OSDOCS-10620

Link to docs preview:

QE review:
- [x] QE has approved this change.
