### PR TITLE
OCPBUGS#34873 adding 2 to supported sno replicas values

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -639,7 +639,7 @@ endif::agent[]
   replicas:
 |The number of control plane machines to provision.
 ifndef::agent[]
-|Supported values are `3`, or `1` when deploying {sno}.
+|Supported values are `1`, `2`, or `3` when deploying {sno}.
 endif::agent[]
 ifdef::agent[]
 |Supported values are `3`, `4`, `5`, or `1` when deploying {sno}.


### PR DESCRIPTION

Version(s):
4.14+ 

Issue:
https://issues.redhat.com/browse/OCPBUGS-34873

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.