### PR TITLE
RHDEVDOCS 6426 Remove language note - gitops-docs-1.14

### DIFF
--- a/release_notes/gitops-release-notes-1-14.adoc
+++ b/release_notes/gitops-release-notes-1-14.adoc
@@ -27,8 +27,6 @@ For an overview of {gitops-title}, see xref:../understanding_openshift_gitops/ab
 // Compatibility and support matrix
 include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
-// Making open source more inclusive
-include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -27,8 +27,6 @@ For an overview of {gitops-title}, see xref:../understanding_openshift_gitops/ab
 // Compatibility and support matrix
 include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
-// Making open source more inclusive
-include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 


### PR DESCRIPTION
Version(s):

this version only

Issue:

RHDEVDOCS 6426

Link to docs preview: N/A

QE review: N/A

Additional information:

This PR removes the "Making open source more inclusive" statement. It does not add any  text and does not modify any functional documentation.
