### PR TITLE
RHDEVDOCS 6426 Remove language note - build-docs-1.3

### DIFF
--- a/release_notes/ob-release-notes.adoc
+++ b/release_notes/ob-release-notes.adoc
@@ -24,7 +24,6 @@ For more information about {builds-shortname}, see xref:../about/overview-opensh
 
 include::modules/ob-compatibility-support-matrix.adoc[leveloffset=+1]
 
-include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 


### PR DESCRIPTION
Version(s):

this version only

Issue:

RHDEVDOCS 6426

Link to docs preview: N/A

QE review: N/A

Additional information:

This PR removes the "Making open source more inclusive" statement. It does not add any  text and does not modify any functional documentation.
