### PR TITLE
RHDEVDOCS 6426 Remove language note - pipelines-docs-1.14

### DIFF
--- a/about/op-release-notes.adoc
+++ b/about/op-release-notes.adoc
@@ -20,7 +20,6 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
-include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 include::modules/op-release-notes-1-14.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):

this version only

Issue:

RHDEVDOCS 6426

Link to docs preview: N/A

QE review: N/A

Additional information:

This PR removes the "Making open source more inclusive" statement. It does not add any text and does not modify any functional documentation.