### PR TITLE
NO-JIRA: Mention Public hosted zone for HCP

### DIFF
--- a/modules/hcp-aws-create-dns-hosted-zone.adoc
+++ b/modules/hcp-aws-create-dns-hosted-zone.adoc
@@ -14,7 +14,7 @@ You can create the public DNS hosted zone to use as the external DNS domain-filt
 
 . In the Route 53 management console, click *Create hosted zone*.
 
-. On the *Hosted zone configuration* page, type a domain name, verify that *Publish hosted zone* is selected as the type, and click *Create hosted zone*.
+. On the *Hosted zone configuration* page, type a domain name, verify that *Public hosted zone* is selected as the type, and click *Create hosted zone*.
 
 . After the zone is created, on the *Records* tab, note the values in the *Value/Route traffic to* column.
 


### PR DESCRIPTION
There was a typo. It should be "Public hosted zone" as can be seen in screenshot below:
![image](https://github.com/user-attachments/assets/29691ce6-1fa8-4555-8f7a-405b0058595e)


Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://92594--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-aws.html#hcp-aws-create-dns-hosted-zone_hcp-deploy-aws
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
