### PR TITLE
standalone logging docs - 6.1 release notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3,6 +3,8 @@ Name: About OpenShift Logging
 Dir: about
 Distros: openshift-logging
 Topics:
+- Name: Release notes
+  File: logging-release-notes-6.1
 - Name: Logging overview
   File: about-logging
 - Name: Cluster logging support

--- a/about/logging-release-notes-6.1.adoc
+++ b/about/logging-release-notes-6.1.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="logging-release-notes-6-1"]
+= Logging 6.1 Release Notes
+:context: logging-release-notes-6-1
+
+toc::[]
+
+include::modules/logging-release-notes-6-1-5.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-1-4.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-1-3.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-1-2.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-1-1.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-1-0.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-6-1-0.adoc
+++ b/modules/logging-release-notes-6-1-0.adoc
@@ -1,0 +1,40 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-0_{context}"]
+= Logging 6.1.0 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2024:9038[{logging-uc} {for} Bug Fix Release 6.1.0].
+
+[id="openshift-logging-release-notes-6-1-0-enhancements"]
+== New Features and Enhancements
+
+=== Log Collection
+
+* This enhancement adds the source `iostream` to the attributes sent from collected container logs. The value is set to either `stdout` or `stderr` based on how the collector received it. (link:https://issues.redhat.com/browse/LOG-5292[LOG-5292])
+
+* With this update, the default memory limit for the collector increases from 1024 Mi to 2048 Mi. Users should adjust resource limits based on their cluster’s specific needs and specifications. (link:https://issues.redhat.com/browse/LOG-6072[LOG-6072])
+
+* With this update, users can now set the syslog output delivery mode of the `ClusterLogForwarder` CR to either `AtLeastOnce` or `AtMostOnce.` (link:https://issues.redhat.com/browse/LOG-6355[LOG-6355])
+
+=== Log Storage
+
+* With this update, the new `1x.pico` LokiStack size supports clusters with fewer workloads and lower log volumes (up to 50GB/day). (link:https://issues.redhat.com/browse/LOG-5939[LOG-5939])
+
+[id="logging-release-notes-6-1-0-technology-preview-features"]
+== Technology Preview
+
+:FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
+include::snippets/technology-preview.adoc[]
+
+* With this update, OpenTelemetry logs can now be forwarded using the `OTel` (OpenTelemetry) data model to a Red Hat Managed LokiStack instance. To enable this feature, add the `observability.openshift.io/tech-preview-otlp-output: "enabled"` annotation to your `ClusterLogForwarder` configuration. For additional configuration information, see link:https://github.com/openshift/cluster-logging-operator/blob/master/docs/features/logforwarding/outputs/opentelemetry-lokistack-forwarding.adoc[OTLP Forwarding].
+
+* With this update, a `dataModel` field has been added to the `lokiStack` output specification. Set the `dataModel` to `Otel` to configure log forwarding using the OpenTelemetry data format. The default is set to `Viaq`. For information about data mapping see link:https://opentelemetry.io/docs/specs/otlp/[OTLP Specification].
+
+[id="logging-release-notes-6-1-0-bug-fixes_{context}"]
+== Bug Fixes
+None.
+
+[id="logging-release-notes-6-1-0-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+* link:https://access.redhat.com/security/cve/CVE-2024-6232[CVE-2024-6232]

--- a/modules/logging-release-notes-6-1-1.adoc
+++ b/modules/logging-release-notes-6-1-1.adoc
@@ -1,0 +1,43 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-1_{context}"]
+= Logging 6.1.1 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2024:10992[{logging-uc} {for} Bug Fix Release 6.1.1].
+
+[id="logging-release-notes-6-1-1-enhancements_{context}"]
+== New Features and Enhancements
+
+* With this update, the {loki-op} supports configuring the workload identity federation on the {gcp-first} by using the Cluster Credential Operator (CCO) in {product-title} 4.17 or later. (link:https://issues.redhat.com/browse/LOG-6420[LOG-6420])
+
+[id="logging-release-notes-6-1-1-bug-fixes_{context}"]
+== Bug Fixes
+
+* Before this update, the collector was discarding longer audit log messages with the following error message: *Internal log [Found line that exceeds max_line_bytes; discarding.]*. With this update, the discarding of longer audit messages is avoided by increasing the audit configuration thresholds: The maximum line size, `max_line_bytes`, is `3145728` bytes. The maximum number of bytes read during a read cycle, `max_read_bytes`, is `262144` bytes. (link:https://issues.redhat.com/browse/LOG-6379[LOG-6379])
+
+* Before this update, an input receiver service was repeatedly created and deleted, causing issues with mounting the TLS secrets. With this update, the service is created once and only deleted if it is not defined in the `ClusterLogForwarder` custom resource. (link:https://issues.redhat.com/browse/LOG-6383[LOG-6383])
+
+* Before this update, pipeline validation might have entered an infinite loop if a name was a substring of another name. With this update, stricter name equality checks prevent the infinite loop. (link:https://issues.redhat.com/browse/LOG-6405[LOG-6405])
+
+* Before this update, the collector alerting rules included the summary and message fields. With this update, the collector alerting rules include the summary and description fields. (link:https://issues.redhat.com/browse/LOG-6407[LOG-6407])
+
+* Before this update, setting up the custom audit inputs in the `ClusterLogForwarder` custom resource with configured `LokiStack` output caused errors due to the nil pointer dereference. With this update, the Operator performs the nil checks, preventing such errors. (link:https://issues.redhat.com/browse/LOG-6449[LOG-6449])
+
+* Before this update, the `ValidLokistackOTLPOutputs` condition appeared in the status of the `ClusterLogForwarder` custom resource even when the output type is not `LokiStack`. With this update, the `ValidLokistackOTLPOutputs` condition is removed, and the validation messages for the existing output conditions are corrected. (link:https://issues.redhat.com/browse/LOG-6469[LOG-6469])
+
+* Before this update, the collector did not correctly mount the `/var/log/oauth-server/` path, which prevented the collection of the audit logs. With this update, the volume mount is added, and the audit logs are collected as expected. (link:https://issues.redhat.com/browse/LOG-6484[LOG-6484])
+
+* Before this update, the `must-gather` script of the {clo} might have failed to gather the LokiStack data. With this update, the `must-gather` script is fixed, and the LokiStack data is gathered reliably. (link:https://issues.redhat.com/browse/LOG-6498[LOG-6498])
+
+* Before this update, the collector did not correctly mount the `oauth-apiserver` audit log file. As a result, such audit logs were not collected. With this update, the volume mount is correctly mounted, and the logs are collected as expected. (link:https://issues.redhat.com/browse/LOG-6533[LOG-6533])
+
+[id="logging-release-notes-6-1-1-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]
+* link:https://access.redhat.com/security/cve/CVE-2024-2511[CVE-2024-2511]
+* link:https://access.redhat.com/security/cve/CVE-2024-3596[CVE-2024-3596]
+* link:https://access.redhat.com/security/cve/CVE-2024-4603[CVE-2024-4603]
+* link:https://access.redhat.com/security/cve/CVE-2024-4741[CVE-2024-4741]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+* link:https://access.redhat.com/security/cve/CVE-2024-10963[CVE-2024-10963]
+* link:https://access.redhat.com/security/cve/CVE-2024-50602[CVE-2024-50602]

--- a/modules/logging-release-notes-6-1-2.adoc
+++ b/modules/logging-release-notes-6-1-2.adoc
@@ -1,0 +1,43 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-2_{context}"]
+= Logging 6.1.2 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:1229[{logging-uc} {for} Bug Fix Release 6.1.2].
+
+[id="logging-release-notes-6-1-2-enhancements_{context}"]
+== New Features and Enhancements
+
+* This enhancement adds `OTel` semantic stream labels to the `lokiStack` output so that you can query logs by using both `ViaQ` and `OTel` stream labels.
+(link:https://issues.redhat.com/browse/LOG-6579[LOG-6579])
+
+[id="logging-release-notes-6-1-2-bug-fixes_{context}"]
+== Bug Fixes
+
+* Before this update, the collector alerting rules contained summary and message fields. With this update, the collector alerting rules contain summary and description fields.
+(link:https://issues.redhat.com/browse/LOG-6126[LOG-6126])
+
+* Before this update, the collector metrics dashboard could get removed after an Operator upgrade due to a race condition during the transition from the old to the new pod deployment. With this update, labels are added to the dashboard `ConfigMap` to identify the upgraded deployment as the current owner so that it will not be removed.
+(link:https://issues.redhat.com/browse/LOG-6280[LOG-6280])
+
+* Before this update, when you included infrastructure namespaces in application inputs, their `log_type` would be set to `application`. With this update, the `log_type` of infrastructure namespaces included in application inputs is set to `infrastructure`.
+(link:https://issues.redhat.com/browse/LOG-6373[LOG-6373])
+
+* Before this update, the Cluster Logging Operator used a cached client to fetch the `SecurityContextConstraint` cluster resource, which could result in an error when the cache is invalid. With this update, the Operator now always retrieves data from the API server instead of using a cache.
+(link:https://issues.redhat.com/browse/LOG-6418[LOG-6418])
+
+* Before this update, the logging `must-gather` did not collect resources such as `UIPlugin`, `ClusterLogForwarder`, `LogFileMetricExporter`, and `LokiStack`. With this update, the `must-gather` now collects all of these resources and places them in their respective namespace directory instead of the `cluster-logging` directory.
+(link:https://issues.redhat.com/browse/LOG-6422[LOG-6422])
+
+* Before this update, the Vector startup script attempted to delete buffer lock files during startup. With this update, the Vector startup script no longer attempts to delete buffer lock files during startup.
+(link:https://issues.redhat.com/browse/LOG-6506[LOG-6506])
+
+* Before this update, the API documentation incorrectly claimed that `lokiStack` outputs would default the target namespace, which could prevent the collector from writing to that output. With this update, this claim has been removed from the API documentation and the Cluster Logging Operator now validates that a target namespace is present.
+(link:https://issues.redhat.com/browse/LOG-6573[LOG-6573])
+
+* Before this update, the Cluster Logging Operator could deploy the collector with output configurations that were not referenced by any inputs. With this update, a validation check for the `ClusterLogForwarder` resource prevents the Operator from deploying the collector.
+(link:https://issues.redhat.com/browse/LOG-6585[LOG-6585])
+
+[id="logging-release-notes-6-1-2-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]

--- a/modules/logging-release-notes-6-1-3.adoc
+++ b/modules/logging-release-notes-6-1-3.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-3_{context}"]
+= Logging 6.1.3 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:1987[{logging-uc} {for} Bug Fix Release 6.1.3].
+
+[id="logging-release-notes-6-1-3-bug-fixes_{context}"]
+== Bug Fixes
+
+* Before this update, when using the new `1x.pico` size with the Loki Operator, the `PodDisruptionBudget` created for the Ingester pod allowed Kubernetes to evict two of the three Ingester pods. With this update, the Operator now creates a `PodDisruptionBudget` that allows eviction of only a single Ingester pod.
+(link:https://issues.redhat.com/browse/LOG-6693[LOG-6693])
+
+* Before this update, the Operator did not support templating of `syslog facility` and `severity level`, which was consistent with the rest of the API. Instead, the Operator relied upon the `5.x` API, which is no longer supported. With this update, the Operator supports templating by adding the required validation to the API and rejecting resources that do not match the required format.
+(link:https://issues.redhat.com/browse/LOG-6788[LOG-6788])
+
+* Before this update, empty `OTEL` tuning configuration caused a validation error. With this update, the validation rules allow empty `OTEL` tuning configurations.
+(link:https://issues.redhat.com/browse/LOG-6532[LOG-6532])
+
+[id="logging-release-notes-6-1-3-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2020-11023[CVE-2020-11023]
+* link:https://access.redhat.com/security/cve/CVE-2024-9287[CVE-2024-9287]
+* link:https://access.redhat.com/security/cve/CVE-2024-12797[CVE-2024-12797]

--- a/modules/logging-release-notes-6-1-4.adoc
+++ b/modules/logging-release-notes-6-1-4.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-4_{context}"]
+= Logging 6.1.4 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHSA-2025:3131[{logging-uc} {for} Bug Fix Release 6.1.4].
+
+[id="logging-release-notes-6-1-4-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, Red{nbsp}Hat Managed Elasticsearch failed to receive logs if the index name did not follow the required patterns (`app-`, `infra-`, `audit-`), resulting in an `index_not_found_exception` error due to a restricted automatic index creation. With this update, improved documentation and explanations in the `oc explain obsclf.spec.outputs.elasticsearch.index` command clarify the index naming limitations, helping users configure log forwarding correctly.
+(link:https://issues.redhat.com/browse/LOG-6623[LOG-6623])
+
+* Before this update, when you used `1x.pico` as the LokiStack size, the number of delete workers was set to zero. This issue occurred because of an error in the Operator that generates the Loki configuration. With this update, the number of delete workers is set to ten.
+(link:https://issues.redhat.com/browse/LOG-6797[LOG-6797])
+
+* Before this update, the Operator failed to update the `securitycontextconstraint` object required by the log collector, which was a regression from previous releases. With this update, the Operator restores the cluster role to the service account and updates the resource.
+(link:https://issues.redhat.com/browse/LOG-6816[LOG-6816])
+
+[id="logging-release-notes-6-1-4-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+* link:https://access.redhat.com/security/cve/CVE-2024-45336[CVE-2024-45336]
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
+* link:https://access.redhat.com/security/cve/CVE-2025-27144[CVE-2025-27144]
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].
+====

--- a/modules/logging-release-notes-6-1-5.adoc
+++ b/modules/logging-release-notes-6-1-5.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-5_{context}"]
+= Logging 6.1.5 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHSA-2025:3907[RHSA-2025:3907].
+
+[id="logging-release-notes-6-1-5-enhancements_{context}"]
+== New features and enhancements
+
+* Before this update, time-based stream sharding was not enabled in Loki, which resulted in Loki being unable to save historical data. With this update, {loki-op} enables time-based stream sharding in Loki, which helps Loki save historical data. (link:https://issues.redhat.com/browse/LOG-6991[LOG-6991])
+
+[id="logging-release-notes-6-1-5-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the Vector collector could not forward Open Virtual Network (OVN) and Auditd logs. With this update, the Vector collector can forward OVN and Auditd logs. (link:https://issues.redhat.com/browse/LOG-6996[LOG-6996])
+
+[id="logging-release-notes-6-1-5-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-30204[CVE-2025-30204]
+
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].
+====


### PR DESCRIPTION

Version(s):
standalone-logging-docs-6.1 only

Issue:
standalone logging 6.1 release notes

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
