### PR TITLE
standalone logging docs - build 6.1

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -497,4 +497,6 @@ openshift-logging:
     standalone-logging-docs-6.0:
       name: '6.0'
       dir: logging/6.0
-
+    standalone-logging-docs-6.1:
+      name: '6.1'
+      dir: logging/6.1


### PR DESCRIPTION
Version(s):
main only

Issue:
standalone logging docs - 6.1 release notes

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
