### PR TITLE
Fix formatting in the Machine Config Operator certificates assembly

### DIFF
--- a/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
+++ b/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
@@ -11,8 +11,9 @@ toc::[]
 This certificate authority is used to secure connections from nodes to Machine Config Server (MCS) during initial provisioning.
 
 There are two certificates:
-. A self-signed CA, the MCS CA
-. A derived certificate, the MCS cert
+
+* A self-signed CA, the MCS CA
+* A derived certificate, the MCS cert
 
 === Provisioning details
 


### PR DESCRIPTION
The list in the assembly is rendering incorrectly. See [current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/security_and_compliance/certificate-types-and-descriptions#cert-types-machine-config-operator-certificates). 

I simply fixed the list; didn't vet the wording of the bullets.

Preview: Machine Config Operator certificates -> [Purpose](https://92605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/machine-config-operator-certificates#purpose) -- Fixed list formatting.

No QE needed. 