### PR TITLE
Updated the docs to cover KeyCloak as an OIDC provider

### DIFF
--- a/modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-cli.adoc
@@ -48,8 +48,9 @@ The following table shows the possible CLI flags you can use when creating your 
 
 .Procedure
 
-* To use the interactive command interface, run the following commands:
+* To use the interactive command-line interface, run the following command:
 +
+.Example input
 [source,terminal]
 ----
 $ rosa create external-auth-provider -c <cluster_name>
@@ -96,47 +97,5 @@ rosa create external-auth-provider --cluster=<cluster_id> \
 +
 [source,terminal]
 ----
-I: Successfully created an external authentication provider for cluster '<cluster_id>'
-----
-
-.Verification
-
-* To verify your external authentication provider, run one of the following options:
-
-** List the external authentication configuration on a specified cluster with the following command:
-+
-[source,terminal]
-----
-$ rosa list external-auth-provider -c <cluster_name>
-----
-+
-.Example output
-+
-The following example shows a configured Microsoft Entra ID external authentication provider:
-+
-[source,terminal]
-----
-NAME        ISSUER URL
-m-entra-id  https://login.microsoftonline.com/<group_id>/v2.0
-----
-
-** Display the external authentication configuration on a specified cluster by using the following command:
-+
-[source,terminal]
-----
-$ rosa describe external-auth-provider \
-    -c <cluster_name> --name <name_of_external_authentication>
-----
-+
-.Example output
-+
-[source,terminal]
-----
-ID:                          ms-entra-id
-Cluster ID:                  <cluster_id>
-Issuer audiences:
-                             - <audience_id>
-Issuer Url:                  https://login.microsoftonline.com/<group_id>/v2.0
-Claim mappings group:        groups
-Claim mappings username:     email
+I: Successfully created an external authentication provider for cluster 'ext-auth-test'
 ----

--- a/modules/rosa-hcp-sts-example-external-auth-provider.adoc
+++ b/modules/rosa-hcp-sts-example-external-auth-provider.adoc
@@ -1,0 +1,156 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-sts-example-external-auth-provider_{context}"]
+= Example external authentication providers
+:source-highlighter: pygments
+:pygments-style: emacs
+:icons: font
+
+You can use one of the following examples of external authentication provider configurations to set up your own configuration.
+
+.Example Microsoft Entra ID configuration
+
+You can use Microsoft Entra ID as an external provider. You must have already configured a Microsoft Entra ID server before using it as an external provider. See the link:https://learn.microsoft.com/en-us/entra/identity/?culture=en-us&country=us[Microsoft Entra ID documentation] for more information.
+
+The following example shows a configured Microsoft Entra ID external authentication provider:
+
+.Procedure
+. Create an external authentication provider that uses Microsoft Entra ID by running the following command:
++
+[NOTE]
+====
+You must set your own environment variables with values specific to your Microsoft Entra ID server.
+====
++
+.Example input
+[source,terminal]
+----
+$ rosa create external-auth-provider -c $CLUSTER_NAME \  
+    --claim-mapping-groups-claim groups \
+    --claim-mapping-username-claim <authorized_user_name> \ 
+    --console-client-id $CONSOLE_CLIENT_ID \ 
+    --console-client-secret $CONSOLE_CLIENT_SECRET_VALUE \ 
+    --issuer-audiences "$AUDIENCE_1" \
+    --issuer-ca-file ca-bundle.crt --issuer-url $ISSUER_URL \
+    --name m-entra-id
+----
++
+.Example output
+[source,terminal]
+----
+I: Successfully created an external authentication provider for cluster 'ext-auth-test'. It can take a few minutes for the creation of an external authentication provider to become fully effective.
+----
+
+. List the external authentication provider for your cluster to see the issuer URL or use the `rosa describe` command to see all details related to this external authentication provider by running one of the following commands:
++
+.. List the external authentication configuration on a specified cluster by running the following command:
++
+.Example input
+[source,terminal]
+----
+$ rosa list external-auth-provider -c <cluster_name> \ <1>
+----
+<1> Provide the name of the cluster with the external authentication provider you want to view.
++
+.Example output
+[source,terminal]
+----
+NAME        ISSUER URL
+m-entra-id  https://login.microsoftonline.com/<group_id>/v2.0
+----
++
+.. Display the external authentication configuration on a specified cluster by running the following command:
++
+.Example input
+[source,terminal]
+----
+$ rosa describe external-auth-provider \
+    -c <cluster_name> --name <name_of_external_authentication> \ <1> <2>
+----
+<1> Provide the name of the cluster that has the external authentication provider you want to see detailed.
+<2> Provide the name of the authentication provider you want to see detailed.
++
+.Example output
++
+[source,terminal]
+----
+ID:                          ms-entra-id
+Cluster ID:                  <cluster_id>
+Issuer audiences:
+                             - <audience_id>
+Issuer Url:                  https://login.microsoftonline.com/<group_id>/v2.0
+Claim mappings group:        groups
+Claim mappings username:     email
+----
+
+.Example Keycloak configuration
+
+You can use Keycloak as an external provider. You must have already configured a Keycloak server before using it as an external provider. See the link:https://www.keycloak.org/server/configuration[Keycloak documentation] for more information.
+
+.Procedure
+. Create an external authentication provider that uses Keycloak by running the following command:
++
+[NOTE]
+====
+You must set your own environment variables with values specific to your Keycloak server.
+====
++
+.Example input
+[source,terminal]
+----
+$ rosa create external-auth-provider -c $CLUSTER_NAME \ 
+--claim-mapping-groups-claim groups \ 
+    --claim-mapping-username-claim <authorized_user_name> \
+    --console-client-id $CONSOLE_CLIENT_ID \ 
+    --console-client-secret $CONSOLE_CLIENT_SECRET_VALUE \
+    --issuer-audiences "$AUDIENCE_1,$AUDIENCE_2" \ 
+    --issuer-ca-file ca-bundle.crt --issuer-url $ISSUER_URL --name keycloak
+----
++
+.Example output
+[source,terminal]
+----
+I: Successfully created an external authentication provider for cluster 'ext-auth-test'. It can take a few minutes for the creation of an external authentication provider to become fully effective.
+----
+
+. List the external authentication provider for your cluster to see the issuer URL or use the `rosa describe` command to see all details related to this external authentication provider by running one of the following commands:
+.. List the external authentication configuration on a specified cluster by running the following command:
++
+.Example input
+[source,terminal]
+----
+$ rosa list external-auth-provider -c <cluster_name>
+----
++
+.Example output
+[source,terminal]
+----
+NAME      ISSUER URL
+keycloak  https://keycloak-keycloak.apps.<keycloak_id>.openshift.org/realms/master
+----
++
+.. Display the external authentication configuration on a specified cluster by running the following command:
++
+.Example input
+[source,terminal]
+----
+$ rosa describe external-auth-provider \
+    -c <cluster_name> --name <name_of_external_authentication>
+----
++
+.Example output
++
+[source,terminal]
+----
+ID:                                    keycloak
+Cluster ID:                            <cluster_id>
+Issuer audiences:
+                                       - <audience_id_1>
+                                       - <audience_id_2>
+Issuer Url:                            https://keycloak-keycloak.apps.<keycloak_id>.openshift.org/realms/master
+Claim mappings group:                  groups
+Claim mappings username:               <authorized_user_name>
+Console client id:                     console-test
+----

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -47,10 +47,13 @@ endif::openshift-rosa-hcp[]
 include::modules/rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli.adoc[leveloffset=+1]
 //Step 2 Create/list/delete external_provider  to HCP cluster that external_auth_config is not enable
 include::modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-cli.adoc[leveloffset=+1]
+include::modules/rosa-hcp-sts-example-external-auth-provider.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about configuring Entra ID for your IDP, see link:https://learn.microsoft.com/en-us/entra/fundamentals/whatis[What is Microsoft Entra ID?] in the Azure documentation or the xref:../cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc#cloud-experts-entra-id-idp[Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider] tutorial section of the documentation.
+* link:https://learn.microsoft.com/en-us/entra/fundamentals/whatis[What is Microsoft Entra ID?] (Microsoft documentation)
+* xref:../cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc#cloud-experts-entra-id-idp[Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider]
+* link:https://www.keycloak.org/guides[Keycloak documentaton]
 ifndef::openshift-rosa-hcp[]
 //* For information about the similar `idps` tool in the ROSA CLI, see xref:#../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-idp_rosa-managing-objects-cli[`create idp`].
 //* For more information about options in the ROSA CLI, see xref:#../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-external-auth-provider_rosa-managing-objects-cli[`create external-auth-provider`], xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-list-external-auth-provider_rosa-managing-objects-cli[`list external-auth-provider`], and xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-delete-external-auth-provider_rosa-managing-objects-cli[`delete external-auth-provider`].


### PR DESCRIPTION
Version(s):
`enterprise-4.18+`

Issue:
**[OSDOCS-10512](https://issues.redhat.com/browse/OSDOCS-10512)**

Link to docs preview:
- **[Creating ROSA with HCP clusters with external authentication](https://92606--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.html)**

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR removes EntraID from the External Auth provider for KeyCloak.