### PR TITLE
standalone logging docs - 6.2 release notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3,6 +3,8 @@ Name: About OpenShift Logging
 Dir: about
 Distros: openshift-logging
 Topics:
+- Name: Release notes
+  File: logging-release-notes-6.2
 - Name: Logging overview
   File: about-logging
 - Name: Cluster logging support

--- a/about/logging-release-notes-6.2.adoc
+++ b/about/logging-release-notes-6.2.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="logging-release-notes-6-2"]
+= Logging 6.2 Release Notes
+:context: loggging-release-notes-6-2
+
+toc::[]
+
+include::modules/logging-release-notes-6-2-1.adoc[leveloffset=+1]
+include::modules/logging-release-notes-6-2-0.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-6-2-0.adoc
+++ b/modules/logging-release-notes-6-2-0.adoc
@@ -1,0 +1,61 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-2-0_{context}"]
+= Logging 6.2.0 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:2398[{logging-uc} {for} Bug Fix Release 6.2.0].
+
+[id="openshift-logging-release-notes-6-2-0-enhancements_{context}"]
+== New Features and Enhancements
+
+
+=== Log Collection
+
+* With this update, HTTP outputs include a `proxy` field that you can use to send log data through an HTTP proxy. (link:https://issues.redhat.com/browse/LOG-6069[LOG-6069])
+
+=== Log Storage
+
+* With this update, time-based stream sharding in Loki is now enabled by the {loki-op}. This solves the issue of ingesting log entries older than the sliding time-window used by Loki. (link:https://issues.redhat.com/browse/LOG-6757[LOG-6757])
+
+* With this update, you can configure a custom certificate authority (CA) certificate with {loki-op} when using Swift as an object store. (link:https://issues.redhat.com/browse/LOG-4818[LOG-4818])
+
+* With this update, you can configure workload identity federation on {gcp-first} by using the Cluster Credential Operator in OpenShift 4.17 and later releases with the {loki-op}. (link:https://issues.redhat.com/browse/LOG-6158[LOG-6158])
+
+[id="logging-release-notes-6-2-0-technology-preview-features_{context}"]
+== Technology Preview
+
+:FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
+include::snippets/technology-preview.adoc[]
+
+* With this update, OpenTelemetry support offered by OpenShift {logging-uc} continues to improve, specifically in the area of enabling migrations from the ViaQ data model to `OpenTelemetry` when forwarding to `LokiStack`. (link:https://issues.redhat.com/browse/LOG-6146[LOG-6146])
+
+* With this update, the `structuredMetadata` field has been removed from {loki-op} in the `otlp` configuration because structured metadata is now the default type. Additionally, the update introduces a `drop` field that administrators can use to drop `OpenTelemetry` attributes when receiving data through `OpenTelemetry` protocol (OTLP). (link:https://issues.redhat.com/browse/LOG-6507[LOG-6507])
+
+[id="logging-release-notes-6-2-0-bug-fixes_{context}"]
+== Bug Fixes
+
+* Before this update, the timestamp shown in the console logs did not match the `@timestamp` field in the message. With this update the timestamp is correctly shown in the console. (link:https://issues.redhat.com/browse/LOG-6222[LOG-6222])
+
+* The introduction of `ClusterLogForwarder` 6.x modified the `ClusterLogForwarder` API to allow for a consistent templating mechanism. However, this was not applied to the `syslog` output spec API for the `facility` and `severity` fields. This update adds the required validation to the `ClusterLogForwarder` API for the `facility` and `severity` fields. (https://issues.redhat.com/browse/LOG-6661[LOG-6661])
+
+* Before this update, an error in the {loki-op} generating the Loki configuration caused the amount of workers to delete to be zero when `1x.pico` was set as the `LokiStack` size. With this update, the number of workers to delete is set to 10. (https://issues.redhat.com/browse/LOG-6781[LOG-6781])
+
+[id="logging-release-notes-6-2-0-known-issues_{context}"]
+== Known Issues
+
+* The previous data model encoded all information in JSON. The console still uses the query of the previous data model to decode both old and new entries. The logs that are stored by using the new `OpenTelemetry` data model for the `LokiStack` output display the following error in the logging console:
++
+----
+__error__ JSONParserErr 
+__error_details__ Value looks like object, but can't find closing '}' symbol
+----
++
+You can ignore the error as it is only a result of the query and not a data-related error. (https://issues.redhat.com/browse/LOG-6808[LOG-6808])
+
+* Currently, the API documentation incorrectly mentions `OpenTelemetry` protocol (OTLP) attributes as `included` instead of `excluded` in the descriptions of the `drop` field. (https://issues.redhat.com/browse/LOG-6839[LOG-6839]).
+
+
+[id="logging-release-notes-6-2-0-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2020-11023[CVE-2020-11023]
+* link:https://access.redhat.com/security/cve/CVE-2024-12797[CVE-2024-12797]

--- a/modules/logging-release-notes-6-2-1.adoc
+++ b/modules/logging-release-notes-6-2-1.adoc
@@ -1,0 +1,38 @@
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-2-1_{context}"]
+= Logging 6.2.1 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:3908[RHBA-2025:3908].
+
+[id="logging-release-notes-6-2-1-bug-fixes_{context}"]
+== Bug Fixes
+
+* Before this update, application programming interface (API) audit logs collected from the management cluster used the `cluster_id` value from the management cluster. With this update, API audit logs use the `cluster_id` value from the guest cluster. (link:https://issues.redhat.com/browse/LOG-4445[LOG-4445])
+
+* Before this update, issuing the `oc explain obsclf.spec.filters` command did not list all the supported filters in the command output. With this update, all the supported filter types are listed in the command output. (link:https://issues.redhat.com/browse/LOG-6753[LOG-6753])
+
+
+* Before this update the log collector flagged a `ClusterLogForwarder` resource with multiple inputs to a LokiStack output as invalid due to  incorrect internal processing logic. This update fixes the issue. (link:https://issues.redhat.com/browse/LOG-6758[LOG-6758])
+
+* Before this update, issuing the `oc explain` command for the `clusterlogforwarder.spec.outputs.syslog` resource returned an incomplete result. With this update, the missing supported types for `rfc` and `enrichment` attributes are listed in the result correctly. (link:https://issues.redhat.com/browse/LOG-6869[LOG-6869])
+
+* Before this update, empty OpenTelemetry (OTEL) tuning configuration caused validation errors. With this update, validation rules have been updated to accept empty tuning configuration. (link:https://issues.redhat.com/browse/LOG-6878[LOG-6878])
+
+* Before this update the {clo} could not update the `securitycontextconstraint` resource that is required by the log collector. With this update, the required cluster role has been provided to the service account of the {clo}. As a result of which, {clo} can create or update the  `securitycontextconstraint` resource. (link:https://issues.redhat.com/browse/LOG-6879[LOG-6879])
+
+* Before this update, the API documentation for the  URL attribute of the `syslog` resource incorrectly mentioned the value `udps` as a supported value. With this update, all references to `udps` have been removed. (link:https://issues.redhat.com/browse/LOG-6896[LOG-6896])
+
+* Before this update, the {CLO} was intermittently unable to update the object in logs due to update conflicts. This update resolves the issue and prevents conflicts during object updates by using the `Patch()` function instead of the `Update()` function. (link:https://issues.redhat.com/browse/LOG-6953[LOG-6953])
+
+* Before this update, Loki ingesters that got into an unhealthy state due to networking issues stayed in that state even after the network recovered. With this update, you can configure  the {loki-op} to perform service discovery more often so that unhealthy ingesters can rejoin the group. (link:https://issues.redhat.com/browse/LOG-6992[LOG-6992])
+
+* Before this update, the Vector collector could not forward Open Virtual Network (OVN) and Auditd logs. With this update, the Vector collector can forward OVN and Auditd logs. (link:https://issues.redhat.com/browse/LOG-6997[LOG-6997])
+
+[id="logging-release-notes-6-2-1-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+* link:https://access.redhat.com/security/cve/CVE-2024-2236[CVE-2024-2236]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]


### PR DESCRIPTION
Version(s):
standalone-logging-docs-6.2

Issue:
standalone logging - add release notes for 6.2

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
