### PR TITLE
build 6.2 standalone logging docs

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -500,3 +500,6 @@ openshift-logging:
     standalone-logging-docs-6.1:
       name: '6.1'
       dir: logging/6.1
+    standalone-logging-docs-6.2:
+      name: '6.2'
+      dir: logging/6.2


### PR DESCRIPTION
Version(s):
main only

Issue:
standalone logging docs - build 6.2

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
