### PR TITLE
fix version srop down for logging standalone

### DIFF
--- a/_javascripts/page-loader.js
+++ b/_javascripts/page-loader.js
@@ -13,6 +13,7 @@ const urlMappings = {
   "openshift-pipelines": "https://docs.openshift.com/pipelines/",
   "openshift-serverless": "https://docs.openshift.com/serverless/",
   "openshift-telco": "https://docs.openshift.com/container-platform-telco/",
+  "openshift-logging": "https://docs.openshift.com/logging/",
 };
 
 function versionSelector(list) {


### PR DESCRIPTION

Version(s):
main, enterprise-4.1

Issue:
standalone logging docs - fix version dropdown

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a