### PR TITLE
OLS-1698: change new chat to clear chat

### DIFF
--- a/modules/ols-starting-a-new-chat.adoc
+++ b/modules/ols-starting-a-new-chat.adoc
@@ -11,7 +11,7 @@ This procedure explains how to clear the chat history and start a new conversati
 
 .Procedure
 
-. In the {ols-official} natural language interface, click *New chat*. 
+. In the {ols-official} natural language interface, click *Clear chat*. 
 +
 This action clears the history of your previous conversation. 
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1698
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://92644--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/operate/ols-using-openshift-lightspeed.html#ols-starting-a-new-chat_ols-using-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
