### PR TITLE
OBSDOCS-1861 remove mention of incident detection from older versions

### DIFF
--- a/modules/coo-monitoring-ui-plugin-install.adoc
+++ b/modules/coo-monitoring-ui-plugin-install.adoc
@@ -6,7 +6,7 @@
 [id="coo-monitoring-ui-plugin-install_{context}"]
 = Installing the {coo-full} monitoring UI plugin
 
-The monitoring UI plugin adds monitoring related UI features to the OpenShift web console, for the Advance Cluster Management (ACM) perspective and for incident detection.
+The monitoring UI plugin adds monitoring related UI features to the OpenShift web console, for the Advance Cluster Management (ACM) perspective.
 
 .Prerequisites
 
@@ -35,8 +35,5 @@ spec:
         url: 'https://alertmanager.open-cluster-management-observability.svc:9095'
       thanosQuerier:
         url: 'https://rbac-query-proxy.open-cluster-management-observability.svc:8443'  
-    incidents: # <2>
-      enabled: true  
 ----
 <1> Enable {rh-rhacm} features. You must configure the Alertmanager and ThanosQuerier Service endpoints.
-<2> Enable incident detection features. 

--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -28,8 +28,6 @@ These release notes track the development of the {coo-full} in {product-title}.
  
 * You can now install the monitoring UI plugin using {coo-short}. (link:https://issues.redhat.com/browse/COO-262[*COO-262*])
 
-* You can enable incident detection in the monitoring UI plugin. (link:https://issues.redhat.com/browse/COO-690[*COO-690*])
-
 * TLS support for the Thanos web endpoint has been added. (link:https://issues.redhat.com/browse/COO-222[*COO-222*])
 
 The following table provides information about which features are available depending on the version of {coo-full} and {product-title}:

--- a/observability/cluster_observability_operator/ui_plugins/monitoring-ui-plugin.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/monitoring-ui-plugin.adoc
@@ -13,12 +13,5 @@ The monitoring UI plugin adds monitoring features to the Administrator perspecti
 
 * **{rh-rhacm}:** The monitoring plugin in {coo-first} allows it to function in {rh-rhacm-first} environments, providing {rh-rhacm} with the same alerting capabilities as {product-title}. You can configure the plugin to fetch alerts from the {rh-rhacm} Alertmanager backend. This enables seamless integration and user experience by aligning {rh-rhacm} and {product-title} monitoring workflows.
 
-* **Incident detection:** The incident detection feature groups related alerts into incidents, to help you identify the root causes of alert bursts, instead of being overwhelmed by individual alerts. It presents a timeline of incidents, color-coded by severity, and you can drill down into the individual alerts within an incident. The system also categorizes alerts by affected component, grouped by severity. This helps you focus on the most critical areas first.
-+
-The incident detection feature is available in the Administrator perspective of the OpenShift web console at **Observe** → **Incidents**. 
-
 include::modules/coo-monitoring-ui-plugin-install.adoc[leveloffset=+1]
 
-include::modules/coo-incident-detection-overview.adoc[leveloffset=+1]
-
-include::modules/coo-incident-detection-using.adoc[leveloffset=+1]

--- a/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.adoc
+++ b/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.adoc
@@ -12,11 +12,9 @@ The plugins extend the default functionality, providing new UI features for trou
 [id="monitoring_{context}"]
 == Monitoring
 
-The monitoring UI plugin adds monitoring related UI features to the OpenShift web console, for the Advance Cluster Management (ACM) perspective and for incident detection.
+The monitoring UI plugin adds monitoring related UI features to the OpenShift web console, for the Advance Cluster Management (ACM) perspective.
 
 * **ACM:** The monitoring plugin in {coo-first} allows it to function in {rh-rhacm-first} environments, providing ACM with the same monitoring capabilities as {product-title}.
-
-* **Incident Detection:** The incident detection feature groups alerts into incidents to help you identify the root causes of alert bursts instead of being overwhelmed by individual alerts. It presents a timeline of incidents, color-coded by severity, and you can drill down into the individual alerts within an incident. The system also categorizes alerts by affected component to help you focus on the most critical areas first.
 
 For more information, see the xref:../../../observability/cluster_observability_operator/ui_plugins/monitoring-ui-plugin.adoc#monitoring-ui-plugin[monitoring UI plugin] page.
 


### PR DESCRIPTION
Version(s):
4.17, and cherrypick back to 4.12

Issue:
[OBSDOCS-1861](https://issues.redhat.com//browse/OBSDOCS-1861)

Link to docs preview:
https://92649--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html
https://92649--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/monitoring-ui-plugin.html
https://92649--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/ui_plugins/observability-ui-plugins-overview.html

QE review:
n/a