### PR TITLE
TELCODOCS-2291: Removing index anchor for index.adoc in S&P assembly

### DIFF
--- a/scalability_and_performance/index.adoc
+++ b/scalability_and_performance/index.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="index"]
+[id="scalability-and-performance-overview"]
 = {product-title} scalability and performance overview
 include::_attributes/common-attributes.adoc[]
 :context: index

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -200,7 +200,7 @@ a|* xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-cr
 | xref:../cicd/builds/advanced-build-operations.adoc#builds-build-pruning-advanced-build-operations[Performing advanced builds]
 
 | xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc#scaling-cluster-monitoring-operator[Scale] and xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[tune] clusters
-| xref:../scalability_and_performance/index.adoc#index[{product-title} scalability and performance]
+| xref:../scalability_and_performance/index.adoc#scalability-and-performance-overview[{product-title} scalability and performance]
 
 |===
 


### PR DESCRIPTION
[TELCODOCS-2291](https://issues.redhat.com//browse/TELCODOCS-2291): Removing index anchor for index.adoc in S&P assembly as it confuses the DRH in single-page view

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2291

Link to docs preview:
We have no way to get a DRH preview so I can't tell for sure if this will fix the problem. This was the only "index" anchor ID in the repo so I think it might be the cause of the rendering issue on DRH. 

The old preview looks ok. I've tried a local asciidoctor build and it seems ok :shrug: 

QE review:
QE not needed this is a rendering issue.