### PR TITLE
OSDOCS-13088: adds 4.17.27 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -86,13 +86,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
 
-//NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
-//[id="microshift-4-17-bug-fixes_{context}"]
-//== Bug fixes
-
-//[id="microshift-4-17-known-issues_{context}"]
-//== Known issues
-
 [id="microshift-4-17-asynchronous-errata-updates_{context}"]
 == Asynchronous errata updates
 
@@ -225,3 +218,17 @@ Issued: 28 January 2025
 Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0682[RHBA-2025:0682] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:0654[RHSA-2025:0654] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-27-dp_{context}"]
+=== RHBA-2025:0682 - {microshift-short} 4.17.27 bug fix and enhancement advisory
+
+Issued: 30 April 2025
+
+{product-title} release 4.17.27 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4217[RHBA-2025:4217] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:4204[RHSA-2025:4204] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="ocp-4-17-27-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, an IPv6 configuration for {microshift-short} was created in the system at first start when an IP address was not configured. This was caused by an erroneous retrieval of the default node IP address because of the order in which the interfaces were listed. Consequentially, the misconfiguration resulted in the {microshift-short} service being unreachable. With this release, the correct node IP address is retrieved first. (link:https://issues.redhat.com/browse/OCPBUGS-52861[OCPBUGS-52861])


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13088](https://issues.redhat.com/browse/OSDOCS-13088)

Link to docs preview:
[microshift-4-17-27-dp_release-notes](https://92667--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-27-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
