### PR TITLE
OSDOCS-13666: adds 4.15.51 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -543,3 +543,12 @@ Issued: 27 February 2025
 The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:1719[RHBA-2025:1719] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:1711[RHSA-2025:1711] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-51-dp_{context}"]
+=== RHBA-2025:4219 - {microshift-short} 4.15.51 bug fix and enhancement advisory
+
+Issued: 30 April 2025
+
+{product-title} release 4.15.51 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4219[RHBA-2025:4219] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:4177[RHSA-2025:4177] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-13666](https://issues.redhat.com/browse/OSDOCS-13666)

Link to docs preview:
[microshift-4-15-51-dp_release-notes](https://92668--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-51-dp_release-notes)

QE review:
- N/A boilerplate text only

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
