### PR TITLE
Configuring backupPVC and restorePVC

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3702,6 +3702,8 @@ Topics:
       File: about-oadp-data-mover
     - Name: Backing up and restoring volumes by using CSI snapshots data movement
       File: oadp-backup-restore-csi-snapshots
+    - Name: Configuring backupPVC and restorePVC for Data Mover
+      File: configuring-backup-restore-pvc-datamover
     - Name: Overriding Kopia algorithms
       File: overriding-kopia-algorithms
   - Name: OADP API

--- a/backup_and_restore/application_backup_and_restore/installing/configuring-backup-restore-pvc-datamover.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/configuring-backup-restore-pvc-datamover.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-backup-restore-pvc-datamover"]
+= Configuring backup and restore PVCs for Data Mover
+include::_attributes/common-attributes.adoc[]
+:context: configuring-backup-restore-pvc-datamover
+
+toc::[]
+
+A backup PVC is an intermediate persistent volume claim (PVC) to store data during the data movement backup operation. For some storage classes, such as, CephFS, creating a read-only volume from a snapshot results in faster Data Mover backups.
+
+You create a `readonly` backup PVC by using the `nodeAgent.backupPVC` section of the `DataProtectionApplication` (DPA) and setting the `readOnly` access mode to `true`.
+
+You can use the following fields in the `nodeAgent.backupPVC` section of the DPA to configure the backup PVC.
+
+* `storageClass`: The name of the storage class to use for the backup PVC.
+* `readOnly`: Indicates if the backup PVC should be mounted as read-only. Setting this field to `true` also requires you to set the `spcNoRelabeling` field to `true`.
+* `spcNoRelabeling`: Disables automatic relabeling of the volume if set to `true`. You can set this field to `true` only when `readOnly` is `true`. When the `readOnly` flag is `true`, SELinux relabeling of the volume is not possible. This causes the Data Mover backup to fail. Therefore, when you are using the `readOnly` access mode for the CephFS storage class, you must disable relabeling.
+
+include::modules/oadp-configuring-backup-pvc-datamover-backup.adoc[leveloffset=+1]
+
+include::modules/oadp-configuring-restore-pvc-datamover-restore.adoc[leveloffset=+1]

--- a/modules/oadp-configuring-backup-pvc-datamover-backup.adoc
+++ b/modules/oadp-configuring-backup-pvc-datamover-backup.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/configuring-backup-restore-pvc-datamover.adoc          
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-backup-pvc_{context}"]
+= Configuring a  backup PVC for a Data Mover backup
+
+Use the `nodeAgent.backupPVC` section of the `DataProtectionApplication` (DPA) object to configure the backup persistent volume claim (PVC) for a storage class.
+
+.Prerequisites
+
+* You have installed the {oadp-short} Operator.
+
+.Procedure
+
+. Configure the `nodeAgent.backupPVC` section in the DPA as shown in the following example:
++
+.Example Data Protection Application
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: ts-dpa
+  namespace: openshift-adp
+spec:
+  backupLocations:
+  - velero:
+      credential:
+        key: cloud
+        name: cloud-credentials-gcp
+      default: true
+      objectStorage:
+        bucket: oadp...2jw
+        prefix: velero
+      provider: gcp
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+      backupPVC: # <1>
+        storage-class-1: 
+          readOnly: true # <2>
+          spcNoRelabeling: true # <3>
+          storageClass: gp3-csi
+        storage-class-2:
+          readOnly: false
+          spcNoRelabeling: false
+          storageClass: gp3-csi      
+    velero:
+      defaultPlugins:
+      - gcp
+      - openshift
+      - csi
+----
+<1> In this example, the `backupPVC` section has configurations for two storage classes, `storage-class-1` and `storage-class-2`.
+<2> The `backupPVC` for `storage-class-1` is configured as `readOnly`.
+<3> Because the `backupPVC` for `storage-class-1` is `readOnly`, the `spcNoRelabeling` field is set to `true`.
+
+. Create a `Backup` custom resource by using the following configuration:
++
+.Example Backup
+[source,yaml]
+----
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: test-backup
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - <application_namespace>
+  snapshotMoveData: true # <1>
+----
+<1> Set to `true` for a Data Mover backup.
+
+.Verification
+
+* Verify that the backup PVCs are created as read-only (`ROX`) by running the following command:
++
+.Example command
+[source,terminal]
+----
+$ oc get pvc -n openshift-adp -w
+----
++
+[source,terminal]
+----
+test-backup1-l..d   Bound   pvc-1298.....22f8   2Gi        ROX            standard-csi   <unset>                 37s
+test-backup1-l..d   Bound   pvc-1298....022f8   2Gi        ROX            standard-csi   <unset>                 37s
+----

--- a/modules/oadp-configuring-restore-pvc-datamover-restore.adoc
+++ b/modules/oadp-configuring-restore-pvc-datamover-restore.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/configuring-backup-restore-pvc-datamover.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-restore-pvc_{context}"]
+= Configuring a restorePVC for a Data Mover restore
+
+A `restorePVC` is an intermediate PVC that is used to write data during the Data Mover restore operation.
+
+You can configure the `restorePVC` in the `DataProtectionApplication` (DPA) object by using the `ignoreDelayBinding` field. Setting the `ignoreDelayBinding` field to `true` allows the restore operation to ignore the `WaitForFirstConsumer` binding mode. The data movement restore operation then creates the restore pod and provisions the associated volume to an arbitrary node. 
+
+The `ignoreDelayBinding` setting is helpful in scenarios where multiple volume restores are happening in parallel. With the `ignoreDelayBinding` field set to `true`, the restore pods can be spread evenly to all nodes.
+
+.Prerequisites
+
+* You have installed the {oadp-short} Operator.
+* You have a created a Data Mover backup of an application.
+
+.Procedure
+
+* Configure the `restorePVC` section in the DPA as shown in the following example:
++
+.Example Data Protection Application
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: ts-dpa
+  namespace: openshift-adp
+spec:
+#  ...
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+    restorePVC: # <1>
+      ignoreDelayBinding: true # <2>
+----
+<1> Add the `restorePVC` section.
+<2> Set the `ignoreDelayBinding` field to `true`.


### PR DESCRIPTION
## Jira 

[OADP-5961](https://issues.redhat.com/browse/OADP-5961) [OADP-5734](https://issues.redhat.com/browse/OADP-5734)

Added docs for configuring the `backupPVC` and `restorePVC` in DPA for Data Mover

##  Version

* OCP 4.19

## Preview

* [Configuring backupPVC](https://92669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/configuring-backup-restore-pvc-datamover.html)
* [Configuring restorePVC](https://92669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/configuring-backup-restore-pvc-datamover.html#configuring-restore-pvc_configuring-backup-restore-pvc-datamover)

## QE Review

* [x] QE has approved this change.
