### PR TITLE
OCPBUGS 55305: Invalid image example in Configuring updated boot images

### DIFF
--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -68,7 +68,7 @@ spec:
 +
 [TIP]
 ====
-If an appropriate label is not present on the machine set, add a key/value pair by running a command similar to following:
+If an appropriate label is not present on the machine set, add a key-value pair by running a command similar to following:
 
 ----
 $ oc label machineset.machine ci-ln-hmy310k-72292-5f87z-worker-a update-boot-image=true -n openshift-machine-api
@@ -140,7 +140,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-416-92-202402201450-0-gcp-x86-64 <1>
+            image: projects/rhcos-cloud/global/images/<boot_image> <1>
 # ...
 ----
 <1> This boot image is the same as the current {product-title} version.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-55305

I had an apparently incorrect image name in an output example. To be safe, I changed the name to a generic `<boot_image>`. As such, I don't think this needs QE review.  