### PR TITLE
OSDOCS-14461:Removed repeated steps and style check on Accessing your cluster section of ROSA/OSD docs

### DIFF
--- a/modules/access-cluster.adoc
+++ b/modules/access-cluster.adoc
@@ -18,12 +18,8 @@ After you have configured your identity providers, users can access the cluster 
 
 .Procedure
 
-. From {cluster-manager-url}, click on the cluster you want to access.
-
-. Click *Open Console*.
-
-. Click on your identity provider and provide your credentials to log into the cluster.
+. From {cluster-manager-url}, select the cluster you want to access.
 
 . Click *Open console* to open the web console for your cluster.
 
-. Click on your identity provider and provide your credentials to log in to the cluster. Complete any authorization requests that are presented by your provider.
+. Select your identity provider and enter your credentials to log in to the cluster. Complete any authorization requests from your provider.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14461

Link to docs preview:
- https://92675--ocpdocs-pr.netlify.app/openshift-dedicated/latest/authentication/sd-configuring-identity-providers.html#access-cluster_sd-configuring-identity-providers

Peer review:
- [x] Peer reviewer has approved this change. 
 
QE review:
QE review not required as this PR only fixes typos and makes some style changes in accordance with S&G.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
