### PR TITLE
OSDOCS-13102: adds 4.18.11 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -147,7 +147,7 @@ See the latest images included with {microshift-short} by xref:../microshift_upd
 [id="microshift-4-18-1-known-issue_{context}"]
 ==== Known issue
 
-* A failed greenboot health check flag does not clear when an RPM-install-based {microshift-short} service is updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. (link:https://issues.redhat.com/browse/OCPBUGS-51198[*OCPBUGS-51198*])
+* A failed greenboot health check flag does not clear when an RPM-install-based {microshift-short} service is updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. (link:https://issues.redhat.com/browse/OCPBUGS-51198[OCPBUGS-51198])
 
 [id="microshift-4-18-2-dp_{context}"]
 === RHBA-2025:1953 - {microshift-short} 4.18.2 bug fix and enhancement advisory
@@ -161,4 +161,22 @@ See the latest images included with {microshift-short} by xref:../microshift_upd
 [id="microshift-4-18-2-bugs_{context}"]
 ==== Bug fix
 
-* Previously, a failed greenboot health check flag did not clear when an RPM-install-based {microshift-short} service was updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. With this release, the primary {microshift-short} greenboot health check clears the condition that causes optional component health checks to continue to fail. (link:https://issues.redhat.com/browse/OCPBUGS-51198[*OCPBUGS-51198*])
+* Previously, a failed greenboot health check flag did not clear when an RPM-install-based {microshift-short} service was updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. With this release, the primary {microshift-short} greenboot health check clears the condition that causes optional component health checks to continue to fail. (link:https://issues.redhat.com/browse/OCPBUGS-51198[OCPBUGS-51198])
+
+[id="microshift-4-18-11-dp_{context}"]
+=== RHBA-2025:4249 - {microshift-short} 4.18.11 bug fix and enhancement advisory
+
+Issued: 1 May 2025
+
+{product-title} release 4.18.11 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4249[RHBA-2025:4249] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-18-11-bugs_{context}"]
+==== Bug fixes
+
+* Previously, {microshift-short} could fail to start on a host without the hostname RPM package installed. With this release, the hostname RPM package is pulled as a dependency during installation. This change means that the hostname RPM package is now required when building the {microshift-short} system, preventing this type of startup failure.  (link:https://issues.redhat.com/browse/OCPBUGS-54448[OCPBUGS-54448])
+
+* In some cases, {microshift-short} did not start when using the default configuration file shipped in the {microshift-short} RPM because certain required values were missing. These values are now added to the default `config.yaml` file to avoid this problem and {microshift-short} starts as expected. (link:https://issues.redhat.com/browse/OCPBUGS-53026[OCPBUGS-53026])
+
+* Previously, when embedding container images during a bootc build procedure, extended attributes were discarded, preventing the router pod from connecting to default `haproxy` ports. With this release, extended attributes are kept for container layers that are embedded into container images. As a result, the bootc container router pod starts normally. (link:https://issues.redhat.com/browse/OCPBUGS-42010[OCPBUGS-42010])


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13102](https://issues.redhat.com/browse/OSDOCS-13102)

Link to docs preview:
[microshift-4-18-11-dp_release-notes](https://92679--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-11-dp_release-notes)

Reviews:
- [x] QE approved this change.
- [x] SME approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
