### PR TITLE
Adds OMR 2.0.6 release notes

### DIFF
--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -14,6 +14,24 @@ These release notes track the development of the _mirror registry for Red{nbsp}H
 
 The following sections provide details for each 2.0 release of the mirror registry for Red{nbsp}Hat OpenShift.
 
+[id="mirror-registry-for-openshift-2-0-6_{context}"]
+=== Mirror registry for Red{nbsp}Hat OpenShift 2.0.6
+
+Issued: 28 April 2025
+
+_Mirror registry for Red{nbsp}Hat OpenShift_ is now available with Red{nbsp}Hat Quay 3.12.8.
+
+The following advisory is available for the _mirror registry for Red{nbsp}Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2025:4251[RHBA-2025:4251 - mirror registry for Red{nbsp}Hat OpenShift 2.0.6]
+
+[id="mirror-registry-bug-fixes-2-0-6_{context}"]
+==== Bug fixes
+
+* Previously, some users could not upgrade the _mirror registry for Red{nbsp}Hat OpenShift_ from version 1.3 to 2.0. This issue occurred because Ansible was unable to detect whether {quay} was running. This issue has been resolved. (link:https://issues.redhat.com/browse/PROJQUAY-8607[*PROJQUAY-8607*])
+
+* Previously, the `mirror-registry` command would fail at the last step when waiting for the host server to become live. This was caused due to deprecations in some parameters for Python 3.12 and the `urllib3` library. With this update, the base images for Ansible have been updated and the `mirror-registry` command no longer fails. (link:https://issues.redhat.com/browse/PROJQUAY-8733[*PROJQUAY-8733*])
+
 [id="mirror-registry-for-openshift-2-0-5_{context}"]
 === Mirror registry for Red{nbsp}Hat OpenShift 2.0.5
 


### PR DESCRIPTION
OMR release notes

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-14462

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE not needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
