### PR TITLE
OBSDOCS-1844 add incidents to overview

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-overview.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-overview.adoc
@@ -16,6 +16,7 @@ The {coo-short} deploys the following monitoring components:
 * **Alertmanager** (optional) - Provides alert configuration capabilities for different services.
 * **UI plugins** (optional) - Enhances the observability capabilities with plugins for monitoring, logging, distributed tracing and troubleshooting.
 * **Korrel8r** (optional) - Provides observability signal correlation, powered by the open source Korrel8r project.
+* **Incident detection** (optional) - Groups related alerts into incidents, to help you identify the root causes of alert bursts.
 
 include::modules/coo-versus-default-ocp-monitoring.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OBSDOCS-1844](https://issues.redhat.com//browse/OBSDOCS-1844)

Link to docs preview:
https://92682--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-overview.html

QE review:
n/a
