### PR TITLE
OSDOCS-14435 created the z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3400,13 +3400,59 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.51
+[id="ocp-4-14-51_{context}"]
+=== RHSA-2025:4177 - {product-title} 4.14.51 bug fix and security update
+
+Issued: 30 April 2025
+
+{product-title} release 4.14.51, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4177[RHSA-2025:4177] advisory. There are no RPM packages for this update.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.51 --pullspecs
+----
+
+[id="ocp-4-14-51-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, an update to the {ibm-cloud-name} Cloud Internet Services (CIS) implementation impacted the upstream Terraform plugin. If you attempted to create an external-facing cluster on {ibm-cloud-name}, the following error occurred:
++
+[source,terminal]
+----
+ERROR Error: Plugin did not respond
+ERROR
+ERROR with module.cis.ibm_cis_dns_record.kubernetes_api_internal[0],
+ERROR on cis/main.tf line 27, in resource "ibm_cis_dns_record" "kubernetes_api_internal":
+ERROR 27: resource "ibm_cis_dns_record" "kubernetes_api_internal"
+----
++
+With this release, you can use the installation program to create an external cluster on {product-title} without the plugin issue. (link:https://issues.redhat.com/browse/OCPBUGS-54264[OCPBUGS-54264]).
+
+* Previously, the *Observe* section on the web console did not show items contributed from plugins unless certain flags related to the monitoring were set. These flags prevented other plugins, such as logging, {DTShortName}, network observability, and others from adding items to the *Observe* section. With this release, the monitoring flags are removed so that other plugins can add items to the *Observe* section. (link:https://issues.redhat.com/browse/OCPBUGS-53437[OCPBUGS-53437])
+
+* Previously, on a `condition.Status`, the ignition-server controller overloaded the Kubernetes agent server (KAS) by updating that condition with the same message in every reconcile loop. With this release, the controller checks the message and validates whether it is the existing message so that the KAS is not overloaded. (link:https://issues.redhat.com/browse/OCPBUGS-53433[OCPBUGS-53433])
+
+* Previously, a custom Security Context Constraint (SCC) impacted pods that the Cluster Version Operator generated from receiving a cluster version upgrade. With this release, {product-title} now sets a default SCC to each pod, so that any custom SCC created does not impact a pod. (link:https://issues.redhat.com/browse/OCPBUGS-50592[OCPBUGS-50592]) 
+
+* Previously, a User Datagram Protocol (UDP) packet that was larger than the maximum transmission unit (MTU) value set for the cluster, could not be sent to the endpoint of the packet using a service. With this release, the pod IP address is used instead of the service IP address regardless of the packet size so that the UDP packet can be sent to the endpoint. (link:https://issues.redhat.com/browse/OCPBUGS-50584[OCPBUGS-50584]) 
+
+[id="ocp-4-14-51-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.50
 [id="ocp-4-14-50_{context}"]
 === RHSA-2025:3569 - {product-title} 4.14.50 bug fix and security update
 
 Issued: 09 April 2025
 
-{product-title} release 4.14.50, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3569[RHSA-2025:3569] advisory.
+{product-title} release 4.14.50, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3569[RHSA-2025:3569] advisory. 
 
 Space precluded documenting all of the container images for this release in the advisory.
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-14435

Link to docs preview:
[4.14.51](https://92691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-51_release-notes)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

