### PR TITLE
OADP-5953-Added a module for nodeAgent pod

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.adoc
@@ -29,3 +29,4 @@ requests:
 
 include::modules/oadp-pod-crash-set-resource-request-velero.adoc[leveloffset=+1]
 include::modules/oadp-pod-crash-set-resource-request-restic.adoc[leveloffset=+1]
+include::modules/setting-resource-requests-for-a-nodeagent-pod.adoc[leveloffset=+1]

--- a/modules/oadp-pod-crash-set-resource-request-restic.adoc
+++ b/modules/oadp-pod-crash-set-resource-request-restic.adoc
@@ -8,6 +8,8 @@
 
 You can use the `configuration.restic.podConfig.resourceAllocations` specification field to set specific resource requests for a `Restic` pod.
 
+include::snippets/about-restic-deprecation.adoc[leveloffset=+1]
+
 .Procedure
 
 * Set the `cpu` and `memory` resource requests in the YAML file:

--- a/modules/setting-resource-requests-for-a-nodeagent-pod.adoc
+++ b/modules/setting-resource-requests-for-a-nodeagent-pod.adoc
@@ -1,0 +1,102 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/pods-crash-or-restart-due-to-lack-of-memory-or-cpu
+:_mod-docs-content-type: PROCEDURE
+
+[id="setting-resource-requests-for-a-nodeagent-pod_{context}"]
+= Setting resource requests for a nodeAgent pod
+
+You can use the `configuration.nodeAgent.podConfig.resourceAllocations` specification field to set specific resource requests for a `nodeAgent` pod.
+
+include::snippets/about-restic-deprecation.adoc[leveloffset=+1]
+
+
+.Procedure
+
+. Set the `cpu` and `memory` resource requests in the YAML file:
++
+.Example `nodeAgent.yaml` file
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: ts-dpa
+spec:
+  backupLocations:
+  - velero:
+      default: true
+      objectStorage:
+        bucket: oadp.....njph 
+        prefix: velero
+      credential:
+        key: cloud
+        name: cloud-credentials-gcp
+      provider: gcp 
+  configuration:
+    velero:
+      defaultPlugins:
+      - gcp
+      - openshift
+      - csi
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+      podConfig:
+        resourceAllocations: <1>
+          requests:
+            cpu: 1000m
+            memory: 16Gi <2>
+----
+<1> The resource allocation examples shown are for average usage.
+<2> You can modify this parameter depending on your infrastructure and usage.
+
+. Create the DPA CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f nodeAgent.yaml
+----
+
+.Verification
+
+. Verify that the `nodeAgent` pods are running by using the following command:
++
+[source,terminal]
+----
+$ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                        READY   STATUS      RESTARTS   AGE
+node-agent-hbj9l                                            1/1     Running     0          97s
+node-agent-wmwgz                                            1/1     Running     0          95s
+node-agent-zvc7k                                            1/1     Running     0          98s
+openshift-adp-controller-manager-7f9db86d96-4lhgq           1/1     Running     0          137m
+velero-7b6c7fb8d7-ppc8m                                     1/1     Running     0          4m2s
+----
+
+. Check the resource requests by describing one of the `nodeAgent` pod:
++
+[source,terminal]
+----
+$ oc describe pod node-agent-hbj9l | grep -C 5 Requests
+----
++
+.Example output
+[source,terminal]
+----
+      --log-format=text
+    State:          Running
+      Started:      Mon, 09 Jun 2025 16:22:15 +0530
+    Ready:          True
+    Restart Count:  0
+    Requests:
+      cpu:     1
+      memory:  1Gi
+    Environment:
+      NODE_NAME:            (v1:spec.nodeName)
+      VELERO_NAMESPACE:    openshift-adp (v1:metadata.namespace)
+----

--- a/snippets/about-restic-deprecation.adoc
+++ b/snippets/about-restic-deprecation.adoc
@@ -1,0 +1,11 @@
+// Snippet included in the following modules
+
+//modules/oadp-pod-crash-set-resource-request-restic.adoc
+//modules/setting-resource-requests-for-a-nodeagent-pod.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[NOTE]
+====
+With {oadp-short} 1.5.0, the `configuration.restic.podConfig.resourceAllocations` specification field is removed from Data Protection Application (DPA). Use the `nodeAgent` section with the `uploaderType` field set to `Kopia` instead of `Restic` .
+====


### PR DESCRIPTION
Version(s):
OCP 4.19

Issue:
[OADP-5953
](https://issues.redhat.com/browse/OADP-5953)

Link to docs preview: [Setting resource requests for a nodeAgent pod](https://92695--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.html#setting-resource-requests-for-a-nodeagent-pod_pods-crash-or-restart-due-to-lack-of-memory-or-cpu)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


