### PR TITLE
OSDOCS-14405: Fix and improve OADP documentation for ROSA

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-intro.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-intro.adoc
@@ -15,14 +15,17 @@ ifndef::openshift-rosa,openshift-rosa-hcp[]
 However, {oadp-short} does not serve as a disaster recovery solution for xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[etcd] or {OCP-short} Operators.
 endif::openshift-rosa,openshift-rosa-hcp[]
 
-{oadp-short} support is provided to customer workload namespaces, and cluster scope resources.
+[IMPORTANT]
+====
+{oadp-short} support is provided to customer workload namespaces and cluster scope resources.
 
 Full cluster xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[backup] and xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#restoring-applications[restore] are not supported.
+====
 
 [id="oadp-apis_{context}"]
 == {oadp-full} APIs
 
-{oadp-first} provides APIs that enable multiple approaches to customizing backups and preventing the inclusion of unnecessary or inappropriate resources.
+{oadp-short} provides APIs that enable multiple approaches to customizing backups and preventing the inclusion of unnecessary or inappropriate resources.
 
 OADP provides the following APIs:
 


### PR DESCRIPTION
[OSDOCS-14405](https://issues.redhat.com//browse/OSDOCS-14405): Fix and improve OADP documentation for ROSA

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14405

Link to docs preview:
ROSA HCP: https://92696--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/backup_and_restore/application_backup_and_restore/oadp-intro.html 
ROSA Classic: https://92696--ocpdocs-pr.netlify.app/openshift-rosa/latest/backup_and_restore/application_backup_and_restore/oadp-intro.html 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
