### PR TITLE
CNV#57866: autoResourceLimits documentation needs update

### DIFF
--- a/modules/virt-about-cpu-and-memory-quota-namespace.adoc
+++ b/modules/virt-about-cpu-and-memory-quota-namespace.adoc
@@ -9,5 +9,3 @@
 A _resource quota_, defined by the `ResourceQuota` object, imposes restrictions on a namespace that limit the total amount of compute resources that can be consumed by resources within that namespace.
 
 The `HyperConverged` custom resource (CR) defines the user configuration for the Containerized Data Importer (CDI). The CPU and memory request and limit values are set to a default value of `0`. This ensures that pods created by CDI that do not specify compute resource requirements are given the default values and are allowed to run in a namespace that is restricted with a quota.
-
-When the `AutoResourceLimits` feature gate is enabled, {VirtProductName} automatically manages CPU and memory limits. If a namespace has both CPU and memory quotas, the memory limit is set to double the base allocation and the CPU limit is one per vCPU.

--- a/modules/virt-setting-resource-quota-limits-for-vms.adoc
+++ b/modules/virt-setting-resource-quota-limits-for-vms.adoc
@@ -4,9 +4,56 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-setting-resource-quota-limits-for-vms_{context}"]
-= Setting resource quota limits for virtual machines
+= Enabling automatic resource quota limits for virtual machines
+
+When the `AutoResourceLimits` feature gate is enabled, {VirtProductName} automatically manages CPU and memory limits for virtual machines.
+
+By default, {VirtProductName} computes resource requests for a virtual machine. When you enable the `AutoResourceLimits` feature gate, {VirtProductName} also computes resource limits to meet namespace quota requirements.
+
+If a namespace enforces both CPU and memory quotas and requires limits to be set, enabling the `AutoResourceLimits` feature gate is recommended. When this feature is enabled, the memory limit is automatically set to double the base memory allocation and the CPU limit is set to one per vCPU.
+
+[NOTE]
+====
+You can customize the memory limit ratio for a specific namespace by adding the `alpha.kubevirt.io/auto-memory-limits-ratio` annotation.
+
+For example, the following command sets the ratio to 1.2 for the `my-virtualization-project` namespace:
+
+[source,terminal]
+----
+$ oc annotate namespace my-virtualization-project alpha.kubevirt.io/auto-memory-limits-ratio=1.2
+----
+====
+
+.Procedure
+
+To enable automatic resource quota limits for virtual machines, perform the following steps:
+
+. Edit the `HyperConverged` custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+----
+
+. In the `spec.featureGates` section, add or set the `autoResourceLimits` parameter to `true`:
++
+[source,yaml]
+----
+spec:
+  featureGates:
+    autoResourceLimits: true
+----
+
+. Save the changes and exit the editor.
+
+== Manually setting resource quota limits for virtual machines
 
 Resource quotas that only use requests automatically work with virtual machines (VMs). If your resource quota uses limits, you must manually set resource limits on VMs. Resource limits must be at least 100 MiB larger than resource requests.
+
+[WARNING]
+====
+Manual management of resource quota limits is not recommended. It is recommended to enable automatic resource quota limit computation instead, as described in the previous section. Manual limit settings can lead to quota misconfigurations or scheduling issues.
+====
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.16-4.18

Issue:
https://issues.redhat.com/browse/CNV-57866

Link to docs preview:
https://92703--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-working-with-resource-quotas-for-vms.html#virt-setting-resource-quota-limits-for-vms_virt-working-with-resource-quotas-for-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
