### PR TITLE
HCIDOCS-633: update supported dell idrac firmware for 15th gen to include v7.10.50.00

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -27,7 +27,7 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 |====
 | Model | Management | Firmware versions
 | 16th Generation | iDRAC 9 | v7.10.70.00
-| 15th Generation | iDRAC 9 | v6.10.30.00 and v7.10.70.00
+| 15th Generation | iDRAC 9 | v6.10.30.00, v7.10.50.00, and v7.10.70.00
 | 14th Generation | iDRAC 9 | v6.10.30.00
 
 |====


### PR DESCRIPTION
Added Dell firmware version v7.10.50.00 to 15th gen iDRAC.

Fixes: [HCIDOCS-633](https://issues.redhat.com//browse/HCIDOCS-633)

See https://issues.redhat.com/browse/HCIDOCS-633 for additional details.

Preview URL: https://92707--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites

For release(s): 4.17-4.19
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
