### PR TITLE
OBSDOCS-1865: Update distr-tracing-tempo-config-default.adoc

### DIFF
--- a/modules/distr-tracing-tempo-config-default.adoc
+++ b/modules/distr-tracing-tempo-config-default.adoc
@@ -36,7 +36,7 @@ spec: # <5>
     metrics: {}
     tracing: {}
   search: {} # <20>
-managementState: managed # <21>
+  managementState: managed # <21>
 ----
 <1> API version to use when creating the object.
 <2> Defines the kind of Kubernetes object to create.


### PR DESCRIPTION
- One TempoStack configuration parameter is incorrectly placed
- Here is the documentation link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/distributed_tracing/distributed-tracing-platform-tempo#distr-tracing-tempo-config-default_distr-tracing-tempo-configuring
- In the `Example TempoStack CR` configuration `spec.managementState` indentation is wrong.
- Here is the current configuration: 
~~~
apiVersion: tempo.grafana.com/v1alpha1 1
kind: TempoStack 2
metadata: 3
  name: <name> 4 
spec: 
managementState: managed 21
~~~
- All other parameters are correctly mentioned.
- We need to change the ``spec.managementState` indentation.

- Here is the correct config:
~~~
apiVersion: tempo.grafana.com/v1alpha1 1
kind: TempoStack 2
metadata: 3
  name: <name> 4 
spec: 5 
  managementState: managed 21 
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.18, RHOCP 4.17, RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13, RHOCP 4.12


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1865

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://92713--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
