### PR TITLE
OCPBUGS#55371: Clarified node types MTU in nw-cluster-mtu-change.adoc

### DIFF
--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -23,14 +23,15 @@ ifndef::outposts[= Changing the cluster network MTU]
 ifdef::outposts[= Changing the cluster network MTU to support AWS Outposts]
 
 ifdef::outposts[]
-During installation, the maximum transmission unit (MTU) for the cluster network is detected automatically based on the MTU of the primary network interface of nodes in the cluster.
-You might need to decrease the MTU value for the cluster network to support an AWS Outposts subnet.
+During installation, the maximum transmission unit (MTU) for the cluster network is detected automatically based on the MTU of the primary network interface of nodes in the cluster. You might need to decrease the MTU value for the cluster network to support an AWS Outposts subnet.
 endif::outposts[]
 
 ifndef::outposts[As a cluster administrator, you can increase or decrease the maximum transmission unit (MTU) for your cluster.]
 
 [IMPORTANT]
 ====
+You cannot roll back an MTU value for nodes during the MTU migration process, but you can roll back the value after the MTU migration process completes.
+
 The migration is disruptive and nodes in your cluster might be temporarily unavailable as the MTU update takes effect.
 ====
 
@@ -45,6 +46,8 @@ endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 * You have installed the {oc-first}.
 * You have access to the cluster using an account with `cluster-admin` permissions.
 * You have identified the target MTU for your cluster. The MTU for the OVN-Kubernetes network plugin must be set to `100` less than the lowest hardware MTU value in your cluster.
+* If your nodes are physical machines, ensure that the cluster network and the connected network switches support jumbo frames. 
+* If your nodes are virtual machines (VMs), ensure that the hypervisor and the connected network switches support jumbo frames.
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-55371](https://issues.redhat.com/browse/OCPBUGS-55371)

Link to docs preview:
* [Localzones](https://92714--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks.html#nw-cluster-mtu-change_aws-compute-edge-zone-tasks)
* [Outposts](https://92714--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-outposts.html#nw-cluster-mtu-change_installing-aws-outposts)
* [Networking docs](https://92714--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu.html#nw-cluster-mtu-change_changing-cluster-network-mtu)


- [x] SME has approved this change (Ramesh Sahoo).
- [x] QE has approved this change (Anurag Saxena: returns from PTO on the 27th of May).

