### PR TITLE
OSDOCS-14436:Release Note for 4.17.27

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2884,6 +2884,45 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.27
+[id="ocp-4-17-27_{context}"]
+=== RHSA-2025:4204 - {product-title} {product-version}.27 bug fix and security update advisory
+
+Issued: 6 May 2025
+
+{product-title} release {product-version}.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4204[RHSA-2025:4204] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4206[RHBA-2025:4206] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.27 --pullspecs
+----
+
+[id="ocp-4-17-27-known-issues_{context}"]
+==== Known issues
+
+* There is a known issue when the grandmaster clock (T-GM) transitions to the Locked state too soon. This happens before the Digital Phase-Locked Loop (DPLL) completes its transition to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored. (link:https://issues.redhat.com/browse/OCPBUGS-54534[*OCPBUGS-54534*])
+
+[id="ocp-4-17-27-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when you selected the load balancer, the installation program picked a fixed internet protocol (IP) address, (`10.0.0.100`), and attached the address to the load balancer even if the IP was outside of the range of the machine network or virtual network. With this release, the installation program checks for an available IP in the provided control plane subnet or machine network and elects an IP that is not reserved if the default IP is not within the range. (link:https://issues.redhat.com/browse/OCPBUGS-55224[*OCPBUGS-55224*])
+
+* Previously, if a scrape failed, Prometheus erroneously considered the samples from the very next scrape as duplicates and dropped them. This issue impacted only the scrape immediately following a failure, while subsequent scrapes were processed correctly. With this release, the scrape following a failure is now correctly handled, ensuring that no valid samples are mistakenly dropped. (link:https://issues.redhat.com/browse/OCPBUGS-54941[*OCPBUGS-54941*])
+
+* Previously, for an Ingress resource with an `IngressWithoutClassName` alert, the Ingress Controller did not delete the alert along with deletion of the resource. The alert continued to show on the {product-title} web console. With this release, the Ingress Controller resets the `openshift_ingress_to_route_controller_ingress_without_class_name` metric to `0` before the controller deletes the Ingress resource, so that the alert is deleted and no longer shows on the web console. (link:https://issues.redhat.com/browse/OCPBUGS-53077[*OCPBUGS-53077*])
+
+* Previously, during cluster creation a control plane node was replaced when it was detected as unhealthy. This replacement irrevocably disabled the cluster and prevented the creation of the cluster. With this fix, the node is not inadvertently replaced, ensuring the stabilization of the control plane and the successful creation of the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-52957[*OCPBUGS-52957*])
+
+* Previously, the Single Root I/O Virtualization (SR-IOV) virtual function (VF) did not revert any unexpected value changes to the maximum transmission unit (MTU) value when a pod was deleted. This issue occurred if the application inside the pod had its MTU value changed; in turn, the pod would also have its MTU value changed. With this release, the SR-IOV Container Network Interface (CNI) now reverts any unexpected MTU value changes to the original value so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-54392[*OCPBUGS-54392*]) 
+
+[id="ocp-4-17-27-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.26
 [id="ocp-4-17-26_{context}"]
 === RHSA-2025:4012 - {product-title} {product-version}.26 bug fix and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-14436

Link to docs preview:
[4.17.27](https://92716--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-27_release-notes)


