### PR TITLE
CNV#58194: Doc new TP virt descheduler profile RelieveAndMigrate

### DIFF
--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -16,98 +16,122 @@ endif::[]
 ifdef::nodes[]
 The following descheduler profiles are available:
 
-`AffinityAndTaints`:: This profile evicts pods that violate inter-pod anti-affinity, node affinity, and node taints.
+AffinityAndTaints:: This profile evicts pods that violate inter-pod anti-affinity, node affinity, and node taints.
 +
 It enables the following strategies:
 +
-* `RemovePodsViolatingInterPodAntiAffinity`: removes pods that are violating inter-pod anti-affinity.
-* `RemovePodsViolatingNodeAffinity`: removes pods that are violating node affinity.
-* `RemovePodsViolatingNodeTaints`: removes pods that are violating `NoSchedule` taints on nodes.
+* RemovePodsViolatingInterPodAntiAffinity: removes pods that are violating inter-pod anti-affinity.
+* RemovePodsViolatingNodeAffinity: removes pods that are violating node affinity.
+* RemovePodsViolatingNodeTaints: removes pods that are violating NoSchedule taints on nodes.
 +
-Pods with a node affinity type of `requiredDuringSchedulingIgnoredDuringExecution` are removed.
+Pods with a node affinity type of requiredDuringSchedulingIgnoredDuringExecution are removed.
 
-`TopologyAndDuplicates`:: This profile evicts pods in an effort to evenly spread similar pods, or pods of the same topology domain, among nodes.
+TopologyAndDuplicates:: This profile evicts pods in an effort to evenly spread similar pods, or pods of the same topology domain, among nodes.
 +
 It enables the following strategies:
 +
 --
-* `RemovePodsViolatingTopologySpreadConstraint`: finds unbalanced topology domains and tries to evict pods from larger ones when `DoNotSchedule` constraints are violated.
-* `RemoveDuplicates`: ensures that there is only one pod associated with a replica set, replication controller, deployment, or job running on same node. If there are more, those duplicate pods are evicted for better pod distribution in a cluster.
+* RemovePodsViolatingTopologySpreadConstraint: finds unbalanced topology domains and tries to evict pods from larger ones when DoNotSchedule constraints are violated.
+* RemoveDuplicates: ensures that there is only one pod associated with a replica set, replication controller, deployment, or job running on same node. If there are more, those duplicate pods are evicted for better pod distribution in a cluster.
 --
 +
 [WARNING]
 ====
-Do not enable `TopologyAndDuplicates` with any of the following profiles: `SoftTopologyAndDuplicates` or `CompactAndScale`. Enabling these profiles together results in a conflict.
+Do not enable TopologyAndDuplicates with any of the following profiles: SoftTopologyAndDuplicates or CompactAndScale. Enabling these profiles together results in a conflict.
 ====
 
-`LifecycleAndUtilization`:: This profile evicts long-running pods and balances resource usage between nodes.
+LifecycleAndUtilization:: This profile evicts long-running pods and balances resource usage between nodes.
 +
 It enables the following strategies:
 +
 --
-* `RemovePodsHavingTooManyRestarts`: removes pods whose containers have been restarted too many times.
+* RemovePodsHavingTooManyRestarts: removes pods whose containers have been restarted too many times.
 +
 Pods where the sum of restarts over all containers (including Init Containers) is more than 100.
 
-* `LowNodeUtilization`: finds nodes that are underutilized and evicts pods, if possible, from overutilized nodes in the hope that recreation of evicted pods will be scheduled on these underutilized nodes.
+* LowNodeUtilization: finds nodes that are underutilized and evicts pods, if possible, from overutilized nodes in the hope that recreation of evicted pods will be scheduled on these underutilized nodes.
 
 ** A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
 
 ** A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
 
 +
-Optionally, you can adjust these underutilized/overutilized threshold percentages by setting the Technology Preview field `devLowNodeUtilizationThresholds` to one the following values: `Low` for 10%/30%, `Medium` for 20%/50%, or `High` for 40%/70%. The default value is `Medium`.
+Optionally, you can adjust these underutilized/overutilized threshold percentages by setting the Technology Preview field devLowNodeUtilizationThresholds to one the following values: Low for 10%/30%, Medium for 20%/50%, or High for 40%/70%. The default value is Medium.
 
-* `PodLifeTime`: evicts pods that are too old.
+* PodLifeTime: evicts pods that are too old.
 +
 By default, pods that are older than 24 hours are removed. You can customize the pod lifetime value.
 --
 +
 [WARNING]
 ====
-Do not enable `LifecycleAndUtilization` with any of the following profiles: `LongLifecycle` or `CompactAndScale`. Enabling these profiles together results in a conflict.
+Do not enable LifecycleAndUtilization with any of the following profiles: LongLifecycle or CompactAndScale. Enabling these profiles together results in a conflict.
 ====
 
-`SoftTopologyAndDuplicates`:: This profile is the same as `TopologyAndDuplicates`, except that pods with soft topology constraints, such as `whenUnsatisfiable: ScheduleAnyway`, are also considered for eviction.
+SoftTopologyAndDuplicates:: This profile is the same as TopologyAndDuplicates, except that pods with soft topology constraints, such as whenUnsatisfiable: ScheduleAnyway, are also considered for eviction.
 +
 [WARNING]
 ====
-Do not enable both `SoftTopologyAndDuplicates` and `TopologyAndDuplicates`. Enabling both results in a conflict.
+Do not enable both SoftTopologyAndDuplicates and TopologyAndDuplicates. Enabling both results in a conflict.
 ====
 
-`EvictPodsWithLocalStorage`:: This profile allows pods with local storage to be eligible for eviction.
+EvictPodsWithLocalStorage:: This profile allows pods with local storage to be eligible for eviction.
 
-`EvictPodsWithPVC`:: This profile allows pods with persistent volume claims to be eligible for eviction. If you are using `Kubernetes NFS Subdir External Provisioner`, you must add an excluded namespace for the namespace where the provisioner is installed.
+EvictPodsWithPVC:: This profile allows pods with persistent volume claims to be eligible for eviction. If you are using Kubernetes NFS Subdir External Provisioner, you must add an excluded namespace for the namespace where the provisioner is installed.
 
-`CompactAndScale`:: This profile enables the `HighNodeUtilization` strategy, which attempts to evict pods from underutilized nodes to allow a workload to run on a smaller set of nodes. A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
+CompactAndScale:: This profile enables the HighNodeUtilization strategy, which attempts to evict pods from underutilized nodes to allow a workload to run on a smaller set of nodes. A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
 +
-Optionally, you can adjust the underutilized percentage by setting the Technology Preview field `devHighNodeUtilizationThresholds` to one the following values: `Minimal` for 10%, `Modest` for 20%, or `Moderate` for 30%. The default value is `Modest`.
+Optionally, you can adjust the underutilized percentage by setting the Technology Preview field devHighNodeUtilizationThresholds to one the following values: Minimal for 10%, Modest for 20%, or Moderate for 30%. The default value is Modest.
 +
 [WARNING]
 ====
-Do not enable `CompactAndScale` with any of the following profiles: `LifecycleAndUtilization`, `LongLifecycle`, or `TopologyAndDuplicates`. Enabling these profiles together results in a conflict.
+Do not enable CompactAndScale with any of the following profiles: LifecycleAndUtilization, LongLifecycle, or TopologyAndDuplicates. Enabling these profiles together results in a conflict.
 ====
 
 endif::nodes[]
 ifdef::virt[]
-Use the `LongLifecycle` profile to enable the descheduler on a virtual machine. This is the only descheduler profile currently available for {VirtProductName}. To ensure proper scheduling, create VMs with CPU and memory requests for the expected load.
+Use the LongLifecycle or RelieveAndMigrate profile to enable the descheduler on a virtual machine. To ensure proper scheduling, create virtual machines with CPU and memory requests based on the expected load.
+
+[IMPORTANT]
+====
+Only one descheduler profile can be enabled at a time. Select the profile that best fits your workload needs.
+====
+
+:FeatureName: The `RelieveAndMigrate` profile
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
 endif::virt[]
 
-// Show LongLifecycle profile both for virt and nodes
-`LongLifecycle`:: This profile balances resource usage between nodes and enables the following strategies:
+// Show both LongLifecycle and RelieveAndMigrate profiles for virt and nodes
+LongLifecycle:: This profile balances resource usage between nodes and enables the following strategies:
 +
 --
-* `RemovePodsHavingTooManyRestarts`: removes pods whose containers have been restarted too many times and pods where the sum of restarts over all containers (including Init Containers) is more than 100. Restarting the VM guest operating system does not increase this count.
-* `LowNodeUtilization`: evicts pods from overutilized nodes when there are any underutilized nodes. The destination node for the evicted pod will be determined by the scheduler.
-** A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
-** A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
+* RemovePodsHavingTooManyRestarts: Removes pods whose containers have restarted too many times and pods where the sum of restarts across all containers (including Init Containers) exceeds 100. Restarting the VM guest operating system does not increase this count.
+* LowNodeUtilization: Evicts pods from overutilized nodes when underutilized nodes are available. The scheduler selects the destination node for the evicted pod.
+** A node is considered underutilized if its usage is below 20% for CPU, memory, and pod count thresholds.
+** A node is considered overutilized if its usage is above 50% for any of these thresholds.
+--
+
+RelieveAndMigrate:: This profile evicts pods from high-cost nodes to reduce overall resource expenses and enable workload migration. Node costs can include the following:
++
+--
+* **Resource utilization**: Increased resource pressure raises the overhead for running applications.
+* **Node maintenance**: A higher number of containers on a node increases resource consumption and maintenance costs.
+
+The profile enables the `LowNodeUtilization` strategy with the `EvictionsInBackground` alpha feature. The profile also exposes the following customization fields:
+
+* `devLowNodeUtilizationThresholds`: Sets experimental thresholds for the LowNodeUtilization strategy.
+* `devActualUtilizationProfile`: Enables load-aware descheduling.
+* `devDeviationThresholds`: Bases thresholds on average utilization instead of fixed values.
+* `devMultiSoftTainting`: Applies multiple soft-taints to nodes instead of a single taint.
+* `devMultiEvictions`: Evicts multiple pods from a node during each descheduling cycle.
 --
 +
 --
 ifdef::nodes[]
 [WARNING]
 ====
-Do not enable `LongLifecycle` with any of the following profiles: `LifecycleAndUtilization` or `CompactAndScale`. Enabling these profiles together results in a conflict.
+Do not enable LongLifecycle with any of the following profiles: LifecycleAndUtilization or CompactAndScale. Enabling these profiles together results in a conflict.
 ====
 endif::nodes[]
 --


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/CNV-58194

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I included `devMultiSoftTainting` and `devMultiEvictions` but need QE to confirm that those are options. It looks like at one time they were, [but now maybe not](https://github.com/openshift/cluster-kube-descheduler-operator/pull/460/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).