### PR TITLE
ROX-29102: Patch release notes for 4.6.6

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -55,7 +55,7 @@ endif::[]
 :osp: Red{nbsp}Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.6.5
+:rhacs-version: 4.6.6
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.18
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS

--- a/release_notes/46-release-notes.adoc
+++ b/release_notes/46-release-notes.adoc
@@ -21,6 +21,7 @@ toc::[]
 |`4.6.3` | 10 March 2025
 |`4.6.4` | 31 March 2025
 |`4.6.5` | 15 April 2025
+|`4.6.6` | 27 May 2025
 
 |====
 
@@ -491,7 +492,7 @@ This release of {product-title-short} fixes the following security vulnerabiliti
 
 This release of {product-title-short} fixes the following bugs:
 
-//ROX-28574	
+//ROX-28574
 * Fixed an issue where Central could perform image scans even when delegated scanning was enabled, due to a race condition during Sensor reconnection.
 
 //ROX-27885
@@ -513,5 +514,18 @@ This release of {product-title-short} fixes the following security vulnerabiliti
 * link:https://access.redhat.com/security/cve/cve-2025-30204[CVE-2025-30204]: Flaw in `jwt-go` allowed excessive memory allocation during header parsing, which could lead to a possible denial of service.
 
 * link:https://access.redhat.com/security/cve/cve-2024-57083[CVE-2024-57083]: Flaw in `redoc` allowed prototypes in `mergeObjects` to be tainted, which allowed a denial of service through crafted payloads.
+
+[id="about-release-466_{context}"]
+== About release 4.6.6
+
+*Release date*: 27 May 2025
+
+This release of {product-title-short} fixes the following bugs:
+
+//ROX-28878
+* Fixed an issue where the number of failed policies reported in *Configuration Management* for a deployment were calculated incorrectly.
+
+//ROX-28954
+* Before this update, long-running GraphQL-based requests would time out. With this update, the default client timeout for GraphQL-based queries has been increased from 60 seconds to 180 seconds to avoid timeouts for long-running requests.
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.6

[Issue](https://issues.redhat.com/browse/ROX-29102)

[Link to docs preview
](https://92755--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/46-release-notes.html)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
