### PR TITLE
OCPBUGS55471-4.16:adds external IP to migration docs

### DIFF
--- a/modules/nw-external-ip-ovn-k.adoc
+++ b/modules/nw-external-ip-ovn-k.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-external-ip-ovn-k_{context}"]
+= Understanding changes to external IP behavior in OVN-Kubernetes
+
+When migrating from OpenShift SDN to OVN-Kubernetes (OVN-K), services that use external IPs might become inaccessible across namespaces due to network policy enforcement.
+
+In OpenShift SDN, external IPs were accessible across namespaces by default. However, in OVN-K, network policies strictly enforce multitenant isolation, preventing access to services exposed via external IPs from other namespaces.
+
+To ensure access, consider the following alternatives:
+
+* Use an ingress or route: Instead of exposing services by using external IPs, configure an ingress or route to allow external access while maintaining security controls.
+
+* Adjust the `NetworkPolicy` custom resource (CR): Modify a `NetworkPolicy` CR to explicitly allow access from required namespaces and ensure that traffic is allowed to the designated service ports. Without explicitly allowing traffic to the required ports, access might still be blocked, even if the namespace is allowed.
+
+* Use a `LoadBalancer` service: If applicable, deploy a `LoadBalancer` service instead of relying on external IPs. For more information about configuring see "NetworkPolicy and external IPs in OVN-Kubernetes".

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -130,3 +130,10 @@ include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
 
 // Migrating to the OVN-Kubernetes network plugin by using the offline migration method
 include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+2]
+
+//External IP behavior difference between SDN and OVN-K
+include::modules/nw-external-ip-ovn-k.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/network_security/network_policy/about-network-policy.adoc#nw-networkpolicy-external-ip-ovn_about-network-policy[NetworkPolicy and external IPs in OVN-Kubernetes].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-55471
https://issues.redhat.com/browse/OCPBUGS-36951 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://92756--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn:~:text=a%20dual%2Dnetwork-,cluster,-network%20that%20supports
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
#92754 places xref content into main.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
