### PR TITLE
OSDOCS#14437: Update the z-stream RN for 4.18.11

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3021,6 +3021,42 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.11
+[id="ocp-4-18-11_{context}"]
+=== RHSA-2025:4211 - {product-title} {product-version}.11 bug fix update and security update
+
+Issued: 01 May 2025
+
+{product-title} release {product-version}.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4213[RHBA-2025:4213] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.11 --pullspecs
+----
+
+[id="ocp-4-18-11-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, service deletion improperly handled API service association, resulting in API service unavailability. When combined with the `ClusterResourceOverride` deletion, the API service for `admission.autoscaling.openshift.io/v1` was unreachable, affecting operator installations. With this release, the `ClusterResourceOverride` deletion removes associated API services, and the API service remains accessible after deleting the `ClusterResourceOverride`.(link:https://issues.redhat.com/browse/OCPBUGS-55242[OCPBUGS-55242])
+
+* Previously, during the Cluster Resource Override Operator (CROO) upgrade from {product-title} version 4.16 to 4.17, old secrets were not deleted, causing the CROO to fail after the {product-title} upgrade. With this release, the pod creation and namespace deletion during the {product-title} 4.17 upgrade completes successfully, resolving CROO errors. (link:https://issues.redhat.com/browse/OCPBUGS-55240[OCPBUGS-55240])
+
+* Previously, a bug that was caused by missing `catalogd` certificate authorities (CA) resulted in failed {product-title} Operator Lifecycle Manager (OLMv1) installations. With this release,  an updated Operator Controller uses a new directory for CA certificates. This change improves the stability of the system, ensuring the correct installation of cluster extensions, and enhancing the user experience. (link:https://issues.redhat.com/browse/OCPBUGS-55172[OCPBUGS-55172]) 
+
+* Previously, a private IP address mismatch for the load balancer led to the failure of fetching Azure IP availability, causing a private IP address conflict in an OpenShift 4.17 deployment. This issue was resolved by checking for IP address availability within the control plane subnet. The fix resulted in resolving the error in Azure IP address availability for OpenShift 4.17 deployment, ensuring that private IP addresses are now validated within subnet ranges. (link:https://issues.redhat.com/browse/OCPBUGS-54947[OCPBUGS-54947])
+
+* Previously, in {product-version} 4.16, a migration failure occurred after a reboot for users moving from OpenShift SDN to `OVNKubernetes` due to an interface configuration issue. The failure occurred because the `mtu-migration` service that was active before the `wait-for-primary-ip` service in the NMState-managed `br-ex`. With this release, the order of these services are reversed to ensure a successful migration and to prevent the `mtu-migration` service failure that occurs after the first reboot. (link:https://issues.redhat.com/browse/OCPBUGS-54817[OCPBUGS-54817])
+
+* Previously, missing ClusterRole permissions for Cluster Network Operator (CNO) in `monitoring.coreos.com` and `monitoring.rhobs` APIs caused monitoring issues because of insufficient permissions. With this release, permissions for CNO to manage `servicemonitors` and `prometheusrules` exist. The CNO patches `servicemonitor` and `prometheusrules` objects in the `monitoring.coreos.com` API group, which corrects the monitoring issues. (link:https://issues.redhat.com/browse/OCPBUGS-54698[OCPBUGS-54698])
+
+[id="ocp-4-18-11-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.10
 [id="ocp-4-18-10_{context}"]
 === RHSA-2025:4019 - {product-title} {product-version}.10 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-14437](https://issues.redhat.com//browse/OSDOCS-14437)

Link to docs preview:
[4.18.11](https://92759--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-11_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream release notes.
