### PR TITLE
[enterprise-4.12] TELCODOCS-2291: Removing index anchor for index.adoc in S&P assembly as it confuses the DRK single-page view

### DIFF
--- a/scalability_and_performance/index.adoc
+++ b/scalability_and_performance/index.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="index"]
+[id="scalability-and-performance-overview"]
 = {product-title} scalability and performance overview
 include::_attributes/common-attributes.adoc[]
 :context: index


### PR DESCRIPTION
CP of https://github.com/openshift/openshift-docs/pull/92665

Version(s):
4.12