### PR TITLE
PR for SRVLOGIC-467: Enhance the "Configuring OpenAPI services" section with the correct references.

### DIFF
--- a/modules/serverless-logic-openAPI-function-definition.adoc
+++ b/modules/serverless-logic-openAPI-function-definition.adoc
@@ -22,15 +22,14 @@
 
 The `operation` attribute is a `string` composed of the following parameters:
 
-* `URI`: The engine uses this to locate the specification file, such as `classpath`.
+* `URI`: The engine uses this to locate the specification file.
 
 * Operation identifier: You can find this identifier in the OpenAPI specification file.
 
 {ServerlessLogicProductName} supports the following URI schemes:
 
-* classpath: Use this for files located in the `src/main/resources` folder of the application project. `classpath` is the default URI scheme. If you do not define a URI scheme, the file location is `src/main/resources/myopenapifile.yaml`.
 * file: Use this for files located in the file system.
-* http or https: Use these for remotely located files.
+* `http` or `https`: Use these for remotely located files.
 
 Ensure the OpenAPI specification files are available during build time. {ServerlessLogicProductName} uses an internal code generation feature to send requests at runtime. After you build the application image, {ServerlessLogicProductName} will not have access to these files.
 

--- a/serverless-logic/serverless-logic-managing-services/serverless-logic-configuring-openAPI-services-endpoints.adoc
+++ b/serverless-logic/serverless-logic-managing-services/serverless-logic-configuring-openAPI-services-endpoints.adoc
@@ -18,7 +18,7 @@ The `kogito.sw.operationIdStrategy` property supports the following values: `FIL
 quarkus.rest-client.stock_portfolio_svc_yaml.url=http://localhost:8282/ # <1>
 ----
 +
-<1> The OpenAPI File Path is `<project_application_dir>/specs/stock-portfolio-svc.yaml`. The generated key that configures the URL for the REST client is `stock_portfolio_svc_yaml`
+<1> The OpenAPI file path is `<project_application_dir>/specs/stock-portfolio-svc.yaml`. The generated key that configures the URL for the REST client is `stock_portfolio_svc_yaml`.
 
 `FULL_URI`:: {ServerlessLogicProductName} uses the complete URI path of the OpenAPI document as the configuration key. The full URI is sanitized to form the key.
 +
@@ -33,7 +33,6 @@ quarkus.rest-client.stock_portfolio_svc_yaml.url=http://localhost:8282/ # <1>
           "operation": "https://my.remote.host/apicatalog/apis/123/document"
         }
     ]
-    ...
 }
 ----
 +
@@ -58,7 +57,6 @@ quarkus.rest-client.apicatalog_apis_123_document.url=http://localhost:8282/ <1>
           "operation": "https://my.remote.host/apicatalog/apis/123/document"
         }
     ]
-    ...
 }
 ----
 +


### PR DESCRIPTION
**Affects version to cherry-pick:** 
- `serverless-docs-1.36`
- `serverless-docs-1.35`
- `serverless-docs-1.34`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-467

**Doc Previews:** 

- [Configuring OpenAPI services endpoints](https://92779--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-services/serverless-logic-configuring-openAPI-services-endpoints.html)

- [Configuring OpenAPI services](https://92779--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-services/serverless-logic-configuring-openAPI-services.html)