### PR TITLE
OCPBUGS-54518: Fixed codeblock to enhance clipboard experience on cus…

### DIFF
--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -65,8 +65,8 @@ $ oc create secret tls <secret> \//<1>
 ----
 $ oc patch apiserver cluster \
      --type=merge -p \
-     '{"spec":{"servingCerts": {"namedCertificates":
-     [{"names": ["<FQDN>"], //<1>
+     '{"spec":{"servingCerts": {"namedCertificates": \
+     [{"names": ["<FQDN>"], \//<1>
      "servingCertificate": {"name": "<secret>"}}]}}}' <2>
 ----
 <1> Replace `<FQDN>` with the FQDN that the API server should provide the certificate for. Do not include the port number.


### PR DESCRIPTION
Clipboard copy of the command fully pastes to a file ion my local editor. Will need to merge this PR to test the clipboard copied data on Pantheon. 

Version(s):
4.12+

Issue:
[OCPBUGS-54518](https://issues.redhat.com/browse/OCPBUGS-54518)

Link to docs preview:
[Add an API server named certificate](https://92783--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/api-server.html#customize-certificates-api-add-named_api-server-certificates)


