### PR TITLE
OSDOCS-8677-OVNK: Applied revised changes to the K8S NMstate docs

### DIFF
--- a/modules/node-network-configuration-policy-file.adoc
+++ b/modules/node-network-configuration-policy-file.adoc
@@ -8,7 +8,7 @@
 
 A `NodeNetworkConfigurationPolicy` (NNCP) manifest file defines policies that the Kubernetes NMState Operator uses to configure networking for nodes that exist in an {product-title} cluster. 
 
-After you apply a node network policy to a node, the Kubernetes NMState Operator creates an interface on the node. A node network policy includes your requested network configuration and the status of execution for the policy on the cluster as a whole.
+After you apply a node network policy to a node, the Kubernetes NMState Operator configures the networking configuration for nodes according to the node network policy details. 
 
 You can create an NNCP by using either the {oc-first} or the {product-title} web console. As a postinstallation task you can create an NNCP or edit an existing NNCP.
 
@@ -17,13 +17,13 @@ You can create an NNCP by using either the {oc-first} or the {product-title} web
 Before you create an NNCP, ensure that you read the "Example policy configurations for different interfaces" document.
 ====
 
-If you want to delete an NNCP, you can use the `oc delete nncp` command to complete this action. However, this command does not delete any created objects, such as a bridge interface. 
+If you want to delete an NNCP, you can use the `oc delete nncp` command to complete this action. However, this command does not delete any objects, such as a bridge interface. 
 
-Deleting the node network policy that added an interface to a node does not change the configuration of the policy on the node. Similarly, removing an interface does not delete the policy, because the Kubernetes NMState Operator recreates the removed interface whenever a pod or a node is restarted.
+Deleting the node network policy that added an interface to a node does not change the configuration of the policy on the node. Similarly, removing an interface does not delete the policy, because the Kubernetes NMState Operator re-adds the removed interface whenever a pod or a node is restarted.
 
-To effectively delete the NNCP, the node network policy, and any created interfaces would typically require the following actions:
+To effectively delete the NNCP, the node network policy, and any interfaces would typically require the following actions:
 
 . Edit the NNCP and remove interface details from the file. Ensure that you do not remove `name`, `state`, and `type` parameters from the file.
 . Add `state: absent` under the `interfaces.state` section of the NNCP.
-. Run `oc apply -f <nncp_file_name>`. After the Kubernetes NMState Operator applies the node network policy to each node in your cluster, the interface that was previously created on each node is now marked _absent_. 
+. Run `oc apply -f <nncp_file_name>`. After the Kubernetes NMState Operator applies the node network policy to each node in your cluster, any interface that exists on each node is now marked as _absent_. 
 . Run `oc delete nncp` to delete the NNCP. 

--- a/modules/virt-creating-interface-on-nodes.adoc
+++ b/modules/virt-creating-interface-on-nodes.adoc
@@ -6,11 +6,16 @@
 [id="virt-creating-interface-on-nodes_{context}"]
 = Creating an interface on nodes
 
-Create an interface on nodes in the cluster by applying a `NodeNetworkConfigurationPolicy` manifest to the cluster. The manifest details the requested configuration for the interface.
+Create an interface on nodes in the cluster by applying a `NodeNetworkConfigurationPolicy` (NNCP) manifest to the cluster. The manifest details the requested configuration for the interface.
 
 By default, the manifest applies to all nodes in the cluster. To add the interface to specific nodes, add the `spec: nodeSelector` parameter and the appropriate `<key>:<value>` for your node selector.
 
-You can configure multiple nmstate-enabled nodes concurrently. The configuration applies to 50% of the nodes in parallel. This strategy prevents the entire cluster from being unavailable if the network connection fails. To apply the policy configuration in parallel to a specific portion of the cluster, use the `maxUnavailable` field.
+You can configure multiple nmstate-enabled nodes concurrently. The configuration applies to 50% of the nodes in parallel. This strategy prevents the entire cluster from being unavailable if the network connection fails. To apply the policy configuration in parallel to a specific portion of the cluster, use the `maxUnavailable` parameter in the `NodeNetworkConfigurationPolicy` manifest configuration file.
+
+[NOTE]
+====
+If you have two nodes and you apply an NNCP manifest with the `maxUnavailable` parameter set to `50%` to these nodes, one node at a time receives the NNCP configuration. If you then introduce an additional NNCP manifest file with the `maxUnavailable` parameter set to `50%`, this NCCP is independent of the initial NNCP; this means that if both NNCP manifests apply a bad configuration to nodes, you can no longer guarantee that half of your cluster is functional.
+====
 
 .Prerequisites
 

--- a/modules/virt-example-host-vrf.adoc
+++ b/modules/virt-example-host-vrf.adoc
@@ -10,7 +10,12 @@ Associate a Virtual Routing and Forwarding (VRF) instance with a network interfa
 :FeatureName: Associating a VRF instance with a network interface
 include::snippets/technology-preview.adoc[]
 
-By associating a VRF instance with a network interface, you can support traffic isolation, independent routing decisions, and the logical separation of network resources. 
+By associating a VRF instance with a network interface, you can support traffic isolation, independent routing decisions, and the logical separation of network resources.
+
+[WARNING]
+====
+When configuring Virtual Route Forwarding (VRF), you must change the VRF value to a table ID lower than `1000` because a value higher than `1000` is reserved for {product-title}.
+====
 
 In a bare-metal environment, you can announce load balancer services through interfaces belonging to a VRF instance by using MetalLB. For more information, see the _Additional resources_ section.
 

--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -134,13 +134,6 @@ Setting a DNS configuration is comparable to modifying the `/etc/resolv.conf` fi
 
 To define a DNS configuration for a network interface, you must initially specify the `dns-resolver` section in the network interface's YAML configuration file. To apply an NNCP configuration to your network interface, you need to run the `oc apply -f <nncp_file_name>` command.
 
-[IMPORTANT]
-====
-You cannot use the `br-ex` bridge, an OVN-Kubernetes-managed Open vSwitch bridge, as the interface when configuring DNS resolvers unless you manually configured a customized `br-ex` bridge.
-
-For more information, see "Creating a manifest object that includes a customized br-ex bridge" in the _Deploying installer-provisioned clusters on bare metal_ document or the _Installing a user-provisioned cluster on bare metal_ document.
-====
-
 The following example shows a default situation that stores DNS values globally:
 
 * Configure a static DNS without a network interface. Note that when updating the `/etc/resolv.conf` file on a host node, you do not need to specify an interface, IPv4 or IPv6, in the `NodeNetworkConfigurationPolicy` (NNCP) manifest.

--- a/modules/virt-nmstate-example-policy-configurations.adoc
+++ b/modules/virt-nmstate-example-policy-configurations.adoc
@@ -8,10 +8,12 @@
 
 Before you read the different example `NodeNetworkConfigurationPolicy` (NNCP) manifest configurations, consider the following factors when you apply a policy to nodes so that your cluster runs under its best performance conditions:
 
-* When you need to apply a policy to more than one node, create a `NodeNetworkConfigurationPolicy` manifest for each target node. The Kubernetes NMState Operator applies the policy to each node with a defined NNCP in an unspecified order. Scoping a policy with this approach reduces the length of time for policy application but risks a cluster-wide outage if an error exists in the cluster's configuration. To avoid this type of error, initially apply an NNCP to some nodes, confirm the NNCP is configured correctly for these nodes, and then proceed with applying the policy to the remaining nodes.
+* When you need to apply a policy to more than one node, create a `NodeNetworkConfigurationPolicy` manifest for each target node. The Kubernetes NMState Operator applies the policy to each node with a defined NNCP in an unspecified order. Scoping a policy with this approach reduces the length of time for policy application but risks a cluster-wide outage if an error exists in the configuration of the cluster. To avoid this type of error, initially apply an NNCP to some nodes, confirm the NNCP is configured correctly for these nodes, and then proceed with applying the policy to the remaining nodes.
 
 * When you need to apply a policy to many nodes but you only want to create a single NNCP for all the nodes, the Kubernetes NMState Operator applies the policy to each node in sequence. You can set the speed and coverage of policy application for target nodes with the `maxUnavailable` parameter in the cluster's configuration file. By setting a lower percentage value for the parameter, you can reduce the risk of a cluster-wide outage if the outage impacts the small percentage of nodes that are receiving the policy application.
 
-* Consider specifying all related network configurations in a single policy.
+* If you set the `maxUnavailable` parameter to `50%` in two NNCP manifests, the policy configuration coverage applies to 100% of the nodes in your cluster. 
 
 * When a node restarts, the Kubernetes NMState Operator cannot control the order to which it applies policies to nodes. The Kubernetes NMState Operator might apply interdependent policies in a sequence that results in a degraded network object.
+
+* Consider specifying all related network configurations in a single policy.

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -11,9 +11,11 @@ After you install the Kubernetes NMState Operator, you can use the Operator to o
 
 For more information about how to install the NMState Operator, see xref:../../networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator].
 
-[WARNING]
+[IMPORTANT]
 ====
-When configuring Virtual Route Forwarding (VRF) users must change their VRFs to a table ID lower than 1000 as higher than 1000 is reserved for {product-title}.
+You cannot provide any configuration that modifies the br-ex bridge, an OVN-Kubernetes-managed Open vSwitch bridge. However, you can configure a customized br-ex bridge.
+
+For more information, see "Creating a manifest object that includes a customized br-ex bridge" in the _Deploying installer-provisioned clusters on bare metal_ document or the _Installing a user-provisioned cluster on bare metal_ document.
 ====
 
 // Viewing the network state of a node by using the CLI
@@ -31,9 +33,6 @@ include::modules/node-network-configuration-policy-file.adoc[leveloffset=+1]
 * xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-nmstate-example-policy-configurations_{context}[Example policy configurations for different interfaces]
 
 * xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-removing-interface-from-nodes_{context}[Removing an interface from nodes]
-
-// Creating an InfiniBand interface on nodes
-include::modules/virt-creating-infiniband-interface-on-nodes.adoc[leveloffset=+1]
 
 // Managing policy from the web console
 include::modules/virt-node-network-config-console.adoc[leveloffset=+1]
@@ -76,14 +75,14 @@ include::modules/virt-removing-interface-from-nodes.adoc[leveloffset=+2]
 // Example policy configurations for different interfaces
 include::modules/virt-nmstate-example-policy-configurations.adoc[leveloffset=+1]
 
+// Example: Ethernet interface node network configuration policy
+include::modules/virt-example-ethernet-nncp.adoc[leveloffset=+2]
+
 // Example: Linux bridge interface node network configuration policy
 include::modules/virt-example-bridge-nncp.adoc[leveloffset=+2]
 
 // Example: VLAN interface node network configuration policy
 include::modules/virt-example-vlan-nncp.adoc[leveloffset=+2]
-
-// Example: Node network configuration policy for virtual functions
-include::modules/virt-example-vf-host-services.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
@@ -94,11 +93,11 @@ include::modules/virt-example-vf-host-services.adoc[leveloffset=+2]
 // Example: Bond interface node network configuration policy
 include::modules/virt-example-bond-nncp.adoc[leveloffset=+2]
 
-// Example: Ethernet interface node network configuration policy
-include::modules/virt-example-ethernet-nncp.adoc[leveloffset=+2]
-
 // Example: Multiple interfaces in the same node network configuration policy
 include::modules/virt-example-nmstate-multiple-interfaces.adoc[leveloffset=+2]
+
+// Example: Node network configuration policy for virtual functions
+include::modules/virt-example-vf-host-services.adoc[leveloffset=+2]
 
 // Example: Network interface with a VRF instance node network configuration policy
 include::modules/virt-example-host-vrf.adoc[leveloffset=+2]
@@ -108,6 +107,9 @@ include::modules/virt-example-host-vrf.adoc[leveloffset=+2]
 
 * xref:../../networking/multiple_networks/about-virtual-routing-and-forwarding.adoc#cnf-about-virtual-routing-and-forwarding_about-virtual-routing-and-forwarding[About virtual routing and forwarding]
 * xref:../../networking/metallb/metallb-configure-bgp-peers.adoc#nw-metallb-bgp-peer-vrf_configure-metallb-bgp-peers[Exposing a service through a network VRF]
+
+// Creating an InfiniBand interface on nodes
+include::modules/virt-creating-infiniband-interface-on-nodes.adoc[leveloffset=+1]
 
 [id="capturing-nic-static-ip_k8s-nmstate-updating-node-network-config"]
 == Example policy configurations that use dynamic matching and templating


### PR DESCRIPTION
Version(s):
4.12+


Issue:
[OSDOCS-8677](https://issues.redhat.com/browse/OSDOCS-8677)

Link to docs preview:
[Observing and updating the node network state and configuration ](https://92800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html)


- [x] SME has approved this change.
- [x] QE has approved this change.

Ugo Palatucci to review the UI elements referenced on https://issues.redhat.com/browse/OPNET-659
