### PR TITLE
Update openshift page templates for local and preview builds

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -10,6 +10,8 @@
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <%= (distro_key == "openshift-webscale") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
+  <%= (distro_key == "openshift-dpu") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
+  <%= ((["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7"].include?(version)) && distro_key == "openshift-enterprise") ? '<meta name="googlebot" content="noindex">' : '' %>
   <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css"/>
   <link href="https://docs.okd.io/latest/_stylesheets/search.css" rel="stylesheet" media="screen"/>
@@ -24,6 +26,7 @@
   <meta content="OpenShift" name="application-name">
   <meta content="#000000" name="msapplication-TileColor">
   <meta content="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" name="msapplication-TileImage">
+
   <!-- Adobe DTM -->
   <script src="//www.redhat.com/dtm.js" type="text/javascript"></script>
   <!-- End Adobe DTM -->
@@ -38,12 +41,45 @@
 <body onload="selectVersion('<%= version %>');">
   <%= render("_templates/_topnav.html.erb", :distro_key => distro_key) %>
   <%
-    unsupported_versions = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5"];
+    unsupported_versions = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.13"];
+
+    unsupported_versions_acs = ["3.65", "3.66", "3.67", "3.68", "3.69", "3.70", "3.71", "3.72", "3.73", "3.74", "4.0", "4.1", "4.2", "4.3"];
+
+    unsupported_versions_serverless = ["1.28", "1.29", "1.30", "1.31"];
+
+    unsupported_versions_pipelines = ["1.10", "1.11", "1.12"];
+
+    unsupported_versions_gitops = ["1.8", "1.9", "1.10", "1.11"];
+
+    unsupported_versions_builds = [];
+
+    unsupported_versions_origin = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "3.11", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"];
+
   %>
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
     <ol class="breadcrumb hide-for-print">
-      <% if (version == "4.11" || distro_key == "openshift-webscale" || distro_key == "openshift-dpu") %>
+      <%
+        unsupported = (unsupported_versions.include?(version) ||
+                      unsupported_versions_acs.include?(version) ||
+                      unsupported_versions_builds.include?(version) ||
+                      unsupported_versions_gitops.include?(version) ||
+                      unsupported_versions_origin.include?(version)
+                      unsupported_versions_pipelines.include?(version) ||
+                      unsupported_versions_serverless.include?(version)
+                      );
+
+        if (!["openshift-webscale", "openshift-dpu", "openshift-lightspeed", "openshift-service-mesh", "openshift-origin", "openshift-acs", "openshift-rosa", "openshift-dedicated"].include?(distro_key) || unsupported)
+      %>
+      <span>
+        <div class="alert alert-info" role="primary" id="support-info">
+          <strong>Starting on March 12, 2025, OpenShift docs will only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>. From that time on, docs.openshift.com links will automatically redirect to their locations on docs.redhat.com.
+          </strong>
+        </div>
+      </span>
+      <% end %>
+
+      <% if (distro_key == "openshift-webscale" || distro_key == "openshift-dpu") %>
       <span>
         <div class="alert alert-danger" role="alert" id="support-alert">
           <strong>This documentation is work in progress and might not be complete or fully tested.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
@@ -51,13 +87,125 @@
       </span>
       <% end %>
 
+      <% if (distro_key == "openshift-lightspeed") %>
+      <span>
+        <div class="alert alert-danger" role="alert" id="support-alert">
+          <strong>OpenShift Lightspeed is a Technology Preview release. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.</strong></a>
+        </div>
+      </span>
+      <% end %>
+
+      <% if (distro_key == "openshift-service-mesh") %>
+      <span>
+        <div class="alert alert-danger" role="alert" id="support-alert">
+          <strong>OpenShift Service Mesh 3.0 is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. This documentation is a work in progress and might not be complete or fully tested.</strong>.
+        </div>
+      </span>
+      <% end %>
+
+      <% if (distro_key == "openshift-acs") %>
+        <span>
+          <div class="alert alert-info" role="primary" id="support-info">
+            <strong>Starting on March 12, 2025, OpenShift docs will only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>. From that time on, docs.openshift.com links will automatically redirect to their locations on docs.redhat.com.
+            </strong>
+          </div>
+        </span>
+      <% end %>
+
+      <% if (distro_key == "openshift-dedicated") %>
+        <span>
+          <div class="alert alert-info" role="primary" id="support-info">
+            <strong>Starting on March 12, 2025, OpenShift docs will only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>. From that time on, docs.openshift.com links will automatically redirect to their locations on docs.redhat.com.
+            </strong>
+          </div>
+        </span>
+      <% end %>
+
+      <% if (distro_key == "openshift-rosa") %>
+        <span>
+          <div class="alert alert-info" role="primary" id="support-info">
+            <strong>Starting on March 12, 2025, OpenShift docs will only be available at <a href="https://docs.redhat.com/en/" style="color: #0C5460 !important" class="link-primary">docs.redhat.com</a>. From that time on, docs.openshift.com links will automatically redirect to their locations on docs.redhat.com.
+            </strong>
+          </div>
+        </span>
+      <% end %>
+
+      <% if ((version == "latest") &&(distro_key == "openshift-origin")) %>
+      <span>
+        <div class="alert alert-danger" role="alert" id="support-alert">
+          <strong>This documentation is a work in progress that aligns to preview releases of the next pending OKD version 4 minor release. It might not be complete or fully tested, and some features and content might be removed before the next release.</a>.
+        </div>
+      </span>
+      <% end %>
       <% if ((unsupported_versions.include? version) && (distro_key == "openshift-enterprise")) %>
 
       <span>
         <div class="alert alert-danger" role="alert" id="support-alert">
-          <strong>You are viewing documentation for a release that is no longer supported.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
+          <strong>You are viewing documentation for a release that is no longer maintained.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
         </div>
       </span>
+
+      <% end %>
+
+      <% if ((unsupported_versions_acs.include? version) && (distro_key == "openshift-acs")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/acs/welcome/index.html" style="color: #545454 !important" class="link-primary">latest RHACS docs</a>.
+          </div>
+        </span>
+
+      <% end %>
+
+      <% if ((unsupported_versions_serverless.include? version) && (distro_key == "openshift-serverless")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/serverless/latest/about/about-serverless.html" style="color: #545454 !important" class="link-primary">latest Serverless docs</a>.
+          </div>
+        </span>
+
+      <% end %>
+
+
+      <% if ((unsupported_versions_pipelines.include? version) && (distro_key == "openshift-pipelines")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/pipelines/latest/about/about-pipelines.html" style="color: #545454 !important" class="link-primary">latest Pipelines docs</a>.
+          </div>
+        </span>
+
+      <% end %>
+
+      <% if ((unsupported_versions_builds.include? version) && (distro_key == "openshift-builds")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html" style="color: #545454 !important" class="link-primary">latest Builds docs</a>.
+          </div>
+        </span>
+
+      <% end %>
+
+
+      <% if ((unsupported_versions_gitops.include? version) && (distro_key == "openshift-gitops")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html" style="color: #545454 !important" class="link-primary">latest GitOps docs</a>.
+          </div>
+        </span>
+
+      <% end %>
+
+      <% if ((unsupported_versions_origin.include? version) && (distro_key == "openshift-origin")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.okd.io/4.14/welcome/index.html" style="color: #545454 !important" class="link-primary">latest OKD docs</a>.
+          </div>
+        </span>
 
       <% end %>
 
@@ -77,6 +225,15 @@
             </a>
           <% end %>
           <select id="version-selector" onchange="versionSelector(this);">
+              <option value="4.18">4.18</option>
+              <option value="4.17">4.17</option>
+              <option value="4.16">4.16</option>
+              <option value="4.15">4.15</option>
+              <option value="4.14">4.14</option>
+              <option value="4.13">4.13</option>
+              <option value="4.12">4.12</option>
+              <option value="4.11">4.11</option>
+              <option value="4.10">4.10</option>
               <option value="4.9">4.9</option>
               <option value="4.8">4.8</option>
               <option value="4.7">4.7</option>
@@ -98,8 +255,141 @@
               <option value="3.1">3.1</option>
               <option value="3.0">3.0</option>
           </select>
+        <% elsif (distro_key == "openshift-acs") %>
+            <a href="https://docs.openshift.com/acs/<%= version %>/welcome/index.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="4.7">4.7</option>
+              <option value="4.6">4.6</option>
+              <option value="4.5">4.5</option>
+              <option value="4.4">4.4</option>
+              <option value="4.3">4.3</option>
+              <option value="4.2">4.2</option>
+              <option value="4.1">4.1</option>
+              <option value="4.0">4.0</option>
+              <option value="3.74">3.74</option>
+              <option value="3.73">3.73</option>
+              <option value="3.72">3.72</option>
+              <option value="3.71">3.71</option>
+              <option value="3.70">3.70</option>
+              <option value="3.69">3.69</option>
+              <option value="3.68">3.68</option>
+              <option value="3.67">3.67</option>
+              <option value="3.66">3.66</option>
+              <option value="3.65">3.65</option>
+            </select>
+        <% elsif (distro_key == "openshift-serverless") %>
+            <a href="https://docs.openshift.com/serverless/<%= version %>/about/about-serverless.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.35">1.35</option>
+              <option value="1.34">1.34</option>
+              <option value="1.33">1.33</option>
+              <option value="1.32">1.32</option>
+              <option value="1.31">1.31</option>
+              <option value="1.30">1.30</option>
+              <option value="1.29">1.29</option>
+              <option value="1.28">1.28</option>
+            </select>
+        <% elsif (distro_key == "openshift-logging") %>
+            <a href="https://docs.openshift.com/logging/<%= version %>/about/about-logging.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="6.2">6.2</option>
+              <option value="6.1">6.1</option>
+              <option value="6.0">6.0</option>
+            </select>
+        <% elsif (distro_key == "openshift-pipelines") %>
+            <a href="https://docs.openshift.com/pipelines/<%= version %>/about/about-pipelines.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.17">1.17</option>
+              <option value="1.16">1.16</option>
+              <option value="1.15">1.15</option>
+              <option value="1.14">1.14</option>
+              <option value="1.13">1.13</option>
+              <option value="1.12">1.12</option>
+              <option value="1.11">1.11</option>
+              <option value="1.10">1.10</option>
+            </select>
+         <% elsif (distro_key == "openshift-builds") %>
+            <a href="https://docs.openshift.com/builds/<%= version %>/about/overview-openshift-builds.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.3">1.3</option>
+              <option value="1.2">1.2</option>
+              <option value="1.1">1.1</option>
+              <option value="1.0">1.0</option>
+            </select>
+        <% elsif (distro_key == "openshift-gitops") %>
+            <a href="https://docs.openshift.com/gitops/<%= version %>/understanding_openshift_gitops/about-redhat-openshift-gitops.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.15">1.15</option>
+              <option value="1.14">1.14</option>
+              <option value="1.13">1.13</option>
+              <option value="1.12">1.12</option>
+              <option value="1.11">1.11</option>
+              <option value="1.10">1.10</option>
+              <option value="1.9">1.9</option>
+              <option value="1.8">1.8</option>
+            </select>
+        <% elsif (distro_key == "openshift-lightspeed") %>
+            <a href="https://docs.openshift.com/lightspeed/<%= version %>/about/ols-about-openshift-lightspeed.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.0tp1">1.0tp1</option>
+            </select>
+        <% elsif (distro_key == "openshift-service-mesh") %>
+            <a href="https://docs.openshift.com/service-mesh/<%= version %>/about/ossm-about-openshift-service-mesh.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="3.0">3.0</option>
+              <option value="3.0.0tp1">3.0.0tp1</option>
+            </select>
+        <% elsif (distro_key == "openshift-telco") %>
+            <a href="https://docs.openshift.com/container-platform-telco/<%= version %>/welcome/index.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="4.14">4.14</option>
+              <option value="4.15">4.15</option>
+            </select>
+        <% elsif (distro_key == "openshift-origin") %>
+              <a href="https://docs.okd.io/<%= version %>/welcome/index.html">
+            <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="latest">latest</option>
+              <option value="4.18">4.18</option>
+              <option value="4.17">4.17</option>
+              <option value="4.16">4.16</option>
+              <option value="4.15">4.15</option>
+              <option value="4.14">4.14</option>
+              <option value="4.13">4.13</option>
+              <option value="4.12">4.12</option>
+              <option value="4.11">4.11</option>
+              <option value="4.10">4.10</option>
+              <option value="4.9">4.9</option>
+              <option value="4.8">4.8</option>
+              <option value="4.7">4.7</option>
+              <option value="4.6">4.6</option>
+              <option value="3.11">3.11</option>
+              <option value="3.10">3.10</option>
+              <option value="3.9">3.9</option>
+              <option value="3.7">3.7</option>
+              <option value="3.6">3.6</option>
+            </select>
         <% else %>
-        <%= breadcrumb_root %>
+          <%= breadcrumb_root %>
         <% end %>
       </li>
       <li class="hidden-xs active">
@@ -110,13 +400,26 @@
       <li class="hidden-xs active">
         <%= breadcrumb_topic %>
       </li>
-      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro") %>
+      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs"  && distro_key != "openshift-serverless"  && distro_key != "openshift-gitops" && distro_key != "openshift-pipelines" && distro_key != "openshift-builds" && distro_key != "openshift-lightspeed" && distro_key != "openshift-service-mesh" && distro_key != "openshift-telco") %>
       <span text-align="right" style="float: right !important">
-        <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-enterprise") ? "enterprise-#{version}" : "dedicated-4" %>/<%= repo_path %>"><span class="material-icons-outlined" title="Page history">history</span></a>
+        <a href="https://github.com/openshift/openshift-docs/commits/<%=
+        ((distro_key == "openshift-enterprise") ? "enterprise-#{version}"
+          : (distro_key == "openshift-aro") ? "aro-work"
+          : (distro_key=="openshift-dedicated" ) ? "dedicated-4"
+          : (distro_key == "openshift-telco") ? "enterprise-#{version}"
+          : "main" ) %>/<%= repo_path %>"><span class="material-icons-outlined" title="Page history">history</span></a>
         <%
           unless (unsupported_versions.include? version)
         %>
-        <a href="https://github.com/openshift/openshift-docs/issues/new?title=<%= (distro_key == "openshift-enterprise") ? "[enterprise-#{version}] Issue in file #{repo_path}" : ((distro_key=="openshift-dedicated" ) ? "[dedicated] Issue in file #{repo_path}" : "[online] Issue in file #{repo_path}" ) %>">
+        <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&issuetype=1&components=12367614&priority=4&summary=<%=
+        ((distro_key == "openshift-enterprise") ? "[enterprise-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-dedicated" ) ? "[dedicated-4]+Issue+in+file+#{repo_path}"
+          : (distro_key=="microshift" ) ? "[microshift-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-aro" ) ? "[aro-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-online" ) ? "[online-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-rosa" ) ? "[rosa-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-telco" ) ? "[enterprise-#{version}]+Issue+in+file+#{repo_path}"
+          : "Issue+in+file+#{repo_path}" ) %>">
           <span class="material-icons-outlined" title="Open an issue">bug_report</span>
         </a>
         <a href="javascript: void(0);" onclick="window.print()"><span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span></a>
@@ -130,10 +433,90 @@
         <% end %>
         <% end %>
       </span>
+      <% elsif (distro_key == "openshift-acs") %>
+        <span text-align="right" style="float: right !important">
+          <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-acs") ? "rhacs-docs-#{version}" : "rhacs-docs" %>/<%= repo_path %>">
+            <span class="material-icons-outlined" title="Page history">history
+            </span>
+          </a>
+          <% unless (unsupported_versions_acs.include? version) %>
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12331224&issuetype=1&components=12366876&priority=4&summary=<%= "[rhacs-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+              <span class="material-icons-outlined" title="Open an issue">bug_report
+              </span>
+            </a>
+            <a href="javascript: void(0);" onclick="window.print()">
+              <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
+            </a>
+          <% end %>
+        </span>
+      <% elsif (distro_key == "openshift-serverless") %>
+        <span text-align="right" style="float: right !important">
+          <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-serverless") ? "serverless-docs-#{version}" : "serverless-docs" %>/<%= repo_path %>">
+            <span class="material-icons-outlined" title="Page history">history
+            </span>
+          </a>
+          <% unless (unsupported_versions_serverless.include? version) %>
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12323143&issuetype=1&components=12334030&priority=4&summary=<%= "[serverless-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+              <span class="material-icons-outlined" title="Open an issue">bug_report
+              </span>
+            </a>
+            <a href="javascript: void(0);" onclick="window.print()">
+              <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
+            </a>
+          <% end %>
+        </span>
+      <% elsif (distro_key == "openshift-pipelines") %>
+        <span text-align="right" style="float: right !important">
+          <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-pipelines") ? "pipelines-docs-#{version}" : "pipelines-docs" %>/<%= repo_path %>">
+            <span class="material-icons-outlined" title="Page history">history
+            </span>
+          </a>
+          <% unless (unsupported_versions_pipelines.include? version) %>
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12317820&issuetype=1&components=12332358&priority=4&summary=<%= "[pipelines-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+              <span class="material-icons-outlined" title="Open an issue">bug_report
+              </span>
+            </a>
+            <a href="javascript: void(0);" onclick="window.print()">
+              <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
+            </a>
+          <% end %>
+        </span>
+      <% elsif (distro_key == "openshift-builds") %>
+        <span text-align="right" style="float: right !important">
+          <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-builds") ? "build-docs-#{version}" : "build-docs" %>/<%= repo_path %>">
+            <span class="material-icons-outlined" title="Page history">history
+            </span>
+          </a>
+          <% unless (unsupported_versions_builds.include? version) %>
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12317820&issuetype=1&components=12393741&priority=4&summary=<%= "[build-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+              <span class="material-icons-outlined" title="Open an issue">bug_report
+              </span>
+            </a>
+            <a href="javascript: void(0);" onclick="window.print()">
+              <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
+            </a>
+          <% end %>
+        </span>
+      <% elsif (distro_key == "openshift-gitops") %>
+        <span text-align="right" style="float: right !important">
+          <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-gitops") ? "gitops-docs-#{version}" : "gitops-docs" %>/<%= repo_path %>">
+            <span class="material-icons-outlined" title="Page history">history
+            </span>
+          </a>
+          <% unless (unsupported_versions_gitops.include? version) %>
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12317820&issuetype=1&components=12342156&priority=4&summary=<%= "[gitops-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+              <span class="material-icons-outlined" title="Open an issue">bug_report
+              </span>
+            </a>
+            <a href="javascript: void(0);" onclick="window.print()">
+              <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
+            </a>
+          <% end %>
+        </span>
       <% end %>
     </ol>
     <div class="row row-offcanvas row-offcanvas-left">
-      <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas">
+      <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas hide-for-print">
         <div class="row-fluid">
           <div id="btn-close">
             <button id="hc-close-btn" onclick="closeNav()" class="close-btn-sm" aria-label="close"><span class="fa fa-times" /></button>
@@ -207,9 +590,16 @@
     'openshift-dedicated': ['docs_dedicated_v4'],
     'openshift-online': ['docs_online', version],
     'openshift-enterprise': ['docs_cp', version],
+    'openshift-telco': ['docs_telco', version],
     'openshift-aro' : ['docs_aro', version],
     'openshift-rosa' : ['docs_rosa'],
-    'openshift-acs' : ['docs_acs', version]
+    'openshift-acs' : ['docs_acs', version],
+    'openshift-serverless' : ['docs_serverless', version],
+    'openshift-pipelines' : ['docs_pipelines', version],
+    'openshift-builds' : ['docs_builds', version],
+    'openshift-gitops' : ['docs_gitops', version],
+    'openshift-lightspeed' : ['docs_lightspeed', version],
+    'openshift-service-mesh' : ['docs_service_mesh', version]
   };
 
   // only OSD v3 docs have the version variable specified
@@ -259,7 +649,7 @@
   <!-- adjust page css based on breadcrumb and/or resize -->
   <script type="text/javascript">
     window.addEventListener('DOMContentLoaded', () => {
-      if (window.innerWidth >= 1425) {
+      if ($(window).width() >= 1008) {
         adjustSide();
         adjustToc();
         adjustMain();
@@ -267,18 +657,26 @@
     });
 
     window.addEventListener('resize', () => {
-      if (window.innerWidth >= 1425) {
-        sidebar.style.display = 'block';
+      if ($(window).width() >= 1008) {
         adjustSide();
         adjustToc();
         adjustMain();
-      } else if (window.innerWidth < 1425) {
-        sidebar.style.display = 'none';
+      } else if ($(window).width() < 1008) {
+        sidebar.classList.remove('wide');
+        document.querySelector('#hc-search').classList.remove('wide');
+        if (sidebar.classList.contains('open')) {
+          sidebar.style.display = 'block';
+        } else {
+          sidebar.style.display = 'none';
+        }
         document.querySelector('.main').style.paddingTop = '0px';
       }
     });
 
     function adjustSide() {
+      sidebar.classList.add('wide');
+      document.querySelector('#hc-search').classList.add('wide');
+      sidebar.style.display = 'block';
       document.querySelector('.sidebar').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 125), 10) + "px";
       document.querySelector('#hc-search').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 95), 10) + "px";
     }
@@ -330,12 +728,16 @@
     function closeNav() {
       let sidebar = document.querySelector(".sidebar");
       sidebar.style.display = "none";
+      sidebar.classList.remove('open');
     }
 
     function openNav() {
       let sidebar = document.querySelector(".sidebar");
+      let hc_search = document.querySelector('#hc-search');
       sidebar.style.display = "block";
       sidebar.style.top = "0px";
+      hc_search.style.top = 'unset';
+      sidebar.classList.add('open');
     }
   </script>
 
@@ -426,41 +828,11 @@
       })
   </script>
 
-  <!--adjust sidebar and toc when footer is displayed -->
-  <script type="text/javascript">
-    sidebar = document.querySelector('.sidebar')
-    toc = document.querySelector('#toc')
-    main = document.querySelector('.main')
-    okd_footer = document.querySelector('.footer-origin-docs')
-    document.addEventListener('scroll', () => {
-      //scroll to bottom
-      if (window.innerWidth >= 1425) {
-        if(sidebar !== null && toc !== null) {
-          if(document.documentElement.scrollHeight === window.pageYOffset + window.innerHeight) {
-              sidebar.style.marginBottom = "38px";
-              toc.style.bottom = "35px";
-              main.style.marginBottom = "35px";
-              //okd footer
-              if(okd_footer !== null) {
-                sidebar.style.marginBottom = "176px";
-                toc.style.bottom = "175px";
-                main.style.marginBottom = "135px";
-              };
-            };
-          if(document.documentElement.scrollHeight != window.pageYOffset + window.innerHeight) {
-            sidebar.style.marginBottom = "0px";
-            toc.style.bottom = "0px";
-          }
-        }
-      }
-    })
-  </script>
-
   <!-- adjust alerts on mobile -->
   <script type="text/javascript">
     alert = document.querySelector('#support-alert')
     window.addEventListener("wheel", () => {
-      if (window.innerWidth < 1425) {
+      if ($(window).width() < 1008) {
         //adjust alert
         if(window.pageYOffset > 0) {
           if(alert !== null) {
@@ -473,7 +845,7 @@
       }
    });
     window.addEventListener('resize', () => {
-      if (window.innerWidth >= 1425) {
+      if ($(window).width() >= 1008) {
         if(alert !== null) {
           document.querySelector('#support-alert').style.removeProperty('position');
           document.querySelector('#support-alert').style.removeProperty('bottom');
@@ -484,5 +856,15 @@
     })
   </script>
 
+  <!-- hide footer after 3 seconds -->
+  <script type="text/javascript">
+    const hideFooter = () => {
+      document.querySelector('footer#rh, footer.footer-origin-docs').style.display = "none";
+    };
+
+    window.addEventListener('load', function() {
+      setTimeout(hideFooter, 3000);
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION

Version(s):
4.18 only

Issue:
Update openshift page template for preview and local builds

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
