### PR TITLE
Update distr-tracing-tempo-object-storage-setup-ibm-storage.adoc

### DIFF
--- a/modules/distr-tracing-tempo-object-storage-setup-ibm-storage.adoc
+++ b/modules/distr-tracing-tempo-object-storage-setup-ibm-storage.adoc
@@ -29,7 +29,7 @@ You can set up {ibm-cloud-title} Object Storage by using the {oc-first}.
 [source,terminal]
 ----
 $ ibmcloud resource service-key-create <tempo_bucket> Writer \
---instance-name <tempo_bucket> --parameters '{"HMAC":true}'
+  --instance-name <tempo_bucket> --parameters '{"HMAC":true}'
 ----
 
 . On {ibm-cloud-title}, create a secret with the bucket credentials by running the following command:


### PR DESCRIPTION
- Incorrect command structure in the Object storage setup documentation.
- Here is the documentation link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/distributed_tracing/distributed-tracing-platform-tempo#distr-tracing-tempo-object-storage-setup-ibm-storage_dist-tracing-tempo-installing

- In the above commands, the "- -" signs are incorrectly placed below the "$" symbol.
- However, they should be aligned parallel to the "ibmcloud" command, where the command begins.

- Here is the updated look for all these commands:

1. On IBM Cloud, create a service key for connecting to the object store bucket by running the following command: 
~~~
$ ibmcloud resource service-key-create <tempo_bucket> Writer \
  --instance-name <tempo_bucket> --parameters '{"HMAC":true}'
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.18, RHOCP 4.17, RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13, RHOCP 4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1875

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://92838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
