### PR TITLE
OSDOCS:14527 Docs for automatic OCL image pruning

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -185,6 +185,7 @@ include::modules/coreos-layering-configuring-on.adoc[leveloffset=+1]
 .Additional resources
 * xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
 * xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools]
+* xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on-remove_mco-coreos-layering[Removing an on-cluster custom layered image]
 
 include::modules/coreos-layering-configuring-on-modifying.adoc[leveloffset=+2]
 
@@ -204,6 +205,8 @@ include::modules/coreos-layering-configuring-on-extensions.adoc[leveloffset=+2]
 // include::modules/coreos-layering-configuring-on-rebuild.adoc[leveloffset=+2] 
 
 include::modules/coreos-layering-configuring-on-revert.adoc[leveloffset=+2]
+
+include::modules/coreos-layering-configuring-on-remove.adoc[leveloffset=+2]
 
 include::modules/coreos-layering-configuring.adoc[leveloffset=+1]
 

--- a/modules/coreos-layering-configuring-on-remove.adoc
+++ b/modules/coreos-layering-configuring-on-remove.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/coreos-layering.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coreos-layering-configuring-on-remove_{context}"]
+= Removing an on-cluster custom layered image
+
+To prevent the custom layered images from taking up excessive space in your registry, you can automatically remove an on-cluster custom layered image from the repository by deleting the `MachineOSBuild` object that created the image. 
+
+The credentials provided by the registry push secret that you added to the the `MachineOSBuild` object must grant the permission for deleting an image from the registry. If the delete permission is not provided, the image is not removed when you delete the `MachineOSBuild` object.
+
+Note that the custom layered image is not deleted if the image is either currently in use on a node or is desired by the nodes, as indicated by the `machineconfiguration.openshift.io/currentConfig` or `machineconfiguration.openshift.io/desiredConfig` annotation on the node.

--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -76,7 +76,7 @@ Note the following limitations when working with the on-cluster layering feature
 ** Changing SSH keys
 ** Removing mirroring rules from `ICSP`, `ITMS`, and `IDMS` objects
 ** Changing the trusted CA, by updating the `user-ca-bundle` configmap in the `openshift-config` namespace
-* The images used in creating custom layered images take up space in your push registry. Always be aware of the free space in your registry and prune the images as needed.
+* The images used in creating custom layered images take up space in your push registry. Always be aware of the free space in your registry and prune the images as needed. You can automatically remove an on-cluster custom layered image from the repository by deleting the `MachineOSBuild` object that created the image. Note that the credentials provided by the registry push secret must also grant permission to delete an image from the registry. For more information, see "Removing an on-cluster custom layered image".
 
 .Prerequisites
 
@@ -93,6 +93,8 @@ Note the following limitations when working with the on-cluster layering feature
 ====
 In a disconnected environment, ensure that the disconnected cluster can access the registry where you want to push the image. Image mirroring applies only to pulling images.
 ====
+
+* You have the push secret of the registry that the MCO needs to push the new custom layered image to. If you want the custom layered image deleted when you delete the associated the `MachineOSBuild` object, the credentials provided by the secret must also grant permission to delete an image from the registry.
 
 * You have a pull secret that your nodes need to pull the new custom layered image from your registry. This should be a different secret than the one used to push the image to the repository.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14527

Previews
[Removing an on-cluster custom layered image](https://92840--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on-remove_mco-coreos-layering) -- New module
[Using on-cluster layering to apply a custom layered image](https://92840--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on_mco-coreos-layering) -> On-cluster layering Technology Preview known limitations -- Added to 5th bullet.
[Using on-cluster layering to apply a custom layered image](https://92840--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on_mco-coreos-layering) - Added link at end.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
