### PR TITLE
removed wrong ocp version nr

### DIFF
--- a/modules/ob-compatibility-support-matrix.adoc
+++ b/modules/ob-compatibility-support-matrix.adoc
@@ -23,7 +23,7 @@ The link:https://access.redhat.com/support/offerings/techpreview[Technology Prev
 
 | Operator | Builds (Shipwright) | CLI | | |
 
-|1.4 | 0.15.0 (GA) | 0.15.0 (GA) | 1.16, 1.17, 1.18 and 1.19        | 4.15, 4.16, 4.17, 4.18, and 4.19         | GA
+|1.4 | 0.15.0 (GA) | 0.15.0 (GA) | 1.16, 1.17, 1.18 and 1.19        | 4.15, 4.16, 4.17, and 4.18         | GA
 |1.3 | 0.14.0 (GA) | 0.14.0 (GA) | 1.14, 1.15, 1.16, and 1.17 | 4.14, 4.15, 4.16, and 4.17         | GA
 
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

build-docs-1.4

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

 doc meaning isn't impacted

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

removed wrong ocp version nr from compatibility support matrix (ocp 4.19 version isn't out yet)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
