### PR TITLE
OSDOCS-14529: Hide Classic for Tel Aviv and Calgary regions

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -184,14 +184,17 @@ endif::rosa-with-hcp[]
 |4.14
 |No
 
+ifdef::rosa-with-hcp[]
 |il-central-1
 |Tel Aviv
 |4.15
+|Yes
 
 |ca-west-1
 |Calgary
 |4.14
 |Yes
+endif::rosa-with-hcp[]
 
 ifndef::rosa-with-hcp[]
 |us-gov-east-1

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -22,14 +22,14 @@ ifdef::openshift-rosa[]
 * **Cluster autoscaling is now available for {hcp-title}.** You can configure cluster autoscaling for {hcp-title}. For more information, see xref:../rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc#rosa-cluster-autoscaling-hcp[Cluster autoscaling].
 endif::openshift-rosa[]
 
-ifdef::openshift-rosa[]
-* **{product-title} region added.** ROSA (classic architecture) is now available in the following regions:
-+
-** Tel Aviv (`il-central-1`)
-** Calgary (`ca-west-1`)
-+
-For more information on region availabilities, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-service-definition[Regions and availability zones].
-endif::openshift-rosa[]
+//ifdef::openshift-rosa[]
+//* **{product-title} region added.** ROSA (classic architecture) is now available in the following regions:
+//+
+//** Tel Aviv (`il-central-1`)
+//** Calgary (`ca-west-1`)
+//+
+//For more information on region availabilities, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-service-definition[Regions and availability zones].
+//endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
 * **{hcp-title} region added.** {hcp-title-first} is now available in the following regions:


### PR DESCRIPTION
[OSDOCS-14529](https://issues.redhat.com//browse/OSDOCS-14529): Hide Classic for Tel Aviv and Calgary regions

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14529

Link to docs preview:
ROSA HCP docs: https://92846--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html
ROSA Classic docs: https://92846--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html
ROSA HCP Release notes: https://92846--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html


QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
