### PR TITLE
[OSDOCS-14530]Enable C3 and N4 Instance types

### DIFF
--- a/modules/sdpolicy-am-gcp-compute-types.adoc
+++ b/modules/sdpolicy-am-gcp-compute-types.adoc
@@ -8,7 +8,8 @@
 {product-title} offers the following worker node types and sizes on Google Cloud that are chosen to have a common CPU and memory capacity that are the same as other cloud instance types:
 [NOTE]
 ====
-`e2`, `a2`, and `a3` instance types are available for CCS only.
+`a2`, `a3`, `e2`, `c3`, and `n4` instance types are available for CCS only.
+`c3` and `n4` instance types are available for {osd} version 4.18 and later.
 ====
 
 .General purpose
@@ -21,6 +22,7 @@
 * custom-48-199608 (48 vCPU, 192 GiB)
 * custom-64-262144 (64 vCPU, 256 GiB)
 * custom-96-393216 (96 vCPU, 384 GiB)
+* c3-standard-192-metal (192 vCPU, 768 GiB)
 * e2-standard-4 (4 vCPU, 16 GiB)
 * n2-standard-4 (4 vCPU, 16 GiB)
 * e2-standard-8 (8 vCPU, 32 GiB)
@@ -34,6 +36,13 @@
 * n2-standard-80 (80 vCPU, 320 GiB)
 * n2-standard-96 (96 vCPU, 384 GiB)
 * n2-standard-128 (128 vCPU, 512 GiB)
+* n4-standard-4 (4 vCPU, 16 GiB)
+* n4-standard-8 (8 vCPU, 32 GiB)
+* n4-standard-16 (16 vCPU, 64 GiB)
+* n4-standard-32 (32 vCPU, 128 GiB)
+* n4-standard-48 (48 vCPU, 192 GiB)
+* n4-standard-64 (64 vCPU, 256 GiB)
+* n4-standard-80 (80 vCPU, 320 GiB)
 ====
 
 .Memory-optimized
@@ -42,6 +51,7 @@
 * custom-4-32768-ext (4 vCPU, 32 GiB)
 * custom-8-65536-ext (8 vCPU, 64 GiB)
 * custom-16-131072-ext (16 vCPU, 128 GiB)
+* c3-highmem-192-metal (192 vCPU, 1536 GiB)
 * e2-highmem-4 (4 vCPU, 32 GiB)
 * e2-highmem-8 (8 vCPU, 64 GiB)
 * e2-highmem-16 (16 vCPU, 128 GiB)
@@ -54,6 +64,13 @@
 * n2-highmem-80 (80 vCPU, 640 GiB)
 * n2-highmem-96 (96 vCPU, 768 GiB)
 * n2-highmem-128 (128 vCPU, 864 GiB)
+* n4-highmem-4 (4 vCPU, 32 GiB)
+* n4-highmem-8 (8 vCPU, 64 GiB)
+* n4-highmem-16 (16 vCPU, 128 GiB)
+* n4-highmem-32 (32 vCPU, 256 GiB)
+* n4-highmem-48 (48 vCPU, 384 GiB)
+* n4-highmem-64 (64 vCPU, 512 GiB)
+* n4-highmem-80 (80 vCPU, 640 GiB)
 ====
 
 .Compute-optimized
@@ -70,6 +87,7 @@
 * c2-standard-16 (16 vCPU, 64 GiB)
 * c2-standard-30 (30 vCPU, 120 GiB)
 * c2-standard-60 (60 vCPU, 240 GiB)
+* c3-highcpu-192-metal (192 vCPU, 512 GiB)
 * e2-highcpu-8 (8 vCPU, 8 GiB)
 * e2-highcpu-16 (16 vCPU, 16 GiB)
 * e2-highcpu-32 (32 vCPU, 32 GiB)
@@ -80,6 +98,17 @@
 * n2-highcpu-64 (64 vCPU, 64 GiB)
 * n2-highcpu-80 (80 vCPU, 80 GiB)
 * n2-highcpu-96 (96 vCPU, 96 GiB)
+* n4-highcpu-4 (4 vCPU, 8 GiB)
+* n4-highcpu-8 (8 vCPU, 16 GiB)
+* n4-highcpu-16 (16 vCPU, 32 GiB)
+* n4-highcpu-32 (32 vCPU, 64 GiB)
+* n4-highcpu-48 (48 vCPU, 96 GiB)
+* n4-highcpu-64 (64 vCPU, 128 GiB)
+* n4-highcpu-80 (80 vCPU, 160 GiB)
+
+
+
+
 ====
 
 .Accelerated computing


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-14530
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://92847--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#gcp-compute-types_osd-service-definition
QE review:
- [ ] QE has approved this change.
QE NA. These instances are already live (confirmed on 5/2/25)
Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
