### PR TITLE
CNV#44025: [Doc] Document how to select the default VolumeSnapshotClass

### DIFF
--- a/modules/virt-customizing-storage-profile-default-cloning-strategy.adoc
+++ b/modules/virt-customizing-storage-profile-default-cloning-strategy.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * virt/storage/virt-configuring-storage-profile.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-customizing-storage-profile-default-cloning-strategy_{context}"]
+= Setting a default cloning strategy by using a storage profile
+
+You can use storage profiles to set a default cloning method for a storage class by creating a cloning strategy. Setting cloning strategies can be helpful, for example, if your storage vendor supports only certain cloning methods. It also allows you to select a method that limits resource usage or maximizes performance.
+
+Cloning strategies are specified by setting the `cloneStrategy` attribute in a storage profile to one of the following values:
+
+* `snapshot` is used by default when snapshots are configured. The Containerized Data Importer (CDI) will use the snapshot method if it recognizes the storage provider and the provider supports Container Storage Interface (CSI) snapshots. This cloning strategy uses a temporary volume snapshot to clone the volume.
+* `copy` uses a source pod and a target pod to copy data from the source volume to the target volume. Host-assisted cloning is the least efficient method of cloning.
+* `csi-clone` uses the CSI clone API to efficiently clone an existing volume without using an interim volume snapshot. Unlike `snapshot` or `copy`, which are used by default if no storage profile is defined, CSI volume cloning is only used when you specify it in the `StorageProfile` object for the provisioner's storage class.
+
+[NOTE]
+====
+You can set clone strategies using the CLI without modifying the default `claimPropertySets` in your YAML `spec` section.
+====
+
+.Example storage profile
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: <provisioner_class>
+# ...
+spec:
+  claimPropertySets:
+  - accessModes:
+    - ReadWriteOnce <1>
+    volumeMode:  Filesystem <2>
+  cloneStrategy: csi-clone <3>
+status:
+  provisioner: <provisioner>
+  storageClass: <provisioner_class>
+----
+<1> Specify the `accessModes`.
+<2> Specify the `volumeMode`.
+<3> Specify the default `cloneStrategy`.

--- a/modules/virt-customizing-storage-profile-snapshot-class-cli.adoc
+++ b/modules/virt-customizing-storage-profile-snapshot-class-cli.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * virt/storage/virt-configuring-storage-profile.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-customizing-storage-profile-snapshot-class-cli_{context}"]
+= Specifying a volume snapshot class by using the CLI
+
+If you are creating a snapshot of a VM, a warning appears if the storage class of the disk has more than one volume snapshot class associated with it. In this case, you must specify one volume snapshot class; otherwise, any disk that has more than one volume snapshot class is excluded from the snapshots list.
+
+You can select which volume snapshot class to use by either:
+
+* Setting the `spec.snapshotClass` for the storage profile.
+* Setting a default volume snapshot class.
+
+.Procedure
+
+* Set the `VolumeSnapshotClass` you want to use. For example:
++
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: ocs-storagecluster-ceph-rbd-virtualization
+spec:
+  snapshotClass: ocs-storagecluster-rbdplugin-snapclass
+----
+
+* Alternatively, set the default volume snapshot class by running the following command:
++
+[source,terminal]
+----
+# oc patch VolumeSnapshotClass ocs-storagecluster-cephfsplugin-snapclass --type=merge -p '{"metadata":{"annotations":{"snapshot.storage.kubernetes.io/is-default-class":"true"}}}'
+----

--- a/modules/virt-customizing-storage-profile-snapshot-class-web.adoc
+++ b/modules/virt-customizing-storage-profile-snapshot-class-web.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * virt/storage/virt-configuring-storage-profile.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-customizing-storage-profile-snapshot-class_web_{context}"]
+= Specifying a volume snapshot class by using the web console
+
+If you are creating a snapshot of a VM, a warning appears if the storage class of the disk has more than one volume snapshot class associated with it. In this case, you must specify one volume snapshot class; otherwise, any disk that has more than one volume snapshot class is excluded from the snapshots list.
+
+You can specify the default volume snapshot class in the {product-title} web console.
+
+.Procedure
+
+. From the *Virtualization* focused view, select *Storage*.
+. Click *VolumeSnapshotClasses*.
+. Select a volume snapshot class from the list.
+. Click the *Annotations* pencil icon.
+. Enter the following *Key*: `snapshot.storage.kubernetes.io/is-default-class`.
+. Enter the following *Value*: `true`.
+. Click *Save*.

--- a/modules/virt-customizing-storage-profile.adoc
+++ b/modules/virt-customizing-storage-profile.adoc
@@ -4,14 +4,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-customizing-storage-profile_{context}"]
-
 = Customizing the storage profile
 
 You can specify default parameters by editing the `StorageProfile` object for the provisioner's storage class. These default parameters only apply to the persistent volume claim (PVC) if they are not configured in the `DataVolume` object.
 
 You cannot modify storage class parameters. To make changes, delete and re-create the storage class. You must then reapply any customizations that were previously made to the storage profile.
 
-An empty `status` section in a storage profile indicates that a storage provisioner is not recognized by the Containerized Data Interface (CDI). Customizing a storage profile is necessary if you have a storage provisioner that is not recognized by CDI. In this case, the administrator sets appropriate values in the storage profile to ensure successful allocations.
+An empty `status` section in a storage profile indicates that a storage provisioner is not recognized by the Containerized Data Importer (CDI). Customizing a storage profile is necessary if you have a storage provisioner that is not recognized by CDI. In this case, the administrator sets appropriate values in the storage profile to ensure successful allocations.
+
+If you are creating a snapshot of a VM, a warning appears if the storage class of the disk has more than one `VolumeSnapshotClass` associated with it. In this case, you must specify one volume snapshot class; otherwise, any disk that has more than one volume snapshot class is excluded from the snapshots list.
 
 [WARNING]
 ====
@@ -31,21 +32,7 @@ If you create a data volume and omit YAML attributes and these attributes are no
 $ oc edit storageprofile <storage_class>
 ----
 +
-.Example storage profile
-[source,yaml]
-----
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: StorageProfile
-metadata:
-  name: <unknown_provisioner_class>
-# ...
-spec: {}
-status:
-  provisioner: <unknown_provisioner>
-  storageClass: <unknown_provisioner_class>
-----
-+
-. Provide the needed attribute values in the storage profile:
+. Specify the `accessModes` and `volumeMode` values you want to configure for the storage profile. For example:
 +
 .Example storage profile
 [source,yaml]
@@ -59,52 +46,10 @@ spec:
   claimPropertySets:
   - accessModes:
     - ReadWriteOnce <1>
-    volumeMode:
-      Filesystem <2>
+    volumeMode: Filesystem <2>
 status:
   provisioner: <unknown_provisioner>
   storageClass: <unknown_provisioner_class>
 ----
-<1> The `accessModes` that you select.
-<2> The `volumeMode` that you select.
-+
-After you save your changes, the selected values appear in the storage profile `status` element.
-
-[id="virt-customizing-storage-profile-default-cloning-strategy_{context}"]
-== Setting a default cloning strategy using a storage profile
-
-You can use storage profiles to set a default cloning method for a storage class, creating a _cloning strategy_. Setting cloning strategies can be helpful, for example, if your storage vendor only supports certain cloning methods. It also allows you to select a method that limits resource usage or maximizes performance.
-
-Cloning strategies can be specified by setting the `cloneStrategy` attribute in a storage profile to one of these values:
-
-* `snapshot` is used by default when snapshots are configured. The CDI will use the snapshot method if it recognizes the storage provider and the provider supports Container Storage Interface (CSI) snapshots. This cloning strategy uses a temporary volume snapshot to clone the volume.
-* `copy` uses a source pod and a target pod to copy data from the source volume to the target volume. Host-assisted cloning is the least efficient method of cloning.
-* `csi-clone` uses the CSI clone API to efficiently clone an existing volume without using an interim volume snapshot. Unlike `snapshot` or `copy`, which are used by default if no storage profile is defined, CSI volume cloning is only used when you specify it in the `StorageProfile` object for the provisioner's storage class.
-
-[NOTE]
-====
-You can also set clone strategies using the CLI without modifying the default `claimPropertySets` in your YAML `spec` section.
-====
-
-.Example storage profile
-[source,yaml]
-----
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: StorageProfile
-metadata:
-  name: <provisioner_class>
-# ...
-spec:
-  claimPropertySets:
-  - accessModes:
-    - ReadWriteOnce <1>
-    volumeMode:
-      Filesystem <2>
-  cloneStrategy: csi-clone <3>
-status:
-  provisioner: <provisioner>
-  storageClass: <provisioner_class>
-----
-<1> Specify the access mode.
-<2> Specify the volume mode.
-<3> Specify the default cloning strategy.
+<1> Specify the `accessModes`.
+<2> Specify the `volumeMode`.

--- a/virt/storage/virt-configuring-storage-profile.adoc
+++ b/virt/storage/virt-configuring-storage-profile.adoc
@@ -22,4 +22,7 @@ To specify RBD block mode PVCs, use the 'ocs-storagecluster-ceph-rbd' storage cl
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/virt-customizing-storage-profile.adoc[leveloffset=+1]
+include::modules/virt-customizing-storage-profile-snapshot-class-web.adoc[leveloffset=+2]
+include::modules/virt-customizing-storage-profile-snapshot-class-cli.adoc[leveloffset=+2]
 include::modules/virt-viewing-automatically-created-storage-profiles.adoc[leveloffset=+2]
+include::modules/virt-customizing-storage-profile-default-cloning-strategy.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): 4.16+

Issue: [CNV-44025](https://issues.redhat.com/browse/CNV-44025)

Link to docs previews:
[Customizing the storage profile](https://92884--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-storage-profile.html#virt-customizing-storage-profile_virt-configuring-storage-profile)
[Specifying a volume snapshot class by using the web console](https://92884--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-storage-profile.html#virt-customizing-storage-profile-snapshot-class_web_virt-configuring-storage-profile)
[Specifying a volume snapshot class by using the CLI](https://92884--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-storage-profile.html#virt-customizing-storage-profile-snapshot-class-cli_virt-configuring-storage-profile)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.


