### PR TITLE
CNV#52870: Multi IOthread with fast storage

### DIFF
--- a/modules/virt-configure-multiple-iothreads.adoc
+++ b/modules/virt-configure-multiple-iothreads.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * virt/managing_vms/virt-edit-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configure-multiple-iothreads_{context}"]
+== Configuring multiple IOThreads for fast storage access
+
+You can improve storage performance by configuring multiple IOThreads for a virtual machine (VM) that uses fast storage, such as solid-state drive (SSD) or non-volatile memory express (NVMe). This configuration option is only available by editing YAML of the VM.
+
+[NOTE]
+====
+Multiple IOThreads are supported only when `blockMultiQueue` is enabled and the disk bus is set to `virtio`. You must set this configuration for the configuration to work correctly.
+====
+
+.Procedure
+
+. Click *Virtualization* -> *VirtualMachines* from the side menu.
+
+. Select a virtual machine to open the *VirtualMachine details* page.
+
+. Click the *YAML* tab to open the VM manifest.
+
+. In the YAML editor, locate the `spec.template.spec.domain` section and add or modify the following fields:
++
+[source,yaml]
+----
+domain:
+  ioThreadsPolicy: supplementalPool
+  ioThreads:
+    supplementalPoolThreadCount: 4
+  devices:
+    blockMultiQueue: true
+    disks:
+    - name: datavolume
+      disk:
+        bus: virtio
+# ...
+----
+
+. Click *Save*.
+
+[IMPORTANT]
+====
+The `spec.template.spec.domain` setting cannot be changed while the VM is running. You must stop the VM before applying the changes, and then restart the VM for the new settings to take effect.
+====

--- a/virt/managing_vms/virt-edit-vms.adoc
+++ b/virt/managing_vms/virt-edit-vms.adoc
@@ -32,6 +32,8 @@ include::modules/virt-adding-secret-configmap-service-account-to-vm.adoc[levelof
 
 include::modules/virt-updating-multiple-vms.adoc[leveloffset=+1]
 
+include::modules/virt-configure-multiple-iothreads.adoc[leveloffsent=+1]
+
 [discrete]
 [id="additional-resources-configmaps"]
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/CNV-52870

Link to docs preview:
https://92893--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html#virt-configure-multiple-iothreads_virt-edit-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
