### PR TITLE
OSDOCS-14483 added zero trust attributes to the common-attributes file

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -382,3 +382,7 @@ endif::openshift-origin[]
 :rhoai-cloud: Red{nbsp}Hat OpenShift AI Cloud Service
 :ai-first: artificial intelligence (AI)
 //RHEL AI attribute listed with RHEL family
+//zero trust workload identity manager
+:zero-trust-full: zero trust workload identity manager for Red{nbsp}Hat OpenShift
+:spiffe-full: Secure Production Identity Framework for Everyone (SPIFFE)
+:svid-full: SPIFFE Verifiable Identity Document (SVID)


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-14483

Link to docs preview:
https://92894--ocpdocs-pr.netlify.app/
Complete list of updated preview URLs: [artifacts/updated_preview_urls.txt](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_openshift-docs/92894/pull-ci-openshift-openshift-docs-main-validate-asciidoc/1918009372051509248/artifacts/validate-asciidoc/openshift-docs-preview-comment-pages/artifacts/updated_preview_urls.txt)

QE review:
- [ ] QE has approved this change.

