### PR TITLE
OSDOCS-14437_v1 updated release notes from branch OSDOCS-14437

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3021,6 +3021,42 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.11
+[id="ocp-4-18-11_{context}"]
+=== RHSA-2025:4211 - {product-title} {product-version}.11 bug fix update and security update
+
+Issued: 01 May 2025
+
+product-title} release {product-version}.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4213[RHBA-2025:4213] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.11 --pullspecs
+----
+
+[id="ocp-4-18-11-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, service deletion improperly handled API service association, resulting in API service unavailability. When the `ClusterResourceOverride` resource was deleted, the `admission.autoscaling.openshift.io/v1` API service was unreachable, affecting Operator installations. With this release, deleting the `ClusterResourceOverride` resource removes associated API services, allowing the operators to retrieve the list of server APIs for successful installation. (link:https://issues.redhat.com/browse/OCPBUGS-55242[OCPBUGS-55242])
+
+* Previously, during the Cluster Resource Override Operator (CROO) upgrade from {product-title} version 4.16 to 4.17, old secrets were not deleted, causing the CROO to fail after the {product-title} upgrade. With this release, the pod creation and namespace deletion during the {product-title} 4.17 upgrade completes successfully, resolving CROO errors. (link:https://issues.redhat.com/browse/OCPBUGS-55240[OCPBUGS-55240])
+
+* Previously, missing catalogd certificate authorities (CA) resulted in failed {olmv1-first} installations. With this release,  an updated Operator Controller uses a new directory for CA certificates. This change improves the stability of the system, ensuring the correct installation of cluster extensions, and enhancing the user experience. (link:https://issues.redhat.com/browse/OCPBUGS-55172[OCPBUGS-55172])
+
+* Previously, a private IP address mismatch for the load balancer led to the failure of fetching Azure IP availability, causing a private IP address conflict in an OpenShift 4.17 deployment. This issue was resolved by checking for IP address availability within the control plane subnet. The fix resulted in resolving the error in Azure IP address availability for OpenShift 4.17 deployment, ensuring that private IP addresses are now validated within subnet ranges. (link:https://issues.redhat.com/browse/OCPBUGS-54947[OCPBUGS-54947])
+
+* Previously, in {product-version} 4.16, a migration failure occurred after a reboot for users moving from OpenShift SDN to `OVNKubernetes` due to an interface configuration issue. The failure occurred because the `mtu-migration` service that was active before the `wait-for-primary-ip` service in the NMState-managed `br-ex`. With this release, the order of these services are reversed to ensure a successful migration and to prevent the `mtu-migration` service failure that occurs after the first reboot. (link:https://issues.redhat.com/browse/OCPBUGS-54817[OCPBUGS-54817])
+
+* Previously, missing cluster role permissions for Cluster Network Operator (CNO) in the `monitoring.coreos.com` and `monitoring.rhobs` APIs caused monitoring issues because of insufficient permissions. With this release, permissions for CNO to manage the `servicemonitors` and `prometheusrules` objects exist. The CNO patches `servicemonitor` and `prometheusrules` objects in the `monitoring.coreos.com` API group, which corrects the monitoring issues. (link:https://issues.redhat.com/browse/OCPBUGS-54698[OCPBUGS-54698])
+
+[id="ocp-4-18-11-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.10
 [id="ocp-4-18-10_{context}"]
 === RHSA-2025:4019 - {product-title} {product-version}.10 bug fix update and security update
@@ -3146,7 +3182,7 @@ $ oc adm release info 4.18.8 --pullspecs
 [id="ocp-4-18-8-bug-fixes_{context}"]
 ==== Bug fixes
 
-* Previously, sometimes network interface controllers (NICs) attached to virtual machines (VMs) that ran on {azure-first} failed because the NICs were in a `ProvisioningFailed` state. With this release, the Machine API controller now checks the provisioning status of a NIC and refreshes the VMs on a regular basis. If a NIC is in `ProvisioningFailed` state, the VM now fails so that you have a better indication of the issue for troubleshooting purposes. (link:https://issues.redhat.com/browse/OCPBUGS-54355[*OCPBUGS-54355*]) 
+* Previously, sometimes network interface controllers (NICs) attached to virtual machines (VMs) that ran on {azure-first} failed because the NICs were in a `ProvisioningFailed` state. With this release, the Machine API controller now checks the provisioning status of a NIC and refreshes the VMs on a regular basis. If a NIC is in `ProvisioningFailed` state, the VM now fails so that you have a better indication of the issue for troubleshooting purposes. (link:https://issues.redhat.com/browse/OCPBUGS-54355[*OCPBUGS-54355*])
 
 // SME review
 * Previously, selecting the *All projects* option on the *VolumeSnapshot* page of the web console in the *Administrator* perspective resulted in a `404: Page Not Found` error. With this release, a fix ensures that when you select the *All projects* option on the *VolumeSnapshot* page, the page shows results as expected without an error. (link:https://issues.redhat.com/browse/OCPBUGS-54269[*OCPBUGS-54269*])
@@ -3163,7 +3199,7 @@ ERROR Error: Plugin did not respond
 ERROR
 ERROR   with module.cis.ibm_cis_dns_record.kubernetes_api_internal[0],
 ERROR   on cis/main.tf line 27, in resource "ibm_cis_dns_record" "kubernetes_api_internal":
-ERROR   27: resource "ibm_cis_dns_record" "kubernetes_api_internal" 
+ERROR   27: resource "ibm_cis_dns_record" "kubernetes_api_internal"
 ----
 +
 With this release, you can use the installation program to create an external cluster on {product-title} without the plugin issue. (link:https://issues.redhat.com/browse/OCPBUGS-53453[*OCPBUGS-53453*])
@@ -3176,7 +3212,7 @@ To update an {product-title} 4.18 cluster to this latest release, see xref:../up
 
 // 4.18.7
 [id="ocp-4-18-7_{context}"]
-=== RHBA-2025:3293 - {product-title} {product-version}.7 bug fix update 
+=== RHBA-2025:3293 - {product-title} {product-version}.7 bug fix update
 
 Issued: 3 April 2025
 
@@ -3224,7 +3260,7 @@ $ oc adm release info 4.18.6 --pullspecs
 [id="ocp-4-18-6-bug-fixes_{context}"]
 ==== Bug fixes
 
-// SME 
+// SME
 * Previously, the Operator Marketplace and the {olm-first} used an older version, v1.24, of the `pod-security.kubernetes.io/` label. With this release, the namespace where Operator Marketplace is deployed now uses the Pod Security Admission (PSA) label marked as `latest`. (link:https://issues.redhat.com/browse/OCPBUGS-53149[OCPBUGS-53149]) (link:https://issues.redhat.com/browse/OCPBUGS-53108[OCPBUGS-53108])
 
 * Previously, during cluster shutdown, a race condition prevented a stage OSTree deployment from finalizing if the deployment was moved to a staging location during a reboot operation. With this release, a fix removes the race condition from the OSTree deployment so that the staged deployment can finalize even during a reboot operation. (link:https://issues.redhat.com/browse/OCPBUGS-53111[OCPBUGS-53111])
@@ -3235,11 +3271,11 @@ $ oc adm release info 4.18.6 --pullspecs
 
 * Previously, if you mirrored an empty catalog during a mirror-to-disk operation, and this caused the disk-to-mirror operation failed. This empty catalog was generated from an invalid Operator entry in the `ImageSetConfiguration` CR. With this release, you can no longer mirror an empty catalog so a disk-to-mirror operation can succeed. (link:https://issues.redhat.com/browse/OCPBUGS-52943[OCPBUGS-52943])
 
-* Previously, if you upgraded {gcp-first} clusters that used a boot disk that was not compatible with UEFI, shielded VM support could not be enabled. This behavior prevented the creation of new machines. With this release, shielded VM support is disabled for disks that are known to be incompatible with UEFI. This change primarily affects customers who are upgrading from {product-title} version 4.12 to 4.13 by using the {gcp-short} marketplace images. (link:https://issues.redhat.com/browse/OCPBUGS-52495[OCPBUGS-52495]) 
+* Previously, if you upgraded {gcp-first} clusters that used a boot disk that was not compatible with UEFI, shielded VM support could not be enabled. This behavior prevented the creation of new machines. With this release, shielded VM support is disabled for disks that are known to be incompatible with UEFI. This change primarily affects customers who are upgrading from {product-title} version 4.12 to 4.13 by using the {gcp-short} marketplace images. (link:https://issues.redhat.com/browse/OCPBUGS-52495[OCPBUGS-52495])
 
-* Previously, node logs on the {product-title} web console did not close when you clicked outside the node logs menu. With this release, the node logs menu now closes when you click outside the node logs menu. (link:https://issues.redhat.com/browse/OCPBUGS-52490[OCPBUGS-52490]) 
+* Previously, node logs on the {product-title} web console did not close when you clicked outside the node logs menu. With this release, the node logs menu now closes when you click outside the node logs menu. (link:https://issues.redhat.com/browse/OCPBUGS-52490[OCPBUGS-52490])
 
-* Previously, when you logged on to the Developer Sandbox from the {product-title} web console, the web console ignored the path in the URL and displayed the `all projects` view on the Developer Sandbox instead of the namespace detailed in the URL. With this release, a fix corrects this behavior so the error no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-52406[OCPBUGS-52406]) 
+* Previously, when you logged on to the Developer Sandbox from the {product-title} web console, the web console ignored the path in the URL and displayed the `all projects` view on the Developer Sandbox instead of the namespace detailed in the URL. With this release, a fix corrects this behavior so the error no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-52406[OCPBUGS-52406])
 
 * Previously, the `capturegroup` inline diff algorithm in the `cluster-compare` tool failed to match the source text in an object with the `capturegroup` regular expression from a reference template. This issue existed if the source text had a similar structure to a regular expression. With this release, a fix to the `capturegroup` inline diff algorithm means that this matching issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-51306[OCPBUGS-51306])
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-14437

Link to docs preview:
https://92897--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html


QE review:
- [ ] QE has approved this change.


Additional information:
This PR replace PR https://github.com/openshift/openshift-docs/pull/92759
