### PR TITLE
OSDOCS-13196 - Virtual Storage Management - Clarify S3

### DIFF
--- a/modules/rosa-policy-change-management.adoc
+++ b/modules/rosa-policy-change-management.adoc
@@ -179,10 +179,10 @@ machine pool using the OpenShift Cluster Manager or the ROSA CLI (`rosa`).
 
 - Set up and configure Amazon EBS to provision local node storage and persistent volume storage for the cluster.
 
-- Set up and configure the built-in image registry to use Amazon S3 bucket storage.
+- Set up and configure the built-in image registry to use Amazon S3 bucket storage. ^[1]^
 
 - Regularly prune image registry resources in
-Amazon S3 to optimize Amazon S3 usage and cluster performance.
+Amazon S3 to optimize Amazon S3 usage and cluster performance. ^[2]^
 
 | - Optionally configure the Amazon EBS CSI driver or the Amazon
 EFS CSI driver to provision persistent volumes on the cluster.
@@ -233,3 +233,7 @@ creation.
 applications and data hosted on the AWS Cloud.
 
 |===
+
+1. For more information on authentication flow for AWS STS, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/authentication_and_authorization/managing-cloud-provider-credentials#cco-short-term-creds-auth-flow-aws-diagram_cco-short-term-creds[Authentication flow for AWS STS].
+
+2. For more information on pruning images, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/registry/registry-overview-1#pruning-images_registry-overview[Automatically Pruning Images].


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-13196](https://issues.redhat.com/browse/OSDOCS-13196)

Link to docs preview:
- [ROSA HCP - Release management](https://92903--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix#rosa-policy-release-management_rosa-policy-responsibility-matrix) - The Virtual Storage Management table row and the two footnotes below the table.

- [ROSA - Release management](https://92903--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-release-management_rosa-policy-responsibility-matrix) - The Virtual Storage Management table row and the two footnotes below the table.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
