### PR TITLE
add version dropdown for logging

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -293,6 +293,15 @@
               <option value="1.29">1.29</option>
               <option value="1.28">1.28</option>
             </select>
+        <% elsif (distro_key == "openshift-logging") %>
+            <a href="https://docs.openshift.com/logging/<%= version %>/about/about-logging.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="6.2">6.2</option>
+              <option value="6.1">6.1</option>
+              <option value="6.0">6.0</option>
+            </select>
         <% elsif (distro_key == "openshift-pipelines") %>
             <a href="https://docs.openshift.com/pipelines/<%= version %>/about/about-pipelines.html">
               <%= distro %>


### PR DESCRIPTION

Version(s):
standalone-logging-docs-main

Issue:
standalone logging docs - fix version dropdown

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
