### PR TITLE
Update persistent-storage-local-removing-devices.adoc

### DIFF
--- a/modules/persistent-storage-local-removing-devices.adoc
+++ b/modules/persistent-storage-local-removing-devices.adoc
@@ -45,7 +45,7 @@ Bound PVs have a status of `Bound` and their corresponding PVCs appear in the `C
 +
 [source, terminal]
 ----
-$ oc delete pvc <name>
+$ oc delete pvc <pvc_name> -n <pvc_namespace>
 ----
 + 
 In this example, you would delete PVC `openshift/storage`.
@@ -56,7 +56,7 @@ In this example, you would delete PVC `openshift/storage`.
 +
 [source,terminal]
 ----
-$ oc delete lv <name>
+$ oc delete localvolume <localvolume_name> -n <localvolume_namespace>
 ----
 +
 or
@@ -64,7 +64,7 @@ or
 .Command for deleting LVS
 [source,terminal]
 ----
-$ oc delete lvs <name>
+$ oc delete localvolumeset <localvolumeset_name> -n <localvolumeset_namespace>
 ----
 
 . If any PV owned by the LV or LVS has a `Retain` reclaim policy, back up any important data, and then delete the PV:
@@ -78,7 +78,7 @@ PVs with a `Delete` policy are automatically deleted when you delete the LVs or 
 +
 [source,terminal]
 ----
-$ oc get pv
+$ oc delete pv <pv_name>
 ----
 +
 .Example output
@@ -96,7 +96,7 @@ In this example,  PV `local-pv-1cec77cf` has a `Retain` reclaim policy and needs
 +
 [source,terminal]
 ----
-$ oc delete pv <name>
+$ oc delete pv <pv_name> 
 ----
 +
-In this example, delete PV `local-pv-1cec77cf`.
+In this example, delete the `local-pv-1cec77cf` PV.


### PR DESCRIPTION
We do not have lv as resource.

Changed the command with localvolume and localvolumeset

Command for deleting LV

$ oc delete localvolume

or Command for deleting LVS

$ oc delete localvolumeset

Version(s):

4.18+
Issue:

https://issues.redhat.com/browse/OSDOCS-13583

Link to docs preview:
https://90117--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-local.html#local-removing-device_persistent-storage-local

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
See https://github.com/openshift/openshift-docs/pull/90117 for peer review.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
