### PR TITLE
add main branch so that cached erb file for package command will be main

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -6,6 +6,9 @@ openshift-logging:
   site_name: Documentation
   site_url: https://docs.openshift.com/
   branches:
+    standalone-logging-docs-main:
+      name: 'main'
+      dir: logging/main
     standalone-logging-docs-6.0:
       name: '6.0'
       dir: logging/6.0

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -298,6 +298,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="main">main</option>
               <option value="6.2">6.2</option>
               <option value="6.1">6.1</option>
               <option value="6.0">6.0</option>


### PR DESCRIPTION

Version(s):
standalone-logging-docs-main

Issue:
standalone logging docs - add main to distro build for erb file cache

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a

