### PR TITLE
ROX-28825: Add ACSCS Central access restriction documentation

### DIFF
--- a/cloud_service/rhacs-cloud-service-service-description.adoc
+++ b/cloud_service/rhacs-cloud-service-service-description.adoc
@@ -137,9 +137,9 @@ To prevent information leakage, logs are shipped to SRE through our security inf
 [id="access-restriction_{context}"]
 === Central access restriction by IP addresses and CIDR ranges
 
-Restricting access to Central ensures that only trusted IP addresses can interact with the security policy enforcement point, thereby strengthening the overall security posture.
+Restricting access to Central ensures that only traffic from trusted IP addresses can reach the security policy enforcement point, thereby strengthening the overall security posture.
 
-To request restricted access to Central, please visit the following link:https://access.redhat.com/support[Red Hat Customer Portal].
+To request restricted access to Central, go to the link:https://access.redhat.com/support[Red Hat Customer Portal] page.
 From the Customer Portal, submit a support case requesting the restriction of access to Central.
 Be sure to provide the list of trusted IP addresses and CIDR ranges.
 The maximum number of IP addresses and CIDR ranges is 55.

--- a/cloud_service/rhacs-cloud-service-service-description.adoc
+++ b/cloud_service/rhacs-cloud-service-service-description.adoc
@@ -134,6 +134,16 @@ Our customer support team offers Bomgar as a remote access solution for troubles
 
 To prevent information leakage, logs are shipped to SRE through our security information and event management (SIEM) application, Splunk.
 
+[id="access-restriction_{context}"]
+=== Central access restriction by IP addresses and CIDR ranges
+
+Restricting access to Central ensures that only trusted IP addresses can interact with the security policy enforcement point, thereby strengthening the overall security posture.
+
+To request restricted access to Central, please visit the following link:https://access.redhat.com/support[Red Hat Customer Portal].
+From the Customer Portal, submit a support case requesting the restriction of access to Central.
+Be sure to provide the list of trusted IP addresses and CIDR ranges.
+The maximum number of IP addresses and CIDR ranges is 55.
+
 include::modules/cloud-svc-compliance.adoc[leveloffset=+1]
 
 include::modules/data-protection.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Add a short description of ACS Cloud Services feature to restrict an access to Central instance by providing IP addresses or CIDR ranges via RH customer support.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
`rhacs-docs-main`

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/ROX-28825

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://92938--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/rhacs-cloud-service-service-description.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
