### PR TITLE
fixed wrong version nr

### DIFF
--- a/modules/ob-release-notes-1-4.adoc
+++ b/modules/ob-release-notes-1-4.adoc
@@ -5,7 +5,7 @@
 [id="ob-release-notes-1-4_{context}"]
 = Release notes for {builds-shortname} 1.4
 
-{builds-shortname} 1.4 is now available on {ocp-product-title} 4.15, 4.16, 4,17, 4.18 and 4.19.
+{builds-shortname} 1.4 is now available on {ocp-product-title} 4.15, 4.16, 4,17, and 4.18.
 
 [id="new-features-1-4_{context}"]
 == New features

--- a/modules/ob-release-notes-1-4.adoc
+++ b/modules/ob-release-notes-1-4.adoc
@@ -5,7 +5,7 @@
 [id="ob-release-notes-1-4_{context}"]
 = Release notes for {builds-shortname} 1.4
 
-{builds-shortname} 1.4 is now available on {ocp-product-title} 4.15, 4.16, 4,17, and 4.18.
+{builds-shortname} 1.4 is now available on {ocp-product-title} 4.15, 4.16, 4.17, and 4.18.
 
 [id="new-features-1-4_{context}"]
 == New features


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

build-docs-1.4

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://github.com/openshift/openshift-docs/pull/92843

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

removed incorrect ocp version from release notes (ocp 4.19 wasn't released yet)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
