### PR TITLE
OSDOCS-10882 [NETOBSERV] bpfman Support TP

### DIFF
--- a/modules/network-observability-ebpf-manager-operator.adoc
+++ b/modules/network-observability-ebpf-manager-operator.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-ebpf-manager-operator_{context}"]
+= Working with the eBPF Manager Operator
+
+The eBPF Manager Operator reduces the attack surface and ensures compliance, security, and conflict prevention by managing all eBPF programs. Network observability can use the eBPF Manager Operator to load hooks. As a result, you no longer need to provide the eBPF Agent with privileged mode or additional Linux capabilities such as `CAP_BPF` and `CAP_PERFMON`. The eBPF Manager Operator with network observability is only supported on 64-bit AMD architecture.
+
+:FeatureName: eBPF Manager Operator with network observability
+include::snippets/technology-preview.adoc[]
+
+.Procedure
+. In the web console, navigate to *Operators* -> *Operator Hub*.
+. Install *eBPF Manager*.
+. Check *Workloads* -> *Pods* in the `bpfman` namespace to make sure they are all up and running.
+. Configure the `FlowCollector` custom resource to use the eBPF Manager Operator:
++
+.Example `FlowCollector` configuration
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    ebpf:
+      features:
+        - EbpfManager
+----
+
+.Verification
+. In the web console, navigate to *Operators* -> *Installed Operators*.
+. Click *eBPF Manager Operator* -> *All instances* tab.
++
+For each node, verify that a `BpfApplication` named `netobserv` and a pair of `BpfProgram` objects, one for Traffic Control (TCx) ingress and another for TCx egress, exist. If you enable other eBPF Agent features, you might have more objects.

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -69,6 +69,14 @@ include::modules/network-observability-working-with-conversations.adoc[leveloffs
 include::modules/network-observability-packet-drops.adoc[leveloffset=+2]
 include::modules/network-observability-dns-tracking.adoc[leveloffset=+2]
 include::modules/network-observability-RTT.adoc[leveloffset=+2]
+include::modules/network-observability-ebpf-manager-operator.adoc[leveloffset=+2]
+
+//eBPF Manager Operator in OCP > Networking
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/networking_operators/ebpf_manager/ebpf-manager-operator-install.adoc[Installing the eBPF Manager Operator]
+
+//Traffic flows continued
 include::modules/network-observability-histogram-trafficflow.adoc[leveloffset=+2]
 include::modules/network-observability-working-with-zones.adoc[leveloffset=+2]
 include::modules/network-observability-filtering-ebpf-rule.adoc[leveloffset=+2]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10882  [NETOBSERV] bpfman Support TP

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the no-1.9 branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the NetObserv content just before its GA.

Cherry-pick to OCP 4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-10882

Link to docs preview:
https://92963--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic.html#network-observability-ebpf-manager_nw-observe-network-traffic

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
06/16/2025: Engineering is still waiting for multi-arch builds to verify support. Sending for Doc Peer Review. Will update support statement as necessary, prior to submitting for Doc Merge Review.

05/02/2025: Initial PR creation resulted in automagically adding 171 commits from `main` that `no-1.9` wasn't aware of which resulted in a flurry of ocpdocs-vale-bot-related comments for a flurry of errors. Those comments have been resolved as a proper rebase of `no-1.9` resolved all the things.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
