### PR TITLE
CNV#58194 02: Doc new TP virt descheduler profile DevKubeVirtRelieveAndMigrate

### DIFF
--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -90,8 +90,72 @@ Do not enable `CompactAndScale` with any of the following profiles: `LifecycleAn
 
 endif::nodes[]
 ifdef::virt[]
-Use the `LongLifecycle` profile to enable the descheduler on a virtual machine. This is the only descheduler profile currently available for {VirtProductName}. To ensure proper scheduling, create VMs with CPU and memory requests for the expected load.
+Use the `DevKubeVirtRelieveAndMigrate` or `LongLifecycle` profile to enable the descheduler on a virtual machine.
+
+[IMPORTANT]
+====
+You can not have both `DevKubeVirtRelieveAndMigrate` and `LongLifeCycle` enabled at the same time.
+====
 endif::virt[]
+
+`DevKubeVirtRelieveAndMigrate`:: This profile is an enhanced version of the `LongLifeCycle` profile.
++
+--
+:FeatureName: The `DevKubeVirtRelieveAndMigrate` profile
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+--
+
+The `DevKubeVirtRelieveAndMigrate` profile evicts pods from high-cost nodes to reduce overall resource expenses and enable workload migration. It also periodically rebalances workloads to help maintain similar spare capacity across nodes, which supports better handling of sudden workload spikes. Nodes can experience the following costs:
+
+--
+* **Resource utilization**: Increased resource pressure raises the overhead for running applications.
+* **Node maintenance**: A higher number of containers on a node increases resource consumption and maintenance costs.
+
+The profile enables the `LowNodeUtilization` strategy with the `EvictionsInBackground` alpha feature. The profile also exposes the following customization fields:
+
+* `devActualUtilizationProfile`: Enables load-aware descheduling.
+* `devLowNodeUtilizationThresholds`: Sets experimental thresholds for the `LowNodeUtilization` strategy. Do not use this field with `devDeviationThresholds`.
+* `devDeviationThresholds`: Treats nodes with below-average resource usage as underutilized to help redistribute workloads from overutilized nodes. Do not use this field with `devLowNodeUtilizationThresholds`. Supported values are: `Low` (10%:10%), `Medium` (20%:20%), `High` (30%:30%), `AsymmetricLow` (0%:10%), `AsymmetricMedium` (0%:20%), `AsymmetricHigh` (0%:30%).
+* `devEnableSoftTainter`: Enables the soft-tainting component to dynamically apply or remove soft taints as scheduling hints.
+
+.Example configuration
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  managementState: Managed
+  deschedulingIntervalSeconds: 30
+  mode: "Automatic"
+  profiles:
+    - DevKubeVirtRelieveAndMigrate
+  profileCustomizations:
+    devEnableSoftTainter: true
+    devDeviationThresholds: AsymmetricLow
+    devActualUtilizationProfile: PrometheusCPUCombined
+----
+
+The `DevKubeVirtRelieveAndMigrate` profile requires PSI metrics to be enabled on all worker nodes. You can enable this by applying the following `MachineConfig` custom resource (CR):
+
+.Example `MachineConfig` CR
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-openshift-machineconfig-worker-psi-karg
+spec:
+  kernelArguments:
+    - psi=1
+----
+
+You can use this profile with the `SoftTopologyAndDuplicates` profile to also rebalance pods based on soft topology constraints, which can be useful in hosted control plane environments.
 
 // Show LongLifecycle profile both for virt and nodes
 `LongLifecycle`:: This profile balances resource usage between nodes and enables the following strategies:
@@ -102,7 +166,6 @@ endif::virt[]
 ** A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
 ** A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
 --
-+
 --
 ifdef::nodes[]
 [WARNING]
@@ -110,7 +173,6 @@ ifdef::nodes[]
 Do not enable `LongLifecycle` with any of the following profiles: `LifecycleAndUtilization` or `CompactAndScale`. Enabling these profiles together results in a conflict.
 ====
 endif::nodes[]
---
 
 ifeval::["{context}" == "nodes-descheduler-about"]
 :!nodes:


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/CNV-58194

Link to docs preview:
https://92977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/index.html
https://92977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-enabling-descheduler-evictions.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* I'm redoing https://github.com/openshift/openshift-docs/pull/92742 in this PR due to some formatting issues I was having with Codium
* I addressed everything that was mentioned in the above original PR that tiraboschi recommended. The only thing I need clarity on is what customization fields does this profile expose because the PR [comment mentions four](https://github.com/openshift/openshift-docs/pull/92742#issuecomment-2841219202) but the upstream docs [only mention three](https://github.com/openshift/cluster-kube-descheduler-operator?tab=readme-ov-file#devkubevirtrelieveandmigrate).
