### PR TITLE
OCPBUGS #34373: Added a note in creating the externally managed certificate section

### DIFF
--- a/modules/nw-ingress-route-secret-load-external-cert.adoc
+++ b/modules/nw-ingress-route-secret-load-external-cert.adoc
@@ -23,6 +23,14 @@ This feature applies to both edge routes and re-encrypt routes.
 * You must have a secret containing a valid certificate/key pair in PEM-encoded format of type `kubernetes.io/tls`, which includes both `tls.key` and `tls.crt` keys.
 * You must place the referenced secret in the same namespace as the route you want to secure.
 
+[NOTE]
+====
+To configure the `spec.tls.externalCertificate` field on a route:
+
+* You must have the `create` permission on the `routes/custom-host` sub-resource to set this field during route creation.
+* You must have either the `create` or `update` permission on the `routes/custom-host` sub-resource to modify this field on an existing route.
+====
+
 .Procedure
 
 . Create a `role` in the same namespace as the secret to allow the router service account read access by running the following command:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-34373
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://92978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
