### PR TITLE
[enterprise-4.12] OBSDOCS-1795: Improve the contents of 'Configuring alert routing for default platform alerts'

### DIFF
--- a/modules/monitoring-configuring-notifications-for-default-platform-alerts.adoc
+++ b/modules/monitoring-configuring-notifications-for-default-platform-alerts.adoc
@@ -6,7 +6,7 @@
 [id="configuring-notifications-for-default-platform-alerts_{context}"]
 = Configuring notifications for default platform alerts
 
-You can configure Alertmanager to send notifications. Customize where and how Alertmanager sends notifications about default platform alerts by editing the default configuration in the `alertmanager-main` secret in the `openshift-monitoring` namespace.
+You can configure Alertmanager to send notifications to receive important alerts coming from your cluster. Customize where and how Alertmanager sends notifications about default platform alerts by editing the default configuration in the `alertmanager-main` secret in the `openshift-monitoring` namespace.
 
 [IMPORTANT]
 ====
@@ -16,28 +16,24 @@ Alertmanager does not send notifications by default. It is recommended to config
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have installed the {oc-first}.
 
 .Procedure
 
-. Open the Alertmanager YAML configuration file:
-
-** To open the Alertmanager configuration from the CLI:
-
-.. Print the currently active Alertmanager configuration from the `alertmanager-main` secret into `alertmanager.yaml` file:
+. Extract the currently active Alertmanager configuration from the `alertmanager-main` secret and save it as a local `alertmanager.yaml` file:
 +
 [source,terminal]
 ----
 $ oc -n openshift-monitoring get secret alertmanager-main --template='{{ index .data "alertmanager.yaml" }}' | base64 --decode > alertmanager.yaml
 ----
 
-.. Open the `alertmanager.yaml` file.
+. Open the `alertmanager.yaml` file.
 
-** To open the Alertmanager configuration from the {product-title} web console:
+. Edit the Alertmanager configuration:
 
-.. Go to the *Administration* -> *Cluster Settings* -> *Configuration* -> *Alertmanager* -> *YAML* page of the web console.
-
-. Edit the Alertmanager configuration by updating parameters in the YAML:
+.. Optional: Change the default Alertmanager configuration:
 +
+.Example of the default Alertmanager secret YAML
 [source,yaml]
 ----
 global:
@@ -52,52 +48,52 @@ route:
     - "alertname=Watchdog"
     repeat_interval: 2m
     receiver: watchdog
-  - matchers:
-    - "service=<your_service>" #<4>
-    routes:
-    - matchers:
-      - <your_matching_rules> #<5>
-      receiver: <receiver> #<6>
 receivers:
 - name: default
 - name: watchdog
-- name: <receiver>
-  <receiver_configuration> #<7>
 ----
 <1> Specify how long Alertmanager waits while collecting initial alerts for a group of alerts before sending a notification.
 <2> Specify how much time must elapse before Alertmanager sends a notification about new alerts added to a group of alerts for which an initial notification was already sent.
 <3> Specify the minimum amount of time that must pass before an alert notification is repeated.
 If you want a notification to repeat at each group interval, set the `repeat_interval` value to less than the `group_interval` value.
 The repeated notification can still be delayed, for example, when certain Alertmanager pods are restarted or rescheduled.
-<4> Specify the name of the service that fires the alerts.
-<5> Specify labels to match your alerts.
-<6> Specify the name of the receiver to use for the alerts.
-<7> Specify the receiver configuration.
-+
-[IMPORTANT]
-====
-* Use the `matchers` key name to indicate the matchers that an alert has to fulfill to match the node.
-Do not use the `match` or `match_re` key names, which are both deprecated and planned for removal in a future release.
 
-* If you define inhibition rules, use the following key names:
-+
---
-** `target_matchers`: to indicate the target matchers
-** `source_matchers`: to indicate the source matchers
---
-+
-Do not use the `target_match`, `target_match_re`, `source_match`, or `source_match_re` key names, which are deprecated and planned for removal in a future release.
-====
-+
-The following Alertmanager configuration example configures PagerDuty as an alert receiver:
+.. Add your alert receiver configuration:
 +
 [source,yaml]
 ----
-global:
-  resolve_timeout: 5m
+# ...
+receivers:
+- name: default
+- name: watchdog
+- name: <receiver> # <1>
+  <receiver_configuration> # <2>
+# ...
+----
+<1> The name of the receiver.
+<2> The receiver configuration. The supported receivers are PagerDuty, webhook, email, Slack, and Microsoft Teams.
++
+.Example of configuring PagerDuty as an alert receiver
+[source,yaml]
+----
+# ...
+receivers:
+- name: default
+- name: watchdog
+- name: team-frontend-page
+  pagerduty_configs:
+  - routing_key: ABCD01234EFGHIJ56789
+# ...
+----
+
+.. Add the routing configuration:
++
+[source,yaml]
+----
+# ...
 route:
-  group_wait: 30s
-  group_interval: 5m
+  group_wait: 30s 
+  group_interval: 5m 
   repeat_interval: 12h
   receiver: default
   routes:
@@ -105,29 +101,71 @@ route:
     - "alertname=Watchdog"
     repeat_interval: 2m
     receiver: watchdog
+  - matchers: # <1>
+    - "<your_matching_rules>" # <2>
+    receiver: <receiver> # <3>
+# ...
+----
+<1> Use the `matchers` key name to specify the matching rules that an alert has to fulfill to match the node.
+If you define inhibition rules, use `target_matchers` key name for target matchers and `source_matchers` key name for source matchers.
+<2> Specify labels to match your alerts.
+<3> Specify the name of the receiver to use for the alerts.
++
+[WARNING]
+====
+Do not use the `match`, `match_re`, `target_match`, `target_match_re`, `source_match`, and `source_match_re` key names, which are deprecated and planned for removal in a future release.
+====
++
+--
+.Example of alert routing 
+[source,yaml]
+----
+# ...
+route:
+  group_wait: 30s 
+  group_interval: 5m 
+  repeat_interval: 12h
+  receiver: default
+  routes:
   - matchers:
+    - "alertname=Watchdog"
+    repeat_interval: 2m
+    receiver: watchdog
+  - matchers: # <1>
     - "service=example-app"
-    routes:
+    routes: # <2>
     - matchers:
       - "severity=critical"
       receiver: team-frontend-page
-receivers:
-- name: default
-- name: watchdog
-- name: team-frontend-page
-  pagerduty_configs:
-  - service_key: "<your_key>"
+# ...
 ----
+<1>  This example matches alerts from the `example-app` service.
+<2> You can create routes within other routes for more complex alert routing. 
+--
 +
-With this configuration, alerts of `critical` severity that are fired by the `example-app` service are sent through the `team-frontend-page` receiver. Typically, these types of alerts would be paged to an individual or a critical response team.
+The previous example routes alerts of `critical` severity that are fired by the `example-app` service to the `team-frontend-page` receiver. Typically, these types of alerts are paged to an individual or a critical response team.
 
 . Apply the new configuration in the file:
-
-** To apply the changes from the CLI, run the following command:
 +
 [source,terminal]
 ----
 $ oc -n openshift-monitoring create secret generic alertmanager-main --from-file=alertmanager.yaml --dry-run=client -o=yaml |  oc -n openshift-monitoring replace secret --filename=-
 ----
 
-** To apply the changes from the {product-title} web console, click *Save*.
+. Verify your routing configuration by visualizing the routing tree:
++
+[source,terminal]
+----
+$ oc exec alertmanager-main-0 -n openshift-monitoring -- amtool config routes show --alertmanager.url http://localhost:9093
+----
++
+.Example output
+[source,terminal]
+----
+Routing tree:
+.
+└── default-route  receiver: default
+    ├── {alertname="Watchdog"}  receiver: Watchdog
+    └── {service="example-app"}  receiver: default
+        └── {severity="critical"}  receiver: team-frontend-page
+----


### PR DESCRIPTION
manual cherry-pick of #91565 to 4.12

**$${\color{red}FOR \space THE \space MERGE \space PERSON:}$$** This issue has already gone through merge reviews. This is just a manual cherry-pick. I'm adding the `merge-review-needed` label because the original merger is on PTO for the next week.
