### PR TITLE
OSDOCS-13976: update bootc for MicroShift GA

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -78,9 +78,9 @@ Distros: microshift
 Topics:
 - Name: Understanding image mode for RHEL
   File: microshift-about-rhel-image-mode
-- Name: Installing a bootc image
+- Name: Installing a bootc image and publishing to a registry
   File: microshift-install-bootc-image
-- Name: Running the bootc image
+- Name: Running the bootc image in a virtual machine
   File: microshift-install-running-bootc-image-vm
 ---
 Name: Using RHEL Kickstarts

--- a/modules/microshift-install-bootc-build-image.adoc
+++ b/modules/microshift-install-bootc-build-image.adoc
@@ -71,14 +71,14 @@ Podman uses the host subscription information and repositories inside the contai
 +
 [source,terminal]
 ----
-PULL_SECRET=~/.pull-secret.json
+$ PULL_SECRET=~/.pull-secret.json
 ----
 
 . Configure the `USER_PASSWD` environment variable:
 +
 [source,terminal,subs="+quotes"]
 ----
-USER_PASSWD=_<redhat_user_password>_ <1>
+$ USER_PASSWD=_<redhat_user_password>_ <1>
 ----
 <1> Replace _<redhat_user_password>_ with your password.
 
@@ -86,7 +86,7 @@ USER_PASSWD=_<redhat_user_password>_ <1>
 +
 [source,terminal,subs="attributes+"]
 ----
-IMAGE_NAME=microshift-{product-version}-bootc
+$ IMAGE_NAME=microshift-{product-version}-bootc
 ----
 
 . Create a local bootc image by running the following image build command:
@@ -98,7 +98,7 @@ $ sudo podman build --authfile "${PULL_SECRET}" -t "${IMAGE_NAME}" \
     -f Containerfile
 ----
 +
-[NOTE]
+[IMPORTANT]
 ====
 How secrets are used during the image build:
 

--- a/modules/microshift-install-bootc-creating-vm.adoc
+++ b/modules/microshift-install-bootc-creating-vm.adoc
@@ -22,15 +22,21 @@ You can create a virtual machine by using the {op-system-base-full} boot ISO ima
 
 . Copy the downloaded file to the `/var/lib/libvirt/images` directory.
 
-. Use your values to configure the following environment variables:
+. Configure the VMNAME environment variable with your value by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
-VMNAME=microshift-{product-version}-bootc
-NETNAME=default
+$ VMNAME=microshift-{product-version}-bootc
 ----
 
-. Create a {op-system-base-full} virtual machine with 2 cores, 2GB of RAM and 20GB of storage by running the following command:
+. Configure the NETNAME environment variable with your value by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ NETNAME=default
+----
+
+. Create a {op-system-base} virtual machine with 2 cores, 2GB of RAM and 20GB of storage by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -49,14 +55,14 @@ $ sudo virt-install \
 +
 [NOTE]
 ====
-The `sudo virt-install` command uses the Kickstart file to pull a bootc image from the remote registry and install the {op-system-base-full} operating system.
+The `sudo virt-install` command uses the Kickstart file to pull a bootc image from the remote registry and install the {op-system-base} operating system.
 ====
 
 . Log in to the virtual machine by using your `redhat` credentials.
 
 .Verification
 
-. Verify that all the {microshift-short} pods are running without error, by running the following command:
+. Verify that all of the {microshift-short} pods are running without error by entering the following command:
 +
 [source,terminal]
 ----
@@ -69,7 +75,6 @@ $ watch sudo oc get pods -A \
 ----
 NAMESPACE                  NAME                                       READY   STATUS    RESTARTS      AGE
 kube-system                csi-snapshot-controller-7cfb9df49c-kc9dx   1/1     Running   0             31s
-kube-system                csi-snapshot-webhook-5c6b978878-jzk5r      1/1     Running   0             28s
 openshift-dns              dns-default-rpnlt                          2/2     Running   0             14s
 openshift-dns              node-resolver-rxvdk                        1/1     Running   0             31s
 openshift-ingress          router-default-69cd7b5545-7zcw7            1/1     Running   0             29s

--- a/modules/microshift-install-bootc-get-published-image.adoc
+++ b/modules/microshift-install-bootc-get-published-image.adoc
@@ -6,7 +6,7 @@
 [id="microshift-install-bootc-get-published-image_{context}"]
 = Getting the published bootc image for {microshift-short}
 
-You can find and use the {microshift-short} container images to install {op-system-image}.
+You can use the {microshift-short} container images to install {op-system-image}.
 
 .Prerequisites
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-13976](https://issues.redhat.com/browse/OSDOCS-13976)

Link to docs preview:
[microshift-install-rhel-bootc-image](https://92989--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-bootc-image.html#microshift-install-bootc-build-image_microshift-install-rhel-bootc-image)

Reviews:
- [x] QE approved this change.
- [x] SME approved this change.

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
