### PR TITLE
OSDOCS-14533 adding tech preview params for vsphere multi disk

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -3087,6 +3087,36 @@ Optional VMware vSphere machine pool configuration parameters are described in t
     memoryMB:
 |The size of a virtual machine's memory in megabytes.
 |Integer
+
+|platform:
+  vsphere:
+    dataDisks:
+      name:
+|The name of the data disk to add to the virtual machines. The maximum name length is 80 characters.
+
+[IMPORTANT]
+====
+[subs="attributes+"]
+Installing {product-title} on {vmw-full} using multiple data disks is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+//You can't put a snippet within a conditional.
+|String
+
+|platform:
+  vsphere:
+    dataDisks:
+      sizeGiB:
+|The size of the data disk to add to the virtual machines. The maximum size is 16384 GiB.
+|Integer
+
+|platform:
+  vsphere:
+    dataDisks:
+      provisioningMode:
+|Optional: The data disk provisioning method. This value defaults to the vSphere default storage policy, if not set.
+|Valid values are `Thin`, `Thick`, or `EagerlyZeroed`.
 |====
 endif::vsphere[]
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-14553

Link to docs preview:
https://93007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-optional-vsphere_installation-config-parameters-vsphere

QE review:
- [x] QE has approved this change.

Release notes PR will contain additional tech preview information.