### PR TITLE
OSDOCS-14525 added files for the installation section

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -384,8 +384,7 @@ endif::openshift-origin[]
 :ai-first: artificial intelligence (AI)
 //RHEL AI attribute listed with RHEL family
 //zero trust workload identity manager
-:zero-trust-full: Zero Trust Workload Identity Manager for Red{nbsp}Hat OpenShift
-:zero-trust-short: Zero Trust Workload Identity Manager
+:zero-trust-full: Zero Trust Workload Identity Manager
 :spiffe-full: Secure Production Identity Framework for Everyone (SPIFFE)
 :svid-full: SPIFFE Verifiable Identity Document (SVID)
 :spire-full: SPIFFE Runtime Environment

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1266,12 +1266,16 @@ Topics:
   - Name: Disaster recovery considerations
     File: nbde-disaster-recovery-considerations
     Distros: openshift-enterprise,openshift-origin
-- Name: zero trust workload identity manager for Red Hat OpenShift
+- Name: Zero Trust Workload Identity Manager
   Dir: zero_trust_workload_identity_manager
   Distros: openshift-enterprise
   Topics:
-  - Name: zero trust workload identity manager for Red Hat OpenShift overview
+  - Name: Zero Trust Workload Identity Manager overview
     File: zero-trust-manager-overview
+  - Name: Installing Zero Trust Workload Identity Manager
+    File: zero-trust-manager-install
+  - Name: Uninstalling Zero Trust Workload Identity Manager
+    File: zero-trust-manager-uninstall
 ---
 Name: Authentication and authorization
 Dir: authentication

--- a/modules/zero-trust-manager-about-agent.adoc
+++ b/modules/zero-trust-manager-about-agent.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manageer/zero-trust-manager-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-about-agent_{context}"]
+= SPIRE agent
+
+The SPIRE Agent is responsible for workload attestation, ensuring that workloads receive a verified identity when requesting authentication through the SPIFFE Workload API. It accomplishes this by using configured workload attestor plugins. In Kubernetes environments, the Kubernetes workload attestor plugin is used.
+
+SPIRE and the SPIRE agent perform node attestation via node plugins. The plugins are used to verify the identity of the node on which the agent is running. For more information, see link:https://spiffe.io/docs/latest/spire-about/spire-concepts/#all-about-the-agent[About the SPIRE Agent].
+

--- a/modules/zero-trust-manager-about-attestation.adoc
+++ b/modules/zero-trust-manager-about-attestation.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manageer/zero-trust-manager-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-about-attestation_{context}"]
+= Attestation
+
+
+Attestation is the process by which the identity of nodes and workloads are verified before SPIFFE IDs and SVIDs are issued. The SPIRE server gathers attributes of both the workload and node that the SPIRE Agent runs on, and then compares them to a set of selectors defined when the workload was registered. If the comparison is successful, the entities are provided with credentials. This ensures that only legitimate and expected entities within the trust domain receive cryptographic identities. The two main types of attestation in SPIFFE/SPIRE are:
+
+* Node attestation: verifies the identity of a machine or a node on a system, before a SPIRE agent running on that node can be trusted to request identities for workloads.
+* Workload attestation: verifies the identity of an application or service running on an attested node before the SPIRE agent on that node can provide it with a SPIFFE ID and SVID.
+
+For more information, see link:https://spiffe.io/docs/latest/spire-about/spire-concepts/#attestation[Attestation].

--- a/modules/zero-trust-manager-about-spiffe.adoc
+++ b/modules/zero-trust-manager-about-spiffe.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manageer/zero-trust-manager-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-about-spiffe_{context}"]
+= SPIFFE
+
+
+{spiffe-full} provides a standardized way to establish trust between software workloads in distributed systems. SPIFFE assigns unique IDs called SPIFFE IDs. These IDs are Uniform Resource Identifiers (URI) that include a trust domain and a workload identifier.
+
+The SPIFFE IDs are contained in the {svid-full}. SVIDs are used by workloads to verify their identity to other workloads so that the workloads can communicate with each other. The two main SVID formats are:
+
+* X.509-SVIDs: X.509 certificates where the SPIFFE ID is embedded in the Subject Alternative Name (SAN) field.
+* JWT-SVIDs: JSON Web Tokens (JWTs) where the SPIFFE ID is included as the `sub` claim.
+
+For more information, see link:https://spiffe.io/docs/latest/spiffe-about/overview/[SPIFFE Overview].

--- a/modules/zero-trust-manager-about-spire.adoc
+++ b/modules/zero-trust-manager-about-spire.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manageer/zero-trust-manager-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-about-spire_{context}"]
+= SPIRE server
+
+
+A SPIRE server is responsible for managing and issuing SPIFFE identities within a trust domain. It stores registration entries (selectors that determine under what conditions a SPIFFE ID should be issued) and signing keys. The SPIRE server works in conjunction with the SPIRE agent to perform node attestion via node plugins. For more information, see link:https://spiffe.io/docs/latest/spire-about/spire-concepts/#all-about-the-server[About the SPIRE server].

--- a/modules/zero-trust-manager-how-it-works.adoc
+++ b/modules/zero-trust-manager-how-it-works.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manageer/zero-trust-manager-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-how-it-works_{context}"]
+== {zero-trust-full} workflow
+
+
+The following is a high-level workflow of the {zero-trust-full} within the Red{nbsp}Hat OpenShift cluster.
+
+. The SPIRE, SPIRE agent, SPIFFE CSI Driver, and the SPIRE OIDC Discovery Provider operands are deployed and managed by {zero-trust-full} via associated Customer Resource Definitions (CRDs).
+
+. Watches are then registered for relevant Kubernetes resources and the necessary SPIRE CRDs are applied to the cluster.
+
+. The CR for the ZeroTrustWorkloadIdentityManager resource named `cluster` is deployed and managed by a controller.
+
+. To deploy the SPIRE server, SPIRE agent, SPIFFE CSI Driver, and SPIRE OIDC Discovery Provider, you need to create a custom resource of a each certain type and name it `cluster`. The custom resource types are as follows:
+
+* SPIRE server - `SpireServer`
+
+* SPIRE agent - `SpireAgent`
+
+* SPIFFE CSI Driver - `SpiffeCSIDriver`
+
+* SPIRE OIDC discovery provider - `SpireOIDCDiscoveryProvider`
+
+. When a node starts, the SPIRE agent initializes, and connects to the SPIRE server.
+
+. The agent begins the node attestation process. The agent collects information on the node's identity such as label name and namespace. The agent securely provides the information it gathered through the attestation to the SPIRE server.
+
+. The SPIRE server then evaluates this information against its configured attestation policies and registration entries. If successful, the server generates an agent SVID and the Trust Bundle (CA Certificate) and securely sends this back to the agent.
+
+. A workload starts on the node and needs a secure identity. The workload connects to the agent's Workload API and requests a SVID.
+
+. The agent receives the request and begins a workload attestation to gather information about the workload.
+
+. After the agent gathers the information, the information is sent to the SPIRE server and the server checks its configured registration entries.
+
+. The agent receives the workload SVID and Trust Bundle and passes it on to the workload. The workload can now present their SVIDs to other SPIFFE-aware devices to communicate with them.
+
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://spiffe.io/docs/latest/deploying/registering/[Registering workloads]
+
+* link:https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/[SPIFFE Concepts]
+
+* link:https://spiffe.io/docs/latest/spire-about/use-cases/[SPIRE Use Cases]

--- a/modules/zero-trust-manager-install-cli.adoc
+++ b/modules/zero-trust-manager-install-cli.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manageer/zero-trust-manager-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-install-cli_{context}"]
+= Installing the {zero-trust-full} by using the CLI
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a new project named `zero-trust-workload-identity-manager` by running the following command:
++
+[source, terminal]
+----
+$ oc new-project zero-trust-workload-identity-manager
+----
+
+. Create an `OperatorGroup` object:
+
+.. Create a YAML file, for example, `operatorGroup.yaml`, with the following content:
++
+.Example `operatorGroup.yaml`
++
+[source, yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-zero-trust-workload-identity-manager
+  namespace: zero-trust-workload-identity-manager
+spec:
+  upgradeStrategy: Default
+----
+
+.. Create the `OperatorGroup` object by running the following command:
++
+[source, terminal]
+----
+$ oc create -f operatorGroup.yaml
+----
+
+. Create a `Subscription` object:
+
+.. Create a YAML file, for example, `subscription.yaml`, that defines the `Subscription` object:
++
+.Example `subscription.yaml`
++
+[source, yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-zero-trust-workload-identity-manager
+  namespace: zero-trust-workload-identity-manager
+spec:
+  channel: tech-preview-v0.1
+  name: openshift-zero-trust-workload-identity-manager
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+----
+
+.. Create the `Subscription` object by running the following command:
++
+[source, terminal]
+----
+$ oc create -f subscription.yaml
+----
+
+.Verification
+
+. Verify that the OLM subscription is created by running the following command:
++
+[source, terminal]
+----
+$ oc get subscription -n zero-trust-workload-identity-manager
+----
++
+.Example output
+[source, terminal]
+----
+NAME                                             PACKAGE                                SOURCE             CHANNEL
+openshift-zero-trust-workload-identity-manager   zero-trust-workload-identity-manager   redhat-operators   tech-preview-v0.1
+----
+
+. Verify whether the Operator is successfully installed by running the following command:
++
+[source, terminal]
+----
+$ oc get csv -n zero-trust-workload-identity-manager
+----
++
+.Example output
+[source, terminal]
+----
+NAME                                         DISPLAY                                VERSION  PHASE
+zero-trust-workload-identity-manager.v0.1.0   Zero Trust Workload Identity Manager   0.1.0    Succeeded
+----
+
+. Verify that the {zero-trust-full} controller manager is ready by running the following command:
++
+[source, terminal]
+----
+$ oc get deployment -l name=zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager
+----
++
+.Example output
+[source, terminal]
+----
+NAME                                                      READY   UP-TO-DATE   AVAILABLE   AGE
+zero-trust-workload-identity-manager-controller-manager   1/1     1            1           43m
+----

--- a/modules/zero-trust-manager-install-console.adoc
+++ b/modules/zero-trust-manager-install-console.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zer-trust-manager-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-install-console_{context}"]
+= Installing the {zero-trust-full} by using the web console
+
+You can use the web console to install the {zero-trust-full}.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Go to *Operators* -> *OperatorHub*.
+
+. Enter *{zero-trust-full}* into the filter box.
+
+. Select the *{zero-trust-full}*
+
+. Select the {zero-trust-full} version from *Version* drop-down list, and click *Install*.
+
+. On the *Install Operator* page:
+.. Update the *Update channel*, if necessary. The channel defaults to *tech-preview-v0.1*, which installs the latest Technology Preview v0.1 release of the {zero-trust-full}.
+.. Choose the *Installed Namespace* for the Operator. The default Operator namespace is `zero-trust-workload-identity-manager`.
++
+If the `zero-trust-workload-identity-manager` namespace does not exist, it is created for you.
+
+.. Select an *Update approval* strategy.
++
+* The *Automatic* strategy allows Operator Lifecycle Manager (OLM) to automatically update the Operator when a new version is available.
++
+* The *Manual* strategy requires a user with appropriate credentials to approve the Operator update.
+
+.. Click *Install*.
+
+.Verification
+
+. Navigate to *Operators* -> *Installed Operators*.
+. Verify that *{zero-trust-full}* is listed with a *Status* of *Succeeded* in the `zero-trust-workload-identity-manager` namespace.
+. Verify that {zero-trust-full} controller manager deployment is ready and available by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment -l name=zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                            READY   UP-TO-DATE    AVAILABLE  AGE
+zero-trust-workload-identity-manager-controller-manager-6c4djb  1/1     1             1          43m
+----

--- a/modules/zero-trust-manager-uninstall-console.adoc
+++ b/modules/zero-trust-manager-uninstall-console.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-uninstall.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-uninstall-console_{context}"]
+= Uninstalling the {zero-trust-full}
+
+You can uninstall the {zero-trust-full} by using the web console.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+* The {zero-trust-full} is installed.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+. Uninstall the {zero-trust-full}.
+.. Go to *Operators* -> *Installed Operators*.
+.. Click the *Options* menu next to the *{zero-trust-full}* entry, and then click *Uninstall Operator*.
+.. In the confirmation dialog, click *Uninstall*.

--- a/modules/zero-trust-manager-uninstall-resources.adoc
+++ b/modules/zero-trust-manager-uninstall-resources.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-uninstall.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-uninstall-resources-console_{context}"]
+= Uninstalling {zero-trust-full} resources by using the CLI
+
+After you have uninstalled the {zero-trust-full}, you have the option to delete its associated resources from your cluster.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Uninstall the operand objects by running each of the following commands:
++
+[source,terminal]
+----
+$ oc delete ZeroTrustWorkloadIdentityManager cluster
+$ oc delete SpireOIDCDiscoveryProvider cluster
+$ oc delete SpiffeCSIDriver cluster
+$ oc delete SpireAgent cluster
+$ oc delete SpireServer cluster
+----
+
+. Delete the Persistent Volume Claim (PVC) and services by running each of the following commands:
++
+[source,terminal]
+----
+$ oc delete pvc -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
+$ oc delete csidriver -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
+$ oc delete service -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
+----
+
+. Delete the namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete ns zero-trust-workload-identity-manager
+----
+
+. Delete the cluster-wide role-based access control (RBAC) by running each of the following commands:
++
+[source,terminal]
+----
+$ oc delete clusterrolebinding -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
+$ oc delete clusterrole -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
+----
+
+. Delete the admission wehhook configuration by running each of the following command:
++
+[source,terminal]
+----
+$ oc delete validatingwebhookconfigurations -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
+----
+
+. Delete the Custom Resource Definitions (CRDs) by running each of the following commands:
++
+[source,terminal]
+----
+$ oc delete crd spireservers.operator.openshift.io
+$ oc delete crd spireagents.operator.openshift.io
+$ oc delete crd spiffecsidrivers.operator.openshift.io
+$ oc delete crd spireoidcdiscoveryproviders.operator.openshift.io
+$ oc delete crd clusterfederatedtrustdomains.spire.spiffe.io
+$ oc delete crd clusterspiffeids.spire.spiffe.io
+$ oc delete crd clusterstaticentries.spire.spiffe.io
+$ oc delete crd zerotrustworkloadidentitymanagers.operator.openshift.io
+----
+
+.Verification
+
+To verify that the resources have been deleted, replace each `oc delete` command with `oc get`, and then run the command. If no resources are returned, the deletion was successful.

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-install.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-install.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="zero-trust-manager-install"]
+= Installing the {zero-trust-full}
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-install
+
+
+toc::[]
+
+:FeatureName: Zero Trust Workload Identity Manager for Red{nbsp}Hat OpenShift
+
+include::snippets/technology-preview.adoc[]
+
+The {zero-trust-full} is not installed in {product-title} by default. You can install the {zero-trust-full} by using either the web console or CLI.
+
+
+== Installing the {zero-trust-full}
+// Installing the {zero-trust-full} using the web console
+include::modules/zero-trust-manager-install-console.adoc[leveloffset=+2]
+
+// Installing the {zero-trust-full} using CLI
+include::modules/zero-trust-manager-install-cli.adoc[leveloffset=+2]
+

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-overview.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-overview.adoc
@@ -1,14 +1,37 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="zero-trust-manager-overview"]
-= zero trust workload identity manager for Red{nbsp}Hat OpenShift overview
+= Zero Trust Workload Identity Manager overview
 
 include::_attributes/common-attributes.adoc[]
 :context: zero-trust-manager-overview
 
 toc::[]
 
-:FeatureName: zero trust workload identity manager for Red{nbsp}Hat OpenShift
+:FeatureName: Zero Trust Workload Identity Manager
 
 include::snippets/technology-preview.adoc[]
 
+The {zero-trust-full} leverages {spiffe-full} and the SPIFFE Runtime Environment (SPIRE) to provide a comprehensive identity management solution for distributed systems. SPIFFE and SPIRE provide a standardized approach to workload identity, allowing workloads to communicate with other services whether on the same cluster, or in another environment.
+
+{zero-trust-full} replaces long-lived, manually managed secrets with cryptographically verifiable identities. It provides strong authentication ensuring workloads that are communicating with each other are who they claim to be. SPIRE automates the issuing, rotating, and revoking of a {svid-full}, reducing the workload of developers and administrators managing secrets.
+
+SPIFFE can work across diverse infrastructures including on-premise, cloud, and hybrid environments. SPIFFE identities are cryptographically enabled providing a basis for auditing and compliance.
+
+The following are components of the {zero-trust-full} architecture:
+
+//SPIFFE
+include::modules/zero-trust-manager-about-spiffe.adoc[leveloffset=+1]
+
+//SPIRE
+include::modules/zero-trust-manager-about-spire.adoc[leveloffset=+1]
+
+//SPIRE agent
+include::modules/zero-trust-manager-about-agent.adoc[leveloffset=+1]
+
+
+//Attestation
+include::modules/zero-trust-manager-about-attestation.adoc[leveloffset=+1]
+
+//How it works
+include::modules/zero-trust-manager-how-it-works.adoc[leveloffset=+1]
 

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-uninstall.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-uninstall.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="zero-trust-manager-uninstall"]
+= Uninstalling the {zero-trust-full}
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-uninstall
+
+toc::[]
+
+:FeatureName: Zero Trust Workload Identity Manager
+
+include::snippets/technology-preview.adoc[]
+
+You can remove the {zero-trust-full} from {product-title} by uninstalling the Operator and removing its related resources.
+
+// Uninstalling the {zero-trust-full}
+include::modules/zero-trust-manager-uninstall-console.adoc[leveloffset=+1]
+
+// Removing {zero-trust-full} resources
+include::modules/zero-trust-manager-uninstall-resources.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14525

Links to docs preview:

https://93011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-install.html
https://93011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-overview.html


QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.


Additional information:

