### PR TITLE
HCIDOCS-249: Metal3 Support for Network Controller Sideband Interface (NC-SI)

### DIFF
--- a/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.adoc
@@ -37,6 +37,13 @@ include::modules/bmo-editing-a-baremetalhost-resource.adoc[leveloffset=+2]
 include::modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc[leveloffset=+2]
 // Attaching a non-bootable ISO to a bare-metal node
 include::modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc[leveloffset=+2]
+// Configuring NC-SI and DisablePowerOff for shared NICs
+include::modules/bmo-configuring-ncsi-disable-poweroff.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
+
 // About the HostFirmwareSettings resource
 include::modules/bmo-about-the-hostfirmwaresettings-resource.adoc[leveloffset=+2]
 // Getting the HostFirmwareSettings resource

--- a/installing/installing_bare_metal/ipi/ipi-install-prerequisites.adoc
+++ b/installing/installing_bare_metal/ipi/ipi-install-prerequisites.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Installer-provisioned installation of {product-title} requires:
 
-ifdef::openshift-origin[. One provisioner node with {op-system-first} installed. The provisioner can be removed after installation.]
+ifdef::openshift-origin[. One provisioner node with {op-system-first} installed. You can remove the provisioner node after installation.]
 ifndef::openshift-origin[. One provisioner node with {op-system-base-full} {op-system-version} installed. The provisioner can be removed after installation.]
 . Three control plane nodes
 . Baseboard management controller (BMC) access to each node
@@ -37,7 +37,14 @@ include::modules/ipi-install-firmware-requirements-for-installing-with-virtual-m
 [role="_additional-resources"]
 .Additional resources
 
-xref:../../../installing/installing_bare_metal/ipi/ipi-install-troubleshooting.adoc#unable-to-discover-new-bare-metal-hosts-using-the-bmc_ipi-install-troubleshooting[Unable to discover new bare metal hosts using the BMC]
+xref:../../../installing/installing_bare_metal/ipi/ipi-install-troubleshooting.adoc#unable-to-discover-new-bare-metal-hosts-using-the-bmc_ipi-install-troubleshooting[Unable to discover new bare-metal hosts by using the BMC]
+
+include::modules/ipi-install-nc-si-hardware-requirements-for-bare-metal.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://specs.openstack.org/openstack/ironic-specs/specs/approved/nc-si.html[Ironic NC-SI Specification]
+* link:https://www.dmtf.org/sites/default/files/standards/documents/DSP0222_1.1.1.pdf[DMTF: Network Controller Sideband Interface (NC-SI) Specification]
 
 include::modules/ipi-install-network-requirements.adoc[leveloffset=+1]
 

--- a/modules/bmo-configuring-ncsi-disable-poweroff.adoc
+++ b/modules/bmo-configuring-ncsi-disable-poweroff.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="bmo-configuring-ncsi-disable-poweroff_{context}"]
+= Configuring NC-SI and DisablePowerOff for shared NICs
+
+The Network Controller Sideband Interface (NC-SI) enables the Baseboard Management Controller (BMC) to share a system network interface card (NIC) with the host for management traffic, using protocols like Redfish, IPMI, or vendor-specific interfaces. The `DisablePowerOff` feature prevents hard power-offs, ensuring soft reboots to maintain BMC connectivity.
+
+*Prerequisites*
+
+* NC-SI-capable hardware and NICs.
+* BMC configured with an IP address and network connection.
+* Administrative access to the BMC.
+* Access to the OpenShift cluster with `cluster-admin` privileges.
+
+*Procedure*
+
+. Configure the BMC to enable NC-SI for a shared NIC.
+
+. Verify BMC connectivity using Redfish or IPMI by running one of the following commands:
++
+[source,terminal]
+----
+$ curl -k https://<bmc_ip>/redfish/v1/Systems/1
+----
++
+[source,terminal]
+----
+$ ipmitool -I lanplus -H <bmc_ip> -U <user> -P <pass> power status
+----
+
+. Enable the `DisablePowerOff` feature by editing the `BareMetalHost` resource in the `openshift-machine-api` namespace:
++
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: example-host
+  namespace: openshift-machine-api
+spec:
+  online: true
+  bmc:
+    address: <protocol>://<bmc_ip>/<bmc_address_format>
+    credentialsName: bmc-secret
+  disablePowerOff: true
+----
++
+See the "BMC addressing" sections for details on supported protocols and BMC address formats.
+
+. Apply the changes by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+* Check the `BareMetalHost` status by running the following command:
++
+[source,terminal]
+----
+$ oc get baremetalhost example-host -n openshift-machine-api -o yaml
+----
++
+Confirm that `disablePowerOff: true` is in the `spec` section.
+
+* Test a reboot by restarting a node pod and verify that BMC connectivity remains active.
+* Attempt to set `BareMetalHost.spec.online=false`. It should fail with an error indicating power-off is disabled.

--- a/modules/ipi-install-nc-si-hardware-requirements-for-bare-metal.adoc
+++ b/modules/ipi-install-nc-si-hardware-requirements-for-bare-metal.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ncsi-hardware-requirements-for-bare-metal_{context}"]
+= NC-SI hardware requirements for bare metal
+
+To deploy {product-title} 4.19 and later with a Network Controller Sideband Interface (NC-SI) on bare metal, you must use hardware with baseboard management controllers (BMCs) and network interface cards (NICs) that support NC-SI. NC-SI enables the BMC to share a system NIC with the host, requiring the `DisablePowerOff` feature to prevent loss of BMC connectivity during power-offs.
+
+.Server compatibility for NC-SI
+[cols="1,1,2,3",options="header"]
+|====
+| Vendor | Models | Generation | Management
+| Dell | PowerEdge | 14th generation and later | iDRAC 9 and later (Redfish, IPMI, racadm, WS-MAN)
+| HPE | ProLiant | 10th generation and later | iLO 5 and later (Redfish, IPMI, iLO RESTful API)
+| Lenovo | ThinkSystem SR | 1st generation and later | XClarity Controller (Redfish, IPMI, proprietary APIs)
+| Supermicro | SuperServer | X11 series and later | Supermicro BMC (Redfish, IPMI, proprietary web/CLI)
+| Intel | Server Systems | S2600BP and later | Intel BMC (Redfish, IPMI, proprietary APIs)
+| Fujitsu | PRIMERGY | M4 series and later | iRMC S5 and later (Redfish, IPMI, proprietary web/CLI)
+| Cisco | UCS C-Series | M5 series and later | Cisco IMC (Redfish, IPMI, proprietary XML API)
+|====
+
+.Compatible Network Interface Cards (NICs) for NC-SI
+[cols="1,2,2",options="header"]
+|====
+| Vendor | Models | Specifications
+| Broadcom | NetXtreme BCM5720, BCM57416, BCM57504 | Gigabit and 10/25/100GbE, RMII sideband, supports Redfish, IPMI, and vendor protocols.
+| Intel | I210, X710, XXV710, E810 | Gigabit to 100GbE, RMII and SMBus sideband, supports Redfish, IPMI, and vendor protocols.
+| NVIDIA | ConnectX-5, ConnectX-6, ConnectX-7 | 25/50/100/200/400GbE, RMII sideband, supports Redfish, IPMI, and NVIDIA BMC APIs.
+| NVIDIA | BlueField-2 and later | 200/400GbE, supports Redfish, IPMI, and NVIDIA BMC APIs.
+| Marvell/Cavium | ThunderX CN88xx, FastLinQ QL41000 | 10/25/50GbE, RMII sideband, supports Redfish, IPMI, and vendor protocols.
+| Mellanox (NVIDIA) | MCX4121A-ACAT, MCX512A-ACAT | 10/25/50GbE, RMII sideband, supports Redfish, IPMI, and Mellanox APIs.
+|====
+
+[NOTE]
+====
+Verify NC-SI support with vendor documentation, because compatibility depends on BMC, NIC, and firmware configurations. NC-SI NICs require a compatible BMC to enable shared NIC functionality.
+====


### PR DESCRIPTION
Added content for network controller sideband interace.

Fixes: [HCIDOCS-249](https://issues.redhat.com//browse/HCIDOCS-249)

See https://issues.redhat.com/browse/HCIDOCS-249 for additional details.

Preview URL: https://93012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-post-installation-configuration.html#bmo-configuring-ncsi-disable-poweroff_ipi-install-post-installation-configuration and
https://93012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-prerequisites.html

For release(s): 4.19
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
