### PR TITLE
OSSM-8953 Add update approval strategy / channel guidance to operator install procedure

### DIFF
--- a/modules/ossm-installing-operator.adoc
+++ b/modules/ossm-installing-operator.adoc
@@ -24,10 +24,24 @@ For clusters without {SMProduct} instances, install the {SMProductShortName} Ope
 
 . Locate the {SMProductShortName} Operator, and click to select it.
 
-. When the prompt that discusses the community operator appears, click *Continue*.
+. When the prompt that discusses the community operator opens, click *Continue*.
 
-. Verify the {SMProductShortName} Operator is version 3.0, and click *Install*.
+. Click *Install*.
 
-. Use the default installation settings presented, and click *Install* to continue.
+. On the *Install Operator* page, perform the following steps:
 
-. Click *Operators* -> *Installed Operators* to verify that the {SMProductShortName} Operator is installed. `Succeeded` should appear in the *Status* column.
+.. Select *All namespaces on the cluster (default)* as the *Installation Mode*. This mode installs the Operator in the default `openshift-operators` namespace, which enables the Operator to watch and be available to all namespaces in the cluster.
+
+.. Select *Automatic* as the *Approval Strategy*. This ensures that the {olm-first} handles the future upgrades to the Operator automatically. If you select the *Manual* approval strategy, {olm} creates an update request. As a cluster administrator, you must then manually approve the {olm} update request to update the Operator to the new version.
+
+.. Select an *Update Channel*.
++
+* Choose the *stable* channel to install the latest stable version of the {SMProductName} 3 Operator. It is the default channel for installing the Operator.
++
+* To install a specific version of the {SMProductName} 3 Operator, choose the corresponding `stable-<version>` channel. For example, to install the {SMProductName} Operator version 3.0.x, use the *stable-3.0* channel.
+
+. Click *Install* to install the Operator.
+
+.Verification
+
+. Click *Operators* -> *Installed Operators* to verify that the {SMProductShortName} Operator is installed. `Succeeded` should show in the *Status* column.


### PR DESCRIPTION
Change type: Doc update; Add update approval strategy / channel guidance to operator install procedure

Doc JIRA: https://issues.redhat.com/browse/OSSM-8953

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://93016--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#ossm-installing-operator_ossm-about-deploying-istio-using-service-mesh-operator

SME Review/QE Review: @FilipB @longmuir 
Peer Review: @eromanova97 