### PR TITLE
OCPBUGS-51316-18: Added release version to RHCOS reference in 4.18 RN…

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. From the {hybrid-console}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.8 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported on {op-system-first}. To understand {op-system-base} versions used by {op-system}, see link:https://access.redhat.com/articles/6907891[{op-system-base} Versions Utilized by {op-system-first} and {product-title}] (Knowledgebase article).
+{product-title} {product-version} is supported on {op-system-base-full} 8.8 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported on {op-system-first} {product-version}. To understand {op-system-base} versions used by {op-system}, see link:https://access.redhat.com/articles/6907891[{op-system-base} Versions Utilized by {op-system-first} and {product-title}] (Knowledgebase article).
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines. {op-system-base} machines are deprecated in {product-title} 4.16 and will be removed in a future release.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
I will need to apply this update to other branches. The 4.18 PR will have the approvals. 


Version(s):
4.18

Issue:
[OCPBUGS-51316](https://issues.redhat.com/browse/OCPBUGS-51316)

Link to docs preview:
* [About this release](https://93036--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-about-this-release_release-notes)

- [x] SME has approved this change (Scott Dobson).
- [x] QE has approved this change (Aashish Radhakrishnan).
