### PR TITLE
remove temp fix for local page-loader.js

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -577,7 +577,7 @@
   <script src="https://docs.okd.io/latest/_javascripts/bootstrap-offcanvas.js" type="text/javascript"></script>
   <script src="https://docs.okd.io/latest/_javascripts/reformat-html.js" type="text/javascript"></script>
   <script src="https://docs.okd.io/latest/_javascripts/hc-search.js" type="text/javascript"></script>
-  <script src="/logging/main/_javascripts/page-loader.js" type="text/javascript"></script>
+  <script src="https://docs.okd.io/latest/_javascripts/page-loader.js" type="text/javascript"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" type="text/javascript"></script>
   <script src="https://docs.okd.io/latest/_javascripts/clipboard.js" type="text/javascript"></script>
   <script src="https://docs.okd.io/latest/_javascripts/collapsible.js" type="text/javascript"></script>


### PR DESCRIPTION

Version(s):
standalone-logging-docs-main

Issue:
standalone logging - remove temp page-loader fix

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
