### PR TITLE
[enterprise-4.12] OSDOCS-12755 adding admonition to only use marketplace images for compute nodes

### DIFF
--- a/modules/installation-aws-marketplace-subscribe.adoc
+++ b/modules/installation-aws-marketplace-subscribe.adoc
@@ -22,6 +22,13 @@ endif::[]
 = Obtaining an AWS Marketplace image
 If you are deploying an {product-title} cluster using an AWS Marketplace image, you must first subscribe through AWS. Subscribing to the offer provides you with the AMI ID that the installation program uses to deploy worker nodes.
 
+:platform-abbreviation: an AWS
+:platform-abbreviation-short: AWS
+[NOTE]
+====
+include::snippets/installation-marketplace-note.adoc[]
+====
+
 .Prerequisites
 
 * You have an AWS account to purchase the offer. This account does not have to be the same account that is used to install the cluster.

--- a/modules/installation-azure-marketplace-subscribe.adoc
+++ b/modules/installation-azure-marketplace-subscribe.adoc
@@ -35,9 +35,14 @@ endif::mapi[]
 * The offer includes a `rh-ocp-worker` SKU and a `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker` SKU represents a Hyper-V generation version 2 VM image. The default instance types used in {product-title} are version 2 compatible. If you plan to use an instance type that is only version 1 compatible, use the image associated with the `rh-ocp-worker-gen1` SKU. The `rh-ocp-worker-gen1` SKU represents a Hyper-V version 1 VM image.
 //What happens with control plane machines? "worker" SKU seems incorrect
 
+:platform-abbreviation: an Azure
+:platform-abbreviation-short: Azure
+
 [IMPORTANT]
 ====
 Installing images with the Azure marketplace is not supported on clusters with 64-bit ARM instances.
+
+include::snippets/installation-marketplace-note.adoc[]
 ====
 
 .Prerequisites

--- a/modules/installation-gcp-marketplace.adoc
+++ b/modules/installation-gcp-marketplace.adoc
@@ -10,6 +10,14 @@ Using the GCP Marketplace offering lets you deploy an {product-title} cluster, w
 
 By default, the installation program downloads and installs the {op-system-first} image that is used to deploy compute machines. To deploy an {product-title} cluster using an {op-system} image from the GCP Marketplace, override the default behavior by modifying the `install-config.yaml` file to reference the location of GCP Marketplace offer.
 
+:platform-abbreviation: a GCP
+:platform-abbreviation-short: GCP
+
+[NOTE]
+====
+include::snippets/installation-marketplace-note.adoc[]
+====
+
 .Prerequisites
 
 * You have an existing `install-config.yaml` file.

--- a/snippets/installation-marketplace-note.adoc
+++ b/snippets/installation-marketplace-note.adoc
@@ -1,0 +1,12 @@
+// Text snippet included in the following modules:
+//
+// * modules/installation-aws-marketplace-subscribe.adoc
+// * modules/installation-azure-marketplace-subscribe.adoc
+// * modules/installation-gcp-marketplace.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+You should only modify the {op-system} image for compute machines to use {platform-abbreviation} Marketplace image. Control plane machines and infrastructure nodes do not require an {product-title} subscription and use the public RHCOS default image by default, which does not incur subscription costs on your {platform-abbreviation-short} bill. Therefore, you should not modify the cluster default boot image or the control plane boot images. Applying the {platform-abbreviation-short} Marketplace image to them will incur additional licensing costs that cannot be recovered.
+
+:!platform-abbreviation:
+:!platform-abbreviation-short:


### PR DESCRIPTION
CP of 0ccdf8ecf5c0266340e0d7678befd024bea868bc

Version(s):
4.12 and 4.13
Removed the change to install config parameters file as the formatting changed in 4.14.
