### PR TITLE
Update CNV HCOVersion to 4.17.11

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -105,7 +105,7 @@ endif::[]
 //openshift virtualization (cnv)
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.17
-:HCOVersion: 4.17.7
+:HCOVersion: 4.17.11
 :CNVNamespace: openshift-cnv
 :CNVOperatorDisplayName: OpenShift Virtualization Operator
 :CNVSubscriptionSpecSource: redhat-operators


### PR DESCRIPTION
This PR updates the CNV HCOVersion attribute to 4.17.11.