### PR TITLE
OLS-1621: Document cluster interaction feature

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -23,3 +23,5 @@ include::modules/ols-about-lightspeed-and-role-based-access-control.adoc[levelof
 include::modules/ols-granting-access-to-individual-users.adoc[leveloffset=+2]
 include::modules/ols-granting-access-to-user-group.adoc[leveloffset=+2]
 include::modules/ols-filtering-and-redacting-information.adoc[leveloffset=+1]
+include::modules/ols-cluster-interaction-overview.adoc[leveloffset=+1]
+include::modules/ols-enabling-cluster-interaction.adoc[leveloffset=+2]

--- a/modules/ols-cluster-interaction-overview.adoc
+++ b/modules/ols-cluster-interaction-overview.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cluster-interaction-overview_{context}"]
+= Cluster interaction overview
+
+A large language model (LLM) is used with the {ols-long} service to generate responses to questions. Use the cluster interaction feature to enhance the knowledge available to the LLM with information about an {ocp-product-title} cluster. Providing cluster information, such as the namespaces or pods that the cluster contains, enables the LLM to generate highly customized responses for your environment.

--- a/modules/ols-enabling-cluster-interaction.adoc
+++ b/modules/ols-enabling-cluster-interaction.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-cluster-interaction_{context}"]
+= Enabling cluster interaction
+
+Modify the `OLSConfig` custom resource to enable the cluster interaction feature.
+
+:FeatureName: The cluster interaction feature
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role. Alternatively, you are logged in to a user account that has permission to create a cluster-scoped CR.
+
+* You have configured the large language model (LLM) provider.
+
+* You have installed the {ols-long} Operator.
+
+.Procedure 
+
+. In the {ocp-product-title} web console, click *Operators* -> *Installed Operators*. 
+
+. Click {ols-long} Operator.
+
+. Click *OLSConfig*, then click the `cluster` configuration instance in the list.
+
+. Click the *YAML* tab.
+
+. Set the `spec.ols.introspectionEnabled` parameter to `true` to enable cluster interaction: 
++
+.Example `OLSconfig` CR file
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+spec:
+  ols:
+    introspectionEnabled: true  
+----
+
+. Click *Save*.
+
+. Access the {ols-long} virtual assistant and submit a question associated with the custom content that was added to the LLM.
++
+The {ols-long} virtual assistant generates a response based on the custom content.

--- a/modules/snippets
+++ b/modules/snippets
@@ -1,0 +1,1 @@
+../snippets


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1621
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://93062--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#cluster-interaction-overview_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
