### PR TITLE
OSDOCS#14546: Update the z-stream RNs for 4.18.12

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3021,13 +3021,47 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.12
+[id="ocp-4-18-12_{context}"]
+=== RHSA-2025:4427 - {product-title} {product-version}.12 bug fix update and security update
+
+Issued: 08 May 2025
+
+{product-title} release {product-version}.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4427[RHSA-2025:4427] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4429[RHBA-2025:4429] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.12 --pullspecs
+----
+
+[id="ocp-4-18-12-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, a race condition in the hostname that handled the code caused inconsistencies between the boot and machine hostnames. With this release, the race condition is resolved, which ensures consistent hostnames in the Ignition configuration file during the operating system installation. (link:https://issues.redhat.com/browse/OCPBUGS-55364[OCPBUGS-55364])
+
+* Previously, a version of the installation program produced boot image update failures and region-specific user issues because of missing Amazon Machine Image (AMI) IDs in certain regions. With this release, when a region AMI is not found, the region defaults to the `us-east-1` AMI, and the installation program has reliable, default AMIs for all regions. (link:https://issues.redhat.com/browse/OCPBUGS-55290[OCPBUGS-55290])
+
+* Previously, when viewing the list of installed Operators and the currently selected project matches an Operator's default namespace while copied cluster service versions (CSV) are disabled in the Operator Lifecycle Manager (OLM), an Operator appeared twice in the list. With this release, the Operator appears one time. (link:https://issues.redhat.com/browse/OCPBUGS-55195[OCPBUGS-55195])
+
+* Previously, certain IP addresses in the `namedCertificates` server configuration conflicted with the internal API URLs. This condition caused users to experience configuration issues with the `HostedCluster` custom resource because of a subject alternative name (SAN) mismatch in the certificates. With this release, the conflicting SANs in the Kasm Workspaces agent (KAS) server certificates are resolved, ensuring proper configuration and improved service functionality. (link:https://issues.redhat.com/browse/OCPBUGS-54946[OCPBUGS-54946])
+
+* Previously, insufficient memory requests for proxy containers, such as `socks5-proxy`, `konnectivity-proxy`, `http-proxy`, and `client-token-minter`, often caused performance issues. With this release, memory requests for these containers are increased to 30 Megabytes and the steady-state performance is improved by providing more memory to the proxy containers. (link:https://issues.redhat.com/browse/OCPBUGS-54737[OCPBUGS-54737])
+
+[id="ocp-4-18-12-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.11
 [id="ocp-4-18-11_{context}"]
 === RHSA-2025:4211 - {product-title} {product-version}.11 bug fix update and security update
 
 Issued: 01 May 2025
 
-product-title} release {product-version}.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4213[RHBA-2025:4213] advisory.
+{product-title} release {product-version}.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4213[RHBA-2025:4213] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-14546](https://issues.redhat.com//browse/OSDOCS-14546)

Link to docs preview:
[4.18.12](https://93063--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html)

QE review:
- [ ] QE has approved this change.
Not required for z-stream release notes.

Additional information:
The errata URLs will return 404 until the go-live date of 05/08/25.
