### PR TITLE
handle subfolder for github pages

### DIFF
--- a/_javascripts/page-loader.js
+++ b/_javascripts/page-loader.js
@@ -5,8 +5,15 @@ let fileRequested = "";
 
 // Get the base URL dynamically
 function getBaseUrl() {
+  const path = window.location.pathname;
+  const pathParts = path.split('/').filter(part => part.length > 0);
 
-  // Fallback to current origin
+  // Check if we're in the openshift-docs subdirectory for github pages
+  if (pathParts.length > 0 && pathParts[0] === 'openshift-docs') {
+    return `${window.location.protocol}//${window.location.host}/openshift-docs/`;
+  }
+
+  // If not in the openshift-docs subdirectory, use the root
   return `${window.location.protocol}//${window.location.host}/`;
 }
 


### PR DESCRIPTION
Version(s):
main only

Issue:
standalone logging docs - fix up version drop down for github pages

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
