### PR TITLE
OCPBUGS-55738 numaresources-operator docs have a mistake in the mustg…

### DIFF
--- a/modules/cnf-about-collecting-nro-data.adoc
+++ b/modules/cnf-about-collecting-nro-data.adoc
@@ -20,5 +20,5 @@ You can use the `oc adm must-gather` CLI command to collect information about yo
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image=registry.redhat.io/numaresources-must-gather/numaresources-must-gather-rhel9:v{product-version}
+$ oc adm must-gather --image=registry.redhat.io/openshift4/numaresources-must-gather-rhel9:v{product-version}
 ----


### PR DESCRIPTION
[OCPBUGS-55738]: numaresources-operator docs have a mistake in the mustgather command

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-55738
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://93074--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-about-collecting-nro-data_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
