### PR TITLE
standalone logging - sudo only for gh actions

### DIFF
--- a/.github/workflows/docs-package-workflow.yml
+++ b/.github/workflows/docs-package-workflow.yml
@@ -1,0 +1,112 @@
+name: Package Documentation
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package type to build'
+        required: true
+        default: 'commercial'
+        type: string
+      branch:
+        description: 'Branch to use from openshift-docs'
+        required: true
+        default: 'standalone-logging-docs-main'
+        type: string
+      repo:
+        description: 'Repository to clone'
+        required: true
+        default: 'https://github.com/openshift/openshift-docs.git'
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        run: |
+          mkdir -p build
+          sudo apt-get update
+          sudo apt-get install -y git
+
+          # Install mikefarah/yq version which has different syntax from python-yq
+          wget https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64 -O /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Setup Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run package script
+        run: |
+          cd build
+          export PACKAGE="${{ github.event.inputs.package }}"
+          export BRANCH="${{ github.event.inputs.branch }}"
+          export REPO="${{ github.event.inputs.repo }}"
+          export CONTAINER_ENGINE="docker"
+
+          # Copy the package.sh script from scripts folder to build directory
+          cp ../scripts/package.sh ./
+          chmod +x package.sh
+
+          # Run the packaging script
+          ./package.sh
+          rm -f package.sh
+
+      - name: Move generated content
+        run: |
+          # Create or clear the docs directory in the repository root
+          rm -rf docs
+          mkdir -p docs
+
+          # Copy the packaged content to the docs directory
+          cp -r build/_package/* docs/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: packaged-docs
+          path: docs/
+
+      - name: Create or update gh-pages branch
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+          # Create a temporary branch
+          git checkout -b temp-docs-branch
+
+          # Add the docs directory
+          git add docs/
+
+          # Commit the changes
+          git commit -m "Update packaged documentation" || echo "No changes to commit"
+
+          # Try to create the gh-pages branch if it doesn't exist, or update it if it does
+          git fetch origin gh-pages || true
+          if git show-ref --quiet refs/remotes/origin/gh-pages; then
+            # gh-pages branch exists, update it
+            git checkout gh-pages
+            git rm -rf . || true
+            git checkout temp-docs-branch -- docs/
+            git mv docs/* . || true
+            rmdir docs || true
+            git add .
+            git commit -m "Update GitHub Pages content" || echo "No changes to commit"
+          else
+            # Create gh-pages branch
+            git checkout --orphan gh-pages
+            git rm -rf . || true
+            git checkout temp-docs-branch -- docs/
+            git mv docs/* . || true
+            rmdir docs || true
+            git add .
+            git commit -m "Initial GitHub Pages content" || echo "No changes to commit"
+          fi
+
+          git push origin gh-pages

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -10,6 +10,13 @@ CONTAINER_ENGINE="${CONTAINER_ENGINE:-podman}"
 # By default, use container for building, but allow using local asciibinder
 USE_LOCAL="${USE_LOCAL:-false}"
 
+# Determine if sudo is needed (typically only in GHA if files are created by root in container)
+SUDO_CMD=""
+if [ "$GITHUB_ACTIONS" == "true" ]; then
+  echo "Running in GitHub Actions. Sudo prefix will be used if necessary."
+  SUDO_CMD="sudo"
+fi
+
 ## CLONE REPO
 echo "---> Cloning docs from $BRANCH branch in $REPO"
 # Clone OpenShift Docs into current directory
@@ -46,8 +53,8 @@ fi
 ## MOVING FILES INTO THE RIGHT PLACES
 rm -rf ../_package
 mkdir -p ../_package
-sudo mv _package/${PACKAGE}/* ../_package/
+$SUDO_CMD mv _package/${PACKAGE}/* ../_package/
 git checkout $BRANCH
 
 cd ..
-sudo rm -rf .docs_source
+$SUDO_CMD rm -rf .docs_source


### PR DESCRIPTION
Version(s):
standalone-logging-docs-main

Issue:
standalone logging - github action to package content

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a