### PR TITLE
MIG-1726: Release notes for MTC 1.8.7

### DIFF
--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,7 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-7.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-6.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-5.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-4.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-7.adoc
+++ b/modules/migration-mtc-release-notes-1-8-7.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes-1-7.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-7_{context}"]
+= {mtc-full} 1.8.7 release notes
+
+[id="resolved-issues-1-8-7_{context}"]
+== Resolved issues
+
+{mtc-first} 1.8.7 has the following major resolved issues:
+
+.{mtc-short} migration stuck in a `Prepare` phase on {product-title} 4.19 due to incompatible {oadp-short} version and outdated DPA specification
+
+When running migrations use {mtc-short} 1.8.7 on {product-title} 4.19, the process halts in the `Prepare` phase and the migration plan enters in the `Suspended` phase.
+
+The root cause is the deployment of an incompatible {oadp-short} version, earlier than 1.5.0, whose DataProtectionApplication (DPA) specification format is incompatible with {product-title}. link:https://issues.redhat.com/browse/MIG-1735[(MIG-1735)]
+
+.Velero backup fails with a `file already closed` error when using the new {aws-short} plugin in {mtc-short}
+
+During stage or full migrations, the backup process intermittently fails for {mtc-short} with {oadp-short} on {product-title} clusters configured with the new {aws-first} plugin. You can see the following error in Velero logs:
+
+[source,terminal]
+----
+error="read |0: file already closed"
+----
+
+As a workaround, use the legacy {aws-short} plugin by performing following actions:
+
+. Set `velero_use_legacy_aws: true` in the `MigrationController` custom resource (CR).
+
+. Restart the {mtc-short} Operator to apply changes.
+
+. Validate the {aws-short} credentials for the cloud-credentials secret.
+
+link:https://issues.redhat.com/browse/MIG-1738[(MIG-1738)]


### PR DESCRIPTION
### JIRA

* [MIG-1726](https://issues.redhat.com/browse/MIG-1726)

### Version(s):

* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19

### Link to docs preview:

* [Migration Toolkit for Containers 1.8.7 release notes](https://93078--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes.html#migration-mtc-release-notes-1-8-7_mtc-release-notes)

### QE review:
- [x] QE has approved this change.
