### PR TITLE
OLS-1347: Document using TLSConfig in CRD

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -15,6 +15,7 @@ The instructions assume that you are installing {ols-long} using the `kubeadmin`
 
 include::modules/ols-creating-the-credentials-secret-using-web-console.adoc[leveloffset=+1]
 include::modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc[leveloffset=+1]
+include::modules/ols-configuring-custom-tls-certificates.adoc[leveloffset=+2]
 include::modules/ols-creating-the-credentials-secret-using-cli.adoc[leveloffset=+1]
 include::modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc[leveloffset=+1]
 include::modules/ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm.adoc[leveloffset=+2]

--- a/modules/ols-configuring-custom-tls-certificates.adoc
+++ b/modules/ols-configuring-custom-tls-certificates.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-custom-tls-certificates_{context}"]
+= Configuring custom TLS certificates
+
+Configure custom TLS certificates for secure {ols-long} service communication.
+
+.Prerequisites
+
+* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role. Alternatively, you are logged in to a user account that has permission to create or edit the `OLSConfig` custom resource (CR).
+
+* You have a large language model (LLM) provider.
+
+* You have installed the {ols-long} Operator.
+
+* You have created the credentials secret and the `OLSconfig` CR.
+
+.Procedure 
+
+. In the {ocp-product-title} web console, click *Operators* -> *Installed Operators*. 
+
+. Select *All Projects* in the  *Project* dropdown at the top of the screen.
+
+. Click {ols-long} Operator.
+
+. Click *OLSConfig*, then click the `cluster` configuration instance in the list.
+
+. Click the *YAML* tab.
+
+. Modify the `OLSconfig` CR to contain the file that contains the TLS secret.
++
+.Example credentials secret and the `OLSconfig` CR file
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata: 
+  name: cluster
+spec: 
+  ols: 
+    tlsConfig: 
+      keyCertSecretRef: 
+        name: <lightspeed_tls> <1>
+---
+apiVersion: v1
+data: 
+  tls.crt: LS0tLS1CRUd... <2>
+  tls.key: LS0tLS1CRUd...
+kind: Secret
+metadata: 
+  name: <lightspeed_tls>
+  namespace: <openshift_lightspeed>
+----
+<1> Refers to the secret that contains the `tls.crt` and `tls.key` file.
+<2> The name of the certificate must be `tls.crt` and the name of the key must be `tls.key`.
+
+. Click *Save*.
+
+.Verification
+
+. Verify that a new pod was created in the `lightspeed-app-server` deployment by running the following command:
++
+[source,terminal]
+----
+$ oc get pod -n openshift-lightspeed
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                     READY   STATUS    RESTARTS   AGE
+lightspeed-app-server-5b45d6dd99-5599w                   2/2     Running   2          8h
+lightspeed-console-plugin-88d878686-tjt5p                1/1     Running   1          8d
+lightspeed-operator-controller-manager-7d7cc4588-p7442   1/1     Running   9          8d
+lightspeed-postgres-server-5484fcfdfc-kcpjh              1/1     Running   2          8d
+----


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1347
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://93111--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#configuring-custom-tls-certificates_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
