### PR TITLE
CNV-56323: Added UI procedure for VM interface link state

### DIFF
--- a/modules/virt-configuring-interface-link-state-web.adoc
+++ b/modules/virt-configuring-interface-link-state-web.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-setting-interface-link-state.adoc
+
+:_mod-docs-content-type: PROCEDURE                                  
+[id="virt-configuring-interface-link-state-web_{context}"]
+= Setting the VM interface link state by using the web console
+
+You can set the link state of a primary or secondary virtual machine (VM) network interface by using the web console.
+
+.Prerequisites
+* You are logged into the {product-title} web console.
+
+.Procedure
+. Navigate to *Virtualization* -> *VirtualMachines*.
+
+. Select a VM to view the *VirtualMachine details* page.
+
+. On the *Configuration* tab, click *Network*. A list of network interfaces is displayed.
+
+. Click the Options menu {kebab} of the interface that you want to edit.
+
+. Choose the appropriate option to set the interface link state:
+** If the current interface link state is `up`, select *Set link down*.
+** If the current interface link state is `down`, select *Set link up*.

--- a/virt/vm_networking/virt-setting-interface-link-state.adoc
+++ b/virt/vm_networking/virt-setting-interface-link-state.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
                                                                
 toc::[]                                                         
 
-You can manage the link state of a primary or secondary virtual machine (VM) interface by using the CLI. By specifying the link state, you can logically connect or disconnect the virtual network interface controller (vNIC) from a network.
+You can manage the link state of a primary or secondary virtual machine (VM) interface by using the {product-title} web console or the CLI. By specifying the link state, you can logically connect or disconnect the virtual network interface controller (vNIC) from a network.
 
 [NOTE]
 ====
@@ -17,6 +17,8 @@ You can specify the desired link state when you first create a VM, by editing th
 
 :FeatureName: Setting the VM interface link state
 include::snippets/technology-preview.adoc[]
+
+include::modules/virt-configuring-interface-link-state-web.adoc[leveloffset=+1]
 
 include::modules/virt-configuring-interface-link-state.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-56323](https://issues.redhat.com//browse/CNV-56323)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://93115--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-setting-interface-link-state.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
