### PR TITLE
OSDOCS-14472: CPMS custom machine name prefixes

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-configuration.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-configuration.adoc
@@ -17,6 +17,18 @@ include::modules/cpmso-yaml-sample-cr.adoc[leveloffset=+1]
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
 
+[id="cpmso-config-options_{context}"]
+== Control plane machine set configuration options
+
+You can configure your control plane machine set to customize your cluster to your needs.
+
+//Adding a custom prefix to control plane machine names
+include::modules/cpmso-config-options.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-replace_cpmso-managing-machines[Replacing a control plane machine]
+
 [id="cpmso-sample-yaml-provider-specific_{context}"]
 == Provider-specific configuration options
 

--- a/modules/cpmso-config-options.adoc
+++ b/modules/cpmso-config-options.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cpmso-config-prefix_{context}"]
+= Adding a custom prefix to control plane machine names
+
+You can customize the prefix of machine names that the control plane machine set creates.
+This can be done by editing the `ControlPlaneMachineSet` custom resource (CR).
+
+.Procedure
+
+. Edit the `ControlPlaneMachineSet` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit controlplanemachineset.machine.openshift.io cluster \
+  -n openshift-machine-api
+----
+
+. Edit the `.spec.machineNamePrefix` field of the `ControlPlaneMachineSet` CR:
++
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+  machineNamePrefix: <machine_prefix>
+# ...
+----
++
+where `<machine_prefix>` specifies a prefix name that follows the requirements for a lowercase RFC 1123 subdomain.
++
+[IMPORTANT]
+====
+A lowercase RFC 1123 subdomain must consist of only lowercase alphanumeric characters, hyphens ('-'), and periods ('.').
+Each block, separated by periods, must start and end with an alphanumeric character.
+Hyphens are not allowed at the start or end of a block, and consecutive periods are not permitted.
+====
+
+. Save your changes.
+
+.Next steps
+
+* If you changed only the value of the `machineNamePrefix` parameter, clusters that use the default `RollingUpdate` update strategy are not automatically updated.
+To propagate this change, you must replace your control plane machines manually, regardless of the update strategy for the cluster.
+For more information, see "Replacing a control plane machine".


### PR DESCRIPTION
[OSDOCS-14472](https://issues.redhat.com/browse/OSDOCS-14472)

Version(s): 4.19+

This PR adds a feature to add custom prefixes to machine names in control plane machine sets.

QE review:
- [x] QE has approved this change.

Preview: [Control plane machine set configuration options](https://93119--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration.html#cpmso-config-options_cpmso-configuration)
