### PR TITLE
TELCODOCS-2300: Clarifying network config limitations for IBI

### DIFF
--- a/modules/ibi-create-standalone-config-iso.adoc
+++ b/modules/ibi-create-standalone-config-iso.adoc
@@ -57,14 +57,8 @@ controlPlane:
   name: master
   replicas: 1
 networking:
-  clusterNetwork:
-  - cidr: 10.128.0.0/14
-    hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.200.0/24
-  networkType: OVNKubernetes
-  serviceNetwork:
-  - 172.30.0.0/16
 platform:
   none: {}
 fips: false
@@ -78,7 +72,7 @@ sshKey: 'ssh-rsa <your_ssh_pub_key>'
 If your cluster deployment requires a proxy configuration, you must do the following:
 
 * Create a seed image from a seed cluster featuring a proxy configuration. The proxy configurations do not have to match.
-* Configure the machineNetwork field in your installation manifest.
+* Configure the `machineNetwork` field in your installation manifest.
 ====
 --
 

--- a/modules/ibi-image-based-install-cluster-guide.adoc
+++ b/modules/ibi-image-based-install-cluster-guide.adoc
@@ -7,13 +7,17 @@
 
 For a successful image-based installation and deployment, see the following guidelines.
 
+[id="ibi-cluster-guidelines_{context}"]
 == Cluster guidelines
 
 * If you are using {rh-rhacm-first}, to avoid including any {rh-rhacm} resources in your seed image, you need to disable all optional {rh-rhacm} add-ons before generating the seed image.
 
+[id="ibi-seed-cluster-guidelines_{context}"]
 == Seed cluster guidelines
 
 * If your cluster deployment at the edge of the network requires a proxy configuration, you must create a seed image from a seed cluster featuring a proxy configuration. The proxy configurations do not have to match.
+
+* The `clusterNetwork` and `serviceNetwork` network configurations in the seed cluster persist to the deployed cluster. The Lifecycle Agent embeds these settings in the seed image. You cannot change these settings later in the image-based installation and deployment process.
 
 * If you set a maximum transmission unit (MTU) in the seed cluster, you must set the same MTU value in the static network configuration for the image-based configuration ISO.
 


### PR DESCRIPTION
[TELCODOCS-2300](https://issues.redhat.com//browse/TELCODOCS-2300): Clarifying network config limitations for IBI

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2300

Link to docs preview:
- https://93143--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install-standalone.html#create-standalone-config-iso_ibi-edge-image-based-install
- https://93143--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi-understanding-image-based-install.html#seed-cluster-guidelines


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

