### PR TITLE
MCO 4.19 release notes for Pinned Images and MachineConfigNodes

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -458,10 +458,10 @@ For more information, see xref:../updating/preparing_for_updates/updating-cluste
 [id="ocp-release-notes-machine-config-operator_{context}"]
 === Machine Config Operator
 
-[id="ocp-release-notes-machine-config-operator-mcn-ga_{context}"]
+[id="ocp-release-notes-machine-config-operator-pis_{context}"]
 ==== Pin and preload images
 
-In clusters with slow and unreliable connections to an image registry you can use a `PinnedImageSet` object to _preload_ the required images by pulling them in advance, before they are actually needed. Then _pin_ them to a machine config pool, ensuring that the images are available when needed. The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster.  For more information, see _About pinning and preloading images_.
+In clusters with slow, unreliable connections to an image registry you can use a `PinnedImageSet` object to _preload_ the required images by pulling them in advance, before they are actually needed. Then _pin_ them to a machine config pool, ensuring that the images are available when needed. The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster.  For more information, see _About pinning and preloading images_.
 
 [id="ocp-release-notes-machine-config-operator-mcn-ga_{context}"]
 ==== Machine config node is now generally available

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -459,9 +459,9 @@ For more information, see xref:../updating/preparing_for_updates/updating-cluste
 === Machine Config Operator
 
 [id="ocp-release-notes-machine-config-operator-pis_{context}"]
-==== Pin and preload images
+==== Pinned images
 
-In clusters with slow, unreliable connections to an image registry you can use a `PinnedImageSet` object to _preload_ the required images by pulling them in advance, before they are actually needed. Then _pin_ them to a machine config pool, ensuring that the images are available when needed. The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster.  For more information, see _About pinning and preloading images_.
+In clusters with slow, unreliable connections to an image registry you can use a `PinnedImageSet` object to pull the images in advance, before they are actually needed, then associate those images with a machine config pool. This ensures that the images are available when needed.  The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster.  For more information, see _About pinning and preloading images_.
 
 [id="ocp-release-notes-machine-config-operator-mcn-ga_{context}"]
 ==== Machine config node is now generally available

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -461,7 +461,7 @@ For more information, see xref:../updating/preparing_for_updates/updating-cluste
 [id="ocp-release-notes-machine-config-operator-mcn-ga_{context}"]
 ==== Pin and preload images
 
-In clusters with slow and unreliable connections to an image registry you can _preload_ the required images by pulling them in advance, before they are actually needed. Then _pin_ them to a machine config pool, ensuring that the images are available when needed. For more information, see _About pinning and preloading images_.
+In clusters with slow and unreliable connections to an image registry you can use a `PinnedImageSet` object to _preload_ the required images by pulling them in advance, before they are actually needed. Then _pin_ them to a machine config pool, ensuring that the images are available when needed. The `must-gather` for the Machine Config Operator now includes a list of the `PinnedImageSet` objects in the cluster.  For more information, see _About pinning and preloading images_.
 
 [id="ocp-release-notes-machine-config-operator-mcn-ga_{context}"]
 ==== Machine config node is now generally available

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -461,12 +461,12 @@ For more information, see xref:../updating/preparing_for_updates/updating-cluste
 [id="ocp-release-notes-machine-config-operator-mcn-ga_{context}"]
 ==== Pin and preload images
 
-In clusters with slow and unreliable connections to an image registry you can use a `PinnedImageSet` object to _preload_ the required images by pulling them in advance, before they are actually needed. Then _pin_ them to a machine config pool, ensuring that the images are available when needed. The `must-gather` for the Machine Config Operator now includes a list of the `PinnedImageSet` objects in the cluster.  For more information, see _About pinning and preloading images_.
+In clusters with slow and unreliable connections to an image registry you can use a `PinnedImageSet` object to _preload_ the required images by pulling them in advance, before they are actually needed. Then _pin_ them to a machine config pool, ensuring that the images are available when needed. The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster.  For more information, see _About pinning and preloading images_.
 
 [id="ocp-release-notes-machine-config-operator-mcn-ga_{context}"]
 ==== Machine config node is now generally available
 
-With the promotion to General Availability, you can now view the status of updates to custom machine config pools in addition to the control plane and worker pools. The functionality for the feature has not changed. However, some of the information in the command output and in the status fields in the `MachineConfigNode` object has been updated. The `must-gather` for the Machine Config Operator now includes data from the `MachineConfigNode` object. For more information, see _About checking machine config node status_.
+With the promotion to General Availability, you can now view the status of updates to custom machine config pools in addition to the control plane and worker pools. The functionality for the feature has not changed. However, some of the information in the command output and in the status fields in the `MachineConfigNode` object has been updated. The `must-gather` for the Machine Config Operator now includes all `MachineConfigNodes` objects in the cluster. For more information, see _About checking machine config node status_.
 
 [id="ocp-release-notes-management-console_{context}"]
 === Management console

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -458,6 +458,16 @@ For more information, see xref:../updating/preparing_for_updates/updating-cluste
 [id="ocp-release-notes-machine-config-operator_{context}"]
 === Machine Config Operator
 
+[id="ocp-release-notes-machine-config-operator-mcn-ga_{context}"]
+==== Pin and preload images
+
+In clusters with slow and unreliable connections to an image registry you can _preload_ the required images by pulling them in advance, before they are actually needed. Then _pin_ them to a machine config pool, ensuring that the images are available when needed. For more information, see _About pinning and preloading images_.
+
+[id="ocp-release-notes-machine-config-operator-mcn-ga_{context}"]
+==== Machine config node is now generally available
+
+With the promotion to General Availability, you can now view the status of updates to custom machine config pools in addition to the control plane and worker pools. The functionality for the feature has not changed. However, some of the information in the command output and in the status fields in the `MachineConfigNode` object has been updated. The `must-gather` for the Machine Config Operator now includes data from the `MachineConfigNode` object. For more information, see _About checking machine config node status_.
+
 [id="ocp-release-notes-management-console_{context}"]
 === Management console
 


### PR DESCRIPTION
[Pinned Images](https://issues.redhat.com/browse/OSDOCS-14467) is slated for a 4.19.z release.
[MachineConfigNodes GA](https://issues.redhat.com/browse/OSDOCS-14404) is either 4.19 or 4.19.z, undetermined as of 5/8.

I moved the release nodes from my [MCO/Node 4.19 release notes PR](https://github.com/openshift/openshift-docs/pull/92358) to here until needed. 