### PR TITLE
4.13 MIG-1690: Release Notes for MTC 1.7.19

### DIFF
--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.adoc
@@ -17,6 +17,8 @@ You can migrate from xref:../../migrating_from_ocp_3_to_4/about-migrating-from-3
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-7-19.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-18.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-17.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-16.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-15.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-7-18.adoc
+++ b/modules/migration-mtc-release-notes-1-7-18.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes-1-7.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-18_{context}"]
+= {mtc-full} 1.7.18 release notes
+
+{mtc-first} 1.7.18 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {mtc-short} 1.7.17.
+
+[id="technical-changes-1-7.18_{context}"]
+== Technical changes
+
+{mtc-first} 1.7.18 has the following technical changes:
+
+.Federal Information Processing Standard (FIPS)
+
+FIPS is a set of computer security standards developed by the United States federal government in accordance with the Federal Information Security Management Act (FISMA).
+
+Starting with version 1.7.18, {mtc-short} is designed for FIPS compliance.

--- a/modules/migration-mtc-release-notes-1-7-19.adoc
+++ b/modules/migration-mtc-release-notes-1-7-19.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes-1-7.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-19_{context}"]
+= {mtc-full} 1.7.19 release notes
+
+{mtc-first} 1.7.19 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {mtc-short} 1.7.18.
+
+[id="resolved-issues-1-7-19_{context}"]
+== Resolved issues
+
+This release has the following resolved issues:
+
+.`python3-requests` package vulnerability
+
+A bug was introduced when building the {mtc-short} Operator for the 1.7.19 release. During QE testing, this bug meant that when attempting to install {mtc-short} 1.7.19 from the OperatorHub, the migration-operator pod failed during startup. The logs indicated that the Ansible Runner was crashing with an unhandled `KeyError: 'http+unix'` issue. The {mtc-short} Operator was in an incomplete state, and the required controller pods were never deployed, which rendered the Operator non-functional. This issue was caused by the `python3-requests` package.
+
+The workaround was to downgrade to the last known working version of the `python3-requests` package, used in {mtc-short} 1.7.19, to `python3-requests-2.20.0-3.el8_8.noarch`. However, this action does mean exposure to the following vulnerability, link:https://access.redhat.com/errata/RHSA-2023:4520[RHSA-2023:4520].
+
+[id="known-issues-1-7-19_{context}"]
+== Known issues
+
+.The restore fails due to a missing backup storage location
+
+Currently, if the backup storage location is not specified, application migration fails. link:https://issues.redhat.com/browse/MIG-1649[(MIG-1649)]
+
+Workaround: Roll back and then restart the migration.


### PR DESCRIPTION
### CHERRY PICKED

* Cherry Picked from f05977660afcce461cf7388b58cc08e55e951ccd xref: https://github.com/openshift/openshift-docs/pull/89354

### JIRA 

* [MIG-1690](https://issues.redhat.com/browse/MIG-1690)

### Version(s):

* 4.13

### Link to docs preview:

* [Migration Toolkit for Containers 1.7.19 release notes](https://93145--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.html#migration-mtc-release-notes-1-7-19_mtc-release-notes)

* [Migration Toolkit for Containers 1.7.18 release notes](https://93145--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.html#migration-mtc-release-notes-1-7-18_mtc-release-notes)

### QE review:

- [X ] QE has approved this change. - [LINK](https://github.com/openshift/openshift-docs/pull/89354#pullrequestreview-2813382038)

- For QE approval for `migration-mtc-release-notes-1-7-18.adoc` , see [MIG-1673: Release notes for MTC 1.7.18](https://github.com/openshift/openshift-docs/pull/86689)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
