### PR TITLE
OSDOCS-13801 remove Egress IP admonition for HCP

### DIFF
--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -9,11 +9,6 @@ toc::[]
 
 As a cluster administrator, you can configure the OVN-Kubernetes Container Network Interface (CNI) network plugin to assign one or more egress IP addresses to a namespace, or to specific pods in a namespace.
 
-[IMPORTANT]
-====
-Configuring egress IPs is not supported for {hcp-title} clusters at this time. 
-====
-
 // Egress IP address architectural design and implementation
 include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Removed admonition now that Egress IPs are available in HCP

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-13801
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://93148--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html

QE review:
QE not required


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
