### PR TITLE
CNV#57866 4.19: autoResourceLimits documentation needs update

### DIFF
--- a/modules/virt-about-cpu-and-memory-quota-namespace.adoc
+++ b/modules/virt-about-cpu-and-memory-quota-namespace.adoc
@@ -9,5 +9,3 @@
 A _resource quota_, defined by the `ResourceQuota` object, imposes restrictions on a namespace that limit the total amount of compute resources that can be consumed by resources within that namespace.
 
 The `HyperConverged` custom resource (CR) defines the user configuration for the Containerized Data Importer (CDI). The CPU and memory request and limit values are set to a default value of `0`. This ensures that pods created by CDI that do not specify compute resource requirements are given the default values and are allowed to run in a namespace that is restricted with a quota.
-
-When the `AutoResourceLimits` feature gate is enabled, {VirtProductName} automatically manages CPU and memory limits. If a namespace has both CPU and memory quotas, the memory limit is set to double the base allocation and the CPU limit is one per vCPU.

--- a/modules/virt-setting-resource-quota-limits-for-vms.adoc
+++ b/modules/virt-setting-resource-quota-limits-for-vms.adoc
@@ -6,7 +6,22 @@
 [id="virt-setting-resource-quota-limits-for-vms_{context}"]
 = Setting resource quota limits for virtual machines
 
-Resource quotas that only use requests automatically work with virtual machines (VMs). If your resource quota uses limits, you must manually set resource limits on VMs. Resource limits must be at least 100 MiB larger than resource requests.
+By default, {VirtProductName} automatically manages CPU and memory limits for virtual machines (VMs) if a namespace enforces resource quotas that require limits to be set. The memory limit is automatically set to twice the requested memory and the CPU limit is set to one per vCPU.
+
+You can customize the memory limit ratio for a specific namespace by adding the `alpha.kubevirt.io/auto-memory-limits-ratio` annotation to the namespace. For example, the following command sets the memory limit ratio to 1.2:
+
+[source,terminal]
+----
+$ oc annotate namespace my-virtualization-project alpha.kubevirt.io/auto-memory-limits-ratio=1.2
+----
+
+[WARNING]
+====
+Avoid managing resource quota limits manually. To prevent misconfigurations or scheduling issues, rely on the automatic resource limit management provided by {VirtProductName} unless you have a specific need to override the defaults.
+====
+
+
+Resource quotas that only use requests automatically work with VMs. If your resource quota uses limits, you must manually set resource limits on VMs. Resource limits must be at least 100 MiB larger than resource requests.
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/CNV-57866

Link to docs preview:
https://93162--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-working-with-resource-quotas-for-vms.html

https://93162--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-cdi-for-namespace-resourcequota.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
