### PR TITLE
[OSDOCS- 14613]Add warning to users about resources being consumed even if a cluster fails

### DIFF
--- a/modules/create-wif-cluster-cli.adoc
+++ b/modules/create-wif-cluster-cli.adoc
@@ -200,6 +200,11 @@ $ ocm create cluster <cluster_name> \ <1>
 If an {product-title} version is specified, the version must also be supported by the assigned WIF configuration. If a version is specified that is not supported by the assigned WIF configuration, cluster creation will fail.  If this occurs, update the assigned WIF configuration to the desired version or create a new WIF configuration with the desired version in the --version <osd_version> field.
 ====
 
+[IMPORTANT]
+====
+If your cluster deployment fails during installation, certain resources created during the installation process are not automatically removed from your {GCP} account. To remove these resources from your GCP account, you must delete the failed cluster.
+====
+
 [id="ocm-cli-list-wif-commands_{context}"]
 == Listing WIF clusters
 

--- a/modules/create-wif-cluster-ocm.adoc
+++ b/modules/create-wif-cluster-ocm.adoc
@@ -208,12 +208,15 @@ In the event of critical security concerns that significantly impact the securit
 +
 . Optional: On the *Overview* tab, you can enable the delete protection feature by selecting *Enable*, which is located directly under *Delete Protection: Disabled*. This will prevent your cluster from being deleted. To disable delete protection, select *Disable*.
 By default, clusters are created with the delete protection feature disabled.
-+
 
 .Verification
 
 * You can monitor the progress of the installation in the *Overview* page for your cluster. You can view the installation logs on the same page. Your cluster is ready when the *Status* in the *Details* section of the page is listed as *Ready*.
 
+[IMPORTANT]
+====
+If your cluster deployment fails during installation, certain resources created during the installation process are not automatically removed from your {GCP} account. To remove these resources from your GCP account, you must delete the failed cluster.
+====
 ifeval::["{context}" == "osd-creating-a-cluster-on-aws"]
 :!osd-on-aws:
 endif::[]

--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -261,3 +261,7 @@ If you delete a cluster that was installed into a GCP Shared VPC, inform the VPC
 
 * You can monitor the progress of the installation in the *Overview* page for your cluster. You can view the installation logs on the same page. Your cluster is ready when the *Status* in the *Details* section of the page is listed as *Ready*.
 
+[IMPORTANT]
+====
+If your cluster deployment fails during installation, certain resources created during the installation process are not automatically removed from your {GCP} account. To remove these resources from your GCP account, you must delete the failed cluster.
+====

--- a/modules/osd-create-cluster-red-hat-account.adoc
+++ b/modules/osd-create-cluster-red-hat-account.adoc
@@ -114,8 +114,12 @@ In the event of critical security concerns that significantly impact the securit
 +
 . Optional: On the *Overview* tab, you can enable the delete protection feature by selecting *Enable*, which is located directly under *Delete Protection: Disabled*. This will prevent your cluster from being deleted. To disable delete protection, select *Disable*.
 By default, clusters are created with the delete protection feature disabled.
-+
 
 .Verification
 
 * You can monitor the progress of the installation in the *Overview* page for your cluster. You can view the installation logs on the same page. Your cluster is ready when the *Status* in the *Details* section of the page is listed as *Ready*.
+
+[IMPORTANT]
+====
+If your cluster deployment fails during installation, certain resources created during the installation process are not automatically removed from your {GCP} account. To remove these resources from your GCP account, you must delete the failed cluster.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-14613
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://93166--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.html#osd-create-gcp-cluster-ccs_osd-creating-a-gcp-cluster-rh-account

https://93166--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-sa.html#osd-create-gcp-cluster-ccs1_osd-creating-a-cluster-on-gcp-sa

https://93166--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.html#create-wif-cluster-ocm_osd-creating-a-cluster-on-gcp-with-workload-identity-federation

https://93166--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.html#create-wif-cluster_osd-creating-a-cluster-on-gcp-with-workload-identity-federation

QE review:
- [ ] QE has approved this change. NO QE needed as I have tested and behavior is verified by SME here: https://issues.redhat.com/browse/OCM-15540
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
