### PR TITLE
DOC: Explain how to opt-out of boot image update in 4.18

### DIFF
--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -7,7 +7,7 @@
 [id="mco-update-boot-images-disable_{context}"]
 = Disabling updated boot images
 
-To disable the updated boot image feature, edit the `MachineConfiguration` object to remove the `managedBootImages` stanza.
+To disable the updated boot image feature, edit the `MachineConfiguration` object so that the `machineManagers` field is an empty array.
 
 If you disable this feature after some nodes have been created with the new boot image version, any existing nodes retain their current boot image. Turning off this feature does not rollback the nodes or machine sets to the originally-installed boot image. The machine sets retain the boot image version that was present when the feature was enabled and is not updated again when the cluster is upgraded to a new {product-title} version in the future.
 
@@ -20,7 +20,7 @@ If you disable this feature after some nodes have been created with the new boot
 $ oc edit MachineConfiguration cluster
 ----
 
-. Remove the `managedBootImages` stanza:
+. Make the `machineManagers` parameter an empty array:
 +
 [source,yaml]
 ----
@@ -32,10 +32,6 @@ metadata:
 spec:
 # ...
   managedBootImages: <1>
-    machineManagers:
-    - resource: machinesets
-      apiGroup: machine.openshift.io
-      selection:
-        mode: All
+    machineManagers: []
 ----
-<1> Remove the entire stanza to disable updated boot images.
+Remove the parameters  that are listed under `machineManagers` and add the `[]` characters to disable the updating of boot images.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14599

Preview:
[Disabling updated boot images](https://93167--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-disable_machine-configs-configure) - Updated existing module.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
