### PR TITLE
OSDOCS-13197 add anchor tag to the resource responsibilities table

### DIFF
--- a/modules/rosa-policy-change-management.adoc
+++ b/modules/rosa-policy-change-management.adoc
@@ -69,6 +69,11 @@ Because the required permissions can change between y-stream releases, the polic
 
 You can review the history of all cluster upgrade events in the {cluster-manager} web console. For more information about releases, see the link:https://access.redhat.com/support/policy/updates/openshift/dedicated[Life Cycle policy].
 
+[id="rosa-policy-resource-responsibilities_{context}"]
+== Service and Customer resource responsibilities
+
+The following table defines the responsibilities for cluster resources. 
+
 [cols="2a,3a,3a",options="header"]
 |===
 


### PR DESCRIPTION
Added a title to customer and service resource responsibility table. 

Version(s):
4.18+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-13197


Link to docs preview:
https://93168--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-resource-responsibilities_rosa-policy-responsibility-matrix

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
