### PR TITLE
HCIDOCS-218: Static dual-stack bootstrap network configuration

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -9,10 +9,20 @@ endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id='modifying-install-config-for-dual-stack-network_{context}']
-= Deploying with dual-stack networking
+= Deploying IP addressing with dual-stack networking
+
+When deploying IP addressing with dual-stack networking for the bootstrap virtual machine (VM), the bootstrap VM functions with a single IP version.
+
+[NOTE]
+====
+The following examples are for DHCP. DHCP-based dual stack clusters can deploy with one IPv4 and one IPv6 virtual IP address (VIP) each from Day 1.
+
+Deploying a cluster with static IP addresses involves configuring IP addresses for the bootstrap VM, API, and ingress VIPs. Configuring dual-stack with a static IP set in `install-config` requires one VIP each for API and ingress. Add secondary VIPs after deployment.
+====
 
 For dual-stack networking in {product-title} clusters, you can configure IPv4 and IPv6 address endpoints for cluster nodes. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. For a cluster with the IPv4 family as the primary address family, specify the IPv4 setting first. For a cluster with the IPv6 family as the primary address family, specify the IPv6 setting first.
 
+.Example NMState YAML configuration file that includes the IPv4 and IPv6 address endpoints for cluster nodes
 [source,yaml]
 ----
 machineNetwork:


### PR DESCRIPTION
**Fixes:** [HCIDOCS-218](https://issues.redhat.com/browse/HCIDOCS-218)

**For:** OCP 4.11-4.17

[**Preview**](https://93170--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow)

**Approvals -** `/lgtm`:
- [x] SME
- [x] Peer Review
**Note:** QE approval unnecessary; this PR is editorial, not procedural.