### PR TITLE
OSDOCS-10892: Allocating load balancers to specific subnets

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1672,6 +1672,9 @@ Topics:
   - Name: Patching existing ingress objects
     File: configuring-ingress-cluster-patch-fields
     Distros: openshift-enterprise,openshift-origin
+  - Name: Allocating load balancers to specific subnets
+    File: allocating-load-balancers
+    Distros: openshift-enterprise,openshift-origin
   # Kubernetes NMState (TECHNOLOGY PREVIEW)
 - Name: Kubernetes NMState
   Dir: k8s_nmstate

--- a/modules/nw-allocate-load-balancers-to-subnets-procedure.adoc
+++ b/modules/nw-allocate-load-balancers-to-subnets-procedure.adoc
@@ -1,0 +1,124 @@
+// Module included in the following assemblies:
+//
+// *networking/allocating-load-balancers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-allocating-load-balancers-to-subnets-procedure_{context}"]
+= Specifying AWS subnets for OpenShift API and ingress load balancers at installation
+
+Perform the following steps to allocate API and ingress load balancers to specific subnets.
+
+.Prerequisites
+
+Before you begin, ensure you have:
+
+* An existing AWS virtual private cloud (VPC).
+
+* Pre-configured AWS subnets intended for use by the OpenShift cluster, with the following considerations:
+
+** You have a list of their subnet IDs (for example, `subnet-0123456789abcdef0`). These IDs will be used in the `install-config.yaml` file.
+
+** Use subnets spanning at least two availability zones (AZs) for high availability of load balancers and other critical components, like control planes.
+
+** You have sufficient available IP addresses within these subnets for all assigned roles.
+
+** The AWS configuration for these subnets, including network ACLs and security groups, must permit necessary traffic for all roles assigned to them. For subnets hosting an ingress controller, this typically includes TCP ports 80 and 443 from required sources.
+
+* You have the OpenShift installer binary for your target OpenShift version.
+
+* You have an `install-config.yaml` file.
+
+.Procedure
+
+. Prepare the `install-config.yaml` file:
++
+If you haven't already, generate the installation configuration file using the OpenShift installer:
++
+[source,terminal]
+----
+$ openshift-install create install-config --dir=<your_installation_directory>
+----
++
+This command creates the `install-config.yaml` file in the specified directory.
+
+. Define subnets and assign roles:
++
+Open the `install-config.yaml` file located in `<your_installation_directory>` using a text editor. You will define your VPC subnets and their designated roles under the `platform.aws.vpc.subnets` field.
++
+For each AWS subnet you intend the cluster to use, you will create an entry specifying its `id` and a list of `roles`. Each role is an object with a `type` key. To designate a subnet for the default Ingress Controller, assign it a role with `type: IngressControllerLB`.
++
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com <1>
+metadata:
+  name: my-cluster # Example cluster name
+platform:
+  aws:
+    region: us-east-1 <2>
+    vpc: <3>
+      subnets: <4>
+      - id: subnet-0fcf8e0392f0910d5 # Public Subnet in AZ us-east-1a <5>
+        roles:
+        - type: IngressControllerLB <6>
+        - type: BootstrapNode
+      - id: subnet-0xxxxxxxxxxxxxxza # Public Subnet in another AZ for HA
+        roles:
+        - type: IngressControllerLB
+      - id: subnet-0fcf8e0392f0910d4 # Private Subnet in AZ us-east-1a
+        roles:
+        - type: ClusterNode <7>
+      - id: subnet-0yyyyyyyyyyyyyyzb # Private Subnet in another AZ for HA
+        roles:
+        - type: ClusterNode
+      # Add other subnet IDs and their roles as needed for your cluster architecture
+pullSecret: '...' <8>
+sshKey: '...' <9>
+----
+<1> Your base domain.
+<2> Your AWS region.
+<3> The vpc object under `platform.aws` contains the subnets list.
+<4> List of all subnet objects that OpenShift will use. Each object defines a subnet id and its roles.
+<5> Replace with your AWS Subnet ID. 
+<6> The `type: IngressControllerLB` role specifically designates this subnet for the default Ingress Controller's LoadBalancer. In private/internal cluster, the subnet with `IngressControllerLB` role must be private.
+<7> The `type: ClusterNode` role designates this subnet for control plane and compute nodes. These are typically private subnets.
+<8> Your pull secret.
+<9> Your SSH key.
++
+Entries for control plane load balancers in the `subnets` list would follow a similar pattern:
++
+[source,yaml]
+----
+# ... (within platform.aws.vpc.subnets list)
+      - id: subnet-0fcf8e0392f0910d6 # Public Subnet for External API LB
+        roles:
+        - type: ControlPlaneExternalLB
+      - id: subnet-0fcf8e0392f0910d7 # Private Subnet for Internal API LB
+        roles:
+        - type: ControlPlaneInternalLB
+# ...
+----
++
+For the default public Ingress Controller, any subnet assigned the `IngressControllerLB` role in your `install-config.yaml` file must be a public subnet. For example, it must have a route table entry in AWS that directs outbound traffic to an internet gateway (IGW).
++
+Ensure you list all necessary subnets, public and private across the AZs, and assign them appropriate roles according to your cluster architecture. 
++
+Subnet IDs define the subnets in an existing VPC and can optionally specify their intended roles. If no roles are specified on any subnet, the subnet roles are decided automatically. In this case, the VPC must not contain any other non-cluster subnets without the `kubernetes.io/cluster/<cluster-id>` tag.
++
+If roles are specified for subnets, each subnet must have at least one assigned role, and the `ClusterNode`, `BootstrapNode`, `IngressControllerLB`, `ControlPlaneExternalLB`, and `ControlPlaneInternalLB` roles must be assigned to at least one subnet. However, if the cluster scope is internal, `ControlPlaneExternalLB` is not required.
+
+. Proceed with the cluster Installation:
++
+After saving your changes to the `install-config.yaml` file, create the cluster:
++
+[source,terminal]
+----
+$ openshift-install create cluster --dir=<your_installation_directory>
+----
++
+The installation program will now use the subnet definitions and explicit role assignments from the `platform.aws.vpc.subnets` section of your `install-config.yaml` file to provision cluster resources, including placing the Ingress Controller's LoadBalancer in the subnets you designated with the `IngressControllerLB` role.
+
+[NOTE]
+====
+The role assignment mechanism within `platform.aws.vpc.subnets`, such as specifying types like `IngressControllerLB`, `ClusterNode`, `ControlPlaneExternalLB`, `ControlPlaneInternalLB`, `BootstrapNode` is the comprehensive way the OpenShift installer identifies suitable subnets for various cluster services and components.
+====

--- a/modules/nw-allocating-load-balancers-to-subnets.adoc
+++ b/modules/nw-allocating-load-balancers-to-subnets.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// *networking/allocating-load-balancers.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-allocating-load-balancers-to-subnets_{context}"]
+= Allocating API and Ingress Load Balancers to Specific Subnets on AWS
+
+You can control the network placement of OpenShift Load Balancers on AWS, including those for the Ingress Controller, by explicitly defining your virtual private cloud's (VPC's) subnets and assigning them specific roles directly within the `platform.aws.vpc.subnets` section of the `install-config.yaml` file. This method provides granular control over which subnets are used for resources, such as the Ingress Controller and other cluster components.

--- a/networking/configuring_ingress_cluster_traffic/allocating-load-balancers.adoc
+++ b/networking/configuring_ingress_cluster_traffic/allocating-load-balancers.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="allocating-load-balancers"]
+= Allocating Load Balancers to Specific Subnets
+include::_attributes/common-attributes.adoc[]
+:context: allocating-load-balancers
+
+toc::[]
+
+You can manage application traffic efficiently by allocating load balancers. Network administrators can allocate load balancers to customize deployments which can ensure optimal traffic distribution, high availability of applications, uninterrupted service, and network segmentation.
+
+// Allocating API and Ingress Load Balancers to Specific Subnets on AWS
+include::modules/nw-allocating-load-balancers-to-subnets.adoc[leveloffset=+1]
+
+// Specifying AWS Subnets for OpenShift Ingress Load Balancers at Installation
+include::modules/nw-allocate-load-balancers-to-subnets-procedure.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10892](https://issues.redhat.com//browse/OSDOCS-10892)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://93173--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/allocating-load-balancers.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
