### PR TITLE
HCIDOCS-699: Missing documentation for BMO configuration

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -465,10 +465,10 @@ Topics:
       File: ipi-install-installing-a-cluster
     - Name: Troubleshooting the installation
       File: ipi-install-troubleshooting
-    - Name: Postinstallation configuration
-      File: ipi-install-post-installation-configuration
-    - Name: Expanding the cluster
-      File: ipi-install-expanding-the-cluster
+  - Name: Postinstallation configuration
+    File: bare-metal-postinstallation-configuration
+  - Name: Expanding the cluster
+    File: bare-metal-expanding-the-cluster
 - Name: Installing IBM Cloud Bare Metal (Classic)
   Dir: installing_ibm_cloud_classic
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc
@@ -1,0 +1,41 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="bare-metal-expanding-the-cluster"]
+= Expanding the cluster
+include::_attributes/common-attributes.adoc[]
+:context: bare-metal-expanding
+
+toc::[]
+
+After deploying a bare-metal cluster, you can use the following procedures to expand the number of worker nodes. Ensure that each prospective worker node meets the prerequisites.
+
+[NOTE]
+====
+Expanding the cluster using RedFish Virtual Media involves meeting minimum firmware requirements. See *Firmware requirements for installing with virtual media* in the *Prerequisites* section for additional details when expanding the cluster using RedFish Virtual Media.
+====
+
+include::modules/ipi-install-preparing-the-bare-metal-node.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow[Optional: Configuring host network interfaces in the install-config.yaml file] for details on configuring the NMState syntax.
+* See xref:../../scalability_and_performance/managing-bare-metal-hosts.adoc#automatically-scaling-machines-to-available-bare-metal-hosts_managing-bare-metal-hosts[Automatically scaling machines to the number of available bare-metal hosts] for details on automatically scaling machines.
+
+include::modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-the-unhealthy-etcd-member[Replacing an unhealthy etcd member]
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[Backing up etcd]
+
+* xref:../../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-config-using-bare-metal-operator_bare-metal-post-installation-configuration[Configuration using the Bare Metal Operator]                                                                      
+
+* xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
+
+include::modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc[leveloffset=+1]
+
+include::modules/ipi-install-diagnosing-duplicate-mac-address.adoc[leveloffset=+1]
+
+include::modules/ipi-install-provisioning-the-bare-metal-node.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+++ b/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
@@ -1,0 +1,65 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="bare-metal-post-installation-configuration"]
+= Postinstallation configuration
+include::_attributes/common-attributes.adoc[]
+:context: bare-metal-post-installation-configuration
+
+toc::[]
+
+After successfully deploying a bare-metal cluster, consider the following postinstallation procedures.
+
+// Configuring NTP for disconnected clusters
+include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+1]
+
+// Enabling a provisioning network after installation
+include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
+
+// Creating a manifest object that includes a customized `br-ex` bridge
+include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+
+// Services for a user-managed load balancer
+include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
+
+// Configuring a user-managed load balancer
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
+
+// Using the Bare Metal Operator
+include::modules/bmo-config-using-bare-metal-operator.adoc[leveloffset=+1]
+// Bare Metal Operator architecture
+include::modules/bmo-bare-metal-operator-architecture.adoc[leveloffset=+2]
+// About the BareMetalHost resource
+include::modules/bmo-about-the-baremetalhost-resource.adoc[leveloffset=+2]
+// Getting the BareMetalHost resource
+include::modules/bmo-getting-the-baremetalhost-resource.adoc[leveloffset=+2]
+// Editing a BareMetalHost resource
+include::modules/bmo-editing-a-baremetalhost-resource.adoc[leveloffset=+2]
+// Troubleshooting latency.
+include::modules/bmo-troubleshooting-latency-when-deleting-a-baremetalhost-resource.adoc[leveloffset=+2]
+// Attaching a non-bootable ISO to a bare-metal node
+include::modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc[leveloffset=+2]
+// About the HostFirmwareSettings resource
+include::modules/bmo-about-the-hostfirmwaresettings-resource.adoc[leveloffset=+2]
+// Getting the HostFirmwareSettings resource
+include::modules/bmo-getting-the-hostfirmwaresettings-resource.adoc[leveloffset=+2]
+// Editing the HostFirmwareSettings resource
+include::modules/bmo-editing-the-hostfirmwaresettings-resource-of-a-provisioned-host.adoc[leveloffset=+2]
+// Patching the HostFirmawareSettings resource
+include::modules/bmo-performing-a-live-update-to-the-hostfirmwaresettings-resource.adoc[leveloffset=+2]
+// Verifying the HostFirmware Settings resource is valid
+include::modules/bmo-verifying-the-hostfirmware-settings-resource-is-valid.adoc[leveloffset=+2]
+// About the FirmwareSchema resource
+include::modules/bmo-about-the-firmwareschema-resource.adoc[leveloffset=+2]
+// Getting the FirmwareSchema resource
+include::modules/bmo-getting-the-firmwareschema-resource.adoc[leveloffset=+2]
+// About the HostFirmwareComponents resource
+include::modules/bmo-about-the-hostfirmwarecomponents-resource.adoc[leveloffset=+2]
+// Getting the HostFirmwareComponents resource
+include::modules/bmo-getting-the-hostfirmwarecomponents-resource.adoc[leveloffset=+2]
+// Editing the HostFirmwareComponents resource
+include::modules/bmo-editing-the-hostfirmwarecomponents-resource-of-a-provisioned-host.adoc[leveloffset=+2]
+// Patching the HostFirmawareComponents resource
+include::modules/bmo-performing-a-live-update-to-the-hostfirmwarecomponents-resource.adoc[leveloffset=+2]
+// About the HostUpdatePolicy resource
+include::modules/bmo-about-the-hostupdatepolicy-resource.adoc[leveloffset=+2]
+// Setting the HostUpdatePolicy resource
+include::modules/bmo-setting-the-hostupdatepolicy-resource.adoc[leveloffset=+2]


### PR DESCRIPTION
Raised IPI postinstallation configuration and expanding the cluster up a level.

Fixes: [HCIDOCS-699](https://issues.redhat.com//browse/HCIDOCS-699)

See https://issues.redhat.com/browse/HCIDOCS-699 for additional details.

Preview URL: http://jowilkin.com:8080/HCIDOCS-699/welcome/index.html

For release(s): 4.17-4.19
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
