### PR TITLE
OSDOCS#12145: Adds release notes for the unified perspectives

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -523,13 +523,13 @@ For more information, see xref:../security/tls-security-profiles.adoc#tls-profil
 [id="ocp-release-notes-web-console_{context}"]
 === Web console
 
-[id="ocp-administrator-perspective_{context}"]
-==== Administrator perspective
+Starting with {product-title} 4.19, the perspectives in the web console have unified to simplify navigation, reduce context switching, streamline tasks, and provide users with a more cohesive {product-title} experience.
 
-[id="ocp-developer-perspective_{context}"]
-==== Developer Perspective
+With this unified design, there is no longer a *Developer* perspective in the default view; however, _all_ {product-title} web console features are discoverable to all users. If you are not the cluster owner, you might need to request permission for certain features from the cluster owner. The *Developer* perspective can still be manually enabled if you prefer.
 
-This release introduces the following updates to the *Developer* perspective of the web console:
+The *Getting Started* pane in the web console provides resources such as, a tour of the console, information on setting up your cluster, a quick start for enabling the *Developer* perspective, and links to explore new features and capabilities.
+
+//See xref:../web_console/web-console-overview#enabling-developer-perspective_web-console_web-console-overview for more information on enabling the *Developer* perspective.
 
 [id="ocp-4-19-notable-technical-changes_{context}"]
 == Notable technical changes


### PR DESCRIPTION
With this release the OCP UI perspectives are unifying. This should be called out somewhere at the beginning of the release notes since it is a noticeable technical change, and the docs will also get some significant updating. I have moved the web console release notes to the top of the release notes.

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-12145

Link to docs preview:
https://93187--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-web-console_release-notes

QE review:
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
