### PR TITLE
OSDOCS-14603: assembly and module creation for ESO docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -60,7 +60,8 @@ endif::[]
 :rh-rhacm-version: 2.13
 :osc: OpenShift sandboxed containers
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
-:external-secrets-operator: external secrets Operator for Red Hat OpenShift
+:external-secrets-operator: External Secrets Operator for Red Hat OpenShift
+:external-secrets-operator-short: External Secrets Operator
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
 :secondary-scheduler-operator: Secondary Scheduler Operator
 :descheduler-operator: Kube Descheduler Operator

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1231,12 +1231,20 @@ Topics:
     File: cert-manager-log-levels
   - Name: Uninstalling the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-operator-uninstall
-- Name: External secrets Operator for Red Hat OpenShift
+- Name: External Secrets Operator for Red Hat OpenShift
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
-  - Name: External secrets Operator for Red Hat OpenShift overview
+  - Name: External Secrets Operator overview
     File: index
+  - Name: External Secrets Operator release notes
+    File: external-secrets-operator-release-notes
+  - Name: Installing the External Secrets Operator
+    File: external-secrets-operator-install
+  - Name: Monitoring the External Secrets Operator
+    File: external-secrets-operator-monitoring
+  - Name: Uninstalling the External Secrets Operator
+    File: external-secrets-operator-uninstall
 - Name: Viewing audit logs
   File: audit-log-view
 - Name: Configuring the audit log policy

--- a/modules/external-secrets-about.adoc
+++ b/modules/external-secrets-about.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-about_{context}"]
+= About the {external-secrets-operator}
+
+Use the {external-secrets-operator} to integrate link:https://external-secrets.io/latest/[external-secrets] application with the {product-title} cluster. The `external-secrets` application fetches secrets stored in the external providers such as link:https://aws.amazon.com/secrets-manager/[AWS Secrets Manager], link:https://developer.hashicorp.com/vault[HashiCorp Vault], link:https://cloud.google.com/security/products/secret-manager[Google Secrets Manager], link:https://azure.microsoft.com/en-us/products/key-vault/[Azure Key Vault], link:https://www.ibm.com/products/secrets-manager[{ibm-cloud-title} Secrets Manager], link:https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html[AWS Systems Manager Parameter Store] and integrates them with Kubernetes in a secure manner.
+
+Using the {external-secrets-operator-short} ensures the following:
+
+* Decouples applications from the secret-lifecycle management.
+* Centralizes secret storage to support compliance requirements.
+* Enables secure and automated secret rotation.
+* Supports multi-cloud secret sourcing with fine-grained access control.
+* Centralizes and audits access control.
+
+[IMPORTANT]
+====
+Do not attempt to use more than one {external-secrets-operator-short} in your cluster. If you have a community {external-secrets-operator-short} installed in your cluster, you must uninstall it before installing the {external-secrets-operator}.
+====
+
+For more information about `external-secrets` application, see link:https://external-secrets.io/latest/[external-secrets].
+
+Use the {external-secrets-operator-short} to authenticate with the external secrets store, retrieve secrets, and inject the retrieved secrets into a native Kubernetes secret. This method removes the need for applications to directly access or manage external secrets.

--- a/modules/external-secrets-enable-metrics.adoc
+++ b/modules/external-secrets-enable-metrics.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-metrics_{context}"]
+= Enabling monitoring for the {external-secrets-operator} by using a service monitor
+
+Enable monitoring and metrics collection for the {external-secrets-operator} by using a service monitor to perform the custom metrics scraping.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* The {external-secrets-operator-short} is installed.
+
+.Procedure
+
+. Enable cluster monitoring by labeling the {external-secrets-operator-short} namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace external-secrets-operator openshift.io/cluster-monitoring=true
+----
+
+. Create a YAML file that defines the `Role`, `RoleBinding`, and `ServiceMonitor` objects:
++
+.Example `monitoring.yaml` file
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-k8s
+  namespace: external-secrets-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: external-secrets-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: external-secrets-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: external-secrets-operator
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+  name: external-secrets
+  namespace: external-secrets-operator
+spec:
+  endpoints:
+  - interval: 30s
+    port: tcp-prometheus-servicemonitor
+    scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: external-secrets
+      app.kubernetes.io/name: external-secrets
+----
+
+. Create the `Role`, `RoleBinding`, and `ServiceMonitor` objects by running the following command:
++
+[source,terminal]
+----
+$ oc create -f monitoring.yaml
+----

--- a/modules/external-secrets-fips-support.adoc
+++ b/modules/external-secrets-fips-support.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-fips-support_{context}"]
+= About FIPS compliance for {external-secrets-operator}
+
+The {external-secrets-operator} supports FIPS compliance. When running on {product-title} in FIPS mode, {external-secrets-operator-short} uses the RHEL cryptographic libraries submitted to NIST for FIPS validation on the x86_64, ppc64le, and s390X architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic module validation program]. For more information about the latest NIST status for the individual versions of the RHEL cryptographic libraries submitted for validation, see link:https://access.redhat.com/articles/2918071#fips-140-2-and-fips-140-3-2[Compliance activities and government standards].
+
+To enable FIPS mode, install the {external-secrets-operator-short} on an {product-title} cluster that runs in FIPS mode. For more information, see "Do you need extra security for your cluster?".

--- a/modules/external-secrets-operator-install-cli.adoc
+++ b/modules/external-secrets-operator-install-cli.adoc
@@ -1,0 +1,124 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-install-cli_{context}"]
+= Installing the {external-secrets-operator} by using the CLI
+
+You can use the command-line interface (CLI) to install the {external-secrets-operator}.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a new project named `external-secrets-operator` by running the following command:
++
+[source,terminal]
+----
+$ oc new-project external-secrets-operator
+----
+
+. Create an `OperatorGroup` object by defining a YAML file with the following content:
++
+.Example `operatorGroup.yaml` file
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  targetNamespaces: []
+  - "external-secrets-operator"
+  spec:{}
+----
+
+. Create the `OperatorGroup` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f operatorGroup.yaml
+----
+
+. Create a `Subscription` object by defining a YAML file with the following content:
++
+.Example `subscription.yaml` file
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  channel: stable-v1
+  name: openshift-external-secrets-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+----
+
+. Create the `Subscription` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f subscription.yaml
+----
+
+.Verification
+
+. Verify that the {olm} subscription is created by running the following command:
++
+[source,terminal]
+----
+$ oc get subscription -n external-secrets-operator
+----
++
+.Example output
+[source,terminal]
+----
+//content to be added
+----
+
+. Verify whether the Operator is successfully installed by running the following command:
++
+[source,terminal]
+----
+$ oc get csv -n external-secrets-operator
+----
++
+.Example output
+[source,terminal]
+----
+//content to be added
+----
+
+. Verify that the status of the {external-secrets-operator-short} is `Running` by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secrets-operator
+----
++
+.Example output
+[source,terminal]
+----
+// content to be added
+----
+
+. Verify that the status of the `external-secrets` pods is `Running` by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secrets
+----
++
+.Example output
+[source,terminal]
+----
+// content to be added
+----

--- a/modules/external-secrets-operator-install-console.adoc
+++ b/modules/external-secrets-operator-install-console.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-install-console_{context}"]
+= Installing the {external-secrets-operator} by using the web console
+
+You can use the web console to install the {external-secrets-operator}.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Navigate to *Operators* -> *OperatorHub*.
+
+. Enter *{external-secrets-operator-short}* in the search box.
+
+. Select the *{external-secrets-operator}* from the generated list and click *Install*.
+//+
+//[NOTE]
+//====
+//place holder for TechPreview release details or See supported {external-secrets-operator-short} versions in the following "Additional resources" section.
+//====
+. On the *Install Operator* page:
+
+.. Update the *Update channel*, if necessary. The channel defaults to *name to be added*, which installs the latest stable release of the {external-secrets-operator-short}.
+
+.. Select the version from *Version* drop-down list.
+
+.. Choose the *Installed Namespace* for the Operator.
++
+* To use the default Operator namespace, select the *Operator recommended Namespace* option.
++
+* To use the namespace that you created, select the *Select a Namespace* option, and then select the namespace from the drop-down list.
++
+* If the default `external-secrets-operator` namespace does not exist, it is created for you by the {olm-first}.
++
+.. Select an *Update approval* strategy.
++
+* The *Automatic* strategy enables {olm} to automatically update the Operator when a new version is available.
++
+* The *Manual* strategy requires a user with appropriate credentials to approve the Operator update.
+
+.. Click *Install*.
+
+.Verification
+
+. Navigate to *Operators* -> *Installed Operators*.
+
+. Verify that *{external-secrets-operator-short}* is listed with a *Status* of *Succeeded* in the `external-secrets-operator` namespace.
+
+. Verify that `external-secrets` pods are up and running by entering the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secrets
+----
++
+.Example output
+[source,terminal]
+----
+//to be added
+----
++
+You can use the {external-secrets-operator-short} only after the `external-secrets` pods are up and running.

--- a/modules/external-secrets-operator-uninstall-console.adoc
+++ b/modules/external-secrets-operator-uninstall-console.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-console_{context}"]
+= Uninstalling the {external-secrets-operator} using the web console
+
+You can uninstall the {external-secrets-operator} by using the web console.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+* The {external-secrets-operator-short} is installed.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Uninstall the {external-secrets-operator} using the following steps:
+
+.. Navigate to *Operators* -> *Installed Operators*.
+
+.. Click the Options menu {kebab} next to the *{external-secrets-operator}* entry and click *Uninstall Operator*.
+
+.. In the confirmation dialog, click *Uninstall*.

--- a/modules/external-secrets-provider-types.adoc
+++ b/modules/external-secrets-provider-types.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-provider-types_{context}"]
+= External secrets providers for the {external-secrets-operator}
+
+The {external-secrets-operator} is tested with the following external secrets provider types:
+
+* link:https://aws.amazon.com/secrets-manager/[AWS Secrets Manager]
+* link:https://developer.hashicorp.com/vault[HashiCorp Vault]
+* link:https://cloud.google.com/security/products/secret-manager[Google Secrets Manager]
+* link:https://azure.microsoft.com/en-us/products/key-vault/[Azure Key Vault]
+* link:https://www.ibm.com/products/secrets-manager[{ibm-cloud-title} Secrets Manager]
+
+[NOTE]
+====
+Red{nbsp}Hat does not test all factors associated with third-party secrets store provider functionality. For more information about third-party support, see the link:https://access.redhat.com/third-party-software-support[Red{nbsp}Hat third-party support policy].
+====
+

--- a/modules/external-secrets-query-metrics.adoc
+++ b/modules/external-secrets-query-metrics.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-query-metrics_{context}"]
+= Querying metrics for the {external-secrets-operator}
+
+After you enable monitoring for the {external-secrets-operator}, you can query its metrics.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You installed the {external-secrets-operator-short}.
+* You enabled monitoring and metrics collection for the {external-secrets-operator-short}.
+
+.Procedure
+
+. Find the endpoint value by running the following command:
++
+[source,terminal]
+----
+$ oc describe service external-secrets -n external-secrets
+----
+
+. From the {product-title} web console, navigate to *Observe* -> *Metrics*.
+
+. Add a query by using the following formats:
+
+.. Specify the endpoints:
++
+[source,promql]
+----
+{instance="<endpoint>"} <1>
+----
+<1> Replace `<endpoint>` with the value of the endpoint for the `external-secrets` service.
+
+.. Specify the `tcp-prometheus-servicemonitor` port:
++
+[source,promql]
+----
+{endpoint="tcp-prometheus-servicemonitor"}
+----

--- a/modules/external-secrets-remove-resources-cli.adoc
+++ b/modules/external-secrets-remove-resources-cli.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * security/external-secrets-operator-uninstall.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-remove-resources-cli_{context}"]
+= Removing {external-secrets-operator} resources by using the CLI
+
+After you have uninstalled the {external-secrets-operator}, you can optionally eliminate its associated resources from your cluster by using the command-line interface (CLI).
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Delete the deployments of the `external-secrets` application components in the `external-secrets` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete deployment -n external-secrets -l app.kubernetes.io/instance=external-secrets
+----
+
+. Delete the custom resource definitions (CRDs) that were installed by the {external-secrets-operator-short}by running the following command:
++
+[source,terminal]
+----
+// to be added
+----
+
+. Delete the `external-secrets-operator` namespace by running the following command:
++
+[source,terminal]
+----
+// to be added
+----

--- a/modules/external-secrets-remove-resources.adoc
+++ b/modules/external-secrets-remove-resources.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * security/external-secrets-operator-uninstall.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-remove-resources_{context}"]
+= Removing {external-secrets-operator} resources by using the web console
+
+After you have uninstalled the {external-secrets-operator}, you can optionally eliminate its associated resources from your cluster.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Remove the deployments of the `external-secrets` application components in the `external-secrets` namespace:
+
+.. Click the *Project* drop-down menu to see a list of all available projects, and select the *external-secrets* project.
+
+.. Navigate to *Workloads* -> *Deployments*.
+
+.. Select the deployment that you want to delete.
+
+.. Click the *Actions* drop-down menu, and select *Delete Deployment* to see a confirmation dialog box.
+
+.. Click *Delete* to delete the deployment.
+
+. Remove the custom resource definitions (CRDs) that were installed by the {external-secrets-operator-short} using the following steps:
+
+.. Navigate to *Administration* -> *CustomResourceDefinitions*.
+
+.. Enter `externalsecrets` in the *Name* field to filter the CRDs.
+
+.. Click the Options menu {kebab} next to each of the following CRDs, and select *Delete Custom Resource Definition*:
+
+*** `//to be added`
+*** `//to be added`
+*** `//to be added`
+
+. Remove the `external-secrets-operator` namespace using the following steps:
+
+.. Navigate to *Administration* -> *Namespaces*.
+
+.. Click the Options menu {kebab} next to the *{external-secrets-operator-short}* and select *Delete Namespace*.
+
+.. In the confirmation dialog, enter `external-secrets-operator` in the field and click *Delete*.

--- a/security/external_secrets_operator/external-secrets-operator-install.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-install.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-install"]
+= Installing the {external-secrets-operator}
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-install
+
+toc::[]
+
+The {external-secrets-operator} is not installed on the {product-title} by default. Install the {external-secrets-operator-short} by using either the web console or the command-line interface (CLI).
+
+:FeatureName: The {external-secrets-operator}
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+//== Installing the {external-secrets-operator}
+
+//Installing the {external-secrets-operator} using the web console
+include::modules/external-secrets-operator-install-console.adoc[leveloffset=+1]
+
+//Installing using CLI
+include::modules/external-secrets-operator-install-cli.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-secrets-operator-install_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+

--- a/security/external_secrets_operator/external-secrets-operator-monitoring.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-monitoring.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-monitoring"]
+= Monitoring the {external-secrets-operator}
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-monitoring
+
+toc::[]
+
+You can expose controller metrics for the {external-secrets-operator} in the format provided by the Prometheus Operator.
+
+:FeatureName: The {external-secrets-operator}
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+// Enabling metrics for the {external-secrets-operator-short}
+include::modules/external-secrets-enable-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Setting up metrics collection for user-defined projects]
+
+// Querying metrics for the {external-secrets-operator-short}
+include::modules/external-secrets-query-metrics.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
@@ -1,0 +1,42 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-release-notes"]
+= {external-secrets-operator} release notes
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-release-notes
+
+toc::[]
+
+The {external-secrets-operator} is a cluster-wide service that provides lifecycle management for secrets fetched from external secret management systems.
+
+These release notes track the development of {external-secrets-operator-short}.
+
+:FeatureName: The {external-secrets-operator}
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+For more information, see xref:../../security/external_secrets_operator/index.adoc#external-secrets-operator-about[{external-secrets-operator-short} overview].
+
+[id="external-secrets-operator-release-notes-0-1-0_{context}"]
+== Release notes for {external-secrets-operator} 0.1.0 (Technology Preview)
+//Issued:
+
+//The following advisory is available for the {external-secrets-operator} 0.1.0:
+
+//For more information, see
+
+[id="external-secrets-operator-0-1-0-features-enhancements_{context}"]
+=== New features and enhancements
+
+* This is the initial, Technology Preview release of the {external-secrets-operator}.
+
+// No bug fixes in the initial release
+//[id="external-secrets-operator-0-1-0-bug-fixes_{context}"]
+//=== Bug fixes
+
+//[id="external-secrets-operator-0-1-0-CVEs_{context}"]
+//=== CVEs
+//content to be added
+
+[id="external-secrets-operator-0-1-0-known-issue_{context}"]
+=== Known issues
+
+//content to be added

--- a/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-uninstall"]
+= Uninstalling the {external-secrets-operator}
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-uninstall
+
+toc::[]
+
+You can remove the {external-secrets-operator} from {product-title} by uninstalling the Operator and removing its related resources.
+
+:FeatureName: The {external-secrets-operator}
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+// Uninstalling the {external-secrets-operator-short}
+include::modules/external-secrets-operator-uninstall-console.adoc[leveloffset=+1]
+
+// Removing {external-secrets-operator-short}
+include::modules/external-secrets-remove-resources.adoc[leveloffset=+1]
+
+// Removing {external-secrets-operator-short} using CLI
+include::modules/external-secrets-remove-resources-cli.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/index.adoc
+++ b/security/external_secrets_operator/index.adoc
@@ -1,15 +1,33 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="external-secrets-operator-about"]
-= External secrets Operator for Red Hat OpenShift overview
+= {external-secrets-operator} overview
 include::_attributes/common-attributes.adoc[]
 :context: external-secrets-operator-about
 
 toc::[]
 
-//Details to be added
+The {external-secrets-operator} operates as a cluster-wide service to deploy and manage the `external-secrets` application. The `external-secrets` application integrates with external secrets management systems and performs secret fetching, refreshing, and provisioning within the cluster.
+
+:FeatureName: The {external-secrets-operator}
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+//About the {external-secrets-operator}
+include::modules/external-secrets-about.adoc[leveloffset=+1]
+
+//About the external secrets provide types
+include::modules/external-secrets-provider-types.adoc[leveloffset=+1]
+
+//The supported versions
+//include::modules/external-secrets-supported-versions.adoc[leveloffset=+1]
+
+//FIPS compliant support
+include::modules/external-secrets-fips-support.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="external-secrets-operator-about_additional-resources"]
 == Additional resources
 
-* link:https://external-secrets.io/latest/[External Secrets Operator]
+* link:https://external-secrets.io/latest/[external-secrets application]
+* xref:../../security/container_security/security-compliance.adoc#security-compliance[Understanding compliance]
+* xref:../../installing/overview/installing-fips.adoc#installing-fips-mode_installing-fips[Installing a cluster in FIPS mode]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing-security[Do you need extra security for your cluster?]


### PR DESCRIPTION
Version(s):
4.19 +

Issue:
[OSDOCS-14603](https://issues.redhat.com/browse/OSDOCS-14603)

Link to docs preview:
[External secrets Operator for Red Hat OpenShift overview](https://93201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/index.html)
[External secrets Operator for Red Hat OpenShift release notes](https://93201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-release-notes.html)
[Installing the external secrets Operator for Red Hat OpenShift](https://93201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-install.html)
[Monitoring external secrets Operator for Red Hat OpenShift](https://93201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-monitoring.html)
[Uninstalling the external secrets Operator for Red Hat OpenShift](https://93201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-uninstall.html)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Additional Information:
There was confusion on the PR https://github.com/openshift/openshift-docs/pull/93087 regarding the format of the name to used for ESO. Here it is confirmed with the OLM sheet (agreed legal name) and with the SME. The approved name is `external secrets operator for Red Hat OpenShift`. As per docs standard O should be capital for operator. Also there is exception to use the capitalization for docs. Hence the name that will be used is `External Secrets Operator for Red Hat OpenShift`. `External Secrets Operator` is the short name that will be used.

Only five sections are added in this PR. One more API section is yet to be added once the content is ready. Even the existing content in the PR need few more details which will be added in the next PR with API. Getting this PR reviewed and merged for the content that is ready. 
