### PR TITLE
OCPBUGS-31697: Added user-managed LB note to nw-configuring-route-tim…

### DIFF
--- a/modules/nw-configuring-route-timeouts.adoc
+++ b/modules/nw-configuring-route-timeouts.adoc
@@ -7,15 +7,19 @@
 [id="nw-configuring-route-timeouts_{context}"]
 = Configuring route timeouts
 
-You can configure the default timeouts for an existing route when you
-have services in need of a low timeout, which is required for Service Level
-Availability (SLA) purposes, or a high timeout, for cases with a slow
-back end.
+You can configure the default timeouts for an existing route when you have services in need of a low timeout, which is required for Service Level Availability (SLA) purposes, or a high timeout, for cases with a slow back end.
+
+[IMPORTANT]
+====
+If you configured a user-managed external load balancer in front of your {product-title} cluster, ensure that the timeout value for the user-managed external load balancer is higher than the timeout value for the route. This configuration prevents network congestion issues over the network that your cluster uses.
+====
 
 .Prerequisites
+
 * You need a deployed Ingress Controller on a running cluster.
 
 .Procedure
+
 . Using the `oc annotate` command, add the timeout to the route:
 +
 [source,terminal]
@@ -23,10 +27,9 @@ back end.
 $ oc annotate route <route_name> \
     --overwrite haproxy.router.openshift.io/timeout=<timeout><time_unit> <1>
 ----
-<1> Supported time units are microseconds (us), milliseconds (ms), seconds (s),
-minutes (m), hours (h), or days (d).
+<1> Supported time units are microseconds (us), milliseconds (ms), seconds (s), minutes (m), hours (h), or days (d).
 +
-The following example sets  a timeout of two seconds on a route named `myroute`:
+The following example sets a timeout of two seconds on a route named `myroute`:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-31697](https://issues.redhat.com/browse/OCPBUGS-31697)

Link to docs preview:
* [Configuring route timeouts](https://93206--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/routes/route-configuration.html#nw-configuring-route-timeouts_route-configuration)

- [x] SME has approved this change (Andrey Lebedev).
- [x] QE has approved this change (Hongan Li).

Add. resources:
* https://github.com/openshift/openshift-docs/pull/85350
