### PR TITLE
OBSDOCS-1779: Logging uninstalling steps

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3045,6 +3045,8 @@ Topics:
       File: log6x-configuring-lokistack-otlp-6.2
     - Name: Visualization for logging
       File: log6x-visual-6.2
+    - Name: Uninstalling Logging
+      File: log6x-cluster-logging-uninstall
   - Name: Logging 6.1
     Dir: logging-6.1
     Topics:
@@ -3066,6 +3068,8 @@ Topics:
       File: log6x-opentelemetry-data-model-6.1
     - Name: Visualization for logging
       File: log6x-visual-6.1
+    - Name: Uninstalling Logging
+      File: log6x-cluster-logging-uninstall
 #  - Name: Support
 #    File: cluster-logging-support
 #  - Name: Troubleshooting logging

--- a/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
@@ -2,6 +2,8 @@
 //
 // * operators/admin/olm-deleting-operators-from-a-cluster.adoc
 // * serverless/install/removing-openshift-serverless.adoc
+// * observability/logging/logging-6.1/log6x-cluster-logging-uninstall.adoc
+// * observability/logging/logging-6.2/log6x-cluster-logging-uninstall.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="olm-deleting-operator-from-a-cluster-using-cli_{context}"]

--- a/modules/proc_deleting-the-cluster-logging-operator-by-using-the-cli.adoc
+++ b/modules/proc_deleting-the-cluster-logging-operator-by-using-the-cli.adoc
@@ -1,0 +1,50 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-05-19
+:_mod-docs-content-type: PROCEDURE
+
+[id="deleting-the-cluster-logging-operator-by-using-the-cli_{context}"]
+= Deleting the {clo} by using the CLI
+
+Delete the {clo} by using the {oc-first}.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You installed the {oc-first}.
+
+.Procedure
+
+. Delete the ClusterLogForwarder custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc delete ClusterLogForwarder __<name>__ -n openshift-logging
+----
+
+. Uninstall the {clo} by running the following command:
++
+[source,terminal]
+----
+$ oc delete OperatorGroup __<name>__ -n openshift-logging
+----
+
+////
+.Verification
+* Provide an example of expected command output or a pop-up window that the user receives when the procedure is successful.
+* List actions for the user to complete, such as entering a command, to determine the success or failure of the procedure.
+* Make each step an instruction.
+* Use an unnumbered bullet (*) if the verification includes only one step.
+
+
+.Next steps
+* Delete this section if it does not apply to your module.
+* Provide a bulleted list of links that contain instructions that might be useful to the user after they complete this procedure.
+* Use an unnumbered bullet (*) if the list includes only one step.
+
+NOTE: Do not use *Next steps* to provide a second list of instructions.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]
+* xref:some-module_{context}[]
+////

--- a/modules/proc_deleting-the-cluster-logging-operator-by-using-the-web-console.adoc
+++ b/modules/proc_deleting-the-cluster-logging-operator-by-using-the-web-console.adoc
@@ -1,0 +1,39 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-05-18
+:_mod-docs-content-type: PROCEDURE
+
+[id="deleting-the-cluster-logging-operator-by-using-the-web-console_{context}"]
+= Deleting the {clo} by using the web console
+
+Delete the {clo} by using the {product-title} web console.
+
+.Prerequisites
+* You have administrator permissions.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, go to *Operators* -> *Installed Operators*.
+
+. Click *{clo}* from the *Installed Operators* list and go to the *Cluster Log Forwarder* tab.
+
+. Click {kebab} for the ClusterLogForwarder entry and select *Delete ClusterLogForwarder*.
+
+. Click the *Actions* button and click *Uninstall Operator*.
++
+You are redirected to the *Installed Operators*. The *{clo}* is no longer listed.
+
+////
+.Next steps
+* Delete this section if it does not apply to your module.
+* Provide a bulleted list of links that contain instructions that might be useful to the user after they complete this procedure.
+* Use an unnumbered bullet (*) if the list includes only one step.
+
+NOTE: Do not use *Next steps* to provide a second list of instructions.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]
+* xref:some-module_{context}[]
+////
+

--- a/modules/proc_deleting-the-loki-operator-by-using-the-cli.adoc
+++ b/modules/proc_deleting-the-loki-operator-by-using-the-cli.adoc
@@ -1,0 +1,51 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-05-19
+:_mod-docs-content-type: PROCEDURE
+
+[id="deleting-the-loki-operator-by-using-the-cli_{context}"]
+= Deleting the {loki-op} by using the CLI
+
+Delete the {loki-op} by using the {oc-first}.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You installed the {oc-first}.
+
+.Procedure
+
+. Delete the LokiStack custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc delete LokiStack __<name>__ -n openshift-logging
+----
+
+. Uninstall the {loki-op} by running the following command:
++
+[source,terminal]
+----
+$ oc delete OperatorGroup __<name>__ -n openshift-operators-redhat
+----
+
+////
+.Verification
+Delete this section if it does not apply to your module. Provide the user with verification methods for the procedure, such as expected output or commands that confirm success or failure.
+
+* Provide an example of expected command output or a pop-up window that the user receives when the procedure is successful.
+* List actions for the user to complete, such as entering a command, to determine the success or failure of the procedure.
+* Make each step an instruction.
+* Use an unnumbered bullet (*) if the verification includes only one step.
+
+.Next steps
+* Delete this section if it does not apply to your module.
+* Provide a bulleted list of links that contain instructions that might be useful to the user after they complete this procedure.
+* Use an unnumbered bullet (*) if the list includes only one step.
+
+NOTE: Do not use *Next steps* to provide a second list of instructions.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]
+* xref:some-module_{context}[]
+////

--- a/modules/proc_deleting-the-loki-operator-by-using-the-web-console.adoc
+++ b/modules/proc_deleting-the-loki-operator-by-using-the-web-console.adoc
@@ -1,0 +1,38 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-05-19
+:_mod-docs-content-type: PROCEDURE
+
+[id="deleting-the-loki-operator-by-using-the-web-console_{context}"]
+= Deleting the {loki-op} by using the web console
+
+Delete the {loki-op} by using the {product-title} web console.
+
+.Prerequisites
+* You have administrator permissions.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, go to *Operators* -> *Installed Operators*.
+
+. Click *{loki-op}* from the *Installed Operators* list and go to the *LokiStack* tab.
+
+. Click {kebab} for the LokiStack entry and select *Delete LokiStack*.
+
+. Click the *Actions* button and click *Uninstall Operator*.
++
+You are redirected to the *Installed Operators*. The *{loki-op}* is no longer listed.
+
+////
+.Next steps
+* Delete this section if it does not apply to your module.
+* Provide a bulleted list of links that contain instructions that might be useful to the user after they complete this procedure.
+* Use an unnumbered bullet (*) if the list includes only one step.
+
+NOTE: Do not use *Next steps* to provide a second list of instructions.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]
+* xref:some-module_{context}[]
+////

--- a/modules/proc_deleting-the-uiplugin-by-using-the-web-console.adoc
+++ b/modules/proc_deleting-the-uiplugin-by-using-the-web-console.adoc
@@ -1,0 +1,36 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-05-19
+:_mod-docs-content-type: PROCEDURE
+
+[id="deleting-the-uiplugin-by-using-the-web-console_{context}"]
+= Deleting the UIPlugin by using the web console
+
+Delete the UIPlugin by using the {product-title} web console.
+
+.Prerequisites
+* You have administrator permissions.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, go to *Operators* -> *Installed Operators*.
+
+. Click *{coo}* from the *Installed Operators* list and go to the *UIPlugin* tab.
+
+. Click {kebab} for the UIPlugin entry and select *Delete UIPlugin*.
+
+
+////
+.Next steps
+* Delete this section if it does not apply to your module.
+* Provide a bulleted list of links that contain instructions that might be useful to the user after they complete this procedure.
+* Use an unnumbered bullet (*) if the list includes only one step.
+
+NOTE: Do not use *Next steps* to provide a second list of instructions.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]
+* xref:some-module_{context}[]
+
+////

--- a/modules/uninstall-cluster-logging-operator.adoc
+++ b/modules/uninstall-cluster-logging-operator.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
 // * observability/logging/cluster-logging-uninstall.adoc
+// * observability/logging/logging-6.1/log6x-cluster-logging-uninstall.adoc
+// * observability/logging/logging-6.2/log6x-cluster-logging-uninstall.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="uninstall-cluster-logging-operator_{context}"]

--- a/modules/uninstall-logging-delete-pvcs.adoc
+++ b/modules/uninstall-logging-delete-pvcs.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
 // * observability/logging/cluster-logging-uninstall.adoc
+// * observability/logging/logging-6.1/log6x-cluster-logging-uninstall.adoc
+// * observability/logging/logging-6.2/log6x-cluster-logging-uninstall.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="uninstall-logging-delete-pvcs_{context}"]

--- a/modules/uninstall-loki-operator.adoc
+++ b/modules/uninstall-loki-operator.adoc
@@ -1,10 +1,14 @@
 // Module included in the following assemblies:
 //
 // * observability/logging/cluster-logging-uninstall.adoc
+// * observability/logging/logging-6.1/log6x-cluster-logging-uninstall.adoc
+// * observability/logging/logging-6.2/log6x-cluster-logging-uninstall.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="uninstall-loki-operator_{context}"]
 = Uninstalling Loki
+
+You can delete the {loki-op} and the `LokiStack` custom resource (CR) by using the web console.
 
 .Prerequisites
 

--- a/observability/logging/logging-6.1/log6x-cluster-logging-uninstall.adoc
+++ b/observability/logging/logging-6.1/log6x-cluster-logging-uninstall.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+:context: cluster-logging-uninstall-6-1
+[id="cluster-logging-uninstall-6-1"]
+= Uninstalling Logging
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+You can remove {logging} from your {product-title} cluster by removing installed Operators and related custom resources (CRs).
+
+include::modules/uninstall-cluster-logging-operator.adoc[leveloffset=+1]
+include::modules/uninstall-logging-delete-pvcs.adoc[leveloffset=+1]
+include::modules/uninstall-loki-operator.adoc[leveloffset=+1]
+
+//Generic deleting operators from a cluster using CLI
+include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+ifdef::openshift-enterprise,openshift-origin[]
+* xref:../../../storage/understanding-persistent-storage.adoc#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]
+endif::[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* link:https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]
+endif::[]

--- a/observability/logging/logging-6.2/log6x-cluster-logging-uninstall.adoc
+++ b/observability/logging/logging-6.2/log6x-cluster-logging-uninstall.adoc
@@ -1,0 +1,45 @@
+:_mod-docs-content-type: ASSEMBLY
+:context: cluster-logging-uninstall-6-2
+[id="cluster-logging-uninstall-6-2"]
+= Uninstalling Logging
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+You can remove {logging} from your {product-title} cluster by removing installed Operators and related custom resources (CRs).
+
+[id="uninstalling-logging-cli_{context}"]
+== Uninstallation by using the cli
+
+include::modules/proc_deleting-the-cluster-logging-operator-by-using-the-cli.adoc[leveloffset=+2]
+
+include::modules/proc_deleting-the-loki-operator-by-using-the-cli.adoc[leveloffset=+2]
+
+
+[id="uninstalling-logging-web-console_{context}"]
+== Uninstallation by using the web console
+
+include::modules/proc_deleting-the-cluster-logging-operator-by-using-the-web-console.adoc[leveloffset=+2]
+
+include::modules/proc_deleting-the-uiplugin-by-using-the-web-console.adoc[leveloffset=+2]
+
+include::modules/proc_deleting-the-loki-operator-by-using-the-web-console.adoc[leveloffset=+2]
+
+////
+include::modules/uninstall-cluster-logging-operator.adoc[leveloffset=+1]
+include::modules/uninstall-logging-delete-pvcs.adoc[leveloffset=+1]
+include::modules/uninstall-loki-operator.adoc[leveloffset=+1]
+
+//Generic deleting operators from a cluster using CLI
+include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]
+////
+
+
+[role="_additional-resources"]
+.Additional resources
+ifdef::openshift-enterprise,openshift-origin[]
+* xref:../../../storage/understanding-persistent-storage.adoc#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]
+endif::[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* link:https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]
+endif::[]


### PR DESCRIPTION
Version(s): 4.18

Issue: https://issues.redhat.com/browse/OBSDOCS-1779


Link to docs preview:

- https://93208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-cluster-logging-uninstall.html
- https://93208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.2/log6x-cluster-logging-uninstall.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
