### PR TITLE
OSDOCS-14611 created z-stream release notes for 4.18.13

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3021,6 +3021,54 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.13
+[id="ocp-4-18-13_{context}"]
+=== RHSA-2025:4712 - {product-title} {product-version}.13 bug fix update and security update
+
+Issued: 14 May 2025
+
+{product-title} release {product-version}.13 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4712[RHSA-2025:4712] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4714[RHBA-2025:4714] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.13 --pullspecs
+----
+
+[id="ocp-4-18-13-known-issues_{context}"]
+==== Known issues
+
+* When a pod uses the CNI plugin for DHCP address assignment, in conjunction with other Container Network Interface (CNI) plugins, the pod's network interface might be unexpectedly deleted. As a result, when the pod's DHCP lease expires, the DHCP proxy enters a loop when trying to re-create a new lease, leading to the node becoming unresponsive. There is currently no known workaround. (link:https://issues.redhat.com/browse/OCPBUGS-55354[OCPBUGS-55354])
+
+[id="ocp-4-18-13-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, unsorted image stream names in the `Progressing` condition caused unnecessary updates. This led to excessive user updates and potential performance degradation. With this release, the failing image imports are sorted within the `activeImageStreams` function. This change improves Cluster Samples Operator efficiency, reduces unnecessary updates, and enhances overall performance. (link:https://issues.redhat.com/browse/OCPBUGS-55783[OCPBUGS-55783])
+
+* Previously, an Operator updated the `Progressing` condition's `lastTransitionTime` value even when the condition's status did not actually change. This led to potential installation errors and perceived instability for end users. With this release, the Operator is prevented from updating the `lastTransitionTime` value unless there is a status change. This enhances Operator stability, minimizes installer errors, and ensures a smoother user experience. (link:https://issues.redhat.com/browse/OCPBUGS-55782[OCPBUGS-55782])
+
+* Previously, the Cluster Samples Operator watched all cluster Operators in the cluster, which triggered the Cluster Samples Operator sync loop to run unnecessarily. This behavior negatively impacted overall performance. With this release, the Cluster Samples Operator only watches specific cluster Operators. (link:https://issues.redhat.com/browse/OCPBUGS-55781[OCPBUGS-55781])
+
+* Previously, when adding a node in a disconnected environment, private registry images were inaccessible for the `oc adm node-image` command. As a result, issues with pulling images prevented adding a node. This error only occurs if the cluster is initially installed with an installation program binary downloaded from `mirror.openshift.com`. The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-55449[OCPBUGS-55449])
+
+* Previously, there was an issue in the image reference digest calculation that led to a failed container creation based on the SchemavVersion 1 image. This prevented new deployment creations. With this release, the image digest calculation is fixed and the new Operators can be installed. (link:https://issues.redhat.com/browse/OCPBUGS-55435[OCPBUGS-55435])
+
+* Previously, {azure-first} Spot Virtual Machines (VMs) that were evicted before their node became ready, could get stuck in the `provisioned` state. With this release, {azure-short} Spot VMs now use a delete eviction policy, ensuring that the VMs correctly transition to the `failed` state if they are preempted. (link:https://issues.redhat.com/browse/OCPBUGS-55373[OCPBUGS-55373])
+
+* Previously, the `oc-mirror` plugin returned an exit status of `0`, indicating success, even when mirroring errors occurred in automated workflows. As a result, customers could not rely on the exit status in the automated workflows. With this release, the `oc mirror` plugin returns a null exit status, indicating failure, when there are errors. (link:https://issues.redhat.com/browse/OCPBUGS-54626[OCPBUGS-54626])
+
+* Previously, an image pull secret generated for the internal image registry was not regenerated until after the embedded credentials expired. This resulted in a small period of time during which the image pull secrets were invalid. With this release, the image pull secrets are refreshed before the embedded credentials expire. (link:https://issues.redhat.com/browse/OCPBUGS-54304[OCPBUGS-54304])
+
+* Previously, the Machine Config Operator (MCO) in {product-title} 4.18 was not updated to reflect that package-based {op-system-base-full} support was removed in 4.19. With this release, this Operator ensures compatibility by blocking updates to {product-title} 4.19 on clusters with packaged-based {op-system-base} nodes. (link:https://issues.redhat.com/browse/OCPBUGS-53427[OCPBUGS-53427])
+
+[id="ocp-4-18-13-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
 // 4.18.12
 [id="ocp-4-18-12_{context}"]
 === RHSA-2025:4427 - {product-title} {product-version}.12 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-14611

Link to docs preview:
https://93209--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html


QE review:
- [ ] QE has approved this change.

