### PR TITLE
OSDOCS-13091: adds 4.16.41 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -425,3 +425,17 @@ Issued: 29 January 2025
 The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0683[RHBA-2025:0683] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0652[RHBA-2025:0652] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-40-dp_{context}"]
+=== RHBA-2025:8127 - {microshift-short} 4.16.41 bug fix and enhancement advisory
+
+Issued: 28 May 2025
+
+{product-title} release 4.16.41 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:8127[RHBA-2025:8127] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:8116[RHBA-2025:8116] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-41-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the greenboot health check was marking a {op-system-ostree} healthy system as unhealthy due to a relatively low 300-second timeout. This timeout was not enough on systems with a slow network. With this release, the default greenboot wait timeout is now 600 seconds, meaning there is more time to download images. This results in an accurate system check.


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-13091](https://issues.redhat.com/browse/OSDOCS-13091)

Link to docs preview:
[microshift-4-16-40-dp_release-notes](https://93225--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-40-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
