### PR TITLE
OSDOCS-14655: use localqueue instead of queue to be more correct

### DIFF
--- a/authentication/rbac-permissions.adoc
+++ b/authentication/rbac-permissions.adoc
@@ -13,8 +13,8 @@ The following procedures provide information about how you can configure role-ba
 
 The {product-title} Operator deploys `kueue-batch-admin-role` and `kueue-batch-user-role` cluster roles by default.
 
-kueue-batch-admin-role:: This cluster role includes the permissions to manage `ClusterQueues`, `Queues`, `Workloads`, and `ResourceFlavors`.
-kueue-batch-user-role:: This cluster role includes the permissions to manage jobs and to view `Queues` and `Workloads`.
+kueue-batch-admin-role:: This cluster role includes the permissions to manage cluster queues, local queues, workloads, and resource flavors.
+kueue-batch-user-role:: This cluster role includes the permissions to manage jobs and to view local queues and workloads.
 
 include::modules/configure-rbac-batch-admins.adoc[leveloffset=+1]
 include::modules/configure-rbac-batch-users.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
RhBok 1.0

Issue:
https://issues.redhat.com/browse/OSDOCS-14655

Link to docs preview:
https://93238--ocpdocs-pr.netlify.app/openshift-kueue/latest/authentication/rbac-permissions.html#authentication-clusterroles

QE review:
Not required
