### PR TITLE
OSDOCS-14588: Updates to egress lockdown documentation

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -54,4 +54,5 @@
 :hcp-title-first: {product-title} (ROSA) with {hcp} (HCP)
 :rosa-classic: ROSA (classic architecture)
 :rosa-classic-first: {product-title} (ROSA) (classic architecture)
+:egress-lockdown: {hcp-title} clusters with zero egress
 //ROSA CLI variables

--- a/modules/rosa-hcp-create-network.adoc
+++ b/modules/rosa-hcp-create-network.adoc
@@ -6,9 +6,8 @@
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
 
 ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
-:egress-lockdown-rosa:
+:rosa-egress-lockdown:
 endif::[]
-
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-hcp-create-network_{context}"]
 = Creating a Virtual Private Cloud using the ROSA CLI
@@ -41,6 +40,8 @@ You can create and customize CloudFormation templates to use with the `rosa crea
 * You have installed the ROSA CLI and configured it to the latest version
 
 .Procedure
+
+ifndef::rosa-egress-lockdown[]
 . Create an AWS VPC using the default CloudFormations template by running the following command:
 +
 [source,terminal]
@@ -58,6 +59,280 @@ $ rosa create network --param Region=us-east-2 --param Name=quickstart-stack --p
 ----
 +
 The command takes about 5 minutes to run and provides regular status updates from AWS as resources are created. If there is an issue with CloudFormation, a rollback is attempted. For all other errors that are encountered, please follow the error message instructions or contact AWS support.
+endif::rosa-egress-lockdown[]
+// ifdef::rosa-egress-lockdown[]
+// . Create a new directory for your CloudFormation templates by running the following command:
+// +
+// [source,terminal]
+// ----
+// $ mkdir TEMPLATES
+// ----
+
+// . Run the following command to create a local copy of this CloudFormation template to create a private VPC:
+// +
+// [source,terminal]
+// ----
+// $ cat<<-EOF>TEMPLATES/rosa-zero-egress-vpc.yaml
+// AWSTemplateFormatVersion: '2010-09-09'
+// Description: |
+//   CloudFormation template for a Zero-Egress VPC for ROSA,
+//   equivalent to the provided Terraform configuration.
+//   This VPC includes private subnets, a security group for internal traffic,
+//   and VPC Endpoints for STS, ECR (API, DKR), and S3 to facilitate
+//   communication for ROSA in a private environment.
+
+// Parameters:
+//   ClusterName:
+//     Type: String
+//     Description: The name of the ROSA cluster, used for naming resources.
+
+//   VpcCidrBlock:
+//     Type: String
+//     Default: 10.0.0.0/16
+//     Description: CIDR block for the VPC.
+
+//   PrivateSubnet1CidrBlock:
+//     Type: String
+//     Default: 10.0.1.0/24
+//     Description: CIDR block for the first private subnet.
+
+//   PrivateSubnet2CidrBlock:
+//     Type: String
+//     Default: 10.0.2.0/24
+//     Description: CIDR block for the second private subnet.
+
+//   AvailabilityZone1:
+//     Type: AWS::EC2::AvailabilityZone::Name
+//     Description: First Availability Zone for the private subnet.
+
+//   AvailabilityZone2:
+//     Type: AWS::EC2::AvailabilityZone::Name
+//     Description: Second Availability Zone for the private subnet.
+
+// Resources:
+//   RosaVPC:
+//     Type: AWS::EC2::VPC
+//     Properties:
+//       CidrBlock: !Ref VpcCidrBlock
+//       EnableDnsSupport: true
+//       EnableDnsHostnames: true
+//       Tags:
+//         - Key: Name
+//           Value: !Sub ${ClusterName}-vpc
+//         - Key: Terraform
+//           Value: "true"
+//         - Key: service
+//           Value: ROSA
+//         - Key: cluster_name
+//           Value: !Ref ClusterName
+
+//   PrivateSubnet1:
+//     Type: AWS::EC2::Subnet
+//     Properties:
+//       VpcId: !Ref RosaVPC
+//       CidrBlock: !Ref PrivateSubnet1CidrBlock
+//       AvailabilityZone: !Ref AvailabilityZone1
+//       MapPublicIpOnLaunch: false # Ensures it's private
+//       Tags:
+//         - Key: Name
+//           Value: !Sub ${ClusterName}-private-subnet-1
+//         - Key: Terraform
+//           Value: "true"
+//         - Key: service
+//           Value: ROSA
+//         - Key: cluster_name
+//           Value: !Ref ClusterName
+//         - Key: kubernetes.io/role/internal-elb
+//           Value: "1" # Tag from Terraform
+
+//   PrivateSubnet2:
+//     Type: AWS::EC2::Subnet
+//     Properties:
+//       VpcId: !Ref RosaVPC
+//       CidrBlock: !Ref PrivateSubnet2CidrBlock
+//       AvailabilityZone: !Ref AvailabilityZone2
+//       MapPublicIpOnLaunch: false # Ensures it's private
+//       Tags:
+//         - Key: Name
+//           Value: !Sub ${ClusterName}-private-subnet-2
+//         - Key: Terraform
+//           Value: "true"
+//         - Key: service
+//           Value: ROSA
+//         - Key: cluster_name
+//           Value: !Ref ClusterName
+//         - Key: kubernetes.io/role/internal-elb
+//           Value: "1" # Tag from Terraform
+
+//   PrivateRouteTable:
+//     Type: AWS::EC2::RouteTable
+//     Properties:
+//       VpcId: !Ref RosaVPC
+//       Tags:
+//         - Key: Name
+//           Value: !Sub ${ClusterName}-private-route-table
+//         - Key: Terraform
+//           Value: "true"
+//         - Key: service
+//           Value: ROSA
+//         - Key: cluster_name
+//           Value: !Ref ClusterName
+
+//   PrivateSubnet1RouteTableAssociation:
+//     Type: AWS::EC2::SubnetRouteTableAssociation
+//     Properties:
+//       SubnetId: !Ref PrivateSubnet1
+//       RouteTableId: !Ref PrivateRouteTable
+
+//   PrivateSubnet2RouteTableAssociation:
+//     Type: AWS::EC2::SubnetRouteTableAssociation
+//     Properties:
+//       SubnetId: !Ref PrivateSubnet2
+//       RouteTableId: !Ref PrivateRouteTable
+
+//   AuthorizeInboundVpcTrafficSecurityGroup:
+//     Type: AWS::EC2::SecurityGroup
+//     Properties:
+//       GroupDescription: Allow all inbound traffic within the VPC
+//       VpcId: !Ref RosaVPC
+//       SecurityGroupIngress:
+//         - IpProtocol: "-1" # All protocols
+//           FromPort: -1 # All ports
+//           ToPort: -1 # All ports
+//           CidrIp: !Ref VpcCidrBlock # Allows all traffic from within the VPC CIDR
+//       SecurityGroupEgress:
+//         - IpProtocol: "-1" # All protocols
+//           FromPort: -1 # All ports
+//           ToPort: -1 # All ports
+//           CidrIp: "0.0.0.0/0" # Allow all outbound traffic (typically for VPC Endpoints)
+//       Tags:
+//         - Key: Name
+//           Value: !Sub ${ClusterName}-inbound-vpc-sg
+//         - Key: Terraform
+//           Value: "true"
+//         - Key: service
+//           Value: ROSA
+//         - Key: cluster_name
+//           Value: !Ref ClusterName
+
+//   STSVpcEndpoint:
+//     Type: AWS::EC2::VPCEndpoint
+//     Properties:
+//       VpcId: !Ref RosaVPC
+//       ServiceName: !Sub com.amazonaws.${AWS::Region}.sts
+//       VpcEndpointType: Interface
+//       PrivateDnsEnabled: true
+//       SubnetIds:
+//         - !Ref PrivateSubnet1
+//         - !Ref PrivateSubnet2
+//       SecurityGroupIds:
+//         - !GetAtt AuthorizeInboundVpcTrafficSecurityGroup.GroupId # Referencing SG ID
+//       Tags:
+//         - Key: Name
+//           Value: !Sub ${ClusterName}-sts-endpoint
+//         - Key: Terraform
+//           Value: "true"
+//         - Key: service
+//           Value: ROSA
+//         - Key: cluster_name
+//           Value: !Ref ClusterName
+
+//   ECRApiVpcEndpoint:
+//     Type: AWS::EC2::VPCEndpoint
+//     Properties:
+//       VpcId: !Ref RosaVPC
+//       ServiceName: !Sub com.amazonaws.${AWS::Region}.ecr.api
+//       VpcEndpointType: Interface
+//       PrivateDnsEnabled: true
+//       SubnetIds:
+//         - !Ref PrivateSubnet1
+//         - !Ref PrivateSubnet2
+//       SecurityGroupIds:
+//         - !GetAtt AuthorizeInboundVpcTrafficSecurityGroup.GroupId
+//       Tags:
+//         - Key: Name
+//           Value: !Sub ${ClusterName}-ecr-api-endpoint
+//         - Key: Terraform
+//           Value: "true"
+//         - Key: service
+//           Value: ROSA
+//         - Key: cluster_name
+//           Value: !Ref ClusterName
+
+//   ECRDkrVpcEndpoint:
+//     Type: AWS::EC2::VPCEndpoint
+//     Properties:
+//       VpcId: !Ref RosaVPC
+//       ServiceName: !Sub com.amazonaws.${AWS::Region}.ecr.dkr
+//       VpcEndpointType: Interface
+//       PrivateDnsEnabled: true
+//       SubnetIds:
+//         - !Ref PrivateSubnet1
+//         - !Ref PrivateSubnet2
+//       SecurityGroupIds:
+//         - !GetAtt AuthorizeInboundVpcTrafficSecurityGroup.GroupId
+//       Tags:
+//         - Key: Name
+//           Value: !Sub ${ClusterName}-ecr-dkr-endpoint
+//         - Key: Terraform
+//           Value: "true"
+//         - Key: service
+//           Value: ROSA
+//         - Key: cluster_name
+//           Value: !Ref ClusterName
+
+//   S3VpcEndpoint:
+//     Type: AWS::EC2::VPCEndpoint
+//     Properties:
+//       VpcId: !Ref RosaVPC
+//       ServiceName: !Sub com.amazonaws.${AWS::Region}.s3
+//       VpcEndpointType: Gateway
+//       RouteTableIds:
+//         - !Ref PrivateRouteTable # Associate with the private route table
+//       Tags:
+//         - Key: Name
+//           Value: !Sub ${ClusterName}-s3-endpoint
+//         - Key: Terraform
+//           Value: "true"
+//         - Key: service
+//           Value: ROSA
+//         - Key: cluster_name
+//           Value: !Ref ClusterName
+
+// Outputs:
+//   VpcId:
+//     Description: The ID of the created VPC.
+//     Value: !Ref RosaVPC
+//     Export:
+//       Name: !Sub ${AWS::StackName}-VpcId
+
+//   PrivateSubnetIds:
+//     Description: A comma-separated list of the private subnet IDs.
+//     Value: !Join [",", [!Ref PrivateSubnet1, !Ref PrivateSubnet2]]
+//     Export:
+//       Name: !Sub ${AWS::StackName}-PrivateSubnetIds
+
+//   PrivateRouteTableId:
+//     Description: The ID of the private route table.
+//     Value: !Ref PrivateRouteTable
+//     Export:
+//       Name: !Sub ${AWS::StackName}-PrivateRouteTableId
+
+//   SecurityGroupId:
+//     Description: The ID of the security group for internal VPC traffic.
+//     Value: !GetAtt AuthorizeInboundVpcTrafficSecurityGroup.GroupId
+//     Export:
+//       Name: !Sub ${AWS::StackName}-SecurityGroupId
+// EOF
+// ----
+
+// . Create an AWS VPC using the default CloudFormations template by running the following command:
+// +
+// [source,terminal]
+// ----
+// $ rosa create network --template-dir TEMPLATES
+// ----
+// endif::rosa-egress-lockdown[]
 
 .Verification
 * When completed, you receive a summary of the created resources:
@@ -65,28 +340,99 @@ The command takes about 5 minutes to run and provides regular status updates fro
 [source,bash]
 ----
 INFO[0140] Resources created in stack:                  
-INFO[0140] Resource: AttachGateway, Type: AWS::EC2::VPCGatewayAttachment, ID: <gateway-id> 
-INFO[0140] Resource: EC2VPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce-id> 
-INFO[0140] Resource: EcrApiVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce-id>
-INFO[0140] Resource: EcrDkrVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce-id> 
+INFO[0140] Resource: AttachGateway, Type: AWS::EC2::VPCGatewayAttachment, ID: <gateway_id> 
+INFO[0140] Resource: EC2VPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
+INFO[0140] Resource: EcrApiVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id>
+INFO[0140] Resource: EcrDkrVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
 INFO[0140] Resource: ElasticIP1, Type: AWS::EC2::EIP, ID: <IP>
 INFO[0140] Resource: ElasticIP2, Type: AWS::EC2::EIP, ID: <IP> 
 INFO[0140] Resource: InternetGateway, Type: AWS::EC2::InternetGateway, ID: igw-016e1a71b9812464e 
-INFO[0140] Resource: KMSVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce-id> 
-INFO[0140] Resource: NATGateway1, Type: AWS::EC2::NatGateway, ID: <nat-gateway-id> 
-INFO[0140] Resource: PrivateRoute, Type: AWS::EC2::Route, ID: <route-id> 
-INFO[0140] Resource: PrivateRouteTable, Type: AWS::EC2::RouteTable, ID: <route-id> 
-INFO[0140] Resource: PrivateSubnetRouteTableAssociation1, Type: AWS::EC2::SubnetRouteTableAssociation, ID: <route-id>
-INFO[0140] Resource: PublicRoute, Type: AWS::EC2::Route, ID: <route-id> 
-INFO[0140] Resource: PublicRouteTable, Type: AWS::EC2::RouteTable, ID: <route-id> 
-INFO[0140] Resource: PublicSubnetRouteTableAssociation1, Type: AWS::EC2::SubnetRouteTableAssociation, ID: <route-id> 
-INFO[0140] Resource: S3VPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce-id> 
-INFO[0140] Resource: STSVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce-id> 
-INFO[0140] Resource: SecurityGroup, Type: AWS::EC2::SecurityGroup, ID: <security-group-id> 
-INFO[0140] Resource: SubnetPrivate1, Type: AWS::EC2::Subnet, ID: <private-subnet-id-1> \ <1>
-INFO[0140] Resource: SubnetPublic1, Type: AWS::EC2::Subnet, ID: <public-subnet-id-1> \ <1>
-INFO[0140] Resource: VPC, Type: AWS::EC2::VPC, ID: <vpc-id>
+INFO[0140] Resource: KMSVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
+INFO[0140] Resource: NATGateway1, Type: AWS::EC2::NatGateway, ID: <nat-gateway_id> 
+INFO[0140] Resource: PrivateRoute, Type: AWS::EC2::Route, ID: <route_id> 
+INFO[0140] Resource: PrivateRouteTable, Type: AWS::EC2::RouteTable, ID: <route_id> 
+INFO[0140] Resource: PrivateSubnetRouteTableAssociation1, Type: AWS::EC2::SubnetRouteTableAssociation, ID: <route_id>
+INFO[0140] Resource: PublicRoute, Type: AWS::EC2::Route, ID: <route_id> 
+INFO[0140] Resource: PublicRouteTable, Type: AWS::EC2::RouteTable, ID: <route_id> 
+INFO[0140] Resource: PublicSubnetRouteTableAssociation1, Type: AWS::EC2::SubnetRouteTableAssociation, ID: <route_id> 
+INFO[0140] Resource: S3VPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
+INFO[0140] Resource: STSVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
+INFO[0140] Resource: SecurityGroup, Type: AWS::EC2::SecurityGroup, ID: <security-group_id> 
+INFO[0140] Resource: SubnetPrivate1, Type: AWS::EC2::Subnet, ID: <private_subnet_id-1> \ <1>
+INFO[0140] Resource: SubnetPublic1, Type: AWS::EC2::Subnet, ID: <public_subnet_id-1> \ <1>
+INFO[0140] Resource: VPC, Type: AWS::EC2::VPC, ID: <vpc_id>
 INFO[0140] Stack rosa-network-stack-5555 created \ <2>
 ----
 <1> These two subnet IDs are used to create your cluster when using the `rosa create cluster` command.
 <2> The network stack name is used to delete the resource later.
+
+ifdef::rosa-egress-lockdown[]
+[discrete]
+[id="rosa-hcp-vpc-subnet-tagging-rosa-network_{context}"]
+== Tagging your subnets
+
+Before you can use your VPC to create a {hcp-title} cluster, you must tag your VPC subnets. Automated service preflight checks verify that these resources are tagged correctly. The following table shows how to tag your resources:
+
+[cols="3a,8a,8a", options="header"]
+|===
+| Resource
+| Key
+| Value
+
+| Public subnet
+| `kubernetes.io/role/elb`	
+| `1` or no value
+
+| Private subnet 
+| `kubernetes.io/role/internal-elb`	
+| `1` or no value
+
+|===
+
+[NOTE]
+====
+You must tag at least one private subnet and one public subnet, if applicable.
+====
+
+. Tag your resources in your terminal:
+.. For public subnets, run the following command:
++
+[source,terminal]
+----
+$ aws ec2 create-tags --resources <public_subnet_id> --region <aws_region> --tags Key=kubernetes.io/role/elb,Value=1
+----
+.. For private subnets, run the following command:
++
+[source,terminal]
+----
+$ aws ec2 create-tags --resources <private_subnet_id> --region <aws_region> --tags Key=kubernetes.io/role/internal-elb,Value=1
+----
+
+.Verification
+
+* Verify that the tag is correct by running the following command:
++
+[source,terminal]
+----
+$ aws ec2 describe-tags --filters "Name=resource-id,Values=<subnet_id>"
+----
++
+.Example output
++
+[source,text]
+----
+TAGS    Name                    <subnet_id>        subnet  <prefix>-subnet-public1-us-east-1a
+TAGS    kubernetes.io/role/elb  <subnet_id>        subnet  1
+----
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-create-network-egress-lockdown"]
+.Additional resources
+
+* link:https://aws.amazon.com/cloudformation/[AWS CloudFormation documentation]
+* link:https://github.com/openshift/rosa/blob/master/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml[Default VPC AWS CloudFormation template]
+endif::rosa-egress-lockdown[]
+
+ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+:!rosa-egress-lockdown:
+endif::[]

--- a/modules/rosa-hcp-set-environment-variables.adoc
+++ b/modules/rosa-hcp-set-environment-variables.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
+
+ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+:rosa-egress-lockdown-install:
+endif::[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-set-environment-variables_{context}"]
+= Setting Environment Variables
+
+Set the following environment variables to streamline resource creation.
+
+.Procedure
+
+. Set your environment variable by running the following command:
++
+[source,terminal]
+----
+$ export <variable_name>=<variable_value>
+----
+
+. You can confirm that your variable has been set by running the following command:
++
+[source,terminal]
+----
+$ echo <variable_name>
+----
++
+ifdef::rosa-egress-lockdown-install[]
+.Suggested variables for disconnected {product-title} (ROSA) clusters
+[cols="3",options="header"]
+|===
+|Variable name
+|Variable value
+|Notes
+
+|`AWS_ACCOUNT_ID`
+|`$(aws sts get-caller-identity --query Account --output text)`
+|You must be logged in to your AWS account with `rosa login`.
+
+|`CLUSTER_NAME`
+|The name you want for your cluster.
+|Your cluster name cannot exceed 26 characters.
+
+|`OIDC_ID`
+|The 32-digit ID for your OpenID Connect (OIDC) configuration.
+|You generate this ID by running `rosa create oidc-config`.
+
+|`OPERATOR_ROLES_PREFIX`
+|The Operator role prefix.
+|If you want to make your AWS account roles use the same prefix as your Operator roles, you can run `ACCOUNT_ROLES_PREFIX=$OPERATOR_ROLES_PREFIX` after setting your Operator role prefix variable.
+
+|`PRIVATE_SUBNET`
+|The ID of your private subnets.
+|You must enclose this value in quotation marks (") and separate the subnet IDs with commas.
+
+|`REGION`
+|Your AWS region.
+| -
+
+|`SUBNET_IDS`
+|The IDs of all your subnets.
+|You must enclose this value in quotation marks (") and separate the subnet IDs with commas.
+|===
+endif::rosa-egress-lockdown-install[]
+
+ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+:!rosa-egress-lockdown-install:
+endif::[]

--- a/modules/rosa-hcp-sts-creating-a-cluster-egress-lockdown-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-egress-lockdown-cli.adoc
@@ -50,19 +50,18 @@ $ rosa create cluster --cluster-name=<cluster_name> \ <1>
 ====
 If you specified custom ARN paths when you created the associated account-wide roles, the custom path is automatically detected. The custom path is applied to the cluster-specific Operator roles when you create them in a later step.
 ====
-
-<3> Provide the AWS account that is responsible for all billing.
+<3> If your billing account is different from your user account, add this argument and specify the AWS account that is responsible for all billing.
 --
 
 * If you set the environment variables, create a cluster with egress lockdown that has a single, initial machine pool, using a privately available API, and a privately available Ingress by running the following command:
 +
 [source,terminal]
 ----
-$ rosa create cluster --private --cluster-name=<cluster_name> \
+$ rosa create cluster --private --cluster-name=$CLUSTER_NAME \
     --mode=auto --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX \
     --oidc-config-id=$OIDC_ID --subnet-ids=$SUBNET_IDS \
-    --region <region> --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 \
-    --pod-cidr 10.128.0.0/14 --host-prefix 23 --billing-account <root-acct-id> \ 
+    --region $REGION --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 \
+    --pod-cidr 10.128.0.0/14 --host-prefix 23 \ 
     --private --properties zero_egress:true
 ----
 +

--- a/modules/rosa-hcp-vpc-manual.adoc
+++ b/modules/rosa-hcp-vpc-manual.adoc
@@ -2,6 +2,10 @@
 //
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
 
+ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+:rosa-egress-lockdown:
+endif::[]
+
 :_mod-docs-content-type: PREFERENCE
 [id="rosa-hcp-vpc-manual_{context}"]
 = Creating a Virtual Private Cloud manually
@@ -9,3 +13,67 @@
 If you choose to manually create your Virtual Private Cloud (VPC) instead of using Terraform, go to link:https://us-east-1.console.aws.amazon.com/vpc/[the VPC page in the AWS console].
 
 include::snippets/rosa-existing-vpc-requirements.adoc[leveloffset=+0]
+
+ifdef::rosa-egress-lockdown[]
+[discrete]
+[id="rosa-hcp-vpc-subnet-tagging-manual_{context}"]
+== Tagging your subnets
+
+Before you can use your VPC to create a {hcp-title} cluster, you must tag your VPC subnets. Automated service preflight checks verify that these resources are tagged correctly. The following table shows how to tag your resources:
+
+[cols="3a,8a,8a", options="header"]
+|===
+| Resource
+| Key
+| Value
+
+| Public subnet
+| `kubernetes.io/role/elb`	
+| `1` or no value
+
+| Private subnet 
+| `kubernetes.io/role/internal-elb`	
+| `1` or no value
+
+|===
+
+[NOTE]
+====
+You must tag at least one private subnet and one public subnet, if applicable.
+====
+
+. Tag your resources in your terminal:
+.. For public subnets, run the following command:
++
+[source,terminal]
+----
+$ aws ec2 create-tags --resources <public_subnet_id> --region <aws_region> --tags Key=kubernetes.io/role/elb,Value=1
+----
+.. For private subnets, run the following command:
++
+[source,terminal]
+----
+$ aws ec2 create-tags --resources <private_subnet_id> --region <aws_region> --tags Key=kubernetes.io/role/internal-elb,Value=1
+----
+
+.Verification
+
+* Verify that the tag is correct by running the following command:
++
+[source,terminal]
+----
+$ aws ec2 describe-tags --filters "Name=resource-id,Values=<subnet_id>"
+----
++
+.Example output
++
+[source,text]
+----
+TAGS    Name                    <subnet_id>        subnet  <prefix>-subnet-public1-us-east-1a
+TAGS    kubernetes.io/role/elb  <subnet_id>        subnet  1
+----
+endif::rosa-egress-lockdown[]
+
+ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+:!rosa-egress-lockdown:
+endif::[]

--- a/modules/rosa-hcp-vpc-terraform.adoc
+++ b/modules/rosa-hcp-vpc-terraform.adoc
@@ -3,7 +3,7 @@
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
 
 ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
-:egress-lockdown-rosa:
+:rosa-egress-lockdown:
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE
@@ -11,6 +11,13 @@ endif::[]
 = Creating a Virtual Private Cloud using Terraform
 
 Terraform is a tool that allows you to create various resources using an established template. The following process uses the default options as required to create a {hcp-title} cluster. For more information about using Terraform, see the additional resources.
+
+ifdef::rosa-egress-lockdown[]
+[NOTE]
+====
+The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use. You should also ensure that when you use this Terraform script, it is in the same region that you intend to install your cluster. These examples use `us-east-2`.
+====
+endif::rosa-egress-lockdown[]
 
 .Prerequisites
 
@@ -27,20 +34,20 @@ $ git clone https://github.com/openshift-cs/terraform-vpc-example
 ----
 
 . Navigate to the created directory by running the following command:
-ifndef::egress-lockdown-rosa[]
+ifndef::rosa-egress-lockdown[]
 +
 [source,terminal]
 ----
 $ cd terraform-vpc-example
 ----
-endif::egress-lockdown-rosa[]
-ifdef::egress-lockdown-rosa[]
+endif::rosa-egress-lockdown[]
+ifdef::rosa-egress-lockdown[]
 +
 [source,terminal]
 ----
 $ cd terraform-vpc-example/zero-egress
 ----
-endif::egress-lockdown-rosa[]
+endif::rosa-egress-lockdown[]
 
 . Initiate the Terraform file by running the following command:
 +
@@ -51,7 +58,7 @@ $ terraform init
 +
 A message confirming the initialization appears when this process completes.
 
-ifdef::egress-lockdown-rosa[]
+ifdef::rosa-egress-lockdown[]
 . To build your VPC Terraform plan based on the existing Terraform template, run the `plan` command. You must include your AWS region, availability zones, CIDR blocks, and private subnets. You can choose to specify a cluster name. A `rosa-zero-egress.tfplan` file is added to the `hypershift-tf` directory after the `terraform plan` completes. For more detailed options, see the link:https://github.com/openshift-cs/terraform-vpc-example/blob/main/README.md[Terraform VPC repository's README file].
 +
 [source,terminal]
@@ -64,35 +71,29 @@ $ terraform plan -out rosa-zero-egress.tfplan -var region=<aws_region> \ <1>
 +
 --
 <1> Enter your AWS region.
-+
-[IMPORTANT]
-====
-You can only use egress lockdown on clusters that use the `us-west-1, us-west-2, us-east-1, us-east-2, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-north-1, eu-west-1, eu-west-2, eu-west-3`, and `sa-east-1` AWS regions.
-====
-
 <2> Enter the availability zones for the VPC. For example, for a VPC that uses `ap-southeast-1`, you would use the following as availability zones: `["ap-southeast-1a", "ap-southeast-1b", "ap-southeast-1c"]`.
 <3> Enter the CIDR block for your VPC.
 <4> Enter each of the subnets that are created for the VPC.
 --
-endif::egress-lockdown-rosa[]
-ifndef::egress-lockdown-rosa[]
+endif::rosa-egress-lockdown[]
+ifndef::rosa-egress-lockdown[]
 . To build your VPC Terraform plan based on the existing Terraform template, run the `plan` command. You must include your AWS region. You can choose to specify a cluster name. A `rosa.tfplan` file is added to the `hypershift-tf` directory after the `terraform plan` completes. For more detailed options, see the link:https://github.com/openshift-cs/terraform-vpc-example/blob/main/README.md[Terraform VPC repository's README file].
 +
 [source,terminal]
 ----
 $ terraform plan -out rosa.tfplan -var region=<region>
 ----
-endif::egress-lockdown-rosa[]
+endif::rosa-egress-lockdown[]
 
 . Apply this plan file to build your VPC by running the following command:
-ifdef::egress-lockdown-rosa[]
+ifdef::rosa-egress-lockdown[]
 +
 [source,terminal]
 ----
 $ terraform apply rosa-zero-egress.tfplan
 ----
-endif::egress-lockdown-rosa[]
-ifndef::egress-lockdown-rosa[]
+endif::rosa-egress-lockdown[]
+ifndef::rosa-egress-lockdown[]
 +
 [source,terminal]
 ----
@@ -119,8 +120,74 @@ $ echo $SUBNET_IDS
 ----
 $ subnet-0a6a57e0f784171aa,subnet-078e84e5b10ecf5b0
 ----
-endif::egress-lockdown-rosa[]
+
+endif::rosa-egress-lockdown[]
+ifdef::rosa-egress-lockdown[]
+[discrete]
+[id="rosa-hcp-vpc-subnet-tagging-terraform_{context}"]
+== Tagging your subnets
+
+Before you can use your VPC to create a {hcp-title} cluster, you must tag your VPC subnets. Automated service preflight checks verify that these resources are tagged correctly. The following table shows how to tag your resources:
+
+[cols="3a,8a,8a", options="header"]
+|===
+| Resource
+| Key
+| Value
+
+| Public subnet
+| `kubernetes.io/role/elb`	
+| `1` or no value
+
+| Private subnet 
+| `kubernetes.io/role/internal-elb`	
+| `1` or no value
+
+|===
+
+[NOTE]
+====
+You must tag at least one private subnet and one public subnet, if applicable.
+====
+
+. Tag your resources in your terminal:
+.. For public subnets, run the following command:
++
+[source,terminal]
+----
+$ aws ec2 create-tags --resources <public_subnet_id> --region <aws_region> --tags Key=kubernetes.io/role/elb,Value=1
+----
+.. For private subnets, run the following command:
++
+[source,terminal]
+----
+$ aws ec2 create-tags --resources <private_subnet_id> --region <aws_region> --tags Key=kubernetes.io/role/internal-elb,Value=1
+----
+
+.Verification
+
+* Verify that the tag is correct by running the following command:
++
+[source,terminal]
+----
+$ aws ec2 describe-tags --filters "Name=resource-id,Values=<subnet_id>"
+----
++
+.Example output
++
+[source,text]
+----
+TAGS    Name                    <subnet_id>        subnet  <prefix>-subnet-public1-us-east-1a
+TAGS    kubernetes.io/role/elb  <subnet_id>        subnet  1
+----
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-vpc-terraform-egress-lockdown"]
+.Additional resources
+
+* link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC example]
+endif::rosa-egress-lockdown[]
 
 ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
-:!egress-lockdown-rosa:
+:!rosa-egress-lockdown:
 endif::[]

--- a/modules/rosa-operator-config.adoc
+++ b/modules/rosa-operator-config.adoc
@@ -17,18 +17,11 @@ When using a {hcp-title} cluster, you must create the Operator IAM roles that ar
 
 .Procedure
 
-. Set your prefix name to an environment variable using the following command:
-+
-[source,terminal]
-----
-$ export OPERATOR_ROLES_PREFIX=<prefix_name>
-----
 . To create your Operator roles, run the following command:
-
 +
 [source,terminal]
 ----
-$ rosa create operator-roles --hosted-cp --prefix=$OPERATOR_ROLES_PREFIX --oidc-config-id=$OIDC_ID --installer-role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role
+$ rosa create operator-roles --hosted-cp --prefix=$OPERATOR_ROLES_PREFIX --oidc-config-id=$OIDC_ID --installer-role-arn arn:aws:iam::$AWS_ACCOUNT_ID:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role
 ----
 +
 The following breakdown provides options for the Operator role creation.
@@ -38,7 +31,7 @@ The following breakdown provides options for the Operator role creation.
 $ rosa create operator-roles --hosted-cp
 	--prefix=$OPERATOR_ROLES_PREFIX <1>
 	--oidc-config-id=$OIDC_ID <2>
-	--installer-role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role <3>
+	--installer-role-arn arn:aws:iam::$AWS_ACCOUNT_ID:role/$ACCOUNT_ROLES_PREFIX-HCP-ROSA-Installer-Role <3>
 ----
 +
 --

--- a/rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
+++ b/rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
@@ -5,35 +5,51 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-egress-lockdown-install
 toc::[]
 
+Creating a {product-title} (ROSA) cluster with egress lockdown provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the internet. Your cluster first tries to pull the images from Quay, and when they aren't reached, it instead pulls the images from the image registry in the local region. 
 
-Creating a {product-title} cluster with egress lockdown provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the Internet. Your cluster will try to pull the images from Quay, but when they aren't reached, it will instead pull the images from the image registry in the local region. 
+All public and private clusters with egress lockdown get their Red{nbsp}Hat container images from an Amazon Elastic Container Registry (ECR) located in the local region of the cluster instead of gathering these images from various endpoints and registries on the internet. ECR provides storage for OpenShift release images as well as Red{nbsp}Hat Operators. All requests for ECR are kept within your AWS network by serving them over a VPC endpoint within your cluster.
 
-[IMPORTANT]
-====
-You can only use egress lockdown on clusters that use the following AWS regions:
+You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster.
 
-* `us-west-2`
-* `us-east-1` 
-* `us-east-2`
-* `ap-northeast-1`
-* `ap-northeast-2`
-* `ap-northeast-3`
-* `ap-south-1`
-* `ap-southeast-1`
-* `ap-southeast-2`
-* `ca-central-1`
-* `eu-central-1`
-* `eu-north-1`
-* `eu-west-1`
-* `eu-west-2`
-* `eu-west-3`
-* `sa-east-1`
+See xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {product-title} clusters] to upgrade clusters using egress lockdown. 
+
+[NOTE]
 ====
 
-All public and private clusters with egress lockdown get their Red Hat container images from a registery that is located in the local region of the cluster instead of gathering these images from various endpoints and registeries on the Internet. You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster.
+Clusters created in restricted network environments may be unable to use certain ROSA features including Red Hat Insights and Telemetry. These clusters may also experience potential failures for workloads that require public access to registries such as `quay.io`. When using clusters installed with egress lockdown, you can also install Red Hat-owned Operators from OperatorHub. For a complete list of Red Hat-owned Operators, see the link:https://catalog.redhat.com/search?searchType=software&target_platforms=Red%20Hat%20OpenShift&deployed_as=Operator&p=1&partnerName=Red%20Hat%2C%20Inc.%7CRed%20Hat[Red{nbsp}Hat Ecosystem Catalog].
+====
 
-:FeatureName: Egress lockdown
-include::snippets/technology-preview.adoc[]
+[discrete]
+[id="rosa-glossary-disconnected_{context}"]
+== Glossary of network environment terms
+
+Although it is used throughout the {product-title} documentation, _disconnected environment_ is a broad term that can refer to environments with various levels of internet connectivity.
+Other terms are sometimes used to refer to a specific level of internet connectivity, and these environments might require additional unique configurations. These network types differ from a "standard network," which has full access to the internet.
+
+The following table describes the different terms used to refer to environments without a full internet connection:
+
+.Disconnected environment terms
+[cols=".^2,.^4",options="header"]
+|====
+|Term |Description
+
+|Air-gapped network
+|An environment or network that is completely isolated from an external network.
+
+This isolation depends on a physical separation, or an "air gap", between machines on the internal network and any part of an external network.
+Air-gapped environments are often used in industries with strict security or regulatory requirements.
+
+|Disconnected environment
+|An environment or network that has some level of isolation from an external network.
+
+This isolation could be enabled by physical or logical separation between machines on the internal network and an external network.
+Regardless of the level of isolation from the external network, a cluster in a disconnected environment does not have access to public services hosted by Red{nbsp}Hat and requires additional setup to maintain full cluster functionality.
+
+|Restricted network
+|An environment or network with limited connection to an external network.
+
+A physical connection might exist between machines on the internal network and an external network, but network traffic is limited by additional configurations, such as firewalls and proxies.
+|====
 
 .Prequisites
 
@@ -45,51 +61,33 @@ include::snippets/technology-preview.adoc[]
 
 [IMPORTANT]
 ====
-You can use egress lockdown on all supported versions of {product-title} that use the hosted control plane architecture; however, Red Hat suggests using the latest available z-stream release for each {ocp} version. 
+* You can use egress lockdown on all supported versions of {product-title} that use the hosted control plane architecture; however, Red{nbsp}Hat suggests using the latest available z-stream release for each {ocp} version. 
 
-While you may install and upgrade your clusters as you would a regular cluster, due to an upstream issue with how the internal image registry functions in disconnected environments, your cluster that uses egress lockdown will not be able to fully use all platform components, such as the image registry. You can restore these features by using the latest ROSA version when upgrading or installing your cluster.
+* While you may install and upgrade your clusters as you would a regular cluster, due to an upstream issue with how the internal image registry functions in disconnected environments, your cluster that uses egress lockdown will not be able to fully use all platform components, such as the image registry. You can restore these features by using the latest ROSA version when upgrading or installing your cluster.
 ====
+
+include::modules/rosa-hcp-set-environment-variables.adoc[leveloffset=+1]
 
 [id="rosa-hcp-egress-lockdown-install-creating_{context}"]
 == Creating a Virtual Private Cloud for your {hcp-title} clusters 
 
-You must have a Virtual Private Cloud (VPC) to create a {hcp-title} cluster. Use one of the following methods to create a VPC:
+You must have a Virtual Private Cloud (VPC) to create a {hcp-title} cluster. To pull images from the local ECR mirror over your VPC endpoint, you must configure a privatelink service connection and modify the default security groups with specific tags. Use one of the following methods to create a VPC:
 
 * Create a VPC using the ROSA command-line interface (CLI)
 * Create a VPC by using a Terraform template
+* Create a VPC using the AWS CLI
 * Manually create the VPC resources in the AWS console
 
-[NOTE]
-====
-The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use. You should also ensure that when you use this Terraform script it is in the same region that you intend to install your cluster. In these examples, use `us-east-2`.
-====
+include::modules/rosa-hcp-create-network.adoc[leveloffset=+2]
+include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+2]
 
-[discrete]
-include::modules/rosa-hcp-create-network.adoc[leveloffset=+3]
+[id="rosa-hcp-vpc-aws_{context}"]
+=== Creating a VPC using the AWS CLI
 
-[role="_additional-resources"]
-[id="additional-resources_rosa-hcp-create-network-egress-lockdown"]
-.Additional resources
+You can create a VPC by using the AWS CLI. For information on using this CLI, see the link:https://docs.aws.amazon.com/cli/latest/reference/ec2/create-vpc.html[AWS create-vpc documentation].
 
-* See the link:https://aws.amazon.com/cloudformation/[AWS CloudFormation documentation] for more information about structuring CloudFormation files to create VPCs.
-* See the link:https://github.com/openshift/rosa/blob/master/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml[default VPC AWS CloudFormation template] for more information.
-
-[discrete]
-include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
-
-[role="_additional-resources"]
-[id="additional-resources_rosa-hcp-vpc-terraform-egress-lockdown"]
-.Additional resources
-
-* See the link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC] repository for a detailed list of all options available when customizing the VPC to your needs.
-
-[discrete]
 include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+2]
-
 include::snippets/vpc-troubleshooting.adoc[leveloffset=+2]
-
-[discrete]
-include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 [id="additional-resources_rosa-hcp-vpc-aws-egress-lockdown"]
@@ -98,14 +96,7 @@ include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+3]
 * link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-getting-started.html[Get Started with Amazon VPC]
 * link:https://developer.hashicorp.com/terraform[HashiCorp Terraform documentation]
 * link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/deploy/subnet_discovery/[Subnet Auto Discovery]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See the link:https://github.com/openshift-cs/terraform-vpc-example/tree/main/zero-egress[Zero Egress Terraform VPC Example] repository for a detailed list of all options available when customizing the VPC for your needs.
-
-[discrete]
-include::modules/rosa-hcp-sgs-and-vpce.adoc[leveloffset=+3]
+* link:https://github.com/openshift-cs/terraform-vpc-example/tree/main/zero-egress[Zero Egress Terraform VPC Example]
 
 include::modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+1]
 

--- a/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
+++ b/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
@@ -36,7 +36,8 @@ The machine that you run the installation process from must have access to the f
 
 * Amazon Web Services API and authentication service endpoints
 * Red Hat OpenShift API and authentication service endpoints (`api.openshift.com` and `sso.redhat.com`)
-* Internet connectivity to obtain installation artifacts
+* Internet connectivity to obtain installation artifacts during deployment
+//TODO OSDOCS-13133 update when zero egress is GA: "either during deployment or prior to deploying a cluster with egress lockdown enabled"
 
 //TODO OSDOCS-11789: This needs to be accessible from parts of the cluster, but not the deploying machine - omit entirely, or leave in place for Classic?
 ifdef::openshift-rosa[]


### PR DESCRIPTION
Version(s):
`enterprise-4.18+`

Issue:

- **[OSDOCS-14588](https://issues.redhat.com/browse/OSDOCS-14588)**
- **[OSDOCS-13521](https://issues.redhat.com/browse/OSDOCS-13521)**
- **[OSDOCS-13532](https://issues.redhat.com/browse/OSDOCS-13532)**

Link to docs preview:
- [Creating a Red Hat OpenShift Service on AWS cluster with egress lockdown](https://93240--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-egress-lockdown-install.html)

QE review:
- [x] QE has approved this change.

Additional information:
This PR updates the disconnected install guide for ROSA with HCP clusters.