### PR TITLE
OSDOCS#14612: Update the z-stream RNs for 4.13.58 

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4528,3 +4528,31 @@ $ oc adm release info 4.13.57 --pullspecs
 [id="ocp-4-13-57-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.13.58
+[id="ocp-4-13-58_{context}"]
+=== RHSA-2025:4677 - {product-title} 4.13.58 bug fix and security updates
+
+Issued: 15 May 2025
+
+{product-title} release 4.13.58, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4677[RHSA-2025:4677] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4679[RHBA-2025:4679] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.58 --pullspecs
+----
+
+[id="ocp-4-13-58-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the {ibm-cloud-title}(R) Internet Services (CIS) plugin caused a crash during the {ibm-cloud-title} installation and prevented the cluster creation. With this release, a fix is applied and the cluster creates successfully after the installation. (link:https://issues.redhat.com/browse/OCPBUGS-55034[*OCPBUGS-55034*])
+
+* Previously, the *Observe* section on the web console did not display items that were contributed from plugins unless certain flags related to monitoring were set. In addition, these flags prevented other plugins, such as logging, distributed tracing, network observability, and so on, from adding items to the *Observe* section. With this release, the monitoring flags are removed so that other plugins can add items to the *Observe* section. (link:https://issues.redhat.com/browse/OCPBUGS-54892[*OCPBUGS-54892*])
+
+[id="ocp-4-13-58-updating_{context}"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-14612](https://issues.redhat.com//browse/OSDOCS-14612)

Link to docs preview:
[4.13.58](https://93242--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-58_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream release notes

Additional information:
The errata URLs will return 404 until the go-live date of 05/15/25.
