### PR TITLE
OLS-1752: Create release notes for OLS 0.3.5

### DIFF
--- a/modules/ols-0-3-5-fixed-issues.adoc
+++ b/modules/ols-0-3-5-fixed-issues.adoc
@@ -1,0 +1,11 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-3-5-fixed-issues_{context}"]
+= Fixed issues
+
+The following issues are fixed with {ols-official} 0.3.5:
+
+* Previously, the {ols-long} service could not support a self-hosted large language model (LLM) with OpenAI-compatible API endpoints by using a self-signed certificate with a custom CA to secure its HTTPS endpoints. Now the {ols-short} service can support a self-signed certificate with a custom CA to secure HTTPS connections to the LLM provider. link:https://issues.redhat.com/browse/OLS-1715[OLS-1715].

--- a/modules/ols-0-3-5-release-notes.adoc
+++ b/modules/ols-0-3-5-release-notes.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-3-5-release-notes_{context}"]
+= {ols-long} version 0.3.5
+
+{ols-official} 0.3.5 is now available on {ocp-product-title} 4.15 and later.
+
+[IMPORTANT]
+====
+{ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
+====
+
+[id="ols-0-3-5-enhancements_{context}"]
+== Enhancements
+
+The following enhancements are made with {ols-official} 0.3.5:
+
+* Beginning in this release, the {ols-long} conversation history is saved to the PostgresSQL database and is retained in persistent volume. The conversation history persists if the PostgreSQL pod restarts or is rescheduled. PostgresSQL persistence is disabled by default. To enable the feature, define the `size` and `class` parameters in the `ols.storage` specification of the `OLSConfig` custom resource (CR).
+
+* This release introduces the cluster interaction feature as a Technology Preview feature. Use the cluster interaction feature to enhance the knowledge available to the large language model (LLM) with information about an {ocp-product-title} cluster. Providing cluster-specific information, such as the namespaces or pods that the cluster contains, enables the LLM to generate responses unique to the cluster.
+
+:FeatureName: The cluster interaction feature
+include::snippets/technology-preview.adoc[]

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 The release notes highlight what is new and what has changed with each {ols-official} release.
 
+include::modules/ols-0-3-5-release-notes.adoc[leveloffset=+1]
+include::modules/ols-0-3-5-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-4-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-3-4-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-3-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1752
https://93243--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html

Link to docs preview:
[<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->](https://93243--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-0-3-5-release-notes_ols-release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
