### PR TITLE
OLS-1753: In cluster interaction task create verification section

### DIFF
--- a/modules/ols-enabling-cluster-interaction.adoc
+++ b/modules/ols-enabling-cluster-interaction.adoc
@@ -44,6 +44,8 @@ spec:
 
 . Click *Save*.
 
-. Access the {ols-long} virtual assistant and submit a question associated with the custom content that was added to the LLM.
+.Verification
+
+* Access the {ols-long} virtual assistant and submit a question associated with the custom content that was added to the LLM.
 +
 The {ols-long} virtual assistant generates a response based on the custom content.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1753
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->](https://93244--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#enabling-cluster-interaction_ols-configuring-openshift-lightspeed)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
