### PR TITLE
ROX-28896: Add CRD upgrade instructions for roxctl upgrade

### DIFF
--- a/modules/upgrade-central-cluster-crds.adoc
+++ b/modules/upgrade-central-cluster-crds.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * upgrade/upgrade-roxctl.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="upgrade-central-cluster-crds{context}"]
+= Upgrading the SecurityPolicy custom resource definition
+
+[role="_abstract"]
+You can update the `SecurityPolicy` custom resource definition (CRD) to the latest version by generating the new CRD and applying it to the cluster.
+
+.Procedure
+
+. Use `roxctl` to generate a new set of resources by entering the following command:
++
+[source,terminal,subs=attributes+]
+----
+$ roxctl central generate k8s pvc > bundle.zip
+----
+
+. Extract the CRD from the archive by entering the following command:
++
+[source,terminal,subs=attributes+]
+----
+$ unzip bundle.zip central/00-securitypolicy-crd.yaml
+----
+
+. Apply the extracted CRD to your cluster by entering the following command:
++
+[source,terminal,subs=attributes+]
+----
+$ oc apply -f central/00-securitypolicy-crd.yaml <1>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.

--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -43,7 +43,9 @@ include::modules/install-roxctl-cli-windows.adoc[leveloffset=+2]
 [id="upgrade-central-cluster"]
 == Upgrading the Central cluster
 
-After you have created a backup of the Central database and generated the necessary resources by using the provisioning bundle, the next step is to upgrade the Central cluster. This process involves upgrading Central and Scanner.
+After you have created a backup of the Central database and generated the necessary resources by using the provisioning bundle, the next step is to upgrade the Central cluster. This process requires upgrading the `SecurityPolicy` custom resource definition (CRD), Central, and Scanner.
+
+include::modules/upgrade-central-cluster-crds.adoc[leveloffset=+2]
 
 include::modules/upgrade-central-cluster-central.adoc[leveloffset=+2]
 


### PR DESCRIPTION
There need to be additional instructions to upgrade the `SecurityPolicy` CRD when `roxctl` was used to install ACS.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.8
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/ROX-28896
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://93245--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl.html#upgrade-central-cluster-crdsupgrade-roxctl

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
