### PR TITLE
OSDOCS#14609: Update the z-stream RNs for 4.16.40

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3362,6 +3362,55 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.40
+[id="ocp-4-16-40_{context}"]
+=== RHSA-2025:4008 - {product-title} {product-version}.40 bug fix and security update
+
+Issued: 15 May 2025
+
+{product-title} release {product-version}.40 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:4008[RHSA-2025:4008] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:4010[RHBA-2025:4010] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.40 --pullspecs
+----
+
+[id="ocp-4-16-40-known-issues_{context}"]
+==== Known issues
+ * The grandmaster clock (T-GM) transitions to the `Locked` state too soon. This is a known issue that happens before the Digital Phase-Locked Loop (DPLL) completes its change to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored. (link:https://issues.redhat.com/browse/OCPBUGS-49826[*OCPBUGS-49826*]) 
+
+[id="ocp-4-16-40-enhancements_{context}"]
+==== Enhancements
+* The `Konnectivity` service failed to proxy requests from the API pod to the `validatingWebhook` service, preventing the creation of additional groups in {product-title} clusters using the `Kyverno` service. This issue is resolved by fixing the `Konnectivity` service's request proxy for the `validatingWebhook` in {product-title} clusters with {hcp}. This enhancement improves the ability to create additional test groups in {product-title} clusters with {hcp}.  (link:https://issues.redhat.com/browse/OCPBUGS-55378[*OCPBUGS-55378*])
+
+[id="ocp-4-16-40-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, if you had permission to view nodes but not Certificate Signing Requests (CSR), you could not access the *Nodes list* page. With this release, permissions to view CSRs are no longer required to access the *Nodes list* page. (link:https://issues.redhat.com/browse/OCPBUGS-55378[*OCPBUGS-55378*])
+
+* Previously, for an ingress resource with an `IngressWithoutClassName` alert, the Ingress Controller did not delete the alert when the resource was deleted. The alert continued to open on the {product-title} web console. With this release, the Ingress Controller resets the `openshift_ingress_to_route_controller_ingress_without_class_name` metric to `0` before the controller deletes the ingress resource. The alert is deleted and no longer opens on the web console. (link:https://issues.redhat.com/browse/OCPBUGS-55201[*OCPBUGS-55201*])
+
+* Previously, a race condition between `Go` routines caused the Cluster Version Operator (CVO) to behave inconsistently after the CVO started. With this release, the `Go`` routines synchronization is improved and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-55156[*OCPBUGS-55156*])
+
+* Previously, {azure-first} network interfaces were created in a `provisioning failed` state, causing potential resource allocation issues. With this release, there is enhanced reliability in {azure-short} network interface controller (NIC) provisioning by adding code to verify and retry the network interface provisioning status by using the {azure-short} software development kit (SDK). (link:https://issues.redhat.com/browse/OCPBUGS-54990[*OCPBUGS-54990*])
+
+* Previously, if a scrape failed, Prometheus incorrectly considered the samples from the next scrape as duplicates and dropped them. This issue affected only the scrape immediately following a failure, while later scrapes were processed correctly. With this release, the scrape following a failure is correctly handled, ensuring that no valid samples are mistakenly dropped. (link:https://issues.redhat.com/browse/OCPBUGS-54942[*OCPBUGS-54942*])
+
+* Previously, containers that used the SELinux `container_logreader_t` domain to view container logs in `/var/log` could not access logs in the `/var/log/containers` subdirectory. This issue occurred because of a missing symbolic link. With this release, a symbolic link is created for `/var/log/containers` and containers can access the logs in `/var/log/containers`. (link:https://issues.redhat.com/browse/OCPBUGS-54818[OCPBUGS-54818])
+
+* Previously, an incomplete container network interface (CNI) redeployment caused an issue during limited live migration. This issue led to potential network connectivity problems during rollback to {product-title} software-defined networking (SDN) for users. With this release, a bug fix adds an annotation for the primary IP address of a node to handle non-cloud platforms during egress IP address rollback. The fix ensures a smooth rollback to {product-title} SDN, resolving stuck issues that occur during limited live migration, and improving network connectivity. (link:https://issues.redhat.com/browse/OCPBUGS-53317[OCPBUGS-53317])
+
+* Previously, a User Datagram Protocol (UDP) packet that was larger than the maximum transmission unit (MTU) value that was set for the cluster could not be sent to the packet endpoint by using a service. With this release, the pod IP address is used instead of the service IP address regardless of the packet size, and the UDP packet is sent to the endpoint. (link:https://issues.redhat.com/browse/OCPBUGS-50581[OCPBUGS-50581])
+
+* Previously, a bug in the internal publishing strategy led to missing ports for private clusters, making them inaccessible. With this release, a fix is added to the necessary ports for private clusters, enhancing deployment success and ensuring seamless access to private clusters. (link:https://issues.redhat.com/browse/OCPBUGS-35040[OCPBUGS-35040])
+
+[id="ocp-4-16-40-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.39
 [id="ocp-4-16-39_{context}"]
 === RHSA-2025:4008 - {product-title} {product-version}.39 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16.40

Issue:
[OSDOCS-14609](https://issues.redhat.com//browse/OSDOCS-14609)

Link to docs preview:
[4.16.40](https://93246--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html)

QE review:
- [ ] QE has approved this change.
N/A for z-stream relnotes.

Additional information:
The errata URLs will return 404 until the go-live date of 05/15/25.
