### PR TITLE
Jira:RHELDOCS-20134 NBDE Tang Server Operator 1.1.1 update

### DIFF
--- a/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc
+++ b/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc
@@ -14,4 +14,5 @@ link:https://access.redhat.com/errata/RHEA-2023:7491[RHEA-2023:7491]:: The NBDE 
 link:https://access.redhat.com/errata/RHEA-2024:0854[RHEA-2024:0854]:: The NBDE Tang Server Operator 1.0.1 has been moved from the `alpha` channel to the `stable` channel.
 link:https://access.redhat.com/errata/RHBA-2024:8681[RHBA-2024:8681]:: The 1.0.2 update contains fixes that increase the Container Health Index of containers deployed with the NBDE Tang Server Operator to the highest grade.
 link:https://access.redhat.com/errata/RHEA-2024:10970[RHEA-2024:10970]:: The 1.0.3 update contains changes that re-increase the Container Health Index to the highest grade.
-link:https://access.redhat.com/errata/RHBA-2025:0663[RHBA-2025:0663]:: With the NBDE Tang Server Operator 1.1, the `golang` package is provided in version 1.23.2 and the `golang.org/x/net/html` package has been updated to version 0.33.0. The updates increase the Container Health Index.
+link:https://access.redhat.com/errata/RHBA-2025:0663[RHBA-2025:0663]:: The NBDE Tang Server Operator 1.1 includes the `golang` package version 1.23.2 and the `golang.org/x/net/html` package version 0.33.0. The updates improve the Container Health Index.
+link:https://access.redhat.com/errata/RHBA-2025:4453[RHBA-2025:4453]:: The 1.1.1 update provides a fix for link:https://access.redhat.com/security/cve/cve-2025-22866[CVE-2025-22866].


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/RHELDOCS-20134

Link to docs preview:
https://93251--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.html

Additional information:
Only a new bullet point covering new version in the release notes of the Operator.
