### PR TITLE
Update etcd-certificates.adoc

### DIFF
--- a/security/certificate_types_descriptions/etcd-certificates.adoc
+++ b/security/certificate_types_descriptions/etcd-certificates.adoc
@@ -27,7 +27,7 @@ These certificates are only managed by the system and are automatically rotated.
 etcd certificates are used for encrypted communication between etcd member peers and encrypted client traffic. The following certificates are generated and used by etcd and other processes that communicate with etcd:
 
 * Peer certificates: Used for communication between etcd members.
-* Client certificates: Used for encrypted server-client communication. Client certificates are currently used by the API server only, and no other service should connect to etcd directly except for the proxy. Client secrets (`etcd-client`, `etcd-metric-client`, `etcd-metric-signer`, and `etcd-signer`) are added to the `openshift-config`, `openshift-monitoring`, and `openshift-kube-apiserver` namespaces.
+* Client certificates: Used for encrypted server-client communication. Client certificates are currently used by the API server only, and no other service should connect to etcd directly except for the proxy. Client secrets (`etcd-client`, `etcd-metric-client`, `etcd-metric-signer`, and `etcd-signer`) are added to the `openshift-config`, `openshift-etcd`, `openshift-monitoring`, and `openshift-kube-apiserver` namespaces.
 * Server certificates: Used by the etcd server for authenticating client requests.
 * Metric certificates: All metric consumers connect to proxy with metric-client certificates.
 


### PR DESCRIPTION
The etcd-metric-client client secret is present in openshift-etcd namespace, and not in openshift-config / openshift-monitoring / openshift-kube-apiserver namespaces starting from RHOCP version 4.16 and above.

Previously till RHOCP version 4.15, it was present in the openshift-config namespace.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 
4.16 and above

Issue:
https://issues.redhat.com/browse/OSDOCS-14653

Link to docs preview:
https://93254--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/etcd-certificates.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
