### PR TITLE
OSDOCS-14645: disconnected env is supported in SSCSI

### DIFF
--- a/modules/persistent-storage-csi-secrets-store-disconnect-environment.adoc
+++ b/modules/persistent-storage-csi-secrets-store-disconnect-environment.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+//
+
+:_mod-docs-content-type: CONCEPT
+[id="persistent-storage-csi-secrets-store-disconnect-environment_{context}"]
+= Support for disconnected environments
+
+The following secrets store providers support using the {secrets-store-driver} in disconnected clusters:
+
+* AWS Secrets Manager
+* Azure Key Vault
+* Google Secret Manager
+* HashiCorp Vault
+
+To enable communication between {secrets-store-driver} and the secrets store provider, configure Virtual Private Cloud (VPC) endpoints or equivalent connectivity to the corresponding secrets store provider, the OpenID Connect (OIDC) issuer, and the Secure Token Service (STS). The exact configuration depends on the secrets store provider, the authentication method, and the type of disconnected cluster.

--- a/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="persistent-storage-csi-secrets-store"]
 = {secrets-store-driver}
 include::_attributes/common-attributes.adoc[]
@@ -15,6 +16,13 @@ Familiarity with xref:../../storage/understanding-persistent-storage.adoc#unders
 include::modules/secrets-store-providers.adoc[leveloffset=+2]
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-secrets-store-disconnect-environment.adoc[leveloffset=+1]
+
+[NOTE]
+====
+For more information about disconnected environments, see xref:../../disconnected/about.adoc#about[About disconnected environments].
+====
 
 include::modules/persistent-storage-csi-secrets-store-driver-install.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.19 +

Issue:
[OSDOCS-14645](https://issues.redhat.com/browse/OSDOCS-14645)

Link to docs preview:
[Support for disconnected environments](https://93255--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-secrets-store#persistent-storage-csi-secrets-store-disconnect-environment_persistent-storage-csi-secrets-store)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
