### PR TITLE
OBSDOCS-1889: Logging Z-Stream Release Notes - 5.9.14

### DIFF
--- a/modules/logging-release-notes-5-9-14.adoc
+++ b/modules/logging-release-notes-5-9-14.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-9-14_{context}"]
+= Logging 5.9.14
+
+This release includes link:https://access.redhat.com/errata/RHSA-2025:7449[RHSA-2025:7449].
+
+[id="logging-release-notes-5-9-14-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]
+* link:https://access.redhat.com/security/cve/CVE-2020-11023[CVE-2020-11023]
+* link:https://access.redhat.com/security/cve/CVE-2024-2236[CVE-2024-2236]
+* link:https://access.redhat.com/security/cve/CVE-2024-2511[CVE-2024-2511]
+* link:https://access.redhat.com/security/cve/CVE-2024-3596[CVE-2024-3596]
+* link:https://access.redhat.com/security/cve/CVE-2024-4603[CVE-2024-4603]
+* link:https://access.redhat.com/security/cve/CVE-2024-4741[CVE-2024-4741]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+* link:https://access.redhat.com/security/cve/CVE-2024-12797[CVE-2024-12797]
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]
+* link:https://access.redhat.com/security/cve/CVE-2025-0395[CVE-2025-0395]
+
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#low[Severity ratings].
+====

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -10,6 +10,8 @@ Logging is provided as an installable component, with a distinct release cycle f
 
 include::snippets/logging-stable-updates-snip.adoc[leveloffset=+1]
 
+include::modules/logging-release-notes-5-9-14.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-9-13.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-9-12.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.13, 4.14, 4.15, 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1889
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://93261--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html#logging-release-notes-5-9-14_logging-5-9-release-notes

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
