### PR TITLE
OBSDOCS-1893: Logging Z-Stream Release Notes - 5.8.20

### DIFF
--- a/modules/logging-release-notes-5-8-20.adoc
+++ b/modules/logging-release-notes-5-8-20.adoc
@@ -1,0 +1,30 @@
+// module included in /logging/logging-5-8-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-20_{context}"]
+= Logging 5.8.20
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:7450[RHBA-2025:7450] and link:https://access.redhat.com/errata/RHSA-2025:7451[RHSA-2025:7451].
+
+[id="logging-release-notes-5-8-20-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]
+* link:https://access.redhat.com/security/cve/CVE-2020-11023[CVE-2020-11023]
+* link:https://access.redhat.com/security/cve/CVE-2024-2236[CVE-2024-2236]
+* link:https://access.redhat.com/security/cve/CVE-2024-2511[CVE-2024-2511]
+* link:https://access.redhat.com/security/cve/CVE-2024-3596[CVE-2024-3596]
+* link:https://access.redhat.com/security/cve/CVE-2024-4603[CVE-2024-4603]
+* link:https://access.redhat.com/security/cve/CVE-2024-4741[CVE-2024-4741]
+* link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+* link:https://access.redhat.com/security/cve/CVE-2024-8176[CVE-2024-8176]
+* link:https://access.redhat.com/security/cve/CVE-2024-12133[CVE-2024-12133]
+* link:https://access.redhat.com/security/cve/CVE-2024-12243[CVE-2024-12243]
+* link:https://access.redhat.com/security/cve/CVE-2024-12797[CVE-2024-12797]
+* link:https://access.redhat.com/security/cve/CVE-2024-42292[CVE-2024-42292]
+* link:https://access.redhat.com/security/cve/CVE-2024-42322[CVE-2024-42322]
+* link:https://access.redhat.com/security/cve/CVE-2024-44990[CVE-2024-44990]
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]
+* link:https://access.redhat.com/security/cve/CVE-2024-46826[CVE-2024-46826]
+* link:https://access.redhat.com/security/cve/CVE-2025-0395[CVE-2025-0395]
+* link:https://access.redhat.com/security/cve/CVE-2025-21927[CVE-2025-21927]
+* link:https://access.redhat.com/security/cve/CVE-2025-27363[CVE-2025-27363]

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-20.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-19.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-18.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.12, 4.13, 4.14, 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1893
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://93262--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html#logging-release-notes-5-8-20_logging-5-8-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
