### PR TITLE
OSDOCS#12034: HCP Kubevirt topology spread constraint

### DIFF
--- a/hosted_control_planes/hcp-manage/hcp-manage-virt.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-virt.adoc
@@ -59,3 +59,10 @@ include::modules/hcp-virt-etcd-storage.adoc[leveloffset=+2]
 include::modules/hcp-virt-attach-nvidia-gpus.adoc[leveloffset=+1]
 
 include::modules/hcp-virt-attach-nvidia-gpus-np-api.adoc[leveloffset=+1]
+
+include::modules/hcp-topology-spread-constraint.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc#nodes-descheduler-installing_virt-enabling-descheduler-evictions[Installing the descheduler]

--- a/modules/hcp-topology-spread-constraint.adoc
+++ b/modules/hcp-topology-spread-constraint.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-manage/hcp-manage-virt.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-topology-spread-constraint_{context}"]
+= Spreading node pool VMs by using topologySpreadConstraint
+
+By default, KubeVirt virtual machines (VMs) created by a node pool are scheduled on any available nodes that have the capacity to run the VMs. By default, the `topologySpreadConstraint` constraint is set to schedule VMs on multiple nodes.
+
+In some scenarios, node pool VMs might run on the same node, which can cause availability issues. To avoid distribution of VMs on a single node, use the descheduler to continuously honor the `topologySpreadConstraint` constraint to spread VMs on multiple nodes.
+
+.Prerequisites
+
+* You installed the {descheduler-operator}. For more information, see "Installing the descheduler".
+
+.Procedure
+
+* Open the `KubeDescheduler` custom resource (CR) by entering the following command, and then modify the `KubeDescheduler` CR to use the `SoftTopologyAndDuplicates` and `DevKubeVirtRelieveAndMigrate` profiles so that you maintain the `topologySpreadConstraint` constraint settings.
++
+The `KubeDescheduler` CR named `cluster` runs in the `openshift-kube-descheduler-operator` namespace.
++
+[source,terminal]
+----
+$ oc edit kubedescheduler cluster -n openshift-kube-descheduler-operator
+----
++
+.Example `KubeDescheduler` configuration
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  mode: Automatic
+  managementState: Managed
+  deschedulingIntervalSeconds: 30 # <1>
+  profiles:
+  - SoftTopologyAndDuplicates   # <2>
+  - DevKubeVirtRelieveAndMigrate          # <3>
+  profileCustomizations:
+    devDeviationThresholds: AsymmetricLow
+    devActualUtilizationProfile: PrometheusCPUCombined
+# ...
+----
+<1> Sets the number of seconds between the descheduler running cycles.
+<2> This profile evicts pods that follow the soft topology constraint: `whenUnsatisfiable: ScheduleAnyway`.
+<3> This profile balances resource usage between nodes and enables the strategies, such as `RemovePodsHavingTooManyRestarts` and `LowNodeUtilization`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: Issue: https://issues.redhat.com/browse/OSDOCS-12034

Link to docs preview: https://93263--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-virt.html#hcp-topology-spread-constraint_hcp-manage-virt

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.---> This content is QE/SME approved and peer-reviewed. It was reverted as per QE's suggestion. Adding the same content back to docs. Newly added content is reviewed by SMEs.
