### PR TITLE
OCPBUGS#55102: Include reserved HCP CIDR ranges

### DIFF
--- a/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
@@ -22,3 +22,10 @@ include::modules/hcp-fips.adoc[leveloffset=+1]
 * link:https://access.redhat.com/articles/7099674[The {mce} 2.8 support matrix]
 * link:https://access.redhat.com/labs/ocpouic/?operator=multicluster-engine&&upgrade_path=4.14%20to%204.16[Red{nbsp}Hat {product-title} Operator Update Information Checker]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc#hcp-shared-infra_hcp-sizing-guidance[Shared infrastructure between hosted and standalone control planes]
+
+include::modules/hcp-cidr-ranges.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/cidr-range-definitions.adoc#cidr-range-definitions[CIDR range definitions]

--- a/modules/hcp-cidr-ranges.adoc
+++ b/modules/hcp-cidr-ranges.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-prepare/hcp-requirements.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="hcp-cidr-ranges_{context}"]
+= CIDR ranges for {hcp}
+
+For deploying {hcp} on {product-title}, use the following required Classless Inter-Domain Routing (CIDR) subnet ranges:
+
+* `v4InternalSubnet`: 100.65.0.0/16 (OVN-Kubernetes)
+* `clusterNetwork`: 10.132.0.0/14 (pod network)
+* `serviceNetwork`: 172.31.0.0/16
+
+
+For more information about {product-title} CIDR range definitions, see "CIDR range definitions".

--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -9,7 +9,7 @@ endif::openshift-dedicated,openshift-rosa[]
 
 toc::[]
 
-If your cluster uses OVN-Kubernetes, you must specify non-overlapping ranges for Classless Inter-Domain Routing (CIDR) subnet ranges.  
+If your cluster uses OVN-Kubernetes, you must specify non-overlapping ranges for Classless Inter-Domain Routing (CIDR) subnet ranges.
 
 [IMPORTANT]
 ====
@@ -18,9 +18,9 @@ For {product-title} 4.17 and later versions, clusters use `169.254.0.0/17` for I
 
 The following subnet types and are mandatory for a cluster that uses OVN-Kubernetes:
 
-* Join: Uses a join switch to connect gateway routers to distributed routers. A join switch reduces the number of IP addresses for a distributed router. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the join switch. 
+* Join: Uses a join switch to connect gateway routers to distributed routers. A join switch reduces the number of IP addresses for a distributed router. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the join switch.
 * Masquerade: Prevents collisions for identical source and destination IP addresses that are sent from a node as hairpin traffic to the same node after a load balancer makes a routing decision.
-* Transit: A transit switch is a type of distributed switch that spans across all nodes in the cluster. A transit switch routes traffic between different zones. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the transit switch. 
+* Transit: A transit switch is a type of distributed switch that spans across all nodes in the cluster. A transit switch routes traffic between different zones. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the transit switch.
 
 [NOTE]
 ====
@@ -122,3 +122,6 @@ endif::openshift-rosa,openshift-dedicated[]
 ifdef::openshift-enterprise[]
 For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 510 cluster nodes, and 510 pod IP addresses per node.
 endif::openshift-enterprise[]
+
+
+include::modules/hcp-cidr-ranges.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-55102
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://93269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-requirements#hcp-cidr-ranges_hcp-requirements

https://93269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/cidr-range-definitions.html#hcp-cidr-description_cidr-range-definitions

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
