### PR TITLE
[enterprise-4.16] OCPBUGS#55102: Include reserved HCP CIDR ranges

### DIFF
--- a/hosted_control_planes/index.adoc
+++ b/hosted_control_planes/index.adoc
@@ -24,3 +24,10 @@ include::modules/hosted-control-planes-version-support.adoc[leveloffset=+1]
 
 * xref:../scalability_and_performance/using-node-tuning-operator.adoc#node-tuning-hosted-cluster_node-tuning-operator[Configuring node tuning in a hosted cluster]
 * xref:../scalability_and_performance/using-node-tuning-operator.adoc#advanced-node-tuning-hosted-cluster_node-tuning-operator[Advanced node tuning for hosted clusters by setting kernel boot parameters]
+
+include::modules/hcp-cidr-ranges.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/cidr-range-definitions.adoc#cidr-range-definitions[CIDR range definitions]

--- a/modules/hcp-cidr-ranges.adoc
+++ b/modules/hcp-cidr-ranges.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="hcp-cidr-ranges_{context}"]
+= CIDR ranges for {hcp}
+
+For deploying {hcp} on {product-title}, use the following required Classless Inter-Domain Routing (CIDR) subnet ranges:
+
+* `v4InternalSubnet`: 100.65.0.0/16 (OVN-Kubernetes)
+* `clusterNetwork`: 10.132.0.0/14 (pod network)
+* `serviceNetwork`: 172.31.0.0/16
+
+For more information about {product-title} CIDR range definitions, see "CIDR range definitions".

--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -9,13 +9,13 @@ endif::openshift-dedicated,openshift-rosa[]
 
 toc::[]
 
-If your cluster uses OVN-Kubernetes, you must specify non-overlapping ranges for Classless Inter-Domain Routing (CIDR) subnet ranges.  
+If your cluster uses OVN-Kubernetes, you must specify non-overlapping ranges for Classless Inter-Domain Routing (CIDR) subnet ranges.
 
 The following subnet types are mandatory for a cluster that uses OVN-Kubernetes:
 
-* Join: Uses a join switch to connect gateway routers to distributed routers. A join switch reduces the number of IP addresses for a distributed router. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the join switch. 
+* Join: Uses a join switch to connect gateway routers to distributed routers. A join switch reduces the number of IP addresses for a distributed router. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the join switch.
 * Masquerade: Prevents collisions for identical source and destination IP addresses that are sent from a node as hairpin traffic to the same node after a load balancer makes a routing decision.
-* Transit: A transit switch is a type of distributed switch that spans across all nodes in the cluster. A transit switch routes traffic between different zones. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the transit switch. 
+* Transit: A transit switch is a type of distributed switch that spans across all nodes in the cluster. A transit switch routes traffic between different zones. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the transit switch.
 
 [NOTE]
 ====
@@ -47,7 +47,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * For more information about configuring join subnets or transit subnets, see xref:../networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc#configure-ovn-kubernetes-subnets[Configuring OVN-Kubernetes internal IP address subnets].
 endif::openshift-rosa,openshift-dedicated[]
 
-[id="machine-cidr-description"]
+[id="machine-cidr-description_{context}"]
 == Machine CIDR
 
 In the Machine classless inter-domain routing (CIDR) field, you must specify the IP address range for machines or cluster nodes.
@@ -77,7 +77,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../networking/networking_operators/cluster-network-operator.adoc#nw-operator-cr_cluster-network-operator[Cluster Network Operator configuration]
 endif::[]
 
-[id="service-cidr-description"]
+[id="service-cidr-description_{context}"]
 == Service CIDR
 In the Service CIDR field, you must specify the IP address range for services.
 ifdef::openshift-rosa,openshift-dedicated[]
@@ -85,7 +85,7 @@ It is recommended, but not required, that the address block is the same between 
 endif::openshift-rosa,openshift-dedicated[]
 The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `172.30.0.0/16`.
 
-[id="pod-cidr-description"]
+[id="pod-cidr-description_{context}"]
 == Pod CIDR
 In the pod CIDR field, you must specify the IP address range for pods.
 
@@ -105,7 +105,7 @@ You can expand the range after cluster installation.
 * xref:../networking/configuring-cluster-network-range.adoc#configuring-cluster-network-range[Configuring the cluster network range]
 endif::openshift-enterprise[]
 
-[id="host-prefix-description"]
+[id="host-prefix-description_{context}"]
 == Host Prefix
 In the Host Prefix field, you must specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine.
 
@@ -116,3 +116,6 @@ endif::openshift-rosa,openshift-dedicated[]
 ifdef::openshift-enterprise[]
 For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 510 cluster nodes, and 510 pod IP addresses per node.
 endif::openshift-enterprise[]
+
+
+include::modules/hcp-cidr-ranges.adoc[leveloffset=+1]


### PR DESCRIPTION

Version(s): 4.16, 4.15, and 4.14

Issue: https://issues.redhat.com/browse/OCPBUGS-55102

Link to docs preview:

QE review:

- [x] QE has approved this change.

Additional information:
