### PR TITLE
OSDOCS-14654:Added cluster installation errors to ROSA Classic Troubleshooting guide

### DIFF
--- a/modules/rosa-troubleshooting-awsapiratelimitexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsapiratelimitexceeded-failure-deployment.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-awsapiratelimitexceeded-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an AWSAPIRateLimitExceeded error
+
+If a cluster creation action fails, you might receive the following error messages.
+
+.Example install logs output
+[source,terminal]
+----
+level=error\nlevel=error msg=Error: error waiting for Route53 Hosted Zone .* creation: timeout while waiting for state to become 'INSYNC' (last state: 'PENDING', timeout: 15m0s)
+----
+
+.Example {cluster-manager} output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3008
+Provisioning Error Message: AWS API rate limit exceeded. Please try again.
+----
+
+This error indicates that the AWS API rate limit has been exceeded while waiting for the Route 53 hosted zone.
+
+.Procedure
+
+* Reattempt the installation.
+
+

--- a/modules/rosa-troubleshooting-awsec2quotaexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsec2quotaexceeded-failure-deployment.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-awsec2quotaexceeded-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an AWSEC2QuotaExceeded error
+
+If a cluster creation action fails, you might receive the following error message.
+
+.Example output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3042
+Provisioning Error Message: AWS E2C quota limit exceeded. Clean unused load balancers or increase quota and try again.
+----
+
+This error indicates that you have reached the EC2 quota limit for the region mentioned in the error log.
+
+.Procedure
+
+Request a quota increase from AWS or delete unused EC2 instances.
+
+* Request a quota increase from AWS.
+.. Sign in to the link:https://aws.amazon.com/console/[AWS Management Console].
+.. Click your user name and select **Service Quotas**.
+.. Under **Manage quotas**, select an AWS service to view available quotas.
+.. If the quota is adjustable, you can choose the button or the name, and then choose **Request quota increase**.
+
+* Delete unused EC2 instances using the console.
+.. Before you delete an EC2 instance, verify your data by checking that your Amazon EBS volumes will still exist after you delete the unused EC2 instances.
+.. Ensure you have copied any data that you need from your instance store volumes to persistent storage, such as Amazon EBS or Amazon S3.
+.. If you have a CNAME record for your domain that points to your load balancer, point it to a new location and wait for the DNS change to take effect before deleting your load balancer.
+.. Open the link:https://console.aws.amazon.com/ec2/[Amazon EC2 console].
+.. On the navigation pane, choose **Instances**.
+.. Select the instance, and choose **Terminate instance**.
+
+
+
+
+

--- a/modules/rosa-troubleshooting-awsinsufficientcapacity-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsinsufficientcapacity-failure-deployment.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-awsinsufficientcapacity-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an AWSInsufficientCapacity error
+
+If a cluster creation action fails, you might receive the following error message.
+
+.Example output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3052
+Provisioning Error Message: AWSInsufficientCapacity.
+----
+
+This error indicates that AWS has run out of capacity for a particular availability zone that you have requested.
+
+.Procedure
+
+* Try reinstalling or select a different AWS region or different availability zones.
+

--- a/modules/rosa-troubleshooting-awsinsufficientpermission-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsinsufficientpermission-failure-deployment.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-awsinsufficientpermission-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an AWSInsufficientPermissions error
+
+If a cluster creation action fails, you might receive the following error message.
+
+.Example {cluster-manager} output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3033
+Provisioning Error Message: Current credentials insufficient for performing cluster installation.
+----
+
+This error indicates that the cluster installation is blocked due to missing or insufficient privileges on the AWS account used to provision the cluster.
+
+.Procedure
+
+Ensure that the prerequisites are met by reviewing _Detailed requirements for deploying ROSA (classic architecture) using STS_ or _Deploying ROSA without AWS STS_ in _Additional resources_ depending on your choice of credential mode for installing clusters.
+
+include::snippets/rosa-sts.adoc[]
+. If needed, you can re-create the permissions and policies by using the `-f` flag:
++
+.Example output
+[source,terminal]
+----
+$ rosa create ocm-role -f
+$ rosa create user-role -f
+$ rosa create account-roles -f
+$ rosa create operator-roles -c ${CLUSTER} -f
+----
+. Validate all the prerequisites and attempt cluster reinstallation.
+
+
+

--- a/modules/rosa-troubleshooting-awsnatgatewaylimitexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsnatgatewaylimitexceeded-failure-deployment.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-awsnatgatewaylimitexceeded-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an AWSNATGatewayLimitExceeded error
+
+If a cluster creation action fails, you might receive the following error messages.
+
+.Example install logs output
+[source,terminal]
+----
+Failed to create cluster: Error creating NAT Gateway: NatGatewayLimitExceeded: Performing this operation would exceed the limit of 5 NAT gateways.
+----
+
+.Example {cluster-manager} output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3019
+Provisioning Error Message: NAT gateway limit exceeded. Clean unused NAT gateways or increase quota and try again.
+----
+
+This error indicates that you have reached the quota for the number of NAT gateways for that availability zone.
+
+.Procedure
+
+. To fix this issue, try one of the following methods:
+
+* Request an increase in the **NAT gateways per Availability Zone quota** page by using the **Service Quotas** console (AWS).
+
+* Check the status of your NAT gateway. A status of `Pending`, `Available`, or `Deleting` counts against your quota. If you have recently deleted a NAT gateway, wait a few minutes for the status to go from `Deleting` to `Deleted`. Then try creating a new NAT gateway.
+
+* If you do not need your NAT gateway in a specific availability zone, try creating a NAT gateway in an availability zone where you have not reached your quota.
+

--- a/modules/rosa-troubleshooting-awssubnetnotexist-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awssubnetnotexist-failure-deployment.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-awssubnetnotexist-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an AWSSubnetDoesNotExist error
+
+If a cluster creation action fails, you can receive the following error messages.
+
+.Example install logs output
+[source,terminal]
+----
+The subnet ID 'subnet-<somesubnetID>' does not exist.
+----
+
+.Example {cluster-manager} output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3032
+Provisioning Error Message: You have specified an invalid subnet. Verify your subnet configuration is correct and try again.
+----
+
+This error indicates that the cluster installation is blocked by an invalid subnet selection error.
+
+.Procedure
+
+* Check your subnets provided in the `platform.aws.subnets` parameter during installation. The subnets must be a part of the same machine Network CIDR ranges that you specify.
+** For a standard cluster, specify a public and a private subnet for each availability zone.
+** For a private cluster, specify a private subnet for each availability zone.
+
+For more information about AWS VPC and subnet requirements and optional parameters, see the _VPC_ section in the _AWS prerequisites for ROSA_ guide.
+

--- a/modules/rosa-troubleshooting-awsvpclimit-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsvpclimit-failure-deployment.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-awsvpclimit-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an AWSVPCLimitExceeded error
+
+If a cluster creation action fails, you might receive the following error message.
+
+.Example {cluster-manager} output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3013
+Provisioning Error Message: VPC limit exceeded. Clean unused VPCs or increase quota and try again.
+----
+
+This error indicates that you have reached the quota for the number of VPCs.
+
+.Procedure
+
+Request a quota increase from AWS or delete unused VPCs.
+
+* Request a quota increase from AWS.
+.. Sign in to the link:https://aws.amazon.com/console/[AWS Management Console].
+.. Click your user name and select **Service Quotas**.
+.. Under **Manage quotas**, select a service to view available quotas.
+.. If the quota is adjustable, you can choose the button or the name, and then choose **Request increase**.
+.. For **Increase quota value**, enter the new value. The new value must be greater than the current value.
+.. Choose **Request**.
+
+* Clean unused VPCs. Before you can delete a VPC, you must first terminate or delete any resources that created a requester-managed network interface in the VPC. For example, you must terminate your EC2 instances and delete your load balancers, NAT gateways, transit gateways, and interface VPC endpoints before deleting a VPC.
+.. Sign in to the link:https://console.aws.amazon.com/ec2/[AWS EC2 console].
+.. Terminate all instances in the VPC. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html[Terminate Amazon EC2 instances].
+.. Open the link:https://console.aws.amazon.com/vpc[Amazon VPC console].
+.. In the navigation pane, choose **Your VPCs**.
+.. Select the VPC to delete and choose **Actions, Delete VPC**.
+.. If you have a Site-to-Site VPN connection, select the option to delete it; otherwise, leave it unselected. Choose **Delete VPC**.
+
+

--- a/modules/rosa-troubleshooting-deleteiamrole-deployment.adoc
+++ b/modules/rosa-troubleshooting-deleteiamrole-deployment.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-deleteiamrole-deployment_{context}"]
+= Troubleshooting cluster creation with a DeletingIAMRole error
+
+If a cluster creation action fails, you might receive the following error message.
+
+.Example output
+[source,terminal]
+----
+OCM3031: Error deleting IAM Role (role-name): DeleteConflict: Cannot delete entity, must detach all policies first.\nlevel=error msg=\tstatus code: 409
+----
+The cluster's installation was blocked as the cluster installer was not able to delete the roles it used during the installation.
+
+.Procedure
+To unblock the cluster installation, ensure that no policies are added to new roles by default.
+
+* Run the following command to list all managed policies that are attached to the specified role:
+
++
+[source,terminal]
+----
+$ aws iam list-attached-role-policies --role-name <role-name>
+----
++
+.Example output
+[source,terminal]
+----
+{
+  "AttachedPolicies": [
+    {
+      "PolicyName": "SecurityAudit",
+      "PolicyArn": "arn:aws:iam::aws:policy/SecurityAudit"
+    }
+  ],
+  "IsTruncated": false
+}
+----
+
++
+If there are no policies attached to the specified role (or none that match the specified path prefix), the command returns an empty list.
+
+For more information about the list-attached-role-policies command, see link:https://docs.aws.amazon.com/cli/latest/reference/iam/list-attached-role-policies.html[list-attached-role-policies] in the official AWS documentation.

--- a/modules/rosa-troubleshooting-general-deployment.adoc
+++ b/modules/rosa-troubleshooting-general-deployment.adoc
@@ -3,7 +3,7 @@
 // * support/rosa-troubleshooting-deployments.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-troubleshooting-general-deployment-failure_{context}"]
-= Obtaining information on a failed cluster
+= Obtaining information about a failed cluster
 
 If a cluster deployment fails, the cluster is put into an "error" state.
 

--- a/modules/rosa-troubleshooting-invalidinstallconfigsubnet-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-invalidinstallconfigsubnet-failure-deployment.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-invalidinstallconfigsubnet-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an InvalidInstallConfigSubnet error
+
+If a cluster creation action fails, you might receive the following error messages.
+
+.Example install logs output
+[source,terminal]
+----
+platform.aws.subnets[1]: Invalid value: "subnet-0babad72exxxxxxxx": subnet's CIDR range start 10.69.1x.3x is outside of the specified machine networks
+----
+
+.Example {cluster-manager} output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3020
+Provisioning Error Message: Subnet CIDR ranges are outside of specified machine CIDR.
+----
+
+These errors indicate that a subnet's CIDR range start is outside of the specified machine networks.
+
+.Procedure
+
+. Check your subnet configuration.
+. Edit your machine CIDR range to include all subnet CIDR ranges.
+Generally, your machine CIDR should match your VPC CIDR.
+
+For more information about CIDR ranges, see _CIDR range definitions_ in the _Additional resources_ section .
+

--- a/modules/rosa-troubleshooting-invalidkmskey-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-invalidkmskey-failure-deployment.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-invalidkmskey-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an invalidKMSKey error
+
+If a cluster creation action fails, you might receive the following error messages.
+
+.Example install logs output
+[source,terminal]
+----
+Client.InvalidKMSKey.InvalidState: The KMS key provided is in an incorrect state
+----
+
+.Example {cluster-manager} output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3055
+Provisioning Error Message: Invalid key.
+----
+
+This error indicates that the KMS key is invalid or the key is in an invalid state.
+
+.Procedure
+
+. Start by checking if EBS encryption is enabled in the EC2 settings. You can check the status by following the steps in link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default[AWS Check EBS Encryption].
+
+. Check to see if the AWS specified key is enabled in there and not an `invalidKMSKey` that does not exist. This could happen when an old key was specified and deleted but EBS did not fall back to another key.
+
+. If the previous two steps failed to fix the issue, disable EBS encryption entirely. If this is still a requirement you cannot disable, you can specify a customer-managed-key during ROSA install following the steps in link:https://cloud.redhat.com/experts/rosa/kms/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[Creating a ROSA cluster in STS mode with custom KMS key].
+
+

--- a/modules/rosa-troubleshooting-lblimitexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-lblimitexceeded-failure-deployment.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-lblimitexceeded-failure-deployment_{context}"]
+= Troubleshooting cluster creation with an ALoadBalancerLimitExceeded error
+
+If a cluster creation action fails, you might receive the following error message.
+
+.Example output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3036
+Provisioning Error Message: AWS Load Balancer quota limit exceeded. Clean unused load balancers or increase quota and try again.
+----
+
+This error indicates that you have reached the quota for the number of load balancers.
+
+.Procedure
+
+Request a quota increase from AWS or delete unused load balancers.
+
+* Request a quota increase from AWS.
+.. Sign in to the link:https://aws.amazon.com/console/[AWS Management Console].
+.. Click your user name and select **Service Quotas**.
+.. Under **Manage quotas**, select a service to view available quotas.
+.. If the quota is adjustable, you can choose the button or the name, and then choose Request quota increase.
+.. If the quota is adjustable, you can choose the button or the name, and then choose Request quota increase.
+.. For **Change quota value**, enter the new value. The new value must be greater than the current value.
+.. Choose **Request**.
+
+* Delete a load balancer using the console.
+.. If you have a CNAME record for your domain that points to your load balancer, point it to a new location and wait for the DNS change to take effect before deleting your load balancer.
+.. Open the link:https://console.aws.amazon.com/ec2/[Amazon EC2 console].
+.. On the navigation pane, under **LOAD BALANCING**, choose **Load Balancers**.
+.. Select the load balancer, and then choose **Actions, Delete**.
+.. When prompted for confirmation, choose **Yes, Delete**.
+
+
+
+

--- a/modules/rosa-troubleshooting-multipleroute53zonesfound-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-multipleroute53zonesfound-failure-deployment.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-multipleroute53zonesfound-failure-deployment_{context}"]
+= Troubleshooting cluster creation with a MultipleRoute53ZonesFound error
+
+If a cluster creation action fails, you might receive the following error message.
+
+.Example output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3049
+Provisioning Error Message: DNS zone conflicts encountered.
+----
+
+The problem occurs because a previous cluster did not have had its Route 53 hosted zone removed during uninstallation. As a result, the existing Route 53 entries are conflicting with the cluster's DNS.
+
+The cluster's installation is blocked because a duplicate Route 53 hosted zone already exists in your account.
+
+.Procedure
+
+. Verify the Route 53 configuration. If the hosted zone is no longer required, remove it.
+. Attempt cluster installation again.

--- a/modules/rosa-troubleshooting-osdccsadmin-deployment.adoc
+++ b/modules/rosa-troubleshooting-osdccsadmin-deployment.adoc
@@ -3,9 +3,9 @@
 // * support/rosa-troubleshooting-deployments.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-troubleshooting-deployment-failure-osdccsadmin_{context}"]
-= Failing to create a cluster with an `osdCcsAdmin` error
+= Troubleshooting cluster creation with an osdCcsAdmin error
 
-If a cluster creation action fails, you can receive the following error message.
+If a cluster creation action fails, you might receive the following error message.
 
 .Example output
 [source,terminal]

--- a/modules/rosa-troubleshooting-pendingverification-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-pendingverification-failure-deployment.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-pendingverification-failure-deployment_{context}"]
+= Troubleshooting cluster creation with a PendingVerification error
+
+If a cluster creation action fails, you might receive the following error message.
+
+.Example output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3021
+Provisioning Error Message: Account pending verification for region. Verify the account and try again.
+----
+
+When creating a cluster, the {rosa-classic-first} service creates small instances in all supported regions. This check ensures the AWS account being used can deploy to each supported region.
+
+For AWS accounts that are not using all supported regions, AWS may send one or more emails confirming that "Your Request For Accessing AWS Resources Has Been Validated". Typically the sender of this email is aws-verification@amazon.com. This is expected behavior as the {rosa-classic-first} service is validating your AWS account configuration.
+
+Normally, this validation gets completed within 15 minutes, but in some cases it can take up to 4 hours for AWS to validate. In order to attempt successful provisioning, Red{nbsp}Hat has configured our installer to reattempt installation if this issue occurs, but the installation can still fail if the validation continues to time out or if the validation itself fails.
+
+.Procedure
+* Reinstall the cluster or select a different AWS region or different availability zone(s).
+

--- a/modules/rosa-troubleshooting-s3bucketslimitexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-s3bucketslimitexceeded-failure-deployment.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-s3bucketslimitexceeded_{context}"]
+= Troubleshooting cluster creation with an S3BucketsLimitExceeded error
+
+If a cluster creation action fails, you might receive the following error messages.
+
+.Example install logs output
+[source,terminal]
+----
+level=error msg="Error: Error creating S3 bucket: TooManyBuckets: You have attempted to create more buckets than allowed"
+----
+
+.Example {cluster-manager} output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3014
+Provisioning Error Message: S3 buckets limit exceeded. Clean unused S3 buckets or increase quota and try again.
+----
+
+This type of error indicates that you have reached the quota for the number of S3 buckets.
+
+.Procedure
+
+Request a quota increase from AWS or clean unused S3 buckets.
+
+* Request a quota increase from AWS.
+.. Sign in to the link:https://aws.amazon.com/console/[AWS Management Console].
+.. Click your user name and select **Service Quotas**.
+.. Under **Manage quotas**, select an AWS service to view available quotas.
+.. If the quota is adjustable, you can choose the button or the name, and then choose **Request quota increase**.
+
+* Clean unused S3 buckets. You can only delete buckets that do not have any objects in them. Make sure the bucket is empty.
+.. Sign in to the link:https://aws.amazon.com/console/[AWS Management Console].
+.. Open the **Amazon S3** console.
+.. In the **Buckets** list, select the option next to the name of the bucket that you want to delete, and then choose **Delete** at the top of the page.
+.. On the **Delete bucket** page, confirm that you want to delete the bucket by entering the bucket name into the text field, and then choose **Delete bucket**.
++
+[NOTE]
+====
+If you empty a bucket, this action cannot be undone.
+====
+
+

--- a/modules/rosa-troubleshooting-toomanyroute53zones-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-toomanyroute53zones-failure-deployment.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-toomanyroute53zones-failure-deployment_{context}"]
+= Troubleshooting cluster creation with a TooManyRoute53Zones error
+
+If a cluster creation action fails, you might receive the following error messages.
+
+.Example install logs output
+[source,terminal]
+----
+error msg=Error: error creating Route53 Hosted Zone: TooManyHostedZones: Limits Exceeded: MAX_HOSTED_ZONES_BY_OWNER - Cannot create more hosted zones.\\nlevel=error msg=\\tstatus code: 400
+----
+
+.Example {cluster-manager} output
+[source,terminal]
+----
+Provisioning Error Code:    OCM3006
+Provisioning Error Message: Zone limit exceeded
+----
+
+This error indicates the cluster installation was blocked as the installation program was unable to create a Route 53 hosted zone. A hosted zone is a container for records, and records contain information about how you want to route traffic for a specific domain, such as example.com, and its subdomains (acme.example.com, zenith.example.com).
+
+The error suggests that the hosted zone quota is at capacity. By default, each Amazon Route 53 account is limited to a maximum of 500 hosted zones and 10,000 resource record sets per hosted zone.
+
+.Procedure
+
+Request a quota increase from AWS or delete unused VPCs.
+
+* Request a quota increase from AWS.
+.. Sign in to the link:https://aws.amazon.com/console/[AWS Management Console].
+.. Click your user name and select **Service Quotas**.
+.. Under **Manage quotas**, select a service to view available quotas.
+.. If the quota is adjustable, you can choose the button or the name, and then choose **Request increase**.
+.. For **Increase quota value**, enter the new value. The new value must be greater than the current value.
+.. Choose **Request**.
+
+* Delete unused VPCs. Before you can delete a VPC, you must first terminate or delete any resources that created a requester-managed network interface in the VPC. For example, you must terminate your EC2 instances and delete your load balancers, NAT gateways, transit gateways, and interface VPC endpoints.
+.. Sign in to the link:https://console.aws.amazon.com/ec2/[AWS EC2 console].
+.. Terminate all instances in the VPC. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html[Terminate Amazon EC2 instances].
+.. Open the link:https://console.aws.amazon.com/vpc[Amazon VPC console].
+.. In the navigation pane, choose **Your VPCs**.
+.. Select the VPC to delete and choose **Actions, Delete VPC**.
+.. If you have a Site-to-Site VPN connection, select the option to delete it; otherwise, leave it unselected. Choose **Delete VPC**.
+
+
+
+

--- a/support/troubleshooting/rosa-troubleshooting-deployments.adoc
+++ b/support/troubleshooting/rosa-troubleshooting-deployments.adoc
@@ -10,5 +10,44 @@ This document describes how to troubleshoot cluster deployment errors.
 
 include::modules/rosa-troubleshooting-general-deployment.adoc[leveloffset=+1]
 include::modules/rosa-troubleshooting-osdccsadmin-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-awsnatgatewaylimitexceeded-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-awsapiratelimitexceeded-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-s3bucketslimitexceeded-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-awsvpclimit-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-awsinsufficientcapacity-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-toomanyroute53zones-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-awssubnetnotexist-failure-deployment.adoc[leveloffset=+1]
+
+// Remove conditional once HCP split happens. Conditional was added due to build break.
+ifndef::openshift-rosa-hcp[]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-vpc_prerequisites[AWS prerequisites for ROSA]
+endif::openshift-rosa-hcp[]
+
+include::modules/rosa-troubleshooting-invalidkmskey-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-multipleroute53zonesfound-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-invalidinstallconfigsubnet-failure-deployment.adoc[leveloffset=+1]
+
+// Remove conditional once HCP split happens. Conditional was added due to build break.
+ifndef::openshift-rosa-hcp[]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/cidr-range-definitions.adoc#cidr-range-definitions[CIDR range definitions]
+endif::openshift-rosa-hcp[]
+
+include::modules/rosa-troubleshooting-awsinsufficientpermission-failure-deployment.adoc[leveloffset=+1]
+// Remove conditional once HCP split happens. Conditional was added due to build break.
+ifndef::openshift-rosa-hcp[]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[Detailed requirements for deploying ROSA (classic architecture) using STS]
+* xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-aws-prereqs[AWS prerequisites for ROSA]
+endif::openshift-rosa-hcp[]
+
+include::modules/rosa-troubleshooting-deleteiamrole-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-awsec2quotaexceeded-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-pendingverification-failure-deployment.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-lblimitexceeded-failure-deployment.adoc[leveloffset=+1]
 include::modules/rosa-troubleshooting-elb-service-role.adoc[leveloffset=+1]
 include::modules/rosa-troubleshooting-cluster-deletion.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14654

Link to docs preview:
[Troubleshooting cluster deployments](https://93291--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/rosa-troubleshooting-deployments.html)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
