### PR TITLE
OSDOCS-14584:updates CUDN invalid scenarios tables

### DIFF
--- a/modules/cudn-status-conditions.adoc
+++ b/modules/cudn-status-conditions.adoc
@@ -80,3 +80,161 @@ h|Message
 |`Network allocation failed for at least one node: [<node_name>], check UDN events for more info.`
 
 |===
+
+.Invalid `mtu` scenarios types for the `ClusterUserDefinedNetwork` CR
+[cols="2a,2a,3a,3a",options="header"]
+|===
+
+|Condition type
+3+|Reason, Message, Resolution
+
+.6+|`invalid mtu`
+3+|One of the following messages is returned when the `mtu` is set incorrect:
+h|Reason
+h|Message
+h|Resolution
+
+|The `mtu` field is set higher than `65536`.
+|`spec.network.localnet.mtu` in body should be less than `65536`.
+|You must set the `mtu` field lower than `65536`.
+
+|The `mtu` field  is set lower than `576`.
+|`spec.network.localnet.mtu` in body should be greater than or equal to `576`.
+|You must set the `mtu` field greater than or equal to `576`.
+
+|The `mtu` field must be at least `1280` when using the IPv6 subnet.
+|`MTU should be greater than or equal to 1280 when an IPv6 subnet is used`
+|You must set the `mtu` field higher than or equal to `1280` when you have an IPv6 subnet defined on your user-defined network configuration.
+|===
+
+.Invalid `PhysicalNetworkName` scenarios types for the `ClusterUserDefinedNetwork` CR
+[cols="2a,2a,3a,3a",options="header"]
+|===
+
+|Condition type
+3+|Reason, Message, Resolution
+
+.6+|`invalid PhysicalNetworkName`
+3+|One of the following messages is returned when the `PhysicalNetworkName` is set incorrect:
+h|Reason
+h|Message
+h|Resolution
+
+|The name of the physical network is not set.
+|`spec.network.localnet.physicalNetworkName: Required value`
+|You must set the `physicalNetworkName` field.
+
+|The name of the physical network does not meet minimum length requirements.
+|`spec.network.localnet.physicalNetworkName in body should be at least 1 chars long`
+|You must set physical network name to be at least one character in length.
+
+|The name of the physical network exceeds the maximum character limit of 253.
+|`spec.network.localnet.physicalNetworkName: Too long: may not be more than 253 bytes`
+|You must set physical network name to not exceed the 253 character in length.
+
+|The name of the physical network must not contain `,` or `:`.
+|`physicalNetworkName cannot contain "," or ":" characters`.
+|You must remove the `,` or `:` from the physical network name.
+|===
+
+.Invalid `role` scenarios types for the `ClusterUserDefinedNetwork` CR
+[cols="2a,2a,3a,3a",options="header"]
+|===
+
+|Condition type
+3+|Reason, Message, Resolution
+
+.6+|`role unset` or `role is primary`
+3+|One of the following messages is returned when the `spec.network.localnet.role` is set incorrect:
+h|Reason
+h|Message
+h|Resolution
+
+|The `role` field must be set for your localnet topology.
+|`spec.network.localnet.role: Required value`
+|You must set the `role` field.
+
+|`Primary` is not a supported value for the Localnet topology.
+|`spec.network.localnet.role: Unsupported value: "Primary": supported values: "Secondary"`
+|You must set the `role` field for your Localnet topology to `Secondary`-the accepted value.
+|===
+
+.Invalid `subnets` and `ipam` scenarios types for the `ClusterUserDefinedNetwork` CR
+[cols="2a,2a,3a,3a",options="header"]
+|===
+
+|Condition type
+3+|Reason, Message, Resolution
+
+.11+|`LocalnetInvalidSubnets`
+3+|One of the following messages is returned when either the `spec.network.localnet.subnets` or `spec.network.localnet.ipam` is set incorrect:
+h|Reason
+h|Message
+h|Resolution
+
+|The optional fields, `subnets` and `ipam.mode`, have to be set together.
+|`Subnets is required with ipam.mode is Enabled or unset, and forbidden otherwise`
+|You must set the `subnets` field unless the `spec.network.localnet.ipam.mode` is explicitly disabled.
+
+|The `spec.network.localnet.subnets` must have an acceptable value when using this optional field.
+|`The ClusterUserDefinedNetwork "localnet-empty-subnets-fail" is invalid: spec.network.localnet.subnets: Invalid value: 0: spec.network.localnet.subnets in body should have at least 1 items`
+|You must set an acceptable value for `spec.network.localnet.subnets`. Acceptable values are IPv4 and IPv6 Classless Inter-Domain Routing (CIDR) ranges that do not overlap with any CIDR ranges used by {product-title}.
+
+|The `subnet` field must be set when using the optional `spec.network.localnet.excludeSubnets` field.
+|`excludeSubnets must be unset when subnets is unset`
+|You must set the `spec.network.localnet.subnets` field when using the `spec.network.localnet.excludeSubnet` field.
+
+|The `excludeSubnets` must be a value within the `subnets` field.
+|`excludeSubnets must be subnetworks of the networks specified in the subnets field`
+|You must set the value for the `excludeSubnets` field to be within the `subnets` field. For example, a `subnets` value of `192.168.100.0/24` and an `excludeSubnets` value of `192.168.200.1/32` is invalid.
+
+|The CIDR range is invalid.
+|`The ClusterUserDefinedNetwork "localnet-subnets-invalid-ipv4-cidr-fail" is invalid: spec.network.localnet.subnets[0]: Invalid value: "string": CIDR is invalid`
+|You must set an acceptable CIDR range for `spec.network.localnet.subnets` field. Acceptable values are IPv4 and IPv6 CIDR ranges which are not in use or reserved by {product-title}.
+
+|You must set the `subnets` field when the `ipam.mode` is `Enabled` or when the IPAM mode is unset because the default value is `Enabled`.
+|`Subnets is required with ipam.mode is Enabled or unset, and forbidden otherwise`.
+|You must set the `spec.network.localnet.subnets` field unless the `spec.network.localnet.ipam.mode` is explicitly disabled.
+
+|Setting two CIDR ranges for `spec.network.localnet.subnets` field requires that one be IPv4 and the other be IPv6.
+|`Invalid value...When 2 CIDRs are set, they must be from different IP families`.
+|You must change one of your CIDR ranges to a different IP family.
+
+|The `spec.network.localnet.ipam.mode` is `Disabled` but the ``spec.network.localnet.lifecycle` has a value of `Persistent`.
+|`lifecycle Persistent is only supported when ipam.mode is Enabled`
+|You must set the `ipam.mode` to `Enabled` when the optional field `lifecycle` has a value of `Persistent`.
+|===
+
+.Invalid `vlan` scenarios types for the `ClusterUserDefinedNetwork` CR
+[cols="4a,2a,3a,3a",options="header"]
+|===
+
+|Condition type
+3+|Reason, Message, Resolution
+
+.8+|`invalid vlan` or `invalid mode`
+3+|One of the following messages is returned when the `spec.network.localnet.vlan` is set incorrect:
+h|Reason
+h|Message
+h|Resolution
+
+|The `spec.network.localnet.vlan.mode` field must be set.
+|`spec.network.localnet.vlan.mode: Unsupported value: "Disabled": supported values: "Access`
+|You must set the `spec.network.localnet.vlan.mode` field to `Access` mode.
+
+|The `spec.network.localnet.vlan` field must be set when `spec.network.localnet.vlan.mode` is set to `Access` mode.
+|`vlan access config is required when vlan mode is 'Access', and forbidden otherwise`.
+|You must set `spec.network.localnet.vlan.mode.access` field when using `Access` mode.
+
+|The `spec.network.localnet.vlan.access.id` value must be set when using `Access` mode.
+|`spec.network.localnet.vlan.access.id: Required value`
+|You must set a value for `spec.network.localnet.mode.access.id`.
+
+|Acceptable values for `access.id` are greater than or equal to 1.
+|`spec.network.localnet.vlan.access.id in body should be greater than or equal to 1`
+|You must set a value of 1 or greater for `access.id` field.
+
+|Acceptable values for `access.id` are less than or equal to 4094.
+|`spec.network.localnet.vlan.access.id in body should be less than or equal to 4094`
+|You must set a value of 4094 or less for `access.id` field.
+|===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-14584
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://93300--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html#cudn-status-conditions_about-user-defined-networks:~:text=for%20more%20info.-,Table,-4.%20Invalid%20mtu
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
