### PR TITLE
Fix typo in SPO section

### DIFF
--- a/security/security_profiles_operator/spo-release-notes.adoc
+++ b/security/security_profiles_operator/spo-release-notes.adoc
@@ -10,7 +10,7 @@ The Security Profiles Operator provides a way to define secure computing (https:
 
 These release notes track the development of the Security Profiles Operator in {product-title}.
 
-For an overview of the Security Profiles Operator, see xref:../../security/security_profiles_operator/spo-overview.adoc#[Security Profiles Operator Overview].
+For an overview of the Security Profiles Operator, see xref:../../security/security_profiles_operator/spo-overview.adoc#spo-overview[Security Profiles Operator Overview].
 
 [id="spo-release-notes-0-8-6"]
 == Security Profiles Operator 0.8.6


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: Found a typo in section 7.2. "Security Profiles Operator release notes"
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://93306--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: QE approval not required, there is no factual change in the doc. 
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
It was:
![image](https://github.com/user-attachments/assets/c5f7b949-4c5a-4208-a4d8-de8a87af7fce)

Now it is: 
![image](https://github.com/user-attachments/assets/457e3643-fd3d-4c68-95f4-d734da89ec7b)


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
