### PR TITLE
Revert "[enterprise-4.17] Remove TP note from Nodes Updated boot images module"

### DIFF
--- a/modules/mco-update-boot-images.adoc
+++ b/modules/mco-update-boot-images.adoc
@@ -17,7 +17,10 @@ This process could cause the following issues:
 * Certificate expiration issues
 * Version skew issues
 
-To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) and Amazon Web Services (AWS) clusters and is not supported for {cluster-capi-operator} managed clusters.
+To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and is not supported for {cluster-capi-operator} managed clusters.
+
+:FeatureName: The updating boot image feature
+include::snippets/technology-preview.adoc[]
 
 To view the current boot image used in your cluster, examine a machine set:
 

--- a/nodes/nodes/nodes-nodes-managing.adoc
+++ b/nodes/nodes/nodes-nodes-managing.adoc
@@ -22,6 +22,12 @@ configuration of nodes. By creating an instance of a `KubeletConfig` object, a m
 
 include::modules/nodes-nodes-managing-about.adoc[leveloffset=+1]
 include::modules/mco-update-boot-images.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+2]
 
 include::modules/nodes-nodes-working-master-schedulable.adoc[leveloffset=+1]


### PR DESCRIPTION
Reverts openshift/openshift-docs#93308

Not  needed. CP'd in error.