### PR TITLE
MCO fix updated boot image on AWS is tech preview

### DIFF
--- a/modules/mco-update-boot-images.adoc
+++ b/modules/mco-update-boot-images.adoc
@@ -17,9 +17,9 @@ This process could cause the following issues:
 * Certificate expiration issues
 * Version skew issues
 
-To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and is not supported for {cluster-capi-operator} managed clusters.
+To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only {gcp-first} clusters as a Generally Available (GA) feature and {aws-first} clusters as a Technology Preview feature and is not supported for {cluster-capi-operator} managed clusters.
 
-:FeatureName: The updating boot image feature
+:FeatureName: The updating boot image feature on {aws-short} clusters
 include::snippets/technology-preview.adoc[]
 
 To view the current boot image used in your cluster, examine a machine set:


### PR DESCRIPTION
The updated boot image feature on AWS is tech preview for 4.17. Replace or update the text to indicate this. 

Preview: [Updated boot images](https://93321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#mco-update-boot-images_nodes-nodes-managing)

No QE