### PR TITLE
Add missing link to the FIO overview for uninstalling

### DIFF
--- a/security/file_integrity_operator/fio-overview.adoc
+++ b/security/file_integrity_operator/fio-overview.adoc
@@ -19,3 +19,5 @@ xref:../../security/file_integrity_operator/file-integrity-operator-configuring.
 xref:../../security/file_integrity_operator/file-integrity-operator-advanced-usage.adoc#file-integrity-operator-advanced-usage[Performing advanced Custom File Integrity Operator tasks]
 
 xref:../../security/file_integrity_operator/file-integrity-operator-troubleshooting.adoc#troubleshooting-file-integrity-operator[Troubleshooting the File Integrity Operator]
+
+xref:../../security/file_integrity_operator/fio-uninstalling.adoc#fio-uninstalling[Uninstalling the File Integrity Operator]

--- a/security/file_integrity_operator/fio-uninstalling.adoc
+++ b/security/file_integrity_operator/fio-uninstalling.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="fio-uninstalliing"]
+[id="fio-uninstalling"]
 = Uninstalling the File Integrity Operator 
 include::_attributes/common-attributes.adoc[]
 :context: fio-uninstalling


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: Missing link in the list of sections in the FIO overview. 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
https://93325--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/fio-overview.html
https://93325--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/fio-uninstalling.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NO QE required for this, no net added content.  
PEER and MERGE REVIEWERS: For that second preview, there's no change to see at all. The section ID was misspelled, so I fixed that and it generated an entire preview with nothing in the section changed at all. But I include the preview so it's obvious that the section still works even though I updated the id= field.

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Docs Before: 
![image](https://github.com/user-attachments/assets/ff651e28-0483-4104-a3ba-ef7edd85770d)

Docs After:
![image](https://github.com/user-attachments/assets/2484fb6b-80f5-4bf9-ba5c-facaf7d0a9f1)

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
