### PR TITLE
PR for SRVLOGIC-530: Add the section to upgrade Serverless Logic Operator from 1.35.0 to 1.36.0

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -412,6 +412,8 @@ Topics:
   Topics:
   - Name: Upgrading Serverless Logic Operator from 1.34.0 to 1.35.0
     File: serverless-logic-upgrading-operator-from-1.34-to-1.35
+  - Name: Upgrading Serverless Logic Operator from 1.35.0 to 1.36.0
+    File: serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 ---
 # Knative kn CLI

--- a/modules/serverless-logic-upgrade-1-36-backing-up-data-index-database.adoc
+++ b/modules/serverless-logic-upgrade-1-36-backing-up-data-index-database.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-backing-up-data-index-database_{context}"]
+= Backing up the Data Index database
+
+You must back up the Data Index database before upgrading to prevent data loss.
+
+.Procedure
+
+* Take a full backup of the Data Index database, ensuring:
+** The backup includes all database objects and not just table data.
+** The backup is stored in a secure location.

--- a/modules/serverless-logic-upgrade-1-36-backing-up-job-service-database.adoc
+++ b/modules/serverless-logic-upgrade-1-36-backing-up-job-service-database.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-backing-up-job-service-database_{context}"]
+= Backing up the Jobs Service database
+
+You must back up the Jobs Service database before upgrading to maintain job scheduling data.
+
+.Procedure
+
+* Take a full backup of the Jobs Service database, ensuring:
+** The backup includes all database objects and not just table data.
+** The backup is stored in a secure location.

--- a/modules/serverless-logic-upgrade-1-36-deleting-migrating-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-deleting-migrating-workflows-with-preview-profile.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-deleting-migrating-workflows-with-preview-profile_{context}"]
+= Deleting workflows with the preview profile
+
+Before upgrading the Operator, you must delete workflows running with the `preview` profile. When the upgrade is complete, you must redeploy the workflows.
+
+.Procedure
+
+. If you are using persistence, back up the workflow database and ensure the backup includes both database objects and table data.
+
+. Ensure you have a backup of all necessary Kubernetes resources, including `SonataFlow` custom resources (CRs), `ConfigMap` resources, or any other related custom configurations.
+
+. Delete the workflow by executing the following command: 
++
+[source,terminal]
+----
+$ oc delete workflow <workflow_name> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-36-deleting-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-deleting-workflows-with-dev-profile.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-deleting-workflows-with-dev-profile_{context}"]
+= Deleting workflows with the dev profile
+
+Before upgrading the Operator, you must delete workflows running with the `dev` profile and redeploy them after the upgrade is complete.
+
+.Procedure
+
+. Ensure you have a backup of all necessary Kubernetes resources, including `SonataFlow` custom resources (CRs), `ConfigMap` resources, or any other related custom configurations.
+
+. Delete the workflow by executing the following command: 
++
+[source,terminal]
+----
+$ oc delete workflow <workflow_name> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-36-finalizing-data-index.adoc
+++ b/modules/serverless-logic-upgrade-1-36-finalizing-data-index.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-finalizing-data-index_{context}"]
+= Finalizing the Data Index upgrade
+
+After the Operator upgrade, if your deployment is configured to use a Knative Eventing Kafka Broker, you must delete the old `data-index-process-definition` trigger that was created in the {ServerlessLogicProductName} 1.35.0 version. Optionally, you can delete the old `ReplicaSet` resource as well.
+
+.Procedure
+
+. List all the triggers by running the following command:
++
+[source,terminal]
+----
+$ oc get triggers -n <target_namespace>
+----
++
+.Example output
+[source,terminal,subs="verbatim,quotes"]
+----
+NAME                                                              BROKER              SUBSCRIBER_URI
+data-index-jobs-a25c8405-f740-47d2-a9a5-f80ccaec2955              example-broker      http://sonataflow-platform-data-index-service.<target_namespace>.svc.cluster.local/jobs
+data-index-process-definition-473e1ddbb3ca1d62768187eb80de99bca   example-broker      http://sonataflow-platform-data-index-service.<target_namespace>.svc.cluster.local/definitions
+data-index-process-error-a25c8405-f740-47d2-a9a5-f80ccaec2955     example-broker      http://sonataflow-platform-data-index-service.<target_namespace>.svc.cluster.local/processes
+data-index-process-instance-mul07f593476e8c14353a337590e0bfd5ae   example-broker      http://sonataflow-platform-data-index-service.<target_namespace>.svc.cluster.local/processes
+data-index-process-node-a25c8405-f740-47d2-a9a5-f80ccaec2955      example-broker      http://sonataflow-platform-data-index-service.<target_namespace>.svc.cluster.local/processes
+data-index-process-state-a25c8405-f740-47d2-a9a5-f80ccaec2955     example-broker      http://sonataflow-platform-data-index-service.<target_namespace>.svc.cluster.local/processes
+data-index-process-variable-487e9a6777fff650e60097c9e17111aea25   example-broker      http://sonataflow-platform-data-index-service.<target_namespace>.svc.cluster.local/processes
+
+jobs-service-create-job-a25c8405-f740-47d2-a9a5-f80ccaec2955      example-broker      http://sonataflow-platform-jobs-service.<target_namespace>.svc.cluster.local/v2/jobs/events
+jobs-service-delete-job-a25c8405-f740-47d2-a9a5-f80ccaec2955      example-broker      http://sonataflow-platform-jobs-service.<target_namespace>.svc.cluster.local/v2/jobs/events
+----
+
+. Based on the generated example output, delete the old `data-index-process-definition` trigger by running the following command:
++
+[source,terminal]
+----
+$ oc delete trigger data-index-process-definition-473e1ddbb3ca1d62768187eb80de99bca -n <target_namespace>
+----
++
+After deletion, a new trigger compatible with {ServerlessLogicProductName} 1.36.0 is automatically created.
+
+. Optional: Identify the old `ReplicaSet` resource by running the following command:
++
+[source,terminal]
+----
+$ oc get replicasets -o custom-columns=Name:metadata.name,Image:spec.template.spec.containers[*].image -n <target_namespace>
+----
++
+.Example output
+[source,terminal,subs="verbatim,quotes"]
+----
+Name                                                Image
+sonataflow-platform-data-index-service-1111111111   registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.35.0
+
+sonataflow-platform-data-index-service-2222222222   registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.36.0
+----
++
+. Optional: Delete your old `ReplicaSet` resource by running the following command:
++
+[source,terminal]
+----
+$ oc delete replicaset <old_replicaset_name> -n <target_namespace>
+----
++
+.Example command based on the example output
+[source,terminal]
+----
+$ oc delete replicaset sonataflow-platform-data-index-service-1111111111 -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-36-finalizing-job-service.adoc
+++ b/modules/serverless-logic-upgrade-1-36-finalizing-job-service.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-finalizing-job-service_{context}"]
+= Finalizing the Job Service upgrade
+
+After the {ServerlessOperatorName} is upgraded to version 1.36.0 you can optionally delete the old `ReplicaSet` resource.
+
+.Procedure
+
+. Identify the old `ReplicaSet` resource by running the following command:
++
+[source,terminal]
+----
+$ oc get replicasets -o custom-columns=Name:metadata.name,Image:spec.template.spec.containers[*].image -n <target_namespace>
+----
++
+.Example output
+[source,terminal,subs="verbatim,quotes"]
+----
+Name                                                Image
+sonataflow-platform-jobs-service-1111111111         registry.redhat.io/openshift-serverless-1/logic-jobs-service-postgresql-rhel8:1.35.0
+sonataflow-platform-jobs-service-2222222222         registry.redhat.io/openshift-serverless-1/logic-jobs-service-postgresql-rhel8:1.36.0
+----
++
+. Delete your old `ReplicaSet` resource by running the following command:
++
+[source,terminal]
+----
+$ oc delete replicaset <old_replicaset_name> -n <target_namespace>
+----
++
+.Example command based on the example output
+[source,terminal]
+----
+$ oc delete replicaset sonataflow-platform-jobs-service-1111111111 -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-36-redeploying-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-redeploying-workflows-with-dev-profile.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-redeploying-workflows-with-dev-profile_{context}"]
+= Redeploying workflows with the dev profile
+
+After the upgrade, you must redeploy workflows that use the `dev` profile and any associated Kubernetes resources.
+
+.Procedure
+
+. Ensure that all required Kubernetes resources, including the `ConfigMap` with the `application.properties` field, are restored before redeploying the workflow.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_name> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-36-restoring-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-restoring-workflows-with-preview-profile.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-restoring-workflows-with-preview-profile_{context}"]
+= Restoring workflows with the preview profile
+
+After the upgrade, you must redeploy workflows that use the `preview` profile and any associated Kubernetes resources.
+
+.Procedure
+
+. Ensure that all required Kubernetes resources, including the `ConfigMap` with the `application.properties` field, are restored before redeploying the workflow.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_name> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-36-scaling-down-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-scaling-down-workflows-with-gitops-profile.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-scaling-down-workflows-with-gitops-profile_{context}"]
+= Scaling down workflows with the gitops profile
+
+Before upgrading the Operator, you must scale down workflows running with the `gitops` profile, and scale them up again after the upgrade is complete.
+
+.Procedure
+
+. Modify the `my-workflow.yaml` custom resources (CR) and scale down each workflow to `0` before upgrading as shown in the following example:
++
+[source,yaml]
+----
+spec:
+  podTemplate:
+    replicas: 0
+  # ...
+----
+
+. Apply the updated `my-workflow.yaml` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f my-workflow.yaml -n <target_namespace>
+----
+
+. Optional: Scale the workflow to `0` by running the following command:
++
+[source,terminal]
+----
+$ oc patch workflow <workflow_name> -n <target_namespace> --type=merge -p '{"spec": {"podTemplate": {"replicas": 0}}}'
+----

--- a/modules/serverless-logic-upgrade-1-36-scaling-up-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-scaling-up-workflows-with-gitops-profile.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-36-scaling-up-workflows-with-gitops-profile_{context}"]
+= Scaling up workflows with the gitops profile
+
+To continue operation, you must scale up workflows that you previously scaled down with the `gitops` profile.
+
+.Procedure
+
+. Modify the `my-workflow.yaml` custom resources (CR) and scale up each workflow to `1` as shown in the following example:
++
+[source,yaml]
+----
+spec:
+  podTemplate:
+    replicas: 1
+  # ...
+----
+
+. Apply the updated CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f my-workflow.yaml -n <target_namespace>
+----
+
+. Optional: Scale the workflow back to `1` by running the following command:
++
+[source,terminal]
+----
+$ oc patch workflow <workflow_name> -n <target_namespace> --type=merge -p '{"spec": {"podTemplate": {"replicas": 1}}}'
+----

--- a/modules/serverless-logic-upgrading-1-36-osl-operator.adoc
+++ b/modules/serverless-logic-upgrading-1-36-osl-operator.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrading-1-36-osl-operator_{context}"]
+= Upgrading the {ServerlessLogicOperatorName} to 1.36.0
+
+To transition from {ServerlessLogicOperatorName} (OSL) version 1.35.0 to 1.36.0, you must upgrade the OSL using the {product-title} web console. This upgrade ensures compatibility with newer features and proper functioning of your workflows.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have access to the OpenShift Management Console for Operator upgrades.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. In the web console, navigate to the *Operators* -> *OperatorHub* -> *Installed Operators* page.
+. Select the `openshift-serverless-logic` namespace from the *Installed Namespace* drop-down list.
+. In the list of installed Operators, find and click the Operator named {ServerlessLogicOperatorName}.
+. In the Operator details page, click on the *Subscription* tab. Click *Edit Subscription*.
+. In the *Upgrade status* tab, click the *Upgrade available* link.
+. Click the *Preview install plan* button and *Approve* to start the update.
+. To monitor the upgrade process, run the following command: 
++
+[source,terminal]
+----
+$ oc get subscription logic-operator-rhel8 -n openshift-serverless-logic -o jsonpath='{.status.installedCSV}'
+----
++
+.Example output
+[source,terminal]
+----
+logic-operator-rhel8.v1.36.0
+----
+
+.Verification
+
+* To verify that the new Operator version is installed, run the following command: 
++
+[source,terminal]
+----
+$ oc get clusterserviceversion logic-operator-rhel8.v1.36.0 -n openshift-serverless-logic
+----
+.Example output
++
+[source,terminal]
+----
+NAME                           DISPLAY                               VERSION   REPLACES                       PHASE
+logic-operator-rhel8.v1.36.0   OpenShift Serverless Logic Operator   1.36.0    logic-operator-rhel8.v1.35.0   Succeeded
+----

--- a/modules/serverless-logic-verifying-the-1-36-0-upgrade.adoc
+++ b/modules/serverless-logic-verifying-the-1-36-0-upgrade.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-verifying-the-1-36-0-upgrade_{context}"]
+= Verifying the 1.36.0 upgrade
+
+After restoring workflows and services, verify that the upgrade was successful and all components are functioning as expected.
+
+.Procedure
+
+. Check if all workflows and services are running by entering the following command:
++
+[source,terminal]
+----
+$ oc get pods -n <target_namespace>
+----
++
+Ensure that all pods related to workflows, Data Index, and Jobs Service are in a `Running` or `Completed` state.
+
+. Verify that the {ServerlessLogicOperatorName} is running correctly by entering the following command:
++
+[source,terminal]
+----
+$ oc get clusterserviceversion logic-operator-rhel8.v1.36.0 -n openshift-serverless-logic
+----
+.Example output
++
+[source,terminal]
+----
+NAME                           DISPLAY                               VERSION   REPLACES                       PHASE
+logic-operator-rhel8.v1.36.0   OpenShift Serverless Logic Operator   1.36.0    logic-operator-rhel8.v1.35.0   Succeeded
+----
+
+. Check Operator logs for any errors by entering the following command:
++
+[source,terminal]
+----
+$ oc logs -l control-plane=sonataflow-operator -n openshift-serverless-logic
+----

--- a/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-35-to-1-36.adoc
+++ b/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-35-to-1-36.adoc
@@ -1,0 +1,72 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-logic-upgrading-operator-from-1-35-to-1-36"]
+= Upgrading OpenShift Serverless Logic Operator from version 1.35.0 to 1.36.0
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-upgrading-operator-from-1-35-to-1-36
+
+toc::[]
+
+You can upgrade the {ServerlessLogicOperatorName} from version 1.35.0 to 1.36.0. The upgrade process involves preparing the existing workflows and services, updating the Operator, and restoring the workflows after the upgrade.
+
+[NOTE]
+====
+Different workflow profiles require different upgrade steps. Follow the instructions for each profile carefully.
+====
+
+[id="serverless-logic-preparing-for-the-upgrade_{context}"]
+== Preparing for the upgrade
+
+Before starting the upgrade process, you need to prepare your {ServerlessLogicProductName} environment to upgrade from version 1.35.0 to 1.36.0. 
+
+The preparation process is as follows:
+
+* Deleting or scaling workflows based on their profiles.
+* Backing up all necessary databases and resources.
+* Ensuring you have a record of all custom configurations.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have access to the *OpenShift Management Console* for Operator upgrades.
+* You have installed the OpenShift CLI (`oc`).
+
+include::modules/serverless-logic-upgrade-1-36-deleting-workflows-with-dev-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-36-deleting-migrating-workflows-with-preview-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-36-scaling-down-workflows-with-gitops-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-36-backing-up-data-index-database.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-36-backing-up-job-service-database.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrading-1-36-osl-operator.adoc[leveloffset=+1]
+
+[id="serverless-logic-finalizing-the-upgrade_{context}"]
+== Finalizing the upgrade
+
+After upgrading the {ServerlessLogicOperatorName} to version 1.36.0, you must finalize the upgrade process by restoring or scaling workflows and cleaning up old services. This ensures that your system runs cleanly on the new version and that all dependent components are configured correctly.
+
+Follow the appropriate steps below based on the profile of your workflows and services.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have access to the *OpenShift Management Console* for Operator upgrades.
+* You have installed the OpenShift CLI (`oc`).
+
+include::modules/serverless-logic-upgrade-1-36-finalizing-data-index.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-36-finalizing-job-service.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-36-redeploying-workflows-with-dev-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-36-restoring-workflows-with-preview-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-36-scaling-up-workflows-with-gitops-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-verifying-the-1-36-0-upgrade.adoc[leveloffset=+1]


### PR DESCRIPTION
**Affected versions:** 
- `serverless-docs-1.36`
- `serverless-docs-1.35`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-530

**Doc preview:** [Upgrading Serverless Logic Operator from the version 1.35.0 to 1.36.0](https://93332--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1.35-to-1.36)

**Reviews:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->