### PR TITLE
[enterprise-4.13] OBSDOCS-1393: Add links to Prometheus write_relabel_configs reference

### DIFF
--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -192,6 +192,13 @@ endif::openshift-dedicated,openshift-rosa[]
 
 // Configuring remote write storage for Prometheus
 include::modules/monitoring-configuring-remote-write-storage.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc#spec-remotewrite-writerelabelconfigs[`writeRelabelConfigs`]
+* link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[`relabel_config`] (Prometheus documentation)
+
 include::modules/monitoring-supported-remote-write-authentication-settings.adoc[leveloffset=+2]
 include::modules/monitoring-example-remote-write-authentication-settings.adoc[leveloffset=+2]
 include::modules/monitoring-example-remote-write-queue-configuration.adoc[leveloffset=+2]


### PR DESCRIPTION
manual CP of https://github.com/openshift/openshift-docs/pull/93247 to 4.13