### PR TITLE
CNV-52798: Added links to new runbook alerts from upstream docs

### DIFF
--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -71,10 +71,20 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CnaoNmstateMigration.md[View the runbook] for the `CnaoNMstateMigration` alert.
 
+[id="virt-runbook-hacontrolplanedown_{context}"]
+== HAControlPlaneDown
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HAControlPlaneDown.md[View the runbook] for the `HAControlPlaneDown` alert.
+
 [id="virt-runbook-hcoinstallationincomplete_{context}"]
 == HCOInstallationIncomplete
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOInstallationIncomplete.md[View the runbook] for the `HCOInstallationIncomplete` alert.
+
+[id="virt-runbook-hcomisconfigureddescheduler_{context}"]
+== HCOMisconfiguredDescheduler
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOMisconfiguredDescheduler.md[View the runbook] for the `HCOMisconfiguredDescheduler` alert.
 
 [id="virt-runbook-hppnotready_{context}"]
 == HPPNotReady
@@ -91,6 +101,11 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HPPSharingPoolPathWithOS.md[View the runbook] for the `HPPSharingPoolPathWithOS` alert.
 
+[id="virt-runbook-highcpuworkload_{context}"]
+== HighCPUWorkload
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HighCPUWorkload.md[View the runbook] for the `HighCPUWorkload` alert.
+
 [id="virt-runbook-kubemacpooldown_{context}"]
 == KubemacpoolDown
 
@@ -104,12 +119,12 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-kubevirtcomponentexceedsrequestedcpu_{context}"]
 == KubeVirtComponentExceedsRequestedCPU
 
-* The `KubeVirtComponentExceedsRequestedCPU` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/deprecated/KubeVirtComponentExceedsRequestedCPU.md[deprecated].
+* The `KubeVirtComponentExceedsRequestedCPU` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtComponentExceedsRequestedCPU.md[deprecated].
 
 [id="virt-runbook-kubevirtcomponentexceedsrequestedmemory_{context}"]
 == KubeVirtComponentExceedsRequestedMemory
 
-* The `KubeVirtComponentExceedsRequestedMemory` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/deprecated/KubeVirtComponentExceedsRequestedMemory.md[deprecated].
+* The `KubeVirtComponentExceedsRequestedMemory` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtComponentExceedsRequestedMemory.md[deprecated].
 
 [id="virt-runbook-kubevirtcrmodified_{context}"]
 == KubeVirtCRModified
@@ -186,6 +201,16 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NoReadyVirtOperator.md[View the runbook] for the `NoReadyVirtOperator` alert.
 
+[id="virt-runbook-nodenetworkinterfacedown_{context}"]
+== NodeNetworkInterfaceDown
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NodeNetworkInterfaceDown.md[View the runbook] for the `NodeNetworkInterfaceDown` alert.
+
+[id="virt-runbook-operatorconditionsunhealthy_{context}"]
+== OperatorConditionsUnhealthy
+
+* The `OperatorConditionsUnhealthy` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/OperatorConditionsUnhealthy.md[deprecated].
+
 [id="virt-runbook-orphanedvirtualmachineinstances_{context}"]
 == OrphanedVirtualMachineInstances
 
@@ -221,15 +246,15 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPHighRateRejectedVms.md[View the runbook] for the `SSPHighRateRejectedVms` alert.
 
-[id="virt-runbook-ssptemplatevalidatordown_{context}"]
-== SSPTemplateValidatorDown
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPTemplateValidatorDown.md[View the runbook] for the `SSPTemplateValidatorDown` alert.
-
 [id="virt-runbook-sspoperatordown_{context}"]
 == SSPOperatorDown
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPOperatorDown.md[View the runbook] for the `SSPOperatorDown` alert.
+
+[id="virt-runbook-ssptemplatevalidatordown_{context}"]
+== SSPTemplateValidatorDown
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPTemplateValidatorDown.md[View the runbook] for the `SSPTemplateValidatorDown` alert.
 
 [id="virt-runbook-unsupportedhcomodification_{context}"]
 == UnsupportedHCOModification
@@ -299,8 +324,9 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtualmachinecrcerrors_{context}"]
 == VirtualMachineCRCErrors
 
-* The runbook for the `VirtualMachineCRCErrors` alert is deprecated because the alert was renamed to `VMStorageClassWarning`. 
-** link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VMStorageClassWarning.md[View the runbook] for the `VMStorageClassWarning` alert.
+* The `VirtualMachineCRCErrors` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineCRCErrors.md[deprecated].
++
+The alert is now called `VMStorageClassWarning`.
 
 [id="virt-runbook-vmcannotbeevicted_{context}"]
 == VMCannotBeEvicted


### PR DESCRIPTION
Version(s):
Main, 4.19

Issue:
https://issues.redhat.com/browse/CNV-52798

[Link to docs preview](https://93337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks)

QE review:
- [x] QE has approved this change.

