### PR TITLE
[SRVKS-1311] Link to the midstream architecture diagrams of Kourier and Istio

### DIFF
--- a/modules/serverless-kourier-and-istio-ingresses-overview.adoc
+++ b/modules/serverless-kourier-and-istio-ingresses-overview.adoc
@@ -36,6 +36,11 @@ See the "Integrating Service Mesh with OpenShift Serverless" section of {Serverl
 [id="serverless-ingresses-traffic-configuration-and-routing_{context}"]
 == Traffic configuration and routing
 
+[NOTE]
+====
+You can find the architecture diagrams for the Kourier and Istio ingresses on the link:https://openshift-knative.github.io/docs/docs/latest/serverless/serving/serving-kourier-istio-ingresses#serverless-ingresses-traffic-configuration-and-routing[Technology and Developer Preview Releases] site.
+====
+
 Regardless of whether you use Kourier or Istio, the traffic for a Knative Service is configured in the `knative-serving` namespace by the `net-kourier-controller` or the `net-istio-controller` respectively.
 
 The controller reads the `KnativeService` and its child custom resources to configure the ingress solution. Both ingress solutions provide an ingress gateway pod that becomes part of the traffic path. Both ingress solutions are based on Envoy. By default, {ServerlessProductShortName} has two routes for each `KnativeService` object:


### PR DESCRIPTION
Version(s):
serverless-docs-1.36

Issue:
- https://issues.redhat.com/browse/SRVKS-1311

Link to docs preview:
- https://93338--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/kourier-and-istio-ingresses.html#serverless-ingresses-traffic-configuration-and-routing_kourier-and-istio-ingresses

QE review:
- [x] QE has approved this change.

Additional information:
A subtask of [SRVKS-1222
](https://github.com/openshift-knative/docs/pull/121)