### PR TITLE
CNV-59720: RN for new alerts

### DIFF
--- a/virt/release_notes/virt-4-19-release-notes.adoc
+++ b/virt/release_notes/virt-4-19-release-notes.adoc
@@ -86,6 +86,11 @@ As a cluster administrator, you can prevent users from enabling VM delete protec
 [id="virt-4-19-monitoring"]
 === Monitoring
 
+//CNV-59720
+* The following xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbooks[alerts for the {CNVOperatorDisplayName}] are now included in the {product-title} runbooks:
+** `HAControlPlaneDown`
+** `HighCPUWorkload`
+** `NodeNetworkInterfaceDown`
 
 [id="virt-4-19-documentation"]
 === Documentation improvements
@@ -105,6 +110,7 @@ As a cluster administrator, you can prevent users from enabling VM delete protec
 
 Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
+* The `OperatorConditionsUnhealthy` alert is deprecated. You can safely xref:../../observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc#silencing-alerts-adm_managing-alerts-as-an-administrator[silence] it.
 
 [id="virt-4-19-removed"]
 === Removed features


### PR DESCRIPTION
Version(s):
4.19 only

Issue:
https://issues.redhat.com/browse/CNV-59720
Release note for: https://issues.redhat.com/browse/CNV-52798

[Link to docs preview](https://93341--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-19-release-notes.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Includes mention of deprecated alerts in deprecated features section, and new alerts in new features section.
