### PR TITLE
No Jira: Fixing xrefs to renamed bare metal content

### DIFF
--- a/etcd/etcd-backup.adoc
+++ b/etcd/etcd-backup.adoc
@@ -121,7 +121,7 @@ include::modules/dr-restoring-etcd-quorum-ha.adoc[leveloffset=+2]
 .Additional resources
 * xref:../installing/installing_bare_metal/upi/installing-bare-metal.adoc[Installing a user-provisioned cluster on bare metal]
 
-//* xref:../installing/installing_bare_metal/ipi/ipi-install-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_ipi-install-expanding[Replacing a bare-metal control plane node]
+* xref:../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_bare-metal-expanding[Replacing a bare-metal control plane node]
 
 // Restoring to a previous cluster state
 include::modules/dr-restoring-cluster-state-about.adoc[leveloffset=+2]
@@ -140,7 +140,7 @@ include::modules/manually-restoring-cluster-etcd-backup.adoc[leveloffset=+3]
 * xref:../etcd/etcd-backup.adoc#backing-up-etcd-data_etcd-backup[Backing up etcd data]
 * xref:../installing/installing_bare_metal/upi/installing-bare-metal.adoc[Installing a user-provisioned cluster on bare metal]
 * xref:../networking/accessing-hosts.adoc#accessing-hosts[Accessing hosts on Amazon Web Services in an installer-provisioned infrastructure cluster]
-//* xref:../installing/installing_bare_metal/ipi/ipi-install-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_ipi-install-expanding[Replacing a bare-metal control plane node]
+* xref:../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_bare-metal-expanding[Replacing a bare-metal control plane node]
 
 // Issues and workarounds for restoring a persistent storage state
 include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+3]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: No Jira - this PR fixes two xrefs
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Restoring etcd quorum for high availability clusters (see Additional resources section): https://93361--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup.html#dr-restoring-etcd-quorum-ha_etcd-backup
- Restoring a cluster manually from an etcd backup (see Additional resources section): https://93361--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup.html#manually-restoring-cluster-etcd-backup_etcd-backup
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
