### PR TITLE
OSDOCS14659: Typo on modules/coreos-layering-configuring-on.adoc

### DIFF
--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -110,7 +110,7 @@ In a disconnected environment, ensure that the disconnected cluster can access t
 +
 [source,yaml]
 ----
-apiVersion: machineconfiguration.openshift.io/v1aplha1 <1>
+apiVersion: machineconfiguration.openshift.io/v1alpha1 <1>
 kind: MachineOSConfig
 metadata:
   name: layered <2>


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14659

Preview:


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

