### PR TITLE
OSDOCS-10892 adding install config params for aws subnets

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1025,19 +1025,6 @@ You can add up to 25 user defined tags during installation. The remaining 25 tag
 | A flag that directs in-cluster Operators to include the specified user tags in the tags of the AWS resources that the Operators create.
 | Boolean values, for example `true` or `false`.
 
-
-|platform:
-  aws:
-    subnets:
-|If you provide the VPC instead of allowing the installation program to create the VPC for you, specify the subnet for the cluster to use. The subnet must be part of the same `machineNetwork[].cidr` ranges that you specify.
-
-For a standard cluster, specify a public and a private subnet for each availability zone.
-
-For a private cluster, specify a private subnet for each availability zone.
-
-For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to this list to ensure edge machine pool creation.
-|Valid subnet IDs.
-
 |platform:
   aws:
     publicIpv4Pool:
@@ -1054,6 +1041,36 @@ BYOIP can be enabled only for customized installations that have no network rest
     preserveBootstrapIgnition:
 |Prevents the S3 bucket from being deleted after completion of bootstrapping.
 |`true` or `false`. The default value is `false`, which results in the S3 bucket being deleted.
+
+|platform:
+  aws:
+    vpc:
+      subnets:
+|A list of subnets in an existing VPC to be used in place of automatically created subnets. You specify a subnet by providing the subnet ID and an optional list of roles that apply to that subnet. If you specify subnet IDs but do not specify roles for any subnet, the subnets' roles will be decided automatically. If you do not specify any roles, you must ensure that any other subnets in your VPC have the `kubernetes.io/cluster/.*: .*` or `kubernetes.io/cluster/unmanaged: true` tags.
+The subnets must be part of the same `machineNetwork[].cidr` ranges that you specify.
+For a public cluster, specify a public and a private subnet for each availability zone.
+For a private cluster, specify a private subnet for each availability zone.
+For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to this list to ensure edge machine pool creation.
+|List of pairs of `id` and `roles` parameters.
+
+|platform:
+  aws:
+    vpc:
+      subnets:
+      - id:
+|The ID of an existing subnet to be used in place of a subnet created by the installation program.
+|String. The subnet ID must be a unique ID containing only alphanumeric characters, beginning with "subnet-". The ID must be exactly 24 characters long.
+
+|platform:
+  aws:
+    vpc:
+      subnets:
+      - id:
+        roles:
+        - type:
+|One or more roles that apply to the subnet specified by `platform.aws.vpc.subnets.id`. If you specify a role for any subnet, each subnet must have at least one assigned role, and the `ClusterNode`, `IngressControllerLB`, `ControlPlaneExternalLB`, `BootstrapNode`, and `ControlPlaneInternalLB` roles must be assigned to at least one subnet. However, if the cluster scope is internal, then the `ControlPlaneExternalLB` role is not required.
+You can only assign the `EdgeNode` role to subnets in {aws-short} Local Zones.
+|List of one or more role types. Valid values include `ClusterNode`, `EdgeNode`, `BootstrapNode`, `IngressControllerLB`, `ControlPlaneExternalLB`, and `ControlPlaneInternalLB`.
 
 |====
 endif::aws[]

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -471,14 +471,17 @@ additionalTrustBundle: |
 The value must be the contents of the certificate file that you used for your mirror registry. The certificate file can be an existing, trusted certificate authority, or the self-signed certificate that you generated for the mirror registry.
 
 ifdef::aws+restricted[]
-.. Define the subnets for the VPC to install the cluster in:
+.. Define the subnets for the VPC to install the cluster in, as in the following example:
 +
 [source,yaml]
 ----
-subnets:
-- subnet-1
-- subnet-2
-- subnet-3
+platform:
+  aws:
+    vpc:
+      subnets:
+        - id: subnet-<id_1>
+        - id: subnet-<id_2>
+        - id: subnet-<id_3>
 ----
 endif::aws+restricted[]
 ifdef::azure+restricted[]


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-10892

Link to docs preview:
https://93385--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-network_installation-config-parameters-aws

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
