### PR TITLE
OSSM-9339 Document Istio-CNI Update Process

### DIFF
--- a/modules/ossm-about-istio-cni-update-process.adoc
+++ b/modules/ossm-about-istio-cni-update-process.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+
+// update/ossm-updating-openshift-service-mesh.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-about-istio-cni-update-process_{context}"]
+= About the Istio CNI update process
+
+The {istio} Container Network Interface (CNI) update process uses in-place updates. When the `IstioCNI` resource changes, the daemonset automatically replaces the existing `istio-cni-node` pods with the specified version of the CNI plugin.
+
+You can use the following field to manage version updates:
+
+`spec.version`:: defines the CNI plugin version to install. Specify the value in the format `vX.Y.Z`, where `X.Y.Z` represents the desired version. For example, use `v1.24.4` to install the CNI plugin version `1.24.4`.
+
+To update the CNI plugin, modify the `spec.version` field with the target version. The `IstioCNI` resource also includes a `values` field that exposes configuration options from the `istio-cni` chart.

--- a/modules/ossm-updating-istio-cni-resource-version.adoc
+++ b/modules/ossm-updating-istio-cni-resource-version.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+
+// update/ossm-updating-openshift-service-mesh.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-updating-istio-cni-resource-version_{context}"]
+= Updating the Istio CNI resource version
+
+You can update the Istio CNI resource version by changing the version in the resource. Then, the {SMProductShortName} Operator deploys a new version of the CNI plugin that replaces the old version of the CNI plugin. The `istio-cni-node` pods automatically reconnect to the new CNI plugin.
+
+.Prerequisites
+
+* You are logged in to {ocp-product-title} as a user with the `cluster-admin` role.
+* You installed the {SMProductName} Operator and deployed {istio}.
+* You installed the {istio} CNI plugin with the desired version. In the following example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
+
+.Procedure
+
+. Change the version in the `{istio}` resource. For example, to update to {istio} `1.24.4`, set the `spec.version` field to `v1.24.4` by running the following command:
++
+[source,terminal]
+----
+$ oc patch istiocni default -n istio-cni --type='merge' -p '{"spec":{"version":"v1.24.4"}}'
+----
+
+. Confirm that the new version of the CNI plugin is ready by running the following command:
++
+[source,terminal]
+----
+$ oc get istiocni default
+----
++
+.Example Output
++
+[source,terminal]
+----
+NAME      READY   STATUS    VERSION   AGE
+default   True    Healthy   v1.24.4   91m
+----

--- a/update/ossm-updating-openshift-service-mesh.adoc
+++ b/update/ossm-updating-openshift-service-mesh.adoc
@@ -31,3 +31,5 @@ include::modules/ossm-installing-istio-with-revisionbased-strategy.adoc[leveloff
 include::modules/ossm-updating-istio-control-plane-with-revisionbased.adoc[leveloffset=+2]
 include::modules/ossm-installing-istio-with-revisionbased-strategy-istiorevisiontag.adoc[leveloffset=+2]
 include::modules/ossm-updating-istio-control-plane-with-revisionbased-istiorevisiontag.adoc[leveloffset=+2]
+include::modules/ossm-about-istio-cni-update-process.adoc[leveloffset=+1]
+include::modules/ossm-updating-istio-cni-resource-version.adoc[leveloffset=+2]


### PR DESCRIPTION
Change type: Doc update; OSSM document Istio-CNI Update Process

Doc JIRA: https://issues.redhat.com/browse/OSSM-9339

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

NOTE TO THE SME and QE: This PR only covers the following sections from the docs:

- About Istio CNI update process
- Updating the Istio CNI resource version

The main story is: [OSSM-8218](https://issues.redhat.com/browse/OSSM-8218)

Doc Preview: https://93404--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/update/ossm-updating-openshift-service-mesh.html#ossm-about-istio-cni-update-process_ossm-updating-openshift-service-mesh

SME Review/QE Review: @MaxBab @pbajjuri20 
Peer Review: @ShaunaDiaz 