### PR TITLE
HCIDOCS-635: Add note that SSL certificates for ISO installation on S…

### DIFF
--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -199,7 +199,7 @@ $ cp install-config.yaml ocp
 ----
 $ ./openshift-install --dir=ocp create single-node-ignition-config
 ----
-
++
 . Embed the ignition data into the {op-system} ISO by running the following commands:
 +
 [source,terminal]
@@ -213,6 +213,11 @@ $ alias coreos-installer='podman run --privileged --pull always --rm \
 ----
 $ coreos-installer iso ignition embed -fi ocp/bootstrap-in-place-for-live-iso.ign rhcos-live.iso
 ----
++
+[IMPORTANT]
+====
+The SSL certificates for the {op-system} ISO installation image are only valid for 24 hours. If you use the ISO image to install a node more than 24 hours after creating the image, the installation can fail. To re-create the image after 24 hours, delete the `ocp` directory and re-create the {product-title} assets.
+====
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 . Generate {product-title} assets by running the following commands:


### PR DESCRIPTION
**Fixes:** [HCIDOCS-635](https://issues.redhat.com/browse/HCIDOCS-635)

**For:** OCP 4.11+

[**Preview**](https://93443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#generating-the-install-iso-manually_install-sno-installing-sno-with-the-assisted-installer)

**Approvals -** `/lgtm`:
- [x] SME
- [x] QE
- [x] Peer Review