### PR TITLE
[enterprise-4.14] OCPBUGS#43364: Add the must-gather image for HCP in the table

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -28,6 +28,9 @@ ifndef::openshift-origin[]
 |`registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion}`
 |Data collection for {VirtProductName}.
 
+|`registry.redhat.io/multicluster-engine/must-gather-rhel8`
+|Data collection for {hcp}.
+
 |`registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8`
 |Data collection for OpenShift Serverless.
 


### PR DESCRIPTION
A manual cherry-pick PR for https://github.com/openshift/openshift-docs/pull/93356, created from the commit id: e40444f14493f0e8523b06eaa2f4947daa5fdb64