### PR TITLE
WMCO 10.18.1 release notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2859,8 +2859,8 @@ Topics:
   Topics:
   - Name: Red Hat OpenShift support for Windows Containers release notes
     File: windows-containers-release-notes-10-18-x
-#  - Name: Past releases
-#    File: windows-containers-release-notes-10-18-x-past
+  - Name: Past releases
+    File: windows-containers-release-notes-10-18-x-past
   - Name: Windows Machine Config Operator prerequisites
     File: windows-containers-release-notes-10-18-x-prereqs
   - Name: Windows Machine Config Operator known limitations

--- a/modules/windows-containers-release-notes-10-18-0.adoc
+++ b/modules/windows-containers-release-notes-10-18-0.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes-10-18-x-past.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-18-0_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.18.0
+
+Issued: 19 March 2025
+
+This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.18.0 were released in link:https://access.redhat.com/errata/RHBA-2025:3040[RHBA-2025:3040].
+
+[id="wmco-10-18-0-new-features"]
+== New features and improvements
+
+[id="wmco-10-18-0-new-features-hpa"]
+=== Horizontal Pod autoscaling is available for Windows workloads
+You can now use a horizontal pod autoscaler (HPA) to scale your Windows pods based on CPU and/or memory resource metrics. For more information on using an HPA, see xref:../../nodes/pods/nodes-pods-autoscaling.adoc#nodes-pods-autoscaling[Automatically scaling pods with the horizontal pod autoscaler].
+
+[id="wmco-10-18-0-new-features-eus"]
+=== Control Plane Only updates are now available for Windows nodes
+You can now use *Control Plane Only* updates, previously known as *EUS-to-EUS* updates, to update your Windows nodes between {product-title} EUS versions. For more information, see xref:../../windows_containers/windows-node-upgrades.adoc#wmco-upgrades-eus_windows-node-upgrades[Windows Machine Config Operator Control Plane Only upgrade].
+
+[id="wmco-10-18-0-new-features-metrics"]
+=== WMCO metrics endpoint is now HTTPS
+The WMCO metrics endpoint is now exposed over HTTPS. Previously, WMCO pod metrics were available over HTTP. This change improves the security posture of the WMCO metrics endpoint.
+// https://issues.redhat.com/browse/WINC-1269
+// https://issues.redhat.com/browse/WINC-588
+
+[id="wmco-10-18-0-new-features-debuglogging"]
+=== WMCO now defaults to info-level logging
+The WMCO is configured to use the `info` log level by default. You can change the log level to `debug` by editing the WMCO subscription object. For more information, see xref:../../windows_containers/enabling-windows-container-workloads.adoc#wmco-configure-debug-logging_enabling-windows-container-workloads[Configuring debug-level logging for the Windows Machine Config Operator].
+
+[id="wmco-10-18-0-new-features-kubernetes"]
+=== Kubernetes upgrade
+The WMCO now uses Kubernetes 1.31.
+
+[id="wmco-10-18-0-bug-fixes"]
+== Bug fixes
+* Previously, if you installed the WMCO into the the default `openshift-windows-machine-config-operator` namespace and removed the WMCO, subsequently installing the WMCO into a namespace other than the default would fail. This was because the role-based access control (RBAC) for the Windows Instance Config Daemon (WICD) was always associated with the default namespace. With this fix, when installing the WMCO to a non-default namespace, the RBAC for the WICD is configured correctly. (link:https://issues.redhat.com/browse/OCPBUGS-46473[*OCPBUGS-46473*])
+
+* Previously, the {product-title} documentation lacked information about WMCO support for the installer-provisioned infrastructure and the user-provisioned infrastructure installation methods. With this fix, the documentation now reports that the installer-provisioned infrastructure method is the preferred installation method and can be used with all platforms. The user-provisioned infrastructure method is limited to specific use cases. For more information, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes-10-18-x-prereqs.adoc#wmco-prerequisites-supported-install-10.18.0_windows-containers-release-notes-10-18-x-prereqs[WMCO supported installation method]. (link:https://issues.redhat.com/browse/OCPBUGS-18898[*OCPBUGS-18898*])

--- a/modules/windows-containers-release-notes-10-18-1.adoc
+++ b/modules/windows-containers-release-notes-10-18-1.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes-10-18-x.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-18-1_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.18.1
+
+Issued: 27 May 2025
+
+This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.18.0 were released in link:https://access.redhat.com/errata/RHSA-2025:8224[RHSA-2025:8224].
+
+////
+Hiding until we get decison on whether to include this RH employee only issue
+[id="wmco-10-18-1-bug-fixes"]
+== Bug fixes
+
+* Previously, Windows nodes were unable to pull from image mirror registries if an organization name or namespace was included in the source of the `ImageTagMirrorSet` (ITMS) object. With this fix, you can include an organization name or namespace in the `ITMS` object. With this change, additional guidelines and requirements around using mirror registries have been added to the {product-title} documentation. (link:https:  
+//issues.redhat.com/browse/OCPBUGS-55787[*OCPBUGS-55787*])
+// The "additional guidelines and requirements" are forthcoming in https://github.com/openshift/openshift-docs/pull/92629 
+
+////

--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-18-x-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-18-x-past.adoc
@@ -10,16 +10,4 @@ The following release notes are for previous versions of the Windows Machine Con
 
 For the current version, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes-10-18-x.adoc#windows-containers-release-notes-10-18-x[{productwinc} release notes].
 
-[id="wmco-10-18-"]
-== Release notes for Red Hat Windows Machine Config Operator 10.18.0
-
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.18.0 were released in
-
-
-[id="wmco-10-18-past-new-features"]
-=== New features and improvements
-
-[id="wmco-10-18-bug-fixes"]
-=== Bug fixes
-
-
+include::modules/windows-containers-release-notes-10-18-0.adoc[leveloffset=+1]

--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-18-x.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-18-x.adoc
@@ -6,44 +6,4 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
-[id="wmco-10-18-0"]
-== Release notes for Red Hat Windows Machine Config Operator 10.18.0
-
-Issued: 19 March 2025
-
-This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.18.0 were released in link:https://access.redhat.com/errata/RHBA-2025:3040[RHBA-2025:3040].
-
-[id="wmco-10-18-0-new-features"]
-=== New features and improvements
-
-[id="wmco-10-18-0-new-features-hpa"]
-==== Horizontal Pod autoscaling is available for Windows workloads
-You can now use a horizontal pod autoscaler (HPA) to scale your Windows pods based on CPU and/or memory resource metrics. For more information on using an HPA, see xref:../../nodes/pods/nodes-pods-autoscaling.adoc#nodes-pods-autoscaling[Automatically scaling pods with the horizontal pod autoscaler].
-
-[id="wmco-10-18-0-new-features-eus"]
-==== Control Plane Only updates are now available for Windows nodes
-You can now use *Control Plane Only* updates, previously known as *EUS-to-EUS* updates, to update your Windows nodes between {product-title} EUS versions. For more information, see xref:../../windows_containers/windows-node-upgrades.adoc#wmco-upgrades-eus_windows-node-upgrades[Windows Machine Config Operator Control Plane Only upgrade].
-
-[id="wmco-10-18-0-new-features-metrics"]
-==== WMCO metrics endpoint is now HTTPS
-The WMCO metrics endpoint is now exposed over HTTPS. Previously, WMCO pod metrics were available over HTTP. This change improves the security posture of the WMCO metrics endpoint.
-// https://issues.redhat.com/browse/WINC-1269
-// https://issues.redhat.com/browse/WINC-588
-
-[id="wmco-10-18-0-new-features-debuglogging"]
-==== WMCO now defaults to info-level logging
-The WMCO is configured to use the `info` log level by default. You can change the log level to `debug` by editing the WMCO subscription object. For more information, see xref:../../windows_containers/enabling-windows-container-workloads.adoc#wmco-configure-debug-logging_enabling-windows-container-workloads[Configuring debug-level logging for the Windows Machine Config Operator].
-
-[id="wmco-10-18-0-new-features-kubernetes"]
-==== Kubernetes upgrade
-The WMCO now uses Kubernetes 1.31.
-
-[id="wmco-10-18-0-bug-fixes"]
-=== Bug fixes
-* Previously, if you installed the WMCO into the the default `openshift-windows-machine-config-operator` namespace and removed the WMCO, subsequently installing the WMCO into a namespace other than the default would fail. This was because the role-based access control (RBAC) for the Windows Instance Config Daemon (WICD) was always associated with the default namespace. With this fix, when installing the WMCO to a non-default namespace, the RBAC for the WICD is configured correctly. (link:https://issues.redhat.com/browse/OCPBUGS-46473[*OCPBUGS-46473*])
-
-* Previously, the {product-title} documentation lacked information about WMCO support for the installer-provisioned infrastructure and the user-provisioned infrastructure installation methods. With this fix, the documentation now reports that the installer-provisioned infrastructure method is the preferred installation method and can be used with all platforms. The user-provisioned infrastructure method is limited to specific use cases. For more information, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes-10-18-x-prereqs.adoc#wmco-prerequisites-supported-install-10.18.0_windows-containers-release-notes-10-18-x-prereqs[WMCO supported installation method]. (link:https://issues.redhat.com/browse/OCPBUGS-18898[*OCPBUGS-18898*])
-
-// Bug fixes listed in https://gitlab.cee.redhat.com/releng/advisories/-/blob/main/data/advisories/windows-machine-conf-tenant/2025/3040/advisory.yaml?ref_type=heads, as the advisory did not contain the list at the time these RN were created.
-// https://issues.redhat.com/browse/WINC-1149, no release note required. Documented via https://github.com/openshift/openshift-docs/pull/80320
+include::modules/windows-containers-release-notes-10-18-1.adoc[leveloffset=+1]


### PR DESCRIPTION
Preview:
[Red Hat OpenShift support for Windows Containers release notes](https://93452--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-18-x)

The [Release notes for Red Hat Windows Machine Config Operator 10.18.0 module](https://github.com/openshift/openshift-docs/pull/93452/files#diff-6a0dbef9167dcaa009d8665a749dbd297d7af71d586f70f9c8d0c3745ef84cd9) is existing text that has been previously peer-reviewed and **DOES NOT** need review. See [current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/windows_container_support_for_openshift/release-notes#wmco-10-18-0).
