### PR TITLE
OSDOCS#13824: Adding an overview page for the tutorials book

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -67,8 +67,8 @@ Name: Tutorials
 Dir: tutorials
 Distros: openshift-enterprise
 Topics:
-# - Name: Tutorials overview
-#   File: index
+- Name: Tutorials overview
+  File: index
 - Name: Deploying an application by using the web console
   File: dev-app-web-console
 - Name: Deploying an application by using the CLI

--- a/tutorials/index.adoc
+++ b/tutorials/index.adoc
@@ -7,20 +7,21 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 ////
-TODO: intro
-
 [id="tutorials-developers_{context}"]
 == Tutorials for developers
+////
 
-// TODO: xrefs to CLI and web console developer tutorials
+You can follow an end-to-end example of deploying an application on {product-title} either by using the {oc-first} or the web console.
 
+* xref:../tutorials/dev-app-cli#dev-app-cli[Tutorial: Deploying an application by using the CLI]
+* xref:../tutorials/dev-app-web-console#dev-app-web-console[Tutorial: Deploying an application by using the web console]
+
+////
 [id="tutorials-admins_{context}"]
 == Tutorials for administrators
-
-// TODO: xrefs to CLI and web console admin tutorials
+////
 
 [id="additional-learning-resources_{context}"]
 == Additional learning resources
 
-// TODO: xref to learning resources assembly
-////
+To discover additional tutorials and hands-on learning resources for {product-title}, see xref:../tutorials/additional-tutorials#additional-tutorials[Additional hands-on learning].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-13824

Link to docs preview:
https://93462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/tutorials/index.html

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
