### PR TITLE
ROX-29306: Updates for admission controller docs

### DIFF
--- a/modules/policy-enforcement-deploy.adoc
+++ b/modules/policy-enforcement-deploy.adoc
@@ -39,12 +39,16 @@ If you make changes to settings in the *Static Configuration* setting, you must 
 
 Soft enforcement is performed by {product-title-short} Sensor. This enforcement prevents an operation from being initiated. With soft enforcement, Sensor scales the replicas to 0, and prevents pods from being scheduled. In this enforcement, a non-ready deployment is available in the cluster.
 
+By design, Sensor only performs this soft enforcement once, to prevent trapping of update requests to scale the deployment back down again.
+
 If soft enforcement is configured, and Sensor is down, then {product-title-short} cannot perform enforcement.
 
 [id="namespace-exclusions_{context}"]
 == Namespace exclusions
 
 By default, {product-title-short} excludes certain administrative namespaces, such as the `stackrox`, `kube-system`, and `istio-system` namespaces, from enforcement blocking. The reason for this is that some items in these namespaces must be deployed for {product-title-short} to work correctly.
+
+In addition, the {product-title-short} admission controller bypasses requests that originate from a `service` account in a `system` namespace. Consider this factor when deploying the CI/CD tool of your choice.
 
 [id="enforcement-existing-deployments_{context}"]
 == Enforcement on existing deployments

--- a/modules/understand-admission-controller-enforcement.adoc
+++ b/modules/understand-admission-controller-enforcement.adoc
@@ -9,7 +9,7 @@ If you intend to use admission controller enforcement, consider the following:
 
 * *API latency*: Using admission controller enforcement increases Kubernetes or {ocp} API latency because it involves additional API validation requests.
 Many standard Kubernetes libraries, such as fabric8, have short Kubernetes or {ocp} API timeouts by default.
-Also, consider API timeouts in any custom automation you might be using.
+Also, consider API timeouts in any custom automation you might be using. If a request does time out due to latency issues, the admission controller will _fail open_, or allow the request to reach the API server.
 * *Image scanning*: You can choose whether the admission controller scans images while reviewing requests by setting the *Contact Image Scanners* option in the cluster configuration panel.
 ** If you enable this setting, {product-title} contacts the image scanners if the scan or image signature verification results are not already available, which adds considerable latency.
 ** If you disable this setting, the enforcement decision only considers image scan criteria if cached scan and signature verification results are available.


### PR DESCRIPTION
Version(s):
4.6+

[Issue]([ROX-29306](https://issues.redhat.com/browse/ROX-29306))

Links to docs previews:

https://93463--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/respond-to-violations.html#namespace-exclusions_respond-to-violations

https://93463--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-ci-systems.html#soft-enforcement_integrate-with-ci-systems

https://93463--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/about-security-policies.html#soft-enforcement_about-security-policies

https://93463--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/use-admission-controller-enforcement.html#understand-admission-controller-enforcement_use-admission-controller-enforcement

QE review: **ACS has no QE, approved by SMEs**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
