### PR TITLE
OSSM-9369: add instructions to Create Istio reader ServiceAccount

### DIFF
--- a/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
@@ -123,14 +123,43 @@ $ oc --context "${CTX_CLUSTER2}" apply -f https://raw.githubusercontent.com/isti
 $ oc --context "${CTX_CLUSTER2}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/expose-services.yaml
 ----
 
+. Create the `istio-reader-service-account` service account for the East cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" create serviceaccount istio-reader-service-account -n istio-system
+----
+
+. Create the `istio-reader-service-account` service account for the West cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" create serviceaccount istio-reader-service-account -n istio-system 
+----
+
+. Add the `cluster-reader` role to the East cluster by running the following command: 
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER1}" adm policy add-cluster-role-to-user cluster-reader -z istio-reader-service-account -n istio-system
+----
+
+. Add the `cluster-reader` role to the West cluster by running the following command: 
++
+[source,terminal]
+----
+$ oc --context="${CTX_CLUSTER2}" adm policy add-cluster-role-to-user cluster-reader -z istio-reader-service-account -n istio-system
+----
+
 . Install a remote secret on the East cluster that provides access to the API server on the West cluster by running the following command:
 +
 [source,terminal]
 ----
 $ istioctl create-remote-secret \
   --context="${CTX_CLUSTER2}" \
-  --name=cluster2 | \
-  oc --context="${CTX_CLUSTER1}" apply -f -
+  --name=cluster2 \
+  --create-service-account=false | \
+  oc --context="${CTX_CLUSTER1}" apply -f - 
 ----
 
 . Install a remote secret on the West cluster that provides access to the API server on the East cluster by running the following command:
@@ -139,6 +168,7 @@ $ istioctl create-remote-secret \
 ----
 $ istioctl create-remote-secret \
   --context="${CTX_CLUSTER1}" \
-  --name=cluster1 | \
-  oc --context="${CTX_CLUSTER2}" apply -f -
+  --name=cluster1 \
+  --create-service-account=false | \
+  oc --context="${CTX_CLUSTER2}" apply -f -  
 ----


### PR DESCRIPTION
Merge to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main
Cherry pick to: https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0

Version(s): 3.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-9369
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://93475--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html#ossm-installing-multi-primary-multi-network-mesh_ossm-multi-cluster-topologies

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
