### PR TITLE
OSDOCS-14051: Update the documentation with details of Storage volumes configured by default.

### DIFF
--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -154,6 +154,15 @@ ifndef::tf-classic,tf-hcp[]
 * Default Operator role prefix: `<cluster_name>-<4_digit_random_string>`
 endif::tf-classic,tf-hcp[]
 
+|Storage
+|* Node volumes:
+** Type: AWS EBS GP3
+** Default size: 300GiB (adjustable at creation time)
+* Workload persistent volumes:
+** Default StorageClass: gp3-csi
+** Provisioner: ebs.csi.aws.com
+** Dynamic persistent volume provisioning
+
 |Cluster update strategy
 |* Individual updates
 * 1 hour grace period for node draining


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-14051

Link to docs preview:

- https://93496--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-quickstart-guide.html
- https://93496--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html
- https://93496--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart-guide-ui.html
- https://93496--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html
- https://93496--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.html
- https://93496--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html
- https://93496--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/terraform/rosa-classic-creating-a-cluster-quickly-terraform.html

QE review:
QE approval not needed, PM request to add content to a table.

