### PR TITLE
[SRVKS-1303] haproxy.router.openshift.io/timeout config for auto-created routes

### DIFF
--- a/knative-serving/external-ingress-routing/configuring-service-routes.adoc
+++ b/knative-serving/external-ingress-routing/configuring-service-routes.adoc
@@ -13,3 +13,8 @@ When you complete the following procedure, the default {ocp-product-title} route
 ====
 
 include::modules/serverless-openshift-routes.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../config-applications/configuring-revision-timeouts.adoc#configuring-default-route-timeouts-globally_configuring-revision-timeouts[Configuring the default route timeouts]

--- a/modules/configuring-default-route-timeouts-globally.adoc
+++ b/modules/configuring-default-route-timeouts-globally.adoc
@@ -10,9 +10,11 @@ By configuring the route timeouts globally, you can ensure consistent timeout se
 
 You can configure the route timeouts globally by updating the `ROUTE_HAPROXY_TIMEOUT` environment value in your `serverless-operator` subscription and updating the `max-revision-timeout-seconds` field in your `KnativeServing` custom resource (CR). This applies the timeout changes across all Knative services, and you can deploy services with specific timeouts up to the maximum value set.
 
+`ROUTE_HAPROXY_TIMEOUT` is an environment variable managed by the Serverless Operator and by default is set to `600`.
+
 .Procedure
 
-. Set the value of `ROUTE_HAPROXY_TIMEOUT` in your subscription to your required timeout in seconds by running the following command:
+. Set the value of `ROUTE_HAPROXY_TIMEOUT` in your subscription to your required timeout in seconds by running the following command. Note that this causes pods in the `openshift-serverless` namespace  to be redeployed.
 +
 .Setting the `ROUTE_HAPROXY_TIMEOUT` value to 900 seconds
 [source,terminal]
@@ -20,7 +22,23 @@ You can configure the route timeouts globally by updating the `ROUTE_HAPROXY_TIM
 $ oc patch subscription.operators.coreos.com serverless-operator -n openshift-serverless --type='merge' -p '{"spec": {"config": {"env": [{"name": "ROUTE_HAPROXY_TIMEOUT", "value": "900"}]}}}'
 ----
 +
-The `ROUTE_HAPROXY_TIMEOUT`  environment variable is managed by the Serverless Operator and by default is set to `600`. Set the value of `ROUTE_HAPROXY_TIMEOUT` in your subscription to your required timeout in seconds by running the following command. Note that this causes pods to be redeployed in the `openshift-serverless` namespace.
+Alternatively, you can set the value of `ROUTE_HAPROXY_TIMEOUT` in your subscription directly:
++
+.A subscription definition with `ROUTE_HAPROXY_TIMEOUT` set to 900 seconds
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+#...
+spec:
+  channel: stable
+  config:
+    env:
+      - name: ROUTE_HAPROXY_TIMEOUT
+        value: '900'
+#...
+----
 +
 [NOTE]
 ====

--- a/modules/serverless-openshift-routes.adoc
+++ b/modules/serverless-openshift-routes.adoc
@@ -108,7 +108,7 @@ spec:
       -----END CERTIFICATE----
   wildcardPolicy: None
 ----
-<1> The timeout value for the {ocp-product-title} route. You must set the same value as the `max-revision-timeout-seconds` setting (`600s` by default).
+<1> The timeout value for the {ocp-product-title} route. You must set the same value as the `max-revision-timeout-seconds` setting (`600s` by default). You can also set the default timeout value for auto-generated {ocp-product-title} routes.
 <2> The name of the {ocp-product-title} route.
 <3> The namespace for the {ocp-product-title} route. This must be `knative-serving-ingress`.
 <4> The hostname for external access. You can set this to `<service_name>-<service_namespace>.<domain>`.


### PR DESCRIPTION
Version(s):
serverless-docs-1.36+

Issue:
https://issues.redhat.com/browse/SRVKS-1303

Link to docs preview:
- https://93501--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/external-ingress-routing/configuring-service-routes.html

QE review:
- [x] QE has approved this change.
