### PR TITLE
[enterprise-4.16] MULTIARCH#5446: Release notes for MTO 1.1.z

### DIFF
--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
@@ -12,10 +12,28 @@ These release notes track the development of the Multiarch Tuning Operator.
 
 For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
 
+[id="multi-arch-tuning-operator-release-notes-1-1-1_{context}"]
+== Release notes for the Multiarch Tuning Operator 1.1.1
+
+Issued: 27 May 2025
+
+[id="multi-arch-tuning-operator-1-1-1-bug-fixes_{context}"]
+=== Bug fixes
+
+* Previously, the pod placement operand did not support authenticating registries using wildcard entries in the hostname of their pull secret. This caused inconsistent behavior with Kubelet when pulling images, because Kubelet supported wildcard entries while the operand required exact hostname matches. As a result, image pulls could fail unexpectedly when registries used wildcard hostnames.
++
+With this release, the pod placement operand supports pull secrets that include wildcard hostnames, ensuring consistent and reliable image authentication and pulling. 
+// (link:https://issues.redhat.com/browse/MULTIARCH-5536[*MULTIARCH-5536*])
+
+* Previously, when image inspection failed after all retries and the `nodeAffinityScoring` plugin was enabled, the pod placement operand applied incorrect `nodeAffinityScoring` labels.
++
+With this release, the operand sets `nodeAffinityScoring` labels correctly, even when image inspection fails. It now applies these labels independently of the required affinity process to ensure accurate and consistent scheduling. 
+// (link:https://issues.redhat.com/browse/MULTIARCH-5363[*MULTIARCH-5363*])
+
 [id="multi-arch-tuning-operator-release-notes-1-1-0_{context}"]
 == Release notes for the Multiarch Tuning Operator 1.1.0
 
-Issued: 18 March 2024
+Issued: 18 March 2025
 
 [id="multi-arch-tuning-operator-1-1-0-new-features-and-enhancements_{context}"]
 === New features and enhancements
@@ -25,7 +43,7 @@ Issued: 18 March 2024
 * With this release, you can configure architecture-aware workload scheduling by using the new `plugins` field in the `ClusterPodPlacementConfig` object. You can use the `plugins.nodeAffinityScoring` field to set architecture preferences for pod placement. If you enable the `nodeAffinityScoring` plugin, the scheduler first filters out nodes that do not meet the pod requirements. Then, the scheduler prioritizes the remaining nodes based on the architecture scores defined in the `nodeAffinityScoring.platforms` field.
 
 [id="multi-arch-tuning-operator-1-1-0-bug-fixes_{context}"]
-==== Bug fixes
+=== Bug fixes
 
 * With this release, the Multiarch Tuning Operator does not update the `nodeAffinity` field for pods that are managed by a daemon set. (link:https://issues.redhat.com/browse/OCPBUGS-45885[*OCPBUGS-45885*])
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[MULTIARCH-5446](https://issues.redhat.com/browse/MULTIARCH-5446)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Release notes for the Multiarch Tuning Operator 1.1.z](https://93517--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.html#multi-arch-tuning-operator-release-notes-1-1-z_multi-arch-tuning-operator-release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Note to the merge reviewer: The Peer review for this content is done in - https://github.com/openshift/openshift-docs/pull/93520
