### PR TITLE
standalone ligging docs - add docinfo.xml

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1,5 +1,5 @@
 ---
-Name: About OpenShift Logging
+Name: About OpenShift logging
 Dir: about
 Distros: openshift-logging
 Topics:
@@ -12,14 +12,14 @@ Topics:
 - Name: Visualization for logging
   File: logging-visualization
 ---
-Name: Installing
+Name: Installing logging
 Dir: installing
 Distros: openshift-logging
 Topics:
 - Name: Installing logging
   File: installing-logging
 ---
-Name: Configuring
+Name: Configuring logging
 Dir: configuring
 Distros: openshift-logging
 Topics:
@@ -32,7 +32,7 @@ Topics:
 - Name: OpenTelemetry data model
   File: opentelemetry-data-model
 ---
-Name: Upgrading
+Name: Upgrading logging
 Dir: upgrading
 Distros: openshift-logging
 Topics:

--- a/about/docinfo.xml
+++ b/about/docinfo.xml
@@ -1,0 +1,13 @@
+<title>About OpenShift logging</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Introduction to OpenShift logging.</subtitle>
+<abstract>
+    <para>This document provides an overview of OpenShift Logging features, and also
+    includes release notes and support information.
+</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/configuring/docinfo.xml
+++ b/configuring/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Configuring logging</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Configuring log forwarding and LokiStack</subtitle>
+<abstract>
+    <para>This document provides an overview of configuring OpenShift logging features including log forwarding and LokiStack.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/installing/docinfo.xml
+++ b/installing/docinfo.xml
@@ -1,0 +1,13 @@
+<title>Installing logging</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Installing Loki Operator, Red Hat OpenShift Logging Operator and Cluster Observability Operator</subtitle>
+<abstract>
+    <para>This document provides information about installing Loki Operator to manage your log store, 
+    Red Hat OpenShift Logging Operator to manage log collection and forwarding, and Cluster Observability Operator for visualization.
+    </para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/upgrading/docinfo.xml
+++ b/upgrading/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Upgrading logging</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Upgrading older viersions and upgrade paths</subtitle>
+<abstract>
+    <para>This document includes information abotu how to upgrade older versiosn of logging, and what upgrade paths are supported.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
Version(s):
standalone-logging-docs-main, CP to 6.0, 6.1, 6.2

Issue:
standalone logging docs

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
