### PR TITLE
[enterprise-4.16] OBSDOCS-1862: Add missing info about alert emails

### DIFF
--- a/modules/monitoring-configuring-alert-routing-console.adoc
+++ b/modules/monitoring-configuring-alert-routing-console.adoc
@@ -53,6 +53,11 @@ Alternatively, you can go to the same page through the notification drawer. Sele
 +
 .. Add SMTP configuration details, including the address to send notifications from, the smarthost and port number used for sending emails, the hostname of the SMTP server, and authentication details.
 +
+[IMPORTANT]
+====
+Alertmanager requires an external SMTP server to send email alerts. To configure email alert receivers, ensure you have the necessary connection details for an external SMTP server.
+====
++
 .. Select whether TLS is required.
 +
 .. Click *Show advanced configuration* if you want to edit the default option not to send resolved alerts to the receiver or edit the body of email notifications configuration.

--- a/modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc
+++ b/modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc
@@ -82,9 +82,40 @@ receivers:
 - name: watchdog
 - name: team-frontend-page
   pagerduty_configs:
-  - routing_key: ABCD01234EFGHIJ56789
+  - routing_key: xxxxxxxxxx # <1>
 # ...
 ----
+<1> Defines the PagerDuty integration key.
++
+--
+.Example of configuring email as an alert receiver
+[source,yaml]
+----
+# ...
+receivers:
+- name: default
+- name: watchdog
+- name: team-frontend-page
+  email_configs:
+    - to: myemail@example.com # <1>
+      from: alertmanager@example.com # <2>
+      smarthost: 'smtp.example.com:587' # <3>
+      auth_username: alertmanager@example.com  # <4>
+      auth_password: password
+      hello: alertmanager # <5>
+# ...
+----
+<1> Specify an email address to send notifications to.
+<2> Specify an email address to send notifications from.
+<3> Specify the SMTP server address used for sending emails, including the port number.
+<4> Specify the authentication credentials that Alertmanager uses to connect to the SMTP server. This example uses username and password.
+<5> Specify the hostname to identify to the SMTP server. If you do not include this parameter, the hostname defaults to `localhost`.
+--
++
+[IMPORTANT]
+====
+Alertmanager requires an external SMTP server to send email alerts. To configure email alert receivers, ensure you have the necessary connection details for an external SMTP server.
+====
 
 .. Add the routing configuration:
 +


### PR DESCRIPTION
Manual cp of https://github.com/openshift/openshift-docs/pull/93264 to 4.16