### PR TITLE
OSDOCS-14694 created 4.14.52 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3400,6 +3400,41 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.52
+[id="ocp-4-14-52_{context}"]
+=== RHSA-2025:7702 - {product-title} 4.14.52 bug fix and security update
+
+Issued: 21 May 2025
+
+{product-title} release 4.14.52, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:7702[RHSA-2025:7702] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:7704[RHBA-2025:7704] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.52 --pullspecs
+----
+
+[id="ocp-4-14-52-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, an Operator would incorrectly appear twice in the installed Operators list if the current project matched its default namespace and the copied CSVs were disabled in the Operator Lifecycle Manager (OLM). With this release, the Operator displays only once. (link:https://issues.redhat.com/browse/OCPBUGS-55942[OCPBUGS-55942])
+
+* Previously, {product-title} release 4.14.52 and later releases remained on the stable-4.14 channel instead of switching to the eus-4.14 channel. This caused 'VersionNotFound' errors when attempting to retrieve update information. Because the version was not found in the stable-4.14 channel, the recommended updates were not available. With this release, the installer directs 4.14.52 and later releases to the Extended Update Support (EUS) channel, ensuring the releases receive the recommended update notices, and the `VersonNotFound` error no longer displays. (link:https://issues.redhat.com/browse/OCPBUGS-55193[OCPBUGS-55193])
+
+* Previously, when the `openshift-host-network` namespace was modified by the user or by an upgrade, the network policy did not correctly set the VXLAN virtual network ID parameter, `VNID`, to `0`. With this release, the VNID parameter is correctly set after the namespace is modified. (link:https://issues.redhat.com/browse/OCPBUGS-54868[OCPBUGS-54868])
+
+* Previously, cluster nodes repeatedly lost communication due to improper remote port binding by Open Virtual Network (OVN)-Kubernetes. This affected pod communication across nodes. With this release, the remote port binding functionality has been updated to be handled by OVN directly, improving the reliability of cluster node communication. (link:https://issues.redhat.com/browse/OCPBUGS-48522[OCPBUGS-48522])
+
+* Previously, when you installed a cluster on {ibm-cloud-name} into an existing Virtual Private Cloud (VPC), the installation program retrieved an unsupported VPC region. If you tried to install into a supported VPC region that followed the unsupported VPC region alphabetically, the installation program crashed. With this release, the installation program ignores any VPC regions that are not fully available during resource lookups. (link:https://issues.redhat.com/browse/OCPBUGS-48196[OCPBUGS-48196])
+
+[id="ocp-4-14-52-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.51
 [id="ocp-4-14-51_{context}"]
 === RHSA-2025:4177 - {product-title} 4.14.51 bug fix and security update
@@ -3437,9 +3472,9 @@ With this release, you can use the installation program to create an external cl
 
 * Previously, on a `condition.Status`, the ignition-server controller overloaded the Kubernetes agent server (KAS) by updating that condition with the same message in every reconcile loop. With this release, the controller checks the message and validates whether it is the existing message so that the KAS is not overloaded. (link:https://issues.redhat.com/browse/OCPBUGS-53433[OCPBUGS-53433])
 
-* Previously, a custom Security Context Constraint (SCC) impacted pods that the Cluster Version Operator generated from receiving a cluster version upgrade. With this release, {product-title} now sets a default SCC to each pod, so that any custom SCC created does not impact a pod. (link:https://issues.redhat.com/browse/OCPBUGS-50592[OCPBUGS-50592]) 
+* Previously, a custom Security Context Constraint (SCC) impacted pods that the Cluster Version Operator generated from receiving a cluster version upgrade. With this release, {product-title} now sets a default SCC to each pod, so that any custom SCC created does not impact a pod. (link:https://issues.redhat.com/browse/OCPBUGS-50592[OCPBUGS-50592])
 
-* Previously, a User Datagram Protocol (UDP) packet that was larger than the maximum transmission unit (MTU) value set for the cluster, could not be sent to the endpoint of the packet using a service. With this release, the pod IP address is used instead of the service IP address regardless of the packet size so that the UDP packet can be sent to the endpoint. (link:https://issues.redhat.com/browse/OCPBUGS-50584[OCPBUGS-50584]) 
+* Previously, a User Datagram Protocol (UDP) packet that was larger than the maximum transmission unit (MTU) value set for the cluster, could not be sent to the endpoint of the packet using a service. With this release, the pod IP address is used instead of the service IP address regardless of the packet size so that the UDP packet can be sent to the endpoint. (link:https://issues.redhat.com/browse/OCPBUGS-50584[OCPBUGS-50584])
 
 [id="ocp-4-14-51-updating_{context}"]
 ==== Updating
@@ -3452,7 +3487,7 @@ To update an existing {product-title} 4.14 cluster to this latest release, see x
 
 Issued: 09 April 2025
 
-{product-title} release 4.14.50, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3569[RHSA-2025:3569] advisory. 
+{product-title} release 4.14.50, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:3569[RHSA-2025:3569] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -3501,7 +3536,7 @@ $ oc adm release info 4.14.49 --pullspecs
 
 * Previously, after a compute node was removed from the cluster, provisioning of a `PersistentVolume` (PV) resource failed with a message that stated: `The object <virtual machine ID> has already been deleted or has not been completely created`. With this release, a fix ensures that when a compute node is removed, this removal does not impact provisioning of a PV resource. (link:https://issues.redhat.com/browse/OCPBUGS-51045[OCPBUGS-51045])
 
-* Previously, requests to the `deploymentconfig/scale` subresource would fail when there was an admission webhook matching the request. With this release, the issue is resolved and requests to the `deploymentconfig/scale` subresource succeed. (link:https://issues.redhat.com/browse/OCPBUGS-50477[OCPBUGS-50477]) 
+* Previously, requests to the `deploymentconfig/scale` subresource would fail when there was an admission webhook matching the request. With this release, the issue is resolved and requests to the `deploymentconfig/scale` subresource succeed. (link:https://issues.redhat.com/browse/OCPBUGS-50477[OCPBUGS-50477])
 
 * Previously, when you used the *Form View* to edit `Deployment` or `DeploymentConfig` API objects on the {product-title} web console, duplicate `ImagePullSecrets` parameters existed in the YAML configuration for either object. With this release, a fix ensures that duplicate `ImagePullSecrets` parameters do not get automatically added for either object. (link:https://issues.redhat.com/browse/OCPBUGS-49753[OCPBUGS-49753])
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-14694

Link to docs preview:
https://93548--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-52_release-notes

QE review:
- [ ] QE has approved this change.


Additional information:

