### PR TITLE
Adds RN for ocpbugs-55453

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -1663,6 +1663,12 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-19-known-issues_{context}"]
 == Known issues
 
+* In {product-title} {product-version}, clusters using IPSEC for network encryption might experience intermittent loss of pod-to-pod connectivity. This prevents some pods on certain nodes from reaching services on other nodes, resulting in connection timeouts.
++
+Internal testing could not reproduce this issue on clusters with 120 nodes or less.
++
+There is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-55453[OCPBUGS-55453])
+
 [id="ocp-telco-ran-4-19-known-issues_{context}"]
 
 [id="ocp-telco-core-4-19-known-issues_{context}"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OCPBUGS-55453

Link to docs preview:
https://93558--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-known-issues_release-notes

QE review:
QE not needed. Known issue ack'd by Peri in Slack. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
