### PR TITLE
OCPBUGS-56101: Clarifying log forwarding for IBU

### DIFF
--- a/modules/cnf-image-based-upgrade-seed-image-config.adoc
+++ b/modules/cnf-image-based-upgrade-seed-image-config.adoc
@@ -119,8 +119,13 @@ ifdef::ibu[]
 |Resource
 |Apply as extra manifest
 
-|`ClusterLogForwarder.yaml`
-|Yes
+a|`ClusterLogForwarder.yaml`
+a|Yes
+
+[NOTE]
+====
+The DU profile includes the Cluster Logging Operator, but the profile does not configure or apply any Cluster Logging Operator CRs. To enable log forwarding, include the `ClusterLogForwarder.yaml` CR as an extra manifest. The extra manifest is applied to the target {sno} cluster during the image-based upgrade process.
+====
 
 |`ReduceMonitoringFootprint.yaml`
 |Yes


### PR DESCRIPTION
OCPBUGS-56101: Clarifying log forwarding for IBU

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-56101

Link to docs preview:
https://93572--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-generate-seed.html#ztp-image-based-upgrade-seed-image-config-ran_generate-seed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

