### PR TITLE
OCPBUGS-56101: Removing CR from seed image config table for IBU [4.16]

### DIFF
--- a/modules/cnf-image-based-upgrade-seed-image-config.adoc
+++ b/modules/cnf-image-based-upgrade-seed-image-config.adoc
@@ -72,9 +72,6 @@ The following table lists the components, resources, and configurations that you
 |All Day 2 Operator subscriptions
 |Yes
 
-|`ClusterLogging.yaml`
-|Yes
-
 |`DisableOLMPprof.yaml`
 |Yes
 


### PR DESCRIPTION
OCPBUGS-56101: Removing `ClusterLogging.yaml` from seed image config table for IBU for version 4.16 only.

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OCPBUGS-56101

Link to docs preview:
https://93574--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-generate-seed.html#ztp-image-based-upgrade-seed-image-config-ran_generate-seed

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

