### PR TITLE
Simplify and deduplicate vSphere machineset wrt infra

### DIFF
--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -17,7 +17,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
 [source,yaml]
@@ -39,40 +39,37 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
         machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <3>
-        machine.openshift.io/cluster-api-machine-type: <infra> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
+        machine.openshift.io/cluster-api-machine-role: infra <3>
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
     spec:
       metadata:
         creationTimestamp: null
         labels:
 ifndef::infra[]
-          node-role.kubernetes.io/<role>: "" <3>
+          node-role.kubernetes.io/<role>: ""
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <3>
-      taints: <4>
-      - key: node-role.kubernetes.io/infra
-        effect: NoSchedule
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
       providerSpec:
         value:
@@ -86,16 +83,10 @@ endif::infra[]
             creationTimestamp: null
           network:
             devices:
-ifndef::infra[]
             - networkName: "<vm_network_name>" <4>
-endif::infra[]
-ifdef::infra[]
-            - networkName: "<vm_network_name>" <5>
-endif::infra[]
           numCPUs: 4
           numCoresPerSocket: 1
           snapshot: ""
-ifndef::infra[]
           template: <vm_template_name> <5>
           userDataSecret:
             name: worker-user-data
@@ -105,17 +96,10 @@ ifndef::infra[]
             folder: <vcenter_vm_folder_path> <8>
             resourcepool: <vsphere_resource_pool> <9>
             server: <vcenter_server_ip> <10>
-endif::infra[]
 ifdef::infra[]
-          template: <vm_template_name> <6>
-          userDataSecret:
-            name: worker-user-data
-          workspace:
-            datacenter: <vcenter_data_center_name> <7>
-            datastore: <vcenter_datastore_name> <8>
-            folder: <vcenter_vm_folder_path> <9>
-            resourcepool: <vsphere_resource_pool> <10>
-            server: <vcenter_server_ip> <11>
+      taints: <11>
+      - key: node-role.kubernetes.io/infra
+        effect: NoSchedule
 endif::infra[]
 ----
 <1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
@@ -127,6 +111,11 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ifndef::infra[]
 <2> Specify the infrastructure ID and node label.
 <3> Specify the node label to add.
+endif::infra[]
+ifdef::infra[]
+<2> Specify the infrastructure ID and `infra` node label.
+<3> Specify the `infra` node label.
+endif::infra[]
 <4> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
 <5> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
 <6> Specify the vCenter data center to deploy the compute machine set on.
@@ -134,24 +123,13 @@ ifndef::infra[]
 <8> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
 <9> Specify the vSphere resource pool for your VMs.
 <10> Specify the vCenter server IP or fully qualified domain name.
-endif::infra[]
 ifdef::infra[]
-<2> Specify the infrastructure ID and `<infra>` node label.
-<3> Specify the `<infra>` node label.
-<4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<11> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====
 After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
 ====
-
-<5> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
-<6> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
-<7> Specify the vCenter data center to deploy the compute machine set on.
-<8> Specify the vCenter datastore to deploy the compute machine set on.
-<9> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
-<10> Specify the vSphere resource pool for your VMs.
-<11> Specify the vCenter server IP or fully qualified domain name.
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
None

Link to docs preview:
* [Sample YAML for a compute machine set custom resource on vSphere](https://93582--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere.html#machineset-yaml-vsphere_creating-machineset-vsphere) (standard compute)
* [Sample YAML for a compute machine set custom resource on vSphere](https://93582--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-vsphere_creating-infrastructure-machinesets) (infra)

QE review:
No content changed, docs plumbing only.

Additional information:
- Removes brackets from some instances of `infra` (which is a literal value)
- Deduplicates reused callout numbers
- Moves infra `taints` stanza to end of block to reduce use of conditionals