### PR TITLE
OSDOCS#14731: Update the z-stream RNs for 4.18.14

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3021,6 +3021,48 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.14
+[id="ocp-4-18-14_{context}"]
+=== RHSA-2025:7863 - {product-title} {product-version}.14 bug fix update and security update
+
+Issued: 20 May 2025
+
+{product-title} release {product-version}.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:7863[RHSA-2025:7863] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:7865[RHBA-2025:7865] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.14 --pullspecs
+----
+
+[id="ocp-4-18-14-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the omission of the `OLMManagedLabelKey` label on objects resulted in cluster operation failures. With this release, an update improves pod stability and ensures that the Operator Lifecycle Manager operates properly. (link:https://issues.redhat.com/browse/OCPBUGS-56098[OCPBUGS-56098])
+
+* Previously, an invalid `.tar` extraction format resulted in an improper file separation in the `ramdisk` logs, and caused file separators to appear randomly. With this release, an updated `ramdisk` log file  processes `.tar`` entries individually. This fix improves log readability, making them easier to interpret. (link:https://issues.redhat.com/browse/OCPBUGS-55938[OCPBUGS-55938])
+
+* Previously, incorrectly formatted proxy variables in an external binary resulted in build failures. With this release, an update removes proxy environment variables from the build pod and prevents any build failures. (link:https://issues.redhat.com/browse/OCPBUGS-55699[OCPBUGS-55699])
+
+* Previously, no event was logged when an error occurred from failed conversion from ingress to route. With this update, this error appear in the event logs. (link:https://issues.redhat.com/browse/OCPBUGS-55338[OCPBUGS-55338])
+
+* Previously, a missing `afterburn` package resulted in the failure of the `gcp-hostname.service`, which caused the `scale-up` job to fail, impacting end-user deployments. With this release, the `afterburn` package is installed in the {op-system-base} `scale-up` job. This fix enables a successful `scale-up` action, resolving the `gcp-hostname` service failure. (link:https://issues.redhat.com/browse/OCPBUGS-55158[OCPBUGS-55158])
+
+* Previously, there was no communication between a `localnet` pod and a pod in the default network when both pods were on the same node. With this release, an update fixes the communication problem when pods are on the same node. (link:https://issues.redhat.com/browse/OCPBUGS-55016[OCPBUGS-55016])
+
+* Previously, image pull timeouts occurred due to the `Zscaler` platform scanning all data transfers. This resulted in timed out image pulls. With this release, the image pull timeout is increased to 30 seconds, allowing successful updates. (link:https://issues.redhat.com/browse/OCPBUGS-54663[OCPBUGS-54663])
+
+* Previously, you could add white space to {aws-first} tag names, but the installation program did not support them. This situation resulted in the installation program returning an `ERROR failed to fetch Metadata` message. With this release, the regular expression for {aws-short} tags now validates any tag name that has white space. The installation program accepts these tags and no longer returns an error because of white space. (link:https://issues.redhat.com/browse/OCPBUGS-53221[OCPBUGS-53221])
+
+* Previously, cluster nodes repeatedly lost communication due to improper remote port binding by Open Virtual Network (OVN)-Kubernetes. This affected pod communication across nodes. With this release, the remote port binding functionality is updated to be handled by OVN directly, improving the reliability of cluster node communication. (link:https://issues.redhat.com/browse/OCPBUGS-51144[OCPBUGS-51144])
+
+[id="ocp-4-18-14-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.13
 [id="ocp-4-18-13_{context}"]
 === RHSA-2025:4712 - {product-title} {product-version}.13 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-14731](https://issues.redhat.com//browse/OSDOCS-14731)

Link to docs preview:
[4.18.14](https://93584--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-14_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RN.

Additional information:
The errata URLs will return 404 until the go-live date of 5/20/25.
