### PR TITLE
OSDOCS-5784: Support multiple disks in vSphere

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
@@ -34,4 +34,7 @@ include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+2,tag=!compute]
 
 //Configuring multiple NICs by using machine sets
 //pulled from 4.18 GA
-//include::modules/machineset-vsphere-multiple-nics.adoc[leveloffset=+1,tag=!compute]
+//include::modules/machineset-vsphere-multiple-nics.adoc[leveloffset=+2,tag=!compute]
+
+//Configuring data disks by using machine sets
+include::modules/machineset-vsphere-data-disks.adoc[leveloffset=+2,tag=!compute]

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -50,3 +50,6 @@ include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+1,tag=!controlplane]
 
 //Configuring multiple NICs by using machine sets
 include::modules/machineset-vsphere-multiple-nics.adoc[leveloffset=+1,tag=!controlplane]
+
+//Configuring data disks by using machine sets
+include::modules/machineset-vsphere-data-disks.adoc[leveloffset=+1,tag=!controlplane]

--- a/modules/cpmso-yaml-provider-spec-vsphere.adoc
+++ b/modules/cpmso-yaml-provider-spec-vsphere.adoc
@@ -26,57 +26,63 @@ spec:
             apiVersion: machine.openshift.io/v1beta1
             credentialsSecret:
               name: vsphere-cloud-credentials <1>
-            diskGiB: 120 <2>
-            kind: VSphereMachineProviderSpec <3>
-            memoryMiB: 16384 <4>
+            dataDisks: <2>
+            - name: "<disk_name>"
+              provisioningMode: "<mode>"
+              sizeGiB: 20
+            diskGiB: 120 <3>
+            kind: VSphereMachineProviderSpec <4>
+            memoryMiB: 16384 <5>
             metadata:
               creationTimestamp: null
-            network: <5>
+            network: <6>
               devices:
               - networkName: <vm_network_name>
-            numCPUs: 4 <6>
-            numCoresPerSocket: 4 <7>
+            numCPUs: 4 <7>
+            numCoresPerSocket: 4 <8>
             snapshot: ""
-            template: <vm_template_name> <8>
+            template: <vm_template_name> <9>
             userDataSecret:
-              name: master-user-data <9>
-            workspace: <10>
-              datacenter: <vcenter_data_center_name> <11>
-              datastore: <vcenter_datastore_name> <12>
-              folder: <path_to_vcenter_vm_folder> <13>
-              resourcePool: <vsphere_resource_pool> <14>
-              server: <vcenter_server_ip> <15>
+              name: master-user-data <10>
+            workspace: <11>
+              datacenter: <vcenter_data_center_name> <12>
+              datastore: <vcenter_datastore_name> <13>
+              folder: <path_to_vcenter_vm_folder> <14>
+              resourcePool: <vsphere_resource_pool> <15>
+              server: <vcenter_server_ip> <16>
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
-<2> Specifies the VM disk size for the control plane machines.
-<3> Specifies the cloud provider platform type. Do not change this value.
-<4> Specifies the memory allocated for the control plane machines.
-<5> Specifies the network on which the control plane is deployed.
+<2> Specifies one or more data disk definitions. 
+For more information, see "Configuring data disks by using machine sets".
+<3> Specifies the VM disk size for the control plane machines.
+<4> Specifies the cloud provider platform type. Do not change this value.
+<5> Specifies the memory allocated for the control plane machines.
+<6> Specifies the network on which the control plane is deployed.
 +
 [NOTE]
 ====
 If the cluster is configured to use a failure domain, this parameter is configured in the failure domain.
 If you specify this value in the provider specification when using failure domains, the Control Plane Machine Set Operator ignores it.
 ====
-<6> Specifies the number of CPUs allocated for the control plane machines.
-<7> Specifies the number of cores for each control plane CPU.
-<8> Specifies the vSphere VM template to use, such as `user-5ddjd-rhcos`.
+<7> Specifies the number of CPUs allocated for the control plane machines.
+<8> Specifies the number of cores for each control plane CPU.
+<9> Specifies the vSphere VM template to use, such as `user-5ddjd-rhcos`.
 +
 [NOTE]
 ====
 If the cluster is configured to use a failure domain, this parameter is configured in the failure domain.
 If you specify this value in the provider specification when using failure domains, the Control Plane Machine Set Operator ignores it.
 ====
-<9> Specifies the control plane user data secret. Do not change this value.
-<10> Specifies the workspace details for the control plane.
+<10> Specifies the control plane user data secret. Do not change this value.
+<11> Specifies the workspace details for the control plane.
 +
 [NOTE]
 ====
 If the cluster is configured to use a failure domain, these parameters are configured in the failure domain.
 If you specify these values in the provider specification when using failure domains, the Control Plane Machine Set Operator ignores them.
 ====
-<11> Specifies the vCenter data center for the control plane.
-<12> Specifies the vCenter datastore for the control plane.
-<13> Specifies the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
-<14> Specifies the vSphere resource pool for your VMs.
-<15> Specifies the vCenter server IP or fully qualified domain name.
+<12> Specifies the vCenter datacenter for the control plane.
+<13> Specifies the vCenter datastore for the control plane.
+<14> Specifies the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+<15> Specifies the vSphere resource pool for your VMs.
+<16> Specifies the vCenter server IP or fully qualified domain name.

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -158,6 +158,10 @@ template:
         apiVersion: machine.openshift.io/v1beta1
         credentialsSecret:
           name: vsphere-cloud-credentials <1>
+        dataDisks: <2>
+        - name: <disk_name>
+          provisioningMode: <mode>
+          sizeGiB: 10
         diskGiB: 120
         kind: VSphereMachineProviderSpec
         memoryMiB: 16384
@@ -167,20 +171,22 @@ template:
         numCPUs: 4
         numCoresPerSocket: 4
         snapshot: ""
-        template: <vm_template_name> <2>
+        template: <vm_template_name> <3>
         userDataSecret:
-          name: worker-user-data <3>
+          name: worker-user-data <4>
         workspace:
           datacenter: <vcenter_data_center_name>
           datastore: <vcenter_datastore_name>
           folder: <vcenter_vm_folder_path>
           resourcepool: <vsphere_resource_pool>
-          server: <vcenter_server_address> <4>
+          server: <vcenter_server_address> <5>
 ----
 <1> The name of the secret in the `openshift-machine-api` namespace that contains the required vCenter credentials.
-<2> The name of the {op-system} VM template for your cluster that was created during installation.
-<3> The name of the secret in the `openshift-machine-api` namespace that contains the required Ignition configuration credentials.
-<4> The IP address or fully qualified domain name (FQDN) of the vCenter server.
+<2> The collection of data disk definitions. 
+For more information, see "Configuring data disks by using machine sets".
+<3> The name of the {op-system} VM template for your cluster that was created during installation.
+<4> The name of the secret in the `openshift-machine-api` namespace that contains the required Ignition configuration credentials.
+<5> The IP address or fully qualified domain name (FQDN) of the vCenter server.
 endif::vsphere[]
 
 . Create a `MachineSet` CR by running the following command:

--- a/modules/machineset-vsphere-data-disks.adoc
+++ b/modules/machineset-vsphere-data-disks.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machineset-vsphere-data-disks_{context}"]
+= Configuring data disks by using machine sets
+
+{product-title} clusters on {vmw-first} support adding up to 29 disks to the virtual machine (VM) controller.
+
+:FeatureName: Configuring {vmw-short} data disks
+include::snippets/technology-preview.adoc[]
+
+By configuring data disks, you can attach disks to VMs and use them to store data for etcd, container images, and other uses.
+Separating data can help avoid filling the primary disk so that important activities such as upgrades have the resources that they require.
+
+[NOTE]
+====
+Adding data disks attaches them to the VM and mounts them to the location that {op-system} designates.
+// To mount the data disks to a specific location, you must configure each machine to use the data disks according to your needs.
+====
+
+.Prerequisites
+
+* You have administrator access to {oc-first} for an {product-title} cluster on {vmw-short}.
+
+.Procedure
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Edit the following lines under the `providerSpec` field:
++
+--
+[source,yaml]
+----
+tag::compute[]
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+end::compute[]
+tag::controlplane[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+end::controlplane[]
+# ...
+spec:
+  template:
+tag::compute[]
+    spec:
+      providerSpec:
+        value:
+          dataDisks: <1>
+          - name: "<disk_name>" <2>
+            provisioningMode: "<mode>" <3>
+            sizeGiB: 20 <4>
+          - name: "<disk_name>"
+            provisioningMode: "<mode>"
+            sizeGiB: 20
+end::compute[]
+tag::controlplane[]
+    machines_v1beta1_machine_openshift_io:
+      spec:
+        providerSpec:
+          value:
+            dataDisks: <1>
+            - name: "<disk_name>" <2>
+              provisioningMode: "<mode>" <3>
+              sizeGiB: 20 <4>
+            - name: "<disk_name>"
+              provisioningMode: "<mode>"
+              sizeGiB: 20
+end::controlplane[]
+# ...
+----
+<1> Specify a collection of 1-29 data disk definitions.
+This sample configuration shows the formatting to include two data disk definitions.
+<2> Specify the name of the data disk.
+The name must meet the following requirements:
+* Start and end with an alphanumeric character
+* Consist only of alphanumeric characters, hyphens (`-`), and underscores (`_`)
+* Have a maximum length of 80 characters
+<3> Specify the data disk provisioning method.
+This value defaults to the vSphere default storage policy if not set. 
+Valid values are `Thin`, `Thick`, and `EagerlyZeroed`.
+<4> Specify the size of the data disk in GiB. 
+The maximum size is 16384 GiB.
+--

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -76,6 +76,10 @@ endif::infra[]
           apiVersion: machine.openshift.io/v1beta1
           credentialsSecret:
             name: vsphere-cloud-credentials
+          dataDisks: <4>
+          - name: "<disk_name>"
+            provisioningMode: "<mode>"
+            sizeGiB: 20
           diskGiB: 120
           kind: VSphereMachineProviderSpec
           memoryMiB: 8192
@@ -83,21 +87,21 @@ endif::infra[]
             creationTimestamp: null
           network:
             devices:
-            - networkName: "<vm_network_name>" <4>
+            - networkName: "<vm_network_name>" <5>
           numCPUs: 4
           numCoresPerSocket: 1
           snapshot: ""
-          template: <vm_template_name> <5>
+          template: <vm_template_name> <6>
           userDataSecret:
             name: worker-user-data
           workspace:
-            datacenter: <vcenter_data_center_name> <6>
-            datastore: <vcenter_datastore_name> <7>
-            folder: <vcenter_vm_folder_path> <8>
-            resourcepool: <vsphere_resource_pool> <9>
-            server: <vcenter_server_ip> <10>
+            datacenter: <vcenter_data_center_name> <7>
+            datastore: <vcenter_datastore_name> <8>
+            folder: <vcenter_vm_folder_path> <9>
+            resourcepool: <vsphere_resource_pool> <10>
+            server: <vcenter_server_ip> <11>
 ifdef::infra[]
-      taints: <11>
+      taints: <12>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -116,15 +120,17 @@ ifdef::infra[]
 <2> Specify the infrastructure ID and `infra` node label.
 <3> Specify the `infra` node label.
 endif::infra[]
-<4> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
-<5> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
-<6> Specify the vCenter data center to deploy the compute machine set on.
-<7> Specify the vCenter datastore to deploy the compute machine set on.
-<8> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
-<9> Specify the vSphere resource pool for your VMs.
-<10> Specify the vCenter server IP or fully qualified domain name.
+<4> Specify one or more data disk definitions. 
+For more information, see "Configuring data disks by using machine sets".
+<5> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
+<6> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
+<7> Specify the vCenter datacenter to deploy the compute machine set on.
+<8> Specify the vCenter datastore to deploy the compute machine set on.
+<9> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+<10> Specify the vSphere resource pool for your VMs.
+<11> Specify the vCenter server IP or fully qualified domain name.
 ifdef::infra[]
-<11> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<12> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-5784](https://issues.redhat.com//browse/OSDOCS-5784)

Link to docs preview:
* **Compute**
  * [Sample YAML for a compute machine set custom resource on vSphere](https://93585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere.html#machineset-yaml-vsphere_creating-machineset-vsphere)
  * [Configuring data disks by using machine sets](https://93585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere.html#machineset-vsphere-data-disks_creating-machineset-vsphere)
* **Control plane**
  * [Sample VMware vSphere provider specification](https://93585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.html#cpmso-yaml-provider-spec-vsphere_cpmso-config-options-vsphere)
  * [Configuring data disks by using machine sets](https://93585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.html#machineset-vsphere-data-disks_cpmso-config-options-vsphere)
* **Infra**
  * [Sample YAML for a compute machine set custom resource on vSphere](https://93585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#machineset-yaml-vsphere_creating-infrastructure-machinesets)

QE review:
- [x] QE has approved this change.

Additional information: