### PR TITLE
OSDOCS-14733 Docs: Replace fcos references with scos

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -23,12 +23,12 @@
 :op-system-version-9: 9
 :op-system-ai: Red{nbsp}Hat Enterprise Linux AI
 ifdef::openshift-origin[]
-:op-system-first: Fedora CoreOS (FCOS)
-:op-system: FCOS
-:op-system-lowercase: fcos
-:op-system-base: Fedora
-:op-system-base-full: Fedora
-:op-system-version: 35
+:op-system-first: CentOS Streams CoreOS (SCOS) 
+:op-system: SCOS
+:op-system-lowercase: scos
+:op-system-base: SCOS
+:op-system-base-full: CentOS Streams
+:op-system-version: 9.x
 endif::[]
 :tsb-name: Template Service Broker
 :kebab: image:kebab.png[title="Options menu"]

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -23,11 +23,11 @@
 :op-system-version-9: 9
 :op-system-ai: Red{nbsp}Hat Enterprise Linux AI
 ifdef::openshift-origin[]
-:op-system-first: CentOS Streams CoreOS (SCOS) 
+:op-system-first: CentOS Stream CoreOS (SCOS) 
 :op-system: SCOS
 :op-system-lowercase: scos
 :op-system-base: SCOS
-:op-system-base-full: CentOS Streams
+:op-system-base-full: CentOS Stream
 :op-system-version: 9.x
 endif::[]
 :tsb-name: Template Service Broker

--- a/modules/installation-gcp-user-infra-rhcos.adoc
+++ b/modules/installation-gcp-user-infra-rhcos.adoc
@@ -27,7 +27,7 @@ The file name contains the {product-title} version number in the format
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 . Obtain the {op-system} image from the
-link:https://getfedora.org/en/coreos/download?tab=cloud_operators&stream=stable[{op-system} Downloads] page
+link:https://cloud.centos.org/centos/scos/9/prod/streams/[CentOS Cloud Images] page
 endif::openshift-origin[]
 
 . Create the Google storage bucket:

--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -233,6 +233,7 @@ ifdef::vsphere[]
 2. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
 endif::vsphere[]
 --
+ifndef::openshift-origin[]
 [NOTE]
 ====
 For {product-title} version 4.18, RHCOS is based on RHEL version 9.4, which updates the micro-architecture requirements. The following list contains the minimum instruction set architectures (ISA) that each architecture requires:
@@ -244,6 +245,7 @@ For {product-title} version 4.18, RHCOS is based on RHEL version 9.4, which upda
 
 For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.2_release_notes/index#architectures[Architectures] ({op-system-base} documentation).
 ====
+endif::openshift-origin[]
 
 ifdef::azure[]
 [IMPORTANT]

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -72,7 +72,7 @@ link:https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/[{o
 endif::ibm-power[]
 endif::openshift-enterprise[]
 ifdef::openshift-origin[]
-link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system}]
+link:https://cloud.centos.org/centos/scos/9/prod/streams/[CentOS Cloud Images]
 endif::openshift-origin[]
 ifdef::ibm-power[]
 link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/[{op-system} image mirror]

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -84,7 +84,7 @@ link:https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/[{o
 endif::ibm-power[]
 endif::openshift-enterprise[]
 ifdef::openshift-origin[]
-link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system}]
+link:https://cloud.centos.org/centos/scos/9/prod/streams/[CentOS Cloud Images]
 endif::openshift-origin[]
 ifdef::ibm-power[]
 link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/[{op-system} image mirror]

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -89,7 +89,7 @@ The {op-system} images might not change with every release of {product-title}. Y
 The filename contains the {product-title} version number in the format `rhcos-vmware.<architecture>.ova`.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-. Obtain the {op-system} images from the link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page
+. Obtain the {op-system} images from the link:https://cloud.centos.org/centos/scos/9/prod/streams/[CentOS Cloud Images] page
 endif::openshift-origin[]
 
 . In the vSphere Client, create a folder in your data center to store your VMs.

--- a/modules/rhcos-about.adoc
+++ b/modules/rhcos-about.adoc
@@ -6,7 +6,12 @@
 [id="rhcos-about_{context}"]
 = About {op-system}
 
+ifndef::openshift-origin[]
 {op-system-first} represents the next generation of single-purpose container operating system technology by providing the quality standards of {op-system-base-full} with automated, remote upgrade features.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+{op-system-first} represents the next generation of single-purpose container operating system technology by providing the quality standards of {op-system-base-full} with automated, remote upgrade features.
+endif::openshift-origin[]
 
 {op-system} is supported only as a component of {product-title} {product-version} for all {product-title} machines. {op-system} is the only supported operating system for all node types in {product-title}. {op-system} is deployed in {product-title} {product-version} in two general ways:
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14733

For 4.16 to 4.19, might need a manual CP to [tailor this note](https://github.com/openshift/openshift-docs/pull/93587/files/71f44d0745c1e45cb23cd130ee6d600bb7f48d34#diff-9feabd6fba77a50c24d9345d96aa23da2d8aac1a98e61ad232bc0f7a873b2484R236-R247) for versions below 4.20. 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
