### PR TITLE
OSDOCS#14696: Update the z-stream RNs for 4.17.30

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2892,6 +2892,36 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.30
+[id="ocp-4-17-30_{context}"]
+=== RHSA-2025:7669 - {product-title} {product-version}.30 bug fix and security update advisory
+
+Issued: 21 May 2025
+
+{product-title} release {product-version}.30 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:7669[RHSA-2025:7669] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:7671[RHBA-2025:7671] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.30 --pullspecs
+----
+
+[id="ocp-4-17-30-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, no event was logged when an error occurred from a failed ingress-to-route conversion. With this update, this error appears in the `event` logs. (link:https://issues.redhat.com/browse/OCPBUGS-55943[OCPBUGS-55943])
+
+* Previously, a bug caused excessive updates to the `progressing` condition because of unsorted failing image imports. This led to unnecessary resource consumption for users. With this release, the excessive updates are fixed in the Samples Operator by sorting failing image imports. As a result, the Operator performance is improved by reducing unnecessary updates for the image imports. (link:https://issues.redhat.com/browse/OCPBUGS-55894[OCPBUGS-55894])
+
+* Previously, when {azure-first} Spot virtual machine (VM) de-allocation occurred during provisioning, the machine controller entered a loop, leading to Spot VM provisioning failures and unavailable nodes. With this release, the `deallocate eviction` policy is replaced with the `delete eviction policy` in {azure-short} Spot VM provisioning. As a result, the machine controller is more resilient and it no longer enters a loop during provisioning. (link:https://issues.redhat.com/browse/OCPBUGS-55729[OCPBUGS-55729])
+
+[id="ocp-4-17-30-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.29
 [id="ocp-4-17-29_{context}"]
 === RHSA-2025:4723 - {product-title} {product-version}.29 bug fix and security update advisory


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-14696](https://issues.redhat.com//browse/OSDOCS-14696)

Link to docs preview:
[4.17.30](url)
https://93600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-30_release-notes
QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 5/21/25.
