### PR TITLE
Changing mode values for 81-enable-global-forwarding machineConfig

### DIFF
--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -67,7 +67,7 @@ spec:
           source: data:text/plain;charset=utf-8;base64,bmV0LmlwdjQuY29uZi5icmlkZ2UtbmV0LmZvcndhcmRpbmcgPSAxCm5ldC5pcHY2LmNvbmYuYnJpZGdlLW5ldC5mb3J3YXJkaW5nID0gMQpuZXQuaXB2NC5jb25mLmJyaWRnZS1uZXQucnBfZmlsdGVyID0gMApuZXQuaXB2Ni5jb25mLmJyaWRnZS1uZXQucnBfZmlsdGVyID0gMAo= <2>
           verification: {}
         filesystem: root
-        mode: 644
+        mode: 420
         path: /etc/sysctl.d/enable-global-forwarding.conf
   osImageURL: ""
 ----


### PR DESCRIPTION

Version(s): OpenShift Version 4.18

Issue: 

When creating the "81-enable-global-forwarding" machineConfig with file mode "644" as defined in documentation, respective newly generated render changing it's value to 132.

Machine config: 
~~~
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: 81-enable-global-forwarding
spec:
  config:
    ignition:
      version: 3.2.0
    storage:
      files:
      - contents:
          source: data:text/plain;charset=utf-8;base64,bmV0LmlwdjQuY29uZi5icmlkZ2UtbmV0LmZvcndhcmRpbmcgPSAxCm5ldC5pcHY2LmNvbmYuYnJpZGdlLW5ldC5mb3J3YXJkaW5nID0gMQpuZXQuaXB2NC5jb25mLmJyaWRnZS1uZXQucnBfZmlsdGVyID0gMApuZXQuaXB2Ni5jb25mLmJyaWRnZS1uZXQucnBfZmlsdGVyID0gMAo= 
          verification: {}
        filesystem: root
        mode: 644
~~~

Respective render-config:
~~~
      - contents:
          source: data:text/plain;charset=utf-8;base64,bmV0LmlwdjQuY29uZi5lbnMyMjQuZm9yd2FyZGluZyA9IDEKbmV0LmlwdjQuY29uZi5lbnMyMjQucnBfZmlsdGVyID0gMAo=
        mode: 132
        overwrite: true
        path: /etc/sysctl.d/enable-global-forwarding.conf
~~~

- This is causing issue as according to the Kubernetes design the "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.

- When we define mode value "644"  which is incorrect and it will set the file permissions(/etc/sysctl.d/enable-global-forwarding.conf) to "132" on respective machine config pool nodes. 

- Hence we have to define the mode value to "420" which will set the file permissions(/etc/sysctl.d/enable-global-forwarding.conf) to "644" on respective machine config pool nodes.

- Reference KCS article for same: https://access.redhat.com/solutions/7068667

Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/load-balancing-with-metallb#nw-enabling-ip-forwarding-specific-interface_about-advertising-ip-address-pool


Steps to reproduce

Follow the steps mentioned in documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/load-balancing-with-metallb#nw-enabling-ip-forwarding-specific-interface_about-advertising-ip-address-pool

1.  Patch the Cluster Network Operator, setting the parameter routingViaHost to true.
2. Enable forwarding for a specific secondary interface, such as bridge-net by creating and applying a MachineConfig CR
    i. Base64-encode the string that is used to configure network kernel parameters by running the following command on your local machine:
   ii. Create the MachineConfig CR defined in documentation to enable IP forwarding for the specified secondary interface named bridge-net.
3. Check the machine config mode value in newly generated "81-enable-global-forwarding" machine config
4. Check the newly generated rendered config for respective MCP and check mode value of "/etc/sysctl.d/enable-global-forwarding.conf" file.