### PR TITLE
Edit command in Removing a local volume or local volume set

### DIFF
--- a/modules/persistent-storage-local-removing-devices.adoc
+++ b/modules/persistent-storage-local-removing-devices.adoc
@@ -30,7 +30,7 @@ Deleting a persistent volume that is still in use can result in data loss or cor
 +
 [source,terminal]
 ----
-$ oc edit localvolume <name> -n openshift-local-storage
+$ oc edit localvolume <local_volume_name> -n openshift-local-storage
 ----
 
 .. Navigate to the lines under `devicePaths`, and delete any representing unwanted disks.
@@ -39,7 +39,7 @@ $ oc edit localvolume <name> -n openshift-local-storage
 +
 [source,terminal]
 ----
-$ oc delete pv <pv-name>
+$ oc delete pv <pv_name>
 ----
 
 . Delete directory and included symlinks on the node.
@@ -51,6 +51,6 @@ The following step involves accessing a node as the root user. Modifying the sta
 +
 [source,terminal]
 ----
-$ oc debug node/<node-name> -- chroot /host rm -rf /mnt/local-storage/<sc-name> <1>
+$ oc debug node/<node_name> -- chroot /host rm -rf /mnt/local-storage/<sc_name> <1>
 ----
 <1> The name of the storage class used to create the local volumes.


### PR DESCRIPTION
- Incorrect command in Removing a local volume or local volume set
- Here is the documentation link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/storage/configuring-persistent-storage#local-removing-device_persistent-storage-local

Here is the current documentation:

1. Edit the cluster resource: 
~~~
$ oc edit localvolume <name> -n openshift-local-storage  
~~~

2. Delete any persistent volumes created. 
~~~
$ oc delete pv <pv-name> 
~~~

3. Delete directory and included symlinks on the node.
~~~
$ oc debug node/<node-name> -- chroot /host rm -rf /mnt/local-storage/<sc-name>
~~~

- These commands are correct, but not in the correct standard format.
- So we need to perform this change in the documentation as well.

Here is the updated documentation:

1. Edit the cluster resource: 
~~~
$ oc edit localvolume <local_volume_name> -n openshift-local-storage   
~~~

2. Delete any persistent volumes created. 
~~~
$ oc delete pv <pv_name>
~~~

3. Delete directory and included symlinks on the node.
~~~
oc debug node/<node_name> -- chroot /host rm -rf /mnt/local-storage/<sc_name>
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.17, RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13, RHOCP 4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1908

Link to docs preview: https://93623--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-local.html#local-removing-device_persistent-storage-local
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
