### PR TITLE
CNV#58546: DOC: UI - Bulk Storage Class Migration within a single cluster

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4729,6 +4729,8 @@ Topics:
     File: virt-using-vtpm-devices
   - Name: Managing virtual machines with OpenShift Pipelines
     File: virt-managing-vms-openshift-pipelines
+  - Name: Migrating VMs in a single cluster to a different storage class
+    File: virt-migrating-vms-in-single-cluster-to-different-storage-class
   - Name: Advanced virtual machine management
     Dir: advanced_vm_management
     Topics:

--- a/modules/virt-migrating-bulk-vms-different-storage-class-web.adoc
+++ b/modules/virt-migrating-bulk-vms-different-storage-class-web.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-migrating-bulk-vms-different-storage-class-web_{context}"]
+= Migrating VMs in a single cluster to a different storage class by using the web console
+
+By using the {product-title} web console, you can migrate single-cluster VMs in bulk from one storage class to another storage class.
+
+.Prerequisites
+
+* The VMs you select for each bulk migration must be in the same namespace.
+* The {mtc-first} must be installed.
+
+.Procedure
+
+. From the {product-title} web console, navigate to *Virtualization* → *VirtualMachines*.
+
+. From the list of VMs in the same namespace, select each VM that you want to move from its current storage class.
+
+. Select *Actions* -> *Migrate storage*.
++
+Alternatively, you can access this option by opening the Options menu {kebab} for a selected VM, and then selecting *Migration* -> *Storage*.
++
+The *Migrate VirtualMachine storage* page opens.
+
+. To review the VMs that you want to migrate, click the link that identifies the number of VMs and volumes. Click *View more* to see the full list.
+
+. Select either the entire VM or only selected volumes for storage class migration. If you choose to migrate only selected volumes, the page expands to allow you to make specific selections.
++
+You can also click *VirtualMachine name* to select all VMs.
+
+. Click *Next*.
+
+. From the list of available storage classes, select the destination storage class for the migration.
+
+. Click *Next*.
+
+. Review the details, and click *Migrate VirtualMachine storage* to start the migration.
+
+. Optional: Click *Stop* to interrupt the migration, or click *View storage migrations* to see the status of current and previous migrations.

--- a/virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc
+++ b/virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-migrating-vms-in-single-cluster-to-different-storage-class"]
+= Migrating VMs in a single cluster to a different storage class
+include::_attributes/common-attributes.adoc[]
+:context: virt-migrating-vms-in-single-cluster-to-different-storage-class
+
+toc::[]
+
+You can migrate virtual machines (VMs) within a single cluster from one storage class to a different storage class. By using the {product-title} web console, you can perform the migration for the VMs in bulk.
+
+include::modules/virt-migrating-bulk-vms-different-storage-class-web.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.19

Issue: [CNV-58546](https://issues.redhat.com/browse/CNV-58546)

Link to docs preview: https://93632--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.html

QE review:
- [x] QE has approved this change.

Additional information: This PR covers feature documentation for both [CNV-58546](https://issues.redhat.com/browse/CNV-58546) (DOC: UI - Bulk Storage Class Migration within a single cluster) and [CNV-57711](https://issues.redhat.com/browse/CNV-57711) (DOC: Bulk storage class migration). 

