### PR TITLE
OBSDOCS-1929 Move quick start section after visualization

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -5,12 +5,12 @@ Distros: openshift-logging
 Topics:
 - Name: Logging overview
   File: about-logging
-- Name: Quick start
-  File: quick-start
 - Name: Cluster logging support
   File: cluster-logging-support
 - Name: Visualization for logging
   File: logging-visualization
+- Name: Quick start
+  File: quick-start
 ---
 Name: Installing logging
 Dir: installing


### PR DESCRIPTION

Version(s):
standalone-logging-docs-main, CP to 6.2, 6.1, 6.0

Issue:
[OBSDOCS-1929](https://issues.redhat.com//browse/OBSDOCS-1929)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
