### PR TITLE
[OSDOCS-11048] IBM Z CEX: Use Butane's boot_device layouts

### DIFF
--- a/modules/ibm-z-configure-hw-based-cex-encryption.adoc
+++ b/modules/ibm-z-configure-hw-based-cex-encryption.adoc
@@ -39,9 +39,58 @@ Enabling hardware-based Linux Unified Key Setup (LUKS) encryption via {ibm-name}
 
 .Procedure
 
-. Create Butane configuration files for the control plane and compute nodes.
+ifdef::ibm-z-kvm[]
+. Create Butane configuration files for the control plane and compute nodes:
+** Create a file named `main-storage.bu` by using the following Butane configuration for a control plane node with disk encryption, for example:
 +
-The following example of a Butane configuration for a control plane node creates a file named `main-storage.bu` for disk encryption:
+[source,yaml,subs="attributes+"]
+----
+variant: openshift
+version: {product-version}.0
+metadata:
+  name: main-storage
+  labels:
+    machineconfiguration.openshift.io/role: master
+boot_device:
+  layout: s390x-virt
+  luks:
+    cex:
+      enabled: true
+openshift:
+  fips: true # <1>
+  kernel_arguments:
+    - rd.luks.key=/etc/luks/cex.key # <2>
+----
+<1> Specifies whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<2> Specifies the location of the key that is required to decrypt the device. You can not change this value.
+endif::ibm-z-kvm[]
+ifndef::ibm-z-kvm[]
+. Choose the appropriate method to create Butane configuration files for the control plane and compute nodes:
+** For installations on DASD-type disks, create a file named `main-storage.bu` by using the following Butane configuration for a control plane node with disk encryption, for example:
++
+[source,yaml,subs="attributes+"]
+----
+variant: openshift
+version: {product-version}.0
+metadata:
+  name: main-storage
+  labels:
+    machineconfiguration.openshift.io/role: master
+boot_device:
+  layout: s390x-eckd
+  luks:
+    device: /dev/dasda
+    cex:
+      enabled: true
+openshift:
+  fips: true # <1>
+  kernel_arguments:
+    - rd.luks.key=/etc/luks/cex.key # <2>
+----
+<1> Specifies whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<2> Specifies the location of the key that is required to decrypt the device. You can not change this value.
++
+** For installations on FCP-type disks, create a file named `main-storage.bu` by using the following Butane configuration for a control plane node with disk encryption, for example:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -52,75 +101,31 @@ metadata:
   labels:
     machineconfiguration.openshift.io/role: master
 storage:
-  luks:
-    - cex:
-        enabled: true
-        options: <1>
-           - --pbkdf
-           - pbkdf2
-ifndef::ibm-z-kvm[]
-      device: /dev/disk/by-partlabel/root <2>
-endif::ibm-z-kvm[]
-ifdef::ibm-z-kvm[]
-      device: /dev/disk/by-partlabel/root
-endif::ibm-z-kvm[]
-      label: luks-root
-      name: root
-      wipe_volume: true
   filesystems:
     - device: /dev/mapper/root
       format: xfs
       label: root
       wipe_filesystem: true
+  luks:
+    - device: /dev/disk/by-label/root
+      label: luks-root
+      name: root
+      wipe_volume: true
+      cex:
+        enabled: true
 openshift:
-ifndef::ibm-z-kvm[]
-  fips: true <3>
-  kernel_arguments: <4>
-endif::ibm-z-kvm[]
-ifdef::ibm-z-kvm[]
-  fips: true <2>
-  kernel_arguments: <3>
-endif::ibm-z-kvm[]
-    - rd.luks.key=/etc/luks/cex.key
+  fips: true # <1>
+  kernel_arguments:
+    - rd.luks.key=/etc/luks/cex.key # <2>
 ----
-<1> The `pbkdf` option is only required if FIPS mode is enabled. Omit the entry if FIPS is disabled.
-ifndef::ibm-z-kvm[]
-<2> For installations on DASD-type disks, replace with `device: /dev/disk/by-label/root`.
-<3> Specifies whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-<4> Specifies the location of the pass key that is required to decrypt the device.
-endif::ibm-z-kvm[]
-ifdef::ibm-z-kvm[]
-<2> Specifies whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-<3> Specifies the location of the pass key that is required to decrypt the device.
+<1> Specifies whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<2> Specifies the location of the key that is required to decrypt the device. You can not change this value.
 endif::ibm-z-kvm[]
 
 . Create a parameter file that includes `ignition.platform.id=metal` and `ignition.firstboot`.
 +
 .Example kernel parameter file for the control plane machine
 +
-ifndef::ibm-z-kvm[]
-[source,terminal]
-----
-cio_ignore=all,!condev rd.neednet=1 \
-console=ttysclp0 \
-coreos.inst.install_dev=/dev/disk/by-id/scsi-<serial_number> \// <1>
-ignition.firstboot ignition.platform.id=metal \
-coreos.inst.ignition_url=http://<http_server>/master.ign \// <2>
-coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img \// <3>
-ip=<ip_address>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> \
-rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1 \
-rd.zfcp=0.0.5677,0x600606680g7f0056,0x034F000000000000 // <4>
-----
-ifdef::ibm-z[]
-<1> Specifies a unique fully qualified path depending on disk type. This can be DASD-type or FCP-type disks.
-endif::ibm-z[]
-ifdef::ibm-z-lpar[]
-<1> Specifies a unique fully qualified path depending on disk type. This can be DASD-type, FCP-type, or NVMe-type disks.
-endif::ibm-z-lpar[]
-<2> Specifies the location of the Ignition config file. Use `master.ign` or `worker.ign`. Only HTTP and HTTPS protocols are supported.
-<3> Specifies the location of the `rootfs` artifact for the `kernel` and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
-<4> Specifies the root device. For installations on DASD-type disks, replace with `rd.dasd=0.0.xxxx` to specify the DASD device.
-endif::ibm-z-kvm[]
 ifdef::ibm-z-kvm[]
 [source,terminal]
 ----
@@ -133,9 +138,26 @@ ip=<ip_address>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> \
 rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1 \
 rd.zfcp=0.0.5677,0x600606680g7f0056,0x034F000000000000
 ----
-<1> Specifies the location of the Ignition config file. Use `master.ign` or `worker.ign`. Only HTTP and HTTPS protocols are supported.
-<2> Specifies the location of the `rootfs` artifact for the `kernel` and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
-
+<1> Specifies the location of the Ignition configuration file. Use `master.ign` or `worker.ign`. You can only use the HTTP and HTTPS protocols.
+<2> Specifies the location of the `rootfs` artifact for the `kernel` and `initramfs` that you want to boot. You can only use the HTTP and HTTPS protocols.
+endif::ibm-z-kvm[]
+ifndef::ibm-z-kvm[]
+[source,terminal]
+----
+cio_ignore=all,!condev rd.neednet=1 \
+console=ttysclp0 \
+coreos.inst.install_dev=/dev/disk/by-id/scsi-<serial_number> \// <1>
+ignition.firstboot ignition.platform.id=metal \
+coreos.inst.ignition_url=http://<http_server>/master.ign \// <2>
+coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img \// <3>
+ip=<ip_address>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> \
+rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1 \
+rd.zfcp=0.0.5677,0x600606680g7f0056,0x034F000000000000 <4>
+----
+<1> Specifies a unique fully qualified path depending on disk type. This can be DASD-type or FCP-type disks.
+<2> Specifies the location of the Ignition configuration file. Use `master.ign` or `worker.ign`. You can only use the HTTP and HTTPS protocols.
+<3> Specifies the location of the `rootfs` artifact for the `kernel` and `initramfs` that you want to boot. You can only use the HTTP and HTTPS protocols.
+<4> Specifies the root device. For installations on DASD-type disks, replace with `rd.dasd=0.0.xxxx` to specify the DASD device.
 endif::ibm-z-kvm[]
 +
 [NOTE]

--- a/modules/ibm-z-configure-nbde-with-static-ip.adoc
+++ b/modules/ibm-z-configure-nbde-with-static-ip.adoc
@@ -58,11 +58,8 @@ storage:
         tang:
           - thumbprint: QcPr_NHFJammnRCA3fFMVdNBwjs
             url: http://clevis.example.com:7500
-        options: <1>
-           - --cipher
-           - aes-cbc-essiv:sha256
 ifndef::ibm-z-kvm[]
-      device: /dev/disk/by-partlabel/root <2>
+      device: /dev/disk/by-partlabel/root # <1>
 endif::ibm-z-kvm[]
 ifdef::ibm-z-kvm[]
       device: /dev/disk/by-partlabel/root
@@ -77,20 +74,18 @@ endif::ibm-z-kvm[]
       wipe_filesystem: true
 openshift:
 ifndef::ibm-z-kvm[]
-  fips: true <3>
+  fips: true # <2>
 endif::ibm-z-kvm[]
 ifdef::ibm-z-kvm[]
-  fips: true <2>
+  fips: true # <1>
 endif::ibm-z-kvm[]
 ----
 ifdef::ibm-z-kvm[]
-<1>  The cipher option is only required if FIPS mode is enabled. Omit the entry if FIPS is disabled.
-<2> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<1> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 endif::ibm-z-kvm[]
 ifndef::ibm-z-kvm[]
-<1>  The cipher option is only required if FIPS mode is enabled. Omit the entry if FIPS is disabled.
-<2> For installations on DASD-type disks, replace with `device: /dev/disk/by-label/root`.
-<3> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<1> For installations on DASD-type disks, replace with `device: /dev/disk/by-label/root`.
+<2> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 endif::ibm-z-kvm[]
 
 . Create a customized initramfs file to boot the machine, by running the following command:


### PR DESCRIPTION
modules/ibm-z-nbde: Do not set luks options

This is already set by Butane when translating the Butane config to a
Machine Config.

Also comment AsciiDoc callouts in yaml.

See: https://github.com/coreos/rhel-coreos-config/issues/10
Fixes: c8241d6688 add NBDE encryption for IBM Z

---

modules/ibm-z-cex: Use Butane's boot_device layouts

Use Butane's boot_device layouts to setup the LUKS encryption with CEX
to properly account for all cases (zVM, LPAR, KVM and DASD or FCP disks).

Remove the NVMe case as it is currently not tested and we don't have
Butane sugar for it.

Do not use the sugar for the zFCP case as there is currently an issue
with mulitpath support with it.

Also remove the `--pbkdf pbkdf2` as it is the default in RHEL and
cryptsetup will refuse to create a LUKS device with another PBKDF
function in FIPS mode.

See: https://coreos.github.io/butane/upgrading-openshift/#luks-cex-support
See: https://coreos.github.io/butane/upgrading-openshift/#boot_device-layouts-s390x-support

---

Version(s): 4.19+

Issue: https://issues.redhat.com/browse/OSDOCS-11048

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

Additional information:
CC @madhu-pillai @SNiemann15

Updates: https://github.com/openshift/openshift-docs/pull/93101