### PR TITLE
OSDOCS-14718: Add HCP sections back to "Customs DNS Tutorial"

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.adoc
+++ b/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.adoc
@@ -124,7 +124,8 @@ $ aws route53resolver list-resolver-endpoint-ip-addresses \
 
 Use the following procedure to configure your DNS server to forward the necessary private hosted zones to your Amazon Route 53 Inbound Resolver. 
 
-ifdef::openshift-rosa-hcp[]
+//ifdef::openshift-rosa-hcp[]
+=== ROSA with HCP
 ROSA with HCP clusters require you to configure DNS forwarding for two private hosted zones:
 
 * `<cluster-name>.hypershift.local`
@@ -197,9 +198,10 @@ zone "rosa.<domain-prefix>.<unique-ID>.p3.openshiftapps.com" { <1>
 ----
 <1> Replace `<domain-prefix>` with your cluster domain prefix and `<unique-ID>` with your unique ID collected above.
 <2> Replace with the IP addresses of your inbound resolver endpoints collected above, ensuring that following each IP address there is a `;`.
-endif::openshift-rosa-hcp[]
+//endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]
+=== ROSA Classic
 ROSA Classic clusters require you to configure DNS forwarding for one private hosted zones:
 
 * `<domain-prefix>.<unique-ID>.p1.openshiftapps.com`


### PR DESCRIPTION
[OSDOCS-14718](https://issues.redhat.com//browse/OSDOCS-14718): Add HCP sections back to "Customs DNS Tutorial"

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-14718

Link to docs preview:
https://93657--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.html#rosa-with-hcp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
