### PR TITLE
OLS-1786: revert release notes publication

### DIFF
--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -8,8 +8,6 @@ toc::[]
 
 The release notes highlight what is new and what has changed with each {ols-official} release.
 
-include::modules/ols-0-3-5-release-notes.adoc[leveloffset=+1]
-include::modules/ols-0-3-5-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-4-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-3-4-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-3-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1786
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://93658--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
