### PR TITLE
OCPBUGS55396 VPA Recommender OOM args are available but undocumented

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-oom.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-oom.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-vertical-autoscaler.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nodes-pods-vertical-autoscaler-oom_{context}"]
+= Custom memory bump-up after OOM event
+
+If your cluster experiences an OOM (out of memory) event, the Vertical Pod Autoscaler Operator (VPA) increases the memory recommendation based on the memory consumption observed during the OOM event and a specified multiplier value in order to prevent future crashes due to insufficient memory.
+
+The recommendation is the higher of two calculations: the memory in use by the pod when the OOM event happened multiplied by a specified number of bytes or a specified percentage. The calculation is represented by the following formula: 
+
+[source,text]
+----
+recommendation = max(memory-usage-in-oom-event + oom-min-bump-up-bytes, memory-usage-in-oom-event * oom-bump-up-ratio)
+----
+
+You can configure the memory increase by specifying the following values in the recommender pod:
+
+* `oom-min-bump-up-bytes`. This value, in bytes, is a specific increase in memory after an OOM event occurs. The default is `100MiB`.
+* `oom-bump-up-ratio`. This value is a percentage increase in memory when the OOM event occurred. The default value is `1.2`.  
+
+For example, if the pod memory usage during an OOM event is 100MB, and `oom-min-bump-up-bytes` is set to 150MB with a `oom-min-bump-ratio` of 1.2, after an OOM event, the VPA would recommend increasing the memory request for that pod to 150 MB, as it is higher than at 120MB (100MB * 1.2).
+
+.Example recommender deployment object
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpa-recommender-default
+  namespace: openshift-vertical-pod-autoscaler
+# ...
+spec:
+# ...
+  template:
+# ...
+    spec
+      containers:
+      - name: recommender
+        args:
+        - --oom-bump-up-ratio=2.0
+        - --oom-min-bump-up-bytes=524288000
+# ...
+----

--- a/nodes/pods/nodes-pods-vertical-autoscaler.adoc
+++ b/nodes/pods/nodes-pods-vertical-autoscaler.adoc
@@ -42,6 +42,11 @@ include::modules/nodes-pods-vertical-autoscaler-using-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-vertical-autoscaler-tuning.adoc[leveloffset=+2]
 
+include::modules/nodes-pods-vertical-autoscaler-oom.adoc[leveloffset=+2]
+
+.Additional resources
+* xref:../../nodes/clusters/nodes-cluster-resource-configure.adoc#nodes-cluster-resource-configure-oom_nodes-cluster-resource-configure[Understanding OOM kill policy]
+
 include::modules/nodes-pods-vertical-autoscaler-custom.adoc[leveloffset=+2]
 
 include::modules/nodes-pods-vertical-autoscaler-configuring.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-55396

Preview:
Nodes -> Working with pods -> Automatically adjust pod resource levels with the vertical pod autoscaler -> [Custom memory bump-up after OOMKill](https://93664--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-oom_nodes-pods-vertical-autoscaler) -- New module

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
