### PR TITLE
RHDEVDOCS-6447: Removal of two fields from the Argo CD CR properties table

### DIFF
--- a/modules/gitops-argo-cd-properties.adoc
+++ b/modules/gitops-argo-cd-properties.adoc
@@ -89,8 +89,6 @@ a|* `name` - The name of an `ArgoCDExport` resource from which data can be impor
 
 |`ingress`    |Ingress configuration options.| `__object__` |
 
-|`initialRepositories`    |Initial Git repositories to configure Argo CD to use upon creation of the cluster.|`__empty__` |
-
 |`initialSSHKnownHosts`    |Defines the initial SSH Known Hosts data for Argo CD to use at cluster creation to connect to Git repositories through SSH.| `__default_Argo_CD_Known_Hosts__`
 a|* `excludedefaulthosts` - Indicates whether you want to add the default list of SSH Known Hosts provided by Argo CD.
   * `keys` - Describes a custom set of SSH Known Hosts that you want to incorporate into your Argo CD server.
@@ -139,8 +137,6 @@ a|* `autotls` - Use the provider to create the Redis server's TLS certificate. O
   * `image` - The container image for Redis. This overrides the `ARGOCD_REDIS_IMAGE` environment variable.
   * `resources` - The container compute resources.
   * `version` - The tag to use with the Redis container image.
-
-|`repositoryCredentials`    |Git repository credential templates to configure Argo CD to use at cluster creation.| `__empty__` |
 
 |`resourceActions` |Customize resource action behavior.|`__empty__` |
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6447

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Removed "initialRespositories" and "repositorycredentials" properties from the [Argo CD custom resource properties table](https://93672--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties.html#argo-cd-properties_argo-cd-cr-component-properties)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: ansingh@redhat.com
QE review: @varshab1210 
Peer review:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
