### PR TITLE
OSSM-9630 Service Mesh 3 doc should make it clear that Kiali needs Prometheus

### DIFF
--- a/modules/ossm-config-openshift-monitoring-only.adoc
+++ b/modules/ossm-config-openshift-monitoring-only.adoc
@@ -12,7 +12,7 @@
 // Possible assembly file may change
 // Assemblies, topic map info needs to be worked out still for 3.0.
 
-You can integrate {SMProductName} with user-workload monitoring.
+You can integrate {SMProductName} with user-workload monitoring to enable observability in your service mesh. User-workload monitoring provides access to essential built-in tools and is required to run Kiali, the dedicated console for {istio}.
 
 .Prerequisites
 


### PR DESCRIPTION
Change type: Doc update; Service Mesh 3 doc should make it clear that Kiali needs Prometheus

Doc JIRA: https://issues.redhat.com/browse/OSSM-9630

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://93673--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/metrics/ossm-metrics.html#ossm-config-openshift-monitoring-only_ossm-metrics

SME Review/QE Review: @jshaughn @leandroberetta 
Peer Review: