### PR TITLE
Update log6x-oc-explain.adoc

### DIFF
--- a/modules/log6x-oc-explain.adoc
+++ b/modules/log6x-oc-explain.adoc
@@ -49,7 +49,7 @@ For example:
 $ oc explain lokistacks.loki.grafana.com.spec.size
 ----
 
-This will show that `size` should be defined using an integer value.
+This will show that `size` should be defined using an string value.
 
 == Default Values
 When applicable, the command shows the default values for fields, providing insights into what values will be used if none are explicitly specified.


### PR DESCRIPTION
Changed loki size type information from integer to string.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> lokistacks.loki.grafana.com.spec.size should be defined using an string value

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> 4.18 and prior

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/OBSDOCS-1887

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
