### PR TITLE
Removed Technology Preview in Insights Operator Runtime Extractor for 4.19 docs

### DIFF
--- a/modules/insights-operator-what-information-is-collected.adoc
+++ b/modules/insights-operator-what-information-is-collected.adoc
@@ -14,7 +14,7 @@ The following information is collected by the Insights Operator:
 * Details of the platform that {product-title} is deployed on and the region that the cluster is located in
 ifndef::openshift-dedicated[]
 * Cluster workload information transformed into discreet Secure Hash Algorithm (SHA) values, which allows Red{nbsp}Hat to assess workloads for security and version vulnerabilities without disclosing sensitive details.
-* Workload information about the operating system and runtime environment, including runtime kinds, names, and version. This data gives Red({nbsp})Hat a better understanding of how you use {product-title} containers so that we can proactively help you make investment decisions to drive optimal utilization.
+* Workload information about the operating system and runtime environment, including runtime kinds, names, and version. This data gives Red{nbsp}Hat a better understanding of how you use {product-title} containers so that we can proactively help you make investment decisions to drive optimal utilization.
 
 endif::openshift-dedicated[]
 * If an Operator reports an issue, information is collected about core {product-title} pods in the `openshift-&#42;` and `kube-&#42;` projects. This includes state, resource, security context, volume information, and more.

--- a/modules/insights-operator-what-information-is-collected.adoc
+++ b/modules/insights-operator-what-information-is-collected.adoc
@@ -13,7 +13,7 @@ The following information is collected by the Insights Operator:
 * Progress information of running updates, and the status of any component upgrades.
 * Details of the platform that {product-title} is deployed on and the region that the cluster is located in
 ifndef::openshift-dedicated[]
-* Cluster workload information transformed into discreet Secure Hash Algorithm (SHA) values, which allows Red({nbsp})Hat to assess workloads for security and version vulnerabilities without disclosing sensitive details.
+* Cluster workload information transformed into discreet Secure Hash Algorithm (SHA) values, which allows Red{nbsp}Hat to assess workloads for security and version vulnerabilities without disclosing sensitive details.
 * Workload information about the operating system and runtime environment, including runtime kinds, names, and version. This data gives Red({nbsp})Hat a better understanding of how you use {product-title} containers so that we can proactively help you make investment decisions to drive optimal utilization.
 
 endif::openshift-dedicated[]

--- a/modules/insights-operator-what-information-is-collected.adoc
+++ b/modules/insights-operator-what-information-is-collected.adoc
@@ -13,13 +13,8 @@ The following information is collected by the Insights Operator:
 * Progress information of running updates, and the status of any component upgrades.
 * Details of the platform that {product-title} is deployed on and the region that the cluster is located in
 ifndef::openshift-dedicated[]
-* Cluster workload information transformed into discreet Secure Hash Algorithm (SHA) values, which allows Red Hat to assess workloads for security and version vulnerabilities without disclosing sensitive details.
-* Workload information about the operating system and runtime environment, including runtime kinds, names, and versions, which you can optionally enable through the `InsightsRuntimeExtractor` feature gate. This data gives Red Hat a better understanding of how you use {product-title} containers so that we can proactively help you make investment decisions to drive optimal utilization.
-+
---
-:FeatureName: InsightsRuntimeExtractor
-include::snippets/technology-preview.adoc[]
---
+* Cluster workload information transformed into discreet Secure Hash Algorithm (SHA) values, which allows Red({nbsp})Hat to assess workloads for security and version vulnerabilities without disclosing sensitive details.
+* Workload information about the operating system and runtime environment, including runtime kinds, names, and version. This data gives Red({nbsp})Hat a better understanding of how you use {product-title} containers so that we can proactively help you make investment decisions to drive optimal utilization.
 
 endif::openshift-dedicated[]
 * If an Operator reports an issue, information is collected about core {product-title} pods in the `openshift-&#42;` and `kube-&#42;` projects. This includes state, resource, security context, volume information, and more.

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -24,7 +24,6 @@ The following Technology Preview features are enabled by this feature set:
 ** Swap memory on nodes. Enables swap memory use for {product-title} workloads on a per-node basis. (`NodeSwap`)
 ** OpenStack Machine API Provider. This gate has no effect and is planned to be removed from this feature set in a future release. (`MachineAPIProviderOpenStack`)
 ** Insights Operator. Enables the `InsightsDataGather` CRD, which allows users to configure some Insights data gathering options. The feature set also enables the `DataGather` CRD, which allows users to run Insights data gathering on-demand. (`InsightsConfigAPI`)
-** Insights Operator. Enables a new data collection feature called 'Insights Runtime Extractor' which, when enabled, allows Red{nbsp}Hat to gather more runtime workload data about your {product-title} containers. (`InsightsRuntimeExtractor`)
 ** Dynamic Resource Allocation API. Enables a new API for requesting and sharing resources between pods and containers. This is an internal feature that most users do not need to interact with. (`DynamicResourceAllocation`)
 ** Pod security admission enforcement. Enables the restricted enforcement mode for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)
 ** StatefulSet pod availability upgrading limits. Enables users to define the maximum number of statefulset pods unavailable during updates which reduces application downtime. (`MaxUnavailableStatefulSet`)


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
In OCP 4.19, the Red Hat Insights Operator - Runtime Extractor feature is no longer supported as a Technology Preview.
Instead, it is now generally available.

This PR removes the referees to Technology Preview in the main content including the instructions for enabling feature gates, which are no longer required.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.19 +
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/HCCDOC-3790
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://93680--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/remote_health_monitoring/about-remote-health-monitoring.html
https://93680--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html
https://93680--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html
https://93680--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/about-remote-health-monitoring.html
https://93680--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/remote_health_monitoring/about-remote-health-monitoring.html
https://93680--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/remote_health_monitoring/about-remote-health-monitoring.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
