### PR TITLE
OSDOCS-13370-1:MicroShift 4.19 Release Note Ingress Controller Params

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -43,9 +43,9 @@ Updates for both single-version minor releases and patch releases are supported.
 [id="microshift-4-19-configuring_{context}"]
 === Configuring
 
-//[id="microshift-4-19-ingress-controller-two-config_{context}"]
-//==== Control ingress for your use case with additional parameters
-//add phase 2 ingress control parameters announcement here
+[id="microshift-4-19-ingress-controller-two-config_{context}"]
+==== Control ingress for your use case with additional parameters
+With this release, the `ingress.certificate.Secret`,`ingress.clientTLS`, `ingress.routeAdmissionPolicy`, and `ingress.tlsSecurityProfile` parameters are added to the YAML configuration file for {microshift-short}. These parameters specify security settings for the ingress controller. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} cluster].
 
 [id="microshift-4-19-tls-config_{context}"]
 ==== {microshift-short} control plane enhanced with TLS


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-13370

Link to docs preview:
https://93710--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.