### PR TITLE
OSDOCS#12096: Add the release note for the Observability service

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -59,6 +59,15 @@ With this release, configurable transport layer security (TLS) protocols on inte
 
 With this release, you can use the `microshift healthcheck` command with various options to run a basic health check on your applications. For more information, see xref:../microshift_running_apps/microshift-greenboot-workload-health-checks.adoc#microshift-greenboot-workload-health-checks[Greenboot workload health checks].
 
+[id="microshift-4-19-observability-metrics_{context}"]
+==== Collecting metrics using the {microshift-short} Observability service 
+
+With this release, you can configure the {microshift-short} Observability service to collect performance and usage metrics for monitoring resources. The following predefined configurations differ in the amount of data collected:
+
+* Small
+* Medium
+* Large (default)
+
 [id="microshift-4-19-support_{context}"]
 === Support
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-12096](https://issues.redhat.com//browse/OSDOCS-12096)

Link to docs preview:
[Collecting metrics using the MicroShift Observability service](https://93714--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-observability-metrics_release-notes) (Updated 6/4/25)

QE review:
- [x ] QE has approved this change.

Additional information:
** A link to the product documentation will be added to the release note after GA.
