### PR TITLE
PR for SRVCOM-3678: Update the Serverless 1.36 release notes

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -29,6 +29,9 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 // Release notes included, most to least recent
 
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-36-0.adoc[leveloffset=+1]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-35-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-35-0.adoc[leveloffset=+1]
 // 1.35.0 additional resources

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -14,24 +14,24 @@ For the most recent list of major functionality deprecated and removed within {S
 [cols="3,1,1,1,1,1,1",options="header"]
 |====
 |Feature 
-|1.30
 |1.31
 |1.32
 |1.33
 |1.34
 |1.35
+|1.36
 
 |Knative client `https://mirror.openshift.com/pub/openshift-v4/clients/serverless/` URL
 |-
 |-
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 
 |EventTypes `v1beta1` API
 |-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
@@ -39,7 +39,7 @@ For the most recent list of major functionality deprecated and removed within {S
 
 |`domain-mapping` and `domain-mapping-webhook` deployments
 |-
-|-
+|Removed
 |Removed
 |Removed
 |Removed
@@ -47,13 +47,13 @@ For the most recent list of major functionality deprecated and removed within {S
 
 |{SMProductName} with {ServerlessProductShortName} when Kourier is enabled
 |-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
 
-|`NamespacedKafka` annotation
+|Namespace-scoped Kafka brokers
 |Deprecated
 |Deprecated
 |Deprecated

--- a/modules/serverless-rn-1-36-0.adoc
+++ b/modules/serverless-rn-1-36-0.adoc
@@ -1,0 +1,125 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-36-0_{context}"]
+= Red Hat {ServerlessProductName} 1.36
+
+{ServerlessProductName} 1.36 is now available. New features, updates, fixed issues, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="new-features-1-36-0_{context}"]
+== New features
+
+[id="new-features-eventing-1-36-0_{context}"]
+=== {ServerlessProductName} Eventing
+
+* {ServerlessProductName} now uses Knative Eventing 1.16.
+
+* {ServerlessProductName} now uses Knative for Apache Kafka 1.16.
+
+* `IntegrationSource` and `IntegrationSink` are now available as a Technology Preview. These are Knative Eventing custom resources that support selected Kamelets from the Apache Camel project. Kamelets enables you to connect to third-party systems for improved connectivity, acting as either sources (event producers) or sinks (event consumers).
+
+* Knative Eventing can now automatically discover and register EventTypes based on the structure of incoming events. This feature simplifies the configuration and management of EventTypes, reducing the need for manual definitions. This feature is available as a Technology Preview.
+
+* {ServerlessProductName} Eventing introduces `EventTransform`, a new API resource that you can use to declaratively transform JSON events without writing custom code. With `EventTransform`, you can modify attributes, extract or reshape data, and streamline event flows across systems. Common use cases include event enrichment, format conversion, and request-response transformation. `EventTransform` integrates seamlessly with Knative sources, triggers, and brokers, enhancing interoperability in event-driven architectures. This feature is now available as a Technology Preview.
++
+
+See the following key features of `EventTransform`:
+
+** Define transformations declaratively using Kubernetes-native resources
+** Use JSONata expressions for advanced and flexible event data manipulation
+** Easily insert transformations at any point within event-driven workflows
+** Support for transforming both sink-bound and reply events for better routing control
+
+* The `sinks.knative.dev` API group has now been added to the `ClusterRoles` namespace in Knative Eventing. Developers now have permissions to `get`, `list`, and `watch` resources in this API group, improving accessibility and integration with sink resources.
+
+* Transport encryption for Knative Eventing is now available as a Generally Available (GA) feature.
+
+* Knative Eventing now supports the ability to define authorization policies that restrict which entities can send events to Eventing custom resources. This enables greater control and security within event-driven architectures. This functionality is available as a Developer Preview.
+
+* Knative Eventing catalog is now integrated into the {RHDHProductName} through the Event Catalog plugin for Backstage. This integration enables users to discover and explore Knative Eventing resources directly within the {RHDHProductName} interface. This functionality is available as a Developer Preview.
+
+* The `KafkaSource` API has now been promoted to version `v1`, signaling its stability and readiness for production use.
+
+* {ServerlessProductName} now supports deployment on ARM architecture as a Generally Available (GA) feature.
+
+* The `kn event` plugin is now available as a GA feature. You can use this plugin to send events directly from the command line to various destinations, streamlining event-driven application development and testing workflows.
+
+[id="new-features-serving-1-36-0_{context}"]
+=== {ServerlessProductName} Serving
+
+* {ServerlessProductName} now uses Knative Serving 1.16.
+
+* {ServerlessProductName} now uses Kourier 1.16.
+
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.16.
+
+[id="new-features-functions-1-36-0_{context}"]
+=== {ServerlessProductName} Functions
+
+* The `kn func` CLI plugin now uses `func` 1.16.
+
+* {ServerlessProductName} Functions support integration with Cert Manager, enabling automated certificate management for the function workloads. This functionality is available as a Developer Preview.
+
+[id="new-features-osl-1-36-0_{context}"]
+=== {ServerlessLogicProductName}
+
+* When starting a workflow via HTTP, you can now include additional properties alongside the `workflowdata` field in the request body. These extra fields are ignored by the runtime but are available in the Data Index as process variables as shown in the following example:
++
+[source,json]
+----
+{"workflowdata": {"name": "John"}, "groupKey": "follower"}
+----
+
+* You can now filter workflow instances by the content of workflow variables using GraphQL queries on `ProcessInstances.variables`. For example, the following query retrieves process instances where the `language` field in `workflowdata` equals `Spanish`:
++
+[source,terminal]
+----
+ProcessInstances (where:{variables:{workflowdata:{language:{equal:Spanish}}}}) {
+    variables,
+    state,
+    lastUpdate,
+    nodes {
+      name
+    }
+}
+----
+
+* {ServerlessLogicProductName} Data Index now supports filtering queries by using workflow definition metadata.
+
+* {ServerlessLogicOperatorName} now emits events to the Data Index to indicate when a workflow definition becomes available or unavailable.
+
+[id="fixed-issues-1-36-0_{context}"]
+== Fixed issues
+
+[id="fixed-issues-eventing-1-36-0_{context}"]
+=== {ServerlessProductName} Eventing
+
+* Previously, the Knative Kafka dispatcher could stop consuming events if a Kafka consumer group rebalance occurred while a sink was processing events out of order. This behavior triggered the following errors:
+
+** `SEVERE: Unhandled exception`
+** `java.lang.IndexOutOfBoundsException: bitIndex < 0`
+** Repeated logs like `Request joining group due to: group is already rebalancing`
+
++
+
+This issue is now fixed. The dispatcher correctly handles out-of-order event consumption during rebalancing and continues processing events without interruption.
+
+* Previously, a KafkaSource remained in a `Ready` state even when `KafkaSource.spec.net.tls.key` failed to load due to the use of unsupported TLS certificates in PKCS #1 format. This issue is now fixed. An appropriate error is now reported when attempting to create a `KafkaBroker`, `KafkaChannel`, `KafkaSource`, or `KafkaSink` using TLS certificates in an unsupported format.
+
+[id="known-issues-1-36-0_{context}"]
+== Known issues
+
+[id="known-issues-osl-1-36-0_{context}"]
+=== {ServerlessLogicProductName}
+
+* If the `swf-dev-mode` image is started with a broken or invalid workflow definition, the container might enter a stuck state.
+
+* When deploying a workflow in the `preview` profile on {ocp-product-title}, if the initial build fails and is later corrected, the Operator does not create the corresponding workflow deployment. As a result, the deployment remains missing and the `SonataFlow` status is not updated, even after the build is fixed.
+
+* The {ServerlessLogicProductName} builder image consistently downloads the `plexus-utils-1.1` artifact during the build process, regardless of local caching or dependency resolution settings.
+
+* When running images in disconnected or restricted network environments, the Maven wrapper might experience timeouts while attempting to download required components.
+
+* The `openshift-serverless-1/logic-swf-builder-rhel8:1.35.0` and `openshift-serverless-1/logic-swf-builder-rhel8:1.36.0` images are currently downloading the persistence extensions from Maven during the build process.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -14,17 +14,33 @@ The following table provides information about which {ServerlessProductName} fea
 [cols="2,1,1,1",options="header"]
 |====
 |Feature 
-|1.33
 |1.34
 |1.35
+|1.36
+
+|`EventTransform` API for JSON event transformation
+|-
+|-
+|TP
+
+|Automatic `EventType` registration
+|-
+|-
+|TP
+
+
+|`IntegrationSource` and `IntegrationSink`
+|-
+|-
+|TP
 
 |Eventing Transport encryption
-|-
 |TP
 |TP
+|GA
 
 |Serving Transport encryption
-|-
+|TP
 |TP
 |TP
 
@@ -36,7 +52,7 @@ The following table provides information about which {ServerlessProductName} fea
 |ARM64 support
 |TP
 |TP
-|TP
+|GA
 
 |Custom Metrics Autoscaler Operator (KEDA)
 |TP
@@ -46,7 +62,7 @@ The following table provides information about which {ServerlessProductName} fea
 |kn event plugin
 |TP
 |TP
-|TP
+|GA
 
 |Pipelines-as-code
 |TP
@@ -60,7 +76,7 @@ The following table provides information about which {ServerlessProductName} fea
 
 |Go function using S2I builder
 |TP
-|TP
+|GA
 |GA
 
 |Installing and using {ServerlessProductShortName} on {sno}
@@ -137,11 +153,6 @@ The following table provides information about which {ServerlessProductName} fea
 |GA
 |GA
 |GA
-
-|Namespace-scoped brokers
-|TP
-|TP
-|TP
 
 |`multi-container support`
 |GA


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.36`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3678

**Doc preview:**

- [Serverless 1.36 release notes](https://93729--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes#serverless-rn-1-36-0_serverless-release-notes)
- [Deprecated and removed features](https://93729--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-deprecated-removed-features_serverless-release-notes)
- [Generally Available and Technology Preview features](https://93729--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes)

**Reviews:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->