### PR TITLE
OBSDOCS-1918: Logging Z-Stream Release Notes - 6.1.7

### DIFF
--- a/modules/log6x-6-1-7-rn.adoc
+++ b/modules/log6x-6-1-7-rn.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.1/log6x-release-notes-6.1.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-7_{context}"]
+= Logging 6.1.7 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:8143[RHBA-2025:8143].
+
+[id="logging-release-notes-6-1-7-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, merging data from the `message` field into the root of a Syslog log event caused the log event to be inconsistent with the ViaQ data model. The inconsistency could lead to overwritten system information, data duplication, or event corruption. This update revises Syslog parsing and merging for the Syslog output to align with other output types, resolving this inconsistency. (link:https://issues.redhat.com/browse/LOG-7184[LOG-7184])
+
+
+* Before this update, log forwarding failed if you configured a cluster-wide proxy with a URL containing a username with an encoded "@" symbol; for example "user%40name". This update resolves the issue by adding correct support for URL-encoded values in proxy configurations. (link:https://issues.redhat.com/browse/LOG-7187[LOG-7187])
+
+[id="logging-release-notes-6-1-7-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+* link:https://access.redhat.com/security/cve/CVE-2024-12087[CVE-2024-12087]
+* link:https://access.redhat.com/security/cve/CVE-2024-12088[CVE-2024-12088]
+* link:https://access.redhat.com/security/cve/CVE-2024-12133[CVE-2024-12133]
+* link:https://access.redhat.com/security/cve/CVE-2024-12243[CVE-2024-12243]
+* link:https://access.redhat.com/security/cve/CVE-2024-12747[CVE-2024-12747]
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-0395[CVE-2025-0395]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
+
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].
+====

--- a/observability/logging/logging-6.1/log6x-release-notes-6.1.adoc
+++ b/observability/logging/logging-6.1/log6x-release-notes-6.1.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/log6x-6-1-7-rn.adoc[leveloffset=+1]
+
 include::modules/log6x-6-1-6-rn.adoc[leveloffset=+1]
 
 include::modules/log6x-6-1-5-rn.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.18, 4.17, 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1918
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://93735--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.1/log6x-release-notes-6.1.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
