### PR TITLE
OBSDOCS-1917: Logging Z-Stream Release Notes - 6.0.9

### DIFF
--- a/modules/log6x-rn-6.0.9.adoc
+++ b/modules/log6x-rn-6.0.9.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-9_{context}"]
+= Logging 6.0.9
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:8144[RHBA-2025:8144].
+
+[id="logging-release-notes-6-0-9-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, merging data from the `message` field into the root of a Syslog log event caused  inconsistencies with the ViaQ data model. These inconsistencies could overwrite system information, duplicate data, or corrupt the log event. This update makes Syslog parsing and merging consistent with the other output types and resolves the issue. (link:https://issues.redhat.com/browse/LOG-7183[LOG-7183])
+
+* Before this update, log forwarding failed when the cluster-wide proxy configuration included a URL with a username containing an encoded `@` symbol; for example, `user%40name`. This update adds the correct support for URL-encoded values in proxy configurations and resolves the issue. (link:https://issues.redhat.com/browse/LOG-7186[LOG-7186])
+
+[id="logging-release-notes-6-0-9-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+* link:https://access.redhat.com/security/cve/CVE-2024-12087[CVE-2024-12087]
+* link:https://access.redhat.com/security/cve/CVE-2024-12088[CVE-2024-12088]
+* link:https://access.redhat.com/security/cve/CVE-2024-12133[CVE-2024-12133]
+* link:https://access.redhat.com/security/cve/CVE-2024-12243[CVE-2024-12243]
+* link:https://access.redhat.com/security/cve/CVE-2024-12747[CVE-2024-12747]
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-0395[CVE-2025-0395]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
+
+For detailed information about Red{nbsp}Hat security ratings, see link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].

--- a/observability/logging/logging-6.0/log6x-release-notes.adoc
+++ b/observability/logging/logging-6.0/log6x-release-notes.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/log6x-rn-6.0.9.adoc[leveloffset=+1]
+
 include::modules/log6x-rn-6.0.8.adoc[leveloffset=+1]
 
 include::modules/log6x-rn-6.0.7.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.17, 4.16, 4.15, 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1917
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://93736--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
