### PR TITLE
RHDEVDOCS-6463: Content creation for GitOps 1.15.3 RN

### DIFF
--- a/modules/gitops-release-notes-1-15-3.adoc
+++ b/modules/gitops-release-notes-1-15-3.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes-1-15.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="gitops-release-notes-1-15-3_{context}"]
+= Release notes for {gitops-title} 1.15.3
+
+{gitops-title} 1.15.3 is now available on {OCP} 4.14, 4.15, 4.16, and 4.17.
+
+[id="errata-updates-1-15.3_{context}"]
+== Errata updates
+
+[id="RHSA-2025:8277-gitops-1-15-3-security-update-advisory_{context}"]
+=== RHSA-2025:8277 - {gitops-title} 1.15.3 security update advisory
+
+Issued: 2025-06-28
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2025:8277[RHSA-2025:8277]
+
+If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----
+
+[id="fixed-issues-1-15-3_{context}"]
+== Fixed issues
+
+* Before this update, the scope configuration in the RBAC `argocd-rbac-cm` config map was configured with `'[groups,email]'` without the corresponding change in `.spec.rbac.scopes`. This discrepancy led to conflicts during config map synchronization when transitioning to Keycloak SSO. With this update, the {gitops-title} Operator now maintains the existing RBAC scope configuration. link:https://issues.redhat.com/browse/GITOPS-5977[GITOPS-5977]

--- a/release_notes/gitops-release-notes-1-15.adoc
+++ b/release_notes/gitops-release-notes-1-15.adoc
@@ -30,6 +30,9 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+// Release notes for Red Hat OpenShift GitOps 1.15.3
+include::modules/gitops-release-notes-1-15-3.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.15.2
 include::modules/gitops-release-notes-1-15-2.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):

gitops-docs-1.15, gitops-docs-1.16, gitops-docs-1.17

Issue:

https://issues.redhat.com/browse/RHDEVDOCS-6463

Link to docs preview:

[Release notes for Red Hat OpenShift GitOps 1.15.3](https://93740--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-15.html#gitops-release-notes-1-15-3_gitops-release-notes)

QE review:

 QE has approved this change:
 
SME review: nmirasch@redhat.com
QE review: @varshab1210 
Peer review: @abrennan89 

Additional information: