### PR TITLE
Command Structure Expanding a persistent volume claim

### DIFF
--- a/modules/lvms-scaling-storage-expand-pvc.adoc
+++ b/modules/lvms-scaling-storage-expand-pvc.adoc
@@ -24,7 +24,7 @@ To expand a PVC, you must update the `storage` field in the PVC.
 [source,terminal]
 ----
 $ oc patch pvc <pvc_name> -n <application_namespace> \ <1>
---type=merge -p \ '{ "spec": { "resources": { "requests": { "storage": "<desired_size>" }}}}' <2>
+  --type=merge -p \ '{ "spec": { "resources": { "requests": { "storage": "<desired_size>" }}}}' <2>
 ----
 <1> Replace `<pvc_name>` with the name of the PVC that you want to expand.
 <2> Replace `<desired_size>` with the new size to expand the PVC.


### PR DESCRIPTION
- Needs to correct the command structure in Expanding a persistent volume claim.
- Here is the documentation link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/storage/configuring-persistent-storage#lvms-scaling-expand-pvc_logical-volume-manager-storage

Here is the current documentation:

2. Update the value of the spec.resources.requests.storage field to a value that is greater than the current value by running the following command: 
~~~
$ oc patch pvc <pvc_name> -n <application_namespace> \ 
--type=merge -p \ '{ "spec": { "resources": { "requests": { "storage": "<desired_size>" }}}}' 
~~~

- In the above commands, the "- -" signs are incorrectly placed below the "$" symbol.
- However, they should be aligned parallel to the "oc" command, where the command begins.*

Here is the updated look:

2. Update the value of the spec.resources.requests.storage field to a value that is greater than the current value by running the following command: 
~~~
$ oc patch pvc <pvc_name> -n <application_namespace> \  1 
  --type=merge -p \ '{ "spec": { "resources": { "requests": { "storage": "<desired_size>" }}}}' 
~~~

- The commands will work as it is, but the structure is incorrect.
- It should be standard format all over the documentation.
- Hence it needs to be changed.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.18, RHOCP 4.17, RHOCP 4.16, RHOCP 4.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1945

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://93741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
