### PR TITLE
Remove unnecessary ~ sign from the documentation.

### DIFF
--- a/modules/persistent-storage-csi-vsphere-install-issues.adoc
+++ b/modules/persistent-storage-csi-vsphere-install-issues.adoc
@@ -23,7 +23,7 @@ To uninstall the third-party vSphere CSI Driver:
 +
 [source,terminal]
 ----
-~ $ oc delete CSIDriver csi.vsphere.vmware.com
+$ oc delete CSIDriver csi.vsphere.vmware.com
 ----
 +
 [source,terminal]


### PR DESCRIPTION
- Remove unnecessary "~" sign from the documentation.
- Here is the documentation link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/storage/using-container-storage-interface-csi#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere

Here is the current documentation:

3. Delete the third-party vSphere CSI driver CSIDriver object: 
~~~
~ $ oc delete CSIDriver csi.vsphere.vmware.com 
~~~

- Above command is correct.
- But there is one unnecessary sign "~".
- We need to remove it, as it is of no use.

Here is the updated look:

3. Delete the third-party vSphere CSI driver CSIDriver object: 
~~~
$ oc delete CSIDriver csi.vsphere.vmware.com 
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.19, RHOCP 4.18, RHOCP 4.17, RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1952

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://93746--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
