### PR TITLE
OSDOCS#14756: Update the z-stream RNs for 4.18.15

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3021,6 +3021,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.15
+[id="ocp-4-18-15_{context}"]
+=== RHBA-2025:8104 - {product-title} {product-version}.15 bug fix update
+
+Issued: 27 May 2025
+
+{product-title} release {product-version}.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:8104[RHBA-2025:8104] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:8106[RHBA-2025:8106] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.15 --pullspecs
+----
+
+[id="ocp-4-18-15-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the web console incorrectly displayed a 60-day update limitation message in version 4.16. This outdated message misled users in {product-title} 4.16 and later versions. With this release, the 60-day update warning is removed from the web console, which ensures an accurate and an up-to-date user experience. (link:https://issues.redhat.com/browse/OCPBUGS-56255[OCPBUGS-56255])
+
+* Previously, secrets and credentials in `MachineConfigs` secrets were added to audit logs, which exposed sensitive data. With this release, an update ignores `MachineConfig` secrets in audit logs, which results in the removal of sensitive data from the logs, and ensures improved data security. (link:https://issues.redhat.com/browse/OCPBUGS-56030[OCPBUGS-56030])
+
+* Previously, the token rotation mechanism incorrectly created a time frame without a valid token for image authentication that resulted in temporary authentication failures in the image registry. This failure affected pod scheduling and build processes. With this release, an update enhances the token refresh mechanism in {product-title} to prevent invalid tokens. This improvement reduces authentication failures and ensures a smoother operation of the image registry and related processes. (link:https://issues.redhat.com/browse/OCPBUGS-54304[OCPBUGS-54304])
+
+* Previously, a host shutdown caused a failure during an Open Virtual Appliance (OVA) import in a {vmw-first} cluster. An update was made to ensure that the {vmw-short} ESXi host was not powered off or in maintenance mode during the import process. With this release, the update allows for a successful OVA import without disruption. (link:https://issues.redhat.com/browse/OCPBUGS-50690[OCPBUGS-50690])
+
+[id="ocp-4-18-15-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.14
 [id="ocp-4-18-14_{context}"]
 === RHSA-2025:7863 - {product-title} {product-version}.14 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.18
Issue:
[OSDOCS-14756](https://issues.redhat.com//browse/OSDOCS-14756)

Link to docs preview:
[4.18.15](https://93750--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-15_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RN.

Additional information:
The errata URLs will return 404 until the go-live date of 5/27/25.
