### PR TITLE
OSDOCS-9009: Add "Expanding persistent volumes" to ROSA 

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -641,6 +641,8 @@ Topics:
     File: persistent-storage-csi-google-cloud-file
 - Name: Generic ephemeral volumes
   File: generic-ephemeral-vols
+- Name: Expanding persistent volumes
+  File: expanding-persistent-volumes
 - Name: Dynamic provisioning
   File: dynamic-provisioning
 ---

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -885,6 +885,8 @@ Topics:
     File: persistent-storage-csi-aws-efs
 - Name: Generic ephemeral volumes
   File: generic-ephemeral-vols
+- Name: Expanding persistent volumes
+  File: expanding-persistent-volumes
 - Name: Dynamic provisioning
   File: dynamic-provisioning
 ---

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -657,6 +657,8 @@ Topics:
     File: persistent-storage-csi-aws-efs
 - Name: Generic ephemeral volumes
   File: generic-ephemeral-vols
+- Name: Expanding persistent volumes
+  File: expanding-persistent-volumes
 - Name: Dynamic provisioning
   File: dynamic-provisioning
 ---

--- a/storage/expanding-persistent-volumes.adoc
+++ b/storage/expanding-persistent-volumes.adoc
@@ -6,21 +6,23 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/storage-expanding-add-volume-expansion.adoc[leveloffset=+1]
 
 include::modules/storage-expanding-csi-volumes.adoc[leveloffset=+1]
 
 :FeatureName: Expanding CSI volumes
 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/storage-expanding-flexvolume.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/storage-expanding-local-volumes.adoc[leveloffset=+1]
 
 include::modules/storage-expanding-filesystem-pvc.adoc[leveloffset=+1]
 
 include::modules/storage-expanding-recovering-failure.adoc[leveloffset=+1]
-endif::openshift-enterprise,openshift-webscale,openshift-origin[]
+endif::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-9009

Link to docs preview:

- https://93765--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/expanding-persistent-volumes.html
- https://93765--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/storage/expanding-persistent-volumes.html
- https://93765--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/expanding-persistent-volumes.html

QE review:
- [ ] QE has approved this change.

