### PR TITLE
OSDOCS-13901 NetObserv 1.9 CLI documentation updates

### DIFF
--- a/modules/network-observability-netobserv-cli-reference.adoc
+++ b/modules/network-observability-netobserv-cli-reference.adoc
@@ -7,8 +7,8 @@
 You can use the Network Observability CLI (`oc netobserv`) to pass command-line arguments to capture flows data, packets data, and metrics for further analysis and enable features supported by the Network Observability Operator.
 
 [id="cli-syntax_{context}"]
-== Syntax 
-The basic syntax for `oc netobserv` commands: 
+== Syntax
+The basic syntax for `oc netobserv` commands:
 
 .`oc netobserv` syntax
 [source,terminal]
@@ -57,12 +57,14 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 | Option | Description | Default
 |--enable_all|                enable all eBPF features                   | false
 |--enable_dns|                enable DNS tracking                        | false
+|--enable_ipsec|              enable IPsec tracking                      | false
 |--enable_network_events|     enable network events monitoring           | false
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
 |--enable_udn_mapping|        enable User Defined Network mapping | false
 |--get-subnets|               get subnets information                   | false
+|--sampling|                  value that determines the ratio of packets being sampled | 1
 |--background|                run in background                          | false
 |--copy|                      copy the output files locally              | prompt
 |--log-level|                 components logs                            | info
@@ -84,12 +86,13 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--regexes|                   filter flows using regular expression      | –
+|--query|                     filter flows using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
 |--tcp_flags|                 filter TCP flags                           | –
-|--interfaces|                interfaces to monitor                      | –
+|--interfaces|                list of interfaces to monitor, comma separated     | –
+|--exclude_interfaces|        list of interfaces to exclude, comma separated     | lo
 |===
 
 .Example running flows capture on TCP protocol and port 49051 with PacketDrop and RTT features enabled:
@@ -131,7 +134,7 @@ $ oc netobserv packets [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--regexes|                   filter flows using regular expression      | –
+|--query|                     filter flows using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
@@ -157,12 +160,14 @@ $ oc netobserv metrics [<option>]
 | Option | Description | Default
 |--enable_all|                enable all eBPF features                   | false
 |--enable_dns|                enable DNS tracking                        | false
+|--enable_ipsec|              enable IPsec tracking                      | false
 |--enable_network_events|     enable network events monitoring           | false
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
 |--enable_udn_mapping|        enable User Defined Network mapping | false
 |--get-subnets|               get subnets information                   | false
+|--sampling|                  value that defines the ratio of packets being sampled | 1
 |--action|                    filter action                              | Accept
 |--cidr|                      filter CIDR                                | 0.0.0.0/0
 |--direction|                 filter direction                           | –
@@ -179,16 +184,50 @@ $ oc netobserv metrics [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--regexes|                   filter flows using regular expression      | –
+|--query|                     filter flows using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
 |--tcp_flags|                 filter TCP flags                           | –
-|--interfaces|                interfaces to monitor                      | –
+|--include_list|              list of metric names to generate, comma separated           | namespace_flows_total,node_ingress_bytes_total,node_egress_bytes_total,workload_ingress_bytes_total
+|--interfaces|                list of interfaces to monitor, comma separated     | –
+|--exclude_interfaces|        list of interfaces to exclude, comma separated     | lo
 |===
 
 .Example running metrics capture for TCP drops
 [source,terminal]
 ----
-$ oc netobserv metrics --enable_pkt_drop --protocol=TCP 
+$ oc netobserv metrics --enable_pkt_drop --protocol=TCP
+----
+
+.Example running metrics capture for list of metric names to generate
+[source,terminal]
+----
+$ oc netobserv metrics --include_list=node,workload
+----
+
+[source,terminal]
+----
+$ oc netobserv metrics --include_list=node_egress_bytes_total,workload_egress_packets_total
+----
+
+[source,terminal]
+----
+$ oc netobserv metrics --enable_all --include_list=node,namespace,workload
+----
+
+.Example output for list of metric names
+[source, terminal]
+----
+opt: include_list, value: node,workload
+Matching metrics:
+ - node_egress_bytes_total
+ - node_ingress_bytes_total
+ - workload_egress_bytes_total
+ - workload_ingress_bytes_total
+ - workload_egress_packets_total
+ - workload_ingress_packets_total
+ - workload_flows_total
+ - workload_drop_packets_total
+ - workload_drop_bytes_total
 ----


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13901 NetObserv 1.9 CLI documentation updates

Version(s):
Merge to only the `no-1.9` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the NetObserv content just before its GA.

Cherry-pick to OCP 4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-13901

Link to docs preview:
* Flow capture options: https://93795--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-reference.html#cli-reference-flows-capture-options_netobserv-cli-reference
* Packets capture options: https://93795--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-reference.html#cli-reference-packet-capture-options_netobserv-cli-reference
* Metrics capture options: https://93795--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-reference.html#cli-reference-metrics-capture-options_netobserv-cli-reference

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
