### PR TITLE
WMCO 10.18.1 release notes add back bug fix

### DIFF
--- a/modules/windows-containers-release-notes-10-18-1.adoc
+++ b/modules/windows-containers-release-notes-10-18-1.adoc
@@ -8,15 +8,11 @@
 
 Issued: 27 May 2025
 
-This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.18.0 were released in link:https://access.redhat.com/errata/RHSA-2025:8224[RHSA-2025:8224].
+This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.18.1 were released in link:https://access.redhat.com/errata/RHSA-2025:8224[RHSA-2025:8224].
 
-////
-Hiding until we get decison on whether to include this RH employee only issue
 [id="wmco-10-18-1-bug-fixes"]
 == Bug fixes
 
-* Previously, Windows nodes were unable to pull from image mirror registries if an organization name or namespace was included in the source of the `ImageTagMirrorSet` (ITMS) object. With this fix, you can include an organization name or namespace in the `ITMS` object. With this change, additional guidelines and requirements around using mirror registries have been added to the {product-title} documentation. (link:https:  
-//issues.redhat.com/browse/OCPBUGS-55787[*OCPBUGS-55787*])
-// The "additional guidelines and requirements" are forthcoming in https://github.com/openshift/openshift-docs/pull/92629 
-
-////
+* Previously, Windows nodes were unable to pull from image mirror registries if an organization name or namespace was included in the source of the `ImageTagMirrorSet` (ITMS) object. With this fix, you can include an organization name or namespace in the `ITMS` object. With this change, additional guidelines and requirements around using mirror registries have been added to the {product-title} documentation. 
+(link:https://issues.redhat.com/browse/OCPBUGS-55787[*OCPBUGS-55787*])
+// The "additional guidelines and requirements" are forthcoming in https://github.com/openshift/openshift-docs/pull/92629


### PR DESCRIPTION
For the WMCO 10.18.1 release notes, a reported bug fix linked to a Red Hat Employee only Jira, which triggered a build fail. I commented-out the bug fix in order to get the release notes to publish, awaiting a resolution. The developer removed the Red Hat Employee status, allowing us to document the fix. This PR removes the comment-out mark up. 
The text of the release note was approved in https://github.com/openshift/openshift-docs/pull/93452

Preview:
[Release notes for Red Hat Windows Machine Config Operator 10.18.1](https://93808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-18-x.html#windows-containers-release-notes-10-18-1_windows-containers-release-notes)
