### PR TITLE
[RHDEVDOCS-6456] Pipelines-as-Code: Remove Plan permissions for GitHub App

### DIFF
--- a/modules/op-pac-configuring-github-app-manually.adoc
+++ b/modules/op-pac-configuring-github-app-manually.adoc
@@ -48,10 +48,9 @@ $ openssl rand -hex 20
 * **Metadata**: `Read-only`
 * **Pull request**: `Read & Write`
 
-. Select the following items in the **Organization permissions** section:
+. Select the following item in the **Organization permissions** section:
 
 * **Members**: `Read-only`
-* **Plan**: `Read-only`
 
 . Subscribe to the following events:
 


### PR DESCRIPTION
Version(s):
pipelines-docs-1.19+

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6456

Link to docs preview:
- https://93815--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/using-pipelines-as-code-repos.html#pac-configuring-github-app-manually_using-pipelines-as-code-repos

QE review:
- [x] QE has approved this change.
