### PR TITLE
TELCODOCS-1874: Fixing typos and adjust TOC

### DIFF
--- a/modules/telco-hub-cluster-topology.adoc
+++ b/modules/telco-hub-cluster-topology.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 [id="telco-hub-cluster-topology_{context}"]
-= Cluster topology
+= Hub cluster topology
 
 In production environments, the {product-title} hub cluster must be highly available to maintain high availability of the management functions.
 

--- a/modules/telco-hub-memory-and-cpu-requirements.adoc
+++ b/modules/telco-hub-memory-and-cpu-requirements.adoc
@@ -12,5 +12,5 @@ Engineering considerations::
 --
 * Before deploying a telco hub cluster, ensure that your cluster host meets cluster requirements.
 
-For more information about scaling the number of managed clusters, see "Hub cluster engineering considerations". 
+For more information about scaling the number of managed clusters, see "Hub cluster scaling target". 
 --

--- a/modules/telco-hub-networking.adoc
+++ b/modules/telco-hub-networking.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 [id="telco-hub-networking_{context}"]
-= Networking
+= Hub cluster networking
 
 The reference hub cluster is designed to operate in a disconnected networking environment where direct access to the internet is not possible.
 As with all {product-title} clusters, the hub cluster requires access to an image registry hosting all OpenShift and Day 2 {olm-first} images.
@@ -16,7 +16,7 @@ Limits and requirements::
 ** `serviceNetwork`
 ** `machineNetwork`
 
-* Yout must configure the following IP addresses for the hub cluster:
+* You must configure the following IP addresses for the hub cluster:
 ** `apiVIP`
 ** `ingressVIP`
 

--- a/modules/telco-hub-resource-utilization.adoc
+++ b/modules/telco-hub-resource-utilization.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 [id="telco-hub-resource-utilization_{context}"]
-= Hubs cluster resource utilization
+= Hub cluster resource utilization
 
 Resource utilization was measured for hub clusters in the following scenario:
 

--- a/modules/telco-hub-storage-requirements.adoc
+++ b/modules/telco-hub-storage-requirements.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 [id="telco-hub-storage-requirements_{context}"]
-= Storage requirements
+= Hub cluster storage requirements
 
 The total amount of storage required by the management hub cluster is dependant on the storage requirements for each of the applications deployed on the cluster.
 The main components that require storage through highly available `PersistentVolume` resources are described in the following sections.

--- a/modules/telco-hub-topology-aware-lifecycle-manager-talm.adoc
+++ b/modules/telco-hub-topology-aware-lifecycle-manager-talm.adoc
@@ -14,7 +14,7 @@ Description::
 * Progressive rollout of policy updates to fleets of clusters in user configurable batches.
 * Per-cluster actions add `ztp-done` labels or other user-configurable labels following configuration changes to managed clusters.
 
-* {cgu-operator} supports optional pre-caching of {product_title}, {olm} Operator, and additional images to {sno} clusters before initiating an upgrade. The pre-caching feature is not applicable when using the recommended image-based upgrade method for upgrading {sno} clusters.
+* {cgu-operator} supports optional pre-caching of {product-title}, {olm} Operator, and additional images to {sno} clusters before initiating an upgrade. The pre-caching feature is not applicable when using the recommended image-based upgrade method for upgrading {sno} clusters.
 
 ** Specifying optional pre-caching configurations with `PreCachingConfig` CRs.
 

--- a/scalability_and_performance/telco-hub-rds.adoc
+++ b/scalability_and_performance/telco-hub-rds.adoc
@@ -34,26 +34,24 @@ include::modules/telco-hub-telco-management-cluster-use-model.adoc[leveloffset=+
 ** link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/about/index#multicluster-architecture[Multicluster architecture]
 ** link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/about/index#observability-arch[Observability]
 
-include::modules/telco-hub-engineering-considerations.adoc[leveloffset=+1]
+include::modules/telco-hub-scaling-targets.adoc[leveloffset=+1]
 
-include::modules/telco-hub-scaling-targets.adoc[leveloffset=+2]
-
-include::modules/telco-hub-resource-utilization.adoc[leveloffset=+2]
+include::modules/telco-hub-resource-utilization.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/governance/index#template-comparison-table[Comparison of hub cluster and managed cluster templates]
 
-include::modules/telco-hub-cluster-topology.adoc[leveloffset=+2]
+include::modules/telco-hub-cluster-topology.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:xref:../welcome/learn_more_about_openshift.adoc#architecture[{product-title} architecture]
-* link:xref:../post_installation_configuration/node-tasks.adoc#post-install-node-tasks[Postinstallation node tasks]
+* xref:../welcome/learn_more_about_openshift.adoc#architecture[{product-title} architecture]
+* xref:../post_installation_configuration/node-tasks.adoc#post-install-node-tasks[Postinstallation node tasks]
 
-include::modules/telco-hub-networking.adoc[leveloffset=+2]
+include::modules/telco-hub-networking.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -67,7 +65,7 @@ include::modules/telco-hub-networking.adoc[leveloffset=+2]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/networking/index[Networking in {rh-rhacm}]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#mce-network-configuration[Network configuration in {rh-rhacm}]
 
-include::modules/telco-hub-memory-and-cpu-requirements.adoc[leveloffset=+2]
+include::modules/telco-hub-memory-and-cpu-requirements.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -75,23 +73,23 @@ include::modules/telco-hub-memory-and-cpu-requirements.adoc[leveloffset=+2]
 * xref:../scalability_and_performance/index.adoc#scalability-and-performance-overview[Scaling your {product-title} cluster and tuning performance in production environments]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/install/installing#sizing-your-cluster[Sizing your cluster]
 
-include::modules/telco-hub-storage-requirements.adoc[leveloffset=+2]
+include::modules/telco-hub-storage-requirements.adoc[leveloffset=+1]
 
-include::modules/telco-hub-assisted-service.adoc[leveloffset=+3]
+include::modules/telco-hub-assisted-service.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/clusters/cluster_mce_overview#enable-cim-disconnected[Enabling central infrastructure management in disconnected environments]
 
-include::modules/telco-hub-acm-observability.adoc[leveloffset=+3]
+include::modules/telco-hub-acm-observability.adoc[leveloffset=+2]
 
-include::modules/telco-hub-storage-considerations.adoc[leveloffset=+3]
+include::modules/telco-hub-storage-considerations.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:xref:../storage/understanding-persistent-storage.adoc#persistent-storage-overview_understanding-persistent-storage[Persistent storage overview]
+* xref:../storage/understanding-persistent-storage.adoc#persistent-storage-overview_understanding-persistent-storage[Persistent storage overview]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.18/html/red_hat_openshift_data_foundation_architecture/index[{rh-storage} architecture]
 * xref:../storage/persistent_storage/persistent_storage_local/persistent-storage-local.adoc#persistent-storage-using-local-volume[Persistent storage using local volumes]
 * xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc#recommended-etcd-practices[Recommended etcd practices]
@@ -139,8 +137,6 @@ include::modules/telco-hub-observability.adoc[leveloffset=+1]
 * For more information about forwarding alerts to other external systems, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/observability/index#forward-alerts[Forwarding alerts]
 
 * For more information about CPU and memory requirements see: link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/observability/index#observability-pod-capacity-requests[Observability pod capacity requests]
-
-For more information about custom metrics, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/observability/index#adding-custom-metrics[Adding custom metrics]
 
 * For more information about custom dashboards, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/observability/index#using-grafana-dashboards[Using Grafana dashboards]
 
@@ -519,13 +515,4 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/install/openshift/install-config.yaml[]
 ----
 
-[id="telco-hub-mirroring-ref-crs_{context}"]
-=== Image mirroring reference YAML
-
-[id="telco-hub-imageset-config-yaml"]
-.imageset-config.yaml
-[source,yaml]
-----
-include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/install/mirror-registry/imageset-config.yaml[]
-----
 :!telco-hub:


### PR DESCRIPTION
[TELCODOCS-1874](https://issues.redhat.com//browse/TELCODOCS-1874): Fixing typos and adjust TOC

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1874

Link to docs preview:
https://93818--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html

No QE needed, typos and TOC level changes only, also removed `imageset-config.yaml` as it is for 4.17. 
