### PR TITLE
TELCODOCS-1874-missing-modules: Adding QE approved missing modules from upstream

### DIFF
--- a/modules/telco-deviations-from-the-ref-design.adoc
+++ b/modules/telco-deviations-from-the-ref-design.adoc
@@ -2,12 +2,13 @@
 //
 // * scalability_and_performance/telco_ran_du_ref_design_specs/telco-ran-du-rds.adoc
 // * scalability_and_performance/telco_ref_design_specs/telco-ref-design-specs-overview.adoc
+// * scalability_and_performance/telco_ref_design_specs/telco-hubs-rds.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="telco-deviations-from-the-ref-design_{context}"]
 = Deviations from the reference design
 
-Deviating from the validated telco core and telco RAN DU reference design specifications (RDS) can have significant impact beyond the specific component or feature that you change.
+Deviating from the validated telco core, telco RAN DU, and telco hub reference design specifications (RDS) can have significant impact beyond the specific component or feature that you change.
 Deviations require analysis and engineering in the context of the complete solution.
 
 [IMPORTANT]

--- a/modules/telco-hub-software-stack.adoc
+++ b/modules/telco-hub-software-stack.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/telco-core-rds.adoc
+// * scalability_and_performance/telco-hub-rds.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="telco-hub-software-stack_{context}"]
+= Telco hub reference configuration software specifications
+
+The telco hub {product-version} solution has been validated using the following Red{nbsp}Hat software products for {product-title} clusters.
+
+.Telco hub cluster validated software components
+[cols=2*, width="80%", options="header"]
+|====
+|Component |Software version
+
+|{product-title}
+|4.18
+
+|Local Storage Operator
+|4.18
+
+|{odf-first}
+|4.18
+
+|{rh-rhacm-first}
+|2.13
+
+|{gitops-title}
+|1.15
+
+|{ztp-first} plugins
+|4.18
+
+|{mce-short} PolicyGenerator plugin
+|2.12
+
+|{cgu-operator-first}
+|4.18
+
+|Cluster Logging Operator
+|6.2
+
+|{oadp-first}
+|The version aligned with the {rh-rhacm} release.
+
+|====

--- a/modules/telco-ran-core-ref-design-spec.adoc
+++ b/modules/telco-ran-core-ref-design-spec.adoc
@@ -2,12 +2,13 @@
 //
 // * scalability_and_performance/telco_ran_du_ref_design_specs/telco-ran-du-rds.adoc
 // * scalability_and_performance/telco_ref_design_specs/telco-ref-design-specs-overview.adoc
+// * scalability_and_performance/telco_ref_design_specs/telco-hubs-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-ran-core-ref-design-spec_{context}"]
 = Reference design scope
 
-The telco core and telco RAN reference design specifications (RDS) capture the recommended, tested, and supported configurations to get reliable and repeatable performance for clusters running the telco core and telco RAN profiles.
+The telco core, telco RAN and telco hub reference design specifications (RDS) capture the recommended, tested, and supported configurations to get reliable and repeatable performance for clusters running the telco core and telco RAN profiles.
 
 Each RDS includes the released features and supported configurations that are engineered and validated for clusters to run the individual profiles.
 The configurations provide a baseline {product-title} installation that meets feature and KPI targets.

--- a/scalability_and_performance/telco-hub-rds.adoc
+++ b/scalability_and_performance/telco-hub-rds.adoc
@@ -3,7 +3,7 @@
 [id="telco-hub-ref-design-specs"]
 = Telco hub reference design specifications
 include::_attributes/common-attributes.adoc[]
-
+:context: telco-hub
 
 toc::[]
 
@@ -11,6 +11,10 @@ The telco hub reference design specifications (RDS) describes the configuration 
 
 :FeatureName: The telco hub RDS
 include::snippets/technology-preview.adoc[]
+
+include::modules/telco-ran-core-ref-design-spec.adoc[leveloffset=+1]
+
+include::modules/telco-deviations-from-the-ref-design.adoc[leveloffset=+1]
 
 include::modules/telco-hub-architecture-overview.adoc[leveloffset=+1]
 
@@ -514,5 +518,7 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 ----
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/install/openshift/install-config.yaml[]
 ----
+
+include::modules/telco-hub-software-stack.adoc[leveloffset=+1]
 
 :!telco-hub:


### PR DESCRIPTION
[TELCODOCS-1874](https://issues.redhat.com//browse/TELCODOCS-1874)-missing-modules: Adding QE approved missing modules from upstream

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1874

Link to docs preview:
- https://93822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html#telco-ran-core-ref-design-spec_telco-hub
- https://93822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html#telco-deviations-from-the-ref-design_telco-hub
- https://93822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html#telco-hub-software-stack_telco-hub

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Missing modules from https://github.com/openshift/openshift-docs/pull/93098 