### PR TITLE
OSDOCS#14771: cert-manager 1.16.0 RN

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,6 +12,51 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1-16-0_{context}"]
+== {cert-manager-operator} 1.16.0
+
+Issued: 2025-05-27
+
+The following advisories are available for the {cert-manager-operator} 1.16.0:
+
+* link:https://access.redhat.com/errata/RHEA-2025:8163[RHEA-2025:8163]
+* link:https://access.redhat.com/errata/RHEA-2025:8164[RHEA-2025:8164]
+* link:https://access.redhat.com/errata/RHEA-2025:8165[RHEA-2025:8165]
+* link:https://access.redhat.com/errata/RHEA-2025:8198[RHEA-2025:8198]
+
+Version `1.16.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.16.4`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.16/#v1164[cert-manager project release notes for v1.16.4].
+
+[id="cert-manager-operator-1-16-0-features-enhancements_{context}"]
+=== New features and enhancements
+
+*Disconnected environment support*
+
+With this release, the {cert-manager-operator} has been verified to be mirrored to and installed in a disconnected environment.
+
+The Operator has also been validated to work with the following issuer types in disconnected environments: ACME, CA, Self-signed, and Vault.
+Specifically, private or self-hosted ACME servers have been validated, as Let's Encrypt or other public ACME services are not feasible options in disconnected environments.
+The oc-mirror plugin v2 is the preferred method to mirror Operator images.
+For more information, see xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2].
+
+*Extended operand metrics support*
+
+With this release, cert-manager webhook and cainjector operands now expose Prometheus metrics on port 9402 by default via the `/metrics` service endpoint.
+You can configure OpenShift Monitoring to collect metrics from all cert-manager operands by enabling the built-in user workload monitoring stack.
+For more information, see xref:../../security/cert_manager_operator/cert-manager-monitoring.adoc#cert-manager-monitoring[Monitoring {cert-manager-operator}].
+
+*Streaming Lists enablement*
+
+With this release, the {cert-manager-operator} now uses the new upstream WatchListClient feature.
+This enables use of the Streaming Lists feature of the Kubernetes API server, which reduces the load on the API server.
+The peak memory use of the cert-manager components when they start up is optimized on {product-title} 4.14 and later.
+
+[id="cert-manager-operator-1-16-0-CVEs_{context}"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2024-45337[CVE-2024-45337]
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]
+* link:https://access.redhat.com/security/cve/CVE-2025-22866[CVE-2025-22866]
+
 [id="cert-manager-operator-release-notes-1-15-1_{context}"]
 == {cert-manager-operator} 1.15.1
 


### PR DESCRIPTION
[OSDOCS-14771](https://issues.redhat.com/browse/OSDOCS-14771)

Version(s): 4.14+

This PR adds release notes for 1.16.0 of the cert manager Operator.

QE review:
- [x] QE has approved this change.

Preview:[cert-manager Operator for Red Hat OpenShift 1.16.0](https://93850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html#cert-manager-operator-release-notes-1-16-0_cert-manager-operator-release-notes)