### PR TITLE
OSDOCS-14007: followup to remove irrelevant prereq task

### DIFF
--- a/machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc
@@ -14,11 +14,6 @@ For the Cluster API Technology Preview, you must manually create some of the pri
 [id="creating-primary-resources_{context}"]
 == Creating the Cluster API primary resources
 
-To create the Cluster API primary resources, you must obtain the cluster ID value, which you use for the `<cluster_name>` parameter in the cluster resource manifest.
-
-//Obtaining the cluster ID value
-include::modules/obtaining-value-cluster-id.adoc[leveloffset=+2]
-
 You can create the Cluster API primary resources manually by creating YAML manifest files and applying them with the {oc-first}.
 
 //Creating a Cluster API machine template

--- a/modules/capi-creating-machine-set.adoc
+++ b/modules/capi-creating-machine-set.adoc
@@ -48,6 +48,13 @@ spec:
 <1> Specify a name for the compute machine set.
 The cluster ID, machine role, and region form a typical pattern for this value in the following format: `<cluster_name>-<role>-<region>`.
 <2> Specify the name of the cluster.
+Obtain the value of the cluster ID by running the following command:
++
+[source,terminal]
+----
+$  oc get infrastructure cluster \
+   -o jsonpath='{.status.infrastructureName}'
+----
 <3> Specify the details for your environment. These parameters are provider specific. For more information, see the sample Cluster API compute machine set YAML for your provider.
 --
 
@@ -62,9 +69,8 @@ $ oc create -f <machine_set_resource_file>.yaml
 +
 [source,terminal]
 ----
-$ oc get machineset -n openshift-cluster-api <1>
+$ oc get machineset.cluster.x-k8s.io -n openshift-cluster-api
 ----
-<1> Specify the `openshift-cluster-api` namespace.
 +
 .Example output
 [source,text]
@@ -83,9 +89,8 @@ When the new compute machine set is available, the `REPLICAS` and `AVAILABLE` va
 +
 [source,terminal]
 ----
-$ oc get machine -n openshift-cluster-api <1>
+$ oc get machine.cluster.x-k8s.io -n openshift-cluster-api
 ----
-<1> Specify the `openshift-cluster-api` namespace.
 +
 .Example output
 [source,text]

--- a/modules/obtaining-value-cluster-id.adoc
+++ b/modules/obtaining-value-cluster-id.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc
+// 
 
 :_mod-docs-content-type: PROCEDURE
 [id="obtaining-value-cluster-id_{context}"]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-14007](https://issues.redhat.com//browse/OSDOCS-14007)

Link to docs preview:
* [Creating the Cluster API primary resources](https://93861--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-getting-started#creating-primary-resources_cluster-api-getting-started)
* [Creating a Cluster API compute machine set](https://93861--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-getting-started#capi-creating-machine-set_cluster-api-getting-started)

QE review:
- [x] QE has approved this change.

Additional information:
Realized that this step is only needed in one place now, so it can just be folded into that callout.