### PR TITLE
OSDOCS#13404: Updated cluster backup policy

### DIFF
--- a/modules/rosa-sdpolicy-platform.adoc
+++ b/modules/rosa-sdpolicy-platform.adoc
@@ -89,64 +89,17 @@ For all containerized workloads running on a Kubernetes based system, it is best
 [id="rosa-sdpolicy-backup-policy_{context}"]
 == Cluster backup policy
 
-[IMPORTANT]
+Red Hat recommends object-level backup solutions for ROSA clusters. OpenShift API for Data Protection (OADP) is included in OpenShift but not enabled by default. Customers can configure OADP on their clusters to achieve object-level backup and restore capabilities.
+
+//Omitted until XCMSTRAT-480 is complete
+//While Red Hat takes frequent backups of etcd, this is for use by Red Hat for maintenance and service restoration purposes, and is never provided to customers for any reason.
+
+Red Hat does not back up customer applications or application data. Customers are solely responsible for applications and their data, and must put their own backup and restore capabilities in place.
+
+[WARNING]
 ====
-Red{nbsp}Hat does not provide a backup method for
-ifndef::openshift-rosa-hcp[]
-ROSA clusters that use STS.
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa-hcp[]
-{hcp-title} clusters.
-endif::openshift-rosa-hcp[]
-It is critical that customers have a backup plan for their applications and application data.
+Customers are solely responsible for backing up and restoring their applications and application data. For more information about customer responsibilities, see "Shared responsibility matrix".
 ====
-
-Application and application data backups are not a part of the
-ifdef::openshift-rosa-hcp[]
-{hcp-title} service.
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-{product-title} service.
-
-ifndef::openshift-rosa-hcp[]
-
-[%collapsible]
-====
-The table below only applies to non-STS clusters. The following components are used by Red Hat in extenuating circumstances.
-
-//Verify if the corresponding tables in policy-incident.adoc and rosa-policy-incident.adoc also need to be updated.
-
-[cols= "3a,2a,2a,3a",options="header"]
-
-|===
-|Component
-|Snapshot frequency
-|Retention
-|Notes
-
-.2+|Full object store backup
-|Daily
-|7 days
-.2+|This is a full backup of all Kubernetes objects like etcd. No persistent volumes (PVs) are backed up in this backup schedule.
-
-|Weekly
-|30 days
-
-|Full object store backup
-|Hourly
-|24 hour
-|This is a full backup of all Kubernetes objects like etcd. No PVs are backed up in this backup schedule.
-
-|Node root volume
-|Never
-|N/A
-|Nodes are considered to be short-term. Nothing critical should be stored on a node's root volume.
-|===
-
-endif::openshift-rosa-hcp[]
-====
-
-endif::openshift-rosa-hcp[]
 
 [id="rosa-sdpolicy-openshift-version_{context}"]
 == OpenShift version

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -81,18 +81,12 @@ include::modules/rosa-sdpolicy-security.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_rosa-service-definition"]
 == Additional resources
-
-* See 
 ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_policy_service_definition/rosa-policy-process-security.html#rosa-policy-process-security[Understanding process and security for ROSA]
+* * xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-responsibility-matrix[Shared responsibility matrix]
+* link:https://docs.openshift.com/rosa/rosa_policy_service_definition/rosa-policy-process-security.html#rosa-policy-process-security[Understanding process and security for ROSA]
+* link:https://docs.openshift.com/rosa/rosa_policy_service_definition/rosa-life-cycle.html#rosa-life-cycle[ROSA life cycle]
 endif::openshift-rosa-hcp[]
 ifndef::openshift-rosa-hcp[]
-xref:../rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding process and security for ROSA]
-endif::openshift-rosa-hcp[]
-* See 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_policy_service_definition/rosa-life-cycle.html#rosa-life-cycle[ROSA life cycle]
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[ROSA life cycle]
+* xref:../rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding process and security for ROSA]
+* xref:../rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[ROSA life cycle]
 endif::openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s): 4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13404

Link to docs preview:
- [HCP section in HCP docs](https://93891--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-backup-policy_rosa-hcp-service-definition)
- [HCP section in Classic docs](https://93891--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-backup-policy_rosa-hcp-service-definition)
- [Classic section in Classic docs](https://93891--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-backup-policy_rosa-service-definition)

QE review: N/A
