### PR TITLE
OSDOCS-13478-tidy: Updated tables in 4.19 release notes

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -701,11 +701,6 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.17 |4.18 |4.19
 
-|OpenShift SDN network plugin
-|Removed
-|Removed
-|Removed
-
 |iptables
 |Deprecated
 |Deprecated
@@ -1209,16 +1204,6 @@ In the following tables, features are marked with the following statuses:
 |On-cluster RHCOS image layering
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|Node disruption policies
-|General Availability
-|General Availability
-|General Availability
-
-|Updating boot images for GCP clusters
-|General Availability
-|General Availability
 |General Availability
 
 |Updating boot images for AWS clusters


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13478](https://issues.redhat.com/browse/OSDOCS-13478)

Link to docs preview:

[4.19 release notes](https://93892--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html)

