### PR TITLE
OSDOCS#11050: Check cluster notifs during troubleshooting

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -383,6 +383,8 @@ Topics:
 # rosa has own troubleshooting installations
 #  - Name: Troubleshooting installations
 #    File: troubleshooting-installations
+  - Name: Review your cluster notifications
+    File: mos-tshoot-cluster-notifications
   - Name: Troubleshooting ROSA installations
     File: rosa-troubleshooting-installations
   - Name: Troubleshooting ROSA with HCP installations

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -390,6 +390,8 @@ Topics:
 # rosa has own troubleshooting installations
 #  - Name: Troubleshooting installations
 #    File: troubleshooting-installations
+  - Name: Review your cluster notifications
+    File: mos-tshoot-cluster-notifications
   - Name: Troubleshooting ROSA installations
     File: rosa-troubleshooting-installations
   - Name: Troubleshooting ROSA with HCP installations

--- a/support/troubleshooting/mos-tshoot-cluster-notifications.adoc
+++ b/support/troubleshooting/mos-tshoot-cluster-notifications.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="mos-tshoot-cluster-notifications"]
+= Review your cluster notifications
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: tshoot-cluster-notifications
+
+toc::[]
+
+When you are trying to resolve a problem with your cluster, your cluster notifications are a good source of information.
+
+Cluster notifications are messages about the status, health, or performance of your cluster. They are also the primary way that Red Hat Site Reliability Engineering (SRE) communicates with you about cluster health and resolving problems with your cluster.
+
+include::modules/managed-cluster-notification-view-in-hcc.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-11050

Link to docs preview:
- [ROSA with HCP version](https://93894--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/troubleshooting/mos-tshoot-cluster-notifications.html)
- [ROSA Classic version](https://93894--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/mos-tshoot-cluster-notifications.html)

QE review: N/A - Support reviewed instead