### PR TITLE
OSDOCS-14773Network Observability - comparison table is screwed up

### DIFF
--- a/modules/network-observability-without-loki.adoc
+++ b/modules/network-observability-without-loki.adoc
@@ -10,15 +10,15 @@ You can use Network Observability without Loki by not performing the Loki instal
 [options="header"]
 |===
 |                                     | *With Loki* | *Without Loki*
-| *Exporters*                         | image:check-solid.png[,10] | image:check-solid.png[,10]
-| *Multi-tenancy*                     | image:check-solid.png[,10] | image:check-solid.png[,10]
-| *Complete filtering and aggregations capabilities* ^[1]^| image:check-solid.png[,10] | image:x-solid.png[,10]
-| *Partial filtering and aggregations capabilities* ^[2]^ | image:check-solid.png[,10] | image:check-solid.png[,10]
-| *Flow-based metrics and dashboards* | image:check-solid.png[,10] | image:check-solid.png[,10]
-| *Traffic flows view overview* ^[3]^  | image:check-solid.png[,10] | image:check-solid.png[,10]
-| *Traffic flows view table*       | image:check-solid.png[,10] | image:x-solid.png[,10]
-| *Topology view*                | image:check-solid.png[,10] | image:check-solid.png[,10]
-| *{product-title} console Network Traffic tab integration* | image:check-solid.png[,10] | image:check-solid.png[,10]
+| *Exporters*                         | X | X
+| *Multi-tenancy*                     | X | X
+| *Complete filtering and aggregations capabilities* ^[1]^| X |
+| *Partial filtering and aggregations capabilities* ^[2]^ | X | X
+| *Flow-based metrics and dashboards* | X | X
+| *Traffic flows view overview* ^[3]^  | X | X
+| *Traffic flows view table*       | X |
+| *Topology view*                | X | X
+| *{product-title} console Network Traffic tab integration* | X | X
 |===
 [.small]
 --


### PR DESCRIPTION
[OSDOCS-14773](https://issues.redhat.com//browse/OSDOCS-14773)Network Observability - comparison table is screwed up


Version(s):
OCP 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-14773

Link to docs preview:
https://93908--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-without-loki_network_observability

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Brings table in line with current style.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
