### PR TITLE
OSDOCS#13498: Updates to the learn more page for 4.19

### DIFF
--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -11,7 +11,7 @@ Use the following sections to find content to help you learn about and better un
 [id="support"]
 == Learning and support
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 | Learn about {product-title} |Optional additional resources
 
@@ -32,7 +32,7 @@ Use the following sections to find content to help you learn about and better un
 [id="architecture"]
 == Architecture
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 | Learn about {product-title} |Optional additional resources
 
@@ -54,7 +54,7 @@ Use the following sections to find content to help you learn about and better un
 == Installation
 Explore the following {product-title} installation tasks:
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 | Learn about installation on {product-title} |Optional additional resources
 
@@ -69,7 +69,7 @@ Explore the following {product-title} installation tasks:
 [id="other-cluster-installer-tasks"]
 == Other cluster installer tasks
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 | Learn about other installer tasks on {product-title} |Optional additional resources
 
@@ -84,7 +84,7 @@ Explore the following {product-title} installation tasks:
 [discrete]
 === Install a cluster in a restricted network
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn about installing in a restricted network |Optional additional resources
 
@@ -104,7 +104,7 @@ a| If your cluster uses user-provisioned infrastructure, and the cluster does no
 [discrete]
 === Install a cluster in an existing network
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn about installing in a restricted network |Optional additional resources
 
@@ -120,13 +120,14 @@ on Microsoft Azure, you can install a cluster
 [id="cluster-administrator"]
 == Cluster Administrator
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn about {product-title} cluster activities |Optional additional resources
 
 | xref:../architecture/architecture.adoc#architecture-overview-architecture[Understand {product-title} management]
 a|* xref:../machine_management/index.adoc#machine-api-overview_overview-of-machine-management[Machine API]
 * xref:../architecture/control-plane.adoc#operators-overview_control-plane[Operators]
+* * xref:../etcd/etcd-overview.adoc#etc-overview[etcd]
 
 | xref:../installing/overview/cluster-capabilities.adoc#enabling-cluster-capabilities_cluster-capabilities[Enable cluster capabilities]
 | xref:../installing/overview/cluster-capabilities.adoc#explanation_of_capabilities_cluster-capabilities[Optional cluster capabilities in {product-title} {product-version}]
@@ -139,17 +140,14 @@ a|* xref:../machine_management/index.adoc#machine-api-overview_overview-of-machi
 [discrete]
 ==== Managing cluster components
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn about managing cluster components |Optional additional resources
 
-| Manage xref:../machine_management/index.adoc#machine-mgmt-intro-managing-compute_overview-of-machine-management[compute] and xref:../machine_management/index.adoc#machine-mgmt-intro-managing-control-plane_overview-of-machine-management[control plane] machines with machine sets.
-|
+| Manage xref:../machine_management/index.adoc#machine-mgmt-intro-managing-compute_overview-of-machine-management[compute] and xref:../machine_management/index.adoc#machine-mgmt-intro-managing-control-plane_overview-of-machine-management[control plane] machines with machine sets
+| xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[Deploy machine health checks]
 
-| xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[Deploying machine health checks]
-| xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[About control plane machine sets]
-
-| xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[Applying autoscaling to an {product-title} cluster]
+| xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[Apply autoscaling to an {product-title} cluster]
 | xref:../nodes/pods/nodes-pods-priority.adoc#nodes-pods-priority[Including pod priority in pod scheduling decisions]
 
 | xref:../registry/index.adoc#registry-overview[Manage container registries]
@@ -180,11 +178,11 @@ a|* xref:../networking/networking_operators/cluster-network-operator.adoc#nw-clu
 [discrete]
 ==== Changing cluster components
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn more about changing cluster components |Optional additional resources
 
-| xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[Updating a cluster]
+| xref:../updating/understanding_updates/intro-to-updates.adoc#intro-to-updates[Introduction to OpenShift updates]
 a|* xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[Updating a cluster using the web console]
 * xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating using the CLI]
 * xref:../disconnected/updating/index.adoc#about-disconnected-updates[Using the OpenShift Update Service in a disconnected environment]
@@ -194,7 +192,7 @@ a|* xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-cr
 * xref:../operators/understanding/crds/crd-managing-resources-from-crds.adoc#crd-managing-resources-from-crds[Manage resources from CRDs]
 
 | xref:../applications/quotas/quotas-setting-per-project.adoc#quotas-setting-per-project[Set resource quotas]
-| xref:../applications/quotas/quotas-setting-per-project.adoc#quotas-setting-per-project[Set quotas]
+| xref:../applications/quotas/quotas-setting-across-multiple-projects.adoc#quotas-setting-across-multiple-projects[Resource quotas across multiple projects]
 
 | xref:../applications/pruning-objects.adoc#pruning-objects[Prune and reclaim resources]
 | xref:../cicd/builds/advanced-build-operations.adoc#builds-build-pruning-advanced-build-operations[Performing advanced builds]
@@ -207,12 +205,9 @@ a|* xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-cr
 [id="observe-cluster"]
 == Observe a cluster
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn about {product-title} |Optional additional resources
-
-// | //xref :../observability/logging/cluster-logging.adoc#cluster-logging[OpenShift Logging]
-// |
 
 | xref:../observability/distr_tracing/distr-tracing-rn.adoc#distr-tracing-rn[Release notes for the {DTProductName}]
 | xref:../observability/distr_tracing/distr-tracing-architecture.adoc#distr-tracing-architecture[{jaegername}]
@@ -233,7 +228,7 @@ a|* xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc
 [id="storage-activities"]
 == Storage activities
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn about {product-title} |Optional additional resources
 
@@ -246,7 +241,7 @@ a| * xref:../storage/understanding-persistent-storage.adoc#understanding-persist
 [id="application_site_reliability_engineer"]
 == Application Site Reliability Engineer (App SRE)
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn about {product-title} |Optional additional resources
 
@@ -256,40 +251,29 @@ a| * xref:../storage/understanding-persistent-storage.adoc#understanding-persist
 | xref:../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[Operators]
 | xref:../operators/operator-reference.adoc#cluster-operator-reference[Cluster Operator reference]
 
-|
-// | xref :../observability/logging/cluster-logging.adoc#cluster-logging[Logging]
-| link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[{product-title} Life Cycle]
-
-|
-| link:https://www.openshift.com/blog/tag/logging[Blogs about logging]
-
 |===
 
 [id="Developer"]
 == Developer
-Develop and deploy containerized applications with {product-title}. {product-title} is a platform for developing and deploying containerized applications. Read the following {product-title} documentation, so that you can better understand {product-title} functions:
+{product-title} is a platform for developing and deploying containerized applications. Read the following {product-title} documentation, so that you can better understand {product-title} functions:
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn about application development in {product-title} |Optional additional resources
 
 | link:https://developers.redhat.com/products/openshift/getting-started#assembly-field-sections-13455[Getting started with OpenShift for developers (interactive tutorial)]
-a|* xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating applications]
-* xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating applications using the Developer perspective]
-
-| xref:../architecture/understanding-development.adoc#understanding-development[Understand {product-title} development]
-a|* xref:../applications/projects/working-with-projects.adoc#working-with-projects[Work with projects]
+a|* xref:../architecture/understanding-development.adoc#understanding-development[Understanding {product-title} development]
+* xref:../applications/projects/working-with-projects.adoc#working-with-projects[Working with projects]
 * xref:../applications/deployments/what-deployments-are.adoc#what-deployments-are[Create deployments]
 
 | link:https://developers.redhat.com/[Red Hat Developers site]
-a|* xref:../cicd/builds/understanding-image-builds.adoc#understanding-image-builds[Builds]
-* xref:../cicd/builds/understanding-image-builds.adoc#understanding-image-builds[Understand image builds]
+| xref:../cicd/builds/understanding-image-builds.adoc#understanding-image-builds[Understanding image builds]
 
 | link:https://developers.redhat.com/products/openshift-dev-spaces/overview[{openshift-dev-spaces-productname} (formerly Red Hat CodeReady Workspaces)]
 | xref:../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[Operators]
 
 | xref:../openshift_images/index.adoc#overview-of-images[Create container images]
-| xref:../openshift_images/index.adoc#overview-of-images[Images]
+| xref:../openshift_images/managing_images/managing-images-overview.adoc#managing-images-overview[Managing images overview]
 
 | link:https://odo.dev/docs/introduction/[`odo`]
 | xref:../cli_reference/odo-important-update.adoc#odo-important_update[Developer-focused CLI]
@@ -308,7 +292,7 @@ a|* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-sched
 [id="self-managed-hcp"]
 == {hcp-capital}
 
-[options="header",cols="2*"]
+[options="header",cols="2*",width="%autowidth.stretch"]
 |===
 |Learn about {hcp} |Optional additional resources
 


### PR DESCRIPTION
Updating some things in the Learn more page. Includes some formatting updates to the tables.

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-13498

Link to docs preview:
https://93935--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/learn_more_about_openshift.html

QE review:

QE not needed for this change.

Additional information:

For writers to review:
- Do you have links to your product area? Are those links accurate?
- Do you have something **major** to add to these tables? That would apply to 4.19+.

We don't want to make these tables huge with a bunch of links, so think of it as a major feature for the product and not as a major feature for your product area specifically. 
