### PR TITLE
WMCO add link from 4.18 release notes

### DIFF
--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-18-x.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-18-x.adoc
@@ -7,3 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 include::modules/windows-containers-release-notes-10-18-1.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../windows_containers/enabling-windows-container-workloads.adoc#images-configuration-registry-mirror-configuring_enabling-windows-container-workloads[Configuring image registry repository mirroring]


### PR DESCRIPTION
A bug fix in WMCO 4.18.1 required "additional guidelines and requirements around using mirror registries have been added to the OpenShift Container Platform documentation." A [separate PR added those guidelines and requirements](https://github.com/openshift/openshift-docs/pull/92629). This PR adds a link from the WMCO 10.18.1 release notes to the new material.

Preview:
[Added Additional reference](https://93943--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-18-x.html) 

No QE
 