### PR TITLE
HCIDOCS-728: Update OSC variables for OCP docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -59,6 +59,7 @@ endif::[]
 :rh-rhacm: RHACM
 :rh-rhacm-version: 2.13
 :osc: OpenShift sandboxed containers
+:osc-operator: OpenShift sandboxed containers Operator
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
 :external-secrets-operator: External Secrets Operator for Red Hat OpenShift
 :external-secrets-operator-short: External Secrets Operator

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -56,7 +56,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 |Data collection for Local Storage Operator.
 
 |`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:v<installed_version_sandboxed_containers>`
-|Data collection for {sandboxed-containers-first}.
+|Data collection for {osc}.
 
 |`registry.redhat.io/workload-availability/node-healthcheck-must-gather-rhel8:v<installed-version-NHC>`
 |Data collection for the Red{nbsp}Hat Workload Availability Operators, including the Self Node Remediation (SNR) Operator, the Fence Agents Remediation (FAR) Operator, the Machine Deletion Remediation (MDR) Operator, the Node Health Check Operator (NHC) Operator, and the Node Maintenance Operator (NMO) Operator.

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -321,7 +321,7 @@ s| Feature s| {oke} s| {product-title} s| Operator name
 | Source to Image and Tekton Builders | Not included | Included | N/A
 | OpenShift Serverless FaaS | Not included | Included | N/A
 | IDE Integrations | Not included | Included | N/A
-| {sandboxed-containers-first} | Not included | Not included | {sandboxed-containers-operator}
+| {osc} | Not included | Not included | {osc-operator}
 | Windows Machine Config Operator | Community Windows Machine Config Operator included - no subscription required | Red Hat Windows Machine Config Operator included - Requires separate subscription | Windows Machine Config Operator
 | Red Hat Quay | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Quay Operator
 | Red Hat Advanced Cluster Management | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Advanced Cluster Management for Kubernetes


### PR DESCRIPTION
**Fixes:** [HCIDOCS-728](https://issues.redhat.com/browse/HCIDOCS-728)

**For:** OCP 4.15+

**Previews**
- [OpenShift Kubernetes Engine and OCP Feature summary table](https://93948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/oke_about#feature-summary)

- [Gathering data about specific features](https://93948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data#gathering-data-specific-features_gathering-cluster-data)

**Approvals -** `/lgtm`:
- [x] Peer Review
**Note:** SME and QE approvals are unnecessary; this PR is editorial, not procedural.