### PR TITLE
OSDOCS-13798 Modifying azure identity params with new default behavior

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1465,6 +1465,30 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
 |compute:
   platform:
     azure:
+      identity:
+        type:
+|The type of identity used for compute virtual machines.
+The `UserAssigned` identity is a standalone Azure resource provided by the user and assigned to compute virtual machines.
+If you specify `identity.type` as `UserAssigned`, but do not provide a user-assigned identity, the installation program creates the identity.
+If you provide a user-assigned identity, the Azure account that you use to create the identity must have either the "User Access Administrator" or "RBAC Access Admin" roles.
+|`UserAssigned` or `None`. If you do not specify a value, the installation program generates a user-assigned identity.
+
+|compute:
+  platform:
+    azure:
+      identity:
+        userAssignedIdentities:
+        - name:
+          resourceGroup:
+          subscription:
+|A group of parameters that specify the name of the user-assigned identity, and the resource group and subscription that contain the identity. All three values must be provided to specify a user-assigned identity.
+Only one user-assigned identity can be supplied.
+Supplying more than one user-assigned identity is an experimental feature, which may be enabled with the `MachineAPIMigration` feature gate.
+|Array of strings.
+
+|compute:
+  platform:
+    azure:
       vmNetworkingType:
 |Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance. If instance type of compute machines support `Accelerated` networking, by default, the installer enables `Accelerated` networking, otherwise the default networking type is `Basic`.
 |`Accelerated` or `Basic`.
@@ -1539,6 +1563,30 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
           securityEncryptionType:
 |Enables the encryption of the virtual machine guest state for compute nodes. This parameter can only be used if you use Confidential VMs.
 |`VMGuestStateOnly` is the only supported value.
+
+|controlPlane:
+  platform:
+    azure:
+      identity:
+        type:
+|The type of identity used for control plane virtual machines.
+The `UserAssigned` identity is a standalone Azure resource provided by the user and assigned to control plane virtual machines.
+If you specify `identity.type` as `UserAssigned`, but do not provide a user-assigned identity, the installation program creates the identity.
+If you provide a user-assigned identity, the Azure account that you use to create the identity must have either the "User Access Administrator" or "RBAC Access Admin" roles.
+|`UserAssigned` or `None`. If you do not specify a value, the installation program generates a user-assigned identity.
+
+|controlPlane:
+  platform:
+    azure:
+      identity:
+        userAssignedIdentities:
+        - name:
+          resourceGroup:
+          subscription:
+|A group of parameters that specify the name of the user-assigned identity, and the resource group and subscription that contain the identity. All three values must be provided to specify a user-assigned identity.
+Only one user-assigned identity can be supplied.
+Supplying more than one user-assigned identity is an experimental feature, which may be enabled with the `MachineAPIMigration` feature gate.
+|Array of strings.
 
 |controlPlane:
   platform:
@@ -1658,6 +1706,30 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
             virtualizedTrustedPlatformModule:
 |Enables the vTPM feature on all nodes if you are using trusted launch.
 |`Enabled` or `Disabled`. The default is `Disabled`.
+
+|platform:
+  azure:
+    defaultMachinePlatform:
+      identity:
+        type:
+|The type of identity used for all virtual machines.
+The `UserAssigned` identity is a standalone Azure resource provided by the user and assigned to all virtual machines.
+If you specify `identity.type` as `UserAssigned`, but do not provide a user-assigned identity, the installation program creates the identity.
+If you provide a user-assigned identity, the Azure account that you use to create the identity must have either the "User Access Administrator" or "RBAC Access Admin" roles.
+|`UserAssigned` or `None`. If you do not specify a value, the installation program generates a user-assigned identity.
+
+|platform:
+  azure:
+    defaultMachinePlatform:
+      identity:
+        userAssignedIdentities:
+        - name:
+          resourceGroup:
+          subscription:
+|A group of parameters that specify the name of the user-assigned identity, and the resource group and subscription that contain the identity. All three values must be provided to specify a user-assigned identity.
+Only one user-assigned identity can be supplied.
+Supplying more than one user-assigned identity is an experimental feature, which may be enabled with the `MachineAPIMigration` feature gate.
+|Array of strings.
 
 |platform:
   azure:

--- a/modules/minimum-required-permissions-ipi-azure.adoc
+++ b/modules/minimum-required-permissions-ipi-azure.adoc
@@ -12,6 +12,8 @@ The following options are available to you:
 
 * You can assign the identity the `Contributor` and `User Access Administrator` roles, which grant all of the required permissions.
 +
+If you set `identity.type` to `None` in the `install-config.yaml` file, you do not need to assign the `User Access Administrator` role to the service principal.
++
 For more information about assigning roles, see the Azure documentation for link:https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal[managing access to Azure resources using the Azure portal].
 
 * If the security policies of your organization require a more restrictive set of permissions, you can create a link:https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles[custom role] with the necessary permissions.
@@ -25,6 +27,26 @@ The following permissions are required for creating an {product-title} cluster o
 * `Microsoft.Authorization/policies/auditIfNotExists/action`
 * `Microsoft.Authorization/roleAssignments/read`
 * `Microsoft.Authorization/roleAssignments/write`
+====
+
+[IMPORTANT]
+====
+The following permissions are not required if you set `identity.type` to `None` in the `install-config.yaml` file:
+
+* `Microsoft.Authorization/roleAssignments/read`
+* `Microsoft.Authorization/roleAssignments/write`
+* `Microsoft.ManagedIdentity/userAssignedIdentities/assign/action`
+* `Microsoft.ManagedIdentity/userAssignedIdentities/read`
+* `Microsoft.ManagedIdentity/userAssignedIdentities/write`
+* `Microsoft.Authorization/roleAssignments/delete`
+
+The following permissions are not required if you set `identity.type` to `UserAssigned` in the `install-config.yaml` file and provide a user-assigned identity:
+
+* `Microsoft.Authorization/roleAssignments/read`
+* `Microsoft.Authorization/roleAssignments/write`
+* `Microsoft.ManagedIdentity/userAssignedIdentities/write`
+* `Microsoft.Authorization/roleAssignments/delete`
+
 ====
 
 .Required permissions for creating compute resources
@@ -132,6 +154,13 @@ The following permissions are not required to create the private {product-title}
 ====
 * `Microsoft.Resources/subscriptions/resourceGroups/read`
 * `Microsoft.Resources/subscriptions/resourcegroups/write`
+====
+
+.Optional permissions for attaching an existing user-assigned identity to a node
+[%collapsible]
+====
+* `Microsoft.ManagedIdentity/userAssignedIdentities/assign/action`
+* `Microsoft.ManagedIdentity/userAssignedIdentities/read`
 ====
 
 .Required permissions for creating resource tags


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-13798

Link to docs preview:
[Config parameters](https://93959--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure#installation-configuration-parameters-additional-azure_installation-config-parameters-azure)
[Required permissions](https://93959--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account#minimum-required-permissions-ipi-azure_installing-azure-account)

QE review:
- [x] QE has approved this change.
