### PR TITLE
OSDOCS-14472: RN for prefix feature

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -464,6 +464,14 @@ For more information, see xref:../updating/preparing_for_updates/updating-cluste
 [id="ocp-release-notes-machine-management_{context}"]
 === Machine management
 
+[id="ocp-4-19-cpms-prefix_{context}"]
+==== Custom prefixes for control plane machine names
+
+With this release, you can customize the prefix of machine names for machines created by the control plane machine set.
+This feature is enabled by modifying the `spec.machineNamePrefix` parameter of the `ControlPlaneMachineSet` custom resource.
+
+For more information, see xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-config-prefix_cpmso-configuration[Adding a custom prefix to control plane machine names].
+
 [id="ocp-release-notes-monitoring_{context}"]
 === Monitoring
 


### PR DESCRIPTION
[OSDOCS-14472](https://issues.redhat.com/browse/OSDOCS-14472)

Version(s): 4.19

This PR adds a release note for a feature to add custom prefixes to machine names in control plane machine sets.

QE review:
- [x] QE has approved this change.

Preview: [Release Note](https://93960--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-cpms-prefix_release-notes)
