### PR TITLE
TELCODOCS-1763: Bug change

### DIFF
--- a/modules/nvidia-gpu-csps.adoc
+++ b/modules/nvidia-gpu-csps.adoc
@@ -15,13 +15,13 @@ ifdef::openshift-dedicated[]
 endif::openshift-dedicated[]
 
 ifndef::openshift-dedicated,openshift-rosa[]
-You can deploy {product-title} to one of the major cloud service providers (CSPs): Amazon Web Services (AWS), Google Cloud Platform (GCP), or Microsoft Azure.
+You can deploy {product-title} to one of the major cloud service providers (CSPs): Amazon Web Services ({aws-short}), Google Cloud Platform ({gcp-short}), or Microsoft Azure.
 
 Two modes of operation are available: a fully managed deployment and a self-managed deployment.
 
-* In a fully managed deployment, everything is automated by Red Hat in collaboration with CSP. You can request an OpenShift instance through the CSP web console, and the cluster is automatically created and fully managed by Red Hat. You do not have to worry about node failures or errors in the environment. Red Hat is fully responsible for maintaining the uptime of the cluster. The fully managed services are available on AWS and Azure. For AWS, the OpenShift service is called ROSA (Red Hat OpenShift Service on AWS). For Azure, the service is called Azure Red Hat OpenShift.
+* In a fully managed deployment, everything is automated by Red{nbsp}Hat in collaboration with CSP. You can request an OpenShift instance through the CSP web console, and the cluster is automatically created and fully managed by Red{nbsp}Hat. You do not have to worry about node failures or errors in the environment. Red{nbsp}Hat is fully responsible for maintaining the uptime of the cluster. The fully managed services are available on {aws-short}, {azure-short}, and {gcp-short}. For {aws-short}, the OpenShift service is called ROSA (Red{nbsp}Hat OpenShift Service on AWS). For Azure, the service is called Azure Red{nbsp}Hat OpenShift. For {gcp-short}, the service is called OpenShift Dedicated on {gcp-short}.
 
-* In a self-managed deployment, you are responsible for instantiating and maintaining the OpenShift cluster. Red Hat provides the OpenShift-install utility to support the deployment of the OpenShift cluster in this case. The self-managed services are available globally to all CSPs.
+* In a self-managed deployment, you are responsible for instantiating and maintaining the OpenShift cluster. Red{nbsp}Hat provides the OpenShift-install utility to support the deployment of the OpenShift cluster in this case. The self-managed services are available globally to all CSPs.
 endif::openshift-dedicated,openshift-rosa[]
 
 ifdef::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
[enterprise-4.14] Issue in file architecture/nvidia-gpu-architecture-overview.adoc

Jira: https://issues.redhat.com/browse/TELCODOCS-1763

Version(s): 4.18+ CP:  openshift-4.17, openshift-4.16.z, openshift-4.15.z, openshift-4.14.z, openshift-4.13.z 

Issue:
Bug: Add 2 sentences for GCP. 

Link to docs preview: https://93962--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_accelerators/nvidia-gpu-architecture.html#nvidia-gpu-csps_nvidia-gpu-architecture

QE review: @wabouhamad 
- [ x] QE has approved this change.


