### PR TITLE
OCPBUGS#56008 known issue - Azure identity 'none' causes ACR pull failure

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -1718,6 +1718,8 @@ There is no workaround for this issue. (link:https://issues.redhat.com/browse/OC
 
 * {product-title} clusters that are installed on {aws-short} in the Mexico Central region (`mx-central-1`) cannot be destroyed. (link:https://issues.redhat.com/browse/OCPBUGS-56020[*OCPBUGS-56020*])
 
+* When installing a cluster on {azure-short}, if you set `compute.platform.azure.identity.type`, `controlplane.platform.azure.identity.type`, or `platform.azure.defaultMachinePlatform.identity.type` to "None", your cluster is unable to pull images from the Azure Container Registry. You can avoid this issue by providing a user-assigned identity, or by leaving the identity field blank, which causes the installation program to generate a user-assigned identity. (link:https://issues.redhat.com/browse/OCPBUGS-56008[*https://issues.redhat.com/browse/OCPBUGS-56008*])
+
 [id="ocp-telco-ran-4-19-known-issues_{context}"]
 
 [id="ocp-telco-core-4-19-known-issues_{context}"]


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OCPBUGS-56008

Link to docs preview:
https://93964--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-known-issues_release-notes

QE review:
- [x] QE has approved this change.
