### PR TITLE
OSDOCS-14804: Remove instances of "on-prem" from the Release Notes

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 {product-title} (ROSA) is a fully-managed, turnkey application platform that allows you to focus on delivering value to your customers by building and deploying applications. Red{nbsp}Hat and AWS site reliability engineering (SRE) experts manage the underlying platform so you do not have to worry about the complexity of infrastructure management. ROSA provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, and other services to further accelerate the building and delivering of differentiating experiences to your customers.
 
-{product-title} clusters are available on the link:https://console.redhat.com/openshift[Hybrid Cloud Console]. With the Red{nbsp}Hat {cluster-manager} application for ROSA, you can deploy {product-title} clusters to either on-premise or cloud environments.
+{product-title} clusters are available on the link:https://console.redhat.com/openshift[Hybrid Cloud Console]. With the Red{nbsp}Hat {cluster-manager} application for ROSA, you can deploy {product-title} clusters to cloud environments.
 
 [id="rosa-new-changes-and-updates_{context}"]
 == New changes and updates


### PR DESCRIPTION
[OSDOCS-14804](https://issues.redhat.com//browse/OSDOCS-14804): Remove instances of "on-prem" from the Release Notes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14804

Link to docs preview:
https://93971--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html

QE review:
No QE needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
