### PR TITLE
OSDOCS-14792: Documented the 4.15.52 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2780,13 +2780,43 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.52
+[id="ocp-4-15-52_{context}"]
+=== RHSA-2025:8299 - {product-title} 4.15.52 bug fix and security update
+
+Issued: 04 June 2025
+
+{product-title} release 4.15.52, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:8299[RHSA-2025:8299] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:8300[RHBA-2025:8300] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.52 --pullspecs
+----
+
+[id="ocp-4-15-52-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, a bug fix altered the availability set configuration by changing the fault domain count to use the maximum available value instead of being fixed at `2`. This inadvertently caused scaling issues for `MachineSets` created prior to the bug fix, as the controller attempted to modify immutable availability sets. With this release, availability sets are no longer modified after creation, allowing affected `MachineSets` to scale properly. (link:https://issues.redhat.com/browse/OCPBUGS-56657[OCPBUGS-56657])
+
+* Previously, the control plane Operator did not honor the set `*_PROXY` environment variables when it checked the API endpoint availability. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-52590[OCPBUGS-52590]) 
+
+* Previously, the build controller looked for secrets that were linked for general use, not specifically for the image pull. With this release, when searching for default image pull secrets, the builds use `ImagePullSecrets` that are linked to the service account. (link:https://issues.redhat.com/browse/OCPBUGS-54344[OCPBUGS-54344])
+
+[id="ocp-4-15-52-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.15.51
 [id="ocp-4-15-51_{context}"]
 === RHSA-2025:7698 - {product-title} 4.15.51 bug fix and security update
 
 Issued: 21 May 2025
 
-{product-title} release 4.15.51, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:7698[RHSA-2025:7698] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/2025:7700[RHBA-2025:7700] advisory.
+{product-title} release 4.15.51, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:7698[RHSA-2025:7698] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2025:7700[RHBA-2025:7700] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -2800,7 +2830,7 @@ $ oc adm release info 4.15.51 --pullspecs
 [id="ocp-4-15-51-known-issues_{context}"]
 ==== Known issues
 
-* Currently, the grandmaster clock (T-GM) transitions to the `Locked` state before the Digital Phase-Locked Loop (DPLL) transitions to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-55466[*OCPBUGS-55466*]). 
+* Currently, the grandmaster clock (T-GM) transitions to the `Locked` state before the Digital Phase-Locked Loop (DPLL) transitions to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-55466[OCPBUGS-55466]). 
 
 [id="ocp-4-15-51-bug-fixes_{context}"]
 ==== Bug fixes


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-14792](https://issues.redhat.com/browse/OSDOCS-14792)

Link to docs preview:

[4.15.52 z-stream notes](https://93976--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-52_release-notes)
