### PR TITLE
TELCODOCS-2186: Updating link variables for 4.19

### DIFF
--- a/modules/network-flow-matrix.adoc
+++ b/modules/network-flow-matrix.adoc
@@ -9,7 +9,7 @@
 The following network flow matrixes describe the ingress flows to {product-title} services for the following environments:
 
 * {product-title} on bare metal
-* {sno-caps} on bare metal
+* {sno-caps} with other platforms
 * {product-title} on {aws-first}
 * {sno-caps} on {aws-short}
 
@@ -23,13 +23,13 @@ Additionally, consider the following dynamic port ranges when managing ingress t
 
 To view or download the complete raw CSV content for an environment, see the following resources:
 
-* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/bm.csv[{product-title} on bare metal]
+* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/raw/bm.csv[{product-title} on bare metal]
 
-* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/bm-sno.csv[{sno-caps} on bare metal]
+* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/raw/none-sno.csv[{sno-caps} with other platforms]
 
-* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/aws.csv[{product-title} on {aws-short}]
+* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/raw/aws.csv[{product-title} on {aws-short}]
 
-* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/aws-sno.csv[{sno-caps} on {aws-short}]
+* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/raw/aws-sno.csv[{sno-caps} on {aws-short}]
 
 [NOTE]
 ====
@@ -50,14 +50,14 @@ For base ingress flows to {sno} clusters, see the _Control plane node base flows
 .Control plane node base flows
 [%header,format=csv]
 |===
-include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/common-master.csv[]
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/unique/common-master.csv[]
 |===
 
 [id="network-flow-matrix-worker_{context}"]
 .Worker node base flows
 [%header,format=csv]
 |===
-include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/common-worker.csv[]
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/unique/common-worker.csv[]
 |===
 
 [id="network-flow-matrix-bm_{context}"]
@@ -68,18 +68,18 @@ In addition to the base network flows, the following matrix describes the ingres
 .{product-title} on bare metal
 [%header,format=csv]
 |===
-include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/bm.csv[]
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/unique/bm.csv[]
 |===
 
 [id="network-flow-matrix-sno_{context}"]
-== Additional network flows for {sno} on bare metal
+== Additional network flows for {sno} with other platforms
 
-In addition to the base network flows, the following matrix describes the ingress flows to {product-title} services that are specific to {sno} on bare metal.
+In addition to the base network flows, the following matrix describes the ingress flows to {product-title} services that are specific to {sno} configured with `platform: none` in the installation manifest.
 
-.{sno-caps} on bare metal
+.{sno-caps} with other platforms
 [%header,format=csv]
 |===
-include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/bm-sno.csv[]
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/unique/none-sno.csv[]
 |===
 
 [id="network-flow-matrix-aws_{context}"]
@@ -90,7 +90,7 @@ In addition to the base network flows, the following matrix describes the ingres
 .{product-title} on AWS
 [%header,format=csv]
 |===
-include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/aws.csv[]
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/unique/aws.csv[]
 |===
 
 [id="network-flow-matrix-aws-sno_{context}"]
@@ -101,5 +101,5 @@ In addition to the base network flows, the following matrix describes the ingres
 .{sno-caps} on AWS
 [%header,format=csv]
 |===
-include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/aws-sno.csv[]
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.19/docs/stable/unique/aws-sno.csv[]
 |===


### PR DESCRIPTION
[TELCODOCS-2186](https://issues.redhat.com//browse/TELCODOCS-2186): Updating links for 4.19 

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2186

Link to docs preview:
https://93977--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html

Additional information:
No QE review required because this is just updating variables for 4.19
