### PR TITLE
OADP self-service uncomment topic map entries

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3723,17 +3723,17 @@ Topics:
     Topics:
     - Name: Restoring applications
       File: restoring-applications
-  #- Name: OADP Self-Service Note:Commenting out this block because the PR is huge and I would like to get the files merged. I will open a separate PR to un-comment this block on the date of GA.
-  #  Dir: oadp-self-service
-  #  Topics:
-  #  - Name: OADP Self-Service
-  #    File: oadp-self-service
-  #  - Name: OADP Self-Service cluster admin use cases
-  #    File: oadp-self-service-cluster-admin-use-cases
-  #  - Name: OADP Self-Service namespace admin use cases
-  #    File: oadp-self-service-namespace-admin-use-cases
-  #  - Name: OADP Self-Service troubleshooting
-  #    File: oadp-self-service-troubleshooting
+  - Name: OADP Self-Service
+    Dir: oadp-self-service
+    Topics:
+    - Name: OADP Self-Service
+      File: oadp-self-service
+    - Name: OADP Self-Service cluster admin use cases
+      File: oadp-self-service-cluster-admin-use-cases
+    - Name: OADP Self-Service namespace admin use cases
+      File: oadp-self-service-namespace-admin-use-cases
+    - Name: OADP Self-Service troubleshooting
+      File: oadp-self-service-troubleshooting
   - Name: OADP and ROSA
     Dir: oadp-rosa
     Topics:

--- a/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service.adoc
@@ -10,6 +10,8 @@ toc::[]
 
 include::modules/oadp-self-service-overview.adoc[leveloffset=+1]
 
+include::modules/oadp-self-service-namespace-scoped.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 

--- a/modules/oadp-self-service-about-nabsl.adoc
+++ b/modules/oadp-self-service-about-nabsl.adoc
@@ -19,7 +19,7 @@ You can create a NABSL CR by using one of the following workflows:
 ** If approved, a `Velero` `BackupStorageLocation` (BSL) is created in the `openshift-adp` namespace, and the NABSL CR status is updated to reflect the approval. 
 ** If rejected, the status of the NABSL CR is updated to reflect the rejection.
 .. The cluster administrator can also revoke a previously approved NABSL CR. The `approve` field is set back to `pending` or `reject`. This results in the deletion of the `Velero` BSL, and the namespace admin user is notified of the rejection. 
-* *Automatic approval workflow*: In this workflow, the cluster administrator has not enforced an approval process for the NABSL CR by setting the `nonAdmin.requireApprovalForBSL` field in the DPA to `false`. The default value of this field is `false`. Not setting the field results in an automatic approval of the NABSL. Therefore, the namespace admin user can create the NABSL CR from their authorized namespace.
+* *Automatic approval workflow*: In this workflow, the cluster administrator does not enforce an approval process for the NABSL CR by setting the `nonAdmin.requireApprovalForBSL` field in the DPA to `false`. The default value of this field is `false`. Not setting the field results in an automatic approval of the NABSL. Therefore, the namespace admin user can create the NABSL CR from their authorized namespace.
 
 [IMPORTANT]
 ====

--- a/modules/oadp-self-service-nab-nar-logs.adoc
+++ b/modules/oadp-self-service-nab-nar-logs.adoc
@@ -6,7 +6,7 @@
 [id="oadp-self-service-nab-nar-logs_{context}"]
 = Reviewing NAB and NAR logs
 
-As a namespace admin user, you can review the logs for the NAB and NAR custom resources (CRs) by creating a `NonAdminDownloadRequest` (NADR) CR.
+As a namespace admin user, you can review the logs for the `NonAdminBackup` (NAB) and `NonAdminRestore` (NAR) custom resources (CRs) by creating a `NonAdminDownloadRequest` (NADR) CR.
 
 [NOTE]
 ====
@@ -19,8 +19,8 @@ You can review the NAB logs only if you are using a `NonAdminBackupStorageLocati
 * The cluster administrator has installed the {oadp-short} Operator.
 * The cluster administrator has configured the `DataProtectionApplication` (DPA) CR to enable {oadp-short} Self-Service.
 * The cluster administrator has created a namespace for you and has authorized you to operate from that namespace.
-* You have a backup of your application by creating a `NonAdminBackup` (NAB) CR.
-* You have restored the application by creating a `NonAdminRestore` (NAR) CR.
+* You have a backup of your application by creating a NAB CR.
+* You have restored the application by creating a NAR CR.
 
 .Procedure
 

--- a/modules/oadp-self-service-namespace-permissions.adoc
+++ b/modules/oadp-self-service-namespace-permissions.adoc
@@ -20,9 +20,9 @@ A cluster administrator can also define their own specifications so that users c
 [id="oadp-self-service-yaml-backup-operation_{context}"]
 == Example RBAC YAML for backup operation
 
-See the following RBAC YAML file example with namespace permissions for a namespace `admin` user to perform a backup operation.
+See the following role-based access control (RBAC) YAML file example with namespace permissions for a namespace `admin` user to perform a backup operation.
 
-.Example RBAC
+.Example RBAC manifest
 [source,yaml]
 ----
 ...

--- a/modules/oadp-self-service-namespace-scoped.adoc
+++ b/modules/oadp-self-service-namespace-scoped.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-self-service-overview-namespace-scope_{context}"]
+= What namespace-scoped backup and restore means
+
+{oadp-short} Self-Service ensures that namespace admin users can only operate within their authorized namespace. For example, if you do not have access to a namespace, as a namespace admin user, you cannot back up that namespace.
+
+A namespace admin user cannot access backup and restore data of other users.
+
+The cluster administrator enforces the access control through custom resources (CRs) that securely manage the backup and restore operations.
+
+Additionally, the cluster administrator can control the allowed options within the CRs, restricting certain operations for added security by using `spec` enforcements in the `DataProtectionApplication` (DPA) CR.
+
+Namespace `admin` users can perform the following Self-Service operations:
+
+* Create and manage backups of their authorized namespaces.
+* Restore data to their authorized namespaces.
+* Configure their own backup storage locations.
+* Check backup and restore status.
+* Request retrieval of relevant logs.

--- a/modules/oadp-self-service-overview.adoc
+++ b/modules/oadp-self-service-overview.adoc
@@ -26,22 +26,3 @@ As a namespace admin user, you can back up and restore applications deployed in 
 ** You can create backup and restore custom resources for your authorized namespace.
 ** You can create dedicated backup storage locations in your authorized namespace.
 ** You have secure access to backup logs and status information.
-
-[id="oadp-self-service-overview-namespace-scope_{context}"]
-= What namespace-scoped backup and restore means
-
-{oadp-short} Self-Service ensures that namespace admin users can only operate within their authorized namespace. For example, if you do not have access to a namespace, as a namespace admin user, you cannot back up that namespace.
-
-A namespace admin user cannot access backup and restore data of other users.
-
-The cluster administrator enforces the access control through custom resources (CRs) that securely manage the backup and restore operations.
-
-Additionally, the cluster administrator can control the allowed options within the CRs, restricting certain operations for added security by using `spec` enforcements in the `DataProtectionApplication` (DPA) CR.
-
-Namespace `admin` users can perform the following Self-Service operations:
-
-* Create and manage backups of their authorized namespaces.
-* Restore data to their authorized namespaces.
-* Configure their own backup storage locations.
-* Check backup and restore status.
-* Request retrieval of relevant logs.

--- a/modules/oadp-self-service-phases.adoc
+++ b/modules/oadp-self-service-phases.adoc
@@ -6,17 +6,17 @@
 [id="oadp-self-service-phases_{context}"]
 = {oadp-short} Self-Service backup and restore phases
 
-The `status.phase` field of a `NonAdminBackup` (NAB) CR and a `NonAdminRestore` (NAR) CR provide an overview of the current state of the CRs. Review the values for the NAB and NAR phases in the following table.
+The `status.phase` field of a `NonAdminBackup` (NAB) custom resource (CR) and a `NonAdminRestore` (NAR) CR provide an overview of the current state of the CRs. Review the values for the NAB and NAR phases in the following table.
 
 The phase of the CRs only progress forward. Once a phase transitions to the next phase, it cannot revert to a previous phase.
 
 .Phases
 |===
 |*Value* |*Description*
-|New|A creation request of the NAB or NAR CR is accepted by the NAC, but it has not yet been validated by the NAC.
-|BackingOff|NAB or NAR CR is invalidated by the NAC CR because of an invalid `spec` of the NAB or NAR  CR. 
+|`New`|A creation request of the NAB or NAR CR is accepted by the NAC, but it has not yet been validated by the NAC.
+|`BackingOff`|NAB or NAR CR is invalidated by the NAC CR because of an invalid `spec` of the NAB or NAR  CR. 
 
 The namespace admin user can update the NAB or NAR `spec` to comply with the policies set by the administrator. After the namespace admin user edits the CRs, the NAC reconciles the CR again.
-|Created|NAB or NAR CR is validated by the NAC, and the `Velero` backup or restore object is created.
-|Deletion|NAB or NAR CR is marked for deletion. The NAC deletes the corresponding `Velero` backup or restore object. When the `Velero` object is deleted, the NAB or NAR CR is also deleted.
+|`Created`|NAB or NAR CR is validated by the NAC, and the `Velero` backup or restore object is created.
+|`Deletion`|NAB or NAR CR is marked for deletion. The NAC deletes the corresponding `Velero` backup or restore object. When the `Velero` object is deleted, the NAB or NAR CR is also deleted.
 |===

--- a/modules/oadp-self-service-unsupported-features.adoc
+++ b/modules/oadp-self-service-unsupported-features.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-self-service-unsupported-features_{context}"]
-= {oadp-short} Self-Service unsupported features
+= {oadp-short} Self-Service limitations
 
 The following features are not supported by {oadp-short} Self-Service:
 
@@ -14,7 +14,9 @@ The following features are not supported by {oadp-short} Self-Service:
 
 * The `ResourceModifiers` CR and volume policies are not supported for a namespace `admin` user.
 
-* A namespace `admin` user can request backup or restore logs by using the `NonAdminDownloadRequest` CR, only if the backup or restore is created by a user through the `NonAdminBackupStorageLocation` CR and not the cluster-wide default backup storage location.
+* A namespace `admin` user can request backup or restore logs by using the `NonAdminDownloadRequest` CR, only if the backup or restore is created by a user by using the `NonAdminBackupStorageLocation` CR. 
++
+If the backup or restore CRs are created by using the cluster-wide default backup storage location, a namespace `admin` user cannot request the backup or restore logs.
 
 * To ensure secure backup and restore, {oadp-short} Self-Service automatically excludes the following CRs from being backed up or restored:
 


### PR DESCRIPTION
## Jira 

* [OADP-4001](https://issues.redhat.com/browse/OADP-4001)

OADP Self-Service feature. This PR uncomments the _topic_map.yaml entries and addresses a few merge review comments.

The SMEs have already reviewed the [original PR](https://github.com/openshift/openshift-docs/pull/89043). And as such, this PR only focusses on uncommenting the topic map entries and a few merge review comments.

##  Version

* OCP 4.19 only

## Preview

* [Self-Service](https://93978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service)

* [Self-Service cluster admin use cases](https://93978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-cluster-admin-use-cases)

* [Self-Service namespace admin use cases](https://93978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-namespace-admin-use-cases)

* [Self-Service troubleshooting](https://93978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-troubleshooting)

## QE Review

* [x] QE has approved this change.
