### PR TITLE
OCPBUGS55735: OpenSSH key Setup

### DIFF
--- a/modules/configuring-secret-for-wmco.adoc
+++ b/modules/configuring-secret-for-wmco.adoc
@@ -11,7 +11,11 @@ To run the Windows Machine Config Operator (WMCO), you must create a secret in t
 .Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
-* You created a PEM-encoded file containing an RSA key.
+* You created a PEM-encoded file containing a private key by using a strong algorithm, such as ECDSA.
++
+--
+include::snippets/wmco-key-ascii-encoding.adoc[]
+--
 
 .Procedure
 

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -10,7 +10,13 @@ Create a vSphere Windows virtual machine (VM) golden image.
 
 .Prerequisites
 
-* You have created a private/public key pair, which is used to configure key-based authentication in the OpenSSH server. The private key must also be configured in the Windows Machine Config Operator (WMCO) namespace. This is required to allow the WMCO to communicate with the Windows VM. See the "Configuring a secret for the Windows Machine Config Operator" section for more details.
+* You have created a private/public key pair, which is used to configure key-based authentication in the OpenSSH server. The private key must be configured in the Windows Machine Config Operator (WMCO) namespace so that the WMCO can communicate with the Windows VM.
++
+--
+include::snippets/wmco-key-ascii-encoding.adoc[]
+--
++
+See the "Configuring a secret for the Windows Machine Config Operator" section for more details.
 
 [NOTE]
 ====

--- a/snippets/wmco-key-ascii-encoding.adoc
+++ b/snippets/wmco-key-ascii-encoding.adoc
@@ -1,0 +1,18 @@
+// Text snippet included in the following modules:
+//
+// * modules/configuring-secret-for-wmco.adoc
+// * modules/creating-the-vsphere-windows-vm-golden-image.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+If you created the key pair on a {op-system-base-full} system, before you can use the public key on a Windows system, make sure the public key is saved using ASCII encoding. For example, the following PowerShell command copies a public key, encoding it for the ASCII character set:
+
+[source,terminal]
+----
+C:\> echo "ssh-rsa <ssh_pub_key>" | Out-File <ssh_key_path> -Encoding ascii
+----
+
+where:
+
+`<ssh_pub_key>`:: Specifies the SSH public key used to access the cluster.
+`<ssh_key_path>`:: Specifies the path to the SSH public key.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-55735


Previews
* Windows Container Support for OpenShift -> Enabling Windows container workloads -> [Configuring a secret for the Windows Machine Config Operator](https://93983--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads#configuring-secret-for-wmco_enabling-windows-container-workloads) -- Note with second bullet.

* Windows Container Support for OpenShift -> Creating Windows machine sets -> [Creating the vSphere Windows VM golden image](https://93983--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#creating-the-vsphere-windows-vm-golden-image_creating-windows-machineset-vsphere) - Second paragraph

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
