### PR TITLE
TELCODOCS-2333: Event API v1: update examples for GET CurrentState

### DIFF
--- a/modules/cnf-fast-event-notifications-api-reference.adoc
+++ b/modules/cnf-fast-event-notifications-api-reference.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * networking/ptp/ptp-events-rest-api-reference.adoc
-
 :_mod-docs-content-type: PROCEDURE
 [id="cnf-fast-event-notifications-api-refererence_{context}"]
 = PTP events REST API v1 endpoints
@@ -317,15 +316,15 @@ Returns the current state of the `os-clock-sync-state`, `clock-class`, `lock-sta
     "version": "1.0",
     "values": [
       {
-        "resource": "/cluster/node/compute-1.example.com/ens5fx/master",
-        "dataType": "notification",
-        "valueType": "enumeration",
+        "ResourceAddress": "/cluster/node/compute-1.example.com/ens5fx/master",
+        "data_type": "notification",
+        "value_type": "enumeration",
         "value": "LOCKED"
       },
       {
-        "resource": "/cluster/node/compute-1.example.com/ens5fx/master",
-        "dataType": "metric",
-        "valueType": "decimal64.3",
+        "ResourceAddress": "/cluster/node/compute-1.example.com/ens5fx/master",
+        "data_type": "metric",
+        "value_type": "decimal64.3",
         "value": "29"
       }
     ]
@@ -348,15 +347,15 @@ Returns the current state of the `os-clock-sync-state`, `clock-class`, `lock-sta
     "version": "1.0",
     "values": [
       {
-        "resource": "/cluster/node/compute-1.example.com/CLOCK_REALTIME",
-        "dataType": "notification",
-        "valueType": "enumeration",
+        "ResourceAddress": "/cluster/node/compute-1.example.com/CLOCK_REALTIME",
+        "data_type": "notification",
+        "value_type": "enumeration",
         "value": "LOCKED"
       },
       {
-        "resource": "/cluster/node/compute-1.example.com/CLOCK_REALTIME",
-        "dataType": "metric",
-        "valueType": "decimal64.3",
+        "ResourceAddress": "/cluster/node/compute-1.example.com/CLOCK_REALTIME",
+        "data_type": "metric",
+        "value_type": "decimal64.3",
         "value": "27"
       }
     ]
@@ -377,9 +376,9 @@ Returns the current state of the `os-clock-sync-state`, `clock-class`, `lock-sta
     "version": "1.0",
     "values": [
       {
-        "resource": "/cluster/node/compute-1.example.com/ens5fx/master",
-        "dataType": "metric",
-        "valueType": "decimal64.3",
+        "ResourceAddress": "/cluster/node/compute-1.example.com/ens5fx/master",
+        "data_type": "metric",
+        "value_type": "decimal64.3",
         "value": "165"
       }
     ]
@@ -425,15 +424,15 @@ Returns the current state of the `os-clock-sync-state`, `clock-class`, `lock-sta
     "version": "1.0",
     "values": [
       {
-        "resource": "/cluster/node/compute-1.example.com/ens2fx/master",
-        "dataType": "notification",
-        "valueType": "enumeration",
+        "ResourceAddress": "/cluster/node/compute-1.example.com/ens2fx/master",
+        "data_type": "notification",
+        "value_type": "enumeration",
         "value": "LOCKED"
       },
       {
-        "resource": "/cluster/node/compute-1.example.com/ens2fx/master",
-        "dataType": "metric",
-        "valueType": "decimal64.3",
+        "ResourceAddress": "/cluster/node/compute-1.example.com/ens2fx/master",
+        "data_type": "metric",
+        "value_type": "decimal64.3",
         "value": "5"
       }
     ]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[TELCODOCS-2333](https://issues.redhat.com//browse/TELCODOCS-2333): Event API v1: update examples for GET CurrentState
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 

- 4.18
- 4.17
- 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2333
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[api/ocloudNotifications/v2/{resource_address}/CurrentState](https://94015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/ptp-events-rest-api-reference-v2#resource-address-current-state-v2_using-ptp-hardware-fast-events-framework-v2)

QE review: 
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
