### PR TITLE
[WIP] OSDOCS-14688: Improving intro content for Kueue alongside Operator descriptions

### DIFF
--- a/welcome/about-kueue.adoc
+++ b/welcome/about-kueue.adoc
@@ -6,19 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} is a Kubernetes-native system that manages access to resources for jobs.
-{product-title} can determine when a job waits, is admitted to start by creating pods, or should be _preempted_, meaning that active pods for that job are deleted.
+{product-title} is a collection of APIs, based on the link:https://kueue.sigs.k8s.io/docs/[Kueue] open source project, that extends Kubernetes to manage access to resources for jobs.
 
-[NOTE]
-====
-In the context of {product-title}, a job can be defined as a one-time or on-demand task that runs to completion.
-====
-
-{product-title} is based on the link:https://kueue.sigs.k8s.io/docs/[Kueue] open source project.
-
-{product-title} is compatible with environments that use heterogeneous, elastic resources. This means that the environment has many different resource types, and those resources are capable of dynamic scaling.
-
-{product-title} does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components.
+{product-title} does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be _preempted_, meaning that active pods for that job are deleted.
 
 {product-title} supports all-or-nothing semantics. This means that either an entire job with all of its components is admitted to the cluster, or the entire job is rejected if it does not fit on the cluster.
 


### PR DESCRIPTION
Version(s):
`kueue-docs` branch

Issue:
https://issues.redhat.com/browse/OSDOCS-14688

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
