### PR TITLE
OBSDOCS-1629: Fix tick

### DIFF
--- a/snippets/distr-tracing-tempo-tempostack-custom-resource.adoc
+++ b/snippets/distr-tracing-tempo-tempostack-custom-resource.adoc
@@ -37,7 +37,7 @@ spec:
       jaegerQuery:
         enabled: true # <13>
 ----
-<1> This CR creates a TempoStack deployment, which is configured to receive Jaeger Thrift over the HTTP and OpenTelemetry Protocol (OTLP).`
+<1> This CR creates a TempoStack deployment, which is configured to receive Jaeger Thrift over the HTTP and OpenTelemetry Protocol (OTLP).
 <2> The namespace that you have chosen for the TempoStack deployment.
 <3> Specifies the storage for storing traces.
 <4> The secret you created in step 2 for the object storage that had been set up as one of the prerequisites.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1629
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- https://94022--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr-tracing-tempo-installing#distr-tracing-tempo-install-tempostack-web-console_distr-tracing-tempo-installing
- https://94022--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr-tracing-tempo-installing#distr-tracing-tempo-install-tempostack-cli_distr-tracing-tempo-installing

QE review: N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
