### PR TITLE
[enterprise-4.12] OBSDOCS-1629: Missing attribute fix for cherrry-pick

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -116,6 +116,7 @@ endif::[]
 :DTProductName: Red Hat OpenShift Distributed Tracing Platform
 :DTShortName: Distributed Tracing Platform
 :DTProductVersion: 3.1
+:odf-full: Red Hat OpenShift Data Foundation
 :JaegerName: Red Hat OpenShift Distributed Tracing Platform (Jaeger)
 :JaegerOperator: Red Hat OpenShift Distributed Tracing Platform
 :JaegerShortName: Distributed Tracing Platform (Jaeger)


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1629
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94031--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr-tracing-tempo-installing#distr-tracing-tempo-object-storage-setup_distr-tracing-tempo-installing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A

Additional information: Cherry-pick fix
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
