### PR TITLE
OSDOCS#12859: Adds RFE console release notes

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -540,11 +540,11 @@ Image mode for OpenShift, formerly called on-cluster layering, is now Generally 
 
 * The `global-pull-secret-copy` is automatically added to the `openshift-machine-config-operator` namespace.
 
-* You can now revert an on-cluster custom layered image back to the base image by removing a label from the `MachineOSConfig` object 
+* You can now revert an on-cluster custom layered image back to the base image by removing a label from the `MachineOSConfig` object
 
-* You can now automatically delete an on-cluster custom layered image by deleting the associated `MachineOSBuild` object. 
+* You can now automatically delete an on-cluster custom layered image by deleting the associated `MachineOSBuild` object.
 
-* The `must-gather` for the Machine Config Operator now includes data on the `MachineOSConfig` and `MachineOSBuild` objects. 
+* The `must-gather` for the Machine Config Operator now includes data on the `MachineOSConfig` and `MachineOSBuild` objects.
 
 * On-cluster layering is now supported in disconnected environments.
 
@@ -553,9 +553,9 @@ Image mode for OpenShift, formerly called on-cluster layering, is now Generally 
 [id="ocp-release-notes-machine-config-operator-boot-image_{context}"]
 ==== Boot image management is now default for {gcp-first} and {aws-first}
 
-The boot image management feature, previously called updated boot images, is now the default behavior in {gcp-first} and {aws-first} clusters. As such, after updating to {product-title} {product-version}, the boot images in your cluster are automatically updated to version {product-version}. With subsequent updates, the Machine Config Operator (MCO) again updates the boot images in your cluster. A boot images is associated with a machine set and is used when scaling new nodes. Any new nodes you create after updating are based on the new version. Current nodes are not affected by this feature. 
+The boot image management feature, previously called updated boot images, is now the default behavior in {gcp-first} and {aws-first} clusters. As such, after updating to {product-title} {product-version}, the boot images in your cluster are automatically updated to version {product-version}. With subsequent updates, the Machine Config Operator (MCO) again updates the boot images in your cluster. A boot images is associated with a machine set and is used when scaling new nodes. Any new nodes you create after updating are based on the new version. Current nodes are not affected by this feature.
 
-Before upgrading to {product-version}, you must opt-out of this default behavior or acknowledge this change before proceeding. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-disable_machine-configs-configure[Disabling boot image management].  
+Before upgrading to {product-version}, you must opt-out of this default behavior or acknowledge this change before proceeding. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-disable_machine-configs-configure[Disabling boot image management].
 
 [NOTE]
 ====
@@ -569,7 +569,7 @@ The MCS signing key is stored in the `machine-config-server-ca` secret in the `o
 
 The MCS CA and MCS cert are valid for 10 years and are automatically rotated by the MCO at approximately 8 years. Upon update to {product-title} {product-version}, the CA signing key is not present. As a result, the CA bundle is immediately considered expired when the MCO certificate controller comes up. This expiration causes an immediate certificate rotation, even if the cluster is not 10 years old. After that point, the next rotation takes place at the standard 8 year period.
 
-For more information about the MCO certificates, see xref:../security/certificate_types_descriptions/machine-config-operator-certificates.adoc#cert-types-machine-config-operator-certificates[Machine Config Operator certificates]. 
+For more information about the MCO certificates, see xref:../security/certificate_types_descriptions/machine-config-operator-certificates.adoc#cert-types-machine-config-operator-certificates[Machine Config Operator certificates].
 
 [id="ocp-release-notes-management-console_{context}"]
 === Management console
@@ -677,7 +677,7 @@ For more information, see xref:../networking/ptp/ptp-cloud-events-consumer-dev-r
 [id="ocp-release-notes-machine-config-operator-cgroup-v1_{context}"]
 ==== cgroup v1 has been removed
 
-cgroup v1, which was deprecated in {product-title} 4.16, is no longer supported and has been removed from {product-title}. If your cluster is using cgroup v1, you must configure cgroup v2 before you can upgrade to  {product-title} {product-version}. All workloads must now be compatible with cgroup v2. 
+cgroup v1, which was deprecated in {product-title} 4.16, is no longer supported and has been removed from {product-title}. If your cluster is using cgroup v1, you must configure cgroup v2 before you can upgrade to  {product-title} {product-version}. All workloads must now be compatible with cgroup v2.
 
 For more information on cgroup v2, see xref:../architecture/index.adoc#architecture-about-cgroup-v2_architecture-overview[About Linux cgroup version 2] and link:https://www.redhat.com/en/blog/rhel-9-changes-context-red-hat-openshift-workloads[Red Hat Enterprise Linux 9 changes in the context of Red Hat OpenShift workloads] (Red{nbsp}Hat blog).
 
@@ -760,6 +760,20 @@ With this unified design, there is no longer a *Developer* perspective in the de
 The *Getting Started* pane in the web console provides resources such as, a tour of the console, information on setting up your cluster, a quick start for enabling the *Developer* perspective, and links to explore new features and capabilities.
 
 //See xref:../web_console/web-console-overview#enabling-developer-perspective_web-console_web-console-overview for more information on enabling the *Developer* perspective.
+//https://github.com/openshift/openshift-docs/pull/93644
+
+[id="ocp-release-notes-patternfly-6-upgrade_{context}"]
+==== Patternfly 6 upgrade
+
+The web console now uses Patternfly 6. Support for Patternfly 4 in the web console is no longer available.
+
+[discrete]
+This release also introduces the following updates to the web console. You can now do the following actions:
+
+* Specify distinct console logos for both light and dark themes using the `logos` field in the `.spec.customization.logos` configuration, allowing for more comprehensive branding.
+* Easily delete identity providers (IDPs) directly from the web console, streamlining authentication configuration without manual YAML file edits.
+* Easily set the default `StorageClass` directly in the web console.
+* Quickly find specific jobs in the web console by sorting the *Created* column by creation date and time.
 
 [id="ocp-4-19-notable-technical-changes_{context}"]
 == Notable technical changes
@@ -1053,15 +1067,16 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.17 |4.18 |4.19
 
+|`useModal` hook for dynamic plugin SDK
+|General Availability
+|General Availability
+|Deprecated
+
 |Patternfly 4
 |Deprecated
 |Deprecated
-|Deprecated
+|Removed
 
-|React Router 5
-|Deprecated
-|Deprecated
-|Deprecated
 |====
 
 [discrete]
@@ -1081,6 +1096,14 @@ In the following tables, features are marked with the following statuses:
 
 [id="ocp-4-19-deprecated-features_{context}"]
 === Deprecated features
+
+[id="ocp-4-19-useModal-dynamic-plugin-removed_{context}"]
+==== useModal hook for dynamic plugin SDK
+With this release, support for the `useModal` hook in dynamic plugins are deprecated.
+
+Starting with this release, use the `useOverlay` API hook to launch modals
+
+//For more information about `useOverlay`, see [Doc link to dynamic plugin api docs TBD.]
 
 [id="ocp-4-19-removed-features_{context}"]
 === Removed features


### PR DESCRIPTION
OSDOCS#12859: Adds RFE console release notes

Version(s):
4.19

Issue:
[Docs for [OCPSTRAT-1843](https://issues.redhat.com//browse/OCPSTRAT-1843) Console: Customer Happiness (RFEs) for 4.19](https://issues.redhat.com/browse/OSDOCS-12859)

Link to docs preview:
https://94036--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-web-console_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
