### PR TITLE
WMCO remove snippet from ifdef

### DIFF
--- a/modules/images-configuration-registry-mirror-configuring.adoc
+++ b/modules/images-configuration-registry-mirror-configuring.adoc
@@ -17,9 +17,7 @@ You can create postinstallation mirror configuration custom resources (CR) to re
 ifdef::winc[]
 [IMPORTANT]
 ====
-Windows images mirrored through `ImageDigestMirrorSet` and `ImageTagMirrorSet` objects have specific naming requirements. 
-
-include::snippets/wmco-mirror-naming-requirements.adoc[]
+Windows images mirrored through `ImageDigestMirrorSet` and `ImageTagMirrorSet` objects have specific naming requirements as described in "Using Windows containers with a mirror registry".
 ====
 endif::winc[]
 

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -55,22 +55,27 @@ include::modules/wmco-configure-debug-logging.adoc[leveloffset=+1]
 
 include::modules/wmco-cluster-wide-proxy.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
-
 * xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[Configuring the cluster-wide proxy].
 
 include::modules/wmco-disconnected-cluster.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
-
 * xref:../disconnected/mirroring/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../windows_containers/enabling-windows-container-workloads.adoc#wmco-disconnected-cluster_enabling-windows-container-workloads[Using Windows containers with a mirror registry]
+
 include::modules/nodes-nodes-rebooting-gracefully.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
 .Additional resources
 * xref:../nodes/nodes/nodes-nodes-rebooting.adoc#nodes-nodes-rebooting-gracefully_nodes-nodes-rebooting[Rebooting a {product-title} node gracefully]
 * xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd data]


### PR DESCRIPTION
Snippets are apparently not allowed in ifdef statements. They break the Pantheon build. This PR removes such a snippet that [was added here](https://github.com/openshift/openshift-docs/pull/92629/files#diff-27a101211672fed423ee44a9a33b205e3f03d0c45f9e6522c230de0a83cb70ed).

Preview:
[Configuring image registry repository mirroring](https://94037--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html#images-configuration-registry-mirror-configuring_enabling-windows-container-workloads) -- Edited Important note and link after module.


No QE

Do not merge 4.16 cherrypick until https://github.com/openshift/openshift-docs/pull/93939 is merged. 