### PR TITLE
Sign "~" is incorrectly placed in command

### DIFF
--- a/modules/persistent-storage-csi-vsphere-top-aware-infra-top.adoc
+++ b/modules/persistent-storage-csi-vsphere-top-aware-infra-top.adoc
@@ -12,7 +12,7 @@
 {product-title} recommends using the infrastructure object for specifying failure domains in a topology aware setup. Specifying failure domains in the infrastructure object and specify topology-categories in the `ClusterCSIDriver` object at the same time is an unsupported operation.
 ====
 
-== Procedure
+.Procedure
 . In the VMware vCenter vSphere client GUI, define appropriate zone and region catagories and tags.
 +
 While vSphere allows you to create categories with any arbitrary name, {product-title} strongly recommends use of `openshift-region` and `openshift-zone` names for defining topology.
@@ -25,7 +25,7 @@ For more information about vSphere categories and tags, see the VMware vSphere d
 +
 [source,terminal]
 ----
-~ $ oc edit clustercsidriver csi.vsphere.vmware.com -o yaml
+$ oc edit clustercsidriver csi.vsphere.vmware.com -o yaml
 ----
 +
 .Example output
@@ -56,7 +56,7 @@ spec:
 +
 [source,terminal]
 ----
-~ $ oc get csinode
+$ oc get csinode
 ----
 +
 .Example output
@@ -75,7 +75,7 @@ co8-4s88d-worker-zlk7d 1 47m
 +
 [source,terminal]
 ----
-~ $ oc get csinode co8-4s88d-worker-j2hmg -o yaml
+$ oc get csinode co8-4s88d-worker-j2hmg -o yaml
 ----
 +
 .Example output


### PR DESCRIPTION
- The sign "~" is incorrectly placed in the command. 
- Here is the documentation link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/storage/using-container-storage-interface-csi#procedure-3 

- "~" is incorrectly placed in the following command: 
~~~
~ $ oc edit clustercsidriver csi.vsphere.vmware.com -o yaml  
~~~
~~~
~ $ oc get csinode 
~~~
~~~
~ $ oc get csinode co8-4s88d-worker-j2hmg -o yaml
~~~

- We need to remove this "~" sign.
- This is an unnecessary sign, and there is no use of it. 
- Hence, we need to remove it.

- Here is the updated look:
~~~
$ oc edit clustercsidriver csi.vsphere.vmware.com -o yaml 
~~~
~~~  
$ oc get csinode
~~~
~~~
$ oc get csinode co8-4s88d-worker-j2hmg -o yaml
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.19, RHOCP 4.18, RHOCP 4.17, RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13, RHOCP 4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-14789

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://94038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
