### PR TITLE
Update persistent-storage-csi-vsphere-top-aware-results.adoc

### DIFF
--- a/modules/persistent-storage-csi-vsphere-top-aware-results.adoc
+++ b/modules/persistent-storage-csi-vsphere-top-aware-results.adoc
@@ -11,7 +11,7 @@ Creating persistent volume claims (PVCs) and PVs from the topology aware storage
 
 [source,terminal]
 ----
-~ $ oc get pv <pv-name> -o yaml
+$ oc get pv <pv_name> -o yaml
 ----
 
 .Example output
@@ -26,14 +26,14 @@ nodeAffinity:
       - key: topology.csi.vmware.com/openshift-zone <1>
         operator: In
         values:
-        - <openshift-zone>
-      -key: topology.csi.vmware.com/openshift-region <1>
+        - <openshift_zone>
+      - key: topology.csi.vmware.com/openshift-region <1>
         operator: In
         values:
-        - <openshift-region>
+        - <openshift_region>
 ...
 peristentVolumeclaimPolicy: Delete
-storageClassName: <zoned-storage-class-name> <2>
+storageClassName: <zoned_storage_class_name> <2>
 volumeMode: Filesystem
 ...
 ----


### PR DESCRIPTION
- Command structure must be adjusted appropriately.
- Here is the documentation link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/storage/using-container-storage-interface-csi#persistent-storage-csi-vsphere-top-aware-results_persistent-storage-csi-vsphere

- In the above command, <pv-name> is mentioned with `hyphens`.
- But as per the standard rule, it needs to be mentioned with an `underscore`.
- Hence, it should be changed to `<pv_name>. In addition, "~" is incorrectly placed in the command.
- This is an unnecessary sign, and there is no use of it.
- We need to remove this "~" sign.
- Also, need to add gap between "-" and "key": 

- Here is the updated look of the command: 
~~~
$ oc get pv <pv_name> -o yaml  
~~~

~~~
nodeAffinity:
  required:
    nodeSelectorTerms:
    - matchExpressions:
      - key: topology.csi.vmware.com/openshift-zone  1 
        operator: In
        values:
        - <openshift-zone>
      - key: topology.csi.vmware.com/openshift-region  2 
        operator: In
        values:
        - <openshift-region>
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.19, RHOCP 4.18, RHOCP 4.17, RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-14802

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://94039--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware-results_persistent-storage-csi-vsphere

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
