### PR TITLE
OSDOCS-14573: Adding ESO operator in release notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -62,6 +62,8 @@ endif::[]
 :osc: OpenShift sandboxed containers
 :osc-operator: OpenShift sandboxed containers Operator
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
+:external-secrets-operator: External Secrets Operator for Red Hat OpenShift
+:external-secrets-operator-short: External Secrets Operator
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
 :secondary-scheduler-operator: Secondary Scheduler Operator
 :descheduler-operator: Kube Descheduler Operator

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -956,6 +956,12 @@ With this release, the control plane supports TLS 1.3. You can now use the `Mode
 
 For more information, see xref:../security/tls-security-profiles.adoc#tls-profiles-kubernetes-configuring_tls-security-profiles[Configuring the TLS security profile for the control plane].
 
+[id="ocp-release-notes-eso-operator_{context}"]
+==== The {external-secrets-operator} (Technology Preview)
+With this release, you can use the {external-secrets-operator} to authenticate with the external secrets store, retrieve secrets, and inject the retrieved secrets into a native Kubernetes secret. The {external-secrets-operator} is available as a Technology Preview.
+
+For more information, see xref:../security/external_secrets_operator/index.adoc#index_external-secrets-operator-about[External Secrets Operator for Red Hat OpenShift overview]
+
 [id="ocp-release-notes-storage_{context}"]
 === Storage
 
@@ -2837,7 +2843,7 @@ $ oc adm release info 4.19.1 --pullspecs
 
 * Previously, the authentication process for the `/metrics` endpoint was missing a token review check and caused unauthorized requests. As a result, the {product-title} console was prone to `TargetDown` alerts. With this release, the token review for unauthorized requests occurs with the user token provided in the request context. As a result, unauthorized requests to the {product-title} console do not cause `TargetDown` alerts. (link:https://issues.redhat.com/browse/OCPBUGS-57180[OCPBUGS-57180])
 
-* Previously, the *Started* column was hidden when screen size was reduced. As a consequence, the `VirtualizedTable` component malfunctioned because of a missing sort function, and the table sorting functionality was affected on the `PipelineRun` list pages. With this release, the table component handles missing sort functions correctly for reduced screen sizes. (link:https://issues.redhat.com/browse/OCPBUGS-57110[OCPBUGS-57110]) 
+* Previously, the *Started* column was hidden when screen size was reduced. As a consequence, the `VirtualizedTable` component malfunctioned because of a missing sort function, and the table sorting functionality was affected on the `PipelineRun` list pages. With this release, the table component handles missing sort functions correctly for reduced screen sizes. (link:https://issues.redhat.com/browse/OCPBUGS-57110[OCPBUGS-57110])
 
 * Previously, if you configured a masthead logo for a theme but used the default settings for the rest of the theme, the logo shown on the user interface was inconsistent. With this release, the masthead logo displays a default option for both light and dark themes, improving the interface consistency. (link:https://issues.redhat.com/browse/OCPBUGS-57054[OCPBUGS-57054])
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14573](https://issues.redhat.com/browse/OSDOCS-14573)

Link to docs preview:
[External Secrets Operator for Red Hat OpenShift (Technology Preview)](https://94049--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-eso-operator_release-notes)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
