### PR TITLE
OSDOCS-14806: SSCSI supports disconnected environment

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -552,6 +552,12 @@ For more information, see xref:../security/tls-security-profiles.adoc#tls-profil
 [id="ocp-release-notes-storage_{context}"]
 === Storage
 
+[id="ocp-release-notes-sscsi-disconnected-environment-support_{context}"]
+==== Support for the Secrets Store CSI driver in disconnected environments
+With this release, the secrets store providers support using the {secrets-store-driver} in disconnected clusters.
+
+For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc#persistent-storage-csi-secrets-store-disconnect-environment_persistent-storage-csi-secrets-store[Support for disconnected environments].
+
 [id="ocp-release-notes-web-console_{context}"]
 === Web console
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14806](https://issues.redhat.com/browse/OSDOCS-14806)

Link to docs preview:
[Secrets Store CSI driver supports disconnected environments](https://94050--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-sscsi-disconnected-environment-support_release-notes)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
