### PR TITLE
RHDEVDOCS-6468: Adding a missing module in GitOps 1.16

### DIFF
--- a/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
+++ b/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
@@ -26,6 +26,9 @@ include::modules/gitops-installing-argo-rollouts-cli-on-linux.adoc[leveloffset=+
 // Installing Argo Rollouts CLI on Mac OS
 include::modules/gitops-installing-argo-rollouts-cli-on-mac-os.adoc[leveloffset=+1]
 
+// Enabling Argo Rollouts UI on an Argo CD instance 
+include::modules/gitops-enabling-argo-rollouts-ui-on-an-argo-cd-instance.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources

--- a/modules/gitops-enabling-argo-rollouts-ui-on-an-argo-cd-instance.adoc
+++ b/modules/gitops-enabling-argo-rollouts-ui-on-an-argo-cd-instance.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-enabling-argo-rollouts-ui-on-an-argo-cd-instance_{context}"]
+= Enabling Argo Rollouts UI on an Argo CD instance
+
+To enable Argo Rollouts UI on an Argo CD instance, complete the following steps.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
+
+* You have configured the `RolloutManager` custom resource (CR).
+
+.Procedure
+
+. Log in to the {OCP} web console.
+
+. In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators*.
+
+. Select *{gitops-title}* from the installed Operators list and click the *Argo CD* tab.
+
+. Select the Argo CD instance in the *Argo CD* tab under the `openshift-gitops` namespace.
+
+. Click *YAML* and add the following configuration to configure the Argo Rollouts UI:
++
+.Example enabling Argo Rollouts UI in the Argo CD CR
+[source,yaml]
+----
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:  
+  name: argocd
+spec:  
+  server:    
+    enableRolloutsUI: true # <1>
+----
+<1> Set this value to `true` to configure the `enableRolloutsUI` field.
+
+. Click *Save*.
+
+. In the *Administrator* perspective of the web console, go to the {rh-app-icon} menu and click *OpenShift GitOps* -> *Cluster Argo CD*. The login page of the Argo CD Web UI is displayed in a new window.
+
+. To access the Argo Rollouts UI in the Argo CD Web UI, configure a sample application that includes the Argo Rollouts resources.
++
+[NOTE]
+====
+The `enableRolloutsUI` field restarts the Argo CD server deployment pod. Therefore, it takes a few seconds for the Argo Rollouts extension to enable in the Argo CD Web UI.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6468

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Enabling Argo Rollouts UI on an Argo CD instance](https://94081--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.html#gitops-enabling-argo-rollouts-ui-on-an-argo-cd-instance_using-argo-rollouts-for-progressive-deployment-delivery)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: cfang@redhat.com
QE review: @varshab1210 
Peer review:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

A user, sshirodk@redhat.com, pointed out in this Slack [thread](https://redhat-internal.slack.com/archives/CMP95ST2N/p1748636741171949) that the module *Enabling Argo Rollouts UI on an Argo CD instance* was unavailable in the GitOps 1.16 branch. This PR is created to ensure that the missing module is added in the correct location. 

CC: sshirodk@redhat.com

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
