### PR TITLE
OSDOCS#14805: adding API section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1263,6 +1263,8 @@ Topics:
     File: external-secrets-operator-monitoring
   - Name: Uninstalling the External Secrets Operator
     File: external-secrets-operator-uninstall
+  - Name: External Secrets Operator APIs
+    File: external-secrets-operator-api
 - Name: Viewing audit logs
   File: audit-log-view
 - Name: Configuring the audit log policy

--- a/modules/eso-bitwarden-secret.adoc
+++ b/modules/eso-bitwarden-secret.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-bitwarden-secret_{context}"]
+= bitwardenSecretManagerProvider
+
+The `bitwardenSecretManagerProvider` field enables the bitwarden secrets manager provider and sets up the additional service required to connect to the bitwarden server.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `enabled`
+| _string_
+| `enabled` field enables the `bitwardenSecretManagerProvider`. you can set this field to `true` or `false`.
+| false
+| enum: [true false] +
+Optional
+
+| `secretRef`
+| _SecretReference_
+| `SecretRef` specifies the kubernetes secret that contains the TLS key pair for the bitwarden server. If this reference is not provided and `certManagerConfig` field is configured, the issuer defined in `certManagerConfig` generates the required certificate. The secret must use `tls.crt` for certificate, `tls.key` for the private key, and `ca.crt` for CA certificate.
+|
+| Optional
+|===

--- a/modules/eso-cert-manager-config.adoc
+++ b/modules/eso-cert-manager-config.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-cert-manager-config_{context}"]
+= certManagerConfig
+
+The `certManagerConfig` field configures the `cert-manager` Operator settings.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `enabled`
+| _string_
+| `enabled` specifies whether cert-manager must obtain and renew certificates for the webhook server instead of using built-in certificates. Set this field to `true` or `false`.
+| false
+| enum: [true false] +
+Required
+
+| `addInjectorAnnotations`
+| _string_
+| `addInjectorAnnotations` adds the `cert-manager.io/inject-ca-from` annotation to the webhooks and custom resource definitions (CRDs) to automatically configure the webhook with the `cert-manager` Operator certificate authority (CA). This requires CA Injector to be enabled in `cert-manager` Operator. Set this field to `true` or `false`.
+| false
+| enum: [true false] +
+Optional
+
+| `issuerRef`
+| _ObjectReference_
+| `issuerRef` contains details of the referenced object used for obtaining certificates. The object must exist in the `external-secrets` namespace unless a cluster-scoped `cert-manager` Operator issuer is used.
+|
+| Required
+
+| `certificateDuration`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
+| `certificateDuration` sets the validity period of the webhook certificate.
+| 8760h
+| Optional
+
+| `certificateRenewBefore`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
+| `certificateRenewBefore` sets the ahead time to renew the webhook certificate before expiry.
+| 30m
+| Optional
+|===

--- a/modules/eso-controller-config.adoc
+++ b/modules/eso-controller-config.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-controller-config_{context}"]
+= controllerConfig
+
+The `controllerConfig` field configures the operator to set the default values for installing `external-secrets` operand.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `namespace`
+| _string_
+| `namespace` configures the namespace for installing the `external-secrets` operand.
+| external-secrets
+| Optional
+
+| `labels`
+| _object (keys:string, values:string)_
+| `labels` field applies labels to all resources created for the `external-secrets` operand deployment.
+|
+| Optional
+|===

--- a/modules/eso-controller-status.adoc
+++ b/modules/eso-controller-status.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-controller-status_{context}"]
+= controllerStatus
+
+The `controllerStatus` field contains the observed conditions of the controllers used by the Operator.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `name`
+| _string_
+| `name` specifies the name of the controller for which the observed condition is recorded.
+|
+| Required
+
+| `conditions`
+| _array_
+| `conditions` contains information about the current state of the {external-secrets-operator-short} controllers.
+|
+|
+
+| `observedGeneration`
+| _integer_
+| `observedGeneration` represents the `.metadata.generation` on the observed resource.
+|
+| Minimum: 0
+|===

--- a/modules/eso-external-secrets-config.adoc
+++ b/modules/eso-external-secrets-config.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-config_{context}"]
+= externalSecretsConfig
+
+The `externalSecretsConfig` field configures the behavior of `external-secrets` operand.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `logLevel`
+| _integer_
+| `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
+| 1
+| The maximum range value is 5 +
+The minimum range value is 1 +
+Optional
+
+| `operatingNamespace`
+| _string_
+| `operatingNamespace` restricts the `external-secrets` operand operations to the provided namespace. Enabling this field disables `ClusterSecretStore` and `ClusterExternalSecret`.
+|
+| Optional
+
+| `bitwardenSecretManagerProvider`
+| _object_
+| `bitwardenSecretManagerProvider` enables the bitwarden secrets manager provider and sets up the additional service required for connecting to the bitwarden server.
+|
+| Optional
+
+| `webhookConfig`
+| _object_
+| `webhookConfig` configures webhook specifics of the `external-secrets` operand.
+|
+|
+
+| `certManagerConfig`
+| _object_
+| `certManagerConfig` configures `cert-manager` Operator settings that are used to generate certificates for the webhook and `bitwarden-sdk-server` components.
+|
+|Optional
+
+| `resources`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core[_ResourceRequirements_]
+| `resources` defines the resource requirements. You cannot change the value of this field after setting it initially. For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[]
+|
+| Optional
+
+| `affinity`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#affinity-v1-core[_Affinity_]
+| `affinity` sets the scheduling affinity rules. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[]
+|
+| Optional
+
+| `tolerations`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
+| `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
+|
+| Optional
+
+| `nodeSelector`
+| _object (keys:string, values:string)_
+| `nodeSelector` defines the scheduling criteria by using node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
+|
+| Optional
+|===

--- a/modules/eso-external-secrets-list.adoc
+++ b/modules/eso-external-secrets-list.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-list_{context}"]
+= externalSecretsList
+
+The `externalSecretsList` object fetches the list of `externalSecrets` objects.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`
+|
+|
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecretsList` for this API.
+|
+|
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta[_ListMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+|
+|
+
+| `items`
+| _array_
+| `Items` contains a list of `externalSecrets` objects.
+|
+|
+|===

--- a/modules/eso-external-secrets-manager-list.adoc
+++ b/modules/eso-external-secrets-manager-list.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager-list_{context}"]
+= externalSecretsManagerList
+
+The `externalSecretsManagerList` object fetches the list of `externalSecretsManager` objects.
+
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
+|
+|
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecretsManagerList` for this API.
+|
+|
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta[_ListMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+|
+|
+
+| `items`
+| _array_
+| `Items` contains a list of `externalSecretsManager` objects.
+|
+|
+|===

--- a/modules/eso-external-secrets-manager-spec.adoc
+++ b/modules/eso-external-secrets-manager-spec.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager-spec_{context}"]
+= externalSecretsManagerSpec
+
+The `externalSecretsManagerSpec` field defines the desired behavior of the `externalSecretsManager` object.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| type
+| Description
+| Default
+| Validation
+
+| `globalConfig`
+| _object_
+| `globalConfig` configures the behavior of deployments that {external-secrets-operator-short} manages.
+|
+| Optional
+
+| `feature`
+| _array_
+| `feature` enables the optional features of the Operator.
+|
+| Optional
+|===

--- a/modules/eso-external-secrets-manager-status.adoc
+++ b/modules/eso-external-secrets-manager-status.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager-status_{context}"]
+= externalSecretsManagerStatus
+
+The `externalSecretsManagerStatus` field shows the most recently observed status of the `externalSecretsManager` object.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `controllerStatus`
+|  _array_
+| `controllerStatus` holds the observed conditions of the controllers used by the Operator.
+|
+|
+
+| `lastTransitionTime`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta[_Time_]
+| `lastTransitionTime` records the most recent time the status of the condition changed.
+|
+| Format: date-time +
+Type: string
+|===

--- a/modules/eso-external-secrets-manager.adoc
+++ b/modules/eso-external-secrets-manager.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager_{context}"]
+= externalSecretsManager
+
+The `externalSecretsManager` object defines the configuration and information of deployments managed by the {external-secrets-operator-short}. Set the name to `cluster` as this allows only one instance of `externalSecretsManager` per cluster.
+
+You can configure global options and enable optional features by using `externalSecretsManager`. This serves as a centralized configuration for managing multiple controllers of the Operator. The Operator automatically creates the `externalSecretsManager` object during installation.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
+|
+|
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecretsManager` for this Object.
+|
+|
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+|
+|
+
+| `spec`
+| _object_
+| `spec` contains specifications of the desired behavior.
+|
+|
+
+| `status`
+| _object_
+| `status` displays the most recently observed state of the controllers in the {external-secrets-operator-short}.
+|
+|
+|===

--- a/modules/eso-external-secrets-spec.adoc
+++ b/modules/eso-external-secrets-spec.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-spec_{context}"]
+= externalSecretsSpec
+
+The `externalSecretsSpec` field defines the desired behavior of the `externalSecrets` object.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `externalSecretsConfig`
+| _object_
+| `externalSecretsConfig` configures the behavior of `external-secrets` operand.
+|
+| Optional
+
+| `controllerConfig`
+| _object_
+| `controllerConfig` configures the controller to set up defaults that enable `external-secrets` operand.
+|
+| Optional
+|===

--- a/modules/eso-external-secrets-status.adoc
+++ b/modules/eso-external-secrets-status.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-status_{context}"]
+= externalSecretsStatus
+
+The `externalSecretsStatus` field shows the most recently observed status of the `externalSecrets` Object.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `conditions`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta[_Condition_] _array_
+| `conditions` contains information about the current state of deployment.
+|
+|
+
+| `externalSecretsImage`
+| _string_
+| `externalSecretsImage` specifies the image name and tag used for deploy `external-secrets` operand.
+|
+|
+|===

--- a/modules/eso-external-secrets.adoc
+++ b/modules/eso-external-secrets.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets_{context}"]
+= externalSecrets
+
+The `externalSecrets` object defines the configuration and information for the managed `external-secrets` operand deployment. Set the name to `cluster` as `externalSecrets` object allows only one instance per cluster.
+
+Creating an `externalSecrets` object triggers the creation of a deployment that manages the `external-secrets` operand and maintains the desired state.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
+|
+|
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecrets` for this object.
+|
+|
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+|
+|
+
+| `spec`
+| _object_
+| `spec` Contains the specifications of the desired behavior of the `externalSecrets` object.
+|
+|
+
+| `status`
+| _object_
+| `status` displays the most recently observed status of the `externalSecrets` object.
+|
+|
+|===

--- a/modules/eso-feature.adoc
+++ b/modules/eso-feature.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-feature_{context}"]
+= feature
+
+The `feature` field enables the optional features.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `name`
+| _string_
+| `name` of the optional feature.
+|
+| Required
+
+| `enabled`
+| _boolean_
+| `enabled` determines whether the feature must be enabled.
+|
+| Required
+|===

--- a/modules/eso-global-config.adoc
+++ b/modules/eso-global-config.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-global-config_{context}"]
+= globalConfig
+
+The `globalConfig` field configures the behavior of the {external-secrets-operator-short}.
+
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `logLevel`
+| _integer_
+| `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
+| 1
+| The maximum range value is 5 +
+The minimum range value is 1 +
+Optional
+
+| `resources`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core[_ResourceRequirements_]
+| `resources` defines the resource requirements. You cannot change the value of this field after setting it initially. For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[]
+|
+| Optional
+
+| `affinity`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#affinity-v1-core[_Affinity_]
+| `affinity` sets the scheduling affinity rules. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[]
+|
+| Optional
+
+| `tolerations`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
+| `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
+|
+| Optional
+
+| `nodeSelector`
+| _object (keys:string, values:string)_
+| nodeSelector defines the scheduling criteria by using the node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
+|
+| Optional
+
+| `labels`
+| _object (keys:string, values:string)_
+| `labels` applies labels to all resources created for the `external-secrets` operand deployment.
+|
+| Optional
+|===

--- a/modules/eso-object-reference.adoc
+++ b/modules/eso-object-reference.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-object-reference_{context}"]
+= objectReference
+
+The `ObjectReference` field refers to an object by its name, kind, and group.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `name`
+| _string_
+| `name` specifies the name of the resource being referred to.
+|
+| Required
+
+| `kind`
+| _string_
+| `kind` specifies the kind of the resource being referred to.
+|
+| Optional
+
+| `group`
+| _string_
+| `group` specifies the group of the resource being referred to.
+|
+| Optional
+|===

--- a/modules/eso-secret-reference.adoc
+++ b/modules/eso-secret-reference.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-secret-reference_{context}"]
+= secretReference
+
+The `secretReference` field refers to a secret with the given name in the same namespace where it used.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `name`
+| _string_
+| `name` specifies the name of the secret resource being referred to.
+|
+| Required
+|===

--- a/modules/eso-web-hook-config.adoc
+++ b/modules/eso-web-hook-config.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-web-hook-config_{context}"]
+= webhookConfig
+
+The `webhookConfig` field configures the specifics of the `external-secrets` application webhook.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `certificateCheckInterval`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
+| `certificateCheckInterval` configures the polling interval to check certificate validity.
+| 5m
+| Optional
+|===

--- a/security/external_secrets_operator/external-secrets-operator-api.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-api.adoc
@@ -1,0 +1,93 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-api"]
+= {external-secrets-operator} APIs
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-api
+
+toc::[]
+
+{external-secrets-operator} uses the following two APIs to configure the `external-secrets` application deployment.
+
+//:FeatureName: The {external-secrets-operator}
+//include::snippets/technology-preview.adoc[leveloffset=+1]
+
+[cols="1,1,1",options="header"]
+|===
+| Group
+| Version
+| Kind
+
+| `operator.openshift.io`
+| `v1alpha1`
+| `externalsecrets`
+
+| `operator.openshift.io`
+| `v1alpha1`
+| `externalsecretsmanager`
+|===
+
+The following list contains the {external-secrets-operator} APIs:
+
+* ExternalSecrets
+* ExternalSecretsList
+* ExternalSecretsManager
+* ExternalSecretsManagerList
+
+//ExternalSecretsManagerList
+include::modules/eso-external-secrets-manager-list.adoc[leveloffset=+1]
+
+//ExternalSecretsManager
+include::modules/eso-external-secrets-manager.adoc[leveloffset=+1]
+
+//ExternalSecretsList
+include::modules/eso-external-secrets-list.adoc[leveloffset=+1]
+
+//ExternalSecrets
+include::modules/eso-external-secrets.adoc[leveloffset=+1]
+
+[id="external-secrets-operator-fields_{context}"]
+== Listing fields in {external-secrets-operator} APIs
+
+The following fields apply to the {external-secrets-operator} APIs.
+
+//ExternalSecretsManagerSpec
+include::modules/eso-external-secrets-manager-spec.adoc[leveloffset=+1]
+
+//externalSecretsManagerStatus
+include::modules/eso-external-secrets-manager-status.adoc[leveloffset=+1]
+
+//ExternalSecretsSpec
+include::modules/eso-external-secrets-spec.adoc[leveloffset=+1]
+
+//externalSecretsStatus
+include::modules/eso-external-secrets-status.adoc[leveloffset=+1]
+
+//GlobalConfig
+include::modules/eso-global-config.adoc[leveloffset=+1]
+
+//Feature
+include::modules/eso-feature.adoc[leveloffset=+1]
+
+//controllerStatus
+include::modules/eso-controller-status.adoc[leveloffset=+1]
+
+//ExternalSecretsConfig
+include::modules/eso-external-secrets-config.adoc[leveloffset=+1]
+
+//ControllerConfig
+include::modules/eso-controller-config.adoc[leveloffset=+1]
+
+//bitwardenSecretManagerProvider
+include::modules/eso-bitwarden-secret.adoc[leveloffset=+1]
+
+//WebhookConfig
+include::modules/eso-web-hook-config.adoc[leveloffset=+1]
+
+//CertManagerConfig
+include::modules/eso-cert-manager-config.adoc[leveloffset=+1]
+
+//ObjectReference
+include::modules/eso-object-reference.adoc[leveloffset=+1]
+
+//secretReference
+include::modules/eso-secret-reference.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-14805](https://issues.redhat.com/browse/OSDOCS-14805)

Link to docs preview:
[External Secrets Operator for Red Hat OpenShift APIs
](https://94101--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-api)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.