### PR TITLE
ROSA limits and scalability updates

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -237,10 +237,10 @@ Topics:
 - Name: ROSA IAM role resources
   File: rosa-sts-ocm-role
 ##### NOTE: THE BELOW IS REMOVED AS PART OF OSDOCS-13310
-# - Name: Limits and scalability
-#   File: rosa-limits-scalability
-#- Name: ROSA with HCP limits and scalability
-#  File: rosa-hcp-limits-scalability
+- Name: Limits and scalability
+  File: rosa-limits-scalability
+- Name: ROSA with HCP limits and scalability
+  File: rosa-hcp-limits-scalability
 ##### NOTE: THE ABOVE IS REMOVED AS PART OF OSDOCS-13310F
 - Name: Planning your environment
   File: rosa-planning-environment

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -168,10 +168,10 @@ Topics:
 - Name: Required IAM roles and resources
   File: rosa-hcp-prepare-iam-roles-resources
 ##### NOTE: THE BELOW IS REMOVED AS PART OF OSDOCS-13310
-# - Name: Limits and scalability
-#   File: rosa-limits-scalability
-#- Name: ROSA with HCP limits and scalability
-#  File: rosa-hcp-limits-scalability
+- Name: Limits and scalability
+  File: rosa-limits-scalability
+- Name: ROSA with HCP limits and scalability
+  File: rosa-hcp-limits-scalability
 ##### NOTE: THE ABOVE IS REMOVED AS PART OF OSDOCS-13310
 - Name: Required AWS service quotas
   File: rosa-sts-required-aws-service-quotas


### PR DESCRIPTION
Replaced by https://github.com/openshift/openshift-docs/pull/94203.

Version(s):

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
**Classic**: https://94102--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-limits-scalability
**HCP** (because I allowed them both to build in this PR but can edit as needed): https://94102--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-hcp-limits-scalability

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
