### PR TITLE
OSDOCS-13385: adds 4.19.0 async relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -60,13 +60,15 @@ With this release, configurable transport layer security (TLS) protocols on inte
 With this release, you can use the `microshift healthcheck` command with various options to run a basic health check on your applications. For more information, see xref:../microshift_running_apps/microshift-greenboot-workload-health-checks.adoc#microshift-greenboot-workload-health-checks[Greenboot workload health checks].
 
 [id="microshift-4-19-observability-metrics_{context}"]
-==== Collecting metrics using the {microshift-short} Observability service 
+==== Collecting metrics using the {microshift-short} Observability service
 
 With this release, you can configure the {microshift-short} Observability service to collect performance and usage metrics for monitoring resources. The following predefined configurations differ in the amount of data collected:
 
 * Small
 * Medium
 * Large (default)
+
+//For more information, see xref:../microshift_running_apps/microshift-observability-service.adoc#microshift-observability-service[Using {microshift-short}] Observability.
 
 [id="microshift-4-19-support_{context}"]
 === Support
@@ -130,9 +132,22 @@ The following functions related to checking workload health in the `/usr/share/m
 [id="microshift-4-19-bug-fixes_{context}"]
 == Bug fixes
 
-//[discrete]
-//[id="microshift-4-19-installation-bug-fixes"]
-//=== Installation
+* Before this update, using `microshift-gitops` in a disconnected environment failed because its manifests had the `imagePullPolicy` set to `Always`. In these cases, GitOps tried to pull images over a non-existent network and failed with an `ImagePullBackoff` error. With this update, the `imagePullPolicy` is set to `IfNotPresent`, which means that GitOps uses a local image and can start normally. (link:https://issues.redhat.com/browse/OCPBUGS-37938[OCPBUGS-37938])
+
+* Previously, specific cipher suites required by {microshift-short} etcd when using TLS 1.2 were not included in the {microshift-short} startup configuration file. As a result, {microshift-short} failed to start when using TLS 1.2. With this release, the required cipher suites are in the configuration file by default and {microshift-short} can start normally when using TLS 1.2. (link:https://issues.redhat.com/browse/OCPBUGS-48735[OCPBUGS-48735])
+
+* Previously, a `.nodename` file that holds the last hostname was created by MicroShift on startup non-atomically. When MicroShift's startup was interrupted, the `.nodename` file was left behind empty. This `.nodename` file was used on the next MicroShift startup, causing the node name to stored as an empty string. This caused the API Server to reject the kubelet's calls and the start up failed. With this release, the `.nodename` file is created atomically with each MicroShift start up, preventing the error. (link:https://issues.redhat.com/browse/OCPBUGS-48163[OCPBUGS-48163])
+
+* By default, the {microshift-short} Logical Volume Manager Storage (LVMS) image copied the manifest list for four platforms because of automatic digest preservation. This action caused unnecessary usage of disk and network space. With this release, the manifest list is replaced with images specific to each architecture. Now, the {microshift-short} LVMS images only contain supported platform images, saving on disk space and network bandwidth. (link:https://issues.redhat.com/browse/OCPBUGS-51329[OCPBUGS-51329])
+
+* Previously, the `kustomizer` sub-service was blocking `microshift.service` readiness by adding a manifest that required a webhook for a Custom Resource (CR) before {microshift-short} had started. This resulted `kustomizer` failing, causing {microshift-short} to fail. With this release, {microshift-short} is no longer dependent on the `kustomizer` sub-service, and can start even if a manifest is malformed by `kustomizer`. (link:https://issues.redhat.com/browse/OCPBUGS-51365[OCPBUGS-51365])
+
+* In previous versions of {microshift-short} and {op-system-base}, the {microshift-short} container-image-embedding procedure used the default container storage directory, which prevented proper image updates. With this release, the recommended image-embedding procedure was changed to use a dedicated directory for each image and a systemd service copying those embedded images into the default container storage. As a result, updates for {op-system-image} are applied as expected with {microshift-short} and embedded containers. (link:https://issues.redhat.com/browse/OCPBUGS-52420[OCPBUGS-52420])
+
+[id="microshift-4-19-known-issues_{context}"]
+== Known issues
+
+* The maximum transmission unit (MTU) value in {microshift-short} OVN-K overlay networking must be 100 bytes smaller than the MTU value of the base network. {microshift-short} automatically configures the value using the MTU value of the default gateway of the host. If the auto-configuration does not work correctly, the MTU value must be configured manually. For more information, see xref:../microshift_networking/microshift-cni.adoc#microshift-network-topology_microshift-about-ovn-k-plugin[Network topology].
 
 [id="microshift-4-19-additional-release-notes_{context}"]
 == Additional release notes
@@ -177,10 +192,12 @@ Red{nbsp}Hat Customer Portal user accounts must have systems registered and cons
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
 [id="microshift-4-19-0-dp_{context}"]
-=== RHEA-2025:1234 - {microshift-short} 4.19.0 bug fix and security update advisory
+=== RHEA-2024:11040 - {microshift-short} 4.19.0 bug fix and security update advisory
 
-Issued: XX Month 2025
+Issued: 17 June 2025
 
-{product-title} release 4.19.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2025:1234[RHEA-2025:1234] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:1234[RHSA-2025:1234] advisory.
+{product-title} release 4.19.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:11040[RHEA-2024:11040] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2024:11038[RHEA-2024:11038] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13384](https://issues.redhat.com/browse/OSDOCS-13384)

Link to docs previews:
[Known issues](https://94115--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-known-issues_release-notes)
[Bug fixes](https://94115--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-bug-fixes_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
