### PR TITLE
OSDOCS#14821: Updates to dynamic plugin sdk docs

### DIFF
--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -269,45 +269,6 @@ K8sResourceCommon type
 |===
 
 [discrete]
-== `VirtualizedTable`
-
-A component for making virtualized tables.
-
-.Example
-[source,text]
-----
-const MachineList: React.FC<MachineListProps> = (props) => {
-  return (
-    <VirtualizedTable<MachineKind>
-     {...props}
-     aria-label='Machines'
-     columns={getMachineColumns}
-     Row={getMachineTableRow}
-    />
-  );
-}
-----
-
-[cols=",",options="header",]
-|===
-|Parameter Name |Description
-|`data` |data for table
-|`loaded` |flag indicating data is loaded
-|`loadError` |error object if issue loading data
-|`columns` |column setup
-|`Row` |row setup
-|`unfilteredData` |original data without filter
-|`NoDataEmptyMsg` |(optional) no data empty message component
-|`EmptyMsg` |(optional) empty message component
-|`scrollNode` |(optional) function to handle scroll
-|`label` |(optional) label for table
-|`ariaLabel` |(optional) aria label
-|`gridBreakPoint` |sizing of how to break up grid for responsiveness
-|`onSelect` |(optional) function for handling select of table
-|`rowData` |(optional) data specific to row
-|===
-
-[discrete]
 == `TableData`
 
 Component for displaying table data within a table row.
@@ -516,96 +477,6 @@ const exampleList: React.FC<MyProps> = () => {
 determine access
 
 |`children` |(optional) children for the dropdown toggle
-|===
-
-[discrete]
-== `ListPageFilter`
-
-Component that generates filter for list page.
-
-.Example
-[source,tsx]
-----
-  // See implementation for more details on RowFilter and FilterValue types
-  const [staticData, filteredData, onFilterChange] = useListPageFilter(
-    data,
-    rowFilters,
-    staticFilters,
-  );
-  // ListPageFilter updates filter state based on user interaction and resulting filtered data can be rendered in an independent component.
-  return (
-    <>
-      <ListPageHeader .../>
-      <ListPagBody>
-        <ListPageFilter data={staticData} onFilterChange={onFilterChange} />
-        <List data={filteredData} />
-      </ListPageBody>
-    </>
-  )
-----
-
-[cols=",",options="header",]
-|===
-|Parameter Name |Description
-|`data` |An array of data points
-
-|`loaded` |indicates that data has loaded
-
-|`onFilterChange` |callback function for when filter is updated
-
-|`rowFilters` |(optional) An array of RowFilter elements that define the
-available filter options
-
-|`nameFilterPlaceholder` |(optional) placeholder for name filter
-
-|`labelFilterPlaceholder` |(optional) placeholder for label filter
-
-|`hideLabelFilter` |(optional) only shows the name filter instead of
-both name and label filter
-
-|`hideNameLabelFilter` |(optional) hides both name and label filter
-
-|`columnLayout` |(optional) column layout object
-
-|`hideColumnManagement` |(optional) flag to hide the column management
-|===
-
-[discrete]
-== `useListPageFilter`
-
-A hook that manages filter state for the ListPageFilter component. It returns a tuple containing the data filtered by all static filters, the data filtered by all static and row filters, and a callback that updates rowFilters.
-
-.Example
-[source,tsx]
-----
-  // See implementation for more details on RowFilter and FilterValue types
-  const [staticData, filteredData, onFilterChange] = useListPageFilter(
-    data,
-    rowFilters,
-    staticFilters,
-  );
-  // ListPageFilter updates filter state based on user interaction and resulting filtered data can be rendered in an independent component.
-  return (
-    <>
-      <ListPageHeader .../>
-      <ListPagBody>
-        <ListPageFilter data={staticData} onFilterChange={onFilterChange} />
-        <List data={filteredData} />
-      </ListPageBody>
-    </>
-  )
-----
-
-[cols=",",options="header",]
-|===
-|Parameter Name |Description
-|`data` |An array of data points
-
-|`rowFilters` |(optional) An array of RowFilter elements that define the
-available filter options
-
-|`staticFilters` |(optional) An array of FilterValue elements that are
-statically applied to the data
 |===
 
 [discrete]
@@ -1364,14 +1235,42 @@ tooltip.
 |===
 
 [discrete]
-== `useModal`
+== `useOverlay`
 
-A hook to launch Modals.
+The `useOverlay` hook inserts a component directly to the DOM outside the web console's page structure. This allows the component to be freely styled and positioning with CSS. For example, to float the overlay in the top right corner of the UI: `style={{ position: 'absolute', right: '2rem', top: '2rem', zIndex: 999 }}`. It is possible to add multiple overlays by calling `useOverlay` multiple times. A `closeOverlay` function is passed to the overlay component. Calling it removes the component from the DOM without affecting any other overlays that might have been added with `useOverlay`. Additional props can be passed to `useOverlay` and they will be passed through to the overlay component.
 
 .Example
 [source,tsx]
 ----
-const context: AppPage: React.FC = () => {<br/> const [launchModal] = useModal();<br/> const onClick = () => launchModal(ModalComponent);<br/> return (<br/>   <Button onClick={onClick}>Launch a Modal</Button><br/> )<br/>}<br/>`
+const OverlayComponent = ({ closeOverlay, heading }) => {
+  return (
+    <div style={{ position: 'absolute', right: '2rem', top: '2rem', zIndex: 999 }}>
+      <h2>{heading}</h2>
+      <Button onClick={closeOverlay}>Close</Button>
+    </div>
+  );
+};
+
+const ModalComponent = ({ body, closeOverlay, title }) => (
+  <Modal isOpen onClose={closeOverlay}>
+    <ModalHeader title={title} />
+    <ModalBody>{body}</ModalBody>
+  </Modal>
+);
+
+const AppPage: React.FC = () => {
+  const launchOverlay = useOverlay();
+  const onClickOverlay = () => {
+    launchOverlay(OverlayComponent, { heading: 'Test overlay' });
+  };
+  const onClickModal = () => {
+    launchOverlay(ModalComponent, { body: 'Test modal', title: 'Overlay modal' });
+  };
+  return (
+    <Button onClick={onClickOverlay}>Launch an Overlay</Button>
+    <Button onClick={onClickModal}>Launch a Modal</Button>
+  )
+}
 ----
 
 [discrete]
@@ -1691,9 +1590,138 @@ Deprecated: This hook is not related to console functionality. Hook that ensures
 :!power-bi-url:
 
 [discrete]
+== `VirtualizedTable`
+
+Deprecated: Use PatternFly's link:https://www.patternfly.org/extensions/data-view/overview/[Data view] instead. A component for making virtualized tables.
+
+.Example
+[source,text]
+----
+const MachineList: React.FC<MachineListProps> = (props) => {
+  return (
+    <VirtualizedTable<MachineKind>
+     {...props}
+     aria-label='Machines'
+     columns={getMachineColumns}
+     Row={getMachineTableRow}
+    />
+  );
+}
+----
+
+[cols=",",options="header",]
+|===
+|Parameter Name |Description
+|`data` |data for table
+|`loaded` |flag indicating data is loaded
+|`loadError` |error object if issue loading data
+|`columns` |column setup
+|`Row` |row setup
+|`unfilteredData` |original data without filter
+|`NoDataEmptyMsg` |(optional) no data empty message component
+|`EmptyMsg` |(optional) empty message component
+|`scrollNode` |(optional) function to handle scroll
+|`label` |(optional) label for table
+|`ariaLabel` |(optional) aria label
+|`gridBreakPoint` |sizing of how to break up grid for responsiveness
+|`onSelect` |(optional) function for handling select of table
+|`rowData` |(optional) data specific to row
+|===
+
+[discrete]
+== `ListPageFilter`
+
+Deprecated: Use PatternFly's link:https://www.patternfly.org/extensions/data-view/overview/[Data view] instead. Component that generates filter for list page.
+
+.Example
+[source,tsx]
+----
+  // See implementation for more details on RowFilter and FilterValue types
+  const [staticData, filteredData, onFilterChange] = useListPageFilter(
+    data,
+    rowFilters,
+    staticFilters,
+  );
+  // ListPageFilter updates filter state based on user interaction and resulting filtered data can be rendered in an independent component.
+  return (
+    <>
+      <ListPageHeader .../>
+      <ListPagBody>
+        <ListPageFilter data={staticData} onFilterChange={onFilterChange} />
+        <List data={filteredData} />
+      </ListPageBody>
+    </>
+  )
+----
+
+[cols=",",options="header",]
+|===
+|Parameter Name |Description
+|`data` |An array of data points
+
+|`loaded` |indicates that data has loaded
+
+|`onFilterChange` |callback function for when filter is updated
+
+|`rowFilters` |(optional) An array of RowFilter elements that define the
+available filter options
+
+|`nameFilterPlaceholder` |(optional) placeholder for name filter
+
+|`labelFilterPlaceholder` |(optional) placeholder for label filter
+
+|`hideLabelFilter` |(optional) only shows the name filter instead of
+both name and label filter
+
+|`hideNameLabelFilter` |(optional) hides both name and label filter
+
+|`columnLayout` |(optional) column layout object
+
+|`hideColumnManagement` |(optional) flag to hide the column management
+|===
+
+[discrete]
+== `useListPageFilter`
+
+Deprecated: Use PatternFly's link:https://www.patternfly.org/extensions/data-view/overview/[Data view] instead. A hook that manages filter state for the ListPageFilter component. It returns a tuple containing the data filtered by all static filters, the data filtered by all static and row filters, and a callback that updates rowFilters.
+
+.Example
+[source,tsx]
+----
+  // See implementation for more details on RowFilter and FilterValue types
+  const [staticData, filteredData, onFilterChange] = useListPageFilter(
+    data,
+    rowFilters,
+    staticFilters,
+  );
+  // ListPageFilter updates filter state based on user interaction and resulting filtered data can be rendered in an independent component.
+  return (
+    <>
+      <ListPageHeader .../>
+      <ListPagBody>
+        <ListPageFilter data={staticData} onFilterChange={onFilterChange} />
+        <List data={filteredData} />
+      </ListPageBody>
+    </>
+  )
+----
+
+[cols=",",options="header",]
+|===
+|Parameter Name |Description
+|`data` |An array of data points
+
+|`rowFilters` |(optional) An array of RowFilter elements that define the
+available filter options
+
+|`staticFilters` |(optional) An array of FilterValue elements that are
+statically applied to the data
+|===
+
+[discrete]
 == `YAMLEditor`
 
-Deprecated: A basic lazy loaded YAML editor with hover help and completion.
+Deprecated: Use `CodeEditor` instead. A basic lazy loaded YAML editor with hover help and completion.
 
 .Example
 [source,text]
@@ -1727,3 +1755,20 @@ section on top of the editor.
 the `editor` property, you are able to access to all methods to control
 the editor.
 |===
+
+[discrete]
+== `useModal`
+
+Deprecated: Use `useOverlay` from `@console/dynamic-plugin-sdk` instead. A hook to launch Modals.
+
+.Example
+[source,tsx]
+----
+const AppPage: React.FC = () => {
+ const launchModal = useModal();
+ const onClick = () => launchModal(ModalComponent);
+ return (
+   <Button onClick={onClick}>Launch a Modal</Button>
+ )
+}
+----

--- a/modules/dynamic-plugin-sdk-extensions.adoc
+++ b/modules/dynamic-plugin-sdk-extensions.adoc
@@ -1483,7 +1483,7 @@ custom environment variables for
 [discrete]
 == `console.dashboards/overview/detail/item`
 
-Deprecated. use `CustomOverviewDetailItem` type instead
+Deprecated: use `CustomOverviewDetailItem` type instead.
 
 [cols=",,,",options="header",]
 |===
@@ -1495,7 +1495,7 @@ on the `DetailItem` component
 [discrete]
 == `console.page/resource/tab`
 
-Deprecated. Use `console.tab/horizontalNav` instead. Adds a new resource tab page to Console router.
+Deprecated: Use `console.tab/horizontalNav` instead. Adds a new resource tab page to Console router.
 
 [cols=",,,",options="header",]
 |===


### PR DESCRIPTION
Updates to the dynamic plugin sdk docs- mainly marking as deprecated. Incorporates https://github.com/openshift/console/pull/14707 

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14821

Link to docs preview:
Direct links to deprecated entries 
https://94126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/dynamic-plugins-reference.html#dynamic-plugin-api_dynamic-plugins-reference:~:text=context%20values%20object.-,PerspectiveContext,-Deprecated%3A%20Use%20the

Direct link to useOverlay entry
https://94126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/dynamic-plugins-reference.html#dynamic-plugin-api_dynamic-plugins-reference:~:text=for%20the%20component.-,useOverlay,-The%20useOverlay%20hook

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Note to peer review its not really a large! Just adding things in from https://github.com/openshift/console/blob/main/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
