### PR TITLE
OSDOCS#14791:Update the z-stream RN for 4.18.16

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3021,6 +3021,44 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.16
+[id="ocp-4-18-16_{context}"]
+=== RHSA-2025:8284 - {product-title} {product-version}.16 bug fix update
+
+Issued: 03 June 2025
+
+{product-title} release {product-version}.16 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:8284[RHSA-2025:8284] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:8285[RHBA-2025:8285] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.16 --pullspecs
+----
+
+[id="ocp-4-18-16-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, in non-Zonal Azure regions, a bug in the dynamically computed fault domain count update caused scaling failures. This issue prevented upgrades to {product-title} version 4.15.48 and later from scaling existing machine sets. With this release, an update is implemented that rectifies the dynamic fault domain calculation and prevents scaling failures in non-Zonal regions. This fix ensures smooth operation of machine set scaling after upgrading to {product-title} version 4.15.48 and later. (link:https://issues.redhat.com/browse/OCPBUGS-56654[OCPBUGS-56654])
+
+* Previously, API server subject alternative name (SAN) validation was performed regardless of public key infrastructure (PKI) reconciliation status, causing potential connectivity issues with hosted control plane clusters due to invalid SANs. With this release, a fix removes validation for {product-title} API server SANs when PKI reconciliation is disabled. The hosted control plane performance is improved by eliminating unnecessary validation, especially when the PKI reconciliation is not managed. (link:https://issues.redhat.com/browse/OCPBUGS-56627[OCPBUGS-56627])
+
+* Previously, a bug in the Bare Metal Operator (BMO) caused JSON parsing errors because of a missing Redfish system ID in Baseboard Management Controller (BMC) URLs. This issue caused users to receive errors when the system ID was left out of the URLs. With this release, the BMO handles URLs without a Redfish system ID as addresses without a system ID. This fix improves software handling of missing a Redfish system ID in BMC URLs. (link:https://issues.redhat.com/browse/OCPBUGS-56431[OCPBUGS-56431])
+
+* Previously, during Ironic Python Agent (IPA) deployments, the absence of NetworkManager logs in RAM disk logs hindered effective debugging, impacting network issue resolution. With this release, NetworkManager logs are included in RAM disk logs for IPA debugging. This results in enhanced IPA logs that provide comprehensive `NetworkManager` data for improved debugging. (link:https://issues.redhat.com/browse/OCPBUGS-56097[OCPBUGS-56097])
+
+* Previously, Helm did not support Docker image mirroring with a tag and digest. This resulted in failed Helm repository mirroring that caused image duplication and inconsistencies in deployment. With this release, a fix addresses Docker references in Helm repository mirroring that allows tag and digest, and improves successful image mirroring. (link:https://issues.redhat.com/browse/OCPBUGS-56043[OCPBUGS-56043])
+
+* Previously, an issue started from an incorrect bucket name that was used for {op-system-first}. Users could not create {product-title} clusters because of a failed {op-system} image import. This problem was resolved by correcting the cluster creation in the Madrid zone for the `PowerVS` installer-provisioned infrastructure {cluster-capi-operator} by using the correct bucket name. With this release, the user can create {product-title} clusters in  the Madrid zone by using the installation program. (link:https://issues.redhat.com/browse/OCPBUGS-53142[OCPBUGS-53142])
+
+* Previously, intermittent resource leaks in the `MachineOSConfig` (MOSC) to `MachineOSBuild` (MOSB) connection due to missing owner references during job creation resulted in potential resource exhaustion, affecting pod updates. With this release, the owner references are added in the job creation to ensure the consistent removal of MOSB resources when MOSC is deleted, preventing resource leaks. (link:https://issues.redhat.com/browse/OCPBUGS-52189[OCPBUGS-52189])
+
+[id="ocp-4-18-16-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.15
 [id="ocp-4-18-15_{context}"]
 === RHBA-2025:8104 - {product-title} {product-version}.15 bug fix update


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-14791](https://issues.redhat.com//browse/OSDOCS-14791)

Link to docs preview:
[4.18.16](https://94134--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-16_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
The errata URLs will return 404 until the go-live date of 6/3/25.
