### PR TITLE
CNV-55497: Added release note about using PVC for DataImportCron instead of registry

### DIFF
--- a/virt/release_notes/virt-4-19-release-notes.adoc
+++ b/virt/release_notes/virt-4-19-release-notes.adoc
@@ -93,6 +93,9 @@ As a cluster administrator, you can prevent users from enabling VM delete protec
 [id="virt-4-19-storage_{context}"]
 === Storage
 
+//CNV-55497 Doc: PVC source support for DataImportCron
+* You can now use a PVC as the source of a custom `DataImportCron` in the `dataImportCronTemplates` section of the `HyperConverged` custom resource (CR). See xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates] for more information.
+
 
 [id="virt-4-19-web_{context}"]
 === Web console


### PR DESCRIPTION
Version(s):
4.19

Issue:
[CNV-55497](https://issues.redhat.com/browse/CNV-55497)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->