### PR TITLE
[RHDEVDOCS-6470] Pipelines 1.16.4 Release Notes

### DIFF
--- a/modules/op-release-notes-1-16.adoc
+++ b/modules/op-release-notes-1-16.adoc
@@ -713,3 +713,20 @@ With this update, {pipelines-title} General Availability (GA) 1.16.3 is availabl
 * Before this update, in some cases the {tekton-chains} controller repeatedly crashed, making the {tekton-chains} component unusable. With this update, the controller no longer crashes.
 
 * Before this update, if you defined a matrix task that included both regular parameters and `matrix` parameters, the `tekton-pipelines-controller` component crashed and logged a segmentation fault message. If the task was not removed, the component continued to crash and did not run any pipelines. With this update, the controller no longer crashes in such cases.
+
+[id="release-notes-1-16-4_{context}"]
+== Release notes for {pipelines-title} General Availability 1.16.4
+
+With this update, {pipelines-title} General Availability (GA) 1.16.4 is available on {OCP} 4.12, 4.14, 4.15, 4.16, 4.17, and 4.18 versions.
+
+[id="known-issues-1-16-4_{context}"]
+== Known issues
+
+* The Pipelines controller no longer adds `taskrun` and `pipelinerun` UID labels to pods. As a result, fetching logs via Results fails. Additionally, any tasks or jobs that rely on these labels might fail or behave unexpectedly.
+
+[id="fixed-issues-1-16-4_{context}"]
+=== Fixed issues
+
+* Before this update, when you used the `buildah` task that is supplied in the `openshift-pipelines` namespace and provided a credentials secret through the `dockerconfig` workspace, the task failed with a `permission denied` error. This failure occurred because directories passed as volumes were assigned default `ReadWrite` permissions, while the entitlement secret was mounted as `read-only`. This mismatch caused the task to fail. With this update, the `buildah` task supports the entitlement use case without encountering permission issues.
+
+* Before this update, the `git-clone` task supplied in the `openshift-pipelines` namespace used an outdated image that failed on disconnected clusters. With this update, a newer image for the `git-clone` task supports operation in disconnected environments.


### PR DESCRIPTION
Version(s):
pipelines-docs-1.16

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6470

Link to docs preview:
- https://94148--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-16.html

QE review:
- [x] QE has approved this change.
