### PR TITLE
4.19 RN - TELCODOCS-2107 - replacement of events REST API v1 with v2

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -546,6 +546,14 @@ You can enable port isolation for a Linux bridge network attachment definition (
 
 To improve the performance of Whereabouts, especially if nodes in your cluster run a high amount of pods, you can now enable the Fast IP Address Management (IPAM) feature. The Fast IPAM feature uses `nodeslicepools`, which are managed by the Whereabouts Controller, to optimize IP address allocation for nodes. For more information, see xref:../networking/multiple_networks/secondary_networks/configuring-ip-secondary-nwt.adoc#nw-multus-whereabouts-fast-ipam_configuring-additional-network[Fast IPAM configuration for the Whereabouts IPAM CNI plugin].
 
+[id="ocp-4-19-ptp-fast-events-rest-api-v2_{context}"]
+==== Removal of PTP events REST API v1 and events consumer application sidecar
+With this release, the PTP events REST API v1 and events consumer application sidecar support are removed.
+
+You must use the O-RAN compliant PTP events REST API v2 instead.
+
+For more information, see xref:../networking/ptp/ptp-cloud-events-consumer-dev-reference-v2.adoc#ptp-cloud-events-consumer-dev-reference-v2[Developing PTP event consumer applications with the REST API v2].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Release Note: 4.19 - [TELCODOCS-2107](https://issues.redhat.com//browse/TELCODOCS-2107) - replacement of events REST API v1 with v2

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2107
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Removal of PTP events REST API v1 and events consumer application sidecar](https://94165--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-ptp-fast-events-rest-api-v2_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
