### PR TITLE
OSDOCS#12643: Release notes for direct auth

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -52,6 +52,17 @@ This release adds improvements related to the following components and concepts:
 [id="ocp-release-notes-auth_{context}"]
 === Authentication and authorization
 
+[id="ocp-release-notes-auth-direct_{context}"]
+==== Enabling direct authentication with an external OIDC identity provider (Technology Preview)
+
+With this release, you can enable direct integration with an external OpenID Connect (OIDC) identity provider to issue tokens for authentication. This bypasses the built-in OAuth server and uses the external identity provider directly.
+
+By integrating directly with an external OIDC provider, you can leverage the advanced capabilities of your preferred OIDC provider instead of being limited by the capabilities of the built-in OAuth server. Your organization can manage users and groups from a single interface, while also streamlining authentication across multiple clusters and in hybrid environments. You can also integrate with existing tools and solutions.
+
+Direct authentication is available as a Technology Preview feature.
+
+For more information, see xref:../authentication/external-auth.adoc#external-auth[Enabling direct authentication with an external OIDC identity provider].
+
 [id="ocp-release-notes-backup-restore_{context}"]
 === Backup and restore
 
@@ -1208,6 +1219,11 @@ In the following tables, features are marked with the following statuses:
 |Pod security admission restricted enforcement
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|Direct authentication with an external OIDC identity provider
+|Not Available
+|Not Available
 |Technology Preview
 
 |====


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-12643

Link to docs preview:
- https://94167--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-auth-direct_release-notes
- https://94167--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-auth-tech-preview_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**Do not merge yet. Link won't work until #93779 merges.**