### PR TITLE
OCPBUGS#56989: Swapped out v4InternalSubnet for internalJoinSubnet

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -190,7 +190,8 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
       "ovnKubernetesConfig": {
         "mtu": <mtu>,
         "genevePort": <port>,
-        "v4InternalSubnet": "<ipv4_subnet>",
+        "ipv4":
+          "InternalJoinSubnet": "<ipv4_subnet>",
         "gatewayConfig": {
           "ipForwarding": "<ip_forwarding>",
           "routingViaHost": <gateway_mode>


### PR DESCRIPTION
Version(s):
4.15 and 4.16

Issue:
[OCPBUGS-56989](https://issues.redhat.com/browse/OCPBUGS-56989)

Link to docs preview:

* [Migrating to the OVN-Kubernetes network plugin by using the offline migration method](https://94168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn)

- [x] SME has approved this change (Ryan Howe).
- [x] QE has approved this change (Arnab Gosh).
