### PR TITLE
OLS-1814: OLS 0.3.6 release notes

### DIFF
--- a/modules/ols-0-3-6-fixed-issues.adoc
+++ b/modules/ols-0-3-6-fixed-issues.adoc
@@ -1,0 +1,11 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-3-6-fixed-issues_{context}"]
+= Fixed issues
+
+The following issues are fixed with {ols-official} 0.3.6:
+
+* Previously, the {ols-long} Operator could not connect to a large language model (LLM) provider when a cluster-wide proxy was configured. Now, the Operator can connect to an LLM provider when a cluster-wide proxy is configured. link:https://issues.redhat.com/browse/OLS-1808[OLS-1808].

--- a/modules/ols-0-3-6-known-issues.adoc
+++ b/modules/ols-0-3-6-known-issues.adoc
@@ -1,0 +1,20 @@
+// This module is used in the following assemblies:
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-3-6-known-issues_{context}"]
+= Known issues
+
+The following issues are identified with {ols-official} 0.3.6:
+
+* For {ocp-product-title} 4.17 and later, the {ols-short} icon disappears when you click *Create Namespace* or *Create Project* from one of the following locations in the {ocp-product-title} web console:
+
+** *Administration -> Namespaces* 
+** *Home -> Projects -> Create Project*
+** The *Project* drop-down menu located at the top of most pages
++
+Workaround: Refresh the web browser and the {ols-short} icon appears. link:https://issues.redhat.com/browse/OLS-1815[OLS-1815].
+
+* Changing the value of the `quota` parameter in the `spec.ols.quota_handlers.conf` specification of the `OLSConfig` CR file does not take effect until the currently defined quota period expires.
++
+Workaround: Delete the {ols-short} Operator. Ensure that any operand pods that the {ols-short} Operator manages, and the Persistent Volume Claim `lightspeed-postgres-pvc` associated with the `postgres` pod are also deleted. Then, install the {ols-short} Operator again.

--- a/modules/ols-0-3-6-release-notes.adoc
+++ b/modules/ols-0-3-6-release-notes.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-3-6-release-notes_{context}"]
+= {ols-long} version 0.3.6
+
+{ols-official} 0.3.6 is now available on {ocp-product-title} 4.15 and later.
+
+[IMPORTANT]
+====
+{ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
+====
+
+[id="ols-0-3-6-enhancements_{context}"]
+== Enhancements
+
+The following enhancements are made with {ols-official} 0.3.6:
+
+* This release provides bug fixes.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 The release notes highlight what is new and what has changed with each {ols-official} release.
 
+include::modules/ols-0-3-6-release-notes.adoc[leveloffset=+1]
+include::modules/ols-0-3-6-fixed-issues.adoc[leveloffset=+2]
+include::modules/ols-0-3-6-known-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-5-release-notes.adoc[leveloffset=+1]
 include::modules/ols-0-3-5-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-0-3-4-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): TP
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-1814
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://94169--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-0-3-6-release-notes_ols-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
