### PR TITLE
CNV#52383: Document spec.EnableCommonBootImageImport

### DIFF
--- a/modules/virt-managing-auto-update-all-system-boot-sources.adoc
+++ b/modules/virt-managing-auto-update-all-system-boot-sources.adoc
@@ -9,7 +9,7 @@
 
 Disabling automatic boot source imports and updates can lower resource usage. In disconnected environments, disabling automatic boot source updates prevents `CDIDataImportCronOutdated` alerts from filling up logs.
 
-To disable automatic updates for all system-defined boot sources, turn off the `enableCommonBootImageImport` feature gate by setting the value to `false`. Setting this value to `true` re-enables the feature gate and turns automatic updates back on.
+To disable automatic updates for all system-defined boot sources, set the `enableCommonBootImageImport` field value to `false`. Setting this value to `true` turns automatic updates back on.
 
 [NOTE]
 ====
@@ -22,24 +22,24 @@ Custom boot sources are not affected by this setting.
 
 .Procedure
 
-* Toggle the feature gate for automatic boot source updates by editing the `HyperConverged` custom resource (CR).
+* Enable or disable automatic boot source updates by editing the `HyperConverged` custom resource (CR).
 
-** To disable automatic boot source updates, set the `spec.featureGates.enableCommonBootImageImport` field in the `HyperConverged` CR to `false`. For example:
+** To disable automatic boot source updates, set the `spec.enableCommonBootImageImport` field value in the `HyperConverged` CR to `false`. For example:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "replace", "path": \
-  "/spec/featureGates/enableCommonBootImageImport", \
+  "/spec/enableCommonBootImageImport", \
   "value": false}]'
 ----
 
-** To re-enable automatic boot source updates, set the `spec.featureGates.enableCommonBootImageImport` field in the `HyperConverged` CR to `true`. For example:
+** To re-enable automatic boot source updates, set the `spec.enableCommonBootImageImport` field value in the `HyperConverged` CR to `true`. For example:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "replace", "path": \
-  "/spec/featureGates/enableCommonBootImageImport", \
+  "/spec/enableCommonBootImageImport", \
   "value": true}]'
 ----

--- a/virt/storage/virt-automatic-bootsource-updates.adoc
+++ b/virt/storage/virt-automatic-bootsource-updates.adoc
@@ -17,9 +17,9 @@ Boot sources can make virtual machine (VM) creation more accessible and efficien
 [id="managing-rh-boot-source-updates_virt-automatic-bootsource-updates"]
 == Managing Red Hat boot source updates
 
-You can opt out of automatic updates for all system-defined boot sources by disabling the `enableCommonBootImageImport` feature gate. If you disable this feature gate, all `DataImportCron` objects are deleted. This does not remove previously imported boot source objects that store operating system images, though administrators can delete them manually.
+You can opt out of automatic updates for all system-defined boot sources by setting the `enableCommonBootImageImport` field value to `false`. If you set the value to `false`, all `DataImportCron` objects are deleted. This does not, however, remove previously imported boot source objects that store operating system images, though administrators can delete them manually.
 
-When the `enableCommonBootImageImport` feature gate is disabled, `DataSource` objects are reset so that they no longer point to the original boot source. An administrator can manually provide a boot source by creating a new persistent volume claim (PVC) or volume snapshot for the `DataSource` object, then populating it with an operating system image.
+When the `enableCommonBootImageImport` field value is set to `false`, `DataSource` objects are reset so that they no longer point to the original boot source. An administrator can manually provide a boot source by creating a new persistent volume claim (PVC) or volume snapshot for the `DataSource` object, and then populating it with an operating system image.
 
 include::modules/virt-managing-auto-update-all-system-boot-sources.adoc[leveloffset=+2]
 
@@ -31,7 +31,7 @@ _Custom_ boot sources that are not provided by {VirtProductName} are not control
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
-You must configure a storage class. Otherwise, the cluster cannot receive automated updates for custom boot sources. See xref:../../storage/dynamic-provisioning.adoc#defining-storage-classes_dynamic-provisioning[Defining a storage class] for details. 
+You must configure a storage class. Otherwise, the cluster cannot receive automated updates for custom boot sources. See xref:../../storage/dynamic-provisioning.adoc#defining-storage-classes_dynamic-provisioning[Defining a storage class] for details.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s): 4.19+

Issue: [CNV-52383](https://issues.redhat.com/browse/CNV-52383)

Link to docs preview: https://94198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-automatic-bootsource-updates.html

QE review:
- [x] QE has approved this change.


