### PR TITLE
OCPBUGS-53450:NFS export options for Filestore SC

### DIFF
--- a/modules/persistent-storage-csi-gcp-filestore-nfs-export-options.adoc
+++ b/modules/persistent-storage-csi-gcp-filestore-nfs-export-options.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_csi-google_cloud_file.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="persistent-storage-csi-gcp-filestore-nfs-export-options_{context}"]
+= NFS export options
+
+By default, a Filestore instance grants root level read/write access to all clients that share the same Google Cloud project and virtual private cloud (VPC) network. Network File System (NFS) export options can limit this access to certain IP ranges and specific user/group IDs for the Filestore instance. When creating a storage class, you can set these options using the `nfs-export-options-on-create` parameter.
+
+.Prerequisites
+* Access to the cluster as a user with the cluster-admin role.
+
+* The {gcp-short} Filestore CSI Driver Operator and {gcp-short} Filestore CSI driver installed.
+
+.Procedure
+
+. Create a storage class using a file similar to the following sample YAML file:
++
+[NOTE]
+====
+For more information about creating a storage class, see Section _Creating a storage class for GCP Filestore Operator_.
+====
++
+.Example storage class YAML file with NFS export options
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+ name: SC-name
+provisioner: filestore.csi.storage.gke.io
+parameters:
+ connect-mode: DIRECT_PEERING
+ network: project-network
+ nfs-export-options-on-create: '[ <1>
+   {
+     "accessMode": "READ_WRITE", <2>
+     "squashMode": "NO_ROOT_SQUASH", <3>
+     "anonUid": 65534 <4>
+     "anonGid": 65534 <5>
+     "ipRanges": [ <6>
+       "10.0.0.0/16"
+     ]
+   }]'
+allowVolumeExpansion: true
+----
+<1> *NFS export options parameter*
+<2> *Access mode*: Either `READ_ONLY,` which allows only read requests on the exported directory; or `READ_WRITE`, which allows both read and write requests. The default is `READ_WRITE`.
+<3> *Squash mode*: Either `NO_ROOT_SQUASH`, which allows root access on the exported directory; or ROOT_SQUASH, which does not allow root access. The default is `NO_ROOT_SQUASH`.
+<4> *AnonUid*: An integer representing the anonymous user ID with a default value of 65534. `AnonUid` can only be set with `squashMode` set to `ROOT_SQUASH`; Otherwise, an error occurs.
+<5> *AnonGid*: An integer representing the anonymous group ID with a default value of 65534. `AnonGid` can only be set with `squashMode` set to `ROOT_SQUASH`. Otherwise, an error occurs.
+<6> *IP ranges*: List of either an IPv4 addresses in the format {octet1}.{octet2}.{octet3}.{octet4}, or CIDR ranges in the format {octet1}.{octet2}.{octet3}.{octet4}/{mask size}, which can mount the file share. Overlapping IP ranges are not allowed, both within and across NfsExportOptions, otherwise, an error is returned. The limit is 64 IP ranges or addresses for each `FileShareConfig` among all NFS export options.

--- a/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
@@ -43,6 +43,8 @@ include::modules/persistent-storage-csi-gcp-file-install.adoc[leveloffset=+2]
 
 include::modules/persistent-storage-csi-google-cloud-file-create-sc.adoc[leveloffset=+1]
 
+include::modules/persistent-storage-csi-gcp-filestore-nfs-export-options.adoc[leveloffset=+1]
+
 include::modules/persistent-storage-csi-google-cloud-file-delete-instances.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-53450
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94199--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.html#persistent-storage-csi-gcp-filestore-nfs-export-options_persistent-storage-csi-google-cloud-file
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

**PTAL**: @chao007 @gnufied @gcharot @rhrmo 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
