### PR TITLE
[OSDOCS-14827]Update "Comparing ROSA with HCP and ROSA Classic" table

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -30,11 +30,11 @@
 | Each machine pool is deployed in a single AZ (private subnet).
 | Machine pools can be deployed in single AZ or across multiple AZs.
 
-| *Infrastructure Nodes*
-| Does not use any dedicated nodes to host platform components, such as ingress and image registry.
-| Uses 2 (single-AZ) or 3 (multi-AZ) dedicated nodes to host platform components.
+| *Infrastructure nodes*
+| Does not use any dedicated infrastructure nodes to host platform components, such as ingress and image registry.
+| Uses 2 (single-AZ) or 3 (multi-AZ) dedicated infrastructure nodes to host platform components.
 
-| *OpenShift Capabilities*
+| *OpenShift capabilities*
 | Platform monitoring, image registry, and the ingress controller are deployed in the worker nodes.
 | Platform monitoring, image registry, and the ingress controller are deployed in the dedicated infrastructure nodes.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-14827
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Added the word "infrastructure"  to make it clear that HCP clusters do not use "Infrastructure nodes" (they don't) and also wanted to match what is in the row beneath the edited row...

Before:
![image](https://github.com/user-attachments/assets/938afd7f-4f11-43f7-9893-7b5a2cfc6480)

After:
![image](https://github.com/user-attachments/assets/715b9bd0-b3dd-4e21-85da-25e1de8ab446)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
