### PR TITLE
OSDOCS-13556 4.19 update to TechPreviewNoUpgrade

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -20,125 +20,93 @@ Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone
 The following Technology Preview features are enabled by this feature set:
 +
 --
-** External cloud providers. Enables support for external cloud providers for clusters on vSphere, AWS, Azure, and GCP. Support for OpenStack is GA. This is an internal feature that most users do not need to interact with. (`ExternalCloudProvider`)
-** Swap memory on nodes. Enables swap memory use for {product-title} workloads on a per-node basis. (`NodeSwap`)
-** OpenStack Machine API Provider. This gate has no effect and is planned to be removed from this feature set in a future release. (`MachineAPIProviderOpenStack`)
-** Insights Operator. Enables the `InsightsDataGather` CRD, which allows users to configure some Insights data gathering options. The feature set also enables the `DataGather` CRD, which allows users to run Insights data gathering on-demand. (`InsightsConfigAPI`)
-** Dynamic Resource Allocation API. Enables a new API for requesting and sharing resources between pods and containers. This is an internal feature that most users do not need to interact with. (`DynamicResourceAllocation`)
-** Pod security admission enforcement. Enables the restricted enforcement mode for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)
-** StatefulSet pod availability upgrading limits. Enables users to define the maximum number of statefulset pods unavailable during updates which reduces application downtime. (`MaxUnavailableStatefulSet`)
-** Image mode behavior of image streams. Enables a new API for controlling the import mode behavior of image streams. (`imageStreamImportMode`)
-** Configuring a local arbiter node. You can configure an {product-title} cluster with two control plane nodes and one local arbiter node to retain high availability (HA) while reducing infrastructure costs. This configuration is supported only for bare-metal installations.
-** `OVNObservability` resource allows you to verify expected network behavior. Supports the following network APIs: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinesdNetwork` isolation, multicast ACLs, and egress firewalls. When enabled, you can view network events in the terminal.
-** `gcpLabelsTags`
-** `vSphereStaticIPs`
-** `routeExternalCertificate`
-** `automatedEtcdBackup`
-** `gcpClusterHostedDNS`
-** `vSphereControlPlaneMachineset`
-** `dnsNameResolver`
-** `machineConfigNodes`
-** `metricsServer`
-** `installAlternateInfrastructureAWS`
-** `mixedCPUsAllocation`
-** `managedBootImages`
-** `onClusterBuild`
-** `signatureStores`
-** `SigstoreImageVerification`
-** `DisableKubeletCloudCredentialProviders`
-** `BareMetalLoadBalancer`
-** `ClusterAPIInstallAWS`
-** `ClusterAPIInstallAzure`
-** `ClusterAPIInstallNutanix`
-** `ClusterAPIInstallOpenStack`
-** `ClusterAPIInstallVSphere`
-** `HardwareSpeed`
-** `KMSv1`
-** `NetworkDiagnosticsConfig`
-** `VSphereDriverConfiguration`
-** `ExternalOIDC`
-** `ChunkSizeMiB`
-** `ClusterAPIInstallGCP`
-** `ClusterAPIInstallPowerVS`
-** `EtcdBackendQuota`
-** `InsightsConfig`
-** `InsightsOnDemandDataGather`
-** `MetricsCollectionProfiles`
-** `NewOLM`
-** `AWSClusterHostedDNS`
 ** `AdditionalRoutingCapabilities`
-** `AutomatedEtcdBackup`
+** `AdminNetworkPolicy`
+** `AlibabaPlatform`
+** `automatedEtcdBackup`
+** `AWSClusterHostedDNS`
+** `AWSEFSDriverVolumeMetrics`
+** `AzureWorkloadIdentity`
+** `BareMetalLoadBalancer`
 ** `BootcNodeManagement`
-** `CSIDriverSharedResource`
+** `BuildCSIVolumes`
+** `ChunkSizeMiB`
+** `CloudDualStackNodeIPs`
 ** `ClusterMonitoringConfig`
 ** `ConsolePluginContentSecurityPolicy`
+** `CPMSMachineNamePrefix`
+** `DisableKubeletCloudCredentialProviders`
 ** `DNSNameResolver`
 ** `DynamicResourceAllocation`
+** `DyanmicServiceEndpointIBMCloud`
 ** `EtcdBackendQuota`
 ** `Example`
-** `GCPClusterHostedDNS`
+** `ExternalOIDC`
+** `ExternalOIDCWithUIDAndExtraClaimMappings`
+** `GatewayAPI`
+** `GatewayAPIController`
+** `gcpClusterHostedDNS`
+** `GCPCustomAPIEndpoints`
+** `GCPLabelsTags`
+** `HardwareSpeed`
+** `HighlyAvailableArbiter`
 ** `ImageStreamImportMode`
 ** `IngressControllerDynamicConfigurationManager`
+** `IngressControllerLBSubnetsAWS`
 ** `InsightsConfig`
 ** `InsightsConfigAPI`
 ** `InsightsOnDemandDataGather`
 ** `InsightsRuntimeExtractor`
+** `KMSEncryptionProvider`
+** `KMSv1`
+** `MachineAPIMigration`
 ** `MachineAPIProviderOpenStack`
 ** `MachineConfigNodes`
+** `ManagedBootImages`
+** `ManagedBootImagesAWS`
 ** `MaxUnavailableStatefulSet`
 ** `MetricsCollectionProfiles`
 ** `MinimumKubeletVersion`
 ** `MixedCPUsAllocation`
+** `MultiArchInstallAWS`
+** `MultiArchInstallGCP`
+** `NetworkDiagnosticsConfig`
+** `NetworkLiveMigration`
 ** `NetworkSegmentation`
+** `NewOLM`
+** `NewOLMCatalogdAPIV1Metas`
+** `NewOLMOwnSingleNamespace`
+** `NewOLMPreflightPermissionChecks`
+** `NodeDisruptionPolicy`
 ** `NodeSwap`
 ** `NutanixMultiSubnets`
-** `OVNObservability`
 ** `OnClusterBuild`
 ** `OpenShiftPodSecurityAdmission`
+** `OVNObservability`
 ** `PersistentIPsForVirtualization`
 ** `PinnedImages`
 ** `PlatformOperators`
+** `PrivateHostedZoneAWS`
 ** `ProcMountType`
 ** `RouteAdvertisements`
 ** `RouteExternalCertificate`
 ** `ServiceAccountTokenNodeBinding`
+** `SetEIPForNLBIngressController`
 ** `SignatureStores`
 ** `SigstoreImageVerification`
 ** `TranslateStreamCloseWebsocketRequests`
 ** `UpgradeStatus`
 ** `UserNamespacesPodSecurityStandards`
 ** `UserNamespacesSupport`
-** `VSphereMultiNetworks`
+** `ValidatingAdmissionPolicy`
 ** `VolumeAttributesClass`
 ** `VolumeGroupSnapshot`
-** `ExternalOIDC`
-** `AWSEFSDriverVolumeMetrics`
-** `AdminNetworkPolicy`
-** `AlibabaPlatform`
-** `AzureWorkloadIdentity`
-** `BareMetalLoadBalancer`
-** `BuildCSIVolumes`
-** `ChunkSizeMiB`
-** `CloudDualStackNodeIPs`
-** `DisableKubeletCloudCredentialProviders`
-** `GCPLabelsTags`
-** `HardwareSpeed`
-** `IngressControllerLBSubnetsAWS`
-** `KMSv1`
-** `ManagedBootImages`
-** `ManagedBootImagesAWS`
-** `MultiArchInstallAWS`
-** `MultiArchInstallGCP`
-** `NetworkDiagnosticsConfig`
-** `NetworkLiveMigration`
-** `NodeDisruptionPolicy`
-** `PrivateHostedZoneAWS`
-** `SetEIPForNLBIngressController`
-** `VSphereControlPlaneMachineSet`
+** `VSphereConfigurableMaxAllowedBlockVolumesPerNode`
 ** `VSphereDriverConfiguration`
+** `VSphereHostVMGroupZonal`
+** `VSphereMultiDisk`
+** `VSphereMultiNetworks`
 ** `VSphereMultiVCenters`
-** `VSphereStaticIPs`
-** `ValidatingAdmissionPolicy`
 --
 
 ////


### PR DESCRIPTION
Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:[OSDOCS-13556](https://issues.redhat.com/browse/OSDOCS-13556)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR updates the TechPreviewNoUpgrade featureset to the 4.19 list. [4.19 TechPreviewNoUpgrade feature set](https://github.com/openshift/api/blob/release-4.19/features.md).
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
