### PR TITLE
OCPBUGS#56848: Remove port 9537 from docummented network flow matrix

### DIFF
--- a/snippets/network-flow-matrix.csv
+++ b/snippets/network-flow-matrix.csv
@@ -30,7 +30,6 @@ Ingress,TCP,9258,openshift-cloud-controller-manager-operator,machine-approver,cl
 Ingress,TCP,9444,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,9445,openshift-kni-infra,,haproxy,haproxy,master,FALSE
 Ingress,TCP,9447,openshift-machine-api,,metal3-baremetal-operator,,master,FALSE
-Ingress,TCP,9537,Host system service,crio-metrics,,,master,FALSE
 Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,master,FALSE
 Ingress,TCP,9978,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE
 Ingress,TCP,9979,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE
@@ -63,7 +62,6 @@ Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-prox
 Ingress,TCP,9103,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-node,worker,FALSE
 Ingress,TCP,9105,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-ovn-metrics,worker,FALSE
 Ingress,TCP,9107,openshift-ovn-kubernetes,egressip-node-healthcheck,ovnkube-node,ovnkube-controller,worker,FALSE
-Ingress,TCP,9537,Host system service,crio-metrics,,,worker,FALSE
 Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,worker,FALSE
 Ingress,TCP,10250,Host system service,kubelet,,,worker,FALSE
 Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,worker,TRUE


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Unnecessary port in 4.16 network flow matrix.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[OpenShift Container Platform network flow matrix](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installation_configuration/configuring-firewall#network-flow-matrix_configuring-firewall) -- Remove a line from Table 2.1.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
