### PR TITLE
OCPBUGS-13539-18-remove-libreswan

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2889,11 +2889,7 @@ In the following tables, features are marked with the following statuses:
 
 * The DNF package manager included in {op-system-first} images cannot be used at runtime, because DNF relies on additional packages to access entitled nodes in a cluster that are under a Red Hat subscription. As a workaround, use the `rpm-ostree` command instead. (link:https://issues.redhat.com/browse/OCPBUGS-35247[OCPBUGS-35247])
 
-* A regression in the behaviour of `libreswan` caused some nodes with IPsec enabled to lose communication with pods on other nodes in the same cluster. To resolve this issue, consider disabling IPsec for your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-43713[OCPBUGS-43713])
-
-* There is a known issue in {product-title} version 4.18 that prevents configuring multiple subnets in the failure domain of a Nutanix cluster during installation.
-There is no workaround for this issue.
-(link:https://issues.redhat.com/browse/OCPBUGS-49885[OCPBUGS-49885])
+* There is a known issue in {product-title} version 4.18 that prevents configuring multiple subnets in the failure domain of a Nutanix cluster during installation. There is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-49885[OCPBUGS-49885])
 
 * The following known issues exist for configuring multiple subnets for an existing Nutanix cluster by using a control plane machine set:
 +


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-13539](https://issues.redhat.com/browse/OSDOCS-13539)

Link to docs preview:
[4.18](https://94235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-known-issues_release-notes)

[x] QE review
[x] SME review