### PR TITLE
OCPBUGS-13539-17-remove-libreswan

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2818,8 +2818,6 @@ To know the status of the {hcp} features on {product-title} 4.17, see xref:../ho
 [id="ocp-4-17-known-issues_{context}"]
 == Known issues
 
-* A regression in the behaviour of `libreswan` caused some nodes with IPsec enabled to lose communication with pods on other nodes in the same cluster. To resolve this issue, consider disabling IPsec for your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-43714[OCPBUGS-43714])
-
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[BZ#1917280])
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13539](https://issues.redhat.com/browse/OSDOCS-13539)

Link to docs preview:
* [4.17](https://94236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-known-issues_release-notes)

[x] QE review
[x] SME review