### PR TITLE
OCPBUGS-13539-15-remove-libreswan

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2588,8 +2588,6 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-15-known-issues"]
 == Known issues
 
-* A regression in the behaviour of `libreswan` caused some nodes with IPsec enabled to lose communication with pods on other nodes in the same cluster. To resolve this issue, consider disabling IPsec for your cluster. (link:https://issues.redhat.com/browse/OCPBUGS-44670[OCPBUGS-44670])
-
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-13539](https://issues.redhat.com/browse/OSDOCS-13539)

Link to docs preview:
* [4.15](https://94238--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-known-issues)

[x] QE review
[x] SME review