### PR TITLE
OSDOCS-14361:Added ROSA HCP cluster install errors troubleshooting section

### DIFF
--- a/modules/rosa-troubleshoot-hcp-install.adoc
+++ b/modules/rosa-troubleshoot-hcp-install.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-installations-hcp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-troubleshoot-hcp-install_{context}"]
+= Troubleshooting {hcp-title} installation error codes
+
+The following table lists {hcp-title-first} installation error codes and what you can do to troubleshoot these errors.
+
+.{hcp-title} installation error codes
+[options="header",cols="3"]
+|===
+| Error code | Description | Resolution
+
+| OCM3999
+| Unknown error.
+| Check the cluster installation logs for more details, or delete this cluster and retry cluster installation. If this issue persists, contact support by logging in to the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support* page].
+
+| OCM5001
+| {hcp-title} cluster provision has failed.
+| Check the cluster installation logs for more details, or delete this cluster and retry cluster installation. If this issue persists, contact support by logging in to the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support* page].
+
+| OCM5002
+| The maximum resource tag size of 25 has been exceeded.
+| Check the cluster information to determine if you can remove any unnecessary tags you have specified and retry cluster installation.
+
+| OCM5003
+| Unable to establish an AWS client to provision the cluster.
+| You must create several role resources on your AWS account to create and manage a {hcp-title} cluster. Ensure that your provided AWS credentials are correct and retry cluster installation.
+
+For more information about {hcp-title} IAM role resources, see _ROSA IAM role resources_ in the _Additional resources_ section.
+
+| OCM5004
+| Unable to establish a cross-account AWS client to provision the cluster.
+| You must create several role resources on your AWS account to create and manage a {hcp-title} cluster. Ensure that your provided AWS credentials are correct and retry cluster installation.
+
+For more information about {hcp-title} IAM role resources, see _ROSA IAM role resources_ in the _Additional resources_ section.
+
+| OCM5005
+| Failed to retrieve AWS subnets defined for the cluster.
+| Review the provided subnet IDs and retry cluster installation.
+
+| OCM5006
+| You must configure at least one private AWS subnet for the cluster.
+| Review the provided subnet IDs and retry cluster installation.
+
+| OCM5007
+| Unable to create AWS STS prerequisites for the cluster.
+| Verify that account and operator roles have been created and are correct. For more information, see _AWS STS and ROSA with HCP explained_ in the _Additional resources_ section.
+
+| OCM5008
+| The provided cluster flavour is incorrect.
+| Verify that the provided name or ID is correct when you are using the flavour parameter and retry cluster creation.
+
+| OCM5009
+| The cluster version could not be found.
+| Ensure that the configured version ID matches a valid {hcp-title} version.
+
+| OCM5010
+| Failed to tag subnets for the cluster.
+| Confirm that the AWS permissions and the subnet configurations are correct. You must tag at least one private subnet and, if applicable, one public subnet.
+
+| OCM5011
+| Cluster installation has failed due to unavailable capacity in the selected region.
+| Try your cluster installation in another region or retry cluster installation.
+
+|===

--- a/support/troubleshooting/rosa-troubleshooting-installations-hcp.adoc
+++ b/support/troubleshooting/rosa-troubleshooting-installations-hcp.adoc
@@ -1,19 +1,30 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="rosa-troubleshooting-installations-hcp"]
-= Troubleshooting ROSA with HCP cluster installations
+= Troubleshooting {hcp-title} cluster installations
 :context: rosa-troubleshooting-installations-hcp
 //Remove this adoc from rosa-classic docs and add xrefs back in once HCP migration occurs.
 toc::[]
 
-For help with the installation of {hcp-title} clusters, refer to the following sections.
+For help with the installation of {hcp-title-first} clusters, refer to the following sections.
 
 include::modules/rosa-verify-hcp-install.adoc[leveloffset=+1]
 
+//remove these conditionals once HCP migration happens
 ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
-* For information about the prerequisites to installing {hcp-title} clusters, see xref:../../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
+* For information about the prerequisites for installing {hcp-title} clusters, see xref:../../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
+endif::openshift-rosa-hcp[]
+
+include::modules/rosa-troubleshoot-hcp-install.adoc[leveloffset=+1]
+
+//remove these conditionals once HCP migration happens
+ifndef::openshift-rosa-hcp[]
+[role="_additional-resources"]
+.Additional resources
+* For information about the required IAM, see xref:../../rosa_planning/rosa-sts-ocm-role.adoc#rosa-sts-ocm-role[ROSA IAM role resources].
+* For information about the AWS STS prerequisites for {hcp-title} clusters, see xref:../../welcome/cloud-experts-rosa-hcp-sts-explained.adoc#cloud-experts-rosa-hcp-sts-explained[AWS STS and ROSA with HCP explained].
 endif::openshift-rosa-hcp[]
 
 include::modules/rosa-hcp-no-console-access.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14361

Link to docs preview:
[Troubleshooting ROSA with HCP installation error codes](https://94251--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/rosa-troubleshooting-installations-hcp.html)

**Note to reviewers**
This section is only relevant to HCP but appears in the Classic docs as the HCP migration has not been finalized yet. Once this happens, this will be removed from the Classic docs section and links to other documents in the Additional resources section will be added.

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- QE approval is not required as no procedural updates

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
