### PR TITLE
OSDOCS-14170-rn: Documented the release note for OSDOCS-14170

### DIFF
--- a/modules/virt-linux-bridge-nad-port-isolation.adoc
+++ b/modules/virt-linux-bridge-nad-port-isolation.adoc
@@ -3,7 +3,7 @@
 // * virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="virt-linux-bridge-nad-port-isolation.adoc_{context}"]
+[id="virt-linux-bridge-nad-port-isolation_{context}"]
 = Enabling port isolation for a Linux bridge NAD
 
 You can enable port isolation for a Linux bridge network attachment definition (NAD) so that virtual machines (VMs) or pods that run on the same virtual LAN (VLAN) can operate in isolation from one another. The Linux bridge NAD creates a virtual bridge, or _virtual switch_, between network interfaces and the physical network.

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -536,6 +536,11 @@ With this release, {product-title} introduces the Data Processing Unit (DPU) Ope
 
 Administrators can now use the `ClusterUserDefinedNetwork` custom resource to deploy secondary networks on a `Localnet` topology. This feature allows pods and virtual machines connected to the localnet network to egress to the physical network. For more information, see xref:../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-cudn-localnet[Creating a ClusterUserDefinedNetwork CR for a Localnet topology].
 
+[id="ocp-4-19-port-isolation-linux-bridge_{context}"]
+==== Enable port isolation for a Linux bridge NAD
+
+You can enable port isolation for a Linux bridge network attachment definition (NAD) so that virtual machines (VMs) or pods that run on the same virtual LAN (VLAN) can operate in isolation from one another. For more information, see xref:../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-linux-bridge-nad-port-isolation_virt-connecting-vm-to-linux-bridge[Enabling port isolation for a Linux bridge NAD].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14836](https://issues.redhat.com/browse/OSDOCS-14836)

Link to docs preview:
* [Enable port isolation for a Linux bridge NAD](https://94263--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-port-isolation-linux-bridge_release-notes)


- [x] SME has approved this change (Petr Horacek).
- [x] QE has approved this change (Yossi Segev).

