### PR TITLE
CNV-59096-Additional multi-VM operations

### DIFF
--- a/modules/virt-updating-multiple-vms.adoc
+++ b/modules/virt-updating-multiple-vms.adoc
@@ -84,4 +84,12 @@ spec:
 <5> You can use the `LABEL_SELECTOR` environment variable to select VMs that receive the job action. If you want the job to go over all VMs in the cluster, do not assign a value to the parameter.
 
 
+[id="virt-performing-actions-on-multiple-virtual-machines_{context}"]
+== Performing bulk actions on virtual machines
 
+You can perform bulk actions on multiple virtual machines (VMs) simultaneously by using the *VirtualMachines* list view in the web console. This allows you to efficiently manage a group of VMs with minimal manual effort.
+
+.Available bulk actions
+* *Label VMs* - Add, edit, or remove labels that are applied across selected VMs.
+* *Delete VMs* - Select multiple VMs to delete. The confirmation dialog displays the number of VMs selected for deletion.
+* *Move VMs to folder* - Move selected VMs to a folder. All VMs must belong to the same namespace.


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/CNV-59096 

Link to docs preview:
https://94266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html#virt-performing-actions-on-multiple-virtual-machines_virt-edit-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

