### PR TITLE
OSDOCS-14794: Documented the release note for OSDOCS-13333

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -541,6 +541,11 @@ Administrators can now use the `ClusterUserDefinedNetwork` custom resource to de
 
 You can enable port isolation for a Linux bridge network attachment definition (NAD) so that virtual machines (VMs) or pods that run on the same virtual LAN (VLAN) can operate in isolation from one another. For more information, see xref:../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-linux-bridge-nad-port-isolation_virt-connecting-vm-to-linux-bridge[Enabling port isolation for a Linux bridge NAD].
 
+[id="ocp-4-19-whereabouts-ipam_{context}"]
+==== Fast IPAM configuration for the Whereabouts IPAM CNI plugin (Technology Preview)
+
+To improve the performance of Whereabouts, especially if nodes in your cluster run a high amount of pods, you can now enable the Fast IP Address Management (IPAM) feature. The Fast IPAM feature uses `nodeslicepools`, which are managed by the Whereabouts Controller, to optimize IP address allocation for nodes. For more information, see xref:../networking/multiple_networks/secondary_networks/configuring-ip-secondary-nwt.adoc#nw-multus-whereabouts-fast-ipam_configuring-additional-network[Fast IPAM configuration for the Whereabouts IPAM CNI plugin].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 
@@ -1467,6 +1472,12 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Not Available
 |Technology Preview
+
+|Fast IPAM for the Whereabouts IPAM CNI plugin
+|Not Available
+|Not Available
+|Technology Preview
+
 |====
 
 [discrete]


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14794](https://issues.redhat.com/browse/OSDOCS-14794)

Link to docs preview:
* [Fast IPAM configuration for the Whereabouts IPAM CNI plugin (Technology Preview)](https://94267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-networking_release-notes)

- [x] SME has approved this change (Ben Pickard).
- [x] QE has approved this change (Weibin Liang/ returns on the 9th of June/Jean Chen)
