### PR TITLE
OSDOCS-14837: Documented the release note for OSDOCS-12848

### DIFF
--- a/modules/k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc
+++ b/modules/k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc
@@ -3,7 +3,7 @@
 // * networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc_{context}"]
+[id="k8s-nmstate-troubleshooting-dns-disconnected-env-resolv_{context}"]
 = Creating a custom DNS host name to resolve DNS connectivity issues
 
 In a disconnected environment where the external DNS server cannot be reached, you can resolve Kubernetes NMState Operator health probe issues by specifying a custom DNS host name in the `NMState` custom resource definition (CRD). 

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -586,10 +586,16 @@ You can enable port isolation for a Linux bridge network attachment definition (
 To improve the performance of Whereabouts, especially if nodes in your cluster run a high amount of pods, you can now enable the Fast IP Address Management (IPAM) feature. The Fast IPAM feature uses `nodeslicepools`, which are managed by the Whereabouts Controller, to optimize IP address allocation for nodes. For more information, see xref:../networking/multiple_networks/secondary_networks/configuring-ip-secondary-nwt.adoc#nw-multus-whereabouts-fast-ipam_configuring-additional-network[Fast IPAM configuration for the Whereabouts IPAM CNI plugin].
 [id="ocp-4-19-metallb-unnumbered-bgp-peering_{context}"]
 
+[id="ocp-4-19-unnumbered-bgp-peering_{context}"]
 ==== Unnumbered BGP peering (Technology Preview)
 
 With this release, {product-title} introduces unnumbered BGP peering.
 Available as a Technology Preview feature, you can use the `spec.interface` field of the BGP peer custom resource to configure unnumbered BGP peering.
+
+[id="ocp-4-19-custom-dns-host-name-disconnected_{context}"]
+==== Create a custom DNS host name to resolve DNS connectivity issues
+
+In a disconnected environment where the external DNS server cannot be reached, you can resolve Kubernetes NMState Operator health probe issues by specifying a custom DNS host name in the `NMState` custom resource definition (CRD). For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc#k8s-nmstate-troubleshooting-dns-disconnected-env-resolv_k8s-nmstate-troubleshooting-node-network[Creating a custom DNS host name to resolve DNS connectivity issues].
 
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14837](https://issues.redhat.com/browse/OSDOCS-14837)

Link to docs preview:
* [Create a custom DNS host name to resolve DNS connectivity issues](https://94269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-custom-dns-host-name-disconnected_release-notes)

- [x] SME has approved this change (Mat K).
- [x] QE has approved this change (Ross B).

