### PR TITLE
OSDOCS-14822 UDN NetObserv Content

### DIFF
--- a/modules/network-observability-con_user-defined-networks.adoc
+++ b/modules/network-observability-con_user-defined-networks.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-user-defined-networks_{context}"]
+= User-defined networks
+
+User-defined networks (UDN) improve the flexibility and segmentation capabilities of the default Layer 3 topology for a Kubernetes pod network by enabling custom Layer 2 and Layer 3 network segments, where all these segments are isolated by default. These segments act as primary or secondary networks for container pods and virtual machines that use the default OVN-Kubernetes CNI plugin.
+
+UDNs enable a wide range of network architectures and topologies, enhancing network flexibility, security, and performance.
+
+When the `UDNMapping` feature is enabled with Network Observability, the *Traffic* flow table has a *UDN labels* column. You can filter on *Source Network Name* and *Destination Network Name*.

--- a/modules/network-observability-proc_working-with-udn.adoc
+++ b/modules/network-observability-proc_working-with-udn.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-working-with-udn_{context}"]
+= Working with user-defined networks
+
+You can enable user-defined networks (UDN) in Network Observability resources.
+The following example shows the configuration for the `FlowCollector` resource.
+
+.Prerequisite
+* You have configured UDN in {openshift-networking}. For more information, see "Creating a UserDefinedNetwork by using the CLI" or "Creating a UserDefinedNetwork by using the web console."
+
+.Procedure
+. Edit the Network Observability `FlowCollector` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit flowcollector
+----
+
+. Configure the `ebpf` section of the `FlowCollector` resource:
++
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    ebpf:
+      sampling: 1  <1>
+      privileged: true
+      features:
+      - UDNMapping
+----
+<1> Recommended so all flows are observed.
+
+.Verification
+
+* Refresh the *Network Traffic* page to view updated UDN information in the *Traffic Flow* and *Topology* views:
+
+** In *Network Traffic* > *Traffic flows*, you can view UDNs under the `SrcK8S_NetworkName` and `DstK8S_NetworkName` fields.
+** In the *Topology* view, you can set *Network* as *Scope* or *Group*.

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -41,6 +41,14 @@ include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 * xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-health-dashboard-overview_network_observability[Health dashboards]
 
+include::modules/network-observability-con_user-defined-networks.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#about-user-defined-networks[About user-defined networks]
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
+* xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-working-with-udn_nw-observe-network-traffic[Working with user-defined networks]
+
 include::modules/network-observability-networking-events-overview.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
@@ -59,6 +67,13 @@ include::modules/network-observability-working-with-zones.adoc[leveloffset=+2]
 include::modules/network-observability-filtering-ebpf-rule.adoc[leveloffset=+2]
 include::modules/network-observability-packet-translation-overview.adoc[leveloffset=+2]
 include::modules/network-observability-packet-translation.adoc[leveloffset=+2]
+include::modules/network-observability-proc_working-with-udn.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
+
 include::modules/network-observability-viewing-network-events.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -78,5 +93,5 @@ Alternatively, you can access the traffic flow data in the *Network Traffic* tab
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters] 
+* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]


### PR DESCRIPTION
[OSDOCS-14822](https://issues.redhat.com//browse/OSDOCS-14822) UDN NetObserv Content

Version(s):
Merge to only the `no-1.9` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the NetObserv content just before its GA.

Cherry-pick to OCP 4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-14822

Link to docs preview:
* User-defined networks concept: https://94271--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic.html#network-observability-user-defined-networks_nw-observe-network-traffic
* User-defined networks procedure: https://94271--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic.html#network-observability-working-with-udn_nw-observe-network-traffic

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
