### PR TITLE
MCO change Updated Boot Images to Managed Boot Images

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2397,7 +2397,7 @@ Topics:
   File: machine-config-node-disruption
 - Name: Configuring MCO-related custom resources
   File: machine-configs-custom
-- Name: Updated boot images
+- Name: Boot image management
   File: mco-update-boot-images
 - Name: Managing unused rendered machine configs
   File: machine-configs-garbage-collection
@@ -2828,7 +2828,7 @@ Topics:
     File: nodes-remediating-fencing-maintaining-rhwa
   - Name: Understanding node rebooting
     File: nodes-nodes-rebooting
-  - Name: Updated boot images
+  - Name: Boot image management
     File: nodes-update-boot-images
   - Name: Freeing node resources using garbage collection
     File: nodes-nodes-garbage-collection

--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -2,7 +2,7 @@
 :context: machine-configs-configure
 include::_attributes/common-attributes.adoc[]
 [id="mco-update-boot-images"]
-= Updated boot images
+= Boot image management
 
 toc::[]
 

--- a/modules/mco-update-boot-images-about.adoc
+++ b/modules/mco-update-boot-images-about.adoc
@@ -5,11 +5,11 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="mco-update-boot-images_{context}"]
-= About updated boot images
+= About boot image management
 
 By default, for {gcp-first} and {aws-first} clusters, the Machine Config Operator (MCO) updates the boot image in the machine sets in your cluster whenever you update your cluster.
 
-For {gcp-short} and {aws-short}, you can disable this default behavior, if needed. When disabled, the boot image no longer updates with the cluster. For example, with the default behavior disabled, if your cluster was originally created with {product-title} 4.16, the boot image that the MCO would use to create nodes is the same 4.16 version, even if your cluster is at a later version.
+For {gcp-short} and {aws-short}, you can disable the boot image management feature, if needed. When the feature is disabled, the boot image no longer updates with the cluster. For example, with the feature disabled, if your cluster was originally created with {product-title} 4.16, the boot image that the MCO would use to create nodes is the same 4.16 version, even if your cluster is at a later version.
 
 However, using an older boot image could cause the following issues:
 
@@ -17,25 +17,25 @@ However, using an older boot image could cause the following issues:
 * Certificate expiration issues
 * Version skew issues
 
-For information on how to disable the default behavior, see "Disabling updated boot images". If you disable the default behavior, you can enable the default behavior at any time. For more information, see "Enabling updated boot images".
+For information on how to disable this feature, see "Disabling boot image management". If you disable this feature, you can re-enable the feature at any time. For information, see "Enabling boot image management".
 
 [NOTE]
 ====
-The ability to configure this behavior is available for only {gcp-short} and {aws-short} clusters. It is not supported for clusters managed by the {cluster-capi-operator}.
+The ability to configure boot image management is available for only {gcp-short} and {aws-short} clusters. It is not supported for clusters managed by the {cluster-capi-operator}.
 ====
 
-How the cluster behaves after disabling or re-enabling the default behavior, depends upon when you made the change, including the following scenarios:
+How the cluster behaves after disabling or re-enabling the feature, depends upon when you made the change, including the following scenarios:
 
-* If you disable the behavior before updating to a new {product-title} version:
+* If you disable the feature before updating to a new {product-title} version:
 ** The boot image version used by the machine sets remains the same {product-title} version as when the feature was disabled. 
 ** When you scale up nodes, the new nodes use that same {product-title} version.
 
-* If you disable the behavior after updating to a new {product-title} version: 
+* If you disable the feature after updating to a new {product-title} version: 
 ** The boot image version used by the machine sets is updated to match the updated {product-title} version. 
 ** When you scale up nodes, the new nodes use the updated {product-title} version. 
 ** If you update to a later {product-title} version, the boot image version in the machine sets remains at the current version and is not updated with the cluster.
 
-* If you enable the behavior after disabling: 
+* If you enable the feature after disabling: 
 ** The boot image version used by the machine sets is updated to the current {product-title} version, if different. 
 ** When you scale up nodes, the new nodes use the current {product-title} version in the cluster. 
 
@@ -75,9 +75,9 @@ spec:
 // The following admonition is intended to address https://issues.redhat.com/browse//OSDOCS-14592
 [IMPORTANT]
 ====
-If any of the machine sets for which you want to enable updated boot images uses a `*-user-data` secret that is based on Ignition version 2.2.0, the Machine Config Operator converts the Ignition version to 3.4.0 when you enable updated boot images. {product-title} versions 4.5 and lower use Ignition version 2.2.0. If this conversion fails, the MCO or your cluster could degrade. An error message that includes _err: converting ignition stub failed: failed to parse Ignition config_ is added to the output of the `oc get ClusterOperator machine-config` command. You can use the following general steps to correct the problem:
+If any of the machine sets for which you want to enable boot image management use a `*-user-data` secret that is based on Ignition version 2.2.0, the Machine Config Operator converts the Ignition version to 3.4.0 when you enable the feature. {product-title} versions 4.5 and lower use Ignition version 2.2.0. If this conversion fails, the MCO or your cluster could degrade. An error message that includes _err: converting ignition stub failed: failed to parse Ignition config_ is added to the output of the `oc get ClusterOperator machine-config` command. You can use the following general steps to correct the problem:
 
-. Disable updated boot images. For more information, see "Disabling updated boot images".
+. Disable the boot image management feature. For information, see "Disabling boot image management".
 . Manually update the `*-user-data` secret to use Ignition version to 3.2.0.
-. Enable updated boot images. For more information, see "Enabling updated boot images".
+. Enable the boot image management feature. For information, see "Enabling boot image management".
 ====

--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -5,24 +5,24 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="mco-update-boot-images-configuring_{context}"]
-= Enabling updated boot images
+= Enabling boot image management
 
 By default, for {gcp-first} and {aws-first} clusters, the Machine Config Operator (MCO) updates the boot image in the machine sets in your cluster whenever you update your cluster.
 
-If you disabled this default behavior, so that the boot images are not updated, you can revert to the default behavior by editing the `MachineConfiguration` object.  
+If you disabled the boot image management feature, so that the boot images are not updated, you can re-enable the feature by editing the `MachineConfiguration` object.  
 
-Enabling the default behavior updates the boot image to the current {product-title} version. If the cluster is again updated to a new {product-title} version in the future, the boot image is updated again. New nodes created after enabling the feature use the updated boot image. This feature has no effect on existing nodes.
+Enabling the feature updates the boot image to the current {product-title} version. If the cluster is again updated to a new {product-title} version in the future, the boot image is updated again. New nodes created after enabling the feature use the updated boot image. This feature has no effect on existing nodes.
 
 .Procedure
 
-. Edit the `MachineConfiguration` object, named `cluster`, to enable the default boot image update behavior for some or all of your machine sets:
+. Edit the `MachineConfiguration` object, named `cluster`, to enable the boot image management feature for some or all of your machine sets:
 +
 [source,terminal]
 ----
 $ oc edit MachineConfiguration cluster
 ----
 
-* Optional: Enable the default behavior for all machine sets:
+* Optional: Enable the boot image management feature for all machine sets:
 +
 [source,yaml]
 ----
@@ -40,12 +40,12 @@ spec:
       selection:
         mode: All <4>
 ----
-<1> Configures the boot image update feature.
+<1> Configures the boot image management feature.
 <2> Specifies the API group. This must be `machine.openshift.io`. 
 <3> Specifies the resource within the specified API group to apply the change. This must be `machinesets`.
-<4> Specifies that the default behavior is enabled for all machine sets in the cluster.
+<4> Specifies that the feature is enabled for all machine sets in the cluster.
 
-* Optional: Enable the default behavior for specific machine sets:
+* Optional: Enable the boot image management feature for specific machine sets:
 +
 [source,yaml]
 ----
@@ -70,7 +70,7 @@ spec:
 <1> Configures the boot image update feature.
 <2> Specifies the API group. This must be `machine.openshift.io`.
 <3> Specifies the resource within the specified API group to apply the change. This must be `machinesets`.
-<4> Specifies that the default behavior is enabled for machine sets with the specified label.
+<4> Specifies that the feature is enabled for machine sets with the specified label.
 +
 [TIP]
 ====

--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -5,26 +5,26 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="mco-update-boot-images-disable_{context}"]
-= Disabling updated boot images
+= Disabling boot image management
 
-By default, for {gcp-first} and {aws-first} clusters, the Machine Config Operator (MCO) updates the boot image in the machine sets in your cluster whenever you update your cluster.
+By default, for {gcp-first} and {aws-first} clusters, the Machine Config Operator (MCO) manages and updates the boot image in the machine sets in your cluster whenever you update your cluster.
 
-You can disable this default behavior on some or all of your machine sets by editing the `MachineConfiguration` object. When disabled, the Machine Config Operator (MCO) no longer manages the boot image in your cluster and no longer updates the boot image with each cluster update.
+You can disable the boot image management feature for your cluster by editing the `MachineConfiguration` object. When disabled, the Machine Config Operator (MCO) no longer manages the boot image in your cluster and no longer updates the boot image with each cluster update.
 
 Disabling this feature does not rollback the nodes or machine sets to the originally-installed boot image. The machine sets retain the boot image version that was present when the feature was disabled and is not updated if the cluster is upgraded to a new {product-title} version in the future. This feature has no effect on existing nodes.
 
-After disabling a {gcp-short} and {aws-short} cluster, you can enable the default behavior at any time. For more information, see "Enabling updated boot images".
+After disabling the feature in a {gcp-short} or {aws-short} cluster, you can re-enable the feature at any time. For more information, see "Enabling updated boot images".
 
 .Procedure
 
-. Edit the `MachineConfiguration` object to disable the default boot image update behavior for some or all of your machine sets:
+. Edit the `MachineConfiguration` object to disable the boot image management feature for some or all of your machine sets:
 +
 [source,terminal]
 ----
 $ oc edit MachineConfiguration cluster
 ----
 
-* Optional: Disable the behavior for all machine sets:
+* Optional: Disable the feature for all machine sets:
 +
 [source,yaml]
 ----
@@ -44,10 +44,10 @@ spec:
 ----
 +
 --
-<1> Configures the boot image update feature.
+<1> Configures the boot image management feature.
 <2> Specifies an API group. This must be `machine.openshift.io`.
 <3> Specifies the resource within the specified API group to apply the change. This must be `machinesets`.
-<4> Specifies that the default behavior is disabled for all machine sets in the cluster.
+<4> Specifies that the feature is disabled for all machine sets in the cluster.
 --
 
 ////
@@ -74,11 +74,11 @@ spec:
             matchLabels:
               region: "east"
 ----
-<1> Configures the boot image update feature.
+<1> Configures the boot image management feature.
 <2> Specifies an API group. This must be `machine.openshift.io`.
 <3> Specifies the resource within the specified API group to apply the change. This must be `machinesets`.
-<4> Specifies that the default behavior is disabled for specific machine sets.
-<5> Specifies that the default behavior is enabled for only machine sets with these labels. The behavior is disabled for any machine set that does not contain the listed labels. 
+<4> Specifies that the feature is disabled for specific machine sets.
+<5> Specifies that the feature is enabled only for machine sets with these labels. The feature is disabled for any machine set that does not contain the listed labels. 
 ////
 
 .Verification

--- a/nodes/nodes/nodes-update-boot-images.adoc
+++ b/nodes/nodes/nodes-update-boot-images.adoc
@@ -2,7 +2,7 @@
 :context: nodes-update-boot-images
 include::_attributes/common-attributes.adoc[]
 [id="nodes-update-boot-images"]
-= Updated boot images
+= Boot image management
 
 toc::[]
 
@@ -12,8 +12,8 @@ include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-disable_machine-configs-configure[Disabling updated boot images]
-* xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-configuring_machine-configs-configure[Enabling updated boot images]
+* xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-disable_machine-configs-configure[Disabling boot image management]
+* xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-configuring_machine-configs-configure[Enabling boot image management]
 
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+1]
 include::modules/mco-update-boot-images-configuring.adoc[leveloffset=+1]

--- a/snippets/mco-update-boot-images-verification.adoc
+++ b/snippets/mco-update-boot-images-verification.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: SNIPPET
 
-* View the current state of the boot image updates by viewing the machine configuration object:
+* View the current state of the boot image management feature by viewing the machine configuration object:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14890

Renaming the feature.

Previews
Machine configuration -> [Boot image management](https://94272--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html)
Nodes -> Working with nodes -> [Boot image management](https://94272--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-update-boot-images.html)