### PR TITLE
OLS-1757: mention tool calling for cluster interaction

### DIFF
--- a/modules/ols-cluster-interaction-overview.adoc
+++ b/modules/ols-cluster-interaction-overview.adoc
@@ -6,3 +6,10 @@
 = Cluster interaction overview
 
 A large language model (LLM) is used with the {ols-long} service to generate responses to questions. Use the cluster interaction feature to enhance the knowledge available to the LLM with information about an {ocp-product-title} cluster. Providing cluster information, such as the namespaces or pods that the cluster contains, enables the LLM to generate highly customized responses for your environment.
+
+Function calling, also known as tool calling, is a capability that enables an LLM to interact with external APIs. {ols-long} uses the `auto` setting for the tool choice parameter of the LLM to make API calls to the LLM provider. To activate the cluster interaction feature in the {ols-long} service, tool calling must be enabled in the LLM provider.
+
+[NOTE]
+====
+Enabling tool calling can dramatically increase token usage. When you use public model providers, increased token usage can result in greater billing costs.
+====


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0tp1 and lightspeed-docs-1.0 branches as GA will occur week of June 9

Version(s): TP

Issue:  https://issues.redhat.com/browse/OLS-1757
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94286--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#cluster-interaction-overview_ols-configuring-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
