### PR TITLE
CNV#63003: Release note: Deprecate feature gates

### DIFF
--- a/virt/release_notes/virt-4-19-release-notes.adoc
+++ b/virt/release_notes/virt-4-19-release-notes.adoc
@@ -134,13 +134,20 @@ Deprecated features are included in the current release and supported. However, 
 
 * The `OperatorConditionsUnhealthy` alert is deprecated. You can safely xref:../../observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc#silencing-alerts-adm_managing-alerts-as-an-administrator[silence] it.
 
+//CNV-63003 Release note: Deprecate feature gates
+* The following `HyperConverged` custom resource (CR) fields have been deprecated and copied from their original location under the `spec.featureGates` fields to a new location in the `spec` field, where they can be used if needed:
+
+    ** `DeployVmConsoleProxy`
+    ** `EnableApplicationAwareQuota`
+    ** `EnableCommonBootImageImport`
+
++
+If used in the `spec.featureGates` location, the old fields are ignored.
 
 [id="virt-4-19-removed_{context}"]
 === Removed features
 
 Removed features are no longer supported in {VirtProductName}.
-
-
 
 [id="virt-4-19-technology-preview_{context}"]
 == Technology Preview features


### PR DESCRIPTION
Version(s): 4.19+

Issue: [CNV-63003](https://issues.redhat.com/browse/CNV-63003)

Link to docs preview:  [Deprecated features](https://94289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-19-release-notes.html#virt-4-19-deprecated_virt-4-19-release-notes)

QE review:
- [x] QE has approved this change.



