### PR TITLE
OSDOCS-14522: Cluster API base YAML updates

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -373,6 +373,9 @@ endif::openshift-origin[]
 // Cluster API Provider VMware vSphere
 :cap-vsphere-first: Cluster API Provider VMware vSphere
 :cap-vsphere-short: Cluster API Provider vSphere
+// Cluster API Provider Metal3
+:cap-bare-metal-first: Cluster API Provider Metal3
+:cap-bare-metal-short: Cluster API Provider Metal3
 // Hosted control planes related attributes
 :hcp-capital: Hosted control planes
 :hcp: hosted control planes

--- a/modules/capi-creating-machine-template.adoc
+++ b/modules/capi-creating-machine-template.adoc
@@ -38,7 +38,7 @@ spec:
 The following values are valid:
 +
 |====
-|Cluster cloud provider |Value
+|Cluster infrastructure provider |Value
 
 |{aws-first}
 |`AWSMachineTemplate`
@@ -54,6 +54,9 @@ The following values are valid:
 
 |{vmw-first}
 |`VSphereMachineTemplate`
+
+|Bare metal
+|`Metal3MachineTemplate`
 
 |====
 <2> Specify a name for the machine template.

--- a/modules/capi-modifying-machine-template.adoc
+++ b/modules/capi-modifying-machine-template.adoc
@@ -29,7 +29,7 @@ $ oc get <machine_template_kind> <1>
 The following values are valid:
 +
 |====
-|Cluster cloud provider |Value
+|Cluster infrastructure provider |Value
 
 |{aws-full}
 |`AWSMachineTemplate`
@@ -45,6 +45,9 @@ The following values are valid:
 
 |{vmw-full}
 |`VSphereMachineTemplate`
+
+|Bare metal
+|`Metal3MachineTemplate`
 
 |====
 --

--- a/modules/cluster-capi-operator.adoc
+++ b/modules/cluster-capi-operator.adoc
@@ -31,6 +31,10 @@ link:https://github.com/openshift/cluster-capi-operator[cluster-capi-operator]
 ** Scope: Namespaced
 ** CR: `gcpmachine`
 
+*  `azuremachines.infrastructure.cluster.x-k8s.io`
+** Scope: Namespaced
+** CR: `azuremachine`
+
 *  `openstackmachines.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `openstackmachine`
@@ -38,6 +42,10 @@ link:https://github.com/openshift/cluster-capi-operator[cluster-capi-operator]
 *  `vspheremachines.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `vspheremachine`
+
+*  `metal3machines.infrastructure.cluster.x-k8s.io`
+** Scope: Namespaced
+** CR: `metal3machine`
 
 * `awsmachinetemplates.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
@@ -47,6 +55,10 @@ link:https://github.com/openshift/cluster-capi-operator[cluster-capi-operator]
 ** Scope: Namespaced
 ** CR: `gcpmachinetemplate`
 
+*  `azuremachinetemplates.infrastructure.cluster.x-k8s.io`
+** Scope: Namespaced
+** CR: `azuremachinetemplate`
+
 *  `openstackmachinetemplates.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `openstackmachinetemplate`
@@ -54,3 +66,7 @@ link:https://github.com/openshift/cluster-capi-operator[cluster-capi-operator]
 *  `vspheremachinetemplates.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `vspheremachinetemplate`
+
+*  `metal3machinetemplates.infrastructure.cluster.x-k8s.io`
+** Scope: Namespaced
+** CR: `metal3machinetemplate`


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-14522](https://issues.redhat.com//browse/OSDOCS-14522)

Link to docs preview:
* [Cluster CAPI Operator](https://94291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-capi-operator_cluster-operators-ref)
* [Creating a Cluster API machine template](https://94291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-getting-started#capi-creating-machine-template_cluster-api-getting-started)
* [Modifying a Cluster API machine template](https://94291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-managing-machines#capi-modifying-machine-template_cluster-api-managing-machines)

QE review:
- [x] QE has approved this change.

Additional information: