### PR TITLE
OLS-1664:  Mention FIPS support in OLS product docs

### DIFF
--- a/about/ols-about-openshift-lightspeed.adoc
+++ b/about/ols-about-openshift-lightspeed.adoc
@@ -14,6 +14,7 @@ include::modules/ols-openshift-requirements.adoc[leveloffset=+1]
 include::modules/ols-large-language-model-overview.adoc[leveloffset=+1]
 //Xavier wanted to remove vLLM until further testing is performed.
 //include::modules/ols-about-openshift-ai-vllm.adoc[leveloffset=+2]
+include::modules/ols-openshift-lightspeed-fips-support.adoc[leveloffset=+1]
 include::modules/ols-supported-platforms.adoc[leveloffset=+1]
 include::modules/ols-about-running-openshift-lightspeed-in-disconnected-mode.adoc[leveloffset=+1]
 

--- a/modules/ols-openshift-lightspeed-fips-support.adoc
+++ b/modules/ols-openshift-lightspeed-fips-support.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="openshift-lightspeed-fips-support_{context}"]
+= {ols-long} FIPS support
+
+{ols-official} is designed for Federal Information Processing Standards (FIPS).
+
+FIPS is a set of publicly announced standards developed by the National Institute of Standards and Technology (NIST), a part of the U.S. Department of Commerce. The primary purpose of FIPS is to ensure the security and interoperability of computer systems used by U.S. federal government agencies and their associated contractors.
+
+[IMPORTANT]
+====
+When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted, or planned to be submitted, to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program] (NIST). For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
+====


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0tp1 and the lightspeed-docs-1.0 branches.

Issue: https://issues.redhat.com/browse/OLS-1664
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://94294--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/about/ols-about-openshift-lightspeed.html#openshift-lightspeed-fips-support_ols-large-language-model-overview

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
