### PR TITLE
WMCO hiding 4.19.0 docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1,4 +1,4 @@
-# trunk-ignore-all(prettier)
+  # trunk-ignore-all(prettier)
 # This configuration file dictates the organization of the topic groups and
 # topics on the main page of the doc site for this branch. Each record
 # consists of the following:
@@ -62,8 +62,8 @@ Name: Release notes
 Dir: release_notes
 Distros: openshift-enterprise
 Topics:
-- Name: OpenShift Container Platform release notes
-  File: ocp-release-notes
+- Name: OpenShift Container Platform 4.19 release notes
+  File: ocp-4-19-release-notes
 - Name: Additional release notes
   File: addtl-release-notes
 ---
@@ -816,7 +816,6 @@ Topics:
   File: managing-cluster-resources
 - Name: Getting support
   File: getting-support
-  Distros: openshift-enterprise
 - Name: Remote health monitoring with connected clusters
   Dir: remote_health_monitoring
   Distros: openshift-enterprise,openshift-origin
@@ -867,8 +866,8 @@ Topics:
     File: troubleshooting-s2i
   - Name: Troubleshooting storage issues
     File: troubleshooting-storage-issues
-  - Name: Troubleshooting Windows container workload issues
-    File: troubleshooting-windows-container-workload-issues
+#  - Name: Troubleshooting Windows container workload issues
+#    File: troubleshooting-windows-container-workload-issues
   - Name: Investigating monitoring issues
     File: investigating-monitoring-issues
   - Name: Diagnosing OpenShift CLI (oc) issues
@@ -1009,6 +1008,14 @@ Topics:
     File: cli-opm-install
   - Name: opm CLI reference
     File: cli-opm-ref
+- Name: Operator SDK
+  Dir: osdk
+  Distros: openshift-enterprise,openshift-origin
+  Topics:
+  - Name: Installing the Operator SDK CLI
+    File: cli-osdk-install
+  - Name: Operator SDK CLI reference
+    File: cli-osdk-ref
 ---
 Name: Security and compliance
 Dir: security
@@ -1229,6 +1236,20 @@ Topics:
     File: cert-manager-log-levels
   - Name: Uninstalling the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-operator-uninstall
+- Name: External Secrets Operator for Red Hat OpenShift
+  Dir: external_secrets_operator
+  Distros: openshift-enterprise
+  Topics:
+  - Name: External Secrets Operator overview
+    File: index
+  - Name: External Secrets Operator release notes
+    File: external-secrets-operator-release-notes
+  - Name: Installing the External Secrets Operator
+    File: external-secrets-operator-install
+  - Name: Monitoring the External Secrets Operator
+    File: external-secrets-operator-monitoring
+  - Name: Uninstalling the External Secrets Operator
+    File: external-secrets-operator-uninstall
 - Name: Viewing audit logs
   File: audit-log-view
 - Name: Configuring the audit log policy
@@ -1310,8 +1331,6 @@ Topics:
     File: configuring-google-identity-provider
   - Name: Configuring an OpenID Connect identity provider
     File: configuring-oidc-identity-provider
-- Name: Enabling direct authentication with an OIDC identity provider
-  File: external-auth
 - Name: Using RBAC to define and apply permissions
   File: using-rbac
 - Name: Removing the kubeadmin user
@@ -1999,6 +2018,59 @@ Topics:
   Dir: operator_sdk
   Distros: openshift-origin,openshift-enterprise
   Topics:
+  - Name: About the Operator SDK
+    File: osdk-about
+  - Name: Installing the Operator SDK CLI
+    File: osdk-installing-cli
+  - Name: Go-based Operators
+    Dir: golang
+    Topics:
+    - Name: Getting started
+      File: osdk-golang-quickstart
+    - Name: Tutorial
+      File: osdk-golang-tutorial
+    - Name: Project layout
+      File: osdk-golang-project-layout
+    - Name: Updating Go-based projects
+      File: osdk-golang-updating-projects
+  - Name: Ansible-based Operators
+    Dir: ansible
+    Topics:
+    - Name: Getting started
+      File: osdk-ansible-quickstart
+    - Name: Tutorial
+      File: osdk-ansible-tutorial
+    - Name: Project layout
+      File: osdk-ansible-project-layout
+    - Name: Updating Ansible-based projects
+      File: osdk-ansible-updating-projects
+    - Name: Ansible support
+      File: osdk-ansible-support
+    - Name: Kubernetes Collection for Ansible
+      File: osdk-ansible-k8s-collection
+    - Name: Using Ansible inside an Operator
+      File: osdk-ansible-inside-operator
+    - Name: Custom resource status management
+      File: osdk-ansible-cr-status
+  - Name: Helm-based Operators
+    Dir: helm
+    Topics:
+    - Name: Getting started
+      File: osdk-helm-quickstart
+    - Name: Tutorial
+      File: osdk-helm-tutorial
+    - Name: Project layout
+      File: osdk-helm-project-layout
+    - Name: Updating Helm-based projects
+      File: osdk-helm-updating-projects
+    - Name: Helm support
+      File: osdk-helm-support
+  - Name: Defining cluster service versions (CSVs)
+    File: osdk-generating-csvs
+  - Name: Working with bundle images
+    File: osdk-working-bundle-images
+  - Name: Complying with pod security admission
+    File: osdk-complying-with-psa
   - Name: Token authentication
     Dir: token_auth
     Topics:
@@ -2010,6 +2082,27 @@ Topics:
       File: osdk-cco-azure
     - Name: CCO-based workflow for OLM-managed Operators with GCP Workload Identity
       File: osdk-cco-gcp
+  - Name: Validating Operators using the scorecard
+    File: osdk-scorecard
+  - Name: Validating Operator bundles
+    File: osdk-bundle-validate
+  - Name: High-availability or single-node cluster detection and support
+    File: osdk-ha-sno
+  - Name: Configuring built-in monitoring with Prometheus
+    File: osdk-monitoring-prometheus
+  - Name: Configuring leader election
+    File: osdk-leader-election
+  - Name: Configuring support for multiple platforms
+    File: osdk-multi-arch-support
+  - Name: Object pruning utility
+    File: osdk-pruning-utility
+  - Name: Migrating package manifest projects to bundle format
+    File: osdk-pkgman-to-bundle
+  - Name: Operator SDK CLI reference
+    File: osdk-cli-ref
+  - Name: Migrating to Operator SDK v0.1.0
+    File: osdk-migrating-to-v0-1-0
+    Distros: openshift-origin
 - Name: Cluster Operators reference
   File: operator-reference
 - Name: OLM v1
@@ -2303,13 +2396,16 @@ Topics:
   File: machine-config-node-disruption
 - Name: Configuring MCO-related custom resources
   File: machine-configs-custom
-- Name: Boot image management
+- Name: Updated boot images
   File: mco-update-boot-images
 - Name: Managing unused rendered machine configs
   File: machine-configs-garbage-collection
-- Name: Image mode for OpenShift
+- Name: Red Hat Enterprise Linux (RHEL) CoreOS image layering
   File: mco-coreos-layering
-  Distros: openshift-enterprise,openshift-origin
+  Distros: openshift-enterprise
+- Name: Fedora CoreOS image layering
+  File: mco-coreos-layering
+  Distros: openshift-origin
 - Name: Machine Config Daemon metrics
   File: machine-config-daemon-metrics
 ---
@@ -2420,8 +2516,6 @@ Topics:
       File: cluster-api-config-options-rhosp
     - Name: Cluster API configuration options for VMware vSphere
       File: cluster-api-config-options-vsphere
-    - Name: Cluster API configuration options for bare metal
-      File: cluster-api-config-options-bare-metal
 #  - Name: Cluster API resiliency and recovery
 #    File: cluster-api-resiliency
   - Name: Troubleshooting Cluster API clusters
@@ -2733,7 +2827,7 @@ Topics:
     File: nodes-remediating-fencing-maintaining-rhwa
   - Name: Understanding node rebooting
     File: nodes-nodes-rebooting
-  - Name: Boot image management
+  - Name: Updated boot images
     File: nodes-update-boot-images
   - Name: Freeing node resources using garbage collection
     File: nodes-nodes-garbage-collection
@@ -2817,47 +2911,47 @@ Distros: openshift-origin,openshift-enterprise
 Topics:
 - Name: Red Hat OpenShift support for Windows Containers overview
   File: index
-- Name: Release notes
-  Dir: wmco_rn
-  Topics:
-  - Name: Red Hat OpenShift support for Windows Containers release notes
-    File: windows-containers-release-notes-10-17-x
-  - Name: Past releases
-    File: windows-containers-release-notes-10-17-x-past
-  - Name: Windows Machine Config Operator prerequisites
-    File: windows-containers-release-notes-10-17-x-prereqs
-  - Name: Windows Machine Config Operator known limitations
-    File: windows-containers-release-notes-10-17-x-limitations
-- Name: Getting support
-  File: windows-containers-support
-  Distros: openshift-enterprise
-- Name: Understanding Windows container workloads
-  File: understanding-windows-container-workloads
-- Name: Enabling Windows container workloads
-  File: enabling-windows-container-workloads
-- Name: Creating Windows machine sets
-  Dir: creating_windows_machinesets
-  Topics:
-  - Name: Creating a Windows machine set on AWS
-    File: creating-windows-machineset-aws
-  - Name: Creating a Windows machine set on Azure
-    File: creating-windows-machineset-azure
-  - Name: Creating a Windows machine set on GCP
-    File: creating-windows-machineset-gcp
-  - Name: Creating a Windows machine set on Nutanix
-    File: creating-windows-machineset-nutanix
-  - Name: Creating a Windows machine set on vSphere
-    File: creating-windows-machineset-vsphere
-- Name: Scheduling Windows container workloads
-  File: scheduling-windows-workloads
-- Name: Windows node updates
-  File: windows-node-upgrades
-- Name: Using Bring-Your-Own-Host Windows instances as nodes
-  File: byoh-windows-instance
-- Name: Removing Windows nodes
-  File: removing-windows-nodes
-- Name: Disabling Windows container workloads
-  File: disabling-windows-container-workloads
+#- Name: Release notes
+#  Dir: wmco_rn
+#  Topics:
+#  - Name: Red Hat OpenShift support for Windows Containers release notes
+#    File: windows-containers-release-notes-10-19-x
+#  - Name: Past releases
+#    File: windows-containers-release-notes-10-19-x-past
+#  - Name: Windows Machine Config Operator prerequisites
+#    File: windows-containers-release-notes-10-19-x-prereqs
+#  - Name: Windows Machine Config Operator known limitations
+#    File: windows-containers-release-notes-10-19-x-limitations
+#- Name: Getting support
+#  File: windows-containers-support
+#  Distros: openshift-enterprise
+#- Name: Understanding Windows container workloads
+#  File: understanding-windows-container-workloads
+#- Name: Enabling Windows container workloads
+#  File: enabling-windows-container-workloads
+#- Name: Creating Windows machine sets
+#  Dir: creating_windows_machinesets
+#  Topics:
+#  - Name: Creating a Windows machine set on AWS
+#    File: creating-windows-machineset-aws
+#  - Name: Creating a Windows machine set on Azure
+#    File: creating-windows-machineset-azure
+#  - Name: Creating a Windows machine set on GCP
+#    File: creating-windows-machineset-gcp
+#  - Name: Creating a Windows machine set on Nutanix
+#    File: creating-windows-machineset-nutanix
+#  - Name: Creating a Windows machine set on vSphere
+#    File: creating-windows-machineset-vsphere
+#- Name: Scheduling Windows container workloads
+#  File: scheduling-windows-workloads
+#- Name: Windows node updates
+#  File: windows-node-upgrades
+#- Name: Using Bring-Your-Own-Host Windows instances as nodes
+#  File: byoh-windows-instance
+#- Name: Removing Windows nodes
+#  File: removing-windows-nodes
+#- Name: Disabling Windows container workloads
+#  File: disabling-windows-container-workloads
 ---
 Name: OpenShift sandboxed containers
 Dir: sandboxed_containers
@@ -3533,10 +3627,6 @@ Topics:
   File: nvidia-gpu-architecture
 - Name: AMD GPU Operator
   File: amd-gpu-operator
-- Name: Intel Gaudi AI accelerators
-  File: gaudi-ai-accelerator
-- Name: Remote Direct Memory Access (RDMA)
-  File: rdma-remote-direct-memory-access
 ---
 Name: Backup and restore
 Dir: backup_and_restore
@@ -3558,8 +3648,6 @@ Topics:
   - Name: OADP release notes
     Dir: release-notes
     Topics:
-    - Name: OADP 1.5 release notes
-      File: oadp-1-5-release-notes
     - Name: OADP 1.4 release notes
       File: oadp-1-4-release-notes
   - Name: OADP performance
@@ -3580,58 +3668,29 @@ Topics:
       File: oadp-usecase-enable-ca-cert
     - Name: Using the legacy-aws Velero plugin
       File: oadp-usecase-legacy-aws-plugin
-    - Name: Backing up workloads on OADP with ROSA STS
-      File: oadp-rosa-backup-restore
-  - Name: Installing OADP
+  - Name: Installing and configuring OADP
     Dir: installing
     Topics:
     - Name: About installing OADP
       File: about-installing-oadp
     - Name: Installing the OADP Operator
       File: oadp-installing-operator
-  - Name: Configuring OADP with AWS S3 compatible storage
-    Dir: installing
-    Topics:
     - Name: Configuring OADP with AWS S3 compatible storage
       File: installing-oadp-aws
-  - Name: Configuring OADP with IBM Cloud
-    Dir: installing
-    Topics:
     - Name: Configuring OADP with IBM Cloud
       File: installing-oadp-ibm-cloud
-  - Name: Configuring OADP with Azure
-    Dir: installing
-    Topics:
     - Name: Configuring OADP with Azure
       File: installing-oadp-azure
-  - Name: Configuring OADP with GCP
-    Dir: installing
-    Topics:
     - Name: Configuring OADP with GCP
       File: installing-oadp-gcp
-  - Name: Configuring OADP with MCG
-    Dir: installing
-    Topics:
     - Name: Configuring OADP with MCG
       File: installing-oadp-mcg
-  - Name: Configuring OADP with ODF
-    Dir: installing
-    Topics:
     - Name: Configuring OADP with ODF
       File: installing-oadp-ocs
-  - Name: Configuring OADP with OpenShift Virtualization
-    Dir: installing
-    Topics:
     - Name: Configuring OADP with OpenShift Virtualization
       File: installing-oadp-kubevirt
-  - Name: Configuring OADP with multiple backup storage locations
-    Dir: installing
-    Topics:
     - Name: Configuring OADP with multiple backup storage locations
       File: configuring-oadp-multiple-bsl
-  - Name: Configuring OADP with multiple Volume Snapshot Locations
-    Dir: installing
-    Topics:
     - Name: Configuring OADP with multiple Volume Snapshot Locations
       File: configuring-oadp-multiple-vsl
   - Name: Uninstalling OADP
@@ -3663,17 +3722,17 @@ Topics:
     Topics:
     - Name: Restoring applications
       File: restoring-applications
-  - Name: OADP Self-Service
-    Dir: oadp-self-service
-    Topics:
-    - Name: OADP Self-Service
-      File: oadp-self-service
-    - Name: OADP Self-Service cluster admin use cases
-      File: oadp-self-service-cluster-admin-use-cases
-    - Name: OADP Self-Service namespace admin use cases
-      File: oadp-self-service-namespace-admin-use-cases
-    - Name: OADP Self-Service troubleshooting
-      File: oadp-self-service-troubleshooting
+  #- Name: OADP Self-Service Note:Commenting out this block because the PR is huge and I would like to get the files merged. I will open a separate PR to un-comment this block on the date of GA.
+  #  Dir: oadp-self-service
+  #  Topics:
+  #  - Name: OADP Self-Service
+  #    File: oadp-self-service
+  #  - Name: OADP Self-Service cluster admin use cases
+  #    File: oadp-self-service-cluster-admin-use-cases
+  #  - Name: OADP Self-Service namespace admin use cases
+  #    File: oadp-self-service-namespace-admin-use-cases
+  #  - Name: OADP Self-Service troubleshooting
+  #    File: oadp-self-service-troubleshooting
   - Name: OADP and ROSA
     Dir: oadp-rosa
     Topics:
@@ -3700,39 +3759,34 @@ Topics:
       File: about-oadp-data-mover
     - Name: Backing up and restoring volumes by using CSI snapshots data movement
       File: oadp-backup-restore-csi-snapshots
-    - Name: Configuring backupPVC and restorePVC for Data Mover
-      File: configuring-backup-restore-pvc-datamover
     - Name: Overriding Kopia algorithms
       File: overriding-kopia-algorithms
   - Name: OADP API
     File: oadp-api
   - Name: Advanced OADP features and functionalities
     File: oadp-advanced-topics
-  - Name: OADP troubleshooting
-    Dir: troubleshooting
-    Topics:
-    - Name: Troubleshooting OADP
-      File: troubleshooting
-    - Name: Velero CLI tool
-      File: velero-cli-tool
-    - Name: Pods crash or restart due to lack of memory or CPU
-      File: pods-crash-or-restart-due-to-lack-of-memory-or-cpu
-    - Name: Issues with Velero and admission webhooks
-      File: issues-with-velero-and-admission-webhooks
-    - Name: OADP installation issues
-      File: oadp-installation-issues
-    - Name: OADP Operator issues
-      File: oadp-operator-issues
-    - Name: OADP timeouts
-      File: oadp-timeouts
-    - Name: Backup and Restore CR issues
-      File: backup-and-restore-cr-issues
-    - Name: Restic issues
-      File: restic-issues
-    - Name: Using the must-gather tool
-      File: using-the-must-gather-tool
-    - Name: OADP monitoring
-      File: oadp-monitoring
+  - Name: Troubleshooting OADP
+    File: troubleshooting
+  - Name: Velero CLI tool
+    File: velero-cli-tool
+  - Name: Pods crash or restart due to lack of memory or CPU
+    File: pods-crash-or-restart-due-to-lack-of-memory-or-cpu
+  - Name: Issues with Velero and admission webhooks
+    File: issues-with-velero-and-admission-webhooks
+  - Name: OADP installation issues
+    File: oadp-installation-issues
+  - Name: OADP Operator issues
+    File: oadp-operator-issues
+  - Name: OADP timeouts
+    File: oadp-timeouts
+  - Name: Backup and Restore CR issues
+    File: backup-and-restore-cr-issues
+  - Name: Restic issues
+    File: restic-issues
+  - Name: Using the must-gather tool
+    File: using-the-must-gather-tool
+  - Name: OADP monitoring
+    File: oadp-monitoring
 - Name: Control plane backup and restore
   Dir: control_plane_backup_and_restore
   Topics:
@@ -4037,10 +4091,6 @@ Topics:
     File: machine-machine-openshift-io-v1beta1
   - Name: 'MachineSet [machine.openshift.io/v1beta1]'
     File: machineset-machine-openshift-io-v1beta1
-  - Name: 'MachineOSBuild [machineconfiguration.openshift.io/v1]'
-    File: machineosbuild-machineconfiguration-openshift-io-v1
-  - Name: 'MachineOSConfig [machineconfiguration.openshift.io/v1]'
-    File: machineosconfig-machineconfiguration-openshift-io-v1
 - Name: Metadata APIs
   Dir: metadata_apis
   Topics:
@@ -4098,8 +4148,6 @@ Topics:
   Topics:
   - Name: About Network APIs
     File: network-apis-index
-  - Name: 'ClusterUserDefinedNetwork [k8s.ovn.org/v1]'
-    File: clusteruserdefinednetwork-k8s-ovn-org-v1
   - Name: 'AdminNetworkPolicy [policy.networking.k8s.io/v1alpha1]'
     File: adminnetworkpolicy-policy-networking-k8s-io-v1alpha1
   - Name: 'AdminPolicyBasedExternalRoute [k8s.ovn.org/v1]'
@@ -4122,20 +4170,10 @@ Topics:
     File: endpointslice-discovery-k8s-io-v1
   - Name: 'EgressRouter [network.operator.openshift.io/v1]'
     File: egressrouter-network-operator-openshift-io-v1
-  - Name: 'GRPCRoute [gateway.networking.k8s.io/v1]'
-    File: grpcroute-gateway-networking-k8s-io-v1
-  - Name: 'Gateway [gateway.networking.k8s.io/v1]'
-    File: gateway-gateway-networking-k8s-io-v1
-  - Name: 'GatewayClass [gateway.networking.k8s.io/v1]'
-    File: gatewayclass-gateway-networking-k8s-io-v1
-  - Name: 'HTTPRoute [gateway.networking.k8s.io/v1]'
-    File: httproute-gateway-networking-k8s-io-v1
   - Name: 'Ingress [networking.k8s.io/v1]'
     File: ingress-networking-k8s-io-v1
   - Name: 'IngressClass [networking.k8s.io/v1]'
     File: ingressclass-networking-k8s-io-v1
-  - Name: 'IPAMClaim [k8s.cni.cncf.io/v1alpha1]'
-    File: ipamclaim-k8s-cni-cncf-io-v1alpha1
   - Name: 'IPPool [whereabouts.cni.cncf.io/v1alpha1]'
     File: ippool-whereabouts-cni-cncf-io-v1alpha1
   - Name: 'MultiNetworkPolicy [k8s.cni.cncf.io/v1beta1]'
@@ -4144,20 +4182,14 @@ Topics:
     File: networkattachmentdefinition-k8s-cni-cncf-io-v1
   - Name: 'NetworkPolicy [networking.k8s.io/v1]'
     File: networkpolicy-networking-k8s-io-v1
-  - Name: 'NodeSlicePool [whereabouts.cni.cncf.io/v1alpha1]'
-    File: nodeslicepool-whereabouts-cni-cncf-io-v1alpha1
   - Name: 'OverlappingRangeIPReservation [whereabouts.cni.cncf.io/v1alpha1]'
     File: overlappingrangeipreservation-whereabouts-cni-cncf-io-v1alpha1
   - Name: 'PodNetworkConnectivityCheck [controlplane.operator.openshift.io/v1alpha1]'
     File: podnetworkconnectivitycheck-controlplane-operator-openshift-io-v1alpha1
-  - Name: 'ReferenceGrant [gateway.networking.k8s.io/v1beta1]'
-    File: referencegrant-gateway-networking-k8s-io-v1beta1
   - Name: 'Route [route.openshift.io/v1]'
     File: route-route-openshift-io-v1
   - Name: 'Service [undefined/v1]'
     File: service-v1
-  - Name: 'UserDefinedNetwork [k8s.ovn.org/v1]'
-    File: userdefinednetwork-k8s-ovn-org-v1
 - Name: Node APIs
   Dir: node_apis
   Topics:
@@ -4252,10 +4284,6 @@ Topics:
     File: operatorhub-apis-index
   - Name: 'CatalogSource [operators.coreos.com/v1alpha1]'
     File: catalogsource-operators-coreos-com-v1alpha1
-  - Name: 'ClusterCatalog [olm.operatorframework.io/v1]'
-    File: clustercatalog-olm-operatorframework-io-v1
-  - Name: 'ClusterExtension [olm.operatorframework.io/v1]'
-    File: clusterextension-olm-operatorframework-io-v1
   - Name: 'ClusterServiceVersion [operators.coreos.com/v1alpha1]'
     File: clusterserviceversion-operators-coreos-com-v1alpha1
   - Name: 'InstallPlan [operators.coreos.com/v1alpha1]'
@@ -4309,8 +4337,6 @@ Topics:
     File: hostfirmwarecomponents-metal3-io-v1alpha1
   - Name: 'HostFirmwareSettings [metal3.io/v1alpha1]'
     File: hostfirmwaresettings-metal3-io-v1alpha1
-  - Name: 'HostUpdatePolicy [metal3.io/v1alpha1]'
-    File: hostupdatepolicy-metal3-io-v1alpha1
   - Name: 'Metal3Remediation [infrastructure.cluster.x-k8s.io/v1beta1]'
     File: metal3remediation-infrastructure-cluster-x-k8s-io-v1beta1
   - Name: 'Metal3RemediationTemplate [infrastructure.cluster.x-k8s.io/v1beta1]'
@@ -4612,13 +4638,10 @@ Topics:
     Distros: openshift-enterprise
 - Name: Release notes
   Dir: release_notes
+  Distros: openshift-enterprise
   Topics:
   - Name: OpenShift Virtualization release notes
-    File: virt-release-notes-placeholder
-    Distros: openshift-enterprise
-  # - Name: OKD Virtualization release notes
-  #   File: virt-release-notes-placeholder
-  #   Distros: openshift-origin
+    File: virt-4-19-release-notes
 - Name: Getting started
   Dir: getting_started
   Topics:
@@ -4686,28 +4709,28 @@ Topics:
 - Name: Advanced VM creation
   Dir: creating_vms_advanced
   Topics:
-  - Name: Advanced virtual machine creation overview
-    File: advanced-vm-creation-overview
-  - Name: Creating VMs in the web console
-    Dir: creating_vms_advanced_web
-    Topics:
-    - Name: Creating VMs from Red Hat images
-      File: virt-creating-vms-from-rh-images-overview
-    - Name: Creating VMs by importing images from web pages
-      File: virt-creating-vms-from-web-images
-    - Name: Creating VMs by uploading images
-      File: virt-creating-vms-uploading-images
-    - Name: Cloning VMs
-      File: virt-cloning-vms
-  - Name: Creating VMs using the CLI
-    Dir: creating_vms_cli
-    Topics:
-    - Name: Creating virtual machines from the command line
-      File: virt-creating-vms-from-cli
-    - Name: Creating VMs by using container disks
-      File: virt-creating-vms-from-container-disks
-    - Name: Creating VMs by cloning PVCs
-      File: virt-creating-vms-by-cloning-pvcs
+    - Name: Advanced virtual machine creation overview
+      File: advanced-vm-creation-overview
+    - Name: Creating VMs in the web console
+      Dir: creating_vms_advanced_web
+      Topics:
+      - Name: Creating VMs from Red Hat images
+        File: virt-creating-vms-from-rh-images-overview
+      - Name: Creating VMs by importing images from web pages
+        File: virt-creating-vms-from-web-images
+      - Name: Creating VMs by uploading images
+        File: virt-creating-vms-uploading-images
+      - Name: Cloning VMs
+        File: virt-cloning-vms
+    - Name: Creating VMs using the CLI
+      Dir: creating_vms_cli
+      Topics:
+      - Name: Creating virtual machines from the command line
+        File: virt-creating-vms-from-cli
+      - Name: Creating VMs by using container disks
+        File: virt-creating-vms-from-container-disks
+      - Name: Creating VMs by cloning PVCs
+        File: virt-creating-vms-by-cloning-pvcs
 - Name: Managing VMs
   Dir: managing_vms
   Topics:
@@ -4735,8 +4758,6 @@ Topics:
     File: virt-using-vtpm-devices
   - Name: Managing virtual machines with OpenShift Pipelines
     File: virt-managing-vms-openshift-pipelines
-  - Name: Migrating VMs in a single cluster to a different storage class
-    File: virt-migrating-vms-in-single-cluster-to-different-storage-class
   - Name: Advanced virtual machine management
     Dir: advanced_vm_management
     Topics:

--- a/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
@@ -109,11 +109,13 @@ include::modules/nw-aws-nlb-new-cluster.adoc[leveloffset=+1]
 
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-
+////
+Hiding until WMCO 10.19.0 GAs
 [NOTE]
 ====
-For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information about using Linux and Windows nodes in the same cluster, see ../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
+////
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/ipi/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/ipi/installing-azure-network-customizations.adoc
@@ -46,11 +46,13 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-
+////
+Hiding until WMCO 10.19.0 GAs
 [NOTE]
 ====
-For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information about using Linux and Windows nodes in the same cluster, see ../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
+////
 
 [role="_additional-resources"]
 .Additional resources

--- a/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.adoc
@@ -50,12 +50,13 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-
+////
+Hiding until WMCO 10.19.0 GAs
 [NOTE]
 ====
-For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information about using Linux and Windows nodes in the same cluster, see ../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-
+////
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/overview/installing-preparing.adoc
+++ b/installing/overview/installing-preparing.adoc
@@ -116,7 +116,11 @@ For a production cluster, you must configure the following integrations:
 == Preparing your cluster for workloads
 
 Depending on your workload needs, you might need to take extra steps before you begin deploying applications. For example, after you prepare infrastructure to support your application xref:../../cicd/builds/build-strategies.adoc#build-strategies[build strategy], you might need to make provisions for xref:../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-low-latency-perf-profile[low-latency] workloads or to xref:../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets[protect sensitive workloads]. You can also configure xref:../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-monitoring-for-user-defined-projects-uwm_preparing-to-configure-the-monitoring-stack-uwm[monitoring] for application workloads.
-If you plan to run xref:../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Windows workloads], you must enable xref:../../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[hybrid networking with OVN-Kubernetes] during the installation process; hybrid networking cannot be enabled after your cluster is installed.
+
+////
+Hiding until WMCO 10.19.0 GAs
+If you plan to run ../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Windows workloads], you must enable xref:../../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[hybrid networking with OVN-Kubernetes] during the installation process; hybrid networking cannot be enabled after your cluster is installed.
+////
 
 [id="supported-installation-methods-for-different-platforms"]
 == Supported installation methods for different platforms

--- a/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/installing-aws-network-customizations.adoc
+// * installing/installing_aws/ipi/installing-aws-network-customizations.adoc
 // * installing/installing_azure/installing-azure-network-customizations.adoc
 // * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 // * networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
@@ -15,11 +15,139 @@ endif::[]
 
 You can configure your cluster to use hybrid networking with the OVN-Kubernetes network plugin. This allows a hybrid cluster that supports different node networking configurations.
 
+////
+Hiding until WMCO 10.19.0 GAs
 [NOTE]
 ====
 This configuration is necessary to run both Linux and Windows nodes in the same cluster.
 ====
+////
 
+ifndef::post-install[]
+.Prerequisites
+
+// Made changes to hide Windows-related material until WMCO 4.19.0 releases. Below this is the full procedure, commented out.
+
+* You defined `OVNKubernetes` for the `networking.networkType` parameter in the `install-config.yaml` file. See the installation documentation for configuring {product-title} network customizations on your chosen cloud provider for more information.
+
+.Procedure
+
+. Change to the directory that contains the installation program and create the manifests:
++
+[source,terminal]
+----
+$ ./openshift-install create manifests --dir <installation_directory>
+----
++
+--
+where:
+
+`<installation_directory>`:: Specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
+--
+
+. Create a stub manifest file for the advanced network configuration that is named `cluster-network-03-config.yml` in the `<installation_directory>/manifests/` directory:
++
+[source,terminal]
+----
+$ cat <<EOF > <installation_directory>/manifests/cluster-network-03-config.yml
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+EOF
+----
++
+--
+where:
+
+`<installation_directory>`:: Specifies the directory name that contains the
+`manifests/` directory for your cluster.
+--
+
+. Open the `cluster-network-03-config.yml` file in an editor and configure OVN-Kubernetes with hybrid networking, as in the following example:
++
+--
+.Specify a hybrid networking configuration
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      hybridOverlayConfig:
+        hybridClusterNetwork: <1>
+        - cidr: 10.132.0.0/14
+          hostPrefix: 23
+----
+<1> Specify the CIDR configuration used for nodes on the additional overlay network. The `hybridClusterNetwork` CIDR must not overlap with the `clusterNetwork` CIDR.
+--
+
+. Save the `cluster-network-03-config.yml` file and quit the text editor.
+. Optional: Back up the `manifests/cluster-network-03-config.yml` file. The
+installation program deletes the `manifests/` directory when creating the
+cluster.
+endif::post-install[]
+ifdef::post-install[]
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster as a user with `cluster-admin` privileges.
+* Ensure that the cluster uses the OVN-Kubernetes network plugin.
+
+.Procedure
+
+
+. To configure the OVN-Kubernetes hybrid network overlay, enter the following command:
++
+[source,terminal]
+----
+$ oc patch networks.operator.openshift.io cluster --type=merge \
+  -p '{
+    "spec":{
+      "defaultNetwork":{
+        "ovnKubernetesConfig":{
+          "hybridOverlayConfig":{
+            "hybridClusterNetwork":[
+              {
+                "cidr": "<cidr>",
+                "hostPrefix": <prefix>
+              }
+            ]
+          }
+        }
+      }
+    }
+  }'
+----
++
+--
+where:
+
+`cidr`:: Specify the CIDR configuration used for nodes on the additional overlay network. This CIDR must not overlap with the cluster network CIDR.
+`hostPrefix`:: Specifies the subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
+--
++
+.Example output
+[source,text]
+----
+network.operator.openshift.io/cluster patched
+----
+
+. To confirm that the configuration is active, enter the following command. It can take several minutes for the update to apply.
++
+[source,terminal]
+----
+$ oc get network.operator.openshift.io -o jsonpath="{.items[0].spec.defaultNetwork.ovnKubernetesConfig}"
+----
+
+endif::post-install[]
+
+////
+Hiding until WMCO 10.19.0 GAs
 ifndef::post-install[]
 .Prerequisites
 
@@ -102,6 +230,7 @@ ifdef::post-install[]
 
 .Procedure
 
+
 . To configure the OVN-Kubernetes hybrid network overlay, enter the following command:
 +
 [source,terminal]
@@ -132,11 +261,6 @@ where:
 `cidr`:: Specify the CIDR configuration used for nodes on the additional overlay network. This CIDR must not overlap with the cluster network CIDR.
 `hostPrefix`:: Specifies the subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
 `hybridOverlayVXLANPort`:: Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `4789` port. For more information on this requirement, see the Microsoft documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken].
-
-[NOTE]
-====
-Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 is not supported on clusters with a custom `hybridOverlayVXLANPort` value because this Windows server version does not support selecting a custom VXLAN port.
-====
 --
 +
 .Example output
@@ -152,6 +276,7 @@ network.operator.openshift.io/cluster patched
 $ oc get network.operator.openshift.io -o jsonpath="{.items[0].spec.defaultNetwork.ovnKubernetesConfig}"
 ----
 endif::post-install[]
+////
 
 ifdef::post-install[]
 :!post-install:

--- a/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
@@ -14,7 +14,10 @@ include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 [id="configuring-hybrid-networking-additional-resources"]
 == Additional resources
 
-* xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads]
-* xref:../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Enabling Windows container workloads]
+////
+Hiding until WMCO 10.19.0 GAs
+* ../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads]
+* ../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Enabling Windows container workloads]
+////
 * xref:../../installing/installing_aws/ipi/installing-aws-network-customizations.adoc#installing-aws-network-customizations[Installing a cluster on AWS with network customizations]
 * xref:../../installing/installing_azure/ipi/installing-azure-network-customizations.adoc#installing-azure-network-customizations[Installing a cluster on Azure with network customizations]

--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -2,14 +2,95 @@
 [id="addtl-release-notes"]
 = Additional release notes
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-microshift.adoc[]
+include::_attributes/servicebinding-document-attributes.adoc[]
 :context: addtl-release-notes
 
 toc::[]
 
-Purpose: A compilation of links to release notes for additional related components, products, or Operators not included in the core OCP release notes.
+Release notes for additional related components and products not included in the core xref:../release_notes/ocp-4-19-release-notes.adoc#ocp-4-19-release-notes[{product-title} {product-version} release notes] are available in the following documentation.
 
-**This file on the `main` branch is a stub, included only to allow builds to work.**
+[IMPORTANT]
+====
+The following release notes are for downstream Red Hat products only; upstream or community release notes for related products are not included.
+====
 
-Do not add or edit this file here on the `main` branch. Edit the `addtl-release-notes.adoc` file directly in the branch that a change is relevant for. Changes to this file should be added or edited in their own PR, per version branch as needed.
+A::
+xref:../networking/networking_operators/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc#aws-load-balancer-operator-release-notes[AWS Load Balancer Operator]
 
-This is because there might be different version compatabilities with OCP, or some components/products/Operators might not be available all for a given OCP version.
+B::
+link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1/html/about_builds/ob-release-notes#ob-release-notes[{builds-v2title}]
+
+C::
+xref:../security/cert_manager_operator/cert-manager-operator-release-notes.adoc#cert-manager-operator-release-notes[{cert-manager-operator}] +
+{nbsp} +
+xref:../observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc#cluster-observability-operator-release-notes[{coo-first}] +
+{nbsp} +
+xref:../security/compliance_operator/compliance-operator-release-notes.adoc#compliance-operator-release-notes[Compliance Operator] +
+{nbsp} +
+xref:../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator]
+
+D::
+link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/#Release%20Notes[{rh-dev-hub} Operator]
+
+E::
+xref:../networking/networking_operators/external_dns_operator/external-dns-operator-release-notes.adoc#external-dns-operator-release-notes[External DNS Operator]
+
+F::
+xref:../security/file_integrity_operator/file-integrity-operator-release-notes.adoc#file-integrity-operator-release-notes-v0[File Integrity Operator]
+
+K::
+xref:../nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc#nodes-descheduler-release-notes[{descheduler-operator}]
+
+L::
+xref:../observability/logging/logging-6.2/log6x-release-notes-6.2.adoc#log6x-release-notes-6-2[{logging-uc}]
+
+M::
+xref:../migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc#mtc-release-notes[{mtc-full} ({mtc-short})]
+
+N::
+xref:../observability/network_observability/network-observability-operator-release-notes.adoc#network-observability-operator-release-notes[Network Observability Operator] +
+{nbsp} +
+xref:../security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc#nbde-tang-server-operator-release-notes[Network-bound Disk Encryption (NBDE) Tang Server Operator]
+
+O::
+xref:../backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc#oadp-1-4-release-notes[{oadp-first}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/#Release%20Notes[{openshift-dev-spaces-productname}] +
+{nbsp} +
+xref:../observability/distr_tracing/distr-tracing-rn.adoc#distr-tracing-rn[{DTProductName}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/#Get%20started[{gitops-title}] +
+{nbsp} +
+link:https://crc.dev/docs/introducing/[{openshift-local-productname} (Upstream CRC documentation)] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/#Getting%20Started[{pipelines-title}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/#Release%20Notes[{osc}] +
+{nbsp} +
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.33/html/about_openshift_serverless/serverless-release-notes#serverless-release-notes[Red Hat {ServerlessProductName}] +
+{nbsp} +
+xref:../service_mesh/v2x/servicemesh-release-notes.adoc#service-mesh-release-notes[{SMProductName} 2.x] +
+{nbsp} +
+link:https://docs.openshift.com/service-mesh/3.0.0tp1/ossm-release-notes/ossm-release-notes-assembly.html[{SMProductName} 3.x] +
+{nbsp} +
+xref:../virt/release_notes/virt-4-19-release-notes.adoc#virt-4-19-release-notes[Red Hat {VirtProductName}] +
+{nbsp} +
+xref:../observability/otel/otel-rn.adoc#otel-rn[{OTELName}]
+
+////
+Hiding until WMCO 10.19.0 GAs 
+xref:../windows_containers/wmco_rn/windows-containers-release-notes-10-19-x.adoc#windows-containers-release-notes-10-19-x[{productwinc}] +
+{nbsp} +
+////
+
+P::
+xref:../observability/power_monitoring/power-monitoring-release-notes.adoc#power-monitoring-release-notes[{PM-title-c}]
+
+R::
+xref:../nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc#run-once-duration-override-release-notes[{run-once-operator}]
+
+S::
+xref:../nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc#nodes-secondary-scheduler-release-notes[{secondary-scheduler-operator-full}] +
+{nbsp} +
+xref:../security/security_profiles_operator/spo-release-notes.adoc#spo-release-notes[Security Profiles Operator]

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -77,7 +77,7 @@ Explore the following {product-title} installation tasks:
 | xref:../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation]
 
 | xref:../storage/persistent_storage/persistent-storage-ocs.adoc#red-hat-openshift-data-foundation[Install {rh-storage-first}]
-| xref:../machine_configuration/mco-coreos-layering.adoc#mco-coreos-layering[{image-mode-os-lower}]
+| xref:../machine_configuration/mco-coreos-layering.adoc#mco-coreos-layering[{op-system-first} image layering]
 
 |===
 
@@ -172,10 +172,13 @@ a|* xref:../networking/networking_operators/cluster-network-operator.adoc#nw-clu
 | xref:../operators/understanding/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[Manage Operators]
 | xref:../operators/user/olm-creating-apps-from-installed-operators.adoc#olm-creating-apps-from-installed-operators[Creating applications from installed Operators]
 
-| xref:../windows_containers/index.adoc#index[{productwinc} overview]
-| xref:../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads_understanding-windows-container-workloads[Understanding Windows container workloads]
-
 |===
+
+//// 
+Hiding until WMCO 10.19.0 releases, replace as the last row of the above table after WMCO GAs
+| xref: ../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads_understanding-windows-container-workloads[Understanding Windows container workloads]
+|
+////
 
 [discrete]
 ==== Changing cluster components

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,7 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.adoc#windows-containers-release-notes-10-17-x[release notes].
+
+Documentation for {productwinc} is planned to be available for {product-title} {product-version} in the near future.
+
+////
+Hiding until WMCO 10.19.0 GAs
+{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/wmco_rn/windows-containers-release-notes-10-19-x.adoc#windows-containers-release-notes-10-19-x[release notes].
 
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
 
@@ -33,7 +38,4 @@ You can xref:../windows_containers/disabling-windows-container-workloads.adoc#di
 
 * Uninstalling the Windows Machine Config Operator
 * Deleting the Windows Machine Config Operator namespace
-
-////
-Documentation for {productwinc} will be available for {product-title} {product-version} in the near future.
 ////


### PR DESCRIPTION
The WMCO version 4.18.0 will not be ready for OCP 4.18.0 GA release. This PR hides the WMCO docs, except for the index.adoc assembly, but with wording explaining the absence of the rest of the doc set. Also, hiding other Windows references and links into the WMCO docs. 

Windows -- Windows book is after Nodes. Hiding all but Red Hat OpenShift support for Windows Containers overview (index.html). Added text to index that the WMCO docs not available.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/windows_container_support_for_openshift/windows-container-overview)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/)

Installing preparing -> Preparing your cluster for workloads -> Preparing your cluster for workloads -> If you plan to run Windows workloads paragraph hidden
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installation_overview/installing-preparing#installing-preparing-cluster-for-workloads)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/installing-preparing#installing-preparing-cluster-for-workloads)

--------
For the [configuring-hybrid-ovnkubernetes.adoc](https://github.com/openshift/openshift-docs/pull/88987/files#diff-7ad795770aa1997333ecebb522fcf6b4786241523796c479a832d542b98f4bcf) module, I need to hide some Windows-related details in the two procedures. However, commenting-out information within steps in the procedure caused issues. I copied the two procedures and manually removed the details. The original steps are commented-out below. **NO NEED TO READ THE NEW STEPS** in the following 4 previews. Just want to make sure everything looks OK. 

The files is used in the following assemblies:

Installing a cluster on AWS with network customizations -> Configuring hybrid networking with OVN-Kubernetes - Note after first paragraph and note at end hidden. The `hybridOverlayVXLANPort: 9898` and call-out text hidden.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installing_on_aws/installer-provisioned-infrastructure#configuring-hybrid-ovnkubernetes_installing-aws-network-customizations)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-network-customizations#configuring-hybrid-ovnkubernetes_installing-aws-network-customizations)

Installing a cluster on Azure with network customizations -> Configuring hybrid networking with OVN-Kubernetes -> Note after first paragraph and note at end hidden. The `hybridOverlayVXLANPort: 9898` and call-out text hidden.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installing_on_azure/installer-provisioned-infrastructure#configuring-hybrid-ovnkubernetes_installing-azure-network-customizations)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-network-customizations#configuring-hybrid-ovnkubernetes_installing-azure-network-customizations)

Installing a cluster on Azure Stack Hub with network customizations -> Configuring hybrid networking with OVN-Kubernetes -> Note after first paragraph and note at end hidden. The `hybridOverlayVXLANPort: 9898` and call-out text hidden.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installing_on_azure_stack_hub/installer-provisioned-infrastructure#configuring-hybrid-ovnkubernetes_installing-azure-stack-hub-network-customizations)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations#configuring-hybrid-ovnkubernetes_installing-azure-stack-hub-network-customizations)

Networking -> OVN-Kubernetes network plugin ->  Configuring hybrid networking - Note after first paragraph hidden. The `hybridOverlayVXLANPort: 9898` and call-out text hidden.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/ovn-kubernetes-network-plugin#configuring-hybrid-networking)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking#configuring-hybrid-ovnkubernetes_configuring-hybrid-networking)

Networking -> OVN -> Configuring hybrid networking -> Additional resources -> Removed two bullets
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/ovn-kubernetes-network-plugin#configuring-hybrid-networking)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking#configuring-hybrid-networking-additional-resources)

--------
**REVIEW AS USUAL**

Troubleshooting Windows container workload issues -- Assembly hidden
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/support/troubleshooting#troubleshooting-windows-container-workload-issues)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-storage-issues)

About -> Learn more about OpenShift Container Platform -- Last row of "Managing cluster components" table hidden
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/about/learn_more_about_openshift#managing-changing-cluster-components)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/learn_more_about_openshift#managing-changing-cluster-components)

Release notes -> Additional release notes -- Removed link to WMCO docs, after Red Hat OpenShift Service Mesh 3.x.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/addtl-release-notes)
[Updated docs](https://88987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/addtl-release-notes)