### PR TITLE
OSDOCS#13470:Update the About-this-release page for 4.19

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -18,19 +18,17 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. From the {hybrid-console}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
-// Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.8 and a later version of {op-system-base} 8 that is released before End of Life of {product-title} {product-version}. {product-title} {product-version} is also supported on {op-system-first} {product-version}. To understand {op-system-base} versions used by {op-system}, see link:https://access.redhat.com/articles/6907891[{op-system-base} Versions Utilized by {op-system-first} and {product-title}] (Knowledgebase article).
-
-You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines. {op-system-base} machines are deprecated in {product-title} 4.16 and will be removed in a future release.
+You must use {op-system} machines for the control plane and for the compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517
-
+//Removed paragraph about the RHEL package because mode workers are removed from 4.19, per Scott Dodson
 //Even-numbered release lifecycle verbiage (Comment in for even-numbered releases)
+//// 
 Starting from {product-title} 4.14, the Extended Update Support (EUS) phase for even-numbered releases increases the total available lifecycle to 24 months on all supported architectures, including `x86_64`, 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures. Beyond this, Red{nbsp}Hat also offers a 12-month additional EUS add-on, denoted as _Additional EUS Term 2_, that extends the total available lifecycle from 24 months to 36 months. The Additional EUS Term 2 is available on all architecture variants of {product-title}. For more information about support for all versions, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
+////
 
 //Odd-numbered release lifecycle verbiage (Comment in for odd-numbered releases)
-////
+
 The support lifecycle for odd-numbered releases, such as {product-title} {product-version}, on all supported architectures, including `x86_64`, 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures is 18 months. For more information about support for all versions, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
-////
 
 Commencing with the {product-title} 4.14 release, Red{nbsp}Hat is simplifying the administration and management of Red{nbsp}Hat shipped cluster Operators with the introduction of three new life cycle classifications; Platform Aligned, Platform Agnostic, and Rolling Stream. These life cycle classifications provide additional ease and transparency for cluster administrators to understand the life cycle policies of each Operator and form cluster maintenance and upgrade plans with predictable support boundaries. For more information, see link:https://access.redhat.com/webassets/avalon/j/includes/session/scribe/?redirectTo=https%3A%2F%2Faccess.redhat.com%2Fsupport%2Fpolicy%2Fupdates%2Fopenshift_operators[OpenShift Operator Life Cycles].
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13470](https://issues.redhat.com//browse/OSDOCS-13470)

Link to docs preview:
[About this release](https://94298--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-about-this-release_release-notes) (Updated 6/11/24)

QE review:
- [x ] QE has approved this change. (proxy - Ju Lim)

Additional information: (Note to merger)
The RHSA ID in the preview will be available and updated in a separate PR after GA.
