### PR TITLE
OLS-1785: cmd to set up TLS cert is missing namespace argument

### DIFF
--- a/modules/ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm.adoc
+++ b/modules/ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm.adoc
@@ -21,7 +21,7 @@ If the LLM provider you are using requires a trust certificate to authenticate t
 +
 [source,terminal]
 ----
-$ oc create configmap trusted-certs --from-file=caCertFileName
+$ oc create configmap trusted-certs --from-file=caCertFileName --namespace openshift-lightspeed
 ----
 +
 .Example output


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0tp1](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0tp1)

This PR is part of the standalone doc set for the Lightspeed project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

PR must be CP'd back to the lightspeed-docs-1.0tp1 branch.

Version(s): TP

Issue: https://issues.redhat.com/browse/OLS-1785
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://94333--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-configuring-lightspeed-with-a-trust-provider-certificate-for-the-llm_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
