### PR TITLE
{enterprise-4.15} Fix variable accidentally added in a cherrypick.

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -59,7 +59,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 |Data collection for Local Storage Operator.
 
 |`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:v<installed_version_sandboxed_containers>`
-|Data collection for {osc}.
+|Data collection for {sandboxed-containers-first}.
 
 |`registry.redhat.io/workload-availability/node-healthcheck-must-gather-rhel8:v<installed_version_NHC>`
 |Data collection for the Red{nbsp}Hat Workload Availability Operators, including the Self Node Remediation (SNR) Operator, the Fence Agents Remediation (FAR) Operator, the Machine Deletion Remediation (MDR) Operator, the Node Health Check (NHC) Operator, and the Node Maintenance Operator (NMO).


### PR DESCRIPTION
This PR fixes a [cherrypick error where we replaced an attribute](https://github.com/openshift/openshift-docs/pull/94324/files#diff-8850fc8756323b54c73334ea2d0e3e2f85d462c7d07b08358037c4418ebc69e7R62) with one that is not in 4.15.